### PR TITLE
Update ckan-validate to pass through exit status.

### DIFF
--- a/bin/ckan-validate
+++ b/bin/ckan-validate
@@ -17,3 +17,6 @@ my $SCHEMA        = "$Bin/../CKAN.schema";
 my $VALIDATOR_JAR = "$Bin/json-schema-validator-2.2.5-lib.jar";
 
 system('java', '-jar', $VALIDATOR_JAR, $SCHEMA, @files);
+
+# Pass through failure status if applicable. This is great for travis.
+$? and die "\nOne or more files failed to validate\n";


### PR DESCRIPTION
This means that tests can examine the ckan-validate
exit value to tell if any files failed validation.

This is going to be handy for doing travis-ci testing.
Also, if you can see this, you should merge it if you
think it looks okay! :)
