### PR TITLE
`ckan gui` or `ckan` (no args) will now start the GUI.

### DIFF
--- a/CKAN/CKAN.sln
+++ b/CKAN/CKAN.sln
@@ -43,6 +43,23 @@ Global
 		$0.DotNetNamingPolicy = $2
 		$2.DirectoryNamespaceAssociation = None
 		$2.ResourceNamePolicy = FileFormatDefault
+		$0.TextStylePolicy = $3
+		$3.inheritsSet = null
+		$3.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $4
+		$4.ElseIfNewLinePlacement = SameLine
+		$4.AfterDelegateDeclarationParameterComma = True
+		$4.inheritsSet = Mono
+		$4.inheritsScope = text/x-csharp
+		$4.scope = text/x-csharp
+		$0.TextStylePolicy = $5
+		$5.NoTabsAfterNonTabs = True
+		$5.inheritsSet = VisualStudio
+		$5.inheritsScope = text/plain
+		$5.scope = text/plain
+		$0.StandardHeader = $6
+		$6.Text = 
+		$6.IncludeInNewFiles = True
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CKAN/CmdLine/CmdLine.csproj
+++ b/CKAN/CmdLine/CmdLine.csproj
@@ -53,5 +53,9 @@
       <Project>{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}</Project>
       <Name>CKAN</Name>
     </ProjectReference>
+    <ProjectReference Include="..\GUI\CKAN-GUI.csproj">
+      <Project>{A79F9D54-315C-472B-928F-713A5860B2BE}</Project>
+      <Name>CKAN-GUI</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -32,6 +32,12 @@ namespace CKAN {
             LogManager.GetRepository ().Threshold = Level.Warn;
             log.Debug ("CKAN started");
 
+            // If we're starting with no options, invoke the GUI instead.
+
+            if (args.Length == 0) {
+                return Gui ();
+            }
+
             Options cmdline;
 
             try {
@@ -73,6 +79,9 @@ namespace CKAN {
 
             switch (cmdline.action) {
 
+                case "gui":
+                    return Gui();
+                
                 case "version":
                     return Version ();
 
@@ -108,6 +117,16 @@ namespace CKAN {
                     return EXIT_BADOPT;
 
             }
+        }
+
+        static int Gui() {
+
+            // TODO: Sometimes when the GUI exits, we get a System.ArgumentException,
+            // but trying to catch it here doesn't seem to help. Dunno why.
+
+            GUI.Main ();
+
+            return EXIT_OK;
         }
 
         static int Version() {
@@ -315,6 +334,9 @@ namespace CKAN {
     // TODO: Figure out how to do per action help screens.
 
     class Actions {
+        [VerbOption("gui", HelpText = "Start the CKAN GUI")]
+        public GuiOptions GuiOptions { get; set; }
+
         [VerbOption("update", HelpText = "Update list of available mods")]
         public UpdateOptions Update { get; set; }
 
@@ -390,6 +412,7 @@ namespace CKAN {
     class VersionOptions   : CommonOptions { }
     class CleanOptions     : CommonOptions { }
     class AvailableOptions : CommonOptions { }
+    class GuiOptions       : CommonOptions { }
 
     class UpdateOptions    : CommonOptions {
 

--- a/CKAN/GUI/Program.cs
+++ b/CKAN/GUI/Program.cs
@@ -7,13 +7,13 @@ using System.Windows.Forms;
 namespace CKAN
 {
 
-    static class Program
+    public static class GUI
     {
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        public static void Main()
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);


### PR DESCRIPTION
This can be tested with [this exe](http://ckan-travis.s3-website-us-east-1.amazonaws.com/ckan-v0.04-51-gfc8ad9c.exe).

Also, I have no idea what's happened with our CKAN.sln
policy stuff. I've managed to get it back to _not_ inserting
tabs, but we might need a bot or similar to monitor this.

(I'm much more used to .vimrc and .perlcriticrc files!)

Also, @AlexanderDzhoganov, I opened up your GUI Program class,
I hope you're cool with that. ;)
