### PR TITLE
Test github integration against the KSP-CKAN/Test repo.

### DIFF
--- a/CKAN/Tests/KerbalStuff/GitHubTests.cs
+++ b/CKAN/Tests/KerbalStuff/GitHubTests.cs
@@ -10,7 +10,7 @@ namespace GitHubTests
         [Test()]
         public void Release ()
         {
-            GithubRelease ckan = CKAN.KerbalStuff.GithubAPI.GetLatestRelease("KSP-CKAN/CKAN");
+            GithubRelease ckan = CKAN.KerbalStuff.GithubAPI.GetLatestRelease("KSP-CKAN/Test");
             Assert.IsNotNull (ckan.author);
             Assert.IsNotNull (ckan.download);
             Assert.IsNotNull (ckan.size);


### PR DESCRIPTION
Because we know that repo will be in a known state.
