### PR TITLE
No longer fill in spec version on the CKAN.

### DIFF
--- a/CKAN/KerbalStuff/Github/GithubRelease.cs
+++ b/CKAN/KerbalStuff/Github/GithubRelease.cs
@@ -45,7 +45,6 @@ namespace CKAN.KerbalStuff
                 metadata["resources"]["github"] = new JObject();
             }
 
-            Inflate(metadata, "spec_version", "1"); // CKAN spec version
             Inflate(metadata, "author", author);
             Inflate(metadata, "version", version.ToString());
             Inflate(metadata, "download", Uri.EscapeUriString(download.ToString()));

--- a/CKAN/KerbalStuff/KS/KSMod.cs
+++ b/CKAN/KerbalStuff/KS/KSMod.cs
@@ -45,7 +45,6 @@ namespace CKAN.KerbalStuff
                 metadata["resources"]["kerbalstuff"] = new JObject();
             }
 
-            Inflate(metadata, "spec_version", "1"); // CKAN spec version
             Inflate(metadata, "name", name);
             Inflate(metadata, "license", license);
             Inflate(metadata, "abstract", short_description);


### PR DESCRIPTION
We want the user to supply this here so we can figure out what the end
user is targeting.
