### PR TITLE
Fixed license on RetroFuture.

### DIFF
--- a/BootKAN/RetroFuture.ckan
+++ b/BootKAN/RetroFuture.ckan
@@ -2,6 +2,7 @@
     "spec_version"   : 1,
     "identifier"     : "RetroFuture",
     "$kref"          : "#/ckan/kerbalstuff",
+    "license"        : "CC-BY-NC-SA-4.0",
     "depends" : [
         { "name" : "Firespitter" },
         { "name" : "ModuleManager", "min_version" : "2.5.1" }


### PR DESCRIPTION
KerbalStuff allows for free-form license fields, and the CKAN gets
unhappy if these don't exactly match what's in our spec. This
overrides the detected field with the actual CKAN-friendly license.
