### PR TITLE
NetKAN: No longer pre-fill KSP version when min/max exists.

### DIFF
--- a/CKAN/NetKAN/KS/KSMod.cs
+++ b/CKAN/NetKAN/KS/KSMod.cs
@@ -7,7 +7,7 @@ namespace CKAN.NetKAN
 {
     public class KSMod : CkanInflator
     {
-        // private static readonly ILog log = LogManager.GetLogger(typeof (KSMod));
+        private static readonly ILog log = LogManager.GetLogger(typeof (KSMod));
         public int id; // KSID
 
         // These get filled in from JSON deserialisation.
@@ -31,6 +31,8 @@ namespace CKAN.NetKAN
         {
             var version = (KSVersion)context;
 
+            log.DebugFormat("Inflating {0}", metadata["identifier"]);
+
             // Check how big our file is
             long download_size = (new FileInfo (filename)).Length;
 
@@ -45,6 +47,15 @@ namespace CKAN.NetKAN
                 metadata["resources"]["kerbalstuff"] = new JObject();
             }
 
+            // Only pre-fill version info if there's none already. GH #199
+            if ((string) metadata["ksp_version_min"] == null && (string) metadata["ksp_version_max"] == null)
+            {
+                // Inflate won't overwrite an existing key, so we don't need to check
+                // for ksp_version itself. :)
+                log.Debug("Pre-filling KSP version field");
+                Inflate(metadata, "ksp_version", version.KSP_version.ToString());
+            }
+
             Inflate(metadata, "name", name);
             Inflate(metadata, "license", license);
             Inflate(metadata, "abstract", short_description);
@@ -55,7 +66,6 @@ namespace CKAN.NetKAN
             Inflate(metadata, "download_size", download_size);
             Inflate((JObject) metadata["resources"], "homepage", website);
             Inflate((JObject) metadata["resources"]["kerbalstuff"], "url", KSHome());
-            Inflate(metadata, "ksp_version", version.KSP_version.ToString());
         }
 
         internal string KSHome()

--- a/CKAN/Tests/NetKAN/KSMod.cs
+++ b/CKAN/Tests/NetKAN/KSMod.cs
@@ -36,5 +36,47 @@ namespace NetKAN.KerbalStuffTests
 
             Assert.AreEqual("https://kerbalstuff.com/mod/123/foo%20bar", ks.KSHome());
         }
+
+        [Test]
+        // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
+        public void KSP_Version_Inflate_199()
+        {
+            JObject metadata = JObject.Parse(Tests.TestData.DogeCoinFlag_101());
+
+            // Add our own field, and remove existing ones.
+            metadata["ksp_version_min"] = "0.23.5";
+            metadata["ksp_version"] = null;
+            metadata["ksp_version_max"] = null;
+
+            // Sanity check: make sure we don't have a ksp_version field to begin with.
+            Assert.AreEqual(null, (string) metadata["ksp_version"]);
+
+            CKAN.NetKAN.KSMod ksmod = test_ksmod();
+
+            ksmod.InflateMetadata(metadata, Tests.TestData.DogeCoinFlagZip(), ksmod.versions[0]);
+
+            // Make sure min is still there, and the rest unharmed.
+            Assert.AreEqual(null, (string) metadata["ksp_version"]);
+            Assert.AreEqual(null, (string) metadata["ksp_version_max"]);
+            Assert.AreEqual("0.23.5", (string) metadata["ksp_version_min"]);
+
+        }
+
+        public CKAN.NetKAN.KSMod test_ksmod()
+        {
+            var ksmod = new CKAN.NetKAN.KSMod();
+            ksmod.license = "CC-BY";
+            ksmod.name = "Dogecoin Flag";
+            ksmod.short_description = "Such test. Very unit. Wow.";
+            ksmod.author = "pjf";
+
+            ksmod.versions = new CKAN.NetKAN.KSVersion[1];
+            ksmod.versions[0] = new CKAN.NetKAN.KSVersion();
+            ksmod.versions[0].friendly_version = new CKAN.Version("0.25");
+            ksmod.versions[0].download_path = "http://example.com/";
+
+            return ksmod;
+        }
+
     }
 }


### PR DESCRIPTION
- Includes tests.
- Closes #199
