### PR TITLE
Always write files in binary mode.

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using System.Threading;
+using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using System.Transactions;
 using ChinhDo.Transactions;
@@ -755,11 +756,17 @@ namespace CKAN
                     file_transaction.CreateDirectory(directory);
                 }
 
+                // Snapshot whatever was there before. If there's nothing, this will just
+                // remove our file on rollback.
+                file_transaction.Snapshot(fullPath);
+
                 // It's a file! Prepare the streams
                 using (Stream zipStream = zipfile.GetInputStream(entry))
-                using (StreamReader reader = new StreamReader(zipStream))
+                using (FileStream writer = File.Create(fullPath))
                 {
-                    file_transaction.WriteAllText(fullPath, reader.ReadToEnd());
+                    // 4k is the block size on practically every disk and OS.
+                    byte[] buffer = new byte[4096];
+                    StreamUtils.Copy(zipStream, writer, buffer);
                 }
             }
 

--- a/CKAN/Tests/Tests.csproj
+++ b/CKAN/Tests/Tests.csproj
@@ -39,6 +39,7 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
+    <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="TestData.cs" />


### PR DESCRIPTION
Fixes #205. Includes tests. Supports transactions (also tested).
