### PR TITLE
Added SRL and QuickRevert to the NetKAN.

### DIFF
--- a/NetKAN/QuickRevert.ckan
+++ b/NetKAN/QuickRevert.ckan
@@ -1,0 +1,9 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "QuickRevert",
+    "$kref"          : "#/ckan/kerbalstuff/237",
+    "license"        : "GPL-3.0",
+    "conflicts"      : [
+        { "name" : "SRL" }
+    ]
+}

--- a/NetKAN/SRL.ckan
+++ b/NetKAN/SRL.ckan
@@ -1,0 +1,9 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "SRL",
+    "$kref"          : "#/ckan/kerbalstuff/145",
+    "license"        : "GPL-3.0",
+    "conflicts"      : [
+        { "name" : "QuickRevert" }
+    ]
+}


### PR DESCRIPTION
@malahx: These files can be inflated by `netkan.exe` to produce
the full CKAN descriptors. The best thing is we've got bots that
check KerbalStuff for new releases each day, so if you make a new
release of SRL or QuickRevert, we'll find it! :)
