### PR TITLE
Fix unused variable warnings.

### DIFF
--- a/CKAN/GUI/Main.Designer.cs
+++ b/CKAN/GUI/Main.Designer.cs
@@ -56,7 +56,7 @@ namespace CKAN
             this.customToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ModList = new System.Windows.Forms.DataGridView();
             this.Installed = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.Update = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.DoUpdate = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ModName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Author = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.InstalledVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -324,7 +324,7 @@ namespace CKAN
             this.ModList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.ModList.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Installed,
-            this.Update,
+            this.DoUpdate,
             this.ModName,
             this.Author,
             this.InstalledVersion,
@@ -351,9 +351,9 @@ namespace CKAN
             // 
             // Update
             // 
-            this.Update.HeaderText = "Update";
-            this.Update.Name = "Update";
-            this.Update.Width = 46;
+            this.DoUpdate.HeaderText = "Update";
+            this.DoUpdate.Name = "Update";
+            this.DoUpdate.Width = 46;
             // 
             // ModName
             // 
@@ -882,7 +882,6 @@ namespace CKAN
         private ToolStripMenuItem exportInstalledModsToolStripMenuItem;
         private ToolStripMenuItem launchKSPToolStripMenuItem;
         private ToolStripMenuItem setCommandlineOptionsToolStripMenuItem;
-        private DataGridViewCheckBoxColumn DoUpdate;
         private DataGridViewCheckBoxColumn Installed;
         private DataGridViewTextBoxColumn ModName;
         private DataGridViewTextBoxColumn Author;
@@ -892,7 +891,7 @@ namespace CKAN
         private DataGridViewTextBoxColumn Description;
         private DataGridViewLinkColumn Homepage;
         private ToolStripMenuItem clearChangesToolStripMenuItem;
-        private DataGridViewCheckBoxColumn Update;
+        private DataGridViewCheckBoxColumn DoUpdate;
     }
 }
 


### PR DESCRIPTION
In b0f96cb0a60caaccc1c6ea5f981ad8dca09d025c the variable `DoUpdate` was
renamed to `Update`¹, re-introducing warnings that were fixed in #173.

This change removes said warnings.

Tested on the GUI; I can tick the update box just fine, and indeed just
updated my version of DeadlyReentry. :)

Attn: @AlexanderDzhoganov in case I've screwed anything up, but I'm
pretty sure I'm good. :)

¹ Git bisect is _seriously_ the best thing ever.
