### PR TITLE
I brokez the NetKAN. This fixes it.

### DIFF
--- a/CKAN/NetKAN/Github/GithubRelease.cs
+++ b/CKAN/NetKAN/Github/GithubRelease.cs
@@ -30,7 +30,11 @@ namespace CKAN.NetKAN
 
             JToken asset = parsed_json["assets"]
                 .Children()
-                .Where(asset_info => asset_info["content_type"].ToString() == "application/x-zip-compressed")
+                .Where(asset_info => 
+                    asset_info["content_type"].ToString() == "application/x-zip-compressed" ||
+                    asset_info["content_type"].ToString() == "application/zip" ||
+                    asset_info["name"].ToString().EndsWith(".zip", StringComparison.OrdinalIgnoreCase)
+                )
                 .FirstOrDefault();
 
             if (asset == null)


### PR DESCRIPTION
Apparently the content-type is provided by the browser, so really it
could be anything for a zip file. We now check a couple more types, and
assume a `.zip` extension is also good.

I'm really sorry. This is why I should write more tests.
