### PR TITLE
Fixed a bug where ships could no longer be installed.

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -630,6 +630,16 @@ namespace CKAN
         {
             string leadingPathToRemove = KSPPathUtils.GetLeadingPathElements(file);
 
+            // Special-casing, if stanza.file is just "GameData" or "Ships", strip it.
+            // TODO: Do we need to do anything special for tutorials or GameRoot?
+            if (
+                leadingPathToRemove == string.Empty &&
+                (file == "GameData" || file == "Ships")
+            )
+            {
+                leadingPathToRemove = file;
+            }
+
             // If there's a leading path to remove, then we have some extra work that
             // needs doing...
             if (leadingPathToRemove != string.Empty)
@@ -646,7 +656,7 @@ namespace CKAN
                 // Strip off leading path name
                 outputName = Regex.Replace(outputName, leadingRegEx, "");
             }
-
+ 
             // Return our snipped, normalised, and ready to go output filename!
             return KSPPathUtils.NormalizePath(
                 Path.Combine(installDir, outputName)

--- a/CKAN/Tests/CKAN/ModuleInstaller.cs
+++ b/CKAN/Tests/CKAN/ModuleInstaller.cs
@@ -237,6 +237,8 @@ namespace CKANTests
         {
             Assert.AreEqual("GameData/kOS/Plugins/kOS.dll", CKAN.ModuleInstaller.TransformOutputName("GameData/kOS", "GameData/kOS/Plugins/kOS.dll", "GameData"));
             Assert.AreEqual("GameData/kOS/Plugins/kOS.dll", CKAN.ModuleInstaller.TransformOutputName("kOS-1.1/GameData/kOS", "kOS-1.1/GameData/kOS/Plugins/kOS.dll", "GameData"));
+            Assert.AreEqual("GameData/ModuleManager.2.5.1.dll", CKAN.ModuleInstaller.TransformOutputName("ModuleManager.2.5.1.dll", "ModuleManager.2.5.1.dll", "GameData"));
+            Assert.AreEqual("SomeDir/Ships/SPH/FAR Firehound.craft", CKAN.ModuleInstaller.TransformOutputName("Ships", "Ships/SPH/FAR Firehound.craft", "SomeDir/Ships"));
         }
 
         private static string CopyDogeFromZip()


### PR DESCRIPTION
Introduced in #287. Oops.

Have tested with our mods that install to GameRoot, and they seem to be
fine.

Have not tested with tutorials. I think they're fine, but we may see
another PR after this.
