### PR TITLE
CmdLine users now get continuous feedback on download progress.

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -388,8 +388,6 @@ namespace CKAN
 
         internal void Install(CkanModule module, string filename = null)
         {
-            User.WriteLine(module.identifier + ":\n");
-
             Version version = registry_manager.registry.InstalledVersion(module.identifier);
 
             // TODO: This really should be handled by higher-up code.

--- a/CKAN/CmdLine/CmdLine.csproj
+++ b/CKAN/CmdLine/CmdLine.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Options.cs" />
     <Compile Include="Action\KSP.cs" />
     <Compile Include="Exit.cs" />
+    <Compile Include="ProgressReporter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -355,10 +355,9 @@ namespace CKAN.CmdLine
             try
             {
                 var installer = ModuleInstaller.Instance;
-                if (options.Verbose)
-                {
-                    installer.onReportProgress = (message, progress) => User.WriteLine(String.Format("{0} - {1}%", message, progress));
-                }
+
+                installer.onReportProgress = ProgressReporter.FormattedDownloads;
+
                 installer.InstallList(options.modules, install_ops);
             }
             catch (ModuleNotFoundKraken ex)
@@ -398,8 +397,6 @@ namespace CKAN.CmdLine
                 User.WriteLine(ex.InconsistenciesPretty);
                 return Exit.ERROR;
             }
-
-            User.WriteLine("\nDone!\n");
 
             return Exit.OK;
         }

--- a/CKAN/CmdLine/ProgressReporter.cs
+++ b/CKAN/CmdLine/ProgressReporter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace CKAN.CmdLine
+{
+    /// <summary>
+    /// A simple class that manages progress report events for the CmdLine.
+    /// This will almost certainly need extra functionality if we deprecate the User class.
+    /// </summary>
+    public static class ProgressReporter
+    {
+        /// <summary>
+        /// Only shows download report messages, and nothing else.
+        /// </summary>
+        public static void FormattedDownloads(string message, int progress)
+        {
+            if (Regex.IsMatch(message, "download", RegexOptions.IgnoreCase))
+            {
+                Console.Write(
+                    // The \r at the front here causes download messages to *overwrite* each other.
+                    String.Format("\r{0} - {1}%           ", message, progress)
+                );
+            }
+            else
+            {
+                // The percent looks weird on non-download messages.
+                // The leading newline makes sure we don't end up with a mess from previous
+                // download messages.
+                Console.WriteLine("\n{0}", message);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This is a fabulously easy change. Works under Linux, and I expect
works everywhere.

I think we want to officially deprecate the User class at some
point. Callbacks are ending up being a much nicer way to signal
information, and they also aid in testing (as we can ensure
operations call back with the right strings).
