### PR TITLE
Provide and use zip validation methods for the cache.

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -135,8 +135,8 @@ namespace CKAN
                 filename = CkanModule.StandardName(identifier, version);
             }
 
-            string full_path;
-            if (!cache.IsCached(url, out full_path))
+            string full_path = cache.GetCachedZip(url);
+            if (full_path == null)
             {
                 return Download(url, filename, cache);
             }
@@ -173,8 +173,7 @@ namespace CKAN
 
             foreach (CkanModule module in modsToInstall)
             {
-                string filename;
-                if (!ksp.Cache.IsCached(module.download, out filename))
+                if (!ksp.Cache.IsCachedZip(module.download))
                 {
                     User.WriteLine(" * {0}", module);
                     downloads.Add(module);
@@ -238,8 +237,9 @@ namespace CKAN
 
         public List<string> GetModuleContentsList(CkanModule module)
         {
-            string filename;
-            if (!KSPManager.CurrentInstance.Cache.IsCached(module.download, out filename))
+            string filename = ksp.Cache.GetCachedZip(module.download);
+
+            if (filename == null)
             {
                 return null;
             }

--- a/CKAN/GUI/MainModInfo.cs
+++ b/CKAN/GUI/MainModInfo.cs
@@ -200,8 +200,7 @@ namespace CKAN
 
         private void _UpdateModContentsTree(CkanModule module)
         {
-            string filename;
-            if (!KSPManager.CurrentInstance.Cache.IsCached(module.download, out filename))
+            if (!KSPManager.CurrentInstance.Cache.IsCachedZip(module.download))
             {
                 NotCachedLabel.Text = "This mod is not in the cache, click 'Download' to preview contents";
                 ContentsDownloadButton.Enabled = true;

--- a/CKAN/NetKAN/MainClass.cs
+++ b/CKAN/NetKAN/MainClass.cs
@@ -81,8 +81,8 @@ namespace CKAN.NetKAN
             }
 
             // Find our cached file, we'll need it later.
-            string file;
-            if (!cache.IsCached(mod.download, out file))
+            string file = cache.GetCachedZip(mod.download);
+            if (file == null)
             {
                 log.FatalFormat("Error: Unable to find {0} in the cache", mod.identifier);
                 return EXIT_ERROR;

--- a/CKAN/Tests/CKAN/Cache.cs
+++ b/CKAN/Tests/CKAN/Cache.cs
@@ -117,6 +117,29 @@ namespace CKANTests
             cache.Store(url, file1);
             FileAssert.AreEqual(file1, cache.GetCachedFilename(url));
         }
+
+        [Test]
+        public void ZipValidation()
+        {
+            // We could use any URL, but this one is awesome. <3
+            Uri url = new Uri("http://kitte.nz/");
+
+            Assert.IsFalse(cache.IsCachedZip(url));
+
+            // Store a bad zip.
+            cache.Store(url, Tests.TestData.DogeCoinFlagZipCorrupt());
+
+            // Make sure it's stored, but not valid as a zip
+            Assert.IsTrue(cache.IsCached(url));
+            Assert.IsFalse(cache.IsCachedZip(url));
+
+            // Store a good zip.
+            cache.Store(url, Tests.TestData.DogeCoinFlagZip());
+
+            // Make sure it's stored, and valid.
+            Assert.IsTrue(cache.IsCached(url));
+            Assert.IsTrue(cache.IsCachedZip(url));
+        }
     }
 }
 


### PR DESCRIPTION
- `IsCachedZip` and `GetCachedZip` test zipfile integrity.
- Existing code modified to prefer these functions.
- NUnit tests included.
- Tested by manually truncating files in my cache directory, too. :)
- Closes #242

The reason I don't have all cache functions testing zipfile integrity is because we may wish to store _other_ things in the cache in the future (eg: mod thumbnails).

Many thanks to @techman83 for providing test data.
