### PR TITLE
Marking `master` (aka development) as unstable.

### DIFF
--- a/CKAN/CKAN/CKAN.csproj
+++ b/CKAN/CKAN/CKAN.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>CKAN</RootNamespace>
     <AssemblyName>CKAN</AssemblyName>
-    <DefineConstants>$(DefineConstants);STABLE</DefineConstants>
+    <!-- <DefineConstants>$(DefineConstants);STABLE</DefineConstants> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/CKAN/CmdLine/CmdLine.csproj
+++ b/CKAN/CmdLine/CmdLine.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>CKAN.CmdLine</RootNamespace>
     <AssemblyName>CmdLine</AssemblyName>
     <StartupObject>CKAN.CmdLine.MainClass</StartupObject>
-    <DefineConstants>$(DefineConstants);STABLE</DefineConstants>
+    <!-- <DefineConstants>$(DefineConstants);STABLE</DefineConstants> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/CKAN/GUI/CKAN-GUI.csproj
+++ b/CKAN/GUI/CKAN-GUI.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>CKAN-GUI</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <DefineConstants>$(DefineConstants);STABLE</DefineConstants>
+    <!-- <DefineConstants>$(DefineConstants);STABLE</DefineConstants> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/CKAN/LocalRepo/LocalRepo.csproj
+++ b/CKAN/LocalRepo/LocalRepo.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>LocalRepo</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <DefineConstants>$(DefineConstants);STABLE</DefineConstants>
+    <!-- <DefineConstants>$(DefineConstants);STABLE</DefineConstants> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/CKAN/NetKAN/NetKAN.csproj
+++ b/CKAN/NetKAN/NetKAN.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>CKAN.NetKAN</RootNamespace>
     <AssemblyName>NetKAN</AssemblyName>
     <StartupObject>CKAN.NetKAN.MainClass</StartupObject>
-    <DefineConstants>$(DefineConstants);STABLE</DefineConstants>
+    <!-- <DefineConstants>$(DefineConstants);STABLE</DefineConstants> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/CKAN/Tests/Tests.csproj
+++ b/CKAN/Tests/Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
-    <DefineConstants>$(DefineConstants);STABLE</DefineConstants>
+    <!-- <DefineConstants>$(DefineConstants);STABLE</DefineConstants> -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>


### PR DESCRIPTION
- Removes the STABLE token in the .csproj files.
- Part of #302.
- Travis will remind us to put these back any time we make
  a stable branch in the future.
