### PR TITLE
Rearranged KSP.cs to make it easier to read and navigate

### DIFF
--- a/CKAN/CKAN/KSP.cs
+++ b/CKAN/CKAN/KSP.cs
@@ -16,35 +16,37 @@ namespace CKAN
     public class KSP
     {
 
+        #region Fields and Properties
+
         private static readonly ILog log = LogManager.GetLogger(typeof(KSP));
 
         private string gamedir;
         private KSPVersion version;
         private NetFileCache _Cache;
-        public NetFileCache Cache
+
+        public NetFileCache Cache 
         {
-            get
-            {
-                return _Cache;
-            }
+            get { return _Cache; }
         }
 
         public RegistryManager RegistryManager
         {
-            get
-            {
-                return RegistryManager.Instance(this);
-            }
+            get { return RegistryManager.Instance(this); }
         }
 
         public Registry Registry
         {
-            get
-            {
-                return this.RegistryManager.registry;
-            }
+            get { return this.RegistryManager.registry; }
         }
 
+        #endregion
+        #region Construction and Initialisation
+
+        /// <summary>
+        /// Returns a KSP object, insisting that directory contains a valid KSP install.
+        /// Will initialise a CKAN instance in the KSP dir if it does not already exist.
+        /// Throws a NotKSPDirKraken if directory is not a KSP install.
+        /// </summary>
         public KSP(string directory)
         {
 
@@ -61,120 +63,10 @@ namespace CKAN
             _Cache = new NetFileCache(DownloadCacheDir());
         }
 
-        public string GameDir()
-        {
-            return gamedir;
-        }
-
-        /// <summary>
-        /// Returns the path to our portable version of KSP if ckan.exe is in the same
-        /// directory as the game. Otherwise, returns null.
-        /// </summary>
-        public static string PortableDir()
-        {
-            // Find the directory our executable is stored in.
-            // In Perl, this is just `use FindBin qw($Bin);` Verbose enough, C#?
-            string exe_dir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-
-            log.DebugFormat("Checking if KSP is in my exe dir: {0}", exe_dir);
-
-            // Checking for a GameData directory probably isn't the best way to
-            // detect KSP, but it works. More robust implementations welcome.
-            if (IsKspDir(exe_dir))
-            {
-                log.InfoFormat("KSP found at {0}", exe_dir);
-                return exe_dir;
-            }
-
-            return null;
-        }
-
-        public static string FindGameDir()
-        {
-
-            // See if we can find KSP as part of a Steam install.
-
-            string steam = KSPPathUtils.SteamPath();
-            if (steam != null)
-            {
-                string ksp_dir = Path.Combine(steam, KSPPathConstants.steamKSP);
-
-                if (Directory.Exists(ksp_dir))
-                {
-                    log.InfoFormat("KSP found at {0}", ksp_dir);
-                    return ksp_dir;
-                }
-
-                log.DebugFormat("Have Steam, but KSP is not at {0}", ksp_dir);
-            }
-
-            // Oh noes! We can't find KSP!
-
-            throw new DirectoryNotFoundException();
-        }
-        
-
-
-        /// <summary>
-        /// Checks if the specified directory looks like a KSP directory.
-        /// Returns true if found, false if not.
-        /// </summary>
-        internal static bool IsKspDir(string directory)
-        {
-            //first we need to check is directory exists
-            if (!Directory.Exists(Path.Combine(directory, "GameData")))
-            {
-                log.DebugFormat("Cannot find GameData in {0}", directory);
-                return false;
-            }
-            //next we should be able to get game version
-            try
-            {
-                DetectVersion(directory);
-            }
-            catch
-            {
-                log.DebugFormat("Cannot detect KSP version in {0}", directory);
-                return false;
-            }
-            log.DebugFormat("{0} looks like a GameDir", directory);
-            return true;
-        }
-
-        public string GameData()
-        {
-            return Path.Combine(GameDir(), "GameData");
-        }
-
-        public string CkanDir()
-        {
-            return Path.Combine(GameDir(), "CKAN");
-        }
-
-        public string DownloadCacheDir()
-        {
-            return Path.Combine(CkanDir(), "downloads");
-        }
-
-        public string Ships()
-        {
-            return Path.Combine(GameDir(), "Ships");
-        }
-
-        public string Tutorial()
-        {
-            return Path.Combine(GameDir(), "saves", "training");
-        }
-
-        public string TempDir()
-        {
-            return Path.Combine(CkanDir(), "temp");
-        }
-
         /// <summary>
         ///     Create the CKAN directory and any supporting files.
         /// </summary>
-        public void Init()
+        private void Init()
         {
             log.DebugFormat("Initialising {0}", CkanDir());
 
@@ -209,6 +101,180 @@ namespace CKAN
             log.DebugFormat("Initialised {0}", CkanDir());
         }
 
+        #endregion
+
+        #region KSP Directory Detection and Versioning
+
+        /// <summary>
+        /// Returns the path to our portable version of KSP if ckan.exe is in the same
+        /// directory as the game. Otherwise, returns null.
+        /// </summary>
+        public static string PortableDir()
+        {
+            // Find the directory our executable is stored in.
+            // In Perl, this is just `use FindBin qw($Bin);` Verbose enough, C#?
+            string exe_dir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+
+            log.DebugFormat("Checking if KSP is in my exe dir: {0}", exe_dir);
+
+            // Checking for a GameData directory probably isn't the best way to
+            // detect KSP, but it works. More robust implementations welcome.
+            if (IsKspDir(exe_dir))
+            {
+                log.InfoFormat("KSP found at {0}", exe_dir);
+                return exe_dir;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Attempts to automatically find a KSP install on this system.
+        /// Returns the path to the install on success.
+        /// Throws a DirectoryNotFoundException on failure.
+        /// </summary>
+        public static string FindGameDir()
+        {
+
+            // See if we can find KSP as part of a Steam install.
+
+            string steam = KSPPathUtils.SteamPath();
+            if (steam != null)
+            {
+                string ksp_dir = Path.Combine(steam, KSPPathConstants.steamKSP);
+
+                if (Directory.Exists(ksp_dir))
+                {
+                    log.InfoFormat("KSP found at {0}", ksp_dir);
+                    return ksp_dir;
+                }
+
+                log.DebugFormat("Have Steam, but KSP is not at {0}", ksp_dir);
+            }
+
+            // Oh noes! We can't find KSP!
+
+            throw new DirectoryNotFoundException();
+        }
+
+        /// <summary>
+        /// Checks if the specified directory looks like a KSP directory.
+        /// Returns true if found, false if not.
+        /// </summary>
+        internal static bool IsKspDir(string directory)
+        {
+            //first we need to check is directory exists
+            if (!Directory.Exists(Path.Combine(directory, "GameData")))
+            {
+                log.DebugFormat("Cannot find GameData in {0}", directory);
+                return false;
+            }
+            //next we should be able to get game version
+            try
+            {
+                DetectVersion(directory);
+            }
+            catch
+            {
+                log.DebugFormat("Cannot detect KSP version in {0}", directory);
+                return false;
+            }
+            log.DebugFormat("{0} looks like a GameDir", directory);
+            return true;
+        }
+
+
+        /// <summary>
+        /// Detects the version of KSP in a given directory.
+        /// Throws a NotKSPDirKraken if anything goes wrong.
+        /// </summary>
+        private static KSPVersion DetectVersion(string path)
+        {
+            string readme = "";
+            try
+            {
+                // Slurp our README into memory
+                readme = File.ReadAllText(Path.Combine(path, "readme.txt"));
+            }
+            catch
+            {
+                log.Error("Could not open KSP readme.txt");
+                throw new NotKSPDirKraken("readme.txt not found or not readable");
+            }
+
+            // And find the KSP version. Easy! :)
+            Match match = Regex.Match(readme, @"^Version\s+(\d+\.\d+\.\d+)",
+                RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+            if (match.Success)
+            {
+                string version = match.Groups[1].Value;
+                log.DebugFormat("Found version {0}", version);
+                return new KSPVersion(version);
+            }
+
+            // Oh noes! We couldn't find the version!
+            log.Error("Could not find KSP version in readme.txt");
+
+            throw new NotKSPDirKraken(path, "Could not find KSP version in readme.txt");
+        }
+
+        #endregion
+
+        #region Things which would be better as Properties
+
+        public string GameDir()
+        {
+            return gamedir;
+        }
+
+        public string GameData()
+        {
+            return Path.Combine(GameDir(), "GameData");
+        }
+
+        public string CkanDir()
+        {
+            return Path.Combine(GameDir(), "CKAN");
+        }
+
+        public string DownloadCacheDir()
+        {
+            return Path.Combine(CkanDir(), "downloads");
+        }
+
+        public string Ships()
+        {
+            return Path.Combine(GameDir(), "Ships");
+        }
+
+        public string Tutorial()
+        {
+            return Path.Combine(GameDir(), "saves", "training");
+        }
+
+        public string TempDir()
+        {
+            return Path.Combine(CkanDir(), "temp");
+        }
+
+        public KSPVersion Version()
+        {
+            if (version != null)
+            {
+                return version;
+            }
+
+            return version = DetectVersion(GameDir());
+        }
+
+        #endregion
+
+        #region CKAN/GameData Directory Maintenance
+
+        /// <summary>
+        /// Removes all files from the download (cache) directory.
+        /// </summary>
         public void CleanCache()
         {
             log.Debug("Cleaning cahce directory");
@@ -267,50 +333,8 @@ namespace CKAN
             this.RegistryManager.Save();
         }
 
-        public KSPVersion Version()
-        {
-            if (version != null)
-            {
-                return version;
-            }
+        #endregion
 
-            return version = DetectVersion(GameDir());
-        }
-
-        internal static KSPVersion DetectVersion(string path)
-        {
-            string readme = "";
-            try
-            {
-                // Slurp our README into memory
-                readme = File.ReadAllText(Path.Combine(path, "readme.txt"));
-            }
-            catch
-            {
-                log.Error("Could not open KSP readme.txt");
-                throw new BadVersionException();
-            }
-
-            // And find the KSP version. Easy! :)
-            Match match = Regex.Match(readme, @"^Version\s+(\d+\.\d+\.\d+)",
-                RegexOptions.IgnoreCase | RegexOptions.Multiline);
-
-            if (match.Success)
-            {
-                string version = match.Groups[1].Value;
-                log.DebugFormat("Found version {0}", version);
-                return new KSPVersion(version);
-            }
-
-            // Oh noes! We couldn't find the version!
-            // (Suggestions for better exceptions welcome!)
-            log.Error("Could not find KSP version in readme.txt");
-            throw new BadVersionException();
-        }
     }
 
-    public class BadVersionException : Exception
-    {
-    }
-   
 }


### PR DESCRIPTION
So, I'm submitting this as a PR to the stable branch. It's not technically a bugfix, but it does make working with KSP.cs much nicer, and the actual code changes themselves are very minimal.

Note that changes hitting the release branch will also be merged into dev (but not vice-versa), so dev is always a super-set of stable.

You can tell me that this is breaking my rules, and this should go into dev (`master`), in which case I'll resubmit to there. :)

---

Changes:
- Added #regions
- Condensed properties
- Added comments
- Grouped similar methods together

Actual code changes:
- Some methods are more private than they were before.
- We throw a `NotKSPDirKraken` where we used to throw a
  `BadVersionException` before.
- `BadVersionExceptions` were never processed by anything, and have been
  removed.
