### PR TITLE
No longer query the user during transactions.

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -681,26 +681,26 @@ namespace CKAN
         /// </summary>
         public void UninstallList(IEnumerable<string> mods)
         {
+            // Find all the things which need uninstalling.
+            IEnumerable<string> goners = registry_manager.registry.FindReverseDependencies(mods);
+
+            User.WriteLine("About to remove:\n");
+
+            foreach (string mod in goners)
+            {
+                User.WriteLine(" * {0}", mod);
+            }
+
+            bool ok = User.YesNo("\nContinue?", FrontEndType.CommandLine);
+
+            if (!ok)
+            {
+                User.WriteLine("Mod removal aborted at user request.");
+                return;
+            }
+
             using (var transaction = new TransactionScope())
             {
-                // Find all the things which need uninstalling.
-                IEnumerable<string> goners = registry_manager.registry.FindReverseDependencies(mods);
-
-                User.WriteLine("About to remove:\n");
-
-                foreach (string mod in goners)
-                {
-                    User.WriteLine(" * {0}", mod);
-                }
-
-                bool ok = User.YesNo("\nContinue?", FrontEndType.CommandLine);
-
-                if (!ok)
-                {
-                    User.WriteLine("Mod removal aborted at user request.");
-                    return;
-                }
-
                 foreach (string mod in goners)
                 {
                     Uninstall(mod);

--- a/CKAN/CKAN/User.cs
+++ b/CKAN/CKAN/User.cs
@@ -2,6 +2,8 @@
 // This class will proxy to either the GUI or cmdline functionality.
 
 using System;
+using System.Transactions;
+using log4net;
 
 namespace CKAN
 {
@@ -25,6 +27,8 @@ namespace CKAN
         public static DisplayMessage displayMessage = WriteLineConsole;
         public static DisplayError displayError = WriteLineConsole;
 
+        private static readonly ILog log = LogManager.GetLogger(typeof (User));
+
         // Send a line to the user. On a console, this does what you expect.
         // In the GUI, this should update the status bar.
         // This is also an obvious place to do logging as well.
@@ -42,6 +46,11 @@ namespace CKAN
             if (_frontEnd != FrontEndType.All && _frontEnd != frontEnd)
             {
                 return true;
+            }
+
+            if (Transaction.Current != null)
+            {
+                log.Warn("Asking the user a question during a transaction! What are we thinking?");
             }
 
             return yesNoDialog(text);


### PR DESCRIPTION
UninstallList used to quiz the user while inside a transaction. We don't
do that anymore.

The User.YesNo function has been altered to give us a warning if it
detects a transaction in progress, so we can spot this if we ever do it
in the future.

Fixes #334.
