### PR TITLE
NetAsyncDownloader: Throw MissingCertificateKraken on missing certs.

### DIFF
--- a/CKAN/CKAN/Net.cs
+++ b/CKAN/CKAN/Net.cs
@@ -64,13 +64,7 @@ namespace CKAN
 
                 if (ex is WebException && Regex.IsMatch(ex.Message, "authentication or decryption has failed"))
                 {
-                    User.WriteLine("\nOh no! Our download failed!\n");
-                    User.WriteLine("\t{0}\n", ex.Message);
-                    User.WriteLine("If you're on Linux, try running:\n");
-                    User.WriteLine("\tmozroots --import --ask-remove\n");
-                    User.WriteLine("on the command-line to update your certificate store, and try again.\n");
-
-                    throw new MissingCertificateException();
+                    throw new MissingCertificateKraken("Failed downloading "+url, ex);
                 }
 
                 // Not the exception we were looking for! Throw it further upwards!
@@ -79,9 +73,5 @@ namespace CKAN
 
             return filename;
         }
-    }
-
-    internal class MissingCertificateException : Exception
-    {
     }
 }

--- a/CKAN/CKAN/NetAsyncDownloader.cs
+++ b/CKAN/CKAN/NetAsyncDownloader.cs
@@ -6,6 +6,7 @@ using ChinhDo.Transactions;
 using log4net;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace CKAN
 {
@@ -168,6 +169,17 @@ namespace CKAN
                 .Select(x => x.error)
                 .Where(ex => ex != null)
                 .ToList();
+
+            // Let's check if any of these are certificate errors. If so,
+            // we'll report that instead, as this is common (and user-fixable)
+            // under Linux.
+            foreach (Exception ex in exceptions)
+            {
+                if (ex is WebException && Regex.IsMatch(ex.Message, "authentication or decryption has failed"))
+                {
+                    throw new MissingCertificateKraken();
+                }
+            }
 
             if (exceptions.Count > 0)
             {

--- a/CKAN/CKAN/Types/Kraken.cs
+++ b/CKAN/CKAN/Types/Kraken.cs
@@ -240,4 +240,21 @@ namespace CKAN
         }
     }
 
+    public class MissingCertificateKraken : Kraken
+    {
+        public MissingCertificateKraken(string reason = null, Exception inner_exception = null)
+            :base(reason, inner_exception)
+        {
+        }
+
+        public override string ToString()
+        {
+            return
+                "\nOh no! Our download failed with a certificate error!\n\n" +
+                "If you're on Linux, try running:\n" +
+                "\tmozroots --import --ask-remove\n" +
+                "on the command-line to update your certificate store, and try again.\n\n"
+            ;
+        }
+    }
 }

--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -182,9 +182,17 @@ namespace CKAN.CmdLine
         {
             User.WriteLine("Downloading updates...");
 
-            int updated = Repo.Update(options.repo);
-
-            User.WriteLine("Updated information on {0} available modules", updated);
+            try
+            {
+                int updated = Repo.Update(options.repo);
+                User.WriteLine("Updated information on {0} available modules", updated);
+            }
+            catch (MissingCertificateKraken kraken)
+            {
+                // Handling the kraken means we have prettier output.
+                Console.WriteLine(kraken);
+                return Exit.ERROR;
+            }
 
             return Exit.OK;
         }
@@ -400,6 +408,12 @@ namespace CKAN.CmdLine
             catch (CancelledActionKraken)
             {
                 User.WriteLine("Installation cancelled at user request.");
+                return Exit.ERROR;
+            }
+            catch (MissingCertificateKraken kraken)
+            {
+                // Another very pretty kraken.
+                Console.WriteLine(kraken);
                 return Exit.ERROR;
             }
 


### PR DESCRIPTION
This means our users get much more useful feedback when they can easily
fix their problem using mozroots.

Fixes #219.
