### PR TITLE
Fix the CKAN schema to comply with the JSON Schema Schema

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -8,14 +8,14 @@
             "description" : "Version of the CKAN spec this document uses",
             "oneOf"       : [
                 {
-                    "type"    : "integer",
-                    "comment" : "The integer '1' is special cased",
-                    "minimum" : 1,
-                    "maximum" : 1
+                    "type"        : "integer",
+                    "description" : "The integer '1' is special cased",
+                    "minimum"     : 1,
+                    "maximum"     : 1
                 },
                 {
                     "type"        : "string",
-                    "comment"     : "A vx.x string",
+                    "description" : "A vx.x string",
                     "pattern"     : "^v[0-9]+\\.[0-9]+$"
                 }
             ]


### PR DESCRIPTION
Apparently "comment" is not allowed. Flipped these to "description".

This reduces spurious warnings when a .ckan document fails to validate.
