### PR TITLE
Provide better output on `ckan available`

### DIFF
--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -213,7 +213,8 @@ namespace CKAN.CmdLine
 
             foreach (CkanModule module in available)
             {
-                User.WriteLine("* {0}", module);
+                string entry = String.Format("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
+                User.WriteLine(entry.PadRight(Console.WindowWidth).Substring(0,Console.WindowWidth));
             }
 
             return Exit.OK;


### PR DESCRIPTION
Now shows the name, as well as identifier and version.

Is aware of console size, so we don't wrap.

```
* InfernalRobotics (0.19.2) - Magic Smoke Industries Infernal Robotics
* Karbonite (0.4.4) - Karbonite
* KAS (0.4.9) - Kerbal Attachement System
* KerbalConstructionTime (1.0.3) - Kerbal Construction Time
* KerbalFlightIndicators (R8) - Kerbal Flight Indicators
* KerbalJointReinforcement (v2.4.4) - Kerbal Joint Reinforcement
* Kerb-fu (v0.20a) - Professor Phineas Kerbenstein's wonderous vertical propulsion emporium.
```

Closes #356.
