### PR TITLE
only truncate when the console appears limited, fixes #364

### DIFF
--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -211,10 +211,18 @@ namespace CKAN.CmdLine
             User.WriteLine("Mods available for KSP {0}", KSPManager.CurrentInstance.Version());
             User.WriteLine("");
 
+            var width = Console.WindowWidth;
+
             foreach (CkanModule module in available)
             {
                 string entry = String.Format("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
-                User.WriteLine(entry.PadRight(Console.WindowWidth).Substring(0,Console.WindowWidth));
+                if (width > 0) {
+                    User.WriteLine(entry.PadRight(Console.WindowWidth).Substring(0,Console.WindowWidth));
+                }
+                else
+                {
+                    User.WriteLine(entry);
+                }
             }
 
             return Exit.OK;


### PR DESCRIPTION
I don't know if there are function pointers in C#, but this would probably run more smoothly by replacing the if check in the for loop with a pointer to either the `User.WriteLine` function or a function which wraps the padding and truncation code.

Works for me though. grep and less handle the list correctly now.
