### PR TITLE
Actually *use* our download hints when downloading files.

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -94,7 +94,7 @@ namespace CKAN
 
             string tmp_file = Net.Download(url);
 
-            return cache.Store(url, tmp_file, move: true);
+            return cache.Store(url, tmp_file, filename, move: true);
         }
 
         /// <summary>


### PR DESCRIPTION
This means we end up with nice filenames when using the old downloader (eg, in NetKAN) rather than ugly ones.

Fixes #307
