### PR TITLE
Make KSP_VERSION_MIN and KSP_VERSION_MAX independent

### DIFF
--- a/CKAN/NetKAN/AVC/AVC.cs
+++ b/CKAN/NetKAN/AVC/AVC.cs
@@ -108,8 +108,14 @@ namespace CKAN.NetKAN
             {
                 log.Debug("Inflating ksp min/max");
                 metadata.Remove("ksp_version"); // In case it's there from KS
-                Inflate(metadata, "ksp_version_min", ksp_version_min.ToString());
-                Inflate(metadata, "ksp_version_max", ksp_version_max.ToString());
+                if (ksp_version_min != null)
+                {
+                    Inflate(metadata, "ksp_version_min", ksp_version_min.ToString());
+                }
+                if (ksp_version_max != null)
+                {
+                    Inflate(metadata, "ksp_version_max", ksp_version_max.ToString());
+                }
             }
             else if (ksp_version != null)
             {


### PR DESCRIPTION
The spec states that KSP_VERSION_MIN and KSP_VERSION_MAX are optional, but if one is present, the parser currently expects the other to be present.
Closes #382 
