### PR TITLE
#238 added aliases uninstall and ksp use

### DIFF
--- a/CKAN/CmdLine/Action/KSP.cs
+++ b/CKAN/CmdLine/Action/KSP.cs
@@ -25,6 +25,9 @@ namespace CKAN.CmdLine
 
             [VerbOption("default", HelpText="Set a default KSP install")]
             public DefaultOptions DefaultOptions { get; set; }
+
+            [VerbOption("use", HelpText="Alternative for `default`")]
+            public UseOptions UseOptions { get; set; }
         }
 
         internal class AddOptions : CommonOptions
@@ -55,6 +58,10 @@ namespace CKAN.CmdLine
         {
             [ValueOption(0)]
             public string name { get; set; }
+        }
+
+        internal class UseOptions : DefaultOptions
+        {
         }
 
         public KSP()
@@ -98,6 +105,7 @@ namespace CKAN.CmdLine
                 case "forget":
                     return ForgetInstall((ForgetOptions)suboptions);
 
+                case "use":
                 case "default":
                     return SetDefaultInstall((DefaultOptions)suboptions);
 

--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -150,6 +150,7 @@ namespace CKAN.CmdLine
                 case "show":
                     return Show((ShowOptions) cmdline.options);
 
+                case "uninstall":
                 case "remove":
                     return Remove((RemoveOptions) cmdline.options);
 

--- a/CKAN/CmdLine/Options.cs
+++ b/CKAN/CmdLine/Options.cs
@@ -64,6 +64,9 @@ namespace CKAN.CmdLine
         [VerbOption("remove", HelpText = "Remove an installed mod")]
         public RemoveOptions Remove { get; set; }
 
+        [VerbOption("uninstall", HelpText = "Alternative for `remove`")]
+        public UninstallOptions Uninstall { get; set; }
+
         [VerbOption("scan", HelpText = "Scan for manually installed KSP mods")]
         public ScanOptions Scan { get; set; }
 
@@ -189,6 +192,10 @@ namespace CKAN.CmdLine
     {
         [ValueOption(0)]
         public string Modname { get; set; }
+    }
+
+    internal class UninstallOptions : RemoveOptions
+    {
     }
 
     internal class ShowOptions : CommonOptions


### PR DESCRIPTION
I went ahead and added VerbOptions for the aliases. I couldn't find a way to not list them in the help text, though, so I'll leave it like this for now.

Closes #238 
