### PR TITLE
Change FixedToolWindow to FixedDialog to avoid a window disappearing bug

### DIFF
--- a/CKAN/GUI/KSPCommandLineOptionsDialog.Designer.cs
+++ b/CKAN/GUI/KSPCommandLineOptionsDialog.Designer.cs
@@ -80,7 +80,7 @@
             this.Controls.Add(this.AcceptChangesButton);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.AdditionalArguments);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Name = "KSPCommandLineOptionsDialog";
             this.Text = "KSP command-line arguments";
             this.ResumeLayout(false);

--- a/CKAN/GUI/RenameInstanceDialog.Designer.cs
+++ b/CKAN/GUI/RenameInstanceDialog.Designer.cs
@@ -72,7 +72,7 @@
             this.Controls.Add(this.CancelRenameInstanceButton);
             this.Controls.Add(this.OKButton);
             this.Controls.Add(this.NameTextBox);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Name = "RenameInstanceDialog";
             this.Text = "Rename installation";
             this.ResumeLayout(false);

--- a/CKAN/GUI/SettingsDialog.Designer.cs
+++ b/CKAN/GUI/SettingsDialog.Designer.cs
@@ -168,7 +168,7 @@
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.CacheGroupBox);
             this.Controls.Add(this.RepositoryGroupBox);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Name = "SettingsDialog";
             this.Text = "Settings";
             this.Load += new System.EventHandler(this.SettingsDialog_Load);

--- a/CKAN/GUI/YesNoDialog.Designer.cs
+++ b/CKAN/GUI/YesNoDialog.Designer.cs
@@ -82,7 +82,7 @@
             this.Controls.Add(this.NoButton);
             this.Controls.Add(this.YesButton);
             this.Controls.Add(this.panel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Name = "YesNoDialog";
             this.Text = "User input required";
             this.panel1.ResumeLayout(false);


### PR DESCRIPTION
This suggestion was from nlight - it works, but I'm unsure how it affects windows users.

This was what happened before:
https://www.youtube.com/watch?v=F-5hmmhRwmc
