### PR TITLE
Update notification - Don't pull yet

### DIFF
--- a/CKAN/CKAN/CKAN.csproj
+++ b/CKAN/CKAN/CKAN.csproj
@@ -36,6 +36,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Net\Github\GithubAPI.cs" />
+    <Compile Include="Net\Github\GithubRelease.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="KSP.cs" />
     <Compile Include="ModuleInstaller.cs" />
@@ -70,8 +72,5 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="Net\" />
-    <Folder Include="Converters\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/CKAN/CKAN/Meta.cs
+++ b/CKAN/CKAN/Meta.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 
 namespace CKAN
@@ -10,6 +11,37 @@ namespace CKAN
         // replaced by our build system with our actual version.
 
         private readonly static string BUILD_VERSION = null;
+
+        /// <summary>
+        /// Returns whether this version of CKAN is the most recently 
+        /// released version. (Fetches from Github)
+        /// Always returns true if this version is not stable.
+        /// </summary>
+        public static bool IsUpdated()
+        {
+            if (!IsStable())
+            {
+                return true;
+            }
+
+            Version version = ReleaseNumber();
+            
+            // TODO: Cache?
+            GithubRelease release = GithubAPI.GetLatestRelease("KSP-CKAN/CKAN");
+
+            if (release != null && release.version.IsGreaterThan(version))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static Version GetMostRecentVersion()
+        {
+            GithubRelease release = GithubAPI.GetLatestRelease("KSP-CKAN/CKAN");
+            return release.version;
+        }
 
         /// <summary>
         /// Returns the version of the CKAN.dll used, complete with git info

--- a/CKAN/CKAN/Net/Github/GithubAPI.cs
+++ b/CKAN/CKAN/Net/Github/GithubAPI.cs
@@ -1,20 +1,18 @@
-using System;
-using System.Net;
-using log4net;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System.Linq;
-
 // We could use OctoKit for this, but since we're only pinging the
 // release API, I'm happy enough without yet another dependency.
+using System;
+using System.Linq;
+using System.Net;
+using log4net;
+using Newtonsoft.Json.Linq;
 
-namespace CKAN.NetKAN
+namespace CKAN
 {
     public static class GithubAPI
     {
 
         private static readonly Uri api_base = new Uri("https://api.github.com/");
-        private static readonly ILog log = LogManager.GetLogger(typeof (KSAPI));
+        private static readonly ILog log = LogManager.GetLogger(typeof (GithubAPI));
         private static readonly WebClient web = new WebClient();
         private static bool done_init = false;
 

--- a/CKAN/CKAN/Net/Github/GithubRelease.cs
+++ b/CKAN/CKAN/Net/Github/GithubRelease.cs
@@ -1,17 +1,16 @@
 using System;
 using System.IO;
 using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using log4net;
+using Newtonsoft.Json.Linq;
 
-namespace CKAN.NetKAN
+namespace CKAN
 {
     /// <summary>
     /// A simple class to pull the relevant details out of a Github release.
     /// For gh2ckan. :)
     /// </summary>
-    public class GithubRelease : CkanInflator
+    public class GithubRelease
     {
         public Version version;
         public Uri download;
@@ -47,28 +46,6 @@ namespace CKAN.NetKAN
             download = new Uri( asset["browser_download_url"].ToString() );
 
             log.DebugFormat("Download {0} is {1} bytes", download, size);
-        }
-
-        override public void InflateMetadata(JObject metadata, string filename, object context)
-        {
-            var repo = (string)context;
-
-            // Check how big our file is
-            long download_size = (new FileInfo (filename)).Length;
-
-            // Make sure resources exist.
-            if (metadata["resources"] == null)
-            {
-                metadata["resources"] = new JObject();
-            }
-
-            Inflate(metadata, "author", author);
-            Inflate(metadata, "version", version.ToString());
-            Inflate(metadata, "download", Uri.EscapeUriString(download.ToString()));
-            Inflate(metadata, "x_generated_by", "netkan");
-            Inflate(metadata, "download_size", download_size);
-            Inflate((JObject) metadata["resources"], "repository", GithubPage(repo));
-
         }
 
         public string Download(string identifier, NetFileCache cache)

--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -204,6 +204,11 @@ namespace CKAN.CmdLine
                 return Exit.ERROR;
             }
 
+            if (!Meta.IsUpdated())
+            {
+                User.WriteLine("CKAN has an update available.  Version {0} can be downloaded at http://www.github.com/KSP-CKAN/CKAN/releases", Meta.GetMostRecentVersion().ToString());
+            }
+
             return Exit.OK;
         }
 

--- a/CKAN/GUI/Main.cs
+++ b/CKAN/GUI/Main.cs
@@ -145,6 +145,11 @@ namespace CKAN
 
             Text = String.Format("CKAN {0} - KSP {1}", Meta.Version(), KSPManager.CurrentInstance.Version());
             KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", KSPManager.CurrentInstance.Version());
+
+            if (!Meta.IsUpdated())
+            {
+                statusStrip1.Text = "CKAN is out of date! Download from: https://www.github.com/KSP-CKAN/CKAN/releases";
+            }
         }
 
         private void RefreshToolButton_Click(object sender, EventArgs e)

--- a/CKAN/NetKAN/CkanInflator.cs
+++ b/CKAN/NetKAN/CkanInflator.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN
@@ -14,7 +13,7 @@ namespace CKAN.NetKAN
         // Inflate will add a value, but only if that key is not
         // already filled with something else.
 
-        internal static void Inflate(JObject metadata, string key, string value)
+        public static void Inflate(JObject metadata, string key, string value)
         {
             if (metadata[key] == null)
             {
@@ -22,7 +21,7 @@ namespace CKAN.NetKAN
             }
         }
 
-        internal static void Inflate(JObject metadata, string key, long value)
+        public static void Inflate(JObject metadata, string key, long value)
         {
             if (metadata[key] == null)
             {

--- a/CKAN/NetKAN/MainClass.cs
+++ b/CKAN/NetKAN/MainClass.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
+using CKAN.NetKAN;
 using log4net;
 using log4net.Config;
 using log4net.Core;
@@ -189,6 +190,7 @@ namespace CKAN.NetKAN
         {
             // Find the release on github and download.
             GithubRelease release = GithubAPI.GetLatestRelease(repo);
+            GithubInflator inflator = new GithubInflator(release);
 
             if (filename == null)
             {
@@ -205,7 +207,7 @@ namespace CKAN.NetKAN
             if (kref == (string)orig_metadata[expand_token] || kref == "#/ckan/github")
             {
                 log.InfoFormat("Inflating from github metadata... {0}", metadata[expand_token]);
-                release.InflateMetadata(metadata, filename, repo);
+                inflator.InflateMetadata(metadata, filename, repo);
                 metadata.Remove(expand_token);
             }
             else

--- a/CKAN/NetKAN/NetKAN.csproj
+++ b/CKAN/NetKAN/NetKAN.csproj
@@ -33,14 +33,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CkanInflator.cs" />
+    <Compile Include="Github\GithubInflator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MainClass.cs" />
     <Compile Include="KS\KSAPI.cs" />
     <Compile Include="KS\KSVersion.cs" />
     <Compile Include="KS\KSMod.cs" />
-    <Compile Include="Github\GithubAPI.cs" />
-    <Compile Include="Github\GithubRelease.cs" />
-    <Compile Include="CkanInflator.cs" />
     <Compile Include="CmdLineOptions.cs" />
     <Compile Include="AVC\AVC.cs" />
     <Compile Include="AVC\JsonAvcToKspVersion.cs" />

--- a/CKAN/Tests/CKAN/GitHubTests.cs
+++ b/CKAN/Tests/CKAN/GitHubTests.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using System;
 using CKAN.NetKAN;
 
-namespace NetKAN.GitHubTests
+namespace CKAN
 {
     [TestFixture()]
     public class GithubAPITests
@@ -16,7 +16,7 @@ namespace NetKAN.GitHubTests
         [Category("FlakyNetwork")]
         public void Release ()
         {
-            GithubRelease ckan = CKAN.NetKAN.GithubAPI.GetLatestRelease("KSP-CKAN/Test");
+            GithubRelease ckan = GithubAPI.GetLatestRelease("KSP-CKAN/Test");
             Assert.IsNotNull (ckan.author);
             Assert.IsNotNull (ckan.download);
             Assert.IsNotNull (ckan.size);

--- a/CKAN/Tests/Tests.csproj
+++ b/CKAN/Tests/Tests.csproj
@@ -41,7 +41,7 @@
     <Compile Include="CKAN\ModuleInstaller.cs" />
     <Compile Include="CKAN\KSPManager.cs" />
     <Compile Include="NetKAN\KSMod.cs" />
-    <Compile Include="NetKAN\GitHubTests.cs" />
+    <Compile Include="CKAN\GitHubTests.cs" />
     <Compile Include="CKAN\ModuleInstallDescriptor.cs" />
     <Compile Include="ZipLib.cs" />
     <Compile Include="CKAN\SanityChecker.cs" />


### PR DESCRIPTION
This is the first PR towards auto updating.
Moves GithubAPI to CKAN/Net/Github so it can be used by ckan.dll
Tells the user CKAN is outdated when ckan update is ran
Tells the user CKAN is outdated when the GUI starts

Closes #385 
