### PR TITLE
Alternative JSON validator

### DIFF
--- a/bin/ckan-validate.py
+++ b/bin/ckan-validate.py
@@ -45,7 +45,7 @@ def main():
                 continue
             print 'Success!'
 
-	sys.exit(error)
+    sys.exit(error)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Just because I don't like Java, here's a Python validator. Needs Python 2.7 and jsonschema which you can get with

```
pip install jsonschema
```
