### PR TITLE
Re-apply sorting upon modlist update.

### DIFF
--- a/CKAN/GUI/MainModList.cs
+++ b/CKAN/GUI/MainModList.cs
@@ -419,6 +419,9 @@ namespace CKAN
                 ModList.Sort(ModList.Columns[2], ListSortDirection.Ascending);
                 ModList.Refresh();
             }
+
+            // Re-apply the sorting of the mods list.
+            _UpdateModNameFilter();
         }
     }
 }


### PR DESCRIPTION
After installing a list of mods (Realism Overhaul for those curious) I noticed the modlist had reset to show all available mods even though text was present in the "Filter by name" textbox.

I don't know if this is the right place to add this change, or if it should be the public function (_UpdateModNameFilter()_) instead of the private (__UpdateModNameFilter()_), but it now behaves as I would expect with regards to sorting the list after a change.

Behavior of the sorting prior to the code change:
![prior](https://cloud.githubusercontent.com/assets/856309/5264782/1299349a-7a3e-11e4-9859-9a64358c2c5e.png)

Sorting after the code change:
![post](https://cloud.githubusercontent.com/assets/856309/5264787/18a04978-7a3e-11e4-9da5-0676bcfea274.png)

As noted in my previous pull request: I have not worked with C#/.Net in a long time, and have never been involved in C#/.Net GUI development before. I haven't really been a part of GitHub collaborations before either, so any critique is welcome.
