### PR TITLE
Allows remove to accept a list of modules

### DIFF
--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -316,12 +316,12 @@ namespace CKAN.CmdLine
         // Uninstalls a module, if it exists.
         private static int Remove(RemoveOptions options)
         {
-            if (options.Modname != null && options.Modname.Length > 0)
+            if (options.modules != null && options.modules.Count > 0)
             {
                 try
                 {
                     var installer = ModuleInstaller.Instance;
-                    installer.UninstallList(options.Modname);
+                    installer.UninstallList(options.modules);
                     return Exit.OK;
                 }
                 catch (ModNotInstalledKraken kraken)

--- a/CKAN/CmdLine/Options.cs
+++ b/CKAN/CmdLine/Options.cs
@@ -187,8 +187,8 @@ namespace CKAN.CmdLine
 
     internal class RemoveOptions : CommonOptions
     {
-        [ValueOption(0)]
-        public string Modname { get; set; }
+        [ValueList(typeof(List<string>))]
+        public List<string> modules { get; set; }
     }
 
     internal class ShowOptions : CommonOptions


### PR DESCRIPTION
Allows `remove` to accept a list of modules, like `install` does (fixes #378).
