### PR TITLE
Tests: Allow for -PRE in stable release numbers.

### DIFF
--- a/CKAN/Tests/CKAN/Meta.cs
+++ b/CKAN/Tests/CKAN/Meta.cs
@@ -32,11 +32,11 @@ namespace CKANTests
             }
 
             // We should always be in the form v0.xx (pre-release series),
-            // or vx.x.x (released). We also permit a (-RC\d) extension for
-            // release candidates.
+            // or vx.x.x (released). We also permit a (-RC\d+) extension for
+            // release candidates, and -PRE\d for pre-releases.
 
             Assert.IsTrue(
-                Regex.IsMatch(version.ToString(), @"^v(?:0.\d+|\d+\.\d+\.\d+(?:-RC\d+)?)$"),
+                Regex.IsMatch(version.ToString(), @"^v(?:0.\d+|\d+\.\d+\.\d+(?:-(?:RC|PRE)\d+)?)$"),
                 version.ToString());
         }
     }


### PR DESCRIPTION
This means we can release `v1.2.0-PRE1` without our test cases going silly. This release will read `v1.2` spec files (since its version number is greater than the spec_version), but we're not necessarily calling it a release candidate.

Internally `ckan.dll` and friends don't care about the version number at all, except to compare it as a `Version` object against the `spec_version` in our metadata. We could have `cheese sandwich` as a version and the core would accept that as being okay. ;)
