### PR TITLE
Starting ckan.exe with no arguments always start the GUI.

### DIFF
--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -33,19 +33,11 @@ namespace CKAN.CmdLine
             LogManager.GetRepository().Threshold = Level.Warn;
             log.Debug("CKAN started");
 
-            // If we're starting with no options, and this isn't
-            // a stable build, then invoke the GUI instead.
+            // If we're starting with no options then invoke the GUI instead.
 
             if (args.Length == 0)
             {
-                if (Meta.IsStable())
-                {
-                    args = new string[] { "--help" };
-                }
-                else
-                {
-                    return Gui();
-                }
+                return Gui();
             }
 
             Options cmdline;


### PR DESCRIPTION
Previously this wouldn't do so if we had a "stable" build.

Hand tested by Australians. :P
