### PR TITLE
Fix recommended by list

### DIFF
--- a/CKAN/GUI/MainInstall.cs
+++ b/CKAN/GUI/MainInstall.cs
@@ -459,7 +459,7 @@ namespace CKAN
                     }
                     else
                     {
-                        first = true;
+                        first = false;
                     }
 
                     recommendedByString += mod;


### PR DESCRIPTION
Currently, if several mods recommends the same mod, their names are listed as `Mod1Mod2Mod3Mod4`. Fixing the state of the variable makes the code perform as intended, such that the mods are listed as `Mod1, Mod2, Mod3, Mod4`.
