### PR TITLE
Catch DownloadErrorsKraken.

### DIFF
--- a/CKAN/GUI/MainInstall.cs
+++ b/CKAN/GUI/MainInstall.cs
@@ -322,6 +322,7 @@ namespace CKAN
                 }
                 catch (DownloadErrorsKraken e)
                 {
+                    // User notified in InstallList
                     return false;
                 }
             }


### PR DESCRIPTION
On windows if it propagates to the Invoke call it is wrapped in a new exception. Given that a error dialog is already given by the downloader we can just silently capture it.
