### PR TITLE
Add default UI behaviour to rename dialog.

### DIFF
--- a/CKAN/GUI/RenameInstanceDialog.cs
+++ b/CKAN/GUI/RenameInstanceDialog.cs
@@ -8,6 +8,10 @@ namespace CKAN
         {
             InitializeComponent();
             ApplyFormCompatibilityFixes();
+
+            // Set the default actions for pressing Enter and Escape.
+            AcceptButton = OKButton;
+            CancelButton = CancelRenameInstanceButton;
         }
 
         public DialogResult ShowRenameInstanceDialog(string name)


### PR DESCRIPTION
These changes make the rename dialog accept Enter and Escape. Pressing Enter will now be equivalent to pressing the Ok button, while pressing Escape will be the same as pressing the cancel button.

It might be possible to do this with the UI designer in Visual Studio, such that the changes reside in `RenameInstanceDialog.Designer.cs` instead, but I do now have a Windows development environment setup.
