### PR TITLE
Adds no-derivatives to the schema

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -267,7 +267,7 @@
                 "Zlib",
                 "Zope",
                 "WTFPL",
-                "open-source", "restricted", "unrestricted", "unknown"
+                "open-source", "restricted", "unrestricted", "no-derivatives", "unknown"
             ]
         },
         "licenses" : {


### PR DESCRIPTION
Adds a new generic "no-derivatives" license to the validation schema.
Closes #431 .
