### PR TITLE
Shows a lot more information with the show command

### DIFF
--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -503,7 +503,10 @@ namespace CKAN.CmdLine
             // TODO: Print *lots* of information out; I should never have to dig through JSON
 
             #region Abstract and description
-            user.RaiseMessage("{0}: {1}", module.Module.name, module.Module.@abstract);
+            if (!string.IsNullOrEmpty(module.Module.@abstract))
+                user.RaiseMessage("{0}: {1}", module.Module.name, module.Module.@abstract);
+            else
+                user.RaiseMessage("{0}", module.Module.name);
 
             if (!string.IsNullOrEmpty(module.Module.description))
                 user.RaiseMessage("\n{0}\n", module.Module.description);


### PR DESCRIPTION
Now displays the abstract, description, basic info about the module, the relationships and the installed files. Most of these are automatically hidden if the list is empty.

Closes #588
