### PR TITLE
Add check that values from win32 registry are actually valid directories...

### DIFF
--- a/CKAN/CKAN/KSPManager.cs
+++ b/CKAN/CKAN/KSPManager.cs
@@ -304,11 +304,16 @@ namespace CKAN
                 var path = KSPPathConstants.GetRegistryValue(@"KSPInstancePath_" + i, "");
 
                 log.DebugFormat("Loading {0} from {1}", name, path);
-
-                var ksp = new KSP(path,User);
-                _Instances.Add(name, ksp);
-
-                log.DebugFormat("Added {0} at {1}", name, path);
+                if (KSP.IsKspDir(path))
+                {
+                    _Instances.Add(name, new KSP(path, User));
+                    log.DebugFormat("Added {0} at {1}", name, path);
+                    instanceCount--;
+                }
+                else
+                {
+                    log.DebugFormat("{0} at {1} is not a vaild install", name, path);
+                }     
             }
 
             instances_loaded = true;


### PR DESCRIPTION
Due to how KSPManager uses PopulateRegistryWithInstances works this will result in invalid entries being removed.
Closes #507.
