### PR TITLE
Renamed 'unstable' to 'beta'.

### DIFF
--- a/CKAN/CKAN/Meta.cs
+++ b/CKAN/CKAN/Meta.cs
@@ -14,7 +14,7 @@ namespace CKAN
         /// <summary>
         /// Returns the version of the CKAN.dll used, complete with git info
         /// and other decorations as filled in by our build system.
-        /// Eg: v1.3.5-12-g055d7c3 (unstable) or "development (unstable)"
+        /// Eg: v1.3.5-12-g055d7c3 (beta) or "development (unstable)"
         /// </summary>
         public static string Version()
         {
@@ -23,7 +23,7 @@ namespace CKAN
             #if (STABLE)
             version += " (stable)";
             #else
-            version += " (unstable)";
+            version += " (beta)";
             #endif
 
             return version;

--- a/CKAN/GUI/AboutDialog.Designer.cs
+++ b/CKAN/GUI/AboutDialog.Designer.cs
@@ -108,7 +108,7 @@ namespace CKAN
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(184, 18);
             this.label2.TabIndex = 5;
-            this.label2.Text = "Version - development (unstable)";
+            this.label2.Text = "Version " + Meta.Version();
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // linkLabel5


### PR DESCRIPTION
Our dev processes are pretty darn good now, and we have a lot more
eyes on code. I'd like to change `unstable` releases to `beta` releases.
(It's good enough for Google and Squad!)
