### PR TITLE
Fix the missing default instance bug

### DIFF
--- a/CKAN/CKAN/KSPManager.cs
+++ b/CKAN/CKAN/KSPManager.cs
@@ -157,10 +157,17 @@ namespace CKAN
         /// </summary>
         public KSP AddInstance(string name, string path)
         {
-            var ksp = new KSP(path, User);
-            GetInstances().Add(name, ksp);
-            PopulateRegistryWithInstances();
-            return ksp;
+            try
+            {
+                var ksp = new KSP(path, User);
+                GetInstances().Add(name, ksp);
+                PopulateRegistryWithInstances();
+                return ksp;
+            }
+            catch (NotKSPDirKraken e)
+            {
+                return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes an unhandled exception when we cannot find a default KSP instance and no instances have been recorded in the CKAN registry instance list.
