### PR TITLE
Copy downloads before iterating, since they may be modified concurrently

### DIFF
--- a/CKAN/CKAN/Net/NetAsyncDownloader.cs
+++ b/CKAN/CKAN/Net/NetAsyncDownloader.cs
@@ -279,7 +279,7 @@ namespace CKAN
             long totalBytesLeft = 0;
             long totalBytesDownloaded = 0;
 
-            foreach (NetAsyncDownloaderDownloadPart t in downloads)
+            foreach (NetAsyncDownloaderDownloadPart t in downloads.ToList())
             {
                 if (t.bytesLeft > 0)
                 {


### PR DESCRIPTION
Without this fix I repeatably see 'System.InvalidOperationException: Collection was modified; enumeration operation may not execute.' exceptions while installing KarbonitePlus.
