### PR TITLE
Change the glyph for "not compatible" to 'X'

### DIFF
--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -289,7 +289,7 @@ namespace CKAN.CmdLine
                         if (latest == null)
                         {
                             // Not compatible!
-                            bullet = "✗";
+                            bullet = "X";
                         }
                         else if (latest.version.IsEqualTo(current_version))
                         {
@@ -314,7 +314,7 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("{0} {1} {2}", bullet, mod.Key, mod.Value);
             }
 
-            user.RaiseMessage("\nLegend: ✓ - Up to date. ✗ - Incompatible. ↑ - Upgradable. ? - Unknown ");
+            user.RaiseMessage("\nLegend: ✓ - Up to date. X - Incompatible. ↑ - Upgradable. ? - Unknown ");
 
             return Exit.OK;
         }


### PR DESCRIPTION
The current marker character, ✗ (U+2717, BALLOT X) uses a glyph that
is not present in most fonts. Primarily, it is not present in any of
the fonts that are available by default to the Windows console
(Consolas, Lucida Console, Raster Fonts). Instead of the desired
character, the Windows console will display a '?' glyph, which is the
same glyph used for "Unkown", making these states indistinguishable.

I have changed the glyph to a standard X in order to be compatible with
a wider range of fonts in common use.
