### PR TITLE
Shows the exception's message

### DIFF
--- a/CKAN/GUI/MainRepo.cs
+++ b/CKAN/GUI/MainRepo.cs
@@ -38,9 +38,9 @@ namespace CKAN
             {
                 m_ErrorDialog.ShowErrorDialog(ex.ToString());
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                m_ErrorDialog.ShowErrorDialog("Failed to connect to repository");
+                m_ErrorDialog.ShowErrorDialog("Failed to connect to repository. Exception: " + ex.Message);
             }
         }
 


### PR DESCRIPTION
Shows the exception's message during a generic "can't connect to the
repo" error.
