### PR TITLE
Use ASCII instead of Unicode for list output

### DIFF
--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -338,12 +338,12 @@ namespace CKAN.CmdLine
                         else if (latest.version.IsEqualTo(current_version))
                         {
                             // Up to date
-                            bullet = "✓";
+                            bullet = "Y";
                         }
                         else if (latest.version.IsGreaterThan(mod.Value))
                         {
                             // Upgradable
-                            bullet = "↑";
+                            bullet = "^";
                         }
 
                     }
@@ -358,7 +358,7 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("{0} {1} {2}", bullet, mod.Key, mod.Value);
             }
 
-            user.RaiseMessage("\nLegend: ✓ - Up to date. X - Incompatible. ↑ - Upgradable. ? - Unknown ");
+            user.RaiseMessage("\nLegend: Y - Up to date. X - Incompatible. ^ - Upgradable. ? - Unknown ");
 
             return Exit.OK;
         }


### PR DESCRIPTION
It's not a guarantee that CKAN users will be able to render Unicode in their console.  For example, I use the `Inconsolata` typeface which does not include a full range of Unicode characters.

To ensure the broadest compatibility, I propose this patch, which replaces the `list` output with standard ASCII characters that are certain to display properly in all users' terminal windows.
