### PR TITLE
Print newlines after operations complete

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -216,7 +216,7 @@ namespace CKAN
 
             ksp.ScanGameData();
 
-            User.RaiseProgress("Done!", 100);
+            User.RaiseProgress("Done!\n", 100);
         }
 
         /// <summary>
@@ -687,7 +687,7 @@ namespace CKAN
                 transaction.Complete();
             }
 
-            User.RaiseMessage("Done!");
+            User.RaiseMessage("Done!\n");
         }
 
         public void UninstallList(string mod)


### PR DESCRIPTION
Upon completing certain operations (upgrading, installing modules), the `Done!` message finishes without a newline.  This quick patch corrects that issue.
