### PR TITLE
GUI: Change the forum link in the "about" to the new thread.

### DIFF
--- a/CKAN/GUI/AboutDialog.cs
+++ b/CKAN/GUI/AboutDialog.cs
@@ -28,7 +28,7 @@ namespace CKAN
 
         private void linkLabel4_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("http://forum.kerbalspaceprogram.com/threads/97434-The-Comprehensive-Kerbal-Archive-Network-Call-for-mod-participation");
+            System.Diagnostics.Process.Start("http://forum.kerbalspaceprogram.com/threads/100067");
         }
 
         private void linkLabel5_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
It was previously pointing to the old one.
