### PR TITLE
Protect Ships/VAB and Ships/SPH from deletion.

### DIFF
--- a/CKAN/CKAN/ModuleInstaller.cs
+++ b/CKAN/CKAN/ModuleInstaller.cs
@@ -584,13 +584,20 @@ namespace CKAN
                 // overwite files, as it ensures deletiion on rollback.
                 file_transaction.Snapshot(fullPath);
 
-                // It's a file! Prepare the streams
-                using (Stream zipStream = zipfile.GetInputStream(entry))
-                using (FileStream writer = File.Create(fullPath))
+                try
                 {
-                    // 4k is the block size on practically every disk and OS.
-                    byte[] buffer = new byte[4096];
-                    StreamUtils.Copy(zipStream, writer, buffer);
+                    // It's a file! Prepare the streams
+                    using (Stream zipStream = zipfile.GetInputStream(entry))
+                    using (FileStream writer = File.Create(fullPath))
+                    {
+                        // 4k is the block size on practically every disk and OS.
+                        byte[] buffer = new byte[4096];
+                        StreamUtils.Copy(zipStream, writer, buffer);
+                    }
+                }
+                catch (DirectoryNotFoundException ex)
+                {
+                    throw new DirectoryNotFoundKraken("", ex.Message, ex);
                 }
             }
         }

--- a/CKAN/CmdLine/Main.cs
+++ b/CKAN/CmdLine/Main.cs
@@ -510,6 +510,11 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("One or more files failed to download, stopped.");
                 return Exit.ERROR;
             }
+            catch (DirectoryNotFoundKraken kraken)
+            {
+                user.RaiseMessage("\n{0}", kraken.Message);
+                return Exit.ERROR;
+            }
 
             return Exit.OK;
         }

--- a/CKAN/GUI/MainInstall.cs
+++ b/CKAN/GUI/MainInstall.cs
@@ -353,6 +353,11 @@ namespace CKAN
                     // User notified in InstallList
                     return false;
                 }
+                catch (DirectoryNotFoundKraken kraken)
+                {
+                    GUI.user.RaiseMessage("\n{0}", kraken.Message);
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
This close #666 by not allowing theses two directory to be erased.
This also protect from the Exception raised when trying to write to a deleted directory by rethrowing a DirectoryNotFoundKraken catched in CmdLine and GUI.

Maybe there should be a more generic way to exclude a directory from deletion, but I can't think of other right now.

I think removing Ships folder should not be supported as it cause an DirectoryNotFoundException in-game (in sandbox or in career with the "Allow Stock Vessels" option), so I think it should close #582 too.
