### PR TITLE
Prevent applying an empty changeset.

### DIFF
--- a/CKAN/GUI/MainChangeset.cs
+++ b/CKAN/GUI/MainChangeset.cs
@@ -42,6 +42,8 @@ namespace CKAN
             UpdateModsList();
             UpdateChangesDialog(null, m_InstallWorker);
             m_TabController.ShowTab("ManageModsTabPage");
+            m_TabController.HideTab("ChangesetTabPage");
+            ApplyToolButton.Enabled = false;
         }
 
         private void ConfirmChangesButton_Click(object sender, EventArgs e)

--- a/CKAN/GUI/MainInstall.cs
+++ b/CKAN/GUI/MainInstall.cs
@@ -375,6 +375,8 @@ namespace CKAN
                 // install successful
                 AddStatusMessage("Success!");
                 HideWaitDialog(true);
+                m_TabController.HideTab("ChangesetTabPage");
+                ApplyToolButton.Enabled = false;
             }
             else
             {


### PR DESCRIPTION
Do nothing if we achieve to click on the Apply button with an empty changeset.
Hide the changeset tab after install and clear.
close #659
