### PR TITLE
Fix for issue #652

### DIFF
--- a/CKAN/GUI/MainModInfo.cs
+++ b/CKAN/GUI/MainModInfo.cs
@@ -178,15 +178,7 @@ namespace CKAN
         private void _UpdateModDependencyGraph()
         {
             var module = (CkanModule) ModInfoTabControl.Tag;
-            if (module == dependencyGraphRootModule)
-            {
-                return;
-            }
-            else
-            {
-                dependencyGraphRootModule = module;
-            }
-
+            dependencyGraphRootModule = module;
 
             if (ModuleRelationshipType.SelectedIndex == -1)
             {


### PR DESCRIPTION
Fixes issue #652 
_UpdateModDependencyGraph had a unnecessary check to see if the node was already set as the root node. I could not find any reason to leave the check in place.
