### PR TITLE
Added version synonyms dictionary

### DIFF
--- a/CKAN/CKAN/Types/License.cs
+++ b/CKAN/CKAN/Types/License.cs
@@ -40,6 +40,14 @@ namespace CKAN
             "open-source", "restricted", "unrestricted", "unknown"
         };
 
+        // TODO: It would be nice to generate these as well
+        /// <summary>
+        /// Contains a mapping between non-valid license name that can be converted and valid one for sanitization.
+        /// </summary>
+        private static readonly Dictionary<string, string> license_synonyms = new Dictionary<string, string> {
+            { "GPLv3", "GPL-3.0" }
+        };
+
         private string license;
 
         /// <summary>
@@ -49,7 +57,9 @@ namespace CKAN
         /// <param name="license">License.</param>
         public License(string license)
         {
-            if (! valid_licenses.Contains(license))
+            license = GetSynonymIfAvaliable(license);
+
+            if (!valid_licenses.Contains(license))
             {
                 throw new BadMetadataKraken(
                     null,
@@ -58,6 +68,21 @@ namespace CKAN
             }
 
             this.license = license;
+        }
+
+        /// <summary>
+        /// If a license has a valid synonym, this method returns it. If not, <paramref name="license"/> is returned.
+        /// </summary>
+        /// <param name="license">License to check for a valid synonym</param>
+        /// <returns>Valid synonym or <paramref name="license"/> if not found</returns>
+        private string GetSynonymIfAvaliable(string license)
+        {
+            if (license_synonyms.ContainsKey(license))
+            {
+                return license_synonyms[license];
+            }
+
+            return license;
         }
 
         /// <summary>

--- a/CKAN/Tests/CKAN/Types/License.cs
+++ b/CKAN/Tests/CKAN/Types/License.cs
@@ -9,7 +9,6 @@ namespace CKANTests
         public void LicenseGood()
         {
             var license = new CKAN.License("GPL-3.0");
-            Assert.IsInstanceOf<CKAN.License>(license);
             Assert.AreEqual("GPL-3.0", license.ToString());
         }
 
@@ -18,9 +17,16 @@ namespace CKANTests
         {
             Assert.Throws<CKAN.BadMetadataKraken>(delegate
             {
-                // Not a valid license string, contains spaces.
-                new CKAN.License("GPL 3.0");
+                // Not a valid license string.
+                new CKAN.License("this is a really invalid license");
             });
+        }
+
+        [Test]
+        public void SynonymCheck()
+        {
+            var license = new CKAN.License("GPLv3");
+            Assert.AreEqual("GPL-3.0", license.ToString());
         }
     }
 }


### PR DESCRIPTION
When adding some of the NetKAN based files from KerbalStuff, I encountered a problem where a license could not be resolved and it was rejected. License name on KS was GPLv3 so it's a valid one that CKAN can understand.

This patch adds a way to sanitize these licenses by using synonyms.
