### PR TITLE
Add ci resource to schema

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -96,10 +96,10 @@
             "description" : "Optional list of recommended, but not essential mods",
             "$ref"        : "#/definitions/relationship"
         },
-	"supports" : {
+    "supports" : {
             "description" : "Optional list of supported mods",
             "$ref"        : "#/definitions/relationship"
-	},
+    },
         "conflicts" : {
             "description" : "Optional list of conflicting mods",
             "$ref"        : "#/definitions/relationship"
@@ -131,6 +131,11 @@
                 },
                 "repository" : {
                     "description" : "Mod repository",
+                    "type" : "string",
+                    "format" : "uri"
+                },
+                "ci" : {
+                    "description" : "Continuous Integration",
                     "type" : "string",
                     "format" : "uri"
                 },

--- a/Spec.md
+++ b/Spec.md
@@ -399,6 +399,7 @@ are described. Unless specified otherwise, these are URLs:
 - `bugtracker` : The mod's bugtracker if it exists.
 - `license` : The mod's license.
 - `repository` : The repository where the module source can be found.
+- `ci` :  (**v1.6**) Continuous Integration (e.g. Jenkins) Server where the module is being built. `x_ci` is an alias used in netkan.
 - `kerbalstuff` : The mod on KerbalStuff.
 - `manual` : The mod's manual, if it exists.
 
@@ -408,6 +409,7 @@ Example resources:
         "homepage"     : "http://tinyurl.com/DogeCoinFlag",
         "bugtracker"   : "https://github.com/pjf/DogeCoinFlag/issues",
         "repository"   : "http://github.com/pjf/DogeCoinFlag",
+        "ci"           : "https://ksp.sarbian.com/jenkins/DogecoinFlag"
         "kerbalstuff"  : "https://kerbalstuff.com/mod/269/Dogecoin%20Flag"
     }
 


### PR DESCRIPTION
Supercedes https://github.com/KSP-CKAN/CKAN/pull/619 , as I don't know how to modify PRs from repos that don't exist anymore :blush: 

For use in the Jenkins inflator support in KSP-CKAN/CKAN#195, I want to add a "ci" property to the list of possible resources.

The current netkan.exe reads "x_ci" as a fallback, but having a properly defined property in the schema would make validation possible.