### PR TITLE
Metapackages in schema

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -28,6 +28,10 @@
             "description" : "Unique identifier for this mod.",
             "$ref"        : "#/definitions/identifier"
         },
+		"kind" : {
+			"description" : "Package type.",
+            "enum" : [ "package", "metapackage" ]
+		},
         "abstract" : {
             "description" : "Short description of the mod",
             "type"        : "string"
@@ -96,10 +100,10 @@
             "description" : "Optional list of recommended, but not essential mods",
             "$ref"        : "#/definitions/relationship"
         },
-    "supports" : {
-            "description" : "Optional list of supported mods",
-            "$ref"        : "#/definitions/relationship"
-    },
+		"supports" : {
+				"description" : "Optional list of supported mods",
+				"$ref"        : "#/definitions/relationship"
+		},
         "conflicts" : {
             "description" : "Optional list of conflicting mods",
             "$ref"        : "#/definitions/relationship"


### PR DESCRIPTION
Adds a new field to the schema, called `kind`, that allows to have metapackages.
`kind` can take two values:
* `package`, for any "normal" package we've had so far;
* `metapackage`, for purely virtual packages.

See the discussion at KSP-CKAN/CKAN-core#63