### PR TITLE
Update Spec.md with RFC 2119 reference

### DIFF
--- a/Spec.md
+++ b/Spec.md
@@ -7,6 +7,11 @@ send pull requests to patch this document and associated files.
 This document, and all associated files, are licensed under the MIT/Expat
 license.
 
+The key words "*must*", "*must not*", "*required*", "*shall*", 
+"*shall not*", "*should*", "*should not*", "*recommended*", "*may*" and 
+"*optional*" in this document are to be interpreted as described in 
+[RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
 ## Introduction
 
 There have been many comprehensive archive networks for various


### PR DESCRIPTION
This spec seems to use the RFC 2119 terminology for standard definitions of terms like "MUST", "SHOULD NOT", etc. -- so attach the commonly-used and recommended boilerplate for it.

Not certain if this is the best place in the file for it but here it is.  I also italicized the terms rather than using the all-caps used by the RFC to match the conventions used by the rest of the spec.

See https://www.ietf.org/rfc/rfc2119.txt