### PR TITLE
Typing nav

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -67,6 +67,9 @@ namespace CKAN
 
         private Timer filterTimer;
 
+        private DateTime lastSearchTime;
+        private string lastSearchKey;
+
         private IEnumerable<KeyValuePair<CkanModule, GUIModChangeType>> change_set;
         private Dictionary<Module, string> conflicts;
 
@@ -496,16 +499,19 @@ namespace CKAN
 
         /// <summary>
         /// Called on key press when the mod is focused. Scrolls to the first mod 
-        /// with name begining with the key pressed. If space is pressed, the checkbox
-        /// at the current row is toggled.
-        /// </summary>        
+        /// with name begining with the key pressed. If more than one unique keys are pressed
+        /// in under a second, it searches for the combination of the keys pressed.
+        /// If the same key is being pressed repeatedly, it cycles through mods names
+        /// beginnng with that key. If space is pressed, the checkbox at the current row is toggled.
+        /// </summary>
         private void ModList_KeyPress(object sender, KeyPressEventArgs e)
         {
-            // Check the key. If it is space, mark the current mod as selected.
-            if (e.KeyChar.ToString() == " ")
-            {
-                var selected_row = ModList.CurrentRow;
+            var selected_row = ModList.CurrentRow;
+            var key = e.KeyChar.ToString();
 
+            // Check the key. If it is space, mark the current mod as selected.
+            if (key == " ")
+            {
                 if (selected_row != null)
                 {
                     // Get the checkbox.
@@ -523,14 +529,44 @@ namespace CKAN
             }
 
             var rows = ModList.Rows.Cast<DataGridViewRow>().Where(row => row.Visible);
-            var does_name_begin_with_char = new Func<DataGridViewRow, bool>(row =>
+
+            // Determine the number of seconds passed since last key press
+            TimeSpan interval = DateTime.Now - this.lastSearchTime;
+            if (interval.TotalSeconds < 1 && key != this.lastSearchKey) {
+                // Last keypress was < 1 sec ago and it was a different key, so combine the last and current keys
+                key = this.lastSearchKey + key;
+            }
+            // Remember the current time and key
+            this.lastSearchTime = DateTime.Now;
+            this.lastSearchKey = key;
+
+            var selected_name = ((GUIMod) selected_row.Tag).ToCkanModule().name;
+            var selected_match = selected_name.StartsWith(key, StringComparison.OrdinalIgnoreCase);
+            DataGridViewRow first_match = null;
+
+            var does_name_begin_with_key = new Func<DataGridViewRow, bool>(row =>
             {
                 var modname = ((GUIMod) row.Tag).ToCkanModule().name;
-                var key = e.KeyChar.ToString();
-                return modname.StartsWith(key, StringComparison.OrdinalIgnoreCase);
+                var row_match = modname.StartsWith(key, StringComparison.OrdinalIgnoreCase);
+                if (row_match && first_match == null) {
+                 // Remember the first match to allow cycling back to it if necessary
+                    first_match = row;
+                }
+                if (row.Index == selected_row.Index || (selected_match && row.Index < selected_row.Index))
+                {
+                    // This row is already selected or a matching row is selected further down the list,
+                    // so the search should continue from there
+                    return false;
+                }
+                return row_match;
             });
             ModList.ClearSelection();
-            DataGridViewRow match = rows.FirstOrDefault(does_name_begin_with_char);
+            DataGridViewRow match = rows.FirstOrDefault(does_name_begin_with_key);
+            if (match == null && first_match != null)
+            {
+             // If there were no matches after the first match, cycle over to the beginning
+                match = first_match;
+            }
             if (match != null)
             {
                 match.Selected = true;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -506,16 +506,16 @@ namespace CKAN
         /// </summary>
         private void ModList_KeyPress(object sender, KeyPressEventArgs e)
         {
-            var selected_row = ModList.CurrentRow;
+            var current_row = ModList.CurrentRow;
             var key = e.KeyChar.ToString();
 
             // Check the key. If it is space, mark the current mod as selected.
             if (key == " ")
             {
-                if (selected_row != null)
+                if (current_row != null && current_row.Selected)
                 {
                     // Get the checkbox.
-                    var selected_row_check_box = selected_row.Cells["Installed"] as DataGridViewCheckBoxCell;
+                    var selected_row_check_box = current_row.Cells["Installed"] as DataGridViewCheckBoxCell;
 
                     // Invert the value.
                     if (selected_row_check_box != null)
@@ -546,8 +546,8 @@ namespace CKAN
                 key = key.Substring(0, 1);
             }
 
-            var selected_name = ((GUIMod) selected_row.Tag).ToCkanModule().name;
-            var selected_match = selected_name.StartsWith(key, StringComparison.OrdinalIgnoreCase);
+            var current_name = ((GUIMod) current_row.Tag).ToCkanModule().name;
+            var current_match = current_name.StartsWith(key, StringComparison.OrdinalIgnoreCase);
             DataGridViewRow first_match = null;
 
             var does_name_begin_with_key = new Func<DataGridViewRow, bool>(row =>
@@ -558,7 +558,7 @@ namespace CKAN
                     // Remember the first match to allow cycling back to it if necessary
                     first_match = row;
                 }
-                if (row.Index == selected_row.Index || (selected_match && row.Index < selected_row.Index))
+                if (row == current_row || (current_match && row.Index < current_row.Index))
                 {
                     // This row is already selected or a matching row is selected further down the list,
                     // so the search should continue from there
@@ -567,6 +567,7 @@ namespace CKAN
                 return row_match;
             });
             ModList.ClearSelection();
+            current_row.Selected = false;
             DataGridViewRow match = rows.FirstOrDefault(does_name_begin_with_key);
             if (match == null && first_match != null)
             {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -203,7 +203,7 @@ namespace CKAN
             ModInfoTabControl.Enabled = false;
 
             // WinForms on Mac OS X has a nasty bug where the UI thread hogs the CPU,
-            // making our download speeds really slow unless you move the mouse while 
+            // making our download speeds really slow unless you move the mouse while
             // downloading. Yielding periodically addresses that.
             // https://bugzilla.novell.com/show_bug.cgi?id=663433
             if (Platform.IsMac)
@@ -415,7 +415,7 @@ namespace CKAN
         private void ModList_SelectedIndexChanged(object sender, EventArgs e)
         {
             var module = GetSelectedModule();
-            
+
             ModInfoTabControl.Enabled = module!=null;
             if (module == null) return;
 
@@ -463,8 +463,8 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Start or restart a timer to update the filter after an interval 
-        /// since the last keypress. On Mac OS X, this prevents the search 
+        /// Start or restart a timer to update the filter after an interval
+        /// since the last keypress. On Mac OS X, this prevents the search
         /// field from locking up due to DataGridViews being slow and
         /// key strokes being interpreted incorrectly when slowed down:
         /// http://mono.1490590.n4.nabble.com/Incorrect-missing-and-duplicate-keypress-events-td4658863.html
@@ -485,7 +485,7 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Updates the filter after an interval of time has passed since the 
+        /// Updates the filter after an interval of time has passed since the
         /// last keypress.
         /// </summary>
         /// <param name="source">Source</param>
@@ -498,7 +498,7 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Called on key press when the mod is focused. Scrolls to the first mod 
+        /// Called on key press when the mod is focused. Scrolls to the first mod
         /// with name begining with the key pressed. If more than one unique keys are pressed
         /// in under a second, it searches for the combination of the keys pressed.
         /// If the same key is being pressed repeatedly, it cycles through mods names
@@ -522,7 +522,7 @@ namespace CKAN
                     {
                         bool selected_value = (bool)selected_row_check_box.Value;
                         selected_row_check_box.Value = !selected_value;
-                    }                    
+                    }
                 }
                 e.Handled = true;
                 return;
@@ -530,15 +530,21 @@ namespace CKAN
 
             var rows = ModList.Rows.Cast<DataGridViewRow>().Where(row => row.Visible);
 
-            // Determine the number of seconds passed since last key press
-            TimeSpan interval = DateTime.Now - this.lastSearchTime;
-            if (interval.TotalSeconds < 1 && key != this.lastSearchKey) {
-                // Last keypress was < 1 sec ago and it was a different key, so combine the last and current keys
-                key = this.lastSearchKey + key;
+            // Determine time passed since last key press
+            TimeSpan interval = DateTime.Now - lastSearchTime;
+            if (interval.TotalSeconds < 1) {
+                // Last keypress was < 1 sec ago, so combine the last and current keys
+                key = lastSearchKey + key;
             }
             // Remember the current time and key
-            this.lastSearchTime = DateTime.Now;
-            this.lastSearchKey = key;
+            lastSearchTime = DateTime.Now;
+            lastSearchKey = key;
+
+            if (key.Distinct().Count() == 1)
+            {
+                // It's the same key being pressed repeatedly, so use only that
+                key = key.Substring(0, 1);
+            }
 
             var selected_name = ((GUIMod) selected_row.Tag).ToCkanModule().name;
             var selected_match = selected_name.StartsWith(key, StringComparison.OrdinalIgnoreCase);
@@ -549,7 +555,7 @@ namespace CKAN
                 var modname = ((GUIMod) row.Tag).ToCkanModule().name;
                 var row_match = modname.StartsWith(key, StringComparison.OrdinalIgnoreCase);
                 if (row_match && first_match == null) {
-                 // Remember the first match to allow cycling back to it if necessary
+                    // Remember the first match to allow cycling back to it if necessary
                     first_match = row;
                 }
                 if (row.Index == selected_row.Index || (selected_match && row.Index < selected_row.Index))
@@ -564,7 +570,7 @@ namespace CKAN
             DataGridViewRow match = rows.FirstOrDefault(does_name_begin_with_key);
             if (match == null && first_match != null)
             {
-             // If there were no matches after the first match, cycle over to the beginning
+                // If there were no matches after the first match, cycle over to the beginning
                 match = first_match;
             }
             if (match != null)
@@ -729,7 +735,7 @@ namespace CKAN
                 return null;
             }
 
-            var module = ((GUIMod) selected_item.Tag).ToCkanModule();            
+            var module = ((GUIMod) selected_item.Tag).ToCkanModule();
             return module;
         }
 
@@ -744,7 +750,7 @@ namespace CKAN
 
             var binary = split[0];
             var args = string.Join(" ",split.Skip(1));
-            
+
             try
             {
                 Directory.SetCurrentDirectory(CurrentInstance.GameDir());
@@ -787,7 +793,7 @@ namespace CKAN
             Enabled = true;
         }
 
-        
+
 
         private void installFromckanToolStripMenuItem_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
From @slikts at https://github.com/KSP-CKAN/CKAN-GUI/pull/139
> This makes ModList behave more like typical data lists and makes it significantly easier to use because it's possible to go directly to a mod by typing in the first few letters of its name. The delay before it forgets the previous key presses is 1 second. The previous implementation wasn't very useful in cases where a number of mod names share the same first letter.