### PR TITLE
Selection enhancements

### DIFF
--- a/GUI/ChooseKSPInstance.Designer.cs
+++ b/GUI/ChooseKSPInstance.Designer.cs
@@ -143,6 +143,7 @@
             // 
             // ChooseKSPInstance
             // 
+            this.AcceptButton = this.SelectButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(486, 355);

--- a/GUI/ChooseKSPInstance.Designer.cs
+++ b/GUI/ChooseKSPInstance.Designer.cs
@@ -64,6 +64,7 @@
             this.KSPInstancesListView.UseCompatibleStateImageBehavior = false;
             this.KSPInstancesListView.View = System.Windows.Forms.View.Details;
             this.KSPInstancesListView.SelectedIndexChanged += new System.EventHandler(this.KSPInstancesListView_SelectedIndexChanged);
+            this.KSPInstancesListView.DoubleClick += new System.EventHandler(this.KSPInstancesListView_DoubleClick);
             // 
             // KSPInstallName
             // 

--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -70,6 +70,11 @@ namespace CKAN
 
         private void SelectButton_Click(object sender, EventArgs e)
         {
+            UseSelectedInstance();
+        }
+
+        private void UseSelectedInstance()
+        {
             var instance = (string) KSPInstancesListView.SelectedItems[0].Tag;
 
             if (SetAsDefaultCheckbox.Checked)
@@ -86,6 +91,13 @@ namespace CKAN
         {
             var has_instance = KSPInstancesListView.SelectedItems.Count != 0;            
             SetButtonsEnabled(has_instance);
+        }
+
+        private void KSPInstancesListView_DoubleClick(object sender, EventArgs r)
+        {
+            var has_instance = KSPInstancesListView.SelectedItems.Count != 0;
+            if(has_instance)
+                UseSelectedInstance();
         }
 
         private void RenameButton_Click(object sender, EventArgs e)

--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -16,7 +16,7 @@ namespace CKAN
             main = Main.Instance;
             manager = Main.Instance.Manager;
             InitializeComponent();
-            
+
             StartPosition = FormStartPosition.CenterScreen;
 
             m_BrowseKSPFolder = new FolderBrowserDialog();
@@ -83,13 +83,14 @@ namespace CKAN
             }
 
             manager.SetCurrentInstance(instance);
-            Hide();    
+            DialogResult = DialogResult.OK;
+            Close();
          //   main.Show();
         }
 
         private void KSPInstancesListView_SelectedIndexChanged(object sender, EventArgs e)
         {
-            var has_instance = KSPInstancesListView.SelectedItems.Count != 0;            
+            var has_instance = KSPInstancesListView.SelectedItems.Count != 0;
             SetButtonsEnabled(has_instance);
         }
 


### PR DESCRIPTION
From solarshado 
> Mostly scratching a personal itch, but this adds two new ways to select a KSP instance:
>
> *    Double-clicking an instance in the list is now the same as choosing it and then clicking "Select"
> *    Pressing the 'Enter' key clicks the "Select" button, making keyboard-only navigation a little faster/easier
>
> The double-click bit feels like it might be cross-platform-finicky, but it works on my Windows 7 box and I don't have a way to test it elsewhere.
