### PR TITLE
Re-enable one-click releases, AND test against three mono versions!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: csharp
 
+mono:
+    - 3.10.0
+    - 3.8.0
+    - 3.2.8
+
 # These commands simulate having a graphical display, which is needed
 # for our GUI tests.
 before_install:
@@ -7,7 +12,7 @@ before_install:
     - "sh -e /etc/init.d/xvfb start"
 
 install:
-    - sudo apt-get install mono-devel mono-gmcs nunit-console libtest-most-perl libipc-system-simple-perl
+    - sudo apt-get install mono-devel nunit-console libtest-most-perl libipc-system-simple-perl
     - mozroots --import --ask-remove
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: csharp
 
 mono:
+    - latest
     - 3.10.0
-    - 3.8.0
     - 3.2.8
+
+# Travis has problems with nunit on 3.8.0, dunno why.
+#    - 3.8.0
 
 # These commands simulate having a graphical display, which is needed
 # for our GUI tests.
@@ -14,11 +17,10 @@ before_install:
 install:
     - sudo apt-get install mono-devel nunit-console libtest-most-perl libipc-system-simple-perl
     - mozroots --import --ask-remove
-    - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
 
 script:
     - bin/build
-    - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console --exclude=FlakyNetwork build/Tests/bin/Debug/CKAN.Tests.dll
+    - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
     - prove  # Run all the tests in t/
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ deploy:
         secure: AjwbRLStNJZb9hAOLfRLK85KlFo2q2Dr1NKCoDS4elek1nqSiOjL1hH0kDgUMx/PJqQVnFU8tbJPL30t9Pj7jcJhp0LhbbPipQE3TCSpafTneSEbdz5HT+OdghWCZhUhfs07wGNTFUwcAO4WBZ7wv1AnfdfogHdA5RMdykiIl38=
     file:
         - ckan.exe
-        - netkan.exe
     on:
         repo: KSP-CKAN/CKAN
         tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ before_install:
 install:
     - sudo apt-get install mono-devel nunit-console libtest-most-perl libipc-system-simple-perl
     - mozroots --import --ask-remove
+    - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
 
 script:
     - bin/build
-    - nunit-console --exclude=FlakyNetwork build/Tests/bin/Debug/CKAN.Tests.dll
+    - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console --exclude=FlakyNetwork build/Tests/bin/Debug/CKAN.Tests.dll
     - prove  # Run all the tests in t/
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 
 script:
     - bin/build
-    - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
+    - nunit-console --exclude=FlakyNetwork build/Tests/bin/Debug/CKAN.Tests.dll
     - prove  # Run all the tests in t/
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+language: csharp
+
+# These commands simulate having a graphical display, which is needed
+# for our GUI tests.
+before_install:
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
+
+install:
+    - sudo apt-get install mono-devel mono-gmcs nunit-console libtest-most-perl libipc-system-simple-perl
+    - mozroots --import --ask-remove
+
+script:
+    - ./t/test-sln.sh # Avoid VS Accidentally changing the project formatting
+    - bin/build
+    - nunit-console --exclude=FlakyNetwork build/Tests/bin/Debug/CKAN.Tests.dll
+    - prove  # Run all the tests in t/
+
+deploy:
+    provider: releases
+    api_key:
+        secure: AjwbRLStNJZb9hAOLfRLK85KlFo2q2Dr1NKCoDS4elek1nqSiOjL1hH0kDgUMx/PJqQVnFU8tbJPL30t9Pj7jcJhp0LhbbPipQE3TCSpafTneSEbdz5HT+OdghWCZhUhfs07wGNTFUwcAO4WBZ7wv1AnfdfogHdA5RMdykiIl38=
+    file:
+        - ckan.exe
+        - netkan.exe
+    on:
+        repo: KSP-CKAN/CKAN
+        tags: true
+        # all_branches needed as a workaround for travis-ci#1675
+        all_branches: true
+
+    # Any merge to master gets sent to
+    # http://ckan-travis.s3-website-us-east-1.amazonaws.com/
+    # 
+    # At least, they used to... Travis seems grumpy if we have
+    # more than one deploy stanza, and we want releases more.
+    #
+    # - provider: s3
+    #   access_key_id: AKIAI5JWAEFPFK6GH3XA
+    #   secret_access_key:
+    #     secure: b0PPlD7auqysK2LHA8N1US03dE/VKH2rOTwIqpIh50l/gURuXEl7Nd8S7qlf2dpEmz+8D5pIWD+J9scfrdD8Uuakhi3sQbqcV26UiR6+Ye06eGQfmIzqzAECt2naqEy7VJ/xrqq5aaaf8QhcOQMba3qVvwDSzkB2fJeh7+D6EY8=
+    #   bucket: ckan-travis
+    #  local-dir: uploads
+    #   acl: public_read
+    #  skip_cleanup: true
+    #  on:
+    #    repo: KSP-CKAN/CKAN
+    #    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
     - mozroots --import --ask-remove
 
 script:
-    - ./t/test-sln.sh # Avoid VS Accidentally changing the project formatting
     - bin/build
     - nunit-console --exclude=FlakyNetwork build/Tests/bin/Debug/CKAN.Tests.dll
     - prove  # Run all the tests in t/
@@ -31,6 +30,7 @@ deploy:
     on:
         repo: KSP-CKAN/CKAN
         tags: true
+        mono: 3.10.0
         # all_branches needed as a workaround for travis-ci#1675
         all_branches: true
 

--- a/bin/build
+++ b/bin/build
@@ -2137,6 +2137,8 @@ my @PROJECTS = qw(Cmdline Core GUI Netkan AutoUpdate Tests);
 
 my @BUILD_OPTS = is_stable() ? "/p:DefineConstants=STABLE" : ();
 
+push @BUILD_OPTS, "/verbosity:minimal";
+
 # Make sure we clean any old build away first.
 remove_tree($BUILD);
 mkdir($BUILD);

--- a/bin/build
+++ b/bin/build
@@ -2126,25 +2126,29 @@ use Fcntl qw(SEEK_SET);
 
 # Simple script to build and repack
 
-my $REPACK  = "CKAN/packages/ILRepack.1.25.0/tools/ILRepack.exe";
+my $REPACK  = "Core/packages/ILRepack.1.25.0/tools/ILRepack.exe";
 my $TARGET  = "Debug";      # Even our releases contain debugging info
 my $OUTNAME = "ckan.exe";   # Or just `ckan` if we want to be unixy
 my $BUILD   = "$Bin/../build";
-my $SOURCE  = "$Bin/../CKAN";
-my $METACLASS = "build/CKAN/Meta.cs";
+my @SOURCE  = map { "$Bin/../$_"} qw(Core Cmdline GUI Netkan Tests AutoUpdate CKAN CKAN.sln);
+my $METACLASS = "build/Core/Meta.cs";
 
-my @PROJECTS = qw(CmdLine CKAN CKAN-GUI NetKAN Tests);
+my @PROJECTS = qw(Cmdline Core GUI Netkan AutoUpdate Tests);
 
 my @BUILD_OPTS = is_stable() ? "/p:DefineConstants=STABLE" : ();
 
 # Make sure we clean any old build away first.
 remove_tree($BUILD);
+mkdir($BUILD);
 
 # Copy our project files over.
-copy($SOURCE, $BUILD);
+foreach my $file (@SOURCE) {
+    copy($file, $BUILD);
+}
 
 # Remove any old build artifacts
 foreach my $project (@PROJECTS) {
+    -d "$project" or die "Can't find project $project in build dir";
     remove_tree(File::Spec->catdir($BUILD, "$project/bin"));
     remove_tree(File::Spec->catdir($BUILD, "$project/obj"));
 }
@@ -2168,7 +2172,7 @@ else {
 chdir($BUILD);
 
 # And build..
-system("xbuild", "/property:Configuration=$TARGET", @BUILD_OPTS, "/property:win32icon=../assets/ckan.ico", "CKAN.sln");
+system("xbuild", "/property:Configuration=$TARGET", @BUILD_OPTS, "/property:win32icon=../GUI/assets/ckan.ico", "CKAN.sln");
 
 say "\n\n=== Repacking ===\n\n";
 
@@ -2180,10 +2184,10 @@ my @cmd = (
     "mono",
     $REPACK,
     "--out:ckan.exe",
-    "--lib:build/CmdLine/bin/$TARGET",
-    "build/CmdLine/bin/$TARGET/CmdLine.exe",
-    glob("build/CmdLine/bin/$TARGET/*.dll"),
-    "build/CmdLine/bin/$TARGET/CKAN-GUI.exe", # Yes, bundle the .exe as a .dll
+    "--lib:build/Cmdline/bin/$TARGET",
+    "build/Cmdline/bin/$TARGET/CmdLine.exe",
+    glob("build/Cmdline/bin/$TARGET/*.dll"),
+    "build/Cmdline/bin/$TARGET/CKAN-GUI.exe", # Yes, bundle the .exe as a .dll
 );
 
 system([0,1], qq{@cmd | grep -v "Duplicate Win32 resource"});
@@ -2194,18 +2198,12 @@ system([0,1], qq{@cmd | grep -v "Duplicate Win32 resource"});
     "mono",
     $REPACK,
     "--out:netkan.exe",
-    "--lib:build/NetKAN/bin/$TARGET",
-    "build/NetKAN/bin/$TARGET/NetKAN.exe",
-    glob("build/NetKAN/bin/$TARGET/*.dll"),
+    "--lib:build/Netkan/bin/$TARGET",
+    "build/Netkan/bin/$TARGET/NetKAN.exe",
+    glob("build/Netkan/bin/$TARGET/*.dll"),
 );
 
 system([0,1], qq{@cmd | grep -v "Duplicate Win32 resource"});
-
-say "\n\n=== Tidying up===\n\n";
-
-# We don't tidy up any more, these provide useful debugging.
-# unlink("$OUTNAME.mdb");
-# unlink("netkan.exe.mdb");
 
 say "Done!";
 

--- a/bin/build.lean
+++ b/bin/build.lean
@@ -24,6 +24,8 @@ my @PROJECTS = qw(Cmdline Core GUI Netkan AutoUpdate Tests);
 
 my @BUILD_OPTS = is_stable() ? "/p:DefineConstants=STABLE" : ();
 
+push @BUILD_OPTS, "/verbosity:minimal";
+
 # Make sure we clean any old build away first.
 remove_tree($BUILD);
 mkdir($BUILD);

--- a/bin/build.lean
+++ b/bin/build.lean
@@ -1,0 +1,149 @@
+#!/usr/bin/perl
+use 5.010;
+use strict;
+use warnings;
+use autodie qw(:all);
+use FindBin qw($Bin);
+use File::Path qw(remove_tree);
+use IPC::System::Simple qw(systemx capturex);
+use File::Spec;
+use File::Copy::Recursive qw(rcopy);
+use autodie qw(rcopy);
+use Fcntl qw(SEEK_SET);
+
+# Simple script to build and repack
+
+my $REPACK  = "Core/packages/ILRepack.1.25.0/tools/ILRepack.exe";
+my $TARGET  = "Debug";      # Even our releases contain debugging info
+my $OUTNAME = "ckan.exe";   # Or just `ckan` if we want to be unixy
+my $BUILD   = "$Bin/../build";
+my @SOURCE  = map { "$Bin/../$_"} qw(Core Cmdline GUI Netkan Tests AutoUpdate CKAN CKAN.sln);
+my $METACLASS = "build/Core/Meta.cs";
+
+my @PROJECTS = qw(Cmdline Core GUI Netkan AutoUpdate Tests);
+
+my @BUILD_OPTS = is_stable() ? "/p:DefineConstants=STABLE" : ();
+
+# Make sure we clean any old build away first.
+remove_tree($BUILD);
+mkdir($BUILD);
+
+# Copy our project files over.
+foreach my $file (@SOURCE) {
+    copy($file, $BUILD);
+}
+
+# Remove any old build artifacts
+foreach my $project (@PROJECTS) {
+    -d "$project" or die "Can't find project $project in build dir";
+    remove_tree(File::Spec->catdir($BUILD, "$project/bin"));
+    remove_tree(File::Spec->catdir($BUILD, "$project/obj"));
+}
+
+# Before we build, see if we can locate a version and add it in.
+# Because travis does a shallow clone, we might fail at this in
+# dev releases, in which case our build will remain as "development"
+# and extra version tests won't run.
+
+my $VERSION = eval { capturex(qw(git describe --tags --long)) };
+
+if ($VERSION) {
+    chomp $VERSION;
+    set_build($METACLASS, $VERSION);
+}
+else {
+    warn "No recent tag found, making development build.\n";
+}
+
+# Change to our build directory
+chdir($BUILD);
+
+# And build..
+system("xbuild", "/property:Configuration=$TARGET", @BUILD_OPTS, "/property:win32icon=../GUI/assets/ckan.ico", "CKAN.sln");
+
+say "\n\n=== Repacking ===\n\n";
+
+chdir("$Bin/..");
+
+# Repack ckan.exe
+
+my @cmd = (
+    "mono",
+    $REPACK,
+    "--out:ckan.exe",
+    "--lib:build/Cmdline/bin/$TARGET",
+    "build/Cmdline/bin/$TARGET/CmdLine.exe",
+    glob("build/Cmdline/bin/$TARGET/*.dll"),
+    "build/Cmdline/bin/$TARGET/CKAN-GUI.exe", # Yes, bundle the .exe as a .dll
+);
+
+system([0,1], qq{@cmd | grep -v "Duplicate Win32 resource"});
+
+# Repack netkan
+
+@cmd = (
+    "mono",
+    $REPACK,
+    "--out:netkan.exe",
+    "--lib:build/Netkan/bin/$TARGET",
+    "build/Netkan/bin/$TARGET/NetKAN.exe",
+    glob("build/Netkan/bin/$TARGET/*.dll"),
+);
+
+system([0,1], qq{@cmd | grep -v "Duplicate Win32 resource"});
+
+say "Done!";
+
+# Do an appropriate copy for our system
+sub copy {
+    my ($src, $dst) = @_;
+
+    if ($^O eq "MSWin32") {
+        # Use File::Copy::Recursive under Windows
+        rcopy($src, $dst);
+    }
+    else {
+        my @CP;
+        if ($^O eq "darwin") {
+            # Simple copy for Macs
+            @CP = qw(cp -r);
+        } else {
+            # Use friggin' awesome btrfs magic under Linux.
+            # This still works, even without btrfs. :)
+            @CP = qw(cp -r --reflink=auto --sparse=always);
+        }
+
+        system(@CP,$src,$dst);
+    }
+    return;
+}
+
+sub set_build {
+    my ($file, $build) = @_;
+
+    local $/;   # Slurp entire files on read
+
+    open(my $fh, '+<', $file);
+    my $contents = <$fh>;
+
+    $contents =~ s{(BUILD_VERSION\s*=\s*)null}{$1"$build"}
+        or die "Could not find BUILD_VERSION string";
+
+    # Truncate our file and overwrite with new info
+    truncate($fh,0);
+    seek($fh,SEEK_SET,0);
+
+    print {$fh} $contents;
+    close($fh);
+}
+
+sub is_stable {
+    my $branch = eval { capturex(qw(git rev-parse --abbrev-ref HEAD)) };
+
+    return 0 if not $branch;    # If git fails, we're not stable. See #546.
+
+    return $branch =~ m{
+        (\b|_)stable(\b|_)|   # Contains stable as a word (underscores ok)
+        v\d+\.\d*[02468]$     # Ends with vx.y, where y is even.
+    }x;
+}

--- a/t/cmdline.t
+++ b/t/cmdline.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+use 5.010;
+use strict;
+use warnings;
+use autodie;
+use Test::More;
+use Test::Exception;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use CkanTests;
+use IPC::System::Simple qw(capturex capture);
+
+my $CMDLINE = CkanTests->cmdline;
+
+# If we're making a dev build, we may not have a tag to describe from.
+diag "Any `No names found` messages are harmless, it just means a dev build.";
+my $GIT_TAG = eval { capture("git describe --long --tags") };
+
+my $version;
+
+lives_ok { $version = capturex($CMDLINE, "version") } "ckan version execute";
+
+SKIP: {
+    unless ($GIT_TAG) { skip "Development build", 1; }
+
+    chomp $GIT_TAG;
+    like($version, qr/^\Q$GIT_TAG\E/, "Version should start with git tag");
+}
+
+done_testing;

--- a/t/lib/CkanTests.pm
+++ b/t/lib/CkanTests.pm
@@ -1,0 +1,22 @@
+package CkanTests;
+use 5.010;
+use strict;
+use warnings;
+use FindBin qw($Bin);
+
+=method cmdline
+
+Returns the C<ckan.exe> command executable, or throws an
+exception if not found.
+
+=cut
+
+sub cmdline {
+    # This isn't the best way to locate our executable, but until
+    # we have tests in sub-dirs, it should work.
+    my $cmdline = "$Bin/../ckan.exe";
+    -x $cmdline or die "Cannot find $cmdline";
+    return $cmdline;
+}
+
+1;


### PR DESCRIPTION
This PR restores much of the old travis functionality, but with extra goodies. In particular:

- To make a new release, we just hit the 'release' button on github and fill in the release notes.
- Travis will exercise our test suite against mono 3.2.8, 3.10.x, and 4.latest
- `ckan version` will once again return the actual git commit that was used to build the executable

All the Perl code for the build script was resurrected from before the great split, and adjusted for the new repo structure.

In this should also test branches and pull-requests to the CKAN repo as well.

Closes #984.
Part of #852.
Relevant to #990.

You can see an example of the travis output at:

- https://travis-ci.org/pjf/CKAN