### PR TITLE
Allow conflicts if mod are to be uninstalled

### DIFF
--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -21,7 +21,7 @@ namespace CKAN
 
         private readonly SortedList<string, KSP> instances = new SortedList<string, KSP>();
 
-        internal string AutoStartInstance
+        public string AutoStartInstance
         {
             get { return Win32Registry.AutoStartInstance; }
             private set

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -855,6 +855,17 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Gets the installed version of a mod. Returns null if provided or autodetected. 
+        /// </summary>
+        /// <param name="mod_identifer"></param>
+        /// <returns></returns>
+        public Module GetInstalledVersion(string mod_identifer)
+        {
+            InstalledModule installedModule;
+            return installed_modules.TryGetValue(mod_identifer, out installedModule) ? installedModule.Module : null;
+        }
+
+        /// <summary>
         ///     Check if a mod is installed (either via CKAN, DLL, or virtually)
         ///     If withProvides is set to false then we skip the check for if the
         ///     mod has been provided (rather than existing as a real mod).

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -208,6 +208,7 @@ namespace CKAN
             foreach (var module in mods)
             {
                 installed_modules.Remove(module);
+                conflicts.RemoveAll(kvp => kvp.Key.Equals(module) || kvp.Value.Equals(module));
             }
         }
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -64,15 +64,15 @@ namespace CKAN
     // If we resolved in things breadth-first order, we're less likely to encounter surprises
     // where a nth-deep recommend blocks a top-level recommend.
 
-    // TODO: Add mechanism so that clients can add mods with relationshup other than UserAdded. 
-    // Currently only made to support the with_{} options. 
+    // TODO: Add mechanism so that clients can add mods with relationshup other than UserAdded.
+    // Currently only made to support the with_{} options.
 
 
     /// <summary>
-    /// A class used to resolve relationships between mods. Primarily used to satisfy missing dependencies and to check for conflicts on proposed installs. 
+    /// A class used to resolve relationships between mods. Primarily used to satisfy missing dependencies and to check for conflicts on proposed installs.
     /// </summary>
     /// <remarks>
-    /// All constructors start with currently installed modules, to remove <see cref="RelationshipResolver.RemoveModsFromInstalledList" />  
+    /// All constructors start with currently installed modules, to remove <see cref="RelationshipResolver.RemoveModsFromInstalledList" />
     /// </remarks>
     public class RelationshipResolver
     {
@@ -82,7 +82,7 @@ namespace CKAN
         private readonly List<CkanModule> user_requested_mods = new List<CkanModule>();
         private readonly List<KeyValuePair<Module, Module>> conflicts =
             new List<KeyValuePair<Module, Module>>();
-        private readonly Dictionary<Module, SelectionReason> reasons = 
+        private readonly Dictionary<Module, SelectionReason> reasons =
             new Dictionary<Module, SelectionReason>(new Module.IdentifierEqualilty());
 
         private readonly Registry registry;
@@ -107,7 +107,7 @@ namespace CKAN
             foreach (var module in installed_modules)
             {
                 reasons.Add(module, installed_relationship);
-            }
+        }
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace CKAN
         /// <summary>
         ///     Returns the default options for relationship resolution.
         /// </summary>
-        
+
         // TODO: This should just be able to return a new RelationshipResolverOptions
         // and the defaults in the class definition should do the right thing.
         public static RelationshipResolverOptions DefaultOpts()
@@ -156,12 +156,12 @@ namespace CKAN
 
         /// <summary>
         /// Add modules to consideration of the relationship resolver. Optional installed parameter defaults
-        /// to installed mods and is intended to be used when this is incorrect, such as when some are to be 
-        /// removed.         
+        /// to installed mods and is intended to be used when this is incorrect, such as when some are to be
+        /// removed.
         /// </summary>
-        /// <param name="modules">Modules to attempt to install</param>        
+        /// <param name="modules">Modules to attempt to install</param>
         public void AddModulesToInstall(IEnumerable<CkanModule> modules)
-        {                        
+            {
             //Count may need to do a full enumeration. Might as well convert to array
             var ckan_modules = modules as CkanModule[] != null ? modules as CkanModule[] : modules.ToArray();
             log.DebugFormat("Processing relationships for {0} modules", ckan_modules.Count());
@@ -174,7 +174,7 @@ namespace CKAN
             {
                 log.DebugFormat("Preparing to resolve relationships for {0} {1}", module.identifier, module.version);
 
-                //Need to check against installed mods and those to install. 
+                //Need to check against installed mods and those to install.
                 var mods = modlist.Values.Concat(installed_modules).Where(listed_mod => listed_mod.ConflictsWith(module));
                 foreach (var listed_mod in mods)
                 {
@@ -218,8 +218,8 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Removes mods from the list of installed modules. Intended to be used for cases 
-        /// in which the mod is to be un-installed.
+        /// Removes mods from the list of installed modules. Intended to be used for cases
+        /// in which the mod is to be uninstalled.
         /// </summary>
         /// <param name="mods">The mods to remove.</param>
         public void RemoveModsFromInstalledList(IEnumerable<Module> mods)
@@ -227,7 +227,6 @@ namespace CKAN
             foreach (var module in mods)
             {
                 installed_modules.Remove(module);
-                conflicts.RemoveAll(kvp => kvp.Key.Equals(module) || kvp.Value.Equals(module));
             }
         }
 
@@ -263,10 +262,10 @@ namespace CKAN
         /// Resolve a relationship stanza (a list of relationships).
         /// This will add modules to be installed, if required.
         /// May recurse back to Resolve for those new modules.
-        /// 
+        ///
         /// If `soft_resolve` is true, we warn rather than throw exceptions on mods we cannot find.
         /// If `soft_resolve` is false (default), we throw a ModuleNotFoundKraken if we can't find a dependency.
-        /// 
+        ///
         /// Throws a TooManyModsProvideKraken if we have too many choices and
         /// options.without_toomanyprovides_kraken is not set.
         ///
@@ -436,7 +435,7 @@ namespace CKAN
 
         /// <summary>
         ///  Returns a IList consisting of keyValuePairs containing conflicting mods.
-        /// Note: (a,b) in the list should imply that (b,a) is in the list. 
+        /// Note: (a,b) in the list should imply that (b,a) is in the list.
         /// </summary>
         public Dictionary<Module, String> ConflictList
         {
@@ -483,7 +482,7 @@ namespace CKAN
             }
 
             var reason = reasons[mod];
-            var is_root_type = reason.GetType() == typeof (SelectionReason.UserRequested) 
+            var is_root_type = reason.GetType() == typeof (SelectionReason.UserRequested)
                 || reason.GetType() == typeof(SelectionReason.Installed);
             return is_root_type
                 ? reason.Reason
@@ -492,14 +491,14 @@ namespace CKAN
     }
 
     /// <summary>
-    /// Used to keep track of the relationships between modules in the resolver. 
-    /// Intended to be used for displaying messages to the user.     
+    /// Used to keep track of the relationships between modules in the resolver.
+    /// Intended to be used for displaying messages to the user.
     /// </summary>
     internal abstract class SelectionReason
     {
         //Currently assumed to exist for any relationship other than useradded or installed
         public virtual CkanModule Parent { get; protected set; }
-        //Should contain a newline at the end of the string. 
+        //Should contain a newline at the end of the string.
         public abstract String Reason { get; }
 
 
@@ -517,7 +516,7 @@ namespace CKAN
             public override string Reason
             {
                 get { return "  Currently installed.\n"; }
-            }            
+            }
         }
 
         public class UserRequested : SelectionReason

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -64,15 +64,15 @@ namespace CKAN
     // If we resolved in things breadth-first order, we're less likely to encounter surprises
     // where a nth-deep recommend blocks a top-level recommend.
 
-    // TODO: Add mechanism so that clients can add mods with relationshup other than UserAdded.
-    // Currently only made to support the with_{} options.
+    // TODO: Add mechanism so that clients can add mods with relationshup other than UserAdded. 
+    // Currently only made to support the with_{} options. 
 
 
     /// <summary>
-    /// A class used to resolve relationships between mods. Primarily used to satisfy missing dependencies and to check for conflicts on proposed installs.
+    /// A class used to resolve relationships between mods. Primarily used to satisfy missing dependencies and to check for conflicts on proposed installs. 
     /// </summary>
     /// <remarks>
-    /// All constructors start with currently installed modules, to remove <see cref="RelationshipResolver.RemoveModsFromInstalledList" />
+    /// All constructors start with currently installed modules, to remove <see cref="RelationshipResolver.RemoveModsFromInstalledList" />  
     /// </remarks>
     public class RelationshipResolver
     {
@@ -80,9 +80,9 @@ namespace CKAN
         private static readonly ILog log = LogManager.GetLogger(typeof (RelationshipResolver));
         private readonly Dictionary<string, CkanModule> modlist = new Dictionary<string, CkanModule>();
         private readonly List<CkanModule> user_requested_mods = new List<CkanModule>();
-        private readonly List<KeyValuePair<Module, Module>> conflicts =
+        private readonly List<KeyValuePair<Module, Module>> conflicts = 
             new List<KeyValuePair<Module, Module>>();
-        private readonly Dictionary<Module, SelectionReason> reasons =
+        private readonly Dictionary<Module, SelectionReason> reasons = 
             new Dictionary<Module, SelectionReason>(new Module.IdentifierEqualilty());
 
         private readonly Registry registry;
@@ -107,7 +107,7 @@ namespace CKAN
             foreach (var module in installed_modules)
             {
                 reasons.Add(module, installed_relationship);
-        }
+            }
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace CKAN
         {
             // Does nothing, just calls the other overloaded constructor
         }
-
+       
         /// <summary>
         /// Creates a new resolver that will find a way to install all the modules specified.
         /// </summary>
@@ -139,7 +139,7 @@ namespace CKAN
         /// <summary>
         ///     Returns the default options for relationship resolution.
         /// </summary>
-
+        
         // TODO: This should just be able to return a new RelationshipResolverOptions
         // and the defaults in the class definition should do the right thing.
         public static RelationshipResolverOptions DefaultOpts()
@@ -156,12 +156,12 @@ namespace CKAN
 
         /// <summary>
         /// Add modules to consideration of the relationship resolver. Optional installed parameter defaults
-        /// to installed mods and is intended to be used when this is incorrect, such as when some are to be
-        /// removed.
+        /// to installed mods and is intended to be used when this is incorrect, such as when some are to be 
+        /// removed.         
         /// </summary>
-        /// <param name="modules">Modules to attempt to install</param>
+        /// <param name="modules">Modules to attempt to install</param>        
         public void AddModulesToInstall(IEnumerable<CkanModule> modules)
-            {
+        {                        
             //Count may need to do a full enumeration. Might as well convert to array
             var ckan_modules = modules as CkanModule[] != null ? modules as CkanModule[] : modules.ToArray();
             log.DebugFormat("Processing relationships for {0} modules", ckan_modules.Count());
@@ -174,7 +174,7 @@ namespace CKAN
             {
                 log.DebugFormat("Preparing to resolve relationships for {0} {1}", module.identifier, module.version);
 
-                //Need to check against installed mods and those to install.
+                //Need to check against installed mods and those to install. 
                 var mods = modlist.Values.Concat(installed_modules).Where(listed_mod => listed_mod.ConflictsWith(module));
                 foreach (var listed_mod in mods)
                 {
@@ -204,7 +204,7 @@ namespace CKAN
             }
 
             var final_modules = new List<Module>(modlist.Values);
-
+            
 
             if (!options.without_enforce_consistency)
             {
@@ -218,8 +218,8 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Removes mods from the list of installed modules. Intended to be used for cases
-        /// in which the mod is to be uninstalled.
+        /// Removes mods from the list of installed modules. Intended to be used for cases 
+        /// in which the mod is to be un-installed.
         /// </summary>
         /// <param name="mods">The mods to remove.</param>
         public void RemoveModsFromInstalledList(IEnumerable<Module> mods)
@@ -263,10 +263,10 @@ namespace CKAN
         /// Resolve a relationship stanza (a list of relationships).
         /// This will add modules to be installed, if required.
         /// May recurse back to Resolve for those new modules.
-        ///
+        /// 
         /// If `soft_resolve` is true, we warn rather than throw exceptions on mods we cannot find.
         /// If `soft_resolve` is false (default), we throw a ModuleNotFoundKraken if we can't find a dependency.
-        ///
+        /// 
         /// Throws a TooManyModsProvideKraken if we have too many choices and
         /// options.without_toomanyprovides_kraken is not set.
         ///
@@ -436,7 +436,7 @@ namespace CKAN
 
         /// <summary>
         ///  Returns a IList consisting of keyValuePairs containing conflicting mods.
-        /// Note: (a,b) in the list should imply that (b,a) is in the list.
+        /// Note: (a,b) in the list should imply that (b,a) is in the list. 
         /// </summary>
         public Dictionary<Module, String> ConflictList
         {
@@ -483,7 +483,7 @@ namespace CKAN
             }
 
             var reason = reasons[mod];
-            var is_root_type = reason.GetType() == typeof (SelectionReason.UserRequested)
+            var is_root_type = reason.GetType() == typeof (SelectionReason.UserRequested) 
                 || reason.GetType() == typeof(SelectionReason.Installed);
             return is_root_type
                 ? reason.Reason
@@ -492,15 +492,15 @@ namespace CKAN
     }
 
     /// <summary>
-    /// Used to keep track of the relationships between modules in the resolver.
-    /// Intended to be used for displaying messages to the user.
+    /// Used to keep track of the relationships between modules in the resolver. 
+    /// Intended to be used for displaying messages to the user.     
     /// </summary>
     internal abstract class SelectionReason
     {
         //Currently assumed to exist for any relationship other than useradded or installed
         public virtual CkanModule Parent { get; protected set; }
-        //Should contain a newline at the end of the string.
-        public abstract String Reason { get; }
+        //Should contain a newline at the end of the string. 
+        public abstract String Reason { get; }       
 
 
         public class Installed : SelectionReason
@@ -517,7 +517,7 @@ namespace CKAN
             public override string Reason
             {
                 get { return "  Currently installed.\n"; }
-            }
+            }            
         }
 
         public class UserRequested : SelectionReason

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -227,6 +227,7 @@ namespace CKAN
             foreach (var module in mods)
             {
                 installed_modules.Remove(module);
+                conflicts.RemoveAll(kvp => kvp.Key.Equals(module) || kvp.Value.Equals(module));
             }
         }
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -425,7 +425,7 @@ namespace CKAN
 
         public bool IsConsistant
         {
-            get { return conflicts.Any(); }
+            get { return !conflicts.Any(); }
         }
 
         internal Relationship ReasonFor(CkanModule mod)

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -80,7 +80,7 @@ namespace CKAN
         private static readonly ILog log = LogManager.GetLogger(typeof (RelationshipResolver));
         private readonly Dictionary<string, CkanModule> modlist = new Dictionary<string, CkanModule>();
         private readonly List<CkanModule> user_requested_mods = new List<CkanModule>();
-        private readonly List<KeyValuePair<Module, Module>> conflicts = 
+        private readonly List<KeyValuePair<Module, Module>> conflicts =
             new List<KeyValuePair<Module, Module>>();
         private readonly Dictionary<Module, SelectionReason> reasons = 
             new Dictionary<Module, SelectionReason>(new Module.IdentifierEqualilty());
@@ -126,7 +126,7 @@ namespace CKAN
         {
             // Does nothing, just calls the other overloaded constructor
         }
-       
+
         /// <summary>
         /// Creates a new resolver that will find a way to install all the modules specified.
         /// </summary>
@@ -204,7 +204,7 @@ namespace CKAN
             }
 
             var final_modules = new List<Module>(modlist.Values);
-            
+
 
             if (!options.without_enforce_consistency)
             {
@@ -500,7 +500,7 @@ namespace CKAN
         //Currently assumed to exist for any relationship other than useradded or installed
         public virtual CkanModule Parent { get; protected set; }
         //Should contain a newline at the end of the string. 
-        public abstract String Reason { get; }       
+        public abstract String Reason { get; }
 
 
         public class Installed : SelectionReason

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -468,7 +468,7 @@ namespace CKAN
 
         public override int GetHashCode()
         {
-                return base.GetHashCode();
+            return base.GetHashCode();
         }
 
 

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using log4net;
 using Newtonsoft.Json;
 using System.Text.RegularExpressions;
+using System.Transactions;
 
 namespace CKAN
 {
@@ -35,7 +36,7 @@ namespace CKAN
     // Base class for both modules (installed via the CKAN) and bundled
     // modules (which are more lightweight)
     [JsonObject(MemberSerialization.OptIn)]
-    public class Module
+    public class Module : IEquatable<Module>
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(Module));
 
@@ -274,6 +275,11 @@ namespace CKAN
             }
         }
 
+        bool IEquatable<Module>.Equals(Module other)
+        {
+            return Equals(other);
+        }
+
         public class IdentifierEqualilty : EqualityComparer<Module>
         {
             public override bool Equals(Module x, Module y)
@@ -448,7 +454,7 @@ namespace CKAN
 
         public override int GetHashCode()
         {
-            return identifier.GetHashCode() ^ version.GetHashCode();
+            return base.GetHashCode();
         }
 
 

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -25,9 +25,10 @@ namespace CKAN
         public Uri homepage;
         public Uri bugtracker;
 
-        [JsonConverter(typeof(JsonOldResourceUrlConverter))]
+        [JsonConverter(typeof (JsonOldResourceUrlConverter))]
         public Uri kerbalstuff;
     }
+
 
     /// <summary>
     ///     Describes a CKAN module (ie, what's in the CKAN.schema file).
@@ -38,13 +39,14 @@ namespace CKAN
     [JsonObject(MemberSerialization.OptIn)]
     public class Module : IEquatable<Module>
     {
-        private static readonly ILog log = LogManager.GetLogger(typeof(Module));
+        private static readonly ILog log = LogManager.GetLogger(typeof (Module));
 
         // identifier, license, and version are always required, so we know
         // what we've got.
 
         [JsonProperty("abstract")]
         public string @abstract;
+
         [JsonProperty("description")]
         public string description;
 
@@ -53,7 +55,7 @@ namespace CKAN
         public string kind;
 
         [JsonProperty("author")]
-        [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
+        [JsonConverter(typeof (JsonSingleOrArrayConverter<string>))]
         public List<string> author;
 
         [JsonProperty("comment")]
@@ -61,13 +63,16 @@ namespace CKAN
 
         [JsonProperty("conflicts")]
         public List<RelationshipDescriptor> conflicts;
+
         [JsonProperty("depends")]
         public List<RelationshipDescriptor> depends;
 
         [JsonProperty("download")]
         public Uri download;
+
         [JsonProperty("download_size")]
         public long download_size;
+
         [JsonProperty("identifier", Required = Required.Always)]
         public string identifier;
 
@@ -76,6 +81,7 @@ namespace CKAN
 
         [JsonProperty("ksp_version_max")]
         public KSPVersion ksp_version_max;
+
         [JsonProperty("ksp_version_min")]
         public KSPVersion ksp_version_min;
 
@@ -90,13 +96,16 @@ namespace CKAN
 
         [JsonProperty("recommends")]
         public List<RelationshipDescriptor> recommends;
+
         [JsonProperty("release_status")]
         public ReleaseStatus release_status;
 
         [JsonProperty("resources")]
         public ResourcesDescriptor resources;
+
         [JsonProperty("suggests")]
         public List<RelationshipDescriptor> suggests;
+
         [JsonProperty("version", Required = Required.Always)]
         public Version version;
 
@@ -169,7 +178,7 @@ namespace CKAN
 
             if (license == null)
             {
-                license = new License ("unknown");
+                license = new License("unknown");
             }
 
             if (@abstract == null)
@@ -188,7 +197,7 @@ namespace CKAN
         /// </summary>
         public bool ConflictsWith(Module module)
         {
-            if(Equals(module)) return false;
+            if (Equals(module)) return false;
             return UniConflicts(this, module) || UniConflicts(module, this);
         }
 
@@ -248,10 +257,7 @@ namespace CKAN
 
         public bool IsMetapackage
         {
-            get
-            {
-                return (!string.IsNullOrEmpty(this.kind) && this.kind == "metapackage");
-            }
+            get { return (!string.IsNullOrEmpty(this.kind) && this.kind == "metapackage"); }
         }
 
         protected bool Equals(Module other)
@@ -295,229 +301,238 @@ namespace CKAN
     }
 
     public class CkanModule : Module
-    {
-        private static readonly ILog log = LogManager.GetLogger(typeof(CkanModule));
-        private static readonly string[] required_fields =
         {
-            "spec_version",
-            "name",
-            "abstract",
-            "identifier",
-            "download",
-            "license",
-            "version"
-        };
-        // Only CKAN modules can have install and bundle instructions.
+            private static readonly ILog log = LogManager.GetLogger(typeof (CkanModule));
 
-        [JsonProperty("install")] public ModuleInstallDescriptor[] install;
-        [JsonProperty("spec_version", Required = Required.Always)] public Version spec_version;
-
-        private static bool validate_json_against_schema(string json)
-        {
-
-            log.Debug("In-client JSON schema validation unimplemented.");
-            return true;
-            // due to Newtonsoft Json not supporting v4 of the standard, we can't actually do this :(
-
-            //            if (metadata_schema == null)
-            //            {
-            //                string schema = "";
-            //
-            //                try
-            //                {
-            //                    schema = File.ReadAllText(metadata_schema_path);
-            //                }
-            //                catch (Exception)
-            //                {
-            //                    if (!metadata_schema_missing_warning_fired)
-            //                    {
-            //                        User.Error("Couldn't open metadata schema at \"{0}\", will not validate metadata files",
-            //                            metadata_schema_path);
-            //                        metadata_schema_missing_warning_fired = true;
-            //                    }
-            //
-            //                    return true;
-            //                }
-            //
-            //                metadata_schema = JsonSchema.Parse(schema);
-            //            }
-            //
-            //            JObject obj = JObject.Parse(json);
-            //            return obj.IsValid(metadata_schema);
-        }
-
-        /// <summary>
-        /// Tries to parse an identifier in the format Modname=version
-        /// If the module cannot be found in the registry, throws a ModuleNotFoundKraken.
-        /// </summary>
-        public static CkanModule FromIDandVersion(Registry registry, string mod, KSPVersion ksp_version)
-        {
-            CkanModule module;
-
-            Match match = Regex.Match(mod, @"^(?<mod>[^=]*)=(?<version>.*)$");
-
-            if (match.Success)
+            private static readonly string[] required_fields =
             {
-                string ident = match.Groups["mod"].Value;
-                string version = match.Groups["version"].Value;
+                "spec_version",
+                "name",
+                "abstract",
+                "identifier",
+                "download",
+                "license",
+                "version"
+            };
 
-                module = registry.GetModuleByVersion(ident, version);
+            // Only CKAN modules can have install and bundle instructions.
+
+            [JsonProperty("install")]
+            public ModuleInstallDescriptor[] install;
+
+            [JsonProperty("spec_version", Required = Required.Always)]
+            public Version spec_version;
+
+            private static bool validate_json_against_schema(string json)
+            {
+
+                log.Debug("In-client JSON schema validation unimplemented.");
+                return true;
+                // due to Newtonsoft Json not supporting v4 of the standard, we can't actually do this :(
+
+                //            if (metadata_schema == null)
+                //            {
+                //                string schema = "";
+                //
+                //                try
+                //                {
+                //                    schema = File.ReadAllText(metadata_schema_path);
+                //                }
+                //                catch (Exception)
+                //                {
+                //                    if (!metadata_schema_missing_warning_fired)
+                //                    {
+                //                        User.Error("Couldn't open metadata schema at \"{0}\", will not validate metadata files",
+                //                            metadata_schema_path);
+                //                        metadata_schema_missing_warning_fired = true;
+                //                    }
+                //
+                //                    return true;
+                //                }
+                //
+                //                metadata_schema = JsonSchema.Parse(schema);
+                //            }
+                //
+                //            JObject obj = JObject.Parse(json);
+                //            return obj.IsValid(metadata_schema);
+            }
+
+            /// <summary>
+            /// Tries to parse an identifier in the format Modname=version
+            /// If the module cannot be found in the registry, throws a ModuleNotFoundKraken.
+            /// </summary>
+            public static CkanModule FromIDandVersion(Registry registry, string mod, KSPVersion ksp_version)
+            {
+                CkanModule module;
+
+                Match match = Regex.Match(mod, @"^(?<mod>[^=]*)=(?<version>.*)$");
+
+                if (match.Success)
+                {
+                    string ident = match.Groups["mod"].Value;
+                    string version = match.Groups["version"].Value;
+
+                    module = registry.GetModuleByVersion(ident, version);
+
+                    if (module == null)
+                        throw new ModuleNotFoundKraken(ident, version,
+                            string.Format("Cannot install {0}, version {1} not available", ident, version));
+                }
+                else
+                    module = registry.LatestAvailable(mod, ksp_version);
 
                 if (module == null)
-                    throw new ModuleNotFoundKraken(ident, version, string.Format("Cannot install {0}, version {1} not available", ident, version));
-            }
-            else
-                module = registry.LatestAvailable(mod, ksp_version);
-
-            if (module == null)
-                throw new ModuleNotFoundKraken(mod, null, string.Format("Cannot install {0}, module not available", mod));
-            else
-                return module;
-        }
-
-        /// <summary> Generates a CKAN.Meta object given a filename</summary>
-        public static CkanModule FromFile(string filename)
-        {
-            string json = File.ReadAllText(filename);
-            return FromJson(json);
-        }
-
-        public static void ToFile(CkanModule module, string filename)
-        {
-            var json = ToJson(module);
-            File.WriteAllText(filename, json);
-        }
-
-        /// <summary>
-        /// Generates a CKAN.META object from a string.
-        /// Also validates that all required fields are present.
-        /// Throws a BadMetaDataKraken if any fields are missing.
-        /// </summary>
-        public static CkanModule FromJson(string json)
-        {
-            if (!validate_json_against_schema(json))
-            {
-                throw new BadMetadataKraken(null, "Validation against spec failed");
+                    throw new ModuleNotFoundKraken(mod, null,
+                        string.Format("Cannot install {0}, module not available", mod));
+                else
+                    return module;
             }
 
-            CkanModule newModule;
-
-            try
+            /// <summary> Generates a CKAN.Meta object given a filename</summary>
+            public static CkanModule FromFile(string filename)
             {
-                newModule = JsonConvert.DeserializeObject<CkanModule>(json);
-            }
-            catch (JsonException ex)
-            {
-                throw new BadMetadataKraken(null, "JSON deserialization error", ex);
+                string json = File.ReadAllText(filename);
+                return FromJson(json);
             }
 
-            // NOTE: Many of these tests may be better inour Deserialisation handler.
-            if (!newModule.IsSpecSupported())
+            public static void ToFile(CkanModule module, string filename)
             {
-                throw new UnsupportedKraken(
-                    String.Format(
-                        "{0} requires CKAN {1}, we can't read it.",
-                        newModule,
-                        newModule.spec_version
-                    )
-                );
+                var json = ToJson(module);
+                File.WriteAllText(filename, json);
             }
 
-            // Check everything in the spec if defined.
-            // TODO: This *can* and *should* be done with JSON attributes!
-
-            foreach (string field in required_fields)
+            /// <summary>
+            /// Generates a CKAN.META object from a string.
+            /// Also validates that all required fields are present.
+            /// Throws a BadMetaDataKraken if any fields are missing.
+            /// </summary>
+            public static CkanModule FromJson(string json)
             {
-                object value = newModule.GetType().GetField(field).GetValue(newModule);
-
-                if (value == null)
+                if (!validate_json_against_schema(json))
                 {
-                    // Metapackages are allowed to have no download field
-                    if (field == "download" && newModule.IsMetapackage) continue;
-
-                    string error = String.Format("{0} missing required field {1}", newModule.identifier, field);
-
-                    log.Error(error);
-                    throw new BadMetadataKraken(null, error);
+                    throw new BadMetadataKraken(null, "Validation against spec failed");
                 }
+
+                CkanModule newModule;
+
+                try
+                {
+                    newModule = JsonConvert.DeserializeObject<CkanModule>(json);
+                }
+                catch (JsonException ex)
+                {
+                    throw new BadMetadataKraken(null, "JSON deserialization error", ex);
+                }
+
+                // NOTE: Many of these tests may be better inour Deserialisation handler.
+                if (!newModule.IsSpecSupported())
+                {
+                    throw new UnsupportedKraken(
+                        String.Format(
+                            "{0} requires CKAN {1}, we can't read it.",
+                            newModule,
+                            newModule.spec_version
+                            )
+                        );
+                }
+
+                // Check everything in the spec if defined.
+                // TODO: This *can* and *should* be done with JSON attributes!
+
+                foreach (string field in required_fields)
+                {
+                    object value = newModule.GetType().GetField(field).GetValue(newModule);
+
+                    if (value == null)
+                    {
+                        // Metapackages are allowed to have no download field
+                        if (field == "download" && newModule.IsMetapackage) continue;
+
+                        string error = String.Format("{0} missing required field {1}", newModule.identifier, field);
+
+                        log.Error(error);
+                        throw new BadMetadataKraken(null, error);
+                    }
+                }
+                // All good! Return module
+                return newModule;
             }
-            // All good! Return module
-            return newModule;
-        }
-        public override bool Equals(object obj)
-        {
-            var other = obj as Module;
-            return other != null
-            ? identifier.Equals(other.identifier) && version.Equals(other.version)
-            : base.Equals(obj);
-        }
 
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-
-
-        public static string ToJson(CkanModule module)
-        {
-            return JsonConvert.SerializeObject(module);
-        }
-
-        /// <summary>
-        /// Returns true if we support at least spec_version of the CKAN spec.
-        /// </summary>
-        internal static bool IsSpecSupported(Version spec_vesion)
-        {
-            // This could be a read-only state variable; do we have those in C#?
-            Version release = Meta.ReleaseNumber();
-
-            return release == null || release.IsGreaterThan(spec_vesion);
-        }
-
-        /// <summary>
-        /// Returns true if we support the CKAN spec used by this module.
-        /// </summary>
-        private bool IsSpecSupported()
-        {
-            return IsSpecSupported(spec_version);
-        }
-
-        /// <summary>
-        ///     Returns a standardised name for this module, in the form
-        ///     "identifier-version.zip". For example, `RealSolarSystem-7.3.zip`
-        /// </summary>
-        public string StandardName()
-        {
-            return StandardName(identifier, version);
-        }
-
-        public static string StandardName(string identifier, Version version)
-        {
-            return identifier + "-" + version + ".zip";
-        }
-    }
-
-    public class InvalidModuleAttributesException : Exception
-    {
-        private readonly Module module;
-        private readonly string why;
-
-        public InvalidModuleAttributesException(string why, Module module = null)
-        {
-            this.why = why;
-            this.module = module;
-        }
-
-        public override string ToString()
-        {
-            string modname = "unknown";
-
-            if (module != null)
+            public override bool Equals(object obj)
             {
-                modname = module.identifier;
+                var other = obj as Module;
+                return other != null
+                    ? identifier.Equals(other.identifier) && version.Equals(other.version)
+                    : base.Equals(obj);
             }
 
-            return string.Format("[InvalidModuleAttributesException] {0} in {1}", why, modname);
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
+
+
+            public static string ToJson(CkanModule module)
+            {
+                return JsonConvert.SerializeObject(module);
+            }
+
+            /// <summary>
+            /// Returns true if we support at least spec_version of the CKAN spec.
+            /// </summary>
+            internal static bool IsSpecSupported(Version spec_vesion)
+            {
+                // This could be a read-only state variable; do we have those in C#?
+                Version release = Meta.ReleaseNumber();
+
+                return release == null || release.IsGreaterThan(spec_vesion);
+            }
+
+            /// <summary>
+            /// Returns true if we support the CKAN spec used by this module.
+            /// </summary>
+            private bool IsSpecSupported()
+            {
+                return IsSpecSupported(spec_version);
+            }
+
+            /// <summary>
+            ///     Returns a standardised name for this module, in the form
+            ///     "identifier-version.zip". For example, `RealSolarSystem-7.3.zip`
+            /// </summary>
+            public string StandardName()
+            {
+                return StandardName(identifier, version);
+            }
+
+            public static string StandardName(string identifier, Version version)
+            {
+                return identifier + "-" + version + ".zip";
+            }
+        }
+
+        public class InvalidModuleAttributesException : Exception
+        {
+            private readonly Module module;
+            private readonly string why;
+
+            public InvalidModuleAttributesException(string why, Module module = null)
+            {
+                this.why = why;
+                this.module = module;
+            }
+
+            public override string ToString()
+            {
+                string modname = "unknown";
+
+                if (module != null)
+                {
+                    modname = module.identifier;
+                }
+
+                return string.Format("[InvalidModuleAttributesException] {0} in {1}", why, modname);
+            }
         }
     }
-}
+

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -252,6 +252,39 @@ namespace CKAN
             }
         }
 
+        protected bool Equals(Module other)
+        {
+            return string.Equals(identifier, other.identifier) && version.Equals(other.version);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Module) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (identifier.GetHashCode()*397) ^ version.GetHashCode();
+            }
+        }
+
+        public class IdentifierEqualilty : EqualityComparer<Module>
+        {
+            public override bool Equals(Module x, Module y)
+            {
+                return x.identifier.Equals(y.identifier);
+            }
+
+            public override int GetHashCode(Module obj)
+            {
+                return obj.identifier.GetHashCode();
+            }
+        }
     }
 
     public class CkanModule : Module

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -187,6 +187,7 @@ namespace CKAN
         /// </summary>
         public bool ConflictsWith(Module module)
         {
+            if(Equals(module)) return false;
             return UniConflicts(this, module) || UniConflicts(module, this);
         }
 

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -48,7 +48,7 @@ namespace Tests.Core.Relationships
             list.Add(mod_a.identifier);
             list.Add(mod_b.identifier);
             AddToRegistry(mod_a, mod_b);
-
+            
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
                 options,
@@ -64,7 +64,32 @@ namespace Tests.Core.Relationships
             Assert.That(resolver.ConflictList, Has.Count.EqualTo(2));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
+        [Test]
+        public void RemoveModsFromInstalledList_RemovedModsDoNotConflict()
+        {
+            var list = new List<string>();
+            var mod_a = generator.GeneratorRandomModule();
+            var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
+            {
+                new RelationshipDescriptor {name=mod_a.identifier}
+            });
+
+            list.Add(mod_a.identifier);
+            list.Add(mod_b.identifier);
+            AddToRegistry(mod_a, mod_b);
+            registry.RegisterModule(mod_a,new string[]{},null);
+
+
+            var resolver = new RelationshipResolver(options, registry, null);
+            resolver.RemoveModsFromInstalledList(new[] {mod_a});
+            resolver.AddModulesToInstall(new[] { mod_b} );
+            Assert.IsTrue(resolver.IsConsistant);
+
+        }
+
+        [Test]
+        [Category("Version")]
+        [Explicit("Versions relationships not implemented")]
         public void Constructor_WithConflictingModulesVersion_Throws()
         {
             var list = new List<string>();
@@ -729,7 +754,7 @@ namespace Tests.Core.Relationships
         public void ReasonFor_WithUserAddedMods_GivesReasonUserAdded()
         {
             var list = new List<string>();
-            var mod = generator.GeneratorRandomModule();
+            var mod = generator.GeneratorRandomModule();                        
             list.Add(mod.identifier);
             registry.AddAvailable(mod);
             AddToRegistry(mod);
@@ -747,7 +772,7 @@ namespace Tests.Core.Relationships
             var mod =
                 generator.GeneratorRandomModule(sugests:
                     new List<RelationshipDescriptor> {new RelationshipDescriptor {name = sugested.identifier}});
-            list.Add(mod.identifier);
+            list.Add(mod.identifier);            
             AddToRegistry(mod, sugested);
 
             options.with_all_suggests = true;
@@ -760,7 +785,7 @@ namespace Tests.Core.Relationships
         [Test]
         public void ReasonFor_WithTreeOfMods_GivesCorrectParents()
         {
-            var list = new List<string>();
+            var list = new List<string>();            
             var sugested = generator.GeneratorRandomModule();
             var recommendedA = generator.GeneratorRandomModule();
             var recommendedB = generator.GeneratorRandomModule();

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -48,7 +48,7 @@ namespace Tests.Core.Relationships
             list.Add(mod_a.identifier);
             list.Add(mod_b.identifier);
             AddToRegistry(mod_a, mod_b);
-
+            
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
                 options,
@@ -754,7 +754,7 @@ namespace Tests.Core.Relationships
         public void ReasonFor_WithUserAddedMods_GivesReasonUserAdded()
         {
             var list = new List<string>();
-            var mod = generator.GeneratorRandomModule();
+            var mod = generator.GeneratorRandomModule();                        
             list.Add(mod.identifier);
             registry.AddAvailable(mod);
             AddToRegistry(mod);
@@ -772,7 +772,7 @@ namespace Tests.Core.Relationships
             var mod =
                 generator.GeneratorRandomModule(sugests:
                     new List<RelationshipDescriptor> {new RelationshipDescriptor {name = sugested.identifier}});
-            list.Add(mod.identifier);
+            list.Add(mod.identifier);            
             AddToRegistry(mod, sugested);
 
             options.with_all_suggests = true;
@@ -785,7 +785,7 @@ namespace Tests.Core.Relationships
         [Test]
         public void ReasonFor_WithTreeOfMods_GivesCorrectParents()
         {
-            var list = new List<string>();
+            var list = new List<string>();            
             var sugested = generator.GeneratorRandomModule();
             var recommendedA = generator.GeneratorRandomModule();
             var recommendedB = generator.GeneratorRandomModule();

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -48,7 +48,7 @@ namespace Tests.Core.Relationships
             list.Add(mod_a.identifier);
             list.Add(mod_b.identifier);
             AddToRegistry(mod_a, mod_b);
-            
+
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
                 options,
@@ -754,14 +754,14 @@ namespace Tests.Core.Relationships
         public void ReasonFor_WithUserAddedMods_GivesReasonUserAdded()
         {
             var list = new List<string>();
-            var mod = generator.GeneratorRandomModule();                        
+            var mod = generator.GeneratorRandomModule();
             list.Add(mod.identifier);
             registry.AddAvailable(mod);
             AddToRegistry(mod);
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(mod);
-            Assert.That(reason, Is.AssignableTo<Relationship.UserRequested>());
+            Assert.That(reason, Is.AssignableTo<SelectionReason.UserRequested>());
         }
 
         [Test]
@@ -772,20 +772,20 @@ namespace Tests.Core.Relationships
             var mod =
                 generator.GeneratorRandomModule(sugests:
                     new List<RelationshipDescriptor> {new RelationshipDescriptor {name = sugested.identifier}});
-            list.Add(mod.identifier);            
+            list.Add(mod.identifier);
             AddToRegistry(mod, sugested);
 
             options.with_all_suggests = true;
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(sugested);
-            Assert.That(reason, Is.AssignableTo<Relationship.Suggested>());
+            Assert.That(reason, Is.AssignableTo<SelectionReason.Suggested>());
             Assert.That(reason.Parent, Is.EqualTo(mod));
         }
 
         [Test]
         public void ReasonFor_WithTreeOfMods_GivesCorrectParents()
         {
-            var list = new List<string>();            
+            var list = new List<string>();
             var sugested = generator.GeneratorRandomModule();
             var recommendedA = generator.GeneratorRandomModule();
             var recommendedB = generator.GeneratorRandomModule();
@@ -806,11 +806,11 @@ namespace Tests.Core.Relationships
             options.with_recommends = true;
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(recommendedA);
-            Assert.That(reason, Is.AssignableTo<Relationship.Recommended>());
+            Assert.That(reason, Is.AssignableTo<SelectionReason.Recommended>());
             Assert.That(reason.Parent, Is.EqualTo(sugested));
 
             reason = relationship_resolver.ReasonFor(recommendedB);
-            Assert.That(reason, Is.AssignableTo<Relationship.Recommended>());
+            Assert.That(reason, Is.AssignableTo<SelectionReason.Recommended>());
             Assert.That(reason.Parent, Is.EqualTo(sugested));
         }
 


### PR DESCRIPTION
From https://github.com/KSP-CKAN/CKAN-GUI/pull/111

Based on https://github.com/KSP-CKAN/CKAN/pull/988

Should allow you to install mods which conflict with mods that will be uninstalled. Such as changing tacls configs. 