### PR TITLE
Main install

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -144,9 +144,7 @@
     <Compile Include="MainDialogs.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="MainInstall.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Include="MainInstall.cs" />
     <Compile Include="MainModList.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -990,8 +990,7 @@ namespace CKAN
             this.CancelCurrentActionButton.Size = new System.Drawing.Size(75, 23);
             this.CancelCurrentActionButton.TabIndex = 9;
             this.CancelCurrentActionButton.Text = "Cancel";
-            this.CancelCurrentActionButton.UseVisualStyleBackColor = true;
-            this.CancelCurrentActionButton.Click += new System.EventHandler(this.CancelCurrentActionButton_Click);
+            this.CancelCurrentActionButton.UseVisualStyleBackColor = true;            
             // 
             // LogTextBox
             // 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -1056,8 +1056,7 @@ namespace CKAN
             this.RecommendedModsCancelButton.Size = new System.Drawing.Size(75, 23);
             this.RecommendedModsCancelButton.TabIndex = 8;
             this.RecommendedModsCancelButton.Text = "Cancel";
-            this.RecommendedModsCancelButton.UseVisualStyleBackColor = true;
-            this.RecommendedModsCancelButton.Click += new System.EventHandler(this.RecommendedModsCancelButton_Click);
+            this.RecommendedModsCancelButton.UseVisualStyleBackColor = true;            
             // 
             // RecommendedModsContinueButton
             // 
@@ -1068,8 +1067,7 @@ namespace CKAN
             this.RecommendedModsContinueButton.Size = new System.Drawing.Size(75, 23);
             this.RecommendedModsContinueButton.TabIndex = 7;
             this.RecommendedModsContinueButton.Text = "Continue";
-            this.RecommendedModsContinueButton.UseVisualStyleBackColor = true;
-            this.RecommendedModsContinueButton.Click += new System.EventHandler(this.RecommendedModsContinueButton_Click);
+            this.RecommendedModsContinueButton.UseVisualStyleBackColor = true;            
             // 
             // RecommendedDialogLabel
             // 
@@ -1137,8 +1135,7 @@ namespace CKAN
             this.ChooseProvidedModsCancelButton.Size = new System.Drawing.Size(75, 23);
             this.ChooseProvidedModsCancelButton.TabIndex = 10;
             this.ChooseProvidedModsCancelButton.Text = "Cancel";
-            this.ChooseProvidedModsCancelButton.UseVisualStyleBackColor = true;
-            this.ChooseProvidedModsCancelButton.Click += new System.EventHandler(this.ChooseProvidedModsCancelButton_Click);
+            this.ChooseProvidedModsCancelButton.UseVisualStyleBackColor = true;            
             // 
             // ChooseProvidedModsContinueButton
             // 
@@ -1149,8 +1146,7 @@ namespace CKAN
             this.ChooseProvidedModsContinueButton.Size = new System.Drawing.Size(75, 23);
             this.ChooseProvidedModsContinueButton.TabIndex = 9;
             this.ChooseProvidedModsContinueButton.Text = "Continue";
-            this.ChooseProvidedModsContinueButton.UseVisualStyleBackColor = true;
-            this.ChooseProvidedModsContinueButton.Click += new System.EventHandler(this.ChooseProvidedModsContinueButton_Click);
+            this.ChooseProvidedModsContinueButton.UseVisualStyleBackColor = true;            
             // 
             // ChooseProvidedModsListView
             // 
@@ -1238,7 +1234,7 @@ namespace CKAN
 
         #endregion
 
-        private System.Windows.Forms.MenuStrip menuStrip1;
+        internal System.Windows.Forms.MenuStrip menuStrip1;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem ExitToolButton;
@@ -1246,7 +1242,7 @@ namespace CKAN
         private System.Windows.Forms.MenuStrip menuStrip2;
         private System.Windows.Forms.ToolStripMenuItem RefreshToolButton;
         private System.Windows.Forms.ToolStripMenuItem UpdateAllToolButton;
-        private System.Windows.Forms.ToolStripMenuItem ApplyToolButton;
+        internal System.Windows.Forms.ToolStripMenuItem ApplyToolButton;
         private ToolStripMenuItem aboutToolStripMenuItem;
         private SplitContainer splitContainer1;
         private Panel StatusPanel;
@@ -1290,7 +1286,7 @@ namespace CKAN
         private TabPage WaitTabPage;
         private Button CancelCurrentActionButton;
         private TextBox LogTextBox;
-        private ProgressBar DialogProgressBar;
+        internal ProgressBar DialogProgressBar;
         private TextBox MessageTextBox;
         private DataGridViewCheckBoxColumn UpdateCell;
         private TabPage ChangesetTabPage;
@@ -1301,20 +1297,20 @@ namespace CKAN
         private ColumnHeader ChangeType;
         private ColumnHeader columnHeader2;
         private TabPage ChooseRecommendedModsTabPage;
-        private Label RecommendedDialogLabel;
-        private ListView RecommendedModsListView;
+        internal Label RecommendedDialogLabel;
+        internal ListView RecommendedModsListView;
         private ColumnHeader columnHeader3;
         private ColumnHeader columnHeader4;
         private ColumnHeader columnHeader5;
         private Button RecommendedModsCancelButton;
         private Button RecommendedModsContinueButton;
         private TabPage ChooseProvidedModsTabPage;
-        private Label ChooseProvidedModsLabel;
-        private ListView ChooseProvidedModsListView;
+        internal Label ChooseProvidedModsLabel;
+        internal ListView ChooseProvidedModsListView;
         private ColumnHeader columnHeader6;
         private ColumnHeader columnHeader8;
         private Button ChooseProvidedModsCancelButton;
-        private Button ChooseProvidedModsContinueButton;
+        internal Button ChooseProvidedModsContinueButton;
         private ToolStripMenuItem cKANSettingsToolStripMenuItem;
         private ToolStripMenuItem kSPCommandlineToolStripMenuItem;
         private RichTextBox MetadataModuleAbstractLabel;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -296,9 +296,9 @@ namespace CKAN
             m_UpdateRepoWorker.RunWorkerCompleted += PostUpdateRepo;
             m_UpdateRepoWorker.DoWork += UpdateRepo;
 
-            m_InstallWorker = new BackgroundWorker { WorkerReportsProgress = true, WorkerSupportsCancellation = true };
-            m_InstallWorker.RunWorkerCompleted += PostInstallMods;
+            m_InstallWorker = new BackgroundWorker {WorkerReportsProgress = true, WorkerSupportsCancellation = true};            
             m_InstallWorker.DoWork += InstallMods;
+            m_InstallWorker.RunWorkerCompleted += PostInstallMods;
 
             UpdateModsList();
 

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -13,7 +13,7 @@ namespace CKAN
         public void UpdateChangesDialog(List<KeyValuePair<CkanModule, GUIModChangeType>> changeset, BackgroundWorker installWorker)
         {
             m_Changeset = changeset;
-            main_install_gui.m_InstallWorker = installWorker;
+            main_install_gui.install_worker = installWorker;
             ChangesListView.Items.Clear();
 
             if (changeset == null)
@@ -40,7 +40,7 @@ namespace CKAN
         private void CancelChangesButton_Click(object sender, EventArgs e)
         {
             UpdateModsList();
-            UpdateChangesDialog(null, main_install_gui.m_InstallWorker);
+            UpdateChangesDialog(null, main_install_gui.install_worker);
             m_TabController.ShowTab("ManageModsTabPage");
             m_TabController.HideTab("ChangesetTabPage");
             ApplyToolButton.Enabled = false;
@@ -56,12 +56,12 @@ namespace CKAN
             RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
             install_ops.with_recommends = false;
 
-            main_install_gui.m_InstallWorker.RunWorkerAsync(
+            main_install_gui.install_worker.RunWorkerAsync(
                 new KeyValuePair<List<KeyValuePair<CkanModule, GUIModChangeType>>, RelationshipResolverOptions>(
                     m_Changeset, install_ops));
             m_Changeset = null;
 
-            UpdateChangesDialog(null, main_install_gui.m_InstallWorker);
+            UpdateChangesDialog(null, main_install_gui.install_worker);
             ShowWaitDialog();
         }
 

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -13,7 +13,7 @@ namespace CKAN
         public void UpdateChangesDialog(List<KeyValuePair<CkanModule, GUIModChangeType>> changeset, BackgroundWorker installWorker)
         {
             m_Changeset = changeset;
-            m_InstallWorker = installWorker;
+            main_install_gui.m_InstallWorker = installWorker;
             ChangesListView.Items.Clear();
 
             if (changeset == null)
@@ -40,7 +40,7 @@ namespace CKAN
         private void CancelChangesButton_Click(object sender, EventArgs e)
         {
             UpdateModsList();
-            UpdateChangesDialog(null, m_InstallWorker);
+            UpdateChangesDialog(null, main_install_gui.m_InstallWorker);
             m_TabController.ShowTab("ManageModsTabPage");
             m_TabController.HideTab("ChangesetTabPage");
             ApplyToolButton.Enabled = false;
@@ -55,13 +55,13 @@ namespace CKAN
 
             RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
             install_ops.with_recommends = false;
-            
-            m_InstallWorker.RunWorkerAsync(
+
+            main_install_gui.m_InstallWorker.RunWorkerAsync(
                 new KeyValuePair<List<KeyValuePair<CkanModule, GUIModChangeType>>, RelationshipResolverOptions>(
                     m_Changeset, install_ops));
             m_Changeset = null;
 
-            UpdateChangesDialog(null, m_InstallWorker);
+            UpdateChangesDialog(null, main_install_gui.m_InstallWorker);
             ShowWaitDialog();
         }
 

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -48,7 +48,7 @@ namespace CKAN
             TaskCompletionSource<CkanModule> task = new TaskCompletionSource<CkanModule>();
             Util.Invoke(this, () =>
             {
-                UpdateProvidedModsDialog(kraken, task);
+                main_install_gui.UpdateProvidedModsDialog(kraken, task);
                 m_TabController.ShowTab("ChooseProvidedModsTabPage", 3);
                 m_TabController.SetTabLock(true);
             });

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -3,11 +3,13 @@ using System.Windows.Forms;
 
 namespace CKAN
 {
-    public delegate void MainCancelCallback();
-
     public partial class Main
-    {
-        public MainCancelCallback cancelCallback;
+    {        
+        public Button CancelCurrentActionButton1
+        {
+            set { CancelCurrentActionButton = value; }
+            get { return CancelCurrentActionButton; }
+        }
 
         public void ShowWaitDialog(bool cancelable = true)
         {
@@ -70,17 +72,6 @@ namespace CKAN
         {
             Util.Invoke(LogTextBox, () => LogTextBox.AppendText(message + "\r\n"));
         }
-
-        private void CancelCurrentActionButton_Click(object sender, EventArgs e)
-        {
-            if (cancelCallback != null)
-            {
-                cancelCallback();
-                CancelCurrentActionButton.Enabled = false;
-                HideWaitDialog(true);
-            }
-        }
-
     }
 
 }

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -3,13 +3,11 @@ using System.Windows.Forms;
 
 namespace CKAN
 {
-
-    internal delegate void MainCancelCallback();
+    public delegate void MainCancelCallback();
 
     public partial class Main
     {
-
-        private MainCancelCallback cancelCallback;
+        public MainCancelCallback cancelCallback;
 
         public void ShowWaitDialog(bool cancelable = true)
         {

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -127,5 +127,18 @@ namespace CKAN
             if(mod==null) throw new ArgumentNullException();
             return !(mod.IsAutodetected || mod.IsIncompatible) || (!mod.IsAutodetected && mod.IsInstalled);
         }
+
+        public static void AppendItemOrAddNewList<K, T>(this Dictionary<K, List<T>> dict, K key, T item)
+        {
+            if (dict.ContainsKey(key))
+            {
+                dict[key].Add(item);
+            }
+            else
+            {
+                dict.Add(key, new List<T> { item });
+            }
+        }
     }
+    
 }


### PR DESCRIPTION
Start to separate out MainInstall so it is not part of Main.

Currently is still tightly coupled as it just passes a Main instance into MainInstall but it is a improvement on what is currently there.

Currently most of the code in the GUI is in the class called Main which, via partial classes, has code spread over

*    Main.cs
*    MainChangset.cs
*    MainModInfo.cs
*    MainRepo.cs
*    MainWait.cs
*    MainInstall.cs
*    Parts of MainModList.cs.

The broad overview of this PR is to extract the code from Main which resides in MainInstall.cs into its own classes, MainInstall and MainInstallGUI. Currently MainInstall contains the code that only interacts with the GUI via the User interface, everything else is in MainInstall.
