### PR TITLE
AVC uses -1 as a wildcard since 1.1.5.0.

### DIFF
--- a/Netkan/AVC/JsonAvcToKspVersion.cs
+++ b/Netkan/AVC/JsonAvcToKspVersion.cs
@@ -60,23 +60,22 @@ namespace CKAN.NetKAN
             //AVC uses -1 to indicate a wildcard.
             int integer;
             string version;
-            if (int.TryParse(patch, out integer))
+            if (int.TryParse(major, out integer) && integer == AVC_WILDCARD)
             {
-                version = integer == AVC_WILDCARD
-                    ? string.Join(".", major, minor)
-                    : string.Join(".", major, minor, patch);
+                version = null;
             }
-            else if (int.TryParse(minor, out integer))
+            else if (int.TryParse(minor, out integer) && integer == AVC_WILDCARD)
             {
-                version = integer == AVC_WILDCARD
-                    ? string.Join(".", major)
-                    : string.Join(".", major, minor);
+                version = major;
+            }
+            else if (int.TryParse(patch, out integer) && integer == AVC_WILDCARD)
+            {
+                version = string.Join(".", major, minor);
             }
             else
             {
                 version = string.Join(".", major, minor, patch);
             }
-
 
             log.DebugFormat("  extracted version: {0}", version);
             KSPVersion result = new KSPVersion(version);

--- a/Netkan/AVC/JsonAvcToKspVersion.cs
+++ b/Netkan/AVC/JsonAvcToKspVersion.cs
@@ -1,7 +1,7 @@
 using System;
+using log4net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using log4net;
 
 namespace CKAN.NetKAN
 {
@@ -11,6 +11,7 @@ namespace CKAN.NetKAN
     public class JsonAvcToKspVersion : JsonConverter
     {
         private static readonly ILog log = LogManager.GetLogger(typeof (JsonAvcToKspVersion));
+        private const int AVC_WILDCARD = -1;
 
         public override bool CanConvert(Type object_type)
         {
@@ -18,48 +19,68 @@ namespace CKAN.NetKAN
             return true;
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
         {
             string major = "0";
             string minor = "0";
             string patch = "0";
 
             JToken token = JToken.Load(reader);
-            log.DebugFormat ("Read Token: {0}, {1}", new Object[] { token.Type, token.ToString() });
-            if (token.Type == JTokenType.String)
+            log.DebugFormat("Read Token: {0}, {1}", new Object[] {token.Type, token.ToString()});
+            switch (token.Type)
             {
-                string[] tokenArray = token.ToString ().Split ('.');
+                case JTokenType.String:
+                    var token_array = token.ToString().Split('.');
 
-                if (tokenArray.Length >= 0)
-                {
-                    major = tokenArray [0];
-                }
+                    if (token_array.Length >= 0)
+                    {
+                        major = token_array[0];
+                    }
 
-                if (tokenArray.Length >= 1)
-                {
-                    minor = tokenArray [1];
-                }
+                    if (token_array.Length >= 1)
+                    {
+                        minor = token_array[1];
+                    }
 
-                if (tokenArray.Length >= 2)
-                {
-                    patch = tokenArray [2];
-                }
+                    if (token_array.Length >= 2)
+                    {
+                        patch = token_array[2];
+                    }
+                    break;
+                case JTokenType.Object:
+                    major = (string) token["MAJOR"];
+                    minor = (string) token["MINOR"];
+                    patch = (string) token["PATCH"];
+                    break;
+                default:
+                    throw new InvalidCastException("Trying to convert non-JSON object to Version object");
             }
-            else if (token.Type == JTokenType.Object)
+
+            //AVC uses -1 to indicate a wildcard.
+            int integer;
+            string version;
+            if (int.TryParse(patch, out integer))
             {
-                major = (string) token ["MAJOR"];
-                minor = (string) token ["MINOR"];
-                patch = (string) token ["PATCH"];
+                version = integer == AVC_WILDCARD
+                    ? string.Join(".", major, minor)
+                    : string.Join(".", major, minor, patch);
+            }
+            else if (int.TryParse(minor, out integer))
+            {
+                version = integer == AVC_WILDCARD
+                    ? string.Join(".", major)
+                    : string.Join(".", major, minor);
             }
             else
             {
-                throw new InvalidCastException("Trying to convert non-JSON object to Version object");
+                version = string.Join(".", major, minor, patch);
             }
 
-            string version = string.Join(".", major, minor, patch);
-            log.DebugFormat ("  extracted version: {0}", version);
+
+            log.DebugFormat("  extracted version: {0}", version);
             KSPVersion result = new KSPVersion(version);
-            log.DebugFormat ("  generated result: {0}", result.ToString());
+            log.DebugFormat("  generated result: {0}", result.ToString());
             return result;
         }
 
@@ -72,7 +93,6 @@ namespace CKAN.NetKAN
         {
             throw new NotImplementedException();
         }
-
     }
 
     /// <summary>
@@ -88,48 +108,48 @@ namespace CKAN.NetKAN
             return true;
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type object_type, object existing_value,
+            JsonSerializer serializer)
         {
             string major = "0";
             string minor = "0";
             string patch = "0";
 
             JToken token = JToken.Load(reader);
-            log.DebugFormat ("Read Token: {0}, {1}", new Object[] { token.Type, token.ToString() });
-            if (token.Type == JTokenType.String)
+            log.DebugFormat("Read Token: {0}, {1}", new Object[] {token.Type, token.ToString()});
+            switch (token.Type)
             {
-                string[] tokenArray = token.ToString ().Split ('.');
+                case JTokenType.String:
+                    var token_array = token.ToString().Split('.');
 
-                if (tokenArray.Length >= 0)
-                {
-                    major = tokenArray [0];
-                }
+                    if (token_array.Length >= 0)
+                    {
+                        major = token_array[0];
+                    }
 
-                if (tokenArray.Length >= 1)
-                {
-                    minor = tokenArray [1];
-                }
+                    if (token_array.Length >= 1)
+                    {
+                        minor = token_array[1];
+                    }
 
-                if (tokenArray.Length >= 2)
-                {
-                    patch = tokenArray [2];
-                }
-            }
-            else if (token.Type == JTokenType.Object)
-            {
-                major = (string) token ["MAJOR"];
-                minor = (string) token ["MINOR"];
-                patch = (string) token ["PATCH"];
-            }
-            else
-            {
-                throw new InvalidCastException("Trying to convert non-JSON object to Version object");
+                    if (token_array.Length >= 2)
+                    {
+                        patch = token_array[2];
+                    }
+                    break;
+                case JTokenType.Object:
+                    major = (string) token["MAJOR"];
+                    minor = (string) token["MINOR"];
+                    patch = (string) token["PATCH"];
+                    break;
+                default:
+                    throw new InvalidCastException("Trying to convert non-JSON object to Version object");
             }
 
             string version = string.Join(".", major, minor, patch);
-            log.DebugFormat ("  extracted version: {0}", version);
+            log.DebugFormat("  extracted version: {0}", version);
             Version result = new Version(version);
-            log.DebugFormat ("  generated result: {0}", result.ToString());
+            log.DebugFormat("  generated result: {0}", result.ToString());
             return result;
         }
 
@@ -142,7 +162,5 @@ namespace CKAN.NetKAN
         {
             throw new NotImplementedException();
         }
-
     }
 }
-

--- a/Tests/NetKAN/AVC.cs
+++ b/Tests/NetKAN/AVC.cs
@@ -1,3 +1,7 @@
+using System.CodeDom;
+using System.IO;
+using CKAN;
+using CKAN.NetKAN;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Tests.Data;
@@ -22,7 +26,7 @@ namespace Tests.NetKAN
         [Test]
         public void JsonOneLineVersion()
         {
-            string json = TestData.KspAvcJsonOneLineVersion ();
+            string json = TestData.KspAvcJsonOneLineVersion();
 
             var avc = JsonConvert.DeserializeObject<CKAN.NetKAN.AVC>(json);
 
@@ -30,6 +34,34 @@ namespace Tests.NetKAN
             Assert.AreEqual("0.24.0", avc.ksp_version_min.ToString());
             Assert.AreEqual("1.0.0", avc.ksp_version_max.ToString());
         }
+
+        [Test]
+        public void WildcardMajor_OutputsAnyVersion()
+        {
+            var converter = new JsonAvcToKspVersion();
+            string json = @"{""MAJOR"":-1, ""MINOR"":-1, ""PATCH"":-1}";
+            var reader = new JsonTextReader(new StringReader(json));
+            var result = (KSPVersion) converter.ReadJson(reader, null, null, null);
+            Assert.That(result.IsAny());
+        }
+
+        [Test]
+        public void WildcardMinor_VersionOnlyHasMajor()
+        {
+            var converter = new JsonAvcToKspVersion();
+            string json = @"{""MAJOR"":1, ""MINOR"":-1, ""PATCH"":-1}";
+            var reader = new JsonTextReader(new StringReader(json));
+            var result = (KSPVersion) converter.ReadJson(reader, null, null, null);
+            Assert.That(result, Is.EqualTo(new KSPVersion("1")));
+        }
+        [Test]
+        public void WildcardPatch_VersionOnlyHasMajorMinor()
+        {
+            var converter = new JsonAvcToKspVersion();
+            string json = @"{""MAJOR"":1, ""MINOR"":5, ""PATCH"":-1}";
+            var reader = new JsonTextReader(new StringReader(json));
+            var result = (KSPVersion)converter.ReadJson(reader, null, null, null);
+            Assert.That(result, Is.EqualTo(new KSPVersion("1.5")));
+        }
     }
 }
-


### PR DESCRIPTION
Thanks to Tivec for reporting and Blu3wolf for diagnosing the issue. 