### PR TITLE
Add in new custom field for kerbalstuff mods.

### DIFF
--- a/Netkan/KS/KSMod.cs
+++ b/Netkan/KS/KSMod.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using log4net;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 [assembly: InternalsVisibleTo("CKAN.Tests")]
@@ -22,6 +23,8 @@ namespace CKAN.NetKAN
         public KSVersion[] versions;
         public Uri website;
         public int default_version_id;
+        [JsonConverter(typeof(KSVersion.JsonConvertFromRelativeKsUri))]
+        public Uri background;
 
         public override string ToString()
         {
@@ -73,6 +76,7 @@ namespace CKAN.NetKAN
 
             Inflate(metadata, "download", version.download_path.OriginalString);
             Inflate(metadata, "x_generated_by", "netkan");
+            if(background!=null) Inflate(metadata, "x_screenshot", Escape(background));
             Inflate(metadata, "download_size", download_size);
 
             if (website != null)

--- a/Netkan/KS/KSVersion.cs
+++ b/Netkan/KS/KSVersion.cs
@@ -32,13 +32,16 @@ namespace CKAN.NetKAN
         /// <summary>
         /// A simple helper class to prepend KerbalStuff URLs.
         /// </summary>
-        private class JsonConvertFromRelativeKsUri : JsonConverter
+        internal class JsonConvertFromRelativeKsUri : JsonConverter
         {
             public override object ReadJson(
                 JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer
             )
             {
-                return KSAPI.ExpandPath(reader.Value.ToString());
+                if(reader.Value!=null)
+                    return KSAPI.ExpandPath(reader.Value.ToString());
+                return null;
+
             }
 
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)


### PR DESCRIPTION
"x_screenshot" contains a url to a screenshot used as a icon on kerbalstuff.
A user on IRC requested a field in which mods can have a screenshot. A number of KS mods have such a screenshot accessible via the API so I thought this might encourage use of it.