### PR TITLE
Change toLongMin and toLongMax to return new copies.

### DIFF
--- a/Core/Types/KSPVersion.cs
+++ b/Core/Types/KSPVersion.cs
@@ -3,43 +3,44 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
-namespace CKAN {
-    [JsonConverter(typeof(JsonSimpleStringConverter))]
+namespace CKAN
+{
+    [JsonConverter(typeof (JsonSimpleStringConverter))]
     public class KSPVersion : IComparable<KSPVersion>
     {
-        private string version;
-        private Version cachedVersionObject;
-        private bool is_short;        
-        private static readonly Dictionary<string, Tuple<string, bool>> NormalCache = new Dictionary<string, Tuple<string, bool>>();        
-        
-        public KSPVersion (string v) {
+        private readonly string version;
+        private Version cached_version_object;
+        private readonly bool is_short;
+
+        private static readonly Dictionary<string, Tuple<string, bool>> NormalCache =
+            new Dictionary<string, Tuple<string, bool>>();
+
+        public KSPVersion(string v)
+        {
             Tuple<string, bool> normalized;
-            
-            if (v!=null && NormalCache.TryGetValue(v, out normalized))
+
+            if (v != null && NormalCache.TryGetValue(v, out normalized))
             {
                 version = normalized.Item1;
-                is_short = version != null && normalized.Item2;                
+                is_short = version != null && normalized.Item2;
             }
             else
             {
                 version = Normalise(v);
                 version = AnyToNull(version);
-                is_short = version != null && Regex.IsMatch(version, @"^\d+\.\d+$");                
+                is_short = version != null && Regex.IsMatch(version, @"^\d+\.\d+$");
                 Validate(); // Throws on error.
                 if (v != null)
                 {
-                    NormalCache.Add(v, new Tuple<string, bool>(version,is_short));
+                    NormalCache.Add(v, new Tuple<string, bool>(version, is_short));
                 }
-                    
             }
-            
-
-
         }
 
         // Casting function
-        public static explicit operator KSPVersion(string v) {
-            return new KSPVersion (v);
+        public static explicit operator KSPVersion(string v)
+        {
+            return new KSPVersion(v);
         }
 
         /// <summary>
@@ -63,25 +64,21 @@ namespace CKAN {
         }
 
         // 0.25 -> 0.25.0
-        public void ToLongMin() {
-            if (IsShortVersion()) {
-                version = version + ".0";
-            }
-            is_short = false;
+        public KSPVersion ToLongMin()
+        {
+            return IsShortVersion() ? new KSPVersion(version + ".0") : this;
         }
 
         // 0.25 -> 0.25.99
-        public void ToLongMax() {
-            if (IsShortVersion ()) {
-                version = version + ".99"; // Ugh, magic number.
-            }
-            is_short = false;
+        public KSPVersion ToLongMax()
+        {
+            return IsShortVersion() ? new KSPVersion(version + ".99") : this;
         }
 
         // True for short version (eg: 0.25), false for long (eg: 0.25.2).
         public bool IsShortVersion()
         {
-            return is_short;            
+            return is_short;
         }
 
         public bool IsLongVersion()
@@ -89,15 +86,18 @@ namespace CKAN {
             return !is_short;
         }
 
-        public bool IsAny() {
+        public bool IsAny()
+        {
             return version == null;
         }
 
-        public bool IsNotAny() {
-            return ! IsAny ();
+        public bool IsNotAny()
+        {
+            return !IsAny();
         }
 
-        public string Version() {
+        public string Version()
+        {
             return version;
         }
 
@@ -105,11 +105,12 @@ namespace CKAN {
         // us with long versions.
         private Version VersionObject()
         {
-            return cachedVersionObject ?? (cachedVersionObject = new Version(version));
+            return cached_version_object ?? (cached_version_object = new Version(version));
         }
 
-        private static readonly Dictionary<Tuple<KSPVersion, KSPVersion>,int> CompareCache 
-            = new Dictionary<Tuple<KSPVersion, KSPVersion>,int>();
+        private static readonly Dictionary<Tuple<KSPVersion, KSPVersion>, int> CompareCache
+            = new Dictionary<Tuple<KSPVersion, KSPVersion>, int>();
+
         public int CompareTo(KSPVersion that)
         {
             int ret;
@@ -119,8 +120,9 @@ namespace CKAN {
 
 
             // We need two long versions to be able to compare properly.
-            if ((! IsLongVersion ()) && (! that.IsLongVersion ())) {
-                throw new KSPVersionIncomparableException (this, that, "CompareTo");
+            if ((!IsLongVersion()) && (!that.IsLongVersion()))
+            {
+                throw new KSPVersionIncomparableException(this, that, "CompareTo");
             }
 
             // Hooray, we can hook the regular Version code here.
@@ -128,79 +130,88 @@ namespace CKAN {
             Version v1 = VersionObject();
             Version v2 = that.VersionObject();
             ret = v1.CompareTo(v2);
-            CompareCache.Add(tuple,ret);
+            CompareCache.Add(tuple, ret);
             return ret;
-
         }
 
         // Returns true if this targets that version of KSP.
         // That must be a long (actual) version.
         // Eg: 0.25 targets 0.25.2
 
-        public bool Targets(KSPVersion that) {
-
+        public bool Targets(KSPVersion that)
+        {
             // Cry if we're not looking at a long version to compare to.
-            if (! that.IsLongVersion()) {
-                throw new KSPVersionIncomparableException (this, that, "Targets");
+            if (!that.IsLongVersion())
+            {
+                throw new KSPVersionIncomparableException(this, that, "Targets");
             }
 
             // If we target any, then yes, it's a match.
-            if (IsAny()) {
+            if (IsAny())
+            {
                 return true;
-            } else if (IsLongVersion()) {
-                return CompareTo (that) == 0;
+            }
+            else if (IsLongVersion())
+            {
+                return CompareTo(that) == 0;
             }
 
             // We've got a short version, so split it into two separate versions,
             // and compare each.
 
-            KSPVersion min = new KSPVersion (Version());
-            min.ToLongMin ();
+            KSPVersion min = ToLongMin();
 
-            KSPVersion max = new KSPVersion (Version());
-            max.ToLongMax ();
+            KSPVersion max = ToLongMax();
 
             return (that >= min && that <= max);
-
         }
 
         // "any" -> null
-        private static string AnyToNull(string v) {
-            if (v != null && v == "any") {
+        private static string AnyToNull(string v)
+        {
+            if (v != null && v == "any")
+            {
                 return null;
             }
             return v;
         }
 
         // Throws on error.
-        private void Validate() {
-            if (version == null || IsShortVersion() || IsLongVersion()) {
+        private void Validate()
+        {
+            if (version == null || IsShortVersion() || IsLongVersion())
+            {
                 return;
             }
-            throw new BadKSPVersionException (version);
+            throw new BadKSPVersionException(version);
         }
 
         // Why don't I get operator overloads for free?
         // Is there a class I can delcare allegiance to that gives me this?
         // Where's my ComparableOperators role?
 
-        public static bool operator <(KSPVersion v1, KSPVersion v2) {
+        public static bool operator <(KSPVersion v1, KSPVersion v2)
+        {
             return v1.CompareTo(v2) < 0;
         }
 
-        public static bool operator <=(KSPVersion v1, KSPVersion v2) {
-            return v1.CompareTo (v2) <= 0;
+        public static bool operator <=(KSPVersion v1, KSPVersion v2)
+        {
+            return v1.CompareTo(v2) <= 0;
         }
 
-        public static bool operator >(KSPVersion v1, KSPVersion v2) {
-            return v1.CompareTo (v2) > 0;
+        public static bool operator >(KSPVersion v1, KSPVersion v2)
+        {
+            return v1.CompareTo(v2) > 0;
         }
 
-        public static bool operator >=(KSPVersion v1, KSPVersion v2) {
-            return v1.CompareTo (v2) >= 0;
+        public static bool operator >=(KSPVersion v1, KSPVersion v2)
+        {
+            return v1.CompareTo(v2) >= 0;
         }
 
-        public override string ToString () {
+        public override string ToString()
+        {
             return Version();
         }
 
@@ -223,34 +234,38 @@ namespace CKAN {
         }
     }
 
-    public class BadKSPVersionException : Exception {
-        private string version;
+    public class BadKSPVersionException : Exception
+    {
+        private readonly string version;
 
-        public BadKSPVersionException(string v) {
+        public BadKSPVersionException(string v)
+        {
             version = v;
         }
 
-        public override string ToString ()
+        public override string ToString()
         {
-            return string.Format ("[BadKSPVersionException] {0} is not a valid KSP version", version);
+            return string.Format("[BadKSPVersionException] {0} is not a valid KSP version", version);
         }
     }
 
-    public class KSPVersionIncomparableException : Exception {
-        private string version1;
-        private string version2;
-        private string method;
+    public class KSPVersionIncomparableException : Exception
+    {
+        private readonly string version1;
+        private readonly string version2;
+        private readonly string method;
 
-        public KSPVersionIncomparableException(KSPVersion v1, KSPVersion v2, string m) {
+        public KSPVersionIncomparableException(KSPVersion v1, KSPVersion v2, string m)
+        {
             version1 = v1.Version();
             version2 = v2.Version();
-            method    = m;
+            method = m;
         }
 
-        public override string ToString ()
+        public override string ToString()
         {
-            return string.Format ("[KSPVersionIncomparableException] {0} and {1} cannot be compared by {2}", version1, version2, method);
+            return string.Format("[KSPVersionIncomparableException] {0} and {1} cannot be compared by {2}", version1,
+                version2, method);
         }
     }
 }
-

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -13,7 +13,7 @@ namespace CKAN
     {
         public string max_version;
         public string min_version;
-        //Why is the identifier called name? 
+        //Why is the identifier called name?
         public /* required */ string name;
         public string version;
     }
@@ -142,7 +142,7 @@ namespace CKAN
             }
             else
             {
-                ksp_version_min.ToLongMin();
+                ksp_version_min = ksp_version_min.ToLongMin();
             }
 
             if (ksp_version_max == null)
@@ -151,7 +151,7 @@ namespace CKAN
             }
             else
             {
-                ksp_version_max.ToLongMax();
+                ksp_version_max = ksp_version_max.ToLongMax();
             }
 
             if (ksp_version == null)

--- a/Tests/Core/Types/KSPVersion.cs
+++ b/Tests/Core/Types/KSPVersion.cs
@@ -20,8 +20,8 @@ namespace Tests.Core.Types
             var min = new CKAN.KSPVersion("0.23");
             var max = new CKAN.KSPVersion("0.23");
 
-            min.ToLongMin();
-            max.ToLongMax();
+            min = min.ToLongMin();
+            max = max.ToLongMax();
 
             Assert.IsTrue(min.Version() == "0.23.0");
             Assert.IsTrue(max.Version() == "0.23.99"); // Ugh, magic version number.


### PR DESCRIPTION
Mutating the existing copy will change its hashcode which is not permissible when it is used in a key or a dictionary.