### PR TITLE
More robust cURL CA bundle file resolution

### DIFF
--- a/Netkan/Web.cs
+++ b/Netkan/Web.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using CurlSharp;
 using log4net;
@@ -22,22 +24,12 @@ namespace CKAN.NetKAN
                 CurlSharp.Curl.GlobalInit(CurlInitFlag.All);
                 init_complete = true;
             }
-            var curl_ca_bundle_crt = "./curl-ca-bundle.crt";
-            if (File.Exists(curl_ca_bundle_crt))
+
+            easy = new CurlEasy
             {
-                easy = new CurlEasy
-                {
-                    UserAgent = Net.UserAgentString,
-                    CaInfo = curl_ca_bundle_crt
-                };
-            }
-            else
-            {
-                easy = new CurlEasy
-                {
-                    UserAgent = Net.UserAgentString,
-                };
-            }
+                UserAgent = Net.UserAgentString,
+                CaInfo = ResolveCurlCaBundle()
+            };
         }
 
         /// <summary>
@@ -81,6 +73,43 @@ namespace CKAN.NetKAN
         {
             CurlSharp.Curl.GlobalCleanup();
             easy.Dispose();
+        }
+
+        /// <summary>
+        /// Resolves the location of the cURL CA bundle file to use.
+        /// </summary>
+        /// <returns>The absolute file path to the bundle file or null if none is found.</returns>
+        private static string ResolveCurlCaBundle()
+        {
+            if (Platform.IsWindows)
+            {
+                const string caBundleFileName = "curl-ca-bundle.crt";
+                const string ckanSubDirectoryName = "CKAN";
+
+                return new[]
+                {
+                    // Working Directory
+                    Environment.CurrentDirectory,
+
+                    // Executable Directory
+                    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+
+                    // %LOCALAPPDATA%/CKAN
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ckanSubDirectoryName),
+
+                    // %APPDATA%/CKAN
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ckanSubDirectoryName),
+
+                    // %PROGRAMDATA%/CKAN
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ckanSubDirectoryName),
+                }
+                .Select(i => Path.Combine(i, caBundleFileName))
+                .FirstOrDefault(File.Exists);
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/Netkan/Web.cs
+++ b/Netkan/Web.cs
@@ -81,35 +81,32 @@ namespace CKAN.NetKAN
         /// <returns>The absolute file path to the bundle file or null if none is found.</returns>
         private static string ResolveCurlCaBundle()
         {
-            if (Platform.IsWindows)
+            const string caBundleFileName = "curl-ca-bundle.crt";
+            const string ckanSubDirectoryName = "CKAN";
+
+            string bundle = new[]
             {
-                const string caBundleFileName = "curl-ca-bundle.crt";
-                const string ckanSubDirectoryName = "CKAN";
+                // Working Directory
+                Environment.CurrentDirectory,
 
-                return new[]
-                {
-                    // Working Directory
-                    Environment.CurrentDirectory,
+                // Executable Directory
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
 
-                    // Executable Directory
-                    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                // %LOCALAPPDATA%/CKAN
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ckanSubDirectoryName),
 
-                    // %LOCALAPPDATA%/CKAN
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ckanSubDirectoryName),
+                // %APPDATA%/CKAN
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ckanSubDirectoryName),
 
-                    // %APPDATA%/CKAN
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ckanSubDirectoryName),
-
-                    // %PROGRAMDATA%/CKAN
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ckanSubDirectoryName),
-                }
-                .Select(i => Path.Combine(i, caBundleFileName))
-                .FirstOrDefault(File.Exists);
+                // %PROGRAMDATA%/CKAN
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ckanSubDirectoryName),
             }
-            else
-            {
-                return null;
-            }
+            .Select(i => Path.Combine(i, caBundleFileName))
+            .FirstOrDefault(File.Exists);
+
+            log.InfoFormat("Using curl-ca bundle: {0}",bundle ?? "(none)");
+
+            return bundle;
         }
     }
 }


### PR DESCRIPTION
Currently the cURL bundle file is only used if it exists in the current working directory, which isn't very convenient. This change makes it so that NetKAN will search a list of directories for the file and use the first one found. Specifically it will use in preference:

- Working Directory
- Executable Directory (wherever `netkan.exe` exists)
- `%LOCALAPPDATA%/CKAN`, which on a typical system will correspond to `C:\Users\User\AppData\Local\CKAN`
- `%APPDATA%/CKAN`, which on a typical system will correspond to `C:\Users\User\AppData\Roaming\CKAN`
- `%PROGRAMDATA%/CKAN`, which on a typical system will correspond to `C:\ProgramData\CKAN`

Basically, the more "local" the file is, the higher priority it has. I'm not entirely keen on including the working directory in the search path, but didn't want to change existing behavior. 