### PR TITLE
Have travis send information to #ckan-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,11 @@ deploy:
     #  on:
     #    repo: KSP-CKAN/CKAN
     #    all_branches: true
+notifications:
+  irc:
+	channels:
+      - "irc.esper.net#ckan-ci"
+    template:
+      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+      - "Change view : %{compare_url}"
+      - "Build details : %{build_url}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,6 @@ notifications:
 	channels:
       - "irc.esper.net#ckan-ci"
     template:
-      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+      - "%{repository_name}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
       - "Change view : %{compare_url}"
       - "Build details : %{build_url}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ deploy:
     #    all_branches: true
 notifications:
   irc:
-	channels:
+    channels:
       - "irc.esper.net#ckan-ci"
     template:
       - "%{repository_name}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"


### PR DESCRIPTION
I like that Jenkins sends information on builds to #ckan-jenkins and think it's awesome because I like getting spammed. I think Travis should do the same thing but to #ckan-ci instead so we don't have poor Travis hang out in hostile Jenkins territory. At a later time it might be advisable to move Jenkins into #ckan-ci aswell as to centralize information. That's a problem for another day though!

As for what I did, I basically copied the proposed things from http://docs.travis-ci.com/user/notifications/#IRC-notification and added the right irc channel. I think (hope) that's all there is to it. The template might be increadibly overkill but I grabbed the default one thinking it's probably default for a reason.