### PR TITLE
Persist column sorting settings

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -14,6 +14,10 @@ namespace CKAN
         public bool CheckForUpdatesOnLaunch = false;
         public bool CheckForUpdatesOnLaunchNoNag = false;
 
+        // Sort by the mod name (index = 2) column by default
+        public int sortByColumnIndex = 2;
+        public bool sortDescending = false;
+
         private string m_Path = "";
         private Point m_window_loc = new Point(0,0);
         //Workaround for bug which miss-sets the window location.

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -15,8 +15,8 @@ namespace CKAN
         public bool CheckForUpdatesOnLaunchNoNag = false;
 
         // Sort by the mod name (index = 2) column by default
-        public int sortByColumnIndex = 2;
-        public bool sortDescending = false;
+        public int SortByColumnIndex = 2;
+        public bool SortDescending = false;
 
         private string m_Path = "";
         private Point m_window_loc = new Point(0,0);

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -506,12 +506,13 @@ namespace CKAN
         private void ModList_HeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)
         {
             var new_sort_column = this.ModList.Columns[e.ColumnIndex];
-            var current_sort_column = this.ModList.Columns[this.sortByColumnIndex];
+            var current_sort_column = this.ModList.Columns[this.m_Configuration.sortByColumnIndex];
             // Reverse the sort order if the current sorting column is clicked again
-            this.sortDescending = new_sort_column == current_sort_column ? !this.sortDescending : false;
+            this.m_Configuration.sortDescending = new_sort_column == current_sort_column ? !this.m_Configuration.sortDescending : false;
             // Reset the glyph
             current_sort_column.HeaderCell.SortGlyphDirection = SortOrder.None;
-            this.sortByColumnIndex = new_sort_column.Index;
+            this.m_Configuration.sortByColumnIndex = new_sort_column.Index;
+            this.m_Configuration.Save();
             this.UpdateFilters(this);
         }
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -506,13 +506,12 @@ namespace CKAN
         private void ModList_HeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)
         {
             var new_sort_column = this.ModList.Columns[e.ColumnIndex];
-            var current_sort_column = this.ModList.Columns[this.m_Configuration.sortByColumnIndex];
+            var current_sort_column = this.ModList.Columns[this.m_Configuration.SortByColumnIndex];
             // Reverse the sort order if the current sorting column is clicked again
-            this.m_Configuration.sortDescending = new_sort_column == current_sort_column ? !this.m_Configuration.sortDescending : false;
+            this.m_Configuration.SortDescending = new_sort_column == current_sort_column ? !this.m_Configuration.SortDescending : false;
             // Reset the glyph
             current_sort_column.HeaderCell.SortGlyphDirection = SortOrder.None;
-            this.m_Configuration.sortByColumnIndex = new_sort_column.Index;
-            this.m_Configuration.Save();
+            this.m_Configuration.SortByColumnIndex = new_sort_column.Index;
             this.UpdateFilters(this);
         }
 

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -20,10 +20,10 @@ namespace CKAN
             Func<DataGridViewRow, string> sort_fn;
 
             // XXX: There should be a better way to identify checkbox columns than hardcoding their indices here
-            if (this.m_Configuration.sortByColumnIndex < 2)
+            if (this.m_Configuration.SortByColumnIndex < 2)
             {
                 sort_fn = new Func<DataGridViewRow, string>(row => {
-                    var cell = row.Cells[this.m_Configuration.sortByColumnIndex];
+                    var cell = row.Cells[this.m_Configuration.SortByColumnIndex];
                     if (cell.ValueType == typeof(bool)) {
                         return (bool)cell.Value ? "a" : "b";
                     }
@@ -33,12 +33,12 @@ namespace CKAN
             }
             else
             {
-                sort_fn = new Func<DataGridViewRow, string>(row => row.Cells[this.m_Configuration.sortByColumnIndex].Value.ToString());
+                sort_fn = new Func<DataGridViewRow, string>(row => row.Cells[this.m_Configuration.SortByColumnIndex].Value.ToString());
             }
             // Update the column sort glyph
-            this.ModList.Columns[this.m_Configuration.sortByColumnIndex].HeaderCell.SortGlyphDirection = this.m_Configuration.sortDescending ? SortOrder.Descending : SortOrder.Ascending;
+            this.ModList.Columns[this.m_Configuration.SortByColumnIndex].HeaderCell.SortGlyphDirection = this.m_Configuration.SortDescending ? SortOrder.Descending : SortOrder.Ascending;
             // The columns will be sorted by mod name in addition to whatever the current sorting column is
-            if (this.m_Configuration.sortDescending)
+            if (this.m_Configuration.SortDescending)
             {
                 return rows.OrderByDescending(sort_fn).ThenBy(get_row_mod_name);
             }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -86,8 +86,6 @@ namespace CKAN
                     ModList.CurrentCell = selected_row.Cells[scroll_col];
                 }
             }
-
-            ModList.Select();
         }
 
         private void UpdateModsList(Boolean repo_updated = false)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -9,10 +9,6 @@ namespace CKAN
 {
     public partial class Main
     {
-        // Sort by the mod name (index = 2) column by default
-        private int sortByColumnIndex = 2;
-        private bool sortDescending = false;
-
         private void UpdateFilters(Main control)
         {
             Util.Invoke(control, _UpdateFilters);
@@ -24,10 +20,10 @@ namespace CKAN
             Func<DataGridViewRow, string> sort_fn;
 
             // XXX: There should be a better way to identify checkbox columns than hardcoding their indices here
-            if (this.sortByColumnIndex < 2)
+            if (this.m_Configuration.sortByColumnIndex < 2)
             {
                 sort_fn = new Func<DataGridViewRow, string>(row => {
-                    var cell = row.Cells[this.sortByColumnIndex];
+                    var cell = row.Cells[this.m_Configuration.sortByColumnIndex];
                     if (cell.ValueType == typeof(bool)) {
                         return (bool)cell.Value ? "a" : "b";
                     }
@@ -37,12 +33,12 @@ namespace CKAN
             }
             else
             {
-                sort_fn = new Func<DataGridViewRow, string>(row => row.Cells[this.sortByColumnIndex].Value.ToString());
+                sort_fn = new Func<DataGridViewRow, string>(row => row.Cells[this.m_Configuration.sortByColumnIndex].Value.ToString());
             }
             // Update the column sort glyph
-            this.ModList.Columns[this.sortByColumnIndex].HeaderCell.SortGlyphDirection = this.sortDescending ? SortOrder.Descending : SortOrder.Ascending;
+            this.ModList.Columns[this.m_Configuration.sortByColumnIndex].HeaderCell.SortGlyphDirection = this.m_Configuration.sortDescending ? SortOrder.Descending : SortOrder.Ascending;
             // The columns will be sorted by mod name in addition to whatever the current sorting column is
-            if (this.sortDescending)
+            if (this.m_Configuration.sortDescending)
             {
                 return rows.OrderByDescending(sort_fn).ThenBy(get_row_mod_name);
             }


### PR DESCRIPTION
Saves settings for the column sorting. Tested on Windows and mono.