### PR TITLE
Fix edge case in version numbering.

### DIFF
--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -73,12 +73,12 @@ namespace CKAN {
         /// Returns +1 if this is greater than that
         /// Returns  0 if equal.
         /// </summary>
-        public int CompareTo(Version that) {            
+        public int CompareTo(Version that) {
 
-            if (that.epoch == epoch && that.version == version) {
+            if (that.epoch == epoch && that.version.Equals(version)) {
                 return 0;
             }
- 
+
             // Compare epochs first.
             if (epoch != that.epoch) {
                 return epoch > that.epoch ?1:-1;
@@ -123,10 +123,17 @@ namespace CKAN {
             }
 
             // Oh, we've run out of one or both strings.
-            // They *can't* be equal, because we would have detected that in our first test.
-            // So, whichever version is empty first is the smallest. (1.2 < 1.2.3)
+
 
             if (comp.remainder1.Length == 0) {
+                if (comp.remainder2.Length == 0)
+                {
+                    cache.Add(tuple, 0);
+                    return 0;
+                }
+
+                // They *can't* be equal, because we would have detected that in our first test.
+                // So, whichever version is empty first is the smallest. (1.2 < 1.2.3)
                 cache.Add(tuple, -1);
                 return -1;
             }
@@ -150,7 +157,7 @@ namespace CKAN {
         /// <summary>
         /// Compare the leading non-numerical parts of two strings
         /// </summary>
-       
+
         internal static Comparison StringComp(string v1, string v2)
         {
             var comp = new Comparison {remainder1 = "", remainder2 = ""};
@@ -265,7 +272,7 @@ namespace CKAN {
         }
 
         override public string ToString()
-        {            
+        {
             return AutodetectedDllString;
         }
     }

--- a/Tests/Core/Types/Version.cs
+++ b/Tests/Core/Types/Version.cs
@@ -29,6 +29,16 @@ namespace Tests.Core.Types
         }
 
         [Test]
+        public void Issue1076()
+        {
+            var v0 = new CKAN.Version("1.01");
+            var v1 = new CKAN.Version("1.1");
+
+            Assert.That(v1.IsEqualTo(v0));
+        }
+
+
+        [Test]
         public void Complex()
         {
             var v1 = new CKAN.Version("v6a12");
@@ -99,7 +109,7 @@ namespace Tests.Core.Types
 
             str = CKAN.Version.StringComp("foobaz", "foobar");
 
-            Assert.That(str.compare_to, Is.GreaterThan(0));            
+            Assert.That(str.compare_to, Is.GreaterThan(0));
             Assert.AreEqual("", str.remainder1);
             Assert.AreEqual("", str.remainder2);
 
@@ -226,6 +236,12 @@ namespace Tests.Core.Types
             Assert.That(str.compare_to,Is.LessThan(0));
             Assert.AreEqual(".2", str.remainder1);
             Assert.AreEqual(".0", str.remainder2);
+
+            str = CKAN.Version.NumComp("01", "1");
+
+            Assert.That(str.compare_to, Is.EqualTo(0));
+            Assert.AreEqual("", str.remainder1);
+            Assert.AreEqual("", str.remainder2);
         }
 
     }


### PR DESCRIPTION
By the spec 1.01 should equal 1.1 while the code had them non-equal with the order depending on which was called first. Closes #1076.