### PR TITLE
Have travis upload "nightly" artefacts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,36 +23,41 @@ script:
     - nunit-console --exclude=FlakyNetwork build/Tests/bin/Debug/CKAN.Tests.dll
     - prove  # Run all the tests in t/
 
+before_deploy:
+    # S3 doesn't support file for some reason, so we have to put things in
+    # a directory
+    - mkdir uploads
+    - cp *.exe uploads
+
 deploy:
-    provider: releases
-    api_key:
+    # Releases (which are tagged) go to github
+    - provider: releases
+      api_key:
         secure: AjwbRLStNJZb9hAOLfRLK85KlFo2q2Dr1NKCoDS4elek1nqSiOjL1hH0kDgUMx/PJqQVnFU8tbJPL30t9Pj7jcJhp0LhbbPipQE3TCSpafTneSEbdz5HT+OdghWCZhUhfs07wGNTFUwcAO4WBZ7wv1AnfdfogHdA5RMdykiIl38=
-    file:
+      file:
         - ckan.exe
-    on:
+      on:
         repo: KSP-CKAN/CKAN
         tags: true
-        mono: 3.10.0
+        condition: $(mono --version | perl -ne'/version (\S+)/ and print $1') = 3.10.0
         # all_branches needed as a workaround for travis-ci#1675
         all_branches: true
 
     # Any merge to master gets sent to
     # http://ckan-travis.s3-website-us-east-1.amazonaws.com/
-    # 
-    # At least, they used to... Travis seems grumpy if we have
-    # more than one deploy stanza, and we want releases more.
-    #
-    # - provider: s3
-    #   access_key_id: AKIAI5JWAEFPFK6GH3XA
-    #   secret_access_key:
-    #     secure: b0PPlD7auqysK2LHA8N1US03dE/VKH2rOTwIqpIh50l/gURuXEl7Nd8S7qlf2dpEmz+8D5pIWD+J9scfrdD8Uuakhi3sQbqcV26UiR6+Ye06eGQfmIzqzAECt2naqEy7VJ/xrqq5aaaf8QhcOQMba3qVvwDSzkB2fJeh7+D6EY8=
-    #   bucket: ckan-travis
-    #  local-dir: uploads
-    #   acl: public_read
-    #  skip_cleanup: true
-    #  on:
-    #    repo: KSP-CKAN/CKAN
-    #    all_branches: true
+    - provider: s3
+      access_key_id: AKIAI5JWAEFPFK6GH3XA
+      secret_access_key:
+        secure: b0PPlD7auqysK2LHA8N1US03dE/VKH2rOTwIqpIh50l/gURuXEl7Nd8S7qlf2dpEmz+8D5pIWD+J9scfrdD8Uuakhi3sQbqcV26UiR6+Ye06eGQfmIzqzAECt2naqEy7VJ/xrqq5aaaf8QhcOQMba3qVvwDSzkB2fJeh7+D6EY8=
+      bucket: ckan-travis
+      acl: public_read
+      skip_cleanup: true
+      local_dir: uploads
+      on:
+        repo: KSP-CKAN/CKAN
+        branch: master
+        condition: $(mono --version | perl -ne'/version (\S+)/ and print $1') = 3.10.0
+        
 notifications:
   irc:
     channels:


### PR DESCRIPTION
- Fixes a bug where we'd try to upload artefacts multiple times (now
  only the 3.10.0 artefacts are uploaded).
- Uploads `netkan.exe` and `ckan.exe` from any code that's been merged
  into master.
- Kinda lazy because it's using pjf's bucket rather than KSP-CKAN's
  bucket.
- Kinda lazy because it doesn't upload versioned artefacts.
- https://ckan-travis.s3.amazonaws.com/ckan.exe and
  https://ckan-travis.s3.amazonaws.com//netkan.exe will always be the
  latest artefacts from master.
- Example successful run can be found at https://travis-ci.org/KSP-CKAN/CKAN/jobs/65685362