### PR TITLE
Target platform v4 (aka .NET 4.5) when building

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2186,6 +2186,7 @@ my @cmd = (
     "mono",
     $REPACK,
     "--out:ckan.exe",
+    "--targetplatform=v4",
     "--lib:build/Cmdline/bin/$TARGET",
     "build/Cmdline/bin/$TARGET/CmdLine.exe",
     glob("build/Cmdline/bin/$TARGET/*.dll"),

--- a/bin/build.lean
+++ b/bin/build.lean
@@ -73,6 +73,7 @@ my @cmd = (
     "mono",
     $REPACK,
     "--out:ckan.exe",
+    "--targetplatform=v4",
     "--lib:build/Cmdline/bin/$TARGET",
     "build/Cmdline/bin/$TARGET/CmdLine.exe",
     glob("build/Cmdline/bin/$TARGET/*.dll"),


### PR DESCRIPTION
Closes #1074.

I don't have a good way to test this work as intended, but can confirm it doesn't cause any issues under mono.

@RichardLake, did you say you had a test machine?