### PR TITLE
Friendly Mod Export 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+packages/
 CKAN/*/bin
 CKAN/*/obj
 Tests/bin

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -117,7 +117,7 @@ namespace CKAN.CmdLine
             return Exit.OK;
         }
 
-        private ExportFileType? GetExportFileType(string export)
+        private static ExportFileType? GetExportFileType(string export)
         {
             export = export.ToLowerInvariant();
 

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -105,29 +105,8 @@ namespace CKAN.CmdLine
             else
             {
                 var stream = Console.OpenStandardOutput();
-
-                switch (exportFileType.Value)
-                {
-                    case ExportFileType.PlainText:
-                        new PlainTextExporter().Export(registry, stream);
-                        break;
-                    case ExportFileType.Markdown:
-                        new MarkdownExporter().Export(registry, stream);
-                        break;
-                    case ExportFileType.BbCode:
-                        new BbCodeExporter().Export(registry, stream);
-                        break;
-                    case ExportFileType.Csv:
-                        new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Comma)
-                            .Export(registry, stream);
-                        break;
-                    case ExportFileType.Tsv:
-                        new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Tab)
-                            .Export(registry, stream);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+                new Exporter(exportFileType.Value).Export(registry, stream);
+                stream.Flush();
             }
 
             if (!(options.porcelain) && exportFileType == null)

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using CKAN.Exporters;
+using CKAN.Types;
 using log4net;
 
 namespace CKAN.CmdLine
@@ -23,7 +26,20 @@ namespace CKAN.CmdLine
 
             Registry registry = RegistryManager.Instance(ksp).registry;
 
-            if (!(options.porcelain))
+
+            ExportFileType? exportFileType = null;
+
+            if (!string.IsNullOrWhiteSpace(options.export))
+            {
+                exportFileType = GetExportFileType(options.export);
+
+                if (exportFileType == null)
+                {
+                    user.RaiseError("Unknown export format: {0}", options.export);
+                }
+            }
+
+            if (!(options.porcelain) && exportFileType == null)
             {
                 user.RaiseMessage("\nKSP found at {0}\n", ksp.GameDir());
                 user.RaiseMessage("KSP Version: {0}\n", ksp.Version());
@@ -31,65 +47,116 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("Installed Modules:\n");
             }
 
-            var installed = new SortedDictionary<string, Version>(registry.Installed());
-
-            foreach (KeyValuePair<string, Version> mod in installed)
+            if (exportFileType == null)
             {
-                Version current_version = mod.Value;
+                var installed = new SortedDictionary<string, Version>(registry.Installed());
 
-                string bullet = "*";
+                foreach (KeyValuePair<string, Version> mod in installed)
+                {
+                    Version current_version = mod.Value;
 
-                if (current_version is ProvidesVersion)
-                {
-                    // Skip virtuals for now.
-                    continue;
-                }
-                else if (current_version is DllVersion)
-                {
-                    // Autodetected dll
-                    bullet = "-";
-                }
-                else
-                {
-                    try
+                    string bullet = "*";
+
+                    if (current_version is ProvidesVersion)
                     {
-                        // Check if upgrades are available, and show appropriately.
-                        CkanModule latest = registry.LatestAvailable(mod.Key, ksp.Version());
+                        // Skip virtuals for now.
+                        continue;
+                    }
+                    else if (current_version is DllVersion)
+                    {
+                        // Autodetected dll
+                        bullet = "-";
+                    }
+                    else
+                    {
+                        try
+                        {
+                            // Check if upgrades are available, and show appropriately.
+                            CkanModule latest = registry.LatestAvailable(mod.Key, ksp.Version());
 
-                        log.InfoFormat("Latest {0} is {1}", mod.Key, latest);
+                            log.InfoFormat("Latest {0} is {1}", mod.Key, latest);
 
-                        if (latest == null)
-                        {
-                            // Not compatible!
-                            bullet = "X";
+                            if (latest == null)
+                            {
+                                // Not compatible!
+                                bullet = "X";
+                            }
+                            else if (latest.version.IsEqualTo(current_version))
+                            {
+                                // Up to date
+                                bullet = "-";
+                            }
+                            else if (latest.version.IsGreaterThan(mod.Value))
+                            {
+                                // Upgradable
+                                bullet = "^";
+                            }
                         }
-                        else if (latest.version.IsEqualTo(current_version))
+                        catch (ModuleNotFoundKraken)
                         {
-                            // Up to date
-                            bullet = "-";
-                        }
-                        else if (latest.version.IsGreaterThan(mod.Value))
-                        {
-                            // Upgradable
-                            bullet = "^";
+                            log.InfoFormat("{0} is installed, but no longer in the registry", mod.Key);
+                            bullet = "?";
                         }
                     }
-                    catch (ModuleNotFoundKraken)
-                    {
-                        log.InfoFormat("{0} is installed, but no longer in the registry", mod.Key);
-                        bullet = "?";
-                    }
-                }
 
-                user.RaiseMessage("{0} {1} {2}", bullet, mod.Key, mod.Value);
+                    user.RaiseMessage("{0} {1} {2}", bullet, mod.Key, mod.Value);
+                }
+            }
+            else
+            {
+                var writer = Console.Out;
+
+                switch (exportFileType.Value)
+                {
+                    case ExportFileType.PlainText:
+                        new PlainTextExporter().Export(registry, writer);
+                        break;
+                    case ExportFileType.Markdown:
+                        new MarkdownExporter().Export(registry, writer);
+                        break;
+                    case ExportFileType.BbCode:
+                        new BbCodeExporter().Export(registry, writer);
+                        break;
+                    case ExportFileType.Csv:
+                        new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Comma)
+                            .Export(registry, writer);
+                        break;
+                    case ExportFileType.Tsv:
+                        new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Tab)
+                            .Export(registry, writer);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
             }
 
-            if (!(options.porcelain))
+            if (!(options.porcelain) && exportFileType == null)
             {
                 user.RaiseMessage("\nLegend: -: Up to date. X: Incompatible. ^: Upgradable. ?: Unknown ");
             }
 
             return Exit.OK;
+        }
+
+        private ExportFileType? GetExportFileType(string export)
+        {
+            export = export.ToLowerInvariant();
+
+            switch (export)
+            {
+                case "text":
+                    return ExportFileType.PlainText;
+                case "markdown":
+                    return ExportFileType.Markdown;
+                case "bbcode":
+                    return ExportFileType.BbCode;
+                case "csv":
+                    return ExportFileType.Csv;
+                case "tsv":
+                    return ExportFileType.Tsv;
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -104,26 +104,26 @@ namespace CKAN.CmdLine
             }
             else
             {
-                var writer = Console.Out;
+                var stream = Console.OpenStandardOutput();
 
                 switch (exportFileType.Value)
                 {
                     case ExportFileType.PlainText:
-                        new PlainTextExporter().Export(registry, writer);
+                        new PlainTextExporter().Export(registry, stream);
                         break;
                     case ExportFileType.Markdown:
-                        new MarkdownExporter().Export(registry, writer);
+                        new MarkdownExporter().Export(registry, stream);
                         break;
                     case ExportFileType.BbCode:
-                        new BbCodeExporter().Export(registry, writer);
+                        new BbCodeExporter().Export(registry, stream);
                         break;
                     case ExportFileType.Csv:
                         new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Comma)
-                            .Export(registry, writer);
+                            .Export(registry, stream);
                         break;
                     case ExportFileType.Tsv:
                         new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Tab)
-                            .Export(registry, writer);
+                            .Export(registry, stream);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -176,6 +176,9 @@ namespace CKAN.CmdLine
     {
         [Option("porcelain", HelpText = "Dump raw list of modules, good for shell scripting")]
         public bool porcelain { get; set; }
+
+        [Option("export", HelpText = "Export list of modules in specified format to stdout")]
+        public string export { get; set; }
     }
 
     internal class VersionOptions : CommonOptions

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Exporters\IExporter.cs" />
+    <Compile Include="Exporters\MarkdownExporter.cs" />
     <Compile Include="Exporters\PlainTextExporter.cs" />
     <Compile Include="Net\AutoUpdate.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -41,6 +41,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exporters\IExporter.cs" />
+    <Compile Include="Exporters\PlainTextExporter.cs" />
     <Compile Include="Net\AutoUpdate.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="KSP.cs" />

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -41,6 +41,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exporters\BbCodeExporter.cs" />
     <Compile Include="Exporters\IExporter.cs" />
     <Compile Include="Exporters\MarkdownExporter.cs" />
     <Compile Include="Exporters\PlainTextExporter.cs" />

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Exporters\BbCodeExporter.cs" />
+    <Compile Include="Exporters\DelimeterSeperatedValueExporter.cs" />
     <Compile Include="Exporters\IExporter.cs" />
     <Compile Include="Exporters\MarkdownExporter.cs" />
     <Compile Include="Exporters\PlainTextExporter.cs" />

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -46,6 +46,7 @@
     <Compile Include="KSP.cs" />
     <Compile Include="ModuleInstaller.cs" />
     <Compile Include="CkanTransaction.cs" />
+    <Compile Include="Types\ExportFileType.cs" />
     <Compile Include="User.cs" />
     <Compile Include="Types\Version.cs" />
     <Compile Include="Types\KSPVersion.cs" />

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="Exporters\BbCodeExporter.cs" />
     <Compile Include="Exporters\DelimeterSeperatedValueExporter.cs" />
+    <Compile Include="Exporters\Exporter.cs" />
     <Compile Include="Exporters\IExporter.cs" />
     <Compile Include="Exporters\MarkdownExporter.cs" />
     <Compile Include="Exporters\PlainTextExporter.cs" />

--- a/Core/Exporters/BbCodeExporter.cs
+++ b/Core/Exporters/BbCodeExporter.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace CKAN.Exporters
+{
+    public sealed class BbCodeExporter : IExporter
+    {
+        public void Export(Registry registry, TextWriter writer)
+        {
+            writer.WriteLine("[LIST]");
+
+            foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+            {
+                writer.WriteLine(@"[*][I]{0}[/I] ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
+            }
+
+            writer.WriteLine("[/LIST]");
+
+            writer.Flush();
+        }
+    }
+}

--- a/Core/Exporters/BbCodeExporter.cs
+++ b/Core/Exporters/BbCodeExporter.cs
@@ -5,18 +5,19 @@ namespace CKAN.Exporters
 {
     public sealed class BbCodeExporter : IExporter
     {
-        public void Export(Registry registry, TextWriter writer)
+        public void Export(Registry registry, Stream stream)
         {
-            writer.WriteLine("[LIST]");
-
-            foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+            using (var writer = new StreamWriter(stream))
             {
-                writer.WriteLine(@"[*][I]{0}[/I] ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
+                writer.WriteLine("[LIST]");
+
+                foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+                {
+                    writer.WriteLine(@"[*][I]{0}[/I] ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
+                }
+
+                writer.WriteLine("[/LIST]");
             }
-
-            writer.WriteLine("[/LIST]");
-
-            writer.Flush();
         }
     }
 }

--- a/Core/Exporters/BbCodeExporter.cs
+++ b/Core/Exporters/BbCodeExporter.cs
@@ -13,7 +13,7 @@ namespace CKAN.Exporters
 
                 foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
                 {
-                    writer.WriteLine(@"[*][I]{0}[/I] ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
+                    writer.WriteLine(@"[*][B]{0}[/B] ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
                 }
 
                 writer.WriteLine("[/LIST]");

--- a/Core/Exporters/DelimeterSeperatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeperatedValueExporter.cs
@@ -27,56 +27,57 @@ namespace CKAN.Exporters
             }
         }
 
-        public void Export(Registry registry, TextWriter writer)
+        public void Export(Registry registry, Stream stream)
         {
-            writer.WriteLine(WritePattern,
-                _delimter,
-                "identifier",
-                "version",
-                "name",
-                "abstract",
-                "description",
-                "author",
-                "kind",
-                "download",
-                "download_size",
-                "ksp_version",
-                "ksp_version_min",
-                "ksp_version_max",
-                "license",
-                "release_status",
-                "repository",
-                "homepage",
-                "bugtracker",
-                "kerbalstuff"
-            );
-
-            foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+            using (var writer = new StreamWriter(stream))
             {
                 writer.WriteLine(WritePattern,
                     _delimter,
-                    mod.Module.identifier,
-                    mod.Module.version,
-                    QuoteIfNecessary(mod.Module.name),
-                    QuoteIfNecessary(mod.Module.@abstract),
-                    QuoteIfNecessary(mod.Module.description),
-                    QuoteIfNecessary(string.Join(";", mod.Module.author)),
-                    QuoteIfNecessary(mod.Module.kind),
-                    WriteUri(mod.Module.download),
-                    mod.Module.download_size,
-                    mod.Module.ksp_version,
-                    mod.Module.ksp_version_min,
-                    mod.Module.ksp_version_max,
-                    mod.Module.license,
-                    mod.Module.release_status,
-                    WriteRepository(mod.Module.resources),
-                    WriteHomepage(mod.Module.resources),
-                    WriteBugtracker(mod.Module.resources),
-                    WriteKerbalStuff(mod.Module.resources)
+                    "identifier",
+                    "version",
+                    "name",
+                    "abstract",
+                    "description",
+                    "author",
+                    "kind",
+                    "download",
+                    "download_size",
+                    "ksp_version",
+                    "ksp_version_min",
+                    "ksp_version_max",
+                    "license",
+                    "release_status",
+                    "repository",
+                    "homepage",
+                    "bugtracker",
+                    "kerbalstuff"
                 );
-            }
 
-            writer.Flush();
+                foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+                {
+                    writer.WriteLine(WritePattern,
+                        _delimter,
+                        mod.Module.identifier,
+                        mod.Module.version,
+                        QuoteIfNecessary(mod.Module.name),
+                        QuoteIfNecessary(mod.Module.@abstract),
+                        QuoteIfNecessary(mod.Module.description),
+                        QuoteIfNecessary(string.Join(";", mod.Module.author)),
+                        QuoteIfNecessary(mod.Module.kind),
+                        WriteUri(mod.Module.download),
+                        mod.Module.download_size,
+                        mod.Module.ksp_version,
+                        mod.Module.ksp_version_min,
+                        mod.Module.ksp_version_max,
+                        mod.Module.license,
+                        mod.Module.release_status,
+                        WriteRepository(mod.Module.resources),
+                        WriteHomepage(mod.Module.resources),
+                        WriteBugtracker(mod.Module.resources),
+                        WriteKerbalStuff(mod.Module.resources)
+                    );
+                }
+            }
         }
 
         private string WriteUri(Uri uri)
@@ -141,5 +142,7 @@ namespace CKAN.Exporters
             Comma,
             Tab
         }
+
+
     }
 }

--- a/Core/Exporters/DelimeterSeperatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeperatedValueExporter.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace CKAN.Exporters
+{
+    public sealed class DelimeterSeperatedValueExporter : IExporter
+    {
+        private const string WritePattern = "{1}{0}{2}{0}{3}{0}{4}{0}{5}" +
+                                            "{0}{6}{0}{7}{0}{8}{0}{9}{0}{10}" +
+                                            "{0}{11}{0}{12}{0}{13}{0}{14}{0}{15}" +
+                                            "{0}{16}{0}{17}{0}{18}";
+        private readonly string _delimter;
+
+        public DelimeterSeperatedValueExporter(Delimter delimter)
+        {
+            switch (delimter)
+            {
+                case Delimter.Comma:
+                    _delimter = ",";
+                    break;
+                case Delimter.Tab:
+                    _delimter = "\t";
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public void Export(Registry registry, TextWriter writer)
+        {
+            writer.WriteLine(WritePattern,
+                _delimter,
+                "identifier",
+                "version",
+                "name",
+                "abstract",
+                "description",
+                "author",
+                "kind",
+                "download",
+                "download_size",
+                "ksp_version",
+                "ksp_version_min",
+                "ksp_version_max",
+                "license",
+                "release_status",
+                "repository",
+                "homepage",
+                "bugtracker",
+                "kerbalstuff"
+            );
+
+            foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+            {
+                writer.WriteLine(WritePattern,
+                    _delimter,
+                    mod.Module.identifier,
+                    mod.Module.version,
+                    QuoteIfNecessary(mod.Module.name),
+                    QuoteIfNecessary(mod.Module.@abstract),
+                    QuoteIfNecessary(mod.Module.description),
+                    QuoteIfNecessary(string.Join(";", mod.Module.author)),
+                    QuoteIfNecessary(mod.Module.kind),
+                    WriteUri(mod.Module.download),
+                    mod.Module.download_size,
+                    mod.Module.ksp_version,
+                    mod.Module.ksp_version_min,
+                    mod.Module.ksp_version_max,
+                    mod.Module.license,
+                    mod.Module.release_status,
+                    WriteRepository(mod.Module.resources),
+                    WriteHomepage(mod.Module.resources),
+                    WriteBugtracker(mod.Module.resources),
+                    WriteKerbalStuff(mod.Module.resources)
+                );
+            }
+
+            writer.Flush();
+        }
+
+        private string WriteUri(Uri uri)
+        {
+            return uri != null ? QuoteIfNecessary(uri.ToString()) : string.Empty;
+        }
+
+        private string WriteRepository(ResourcesDescriptor resources)
+        {
+            if (resources != null && resources.repository != null)
+            {
+                return QuoteIfNecessary(resources.repository.ToString());
+            }
+
+            return string.Empty;
+        }
+
+        private string WriteHomepage(ResourcesDescriptor resources)
+        {
+            if (resources != null && resources.homepage != null)
+            {
+                return QuoteIfNecessary(resources.homepage.ToString());
+            }
+
+            return string.Empty;
+        }
+
+        private string WriteBugtracker(ResourcesDescriptor resources)
+        {
+            if (resources != null && resources.bugtracker != null)
+            {
+                return QuoteIfNecessary(resources.bugtracker.ToString());
+            }
+
+            return string.Empty;
+        }
+
+        private string WriteKerbalStuff(ResourcesDescriptor resources)
+        {
+            if (resources != null && resources.kerbalstuff != null)
+            {
+                return QuoteIfNecessary(resources.kerbalstuff.ToString());
+            }
+
+            return string.Empty;
+        }
+
+        private string QuoteIfNecessary(string value)
+        {
+            if (value != null && value.IndexOf(_delimter, StringComparison.Ordinal) >= 0)
+            {
+                return "\"" + value + "\"";
+            }
+            else
+            {
+                return value;
+            }
+        }
+
+        public enum Delimter
+        {
+            Comma,
+            Tab
+        }
+    }
+}

--- a/Core/Exporters/Exporter.cs
+++ b/Core/Exporters/Exporter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using CKAN.Types;
+
+namespace CKAN.Exporters
+{
+    public sealed class Exporter : IExporter
+    {
+        private readonly IExporter _exporter;
+
+        public Exporter(ExportFileType exportFileType)
+        {
+            switch (exportFileType)
+            {
+                case ExportFileType.PlainText:
+                    _exporter = new PlainTextExporter();
+                    break;
+                case ExportFileType.Markdown:
+                    _exporter = new MarkdownExporter();
+                    break;
+                case ExportFileType.BbCode:
+                    _exporter = new BbCodeExporter();
+                    break;
+                case ExportFileType.Csv:
+                    _exporter = new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Comma);
+                    break;
+                case ExportFileType.Tsv:
+                    _exporter = new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Tab);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public void Export(Registry registry, Stream stream)
+        {
+            _exporter.Export(registry, stream);
+        }
+    }
+}

--- a/Core/Exporters/Exporter.cs
+++ b/Core/Exporters/Exporter.cs
@@ -4,6 +4,14 @@ using CKAN.Types;
 
 namespace CKAN.Exporters
 {
+    /// <summary>
+    /// An implementation of <see cref="IExporter"/> that knows how to export to the different types of
+    /// <see cref="ExportFileType"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ExportFileType.Ckan"/> is currently unhandled as that requires use of the
+    /// <see cref="RegistryManager"/> rather than just the <see cref="Registry"/>.
+    /// </remarks>
     public sealed class Exporter : IExporter
     {
         private readonly IExporter _exporter;

--- a/Core/Exporters/IExporter.cs
+++ b/Core/Exporters/IExporter.cs
@@ -3,15 +3,15 @@
 namespace CKAN.Exporters
 {
     /// <summary>
-    /// Represents an object that can export a list of mods in a machine/human readable text format.
+    /// Represents an object that can export a list of mods in a machine or human readable format.
     /// </summary>
     public interface IExporter
     {
         /// <summary>
-        /// Export the installed mods.
+        /// Export installed mods.
         /// </summary>
         /// <param name="registry">The registry of mods to be exported.</param>
-        /// <param name="writer">The text writer to write the export to.</param>
-        void Export(Registry registry, TextWriter writer);
+        /// <param name="stream">The output stream to be written to.</param>
+        void Export(Registry registry, Stream stream);
     }
 }

--- a/Core/Exporters/IExporter.cs
+++ b/Core/Exporters/IExporter.cs
@@ -3,15 +3,15 @@
 namespace CKAN.Exporters
 {
     /// <summary>
-    /// Represents an object that can 
+    /// Represents an object that can export a list of mods in a machine/human readable text format.
     /// </summary>
     public interface IExporter
     {
         /// <summary>
-        /// 
+        /// Export the installed mods.
         /// </summary>
-        /// <param name="registry"></param>
-        /// <param name="writer"></param>
+        /// <param name="registry">The registry of mods to be exported.</param>
+        /// <param name="writer">The text writer to write the export to.</param>
         void Export(Registry registry, TextWriter writer);
     }
 }

--- a/Core/Exporters/IExporter.cs
+++ b/Core/Exporters/IExporter.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+
+namespace CKAN.Exporters
+{
+    /// <summary>
+    /// Represents an object that can 
+    /// </summary>
+    public interface IExporter
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="registry"></param>
+        /// <param name="writer"></param>
+        void Export(Registry registry, TextWriter writer);
+    }
+}

--- a/Core/Exporters/MarkdownExporter.cs
+++ b/Core/Exporters/MarkdownExporter.cs
@@ -11,7 +11,7 @@ namespace CKAN.Exporters
             {
                 foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
                 {
-                    writer.WriteLine(@"  - **{0}** `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
+                    writer.WriteLine(@"- **{0}** `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
                 }
             }
         }

--- a/Core/Exporters/MarkdownExporter.cs
+++ b/Core/Exporters/MarkdownExporter.cs
@@ -11,7 +11,7 @@ namespace CKAN.Exporters
             {
                 foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
                 {
-                    writer.WriteLine(@"  - *{0}* `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
+                    writer.WriteLine(@"  - **{0}** `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
                 }
             }
         }

--- a/Core/Exporters/MarkdownExporter.cs
+++ b/Core/Exporters/MarkdownExporter.cs
@@ -9,7 +9,7 @@ namespace CKAN.Exporters
         {
             foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
             {
-                writer.WriteLine(@"- *{0}* `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
+                writer.WriteLine(@"  - *{0}* `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
             }
 
             writer.Flush();

--- a/Core/Exporters/MarkdownExporter.cs
+++ b/Core/Exporters/MarkdownExporter.cs
@@ -3,13 +3,13 @@ using System.Linq;
 
 namespace CKAN.Exporters
 {
-    public sealed class PlainTextExporter : IExporter
+    public sealed class MarkdownExporter : IExporter
     {
         public void Export(Registry registry, TextWriter writer)
         {
             foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
             {
-                writer.WriteLine(@"{0} ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
+                writer.WriteLine(@"- *{0}* `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
             }
 
             writer.Flush();

--- a/Core/Exporters/MarkdownExporter.cs
+++ b/Core/Exporters/MarkdownExporter.cs
@@ -5,14 +5,15 @@ namespace CKAN.Exporters
 {
     public sealed class MarkdownExporter : IExporter
     {
-        public void Export(Registry registry, TextWriter writer)
+        public void Export(Registry registry, Stream stream)
         {
-            foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+            using (var writer = new StreamWriter(stream))
             {
-                writer.WriteLine(@"  - *{0}* `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
+                foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+                {
+                    writer.WriteLine(@"  - *{0}* `{1} {2}`", mod.Module.name, mod.identifier, mod.Module.version);
+                }
             }
-
-            writer.Flush();
         }
     }
 }

--- a/Core/Exporters/PlainTextExporter.cs
+++ b/Core/Exporters/PlainTextExporter.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+
+namespace CKAN.Exporters
+{
+    public sealed class PlainTextExporter : IExporter
+    {
+        public void Export(Registry registry, TextWriter writer)
+        {
+            foreach (var mod in registry.InstalledModules)
+            {
+                writer.WriteLine(@"{0} ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
+            }
+
+            writer.Flush();
+        }
+    }
+}

--- a/Core/Exporters/PlainTextExporter.cs
+++ b/Core/Exporters/PlainTextExporter.cs
@@ -5,14 +5,16 @@ namespace CKAN.Exporters
 {
     public sealed class PlainTextExporter : IExporter
     {
-        public void Export(Registry registry, TextWriter writer)
-        {
-            foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
-            {
-                writer.WriteLine(@"{0} ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
-            }
 
-            writer.Flush();
+        public void Export(Registry registry, Stream stream)
+        {
+            using (var writer = new StreamWriter(stream))
+            {
+                foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
+                {
+                    writer.WriteLine(@"{0} ({1} {2})", mod.Module.name, mod.identifier, mod.Module.version);
+                }
+            }
         }
     }
 }

--- a/Core/Types/ExportFileType.cs
+++ b/Core/Types/ExportFileType.cs
@@ -1,0 +1,12 @@
+﻿namespace CKAN.Types
+{
+    public enum ExportFileType
+    {
+        Ckan,
+        PlainText,
+        Markdown,
+        BbCode,
+        Csv,
+        Tsv
+    }
+}

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -77,6 +77,7 @@
     <Compile Include="ChooseKSPInstance.Designer.cs">
       <DependentUpon>ChooseKSPInstance.cs</DependentUpon>
     </Compile>
+    <Compile Include="ExportOption.cs" />
     <Compile Include="IGUIPlugin.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/GUI/ExportOption.cs
+++ b/GUI/ExportOption.cs
@@ -1,0 +1,27 @@
+﻿using CKAN.Types;
+
+namespace CKAN
+{
+    internal sealed class ExportOption
+    {
+        private readonly string _string;
+
+        public ExportFileType ExportFileType { get; private set; }
+        public string FriendlyName { get; private set; }
+        public string Extension { get; private set; }
+
+        public ExportOption(ExportFileType exportFileType, string friendlyName, string extension)
+        {
+            ExportFileType = exportFileType;
+            FriendlyName = friendlyName;
+            Extension = extension;
+
+            _string = string.Format("{0}|{1}", FriendlyName, "*." + Extension);
+        }
+
+        public override string ToString()
+        {
+            return _string;
+        }
+    }
+}

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using CKAN.Exporters;
 using CKAN.Properties;
 using CKAN.Types;
 using log4net;
@@ -945,31 +946,37 @@ namespace CKAN
                 Title = Resources.ExportInstalledModsDialogTitle
             };
 
-            if (dlg.ShowDialog() == DialogResult.OK) {
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                var exportOption = exportOptions[dlg.FilterIndex - 1]; // FilterIndex is 1-indexed
 
-                var exportOption = exportOptions[dlg.FilterIndex];
-
-                switch (exportOption.ExportFileType)
+                using (var writer = new StreamWriter(new FileStream(dlg.FileName, FileMode.OpenOrCreate)))
                 {
-                    case ExportFileType.Ckan:
-                        // Save, just to be certain that the installed-*.ckan metapackage is generated
-                        RegistryManager.Instance(CurrentInstance).Save();
+                    var registry = RegistryManager.Instance(CurrentInstance).registry;
 
-                        // TODO: The core might eventually save as something other than 'installed-default.ckan'
-                        File.Copy(Path.Combine(CurrentInstance.CkanDir(), "installed-default.ckan"), dlg.FileName);
-                        break;
-                    case ExportFileType.PlainText:
-                        break;
-                    case ExportFileType.Markdown:
-                        break;
-                    case ExportFileType.BbCode:
-                        break;
-                    case ExportFileType.Csv:
-                        break;
-                    case ExportFileType.Tsv:
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
+                    switch (exportOption.ExportFileType)
+                    {
+                        case ExportFileType.Ckan:
+                            // Save, just to be certain that the installed-*.ckan metapackage is generated
+                            RegistryManager.Instance(CurrentInstance).Save();
+
+                            // TODO: The core might eventually save as something other than 'installed-default.ckan'
+                            File.Copy(Path.Combine(CurrentInstance.CkanDir(), "installed-default.ckan"), dlg.FileName);
+                            break;
+                        case ExportFileType.PlainText:
+                            new PlainTextExporter().Export(registry, writer);
+                            break;
+                        case ExportFileType.Markdown:
+                            break;
+                        case ExportFileType.BbCode:
+                            break;
+                        case ExportFileType.Csv:
+                            break;
+                        case ExportFileType.Tsv:
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
                 }
             }
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -950,7 +950,9 @@ namespace CKAN
             {
                 var exportOption = exportOptions[dlg.FilterIndex - 1]; // FilterIndex is 1-indexed
 
-                using (var writer = new StreamWriter(new FileStream(dlg.FileName, FileMode.OpenOrCreate)))
+                var fileMode = File.Exists(dlg.FileName) ? FileMode.Truncate : FileMode.CreateNew;
+
+                using (var writer = new StreamWriter(new FileStream(dlg.FileName, fileMode)))
                 {
                     var registry = RegistryManager.Instance(CurrentInstance).registry;
 
@@ -967,6 +969,7 @@ namespace CKAN
                             new PlainTextExporter().Export(registry, writer);
                             break;
                         case ExportFileType.Markdown:
+                            new MarkdownExporter().Export(registry, writer);
                             break;
                         case ExportFileType.BbCode:
                             break;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -952,7 +952,7 @@ namespace CKAN
 
                 var fileMode = File.Exists(dlg.FileName) ? FileMode.Truncate : FileMode.CreateNew;
 
-                using (var writer = new StreamWriter(new FileStream(dlg.FileName, fileMode)))
+                using (var stream = new FileStream(dlg.FileName, fileMode))
                 {
                     var registry = RegistryManager.Instance(CurrentInstance).registry;
 
@@ -966,21 +966,21 @@ namespace CKAN
                             File.Copy(Path.Combine(CurrentInstance.CkanDir(), "installed-default.ckan"), dlg.FileName);
                             break;
                         case ExportFileType.PlainText:
-                            new PlainTextExporter().Export(registry, writer);
+                            new PlainTextExporter().Export(registry, stream);
                             break;
                         case ExportFileType.Markdown:
-                            new MarkdownExporter().Export(registry, writer);
+                            new MarkdownExporter().Export(registry, stream);
                             break;
                         case ExportFileType.BbCode:
-                            new BbCodeExporter().Export(registry, writer);
+                            new BbCodeExporter().Export(registry, stream);
                             break;
                         case ExportFileType.Csv:
                             new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Comma)
-                                .Export(registry, writer);
+                                .Export(registry, stream);
                             break;
                         case ExportFileType.Tsv:
                             new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Tab)
-                                .Export(registry, writer);
+                                .Export(registry, stream);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException();

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using CKAN.Properties;
+using CKAN.Types;
 using log4net;
 using Timer = System.Windows.Forms.Timer;
 
@@ -926,16 +927,50 @@ namespace CKAN
         /// <param name="e"></param>
         private void exportModListToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var dlg = new SaveFileDialog();
-            dlg.Filter = Resources.CKANFileFilter;
-            dlg.Title = Resources.ExportInstalledModsDialogTitle;
+            var exportOptions = new List<ExportOption>
+            {
+                new ExportOption(Types.ExportFileType.Ckan, "CKAN metadata (*.ckan)", "ckan"),
+                new ExportOption(Types.ExportFileType.PlainText, "Plain text (*.txt)", "txt"),
+                new ExportOption(Types.ExportFileType.Markdown, "Markdown (*.md)", "md"),
+                new ExportOption(Types.ExportFileType.BbCode, "BBCode (*.txt)", "txt"),
+                new ExportOption(Types.ExportFileType.Csv, "Comma-seperated values (*.csv)", "csv"),
+                new ExportOption(Types.ExportFileType.Tsv, "Tab-seperated values (*.tsv)", "tsv")
+            };
+
+            var filter = string.Join("|", exportOptions.Select(i => i.ToString()).ToArray());
+
+            var dlg = new SaveFileDialog
+            {
+                Filter = filter,
+                Title = Resources.ExportInstalledModsDialogTitle
+            };
 
             if (dlg.ShowDialog() == DialogResult.OK) {
-                // Save, just to be certain that the installed-*.ckan metapackage is generated
-                RegistryManager.Instance(CurrentInstance).Save();
 
-                // TODO: The core might eventually save as something other than 'installed-default.ckan'
-                File.Copy(Path.Combine(CurrentInstance.CkanDir(), "installed-default.ckan"), dlg.FileName);
+                var exportOption = exportOptions[dlg.FilterIndex];
+
+                switch (exportOption.ExportFileType)
+                {
+                    case ExportFileType.Ckan:
+                        // Save, just to be certain that the installed-*.ckan metapackage is generated
+                        RegistryManager.Instance(CurrentInstance).Save();
+
+                        // TODO: The core might eventually save as something other than 'installed-default.ckan'
+                        File.Copy(Path.Combine(CurrentInstance.CkanDir(), "installed-default.ckan"), dlg.FileName);
+                        break;
+                    case ExportFileType.PlainText:
+                        break;
+                    case ExportFileType.Markdown:
+                        break;
+                    case ExportFileType.BbCode:
+                        break;
+                    case ExportFileType.Csv:
+                        break;
+                    case ExportFileType.Tsv:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
             }
         }
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -975,8 +975,12 @@ namespace CKAN
                             new BbCodeExporter().Export(registry, writer);
                             break;
                         case ExportFileType.Csv:
+                            new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Comma)
+                                .Export(registry, writer);
                             break;
                         case ExportFileType.Tsv:
+                            new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Tab)
+                                .Export(registry, writer);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException();

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -972,6 +972,7 @@ namespace CKAN
                             new MarkdownExporter().Export(registry, writer);
                             break;
                         case ExportFileType.BbCode:
+                            new BbCodeExporter().Export(registry, writer);
                             break;
                         case ExportFileType.Csv:
                             break;


### PR DESCRIPTION
Fixes #1094

Allow CKAN to export the mod list in multiple formats.

- Plain Text
- Markdown
- BBCode
- CSV
- TSV

This is accomplished in the GUI by expanding the "Save as type" option. In the command line an extra option is added to the `list` command, `--export` that will output the list in the specified format (`text`, `markdown`, `bbcode`, `csv`, `tsv`) to stdout. Users can then redirect to a file as appropriate.

The exact format of the "pretty" formats is just what I came up with, suggestions welcome.

Also, I noticed that the `list` command has a `porcelain` option that's used in the [exact opposite sense that git uses that word](http://stackoverflow.com/questions/6976473/what-does-the-term-porcelain-mean-in-git). We should probably change that?






