### PR TITLE
Catch XML parsing error correctly

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -73,9 +73,14 @@ namespace CKAN
                 {
                     configuration = (Configuration) serializer.Deserialize(stream);
                 }
-                catch (System.InvalidOperationException)
+                catch (System.InvalidOperationException e)
                 {
-                    string message = string.Format("Error trying to parse \"{0}\". Try to move it out of the folder and restart CKAN.", path);
+                    string additionalErrorData = "";
+
+                    if (e.InnerException != null)
+                        additionalErrorData = ": " + e.InnerException.Message;
+
+                    string message = string.Format("Error trying to parse \"{0}\"{1}. Try to move it out of the folder and restart CKAN.", path, additionalErrorData);
                     throw new Kraken(message);
                 }
             }

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -73,12 +73,23 @@ namespace CKAN
                 {
                     configuration = (Configuration) serializer.Deserialize(stream);
                 }
-                catch (System.InvalidOperationException e)
+                catch (System.Exception e)
                 {
                     string additionalErrorData = "";
 
-                    if (e.InnerException != null)
-                        additionalErrorData = ": " + e.InnerException.Message;
+                    if(e is System.InvalidOperationException) // Exception thrown in Windows / .NET
+                    {
+                        if(e.InnerException != null)
+                            additionalErrorData = ": " + e.InnerException.Message;
+                    }
+                    else if(e is System.Xml.XmlException) // Exception thrown in Mono
+                    {
+                        additionalErrorData = ": " + e.Message;
+                    }
+                    else
+                    {
+                        throw;
+                    }
 
                     string message = string.Format("Error trying to parse \"{0}\"{1}. Try to move it out of the folder and restart CKAN.", path, additionalErrorData);
                     throw new Kraken(message);

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -73,7 +73,7 @@ namespace CKAN
                 {
                     configuration = (Configuration) serializer.Deserialize(stream);
                 }
-                catch(System.Xml.XmlException)
+                catch (System.InvalidOperationException)
                 {
                     string message = string.Format("Error trying to parse \"{0}\". Try to move it out of the folder and restart CKAN.", path);
                     throw new Kraken(message);

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -362,6 +362,28 @@ namespace Tests.Data
                 File.Copy(file, file.Replace(src, dst));
             }
         }
+
+        public static string ConfigurationFile()
+        {
+            return @"<?xml version=""1.0"" encoding=""utf-8""?>
+            <Configuration xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+              <CommandLineArguments>KSP.exe -force-opengl</CommandLineArguments>
+              <AutoCloseWaitDialog>false</AutoCloseWaitDialog>
+              <URLHandlerNoNag>false</URLHandlerNoNag>
+              <CheckForUpdatesOnLaunch>true</CheckForUpdatesOnLaunch>
+              <CheckForUpdatesOnLaunchNoNag>true</CheckForUpdatesOnLaunchNoNag>
+              <SortByColumnIndex>2</SortByColumnIndex>
+              <SortDescending>false</SortDescending>
+              <WindowSize>
+                <Width>1024</Width>
+                <Height>664</Height>
+              </WindowSize>
+              <WindowLoc>
+                <X>512</X>
+                <Y>136</Y>
+              </WindowLoc>
+            </Configuration>";
+        }
     }
 
     public class RandomModuleGenerator

--- a/Tests/GUI/Configuration.cs
+++ b/Tests/GUI/Configuration.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using CKAN;
+using NUnit.Framework;
+using Tests.Data;
+
+namespace Tests.GUI
+{
+    [TestFixture]
+    public class ConfigurationTests
+    {
+        [Test]
+        public void LoadConfiguration_MalformedXMLFile_ThrowsKraken()
+        {
+            string tempDir = TestData.NewTempDir();
+            string tempFile = Path.Combine(tempDir, "invalid.xml");
+
+            using (var stream = new StreamWriter(tempFile))
+            {
+                stream.Write("This is not a valid XML file.");
+            }
+
+            Assert.Throws<Kraken>(() => Configuration.LoadConfiguration(tempFile));
+        }
+
+        [Test]
+        public void LoadConfiguration_CorrectConfigurationFile_Loaded()
+        {
+            string tempDir = TestData.NewTempDir();
+            string tempFile = Path.Combine(tempDir, "valid.xml");
+
+            using (var stream = new StreamWriter(tempFile))
+            {
+                stream.Write(TestData.ConfigurationFile());
+            }
+
+            var result = Configuration.LoadConfiguration(tempFile);
+
+            Assert.IsNotNull(result);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Data\DisposableKSP.cs" />
     <Compile Include="Data\TestData.cs" />
     <Compile Include="Data\ZipLib.cs" />
+    <Compile Include="GUI\Configuration.cs" />
     <Compile Include="GUI\GUIMod.cs" />
     <Compile Include="GUI\MainModList.cs" />
     <Compile Include="NetKAN\AVC.cs" />
@@ -164,6 +165,9 @@
       <Project>{4336f356-33db-442a-bf74-5e89af47a5b9}</Project>
       <Name>CKAN-netkan</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
   <ProjectExtensions>


### PR DESCRIPTION
When loading a corrupt configuration file, the exception thrown is not caught as (at least in Windows) what gets thrown is an InvalidOperationException, not a XmlException. I've changed it and also added some additional information so the user can try and repair the file, as I think it can be useful.

Greetings and thanks for your hard work with CKAN!