### PR TITLE
gitignore: Don't track .exe.config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ StyleCop.Cache
 ckan.exe
 ks2ckan.exe
 netkan.exe
+*.exe.config
 *.exe.mdb
 .*.swp
 .fatten.out


### PR DESCRIPTION
`ckan.exe.config` and related files are auto-generated, so we should
ignore them when it comes to version control.