### PR TITLE
Relationship Resolver Versions w/Spec changes

### DIFF
--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -39,11 +39,11 @@ namespace CKAN
         }
 
         /// <summary>
-        ///     Return the most recent release of a module.
-        ///     Optionally takes a KSP version number to target.
-        ///     If no KSP version is supplied, we return the latest release of that module for any KSP.
-        ///     Returns null if there are no compatible versions.
+        /// Return the most recent release of a module with a optional ksp version to target and a RelationshipDescriptor to satisfy. 
         /// </summary>
+        /// <param name="ksp_version">If not null only consider mods which match this ksp version.</param>
+        /// <param name="relationship">If not null only consider mods which satisfy the RelationshipDescriptor.</param>
+        /// <returns></returns>
         public CkanModule Latest(KSPVersion ksp_version = null, RelationshipDescriptor relationship=null)
         {            
             var available_versions = new List<Version>(module_version.Keys);

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using log4net;
 using Newtonsoft.Json;
@@ -43,10 +44,10 @@ namespace CKAN
         ///     If no KSP version is supplied, we return the latest release of that module for any KSP.
         ///     Returns null if there are no compatible versions.
         /// </summary>
-        public CkanModule Latest(KSPVersion ksp_version = null)
+        public CkanModule Latest(KSPVersion ksp_version = null, RelationshipDescriptor relationship=null)
         {            
             var available_versions = new List<Version>(module_version.Keys);
-
+            CkanModule module;
             log.DebugFormat("Our dictionary has {0} keys", module_version.Keys.Count);
             log.DebugFormat("Choosing between {0} available versions", available_versions.Count);            
             // Uh oh, nothing available. Maybe this existed once, but not any longer.
@@ -58,26 +59,39 @@ namespace CKAN
             // Sort most recent versions first.            
             available_versions.Reverse();
 
-            if (ksp_version == null)
+            if (ksp_version == null && relationship == null)
             {
-                CkanModule module = module_version[available_versions.First()];
+                module = module_version[available_versions.First()];
 
                 log.DebugFormat("No KSP version restriction, {0} is most recent", module);
                 return module;
             }
-
-            // Time to check if there's anything that we can satisfy.
-
-            foreach (Version v in available_versions.Where(v => module_version[v].IsCompatibleKSP(ksp_version)))
+            if (relationship == null)
             {
-                return module_version[v];
+                // Time to check if there's anything that we can satisfy.
+                var version =
+                    available_versions.FirstOrDefault(v => module_version[v].IsCompatibleKSP(ksp_version));
+                if (version != null)
+                    return module_version[version];
+
+                log.DebugFormat("No version of {0} is compatible with KSP {1}",
+                    module_version[available_versions[0]].identifier, ksp_version);
+
+                return null;
             }
-
-            log.DebugFormat("No version of {0} is compatible with KSP {1}",
-                module_version[available_versions[0]].identifier, ksp_version);
-
-            // Oh noes! Nothing available!
-            return null;
+            if (ksp_version == null)
+            {
+                var version = available_versions.FirstOrDefault(relationship.version_within_bounds);
+                return version == null ? null : module_version[version];
+            }
+            else
+            {                
+                var version = available_versions.FirstOrDefault(v =>
+                    relationship.version_within_bounds(v) &&
+                    module_version[v].IsCompatibleKSP(ksp_version));
+                return version == null ? null : module_version[version];                
+            }
+            
         }
 
         /// <summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -484,7 +484,10 @@ namespace CKAN
          
         // TODO: Consider making this internal, because practically everything should
         // be calling LatestAvailableWithProvides()
-        public CkanModule LatestAvailable(string module, KSPVersion ksp_version)
+        public CkanModule LatestAvailable(
+            string module,
+            KSPVersion ksp_version,
+            RelationshipDescriptor relationship_descriptor =null)
         {
             log.DebugFormat("Finding latest available for {0}", module);
 
@@ -492,7 +495,7 @@ namespace CKAN
 
             try
             {
-                return available_modules[module].Latest(ksp_version);
+                return available_modules[module].Latest(ksp_version,relationship_descriptor);
             }
             catch (KeyNotFoundException)
             {
@@ -500,20 +503,22 @@ namespace CKAN
             }
         }
 
+        
+
         /// <summary>
-        ///     Returns the latest available version of a module that
-        ///     satisifes the specified version. Takes into account module 'provides',
-        ///     which may result in a list of alternatives being provided.
+        ///     Returns the latest available version of a module that satisifes the specified version and 
+        ///     optionally a RelationshipDescriptor. Takes into account module 'provides', which may
+        ///     result in a list of alternatives being provided. 
         ///     Returns an empty list if nothing is available for our system, which includes if no such module exists.
         ///     If no KSP version is provided, the latest module for *any* KSP version is given.
         /// </summary>
-        public List<CkanModule> LatestAvailableWithProvides(string module, KSPVersion ksp_version)
+        public List<CkanModule> LatestAvailableWithProvides(string module, KSPVersion ksp_version, RelationshipDescriptor relationship_descriptor = null)
         {
             // This public interface calcultes a cache of modules which
             // are compatible with the current version of KSP, and then
             // calls the private version below for heavy lifting.
             return LatestAvailableWithProvides(module, ksp_version,
-                available_modules.Values.Where(pair => pair.Latest(ksp_version) != null));
+                available_modules.Values.Where(pair => pair.Latest(ksp_version) != null),relationship_descriptor);
         }
 
         /// <summary>
@@ -523,7 +528,7 @@ namespace CKAN
         /// calculated. Not for direct public consumption. ;)
         /// </summary>
         private List<CkanModule> LatestAvailableWithProvides(string module, KSPVersion ksp_version,
-            IEnumerable<AvailableModule> available_for_current_version)
+            IEnumerable<AvailableModule> available_for_current_version, RelationshipDescriptor relationship_descriptor=null)
         {
             log.DebugFormat("Finding latest available with provides for {0}", module);
 
@@ -534,7 +539,7 @@ namespace CKAN
             try
             {
                 // If we can find the module requested for our KSP, use that.
-                CkanModule mod = LatestAvailable(module, ksp_version);
+                CkanModule mod = LatestAvailable(module, ksp_version, relationship_descriptor);
                 if (mod != null)
                 {
                     modules.Add(mod);

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -234,8 +234,11 @@ namespace CKAN
                     if (descriptor.version_within_bounds(modlist[dep_name].version))
                         continue;
                     //TODO Ideally we could check here if it can be replaced by the version we want.
-                    throw new InconsistentKraken(string.Format("A certain version of {0} is needed. " +
-                                                               "However a incompatible version is in the resolver", dep_name));
+                    throw new InconsistentKraken(
+                        string.Format(
+                            "{0} requires a version {1}. However a incompatible version, {2}, is in the resolver",
+                            dep_name, descriptor.RequiredVersion, modlist[dep_name].version));
+
                 }
 
                 if (registry.IsInstalled(dep_name))
@@ -243,9 +246,10 @@ namespace CKAN
                     if(descriptor.version_within_bounds(registry.InstalledVersion(dep_name)))
                     continue;
                     //TODO Ideally we could check here if it can be replaced by the version we want.
-                    throw new InconsistentKraken(string.Format("A certain version of {0} is needed. " +
-                                                           "However a incompatible version is already installed", dep_name));
-
+                    throw new InconsistentKraken(
+                        string.Format(
+                            "{0} requires a version {1}. However a incompatible version, {2}, is already installed",
+                            dep_name, descriptor.RequiredVersion, modlist[dep_name].version));
                 }
 
                 List<CkanModule> candidates = registry.LatestAvailableWithProvides(dep_name, kspversion, descriptor)

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -46,6 +46,20 @@ namespace CKAN
             }
             return false;
         }
+
+        /// <summary>
+        /// A user friendly message for what versions satisfies this descriptor.
+        /// </summary>
+        [JsonIgnore]
+        public string RequiredVersion {
+            get
+            {
+                if (version != null)
+                    return version.ToString();
+                return $"between {min_version?.ToString() ?? "any version"} and {max_version?.ToString() ?? "any version"} inclusive.";
+            }
+        }
+        
     }
 
     public class ResourcesDescriptor

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -20,6 +20,15 @@ namespace CKAN
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        
         public Version version;
 
+
+        /// <summary>
+        /// Returns if the other version satisfies this RelationshipDescriptor. 
+        /// If the RelationshipDescriptor has version set it compares against that. 
+        /// Else it uses the {min,max}_version fields treating nulls as unbounded. 
+        /// Note: Uses inclusive inequalities. 
+        /// </summary>
+        /// <param name="other_version"></param>
+        /// <returns>True if other_version is within the bounds</returns>
         public bool version_within_bounds(Version other_version)
         {
             if (version == null)

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -19,6 +19,24 @@ namespace CKAN
         public /* required */ string name;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        
         public Version version;
+
+        public bool version_within_bounds(Version other_version)
+        {
+            if (version == null)
+            {
+                if (max_version == null && min_version == null)
+                    return true;
+                bool min_sat = min_version == null || min_version <= other_version;
+                bool max_sat = max_version == null || max_version >= other_version;
+                if (min_sat && max_sat) return true;
+            }
+            else
+            {
+                if (version.Equals(other_version))
+                    return true;
+            }
+            return false;
+        }
     }
 
     public class ResourcesDescriptor

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -15,17 +15,17 @@ namespace CKAN
         public Version max_version;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public Version min_version;
-        //Why is the identifier called name? 
+        //Why is the identifier called name?
         public /* required */ string name;
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public Version version;
 
 
         /// <summary>
-        /// Returns if the other version satisfies this RelationshipDescriptor. 
-        /// If the RelationshipDescriptor has version set it compares against that. 
-        /// Else it uses the {min,max}_version fields treating nulls as unbounded. 
-        /// Note: Uses inclusive inequalities. 
+        /// Returns if the other version satisfies this RelationshipDescriptor.
+        /// If the RelationshipDescriptor has version set it compares against that.
+        /// Else it uses the {min,max}_version fields treating nulls as unbounded.
+        /// Note: Uses inclusive inequalities.
         /// </summary>
         /// <param name="other_version"></param>
         /// <returns>True if other_version is within the bounds</returns>
@@ -56,10 +56,12 @@ namespace CKAN
             {
                 if (version != null)
                     return version.ToString();
-                return $"between {min_version?.ToString() ?? "any version"} and {max_version?.ToString() ?? "any version"} inclusive.";
+                return string.Format("between {0} and {1} inclusive.",
+                    min_version != null ?min_version.ToString() : "any version",
+                    max_version != null ? max_version.ToString() : "any version");
             }
         }
-        
+
     }
 
     public class ResourcesDescriptor
@@ -244,13 +246,7 @@ namespace CKAN
             {
                 return false;
             }
-            foreach (var conflict in mod1.conflicts)
-            {
-                if (!mod2.ProvidesList.Contains(conflict.name))
-                    continue;
-               if(conflict.version_within_bounds(mod2.version)) return true;
-            }
-            return false;
+            return mod1.conflicts.Any(conflict => mod2.ProvidesList.Contains(conflict.name) && conflict.version_within_bounds(mod2.version));
         }
 
         /// <summary>

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -3,19 +3,22 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
 using log4net;
 using Newtonsoft.Json;
-using System.Text.RegularExpressions;
 
 namespace CKAN
 {
     public class RelationshipDescriptor
     {
-        public string max_version;
-        public string min_version;
-        //Why is the identifier called name?
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public Version max_version;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public Version min_version;
+        //Why is the identifier called name? 
         public /* required */ string name;
-        public string version;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]        
+        public Version version;
     }
 
     public class ResourcesDescriptor

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -221,7 +221,13 @@ namespace CKAN
             {
                 return false;
             }
-            return mod1.conflicts.Any(conflict => mod2.ProvidesList.Contains(conflict.name));
+            foreach (var conflict in mod1.conflicts)
+            {
+                if (!mod2.ProvidesList.Contains(conflict.name))
+                    continue;
+               if(conflict.version_within_bounds(mod2.version)) return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -260,6 +260,27 @@ namespace CKAN {
         {
             return CompareTo(other);
         }
+
+        public static bool operator <(Version v1, Version v2)
+        {
+            return v1.CompareTo(v2) < 0;
+        }
+
+        public static bool operator <=(Version v1, Version v2)
+        {
+            return v1.CompareTo(v2) <= 0;
+        }
+
+        public static bool operator >(Version v1, Version v2)
+        {
+            return v1.CompareTo(v2) > 0;
+        }
+
+        public static bool operator >=(Version v1, Version v2)
+        {
+            return v1.CompareTo(v2) >= 0;
+        }
+
     }
 
     /// <summary>

--- a/Spec.md
+++ b/Spec.md
@@ -352,8 +352,10 @@ and identifier:
     ]
 
 Each relationship is an array of entries, each entry *must*
-have a `name`, and the optional fields `min_version`, `max_version`,
-and `version`, to more precisely describe which vesions are needed:
+have a `name`.
+
+The optional fields `min_version`, `max_version`,
+and `version`, may more precisely describe which vesions are needed:
 
     "depends" : [
         { "name" : "ModuleManager",   "min_version" : "2.1.5" },
@@ -363,6 +365,12 @@ and `version`, to more precisely describe which vesions are needed:
 
 It is an error to mix `version` (which specifies an exact vesion) with
 either `min_version` or `max_version` in the same object.
+
+(**v1.0**) Clients implementing versions of the spec older than `v1.8`
+*must* allow for the optional version fields to be present, but *may* choose
+to treat them as if they were absent. (**v1.8**) Clients implementing the
+`v1.8` spec and above *must* respect the optional version fields if
+present.
 
 ##### depends
 

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -8,7 +8,8 @@ using Version = CKAN.Version;
 
 namespace Tests.Core.Relationships
 {
-    [TestFixture] public class RelationshipResolverTests
+    [TestFixture]
+    public class RelationshipResolverTests
     {
         private CKAN.Registry registry;
         private RelationshipResolverOptions options;
@@ -42,13 +43,13 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule();
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier}
+                new RelationshipDescriptor {name=mod_a.identifier}
             });
 
             list.Add(mod_a.identifier);
             list.Add(mod_b.identifier);
             AddToRegistry(mod_a, mod_b);
-
+            
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
                 options,
@@ -64,14 +65,15 @@ namespace Tests.Core.Relationships
             Assert.That(resolver.ConflictList, Has.Count.EqualTo(2));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
+        [Test]
+        [Category("Version")]
         public void Constructor_WithConflictingModulesVersion_Throws()
         {
             var list = new List<string>();
             var mod_a = generator.GeneratorRandomModule();
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, version = mod_a.version}
+                new RelationshipDescriptor {name=mod_a.identifier, version=mod_a.version}
             });
 
             list.Add(mod_a.identifier);
@@ -85,9 +87,10 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "0.5"),
-         TestCase("1.0", "1.0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "0.5")]
+        [TestCase("1.0", "1.0")]
         public void Constructor_WithConflictingModulesVersionMin_Throws(string ver, string conf_min)
         {
             var list = new List<string>();
@@ -108,9 +111,10 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "2.0"),
-         TestCase("1.0", "1.0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "2.0")]
+        [TestCase("1.0", "1.0")]
         public void Constructor_WithConflictingModulesVersionMax_Throws(string ver, string conf_max)
         {
             var list = new List<string>();
@@ -131,10 +135,11 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "0.5", "2.0"),
-         TestCase("1.0", "1.0", "2.0"),
-         TestCase("1.0", "0.5", "1.0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "0.5", "2.0")]
+        [TestCase("1.0", "1.0", "2.0")]
+        [TestCase("1.0", "0.5", "1.0")]
         public void Constructor_WithConflictingModulesVersionMinMax_Throws(string ver, string conf_min, string conf_max)
         {
             var list = new List<string>();
@@ -155,9 +160,10 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "0.5"),
-         TestCase("1.0", "2.0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "0.5")]
+        [TestCase("1.0", "2.0")]
         public void Constructor_WithNonConflictingModulesVersion_DoesNotThrows(string ver, string conf)
         {
             var list = new List<string>();
@@ -178,7 +184,8 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
+        [Test]
+        [Category("Version")]
         [TestCase("1.0", "2.0")]
         public void Constructor_WithConflictingModulesVersionMin_DoesNotThrows(string ver, string conf_min)
         {
@@ -200,8 +207,9 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "2.0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("2.0", "1.0")]
         public void Constructor_WithConflictingModulesVersionMax_DoesNotThrows(string ver, string conf_max)
         {
             var list = new List<string>();
@@ -222,11 +230,11 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "2.0", "3.0"),
-         TestCase("4.0", "2.0", "3.0")]
-        public void Constructor_WithConflictingModulesVersionMinMax_DoesNotThrows(string ver, string conf_min,
-            string conf_max)
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "2.0", "3.0")]
+        [TestCase("4.0", "2.0", "3.0")]
+        public void Constructor_WithConflictingModulesVersionMinMax_DoesNotThrows(string ver, string conf_min, string conf_max)
         {
             var list = new List<string>();
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
@@ -263,7 +271,7 @@ namespace Tests.Core.Relationships
             });
             var mod_d = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier}
+                new RelationshipDescriptor {name=mod_a.identifier}
             });
 
             list.Add(mod_d.identifier);
@@ -273,32 +281,7 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
-        }
 
-        [Test]
-        public void WithMultipleModulesProviding_AllButOneHasUnmatchDependancy_DoesNotThrow()
-        {
-            options.without_toomanyprovides_kraken = false;
-
-            var list = new List<string>();
-            var mod_a = generator.GeneratorRandomModule();
-            var mod_b = generator.GeneratorRandomModule(provides: new List<string>
-            {
-                mod_a.identifier
-            });
-            var mod_c = generator.GeneratorRandomModule(provides: new List<string>
-            {
-                mod_a.identifier
-            }, depends: new List<RelationshipDescriptor> {new RelationshipDescriptor {name = "invaild"}});
-            var mod_d = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
-            {
-                new RelationshipDescriptor {name = mod_a.identifier}
-            });
-
-            list.Add(mod_d.identifier);
-            AddToRegistry(mod_b, mod_c, mod_d);
-            var mod_list = new RelationshipResolver(list,options,registry,null).ModList();
-            Assert.That(mod_list,Contains.Item(mod_b));
         }
 
         [Test]
@@ -313,6 +296,7 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
+
         }
 
         // Right now our RR always returns the modules it was provided. However
@@ -320,7 +304,7 @@ namespace Tests.Core.Relationships
         // return a list *without* them. This isn't a hard error at the moment,
         // since ModuleInstaller.InstallList will ignore already installed mods, but
         // it would be nice to have. Discussed a little in GH #521.
-        [Test, Category("TODO"), Explicit]
+        [Test][Category("TODO")][Explicit]
         public void ModList_WithInstalledModules_DoesNotContainThem()
         {
             var list = new List<string>();
@@ -386,7 +370,7 @@ namespace Tests.Core.Relationships
             });
             var conflicts_with_dependant = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier}
+                new RelationshipDescriptor {name=dependant.identifier}
             });
 
 
@@ -468,6 +452,7 @@ namespace Tests.Core.Relationships
                 mod_b,
                 depender
             });
+
         }
 
 
@@ -488,13 +473,15 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
+
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "2.0"),
-         TestCase("1.0", "0.2"),
-         TestCase("0", "0.2"),
-         TestCase("1.0", "0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "2.0")]
+        [TestCase("1.0", "0.2")]
+        [TestCase("0", "0.2")]
+        [TestCase("1.0", "0")]
         public void Constructor_WithMissingDependantsVersion_Throws(string ver, string dep)
         {
             var list = new List<string>();
@@ -503,8 +490,7 @@ namespace Tests.Core.Relationships
             {
                 new RelationshipDescriptor {name = dependant.identifier, version = new Version(dep)}
             });
-            list.Add(depender.identifier);
-            list.Add(dependant.identifier);
+            list.Add(depender.identifier);            
             AddToRegistry(depender, dependant);
 
             Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
@@ -512,9 +498,11 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
+
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
+        [Test]
+        [Category("Version")]
         [TestCase("1.0", "2.0")]
         public void Constructor_WithMissingDependantsVersionMin_Throws(string ver, string dep_min)
         {
@@ -524,8 +512,7 @@ namespace Tests.Core.Relationships
             {
                 new RelationshipDescriptor {name = dependant.identifier, min_version = new Version(dep_min)}
             });
-            list.Add(depender.identifier);
-            list.Add(dependant.identifier);
+            list.Add(depender.identifier);            
             AddToRegistry(depender, dependant);
 
             Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
@@ -533,9 +520,17 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
+            list.Add(dependant.identifier);
+            Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
+                list,
+                options,
+                registry,
+                null));
+
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
+        [Test]
+        [Category("Version")]
         [TestCase("1.0", "0.5")]
         public void Constructor_WithMissingDependantsVersionMax_Throws(string ver, string dep_max)
         {
@@ -549,16 +544,18 @@ namespace Tests.Core.Relationships
             list.Add(dependant.identifier);
             AddToRegistry(depender, dependant);
 
-            Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
+            Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
                 options,
                 registry,
                 null));
+
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "2.0", "3.0"),
-         TestCase("4.0", "2.0", "3.0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "2.0", "3.0")]
+        [TestCase("4.0", "2.0", "3.0")]
         public void Constructor_WithMissingDependantsVersionMinMax_Throws(string ver, string dep_min, string dep_max)
         {
             var list = new List<string>();
@@ -574,32 +571,30 @@ namespace Tests.Core.Relationships
             list.Add(dependant.identifier);
             AddToRegistry(depender, dependant);
 
-            Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
+            Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
                 options,
                 registry,
                 null));
+
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("1.0", "1.0", "2.0"),
-         TestCase("1.0", "1.0", "0.5")]
-         //what to do if a mod is present twice with the same version ?
+        [Test]
+        [Category("Version")]
+        [TestCase("1.0", "1.0", "2.0")]
+        [TestCase("1.0", "1.0", "0.5")]//what to do if a mod is present twice with the same version ?
         public void Constructor_WithDependantVersion_ChooseCorrectly(string ver, string dep, string other)
         {
             var list = new List<string>();
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier,
-                version: new Version(other));
+            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new Version(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
                 new RelationshipDescriptor {name = dependant.identifier, version = new Version(dep)}
             });
 
-            list.Add(depender.identifier);
-            list.Add(dependant.identifier);
-            list.Add(other_dependant.identifier);
+            list.Add(depender.identifier);            
             AddToRegistry(depender, dependant, other_dependant);
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
@@ -608,26 +603,25 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
+            
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("2.0", "1.0", "0.5"),
-         TestCase("2.0", "1.0", "1.5"),
-         TestCase("2.0", "2.0", "0.5")]
+        [Test]
+        [Category("Version")]
+        [TestCase("2.0", "1.0", "0.5")]
+        [TestCase("2.0", "1.0", "1.5")]
+        [TestCase("2.0", "2.0", "0.5")]
         public void Constructor_WithDependantVersionMin_ChooseCorrectly(string ver, string dep_min, string other)
         {
             var list = new List<string>();
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier,
-                version: new Version(other));
+            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new Version(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
                 new RelationshipDescriptor {name = dependant.identifier, min_version = new Version(dep_min)}
             });
             list.Add(depender.identifier);
-            list.Add(dependant.identifier);
-            list.Add(other_dependant.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
@@ -636,18 +630,19 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
+
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented")]
-        [TestCase("2.0", "2.0", "0.5"),
-         TestCase("2.0", "3.0", "0.5"),
-         TestCase("2.0", "3.0", "4.0")]
+        [Test]
+        [Category("Version")]
+        [TestCase("2.0", "2.0", "0.5")]
+        [TestCase("2.0", "3.0", "0.5")]
+        [TestCase("2.0", "3.0", "4.0")]
         public void Constructor_WithDependantVersionMax_ChooseCorrectly(string ver, string dep_max, string other)
         {
             var list = new List<string>();
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier,
-                version: new Version(other));
+            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new Version(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
@@ -662,27 +657,25 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
+
         }
 
-        [Test, Category("Version"), Explicit("Versions relationships not implemented"),
-         TestCase("2.0", "1.0", "3.0", "0.5"),
-         TestCase("2.0", "1.0", "3.0", "1.5"),
-         TestCase("2.0", "1.0", "3.0", "3.5")]
-        public void Constructor_WithDependantVersionMinMax_ChooseCorrectly(string ver, string dep_min, string dep_max,
-            string other)
+        [Test]
+        [Category("Version")]
+        [TestCase("2.0", "1.0", "3.0", "0.5")]
+        [TestCase("2.0", "1.0", "3.0", "1.5")]
+        [TestCase("2.0", "1.0", "3.0", "3.5")]
+        public void Constructor_WithDependantVersionMinMax_ChooseCorrectly(string ver, string dep_min, string dep_max, string other)
         {
             var list = new List<string>();
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier,
-                version: new Version(other));
+            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new Version(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
                 new RelationshipDescriptor {name = dependant.identifier, min_version = new Version(dep_min), max_version = new Version(dep_max)}
             });
             list.Add(depender.identifier);
-            list.Add(dependant.identifier);
-            list.Add(other_dependant.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
@@ -691,6 +684,7 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
+
         }
 
         [Test]
@@ -722,22 +716,23 @@ namespace Tests.Core.Relationships
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
 
             var mod_not_in_resolver_list = generator.GeneratorRandomModule();
-            CollectionAssert.DoesNotContain(relationship_resolver.ModList(), mod_not_in_resolver_list);
+            CollectionAssert.DoesNotContain(relationship_resolver.ModList(),mod_not_in_resolver_list);            
             Assert.Throws<ArgumentException>(() => relationship_resolver.ReasonFor(mod_not_in_resolver_list));
+            
         }
 
         [Test]
         public void ReasonFor_WithUserAddedMods_GivesReasonUserAdded()
         {
             var list = new List<string>();
-            var mod = generator.GeneratorRandomModule();
+            var mod = generator.GeneratorRandomModule();                        
             list.Add(mod.identifier);
             registry.AddAvailable(mod);
             AddToRegistry(mod);
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(mod);
-            Assert.That(reason, Is.AssignableTo<Relationship.UserRequested>());
+            Assert.That(reason,Is.AssignableTo<Relationship.UserRequested>());
         }
 
         [Test]
@@ -745,37 +740,31 @@ namespace Tests.Core.Relationships
         {
             var list = new List<string>();
             var sugested = generator.GeneratorRandomModule();
-            var mod =
-                generator.GeneratorRandomModule(sugests:
-                    new List<RelationshipDescriptor> {new RelationshipDescriptor {name = sugested.identifier}});
-            list.Add(mod.identifier);
-            AddToRegistry(mod, sugested);
+            var mod = generator.GeneratorRandomModule(sugests: new List<RelationshipDescriptor> {new RelationshipDescriptor { name = sugested.identifier } } );                        
+            list.Add(mod.identifier);            
+            AddToRegistry(mod,sugested);
 
             options.with_all_suggests = true;
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
             var reason = relationship_resolver.ReasonFor(sugested);
             Assert.That(reason, Is.AssignableTo<Relationship.Suggested>());
-            Assert.That(reason.Parent, Is.EqualTo(mod));
+            Assert.That(reason.Parent,Is.EqualTo(mod));
         }
 
         [Test]
         public void ReasonFor_WithTreeOfMods_GivesCorrectParents()
         {
-            var list = new List<string>();
+            var list = new List<string>();            
             var sugested = generator.GeneratorRandomModule();
             var recommendedA = generator.GeneratorRandomModule();
             var recommendedB = generator.GeneratorRandomModule();
-            var mod =
-                generator.GeneratorRandomModule(sugests:
-                    new List<RelationshipDescriptor> {new RelationshipDescriptor {name = sugested.identifier}});
+            var mod = generator.GeneratorRandomModule(sugests: new List<RelationshipDescriptor> { new RelationshipDescriptor { name = sugested.identifier}});
             list.Add(mod.identifier);
             sugested.recommends = new List<RelationshipDescriptor>
-            {
-                new RelationshipDescriptor {name = recommendedA.identifier},
-                new RelationshipDescriptor {name = recommendedB.identifier}
-            };
+            { new RelationshipDescriptor {name=recommendedA.identifier},
+              new RelationshipDescriptor { name = recommendedB.identifier}};
 
-            AddToRegistry(mod, sugested, recommendedA, recommendedB);
+            AddToRegistry(mod, sugested,recommendedA,recommendedB);
 
 
             options.with_all_suggests = true;
@@ -789,6 +778,11 @@ namespace Tests.Core.Relationships
             Assert.That(reason, Is.AssignableTo<Relationship.Recommended>());
             Assert.That(reason.Parent, Is.EqualTo(sugested));
         }
+
+
+
+
+
 
 
         private void AddToRegistry(params CkanModule[] modules)

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -71,7 +71,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule();
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, version = mod_a.version.ToString()}
+                new RelationshipDescriptor {name = mod_a.identifier, version = mod_a.version}
             });
 
             list.Add(mod_a.identifier);
@@ -94,7 +94,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, min_version = conf_min}
+                new RelationshipDescriptor {name=mod_a.identifier, min_version=new Version(conf_min)}
             });
 
             list.Add(mod_a.identifier);
@@ -117,7 +117,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, max_version = conf_max}
+                new RelationshipDescriptor {name=mod_a.identifier, max_version=new Version(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -141,7 +141,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, min_version = conf_min, max_version = conf_max}
+                new RelationshipDescriptor {name=mod_a.identifier, min_version=new Version(conf_min), max_version=new Version(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -164,7 +164,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, version = conf}
+                new RelationshipDescriptor {name=mod_a.identifier, version=new Version(conf)}
             });
 
             list.Add(mod_a.identifier);
@@ -186,7 +186,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, min_version = "2.0"}
+                new RelationshipDescriptor {name=mod_a.identifier, min_version=new Version(conf_min)}
             });
 
             list.Add(mod_a.identifier);
@@ -208,7 +208,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, max_version = conf_max}
+                new RelationshipDescriptor {name=mod_a.identifier, max_version=new Version(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -232,7 +232,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new Version(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier, min_version = conf_min, max_version = conf_max}
+                new RelationshipDescriptor {name=mod_a.identifier, min_version=new Version(conf_min), max_version=new Version(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -501,7 +501,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, version = dep}
+                new RelationshipDescriptor {name = dependant.identifier, version = new Version(dep)}
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);
@@ -522,7 +522,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, min_version = dep_min}
+                new RelationshipDescriptor {name = dependant.identifier, min_version = new Version(dep_min)}
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);
@@ -543,7 +543,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, max_version = dep_max}
+                new RelationshipDescriptor {name = dependant.identifier, max_version = new Version(dep_max)}
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);
@@ -565,7 +565,10 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new Version(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, min_version = dep_max}
+                new RelationshipDescriptor {
+                    name = dependant.identifier,
+                    min_version = new Version(dep_min),
+                    max_version = new Version(dep_max)}
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);
@@ -591,7 +594,7 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, version = dep}
+                new RelationshipDescriptor {name = dependant.identifier, version = new Version(dep)}
             });
 
             list.Add(depender.identifier);
@@ -620,7 +623,7 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, min_version = dep_min}
+                new RelationshipDescriptor {name = dependant.identifier, min_version = new Version(dep_min)}
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);
@@ -648,11 +651,9 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, max_version = dep_max}
+                new RelationshipDescriptor {name = dependant.identifier, max_version = new Version(dep_max)}
             });
             list.Add(depender.identifier);
-            list.Add(dependant.identifier);
-            list.Add(other_dependant.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
@@ -677,7 +678,7 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, min_version = dep_min, max_version = dep_max}
+                new RelationshipDescriptor {name = dependant.identifier, min_version = new Version(dep_min), max_version = new Version(dep_max)}
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);


### PR DESCRIPTION
This is #989, with the addition of:

- A merge commit, so everything works with current master.
- An update to the spec, describing how versions should work in older clients.