### PR TITLE
Add command line option to launch debugger

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -29,6 +31,14 @@ namespace CKAN.CmdLine
         [STAThread]
         public static int Main(string[] args)
         {
+            // Launch debugger if the "--debugger" flag is present in the command line arguments.
+            // We want to do this as early as possible so just check the flag manually, rather than doing the
+            // more robust argument parsing.
+            if (args.Any(i => i == "--debugger"))
+            {
+                Debugger.Launch();
+            }
+
             BasicConfigurator.Configure();
             LogManager.GetRepository().Threshold = Level.Warn;
             log.Debug("CKAN started");

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -98,6 +98,9 @@ namespace CKAN.CmdLine
         [Option('d', "debug", DefaultValue = false, HelpText = "Show debugging level messages. Implies verbose")]
         public bool Debug { get; set; }
 
+        [Option("debugger", DefaultValue = false, HelpText = "Launch debugger at start")]
+        public bool Debugger { get; set; }
+
         [Option("ksp", DefaultValue = null, HelpText = "KSP install to use")]
         public string KSP { get; set; }
 


### PR DESCRIPTION
Adds support for detecting a `--debugger` command line argument and using `System.Diagnostics.Debugger.Launch()` to launch a debugger. On Windows this opens a dialog prompt to either start or use an existing Visual Studio instance to attach to the process for debugging. Not sure what the exact behavior on Linux is, but from some quick googling it seems it's at least supported to some degree.

This flag is checked as early as possible to ensure maximal utility, it's even done before full command line argument parsing so you could even debug that.
