### PR TITLE
KeyNotFoundException fix in ResolveStanza

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -308,7 +308,7 @@ namespace CKAN
                     throw new InconsistentKraken(
                         string.Format(
                             "{0} requires a version {1}. However a incompatible version, {2}, is already installed",
-                            dep_name, descriptor.RequiredVersion, modlist[dep_name].version));
+                            dep_name, descriptor.RequiredVersion, registry.InstalledVersion(dep_name)));
                 }
 
                 List<CkanModule> candidates = registry.LatestAvailableWithProvides(dep_name, kspversion, descriptor)


### PR DESCRIPTION
This was caused by us checking the wrong data structure to report where
our incompatible version of a mod was found.

Closes #1146.