### PR TITLE
Enforce Visual Studio formatting.

### DIFF
--- a/CKAN.sln
+++ b/CKAN.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
+# Visual Studio 2012
 VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CKAN-core", "Core\CKAN-core.csproj", "{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}"
@@ -25,18 +25,6 @@ Global
 		{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{A79F9D54-315C-472B-928F-713A5860B2BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A79F9D54-315C-472B-928F-713A5860B2BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A79F9D54-315C-472B-928F-713A5860B2BE}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{A79F9D54-315C-472B-928F-713A5860B2BE}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{4336F356-33DB-442A-BF74-5E89AF47A5B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4336F356-33DB-442A-BF74-5E89AF47A5B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4336F356-33DB-442A-BF74-5E89AF47A5B9}.Release|Any CPU.ActiveCfg = Debug|Any CPU
@@ -45,6 +33,53 @@ Global
 		{4F41255E-8BC1-465B-82D5-1C5665BC099A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F41255E-8BC1-465B-82D5-1C5665BC099A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F41255E-8BC1-465B-82D5-1C5665BC099A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A79F9D54-315C-472B-928F-713A5860B2BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A79F9D54-315C-472B-928F-713A5860B2BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A79F9D54-315C-472B-928F-713A5860B2BE}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{A79F9D54-315C-472B-928F-713A5860B2BE}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5B1C768-349E-4DAF-A134-56E4ECF1EEEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E97D81F6-85E2-4F1F-906D-BE21766602E5}.Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.inheritsSet = VisualStudio
+		$1.inheritsScope = text/plain
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.IndentSwitchBody = True
+		$2.IndentBlocksInsideExpressions = True
+		$2.AnonymousMethodBraceStyle = NextLine
+		$2.PropertyBraceStyle = NextLine
+		$2.PropertyGetBraceStyle = NextLine
+		$2.PropertySetBraceStyle = NextLine
+		$2.EventBraceStyle = NextLine
+		$2.EventAddBraceStyle = NextLine
+		$2.EventRemoveBraceStyle = NextLine
+		$2.StatementBraceStyle = NextLine
+		$2.ElseNewLinePlacement = NewLine
+		$2.CatchNewLinePlacement = NewLine
+		$2.FinallyNewLinePlacement = NewLine
+		$2.WhileNewLinePlacement = DoNotCare
+		$2.ArrayInitializerWrapping = DoNotChange
+		$2.ArrayInitializerBraceStyle = NextLine
+		$2.BeforeMethodDeclarationParentheses = False
+		$2.BeforeMethodCallParentheses = False
+		$2.BeforeConstructorDeclarationParentheses = False
+		$2.NewLineBeforeConstructorInitializerColon = NewLine
+		$2.NewLineAfterConstructorInitializerColon = SameLine
+		$2.BeforeDelegateDeclarationParentheses = False
+		$2.NewParentheses = False
+		$2.SpacesBeforeBrackets = False
+		$2.inheritsSet = Mono
+		$2.inheritsScope = text/x-csharp
+		$2.scope = text/x-csharp
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -26,12 +26,11 @@
     <Reference Include="log4net">
       <HintPath>..\Core\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\CKAN\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\CKAN\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Action\Compare.cs" />
@@ -57,11 +56,11 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Core\CKAN-core.csproj">
-      <Project>{3b9aea22-fa3b-4e43-9283-eabdd81cf271}</Project>
+      <Project>{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}</Project>
       <Name>CKAN-core</Name>
     </ProjectReference>
     <ProjectReference Include="..\GUI\CKAN-GUI.csproj">
-      <Project>{a79f9d54-315c-472b-928f-713a5860b2be}</Project>
+      <Project>{A79F9D54-315C-472B-928F-713A5860B2BE}</Project>
       <Name>CKAN-GUI</Name>
     </ProjectReference>
   </ItemGroup>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -43,10 +43,6 @@
     <Reference Include="log4net">
       <HintPath>..\Core\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\CKAN\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -57,6 +53,9 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Transactions" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\CKAN\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AboutDialog.cs">
@@ -279,7 +278,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\CKAN-core.csproj">
-      <Project>{3b9aea22-fa3b-4e43-9283-eabdd81cf271}</Project>
+      <Project>{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}</Project>
       <Name>CKAN-core</Name>
     </ProjectReference>
   </ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -44,9 +44,6 @@
       <HintPath>..\Core\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\Core\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\Core\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
@@ -58,6 +55,9 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\Core\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Data\CKAN-meta-badkan.zip" />
@@ -153,15 +153,15 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\CKAN-core.csproj">
-      <Project>{3b9aea22-fa3b-4e43-9283-eabdd81cf271}</Project>
+      <Project>{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}</Project>
       <Name>CKAN-core</Name>
     </ProjectReference>
     <ProjectReference Include="..\GUI\CKAN-GUI.csproj">
-      <Project>{a79f9d54-315c-472b-928f-713a5860b2be}</Project>
+      <Project>{A79F9D54-315C-472B-928F-713A5860B2BE}</Project>
       <Name>CKAN-GUI</Name>
     </ProjectReference>
     <ProjectReference Include="..\Netkan\CKAN-netkan.csproj">
-      <Project>{4336f356-33db-442a-bf74-5e89af47a5b9}</Project>
+      <Project>{4336F356-33DB-442A-BF74-5E89AF47A5B9}</Project>
       <Name>CKAN-netkan</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
I suspect during the great merge we ended up with solution files that
work for visual studio, but cause monodevelop to try and do its own
thing.

These get monodevelop to VS formatting for me.