### PR TITLE
netkan.exe add '.0' to two-part releases when indxing from KS

### DIFF
--- a/Netkan/KS/KSVersion.cs
+++ b/Netkan/KS/KSVersion.cs
@@ -1,6 +1,7 @@
 using System;
 using log4net;
 using Newtonsoft.Json;
+using System.Text.RegularExpressions;
 
 namespace CKAN.NetKAN
 {
@@ -9,6 +10,8 @@ namespace CKAN.NetKAN
         private static readonly ILog log = LogManager.GetLogger(typeof (KSVersion));
 
         // These all get filled by JSON deserialisation.
+
+        [JsonConverter(typeof(JsonConvertKSPVersion))]
         public KSPVersion KSP_version;
         public string changelog;
 
@@ -27,6 +30,51 @@ namespace CKAN.NetKAN
             log.Debug("Downloaded.");
 
             return filename;
+        }
+
+        /// <summary>
+        /// KerbalStuff always trims trailing zeros from a three-part version
+        /// (eg: 1.0.0 -> 1.0). This means we could potentially think some mods
+        /// will work with more versions than they actually will. This converter
+        /// puts the .0 back on when appropriate. GH #1156.
+        /// </summary>
+        internal class JsonConvertKSPVersion : JsonConverter
+        {
+            public override object ReadJson(
+                JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer
+            )
+            {
+                if (reader.Value == null)
+                    return null;
+
+                string raw_version = reader.Value.ToString();
+
+                return new KSPVersion( ExpandVersionIfNeeded(raw_version) );
+            }
+
+            /// <summary>
+            /// Actually expand the KSP version. It's way easier to test this than the override. :)
+            /// </summary>
+            public static string ExpandVersionIfNeeded(string version)
+            {
+                if (Regex.IsMatch(version,@"^\d+\.\d+$"))
+                {
+                    // Two part string, add our .0
+                    return version + ".0";
+                }
+
+                return version;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         /// <summary>

--- a/Tests/NetKAN/KSMod.cs
+++ b/Tests/NetKAN/KSMod.cs
@@ -84,6 +84,17 @@ namespace Tests.NetKAN
             return KSAPI.ExpandPath(path).OriginalString;
         }
 
+        [Test]
+        [TestCase("1.0","1.0.0")]
+        [TestCase("1.0.3","1.0.3")]
+        public void KS_Expand_KSP_Version_1156(string original, string expected)
+        {
+            Assert.AreEqual(
+                expected,
+                CKAN.NetKAN.KSVersion.JsonConvertKSPVersion.ExpandVersionIfNeeded(original)
+            );
+        }
+
         public static CKAN.NetKAN.KSMod test_ksmod()
         {
             var ksmod = new CKAN.NetKAN.KSMod


### PR DESCRIPTION
Closes #1156.

You can test this on the current `NetKAN/UniversalStorage-ECLSS.netkan` file, which
has a '0.90' release on KS, but comes out as '0.90.0' in the metadata:

```
$ netkan.exe NetKAN/UniversalStorage-ECLSS.netkan
$ grep ksp_version  UniversalStorage-ECLSS-Deprecated.ckan 
    "ksp_version": "0.90.0",
```