### PR TITLE
Commandline: Show a user friendly error on upgrade

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -118,7 +118,7 @@ namespace CKAN.CmdLine
             }
             catch (ModuleNotFoundKraken kraken)
             {
-                User.RaiseMessage(kraken.Message);
+                User.RaiseMessage("Module {0} not found", kraken.module);
                 return Exit.ERROR;
             }
             User.RaiseMessage("\nDone!\n");


### PR DESCRIPTION
when one of the mods are not found.
Maybe the ModuleNotFoundKraken should be thrown for every non existant mod the user wants to update?
See #1140