### PR TITLE
Fix: Issues with version handling.

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -311,8 +311,9 @@ namespace CKAN
                             dep_name, descriptor.RequiredVersion, registry.InstalledVersion(dep_name)));
                 }
 
+                var descriptor1 = descriptor;
                 List<CkanModule> candidates = registry.LatestAvailableWithProvides(dep_name, kspversion, descriptor)
-                    .Where(mod=>MightBeInstallable(mod)).ToList();
+                    .Where(mod=>descriptor1.version_within_bounds(mod.version) && MightBeInstallable(mod)).ToList();
 
                 if (candidates.Count == 0)
                 {

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace CKAN
@@ -55,10 +56,13 @@ namespace CKAN
 
             RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
             install_ops.with_recommends = false;
-            
+            //Using the changeset passed in can cause issues with versions.
+            // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.
+            // TODO Work out why this is.
+            var user_change_set = mainModList.ComputeUserChangeSet().ToList();
             m_InstallWorker.RunWorkerAsync(
                 new KeyValuePair<List<KeyValuePair<GUIMod, GUIModChangeType>>, RelationshipResolverOptions>(
-                    m_Changeset, install_ops));
+                    user_change_set, install_ops));
             m_Changeset = null;
 
             UpdateChangesDialog(null, m_InstallWorker);


### PR DESCRIPTION
RelRes was not filtering candiade dependancies by the version.
The GUI is passing incorrect versions to the installer.

For a example of the second try to install MechJeb Modules for Far in a clean 1.0.2 install. It will fail. 
Reported by @BasharMilesTeg

Needs testing. 