### PR TITLE
Adjust spec version requirements to match usage.

### DIFF
--- a/Spec.md
+++ b/Spec.md
@@ -207,8 +207,9 @@ The comparison behavior of the package management system with respect to the
 `mod_version` is described below. The `mod_version` portion of the version
 number is mandatory.
 
-The `mod_version` may contain only alphanumerics and the characters `.` `+`
-(full stop, plus) and should start with a digit.
+While the CKAN will accept *any* string as a `mod_version`, mod authors are
+encouraged to restrict version names to alphanumerics and the characters `.`
+`+` (full stop, plus), and should start with a digit.
 
 ###### version ordering
 


### PR DESCRIPTION
While the spec has always had strict requirements as to what characters
are allowed in versions, this has not been reflected by our software.
Indeed, we're not really able to restrict how authors version their
releases, the best we can do is hope they're sane, or bump the epoch
if they're not.

This change alters the spec to weaken the requirement on spec numbers
to be a recommendation, reflecting how we actually handle things.

This *is* changing the spec as written, but it's matching reality, so
we're not changing what users see. Even so, discussion is welcome (even
after this is merged).

Closes #1174.
Not as cool as #834.

[Our policy on versions](https://github.com/KSP-CKAN/CKAN/blob/master/policy/version-comparison.md) should be kept in mind in discussions.