### PR TITLE
Strip NetKan Properties

### DIFF
--- a/Netkan/MainClass.cs
+++ b/Netkan/MainClass.cs
@@ -190,6 +190,7 @@ namespace CKAN.NetKAN
 
             // Fix our version string, if required.
             metadata = FixVersionStrings(metadata);
+            metadata = StripNetkanMetadata(metadata);
 
             // Re-inflate our mod, in case our vref or FixVersionString routines have
             // altered it at all.
@@ -614,7 +615,34 @@ namespace CKAN.NetKAN
 
         }
 
+        /// <summary>
+        /// Remove any metadata entries that start with 'x_netkan'.
+        /// </summary>
+        /// <param name="metadata">The metadata object</param>
+        /// <returns>The metadata object stripped of netkan-specific entries.</returns>
+        internal static JObject StripNetkanMetadata(JObject metadata)
+        {
+            var propertiesToRemove = new List<string>();
 
+            foreach (var property in metadata.Properties())
+            {
+                if (property.Name.StartsWith("x_netkan"))
+                {
+                    propertiesToRemove.Add(property.Name);
+                }
+                else if (property.Value.Type == JTokenType.Object)
+                {
+                    metadata[property.Name] = StripNetkanMetadata((JObject)property.Value);
+                }
+            }
+
+            foreach (var property in propertiesToRemove)
+            {
+                metadata.Remove(property);
+            }
+
+            return metadata;
+        }
     }
 
     internal class NetKanRemote

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -1,4 +1,5 @@
-﻿using CKAN;
+﻿using System.Collections.Generic;
+using CKAN;
 using CKAN.NetKAN;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -61,6 +62,70 @@ namespace Tests.NetKAN
                 Assert.Throws<BadMetadataKraken>(test_delegate);
             else
                 Assert.DoesNotThrow(test_delegate);
+        }
+
+        [TestCaseSource("StripNetkanMetadataTestCaseSource")]
+        public void StripNetkanMetadata(string json, string expected)
+        {
+            var metadata = MainClass.StripNetkanMetadata(JObject.Parse(json));
+            var expectedMetadata = JObject.Parse(expected);
+
+            Assert.AreEqual(metadata, expectedMetadata);
+        }
+
+        private IEnumerable<object[]> StripNetkanMetadataTestCaseSource
+        {
+            get
+            {
+                yield return new object[]
+                {
+@"
+{
+    ""foo"": ""bar""
+}
+",
+@"
+{
+    ""foo"": ""bar""
+}
+                    "
+                };
+
+                yield return new object[]
+                {
+@"
+{
+    ""foo"": ""bar"",
+    ""x_netkan"": ""foobar""
+}
+",
+@"
+{
+    ""foo"": ""bar""
+}
+                    "
+                };
+
+
+                yield return new object[]
+                {
+@"
+{
+    ""foo"": ""bar"",
+    ""x_netkan"": ""foobar"",
+    ""baz"": {
+        ""x_netkan_foo"": ""foobar""
+    }
+}
+",
+@"
+{
+    ""foo"": ""bar"",
+    ""baz"": {}
+}
+                    "
+                };
+            }
         }
     }
 }

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -20,12 +20,12 @@ namespace Tests.NetKAN
             Assert.AreEqual("1.01", (string) metadata["version"], "Version unharmed without x_netkan_force_v");
         }
 
-        [Test, TestCase(@"{""version"" : ""1.01""}", "1.01", "1.01"),
-         TestCase(@"{""version"" : ""1.01"", ""x_netkan_force_v"" : ""true""}", "1.01", "v1.01"),
-         TestCase(@"{""version"" : ""1.01"", ""x_netkan_force_v"" : ""false""}", "1.01", "1.01"),
-         TestCase(@"{""version"" : ""v1.01""}", "v1.01", "v1.01"),
-         TestCase(@"{""version"" : ""v1.01"", ""x_netkan_force_v"" : ""true""}", "v1.01", "v1.01"),
-         TestCase(@"{""version"" : ""v1.01"", ""x_netkan_force_v"" : ""false""}", "v1.01", "v1.01")]
+        [TestCase(@"{""version"" : ""1.01""}", "1.01", "1.01")]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_force_v"" : ""true""}", "1.01", "v1.01")]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_force_v"" : ""false""}", "1.01", "1.01")]
+        [TestCase(@"{""version"" : ""v1.01""}", "v1.01", "v1.01")]
+        [TestCase(@"{""version"" : ""v1.01"", ""x_netkan_force_v"" : ""true""}", "v1.01", "v1.01")]
+        [TestCase(@"{""version"" : ""v1.01"", ""x_netkan_force_v"" : ""false""}", "v1.01", "v1.01")]
         // Test with and without x_netkan_force_v, and with and without a 'v' prepended already.
         public void FixVersionStrings(string json, string orig_version, string new_version)
         {
@@ -38,11 +38,11 @@ namespace Tests.NetKAN
             Assert.AreEqual(new_version, (string) metadata["version"], "Output string as expected");
         }
 
-        [TestCase(@"{""version"" : ""1.01""}", "1.01", "1.01"),
-         TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""0""}",
-             "1.01", "1.01", Description = "Implicit 0"),
-         TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""1""}", "1.01", "1:1.01"),
-         TestCase(@"{""version"" : ""v1.01"", ""x_netkan_epoch"" : ""9""}", "v1.01", "9:v1.01")]
+        [TestCase(@"{""version"" : ""1.01""}", "1.01", "1.01")]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""0""}",
+             "1.01", "1.01", Description = "Implicit 0")]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""1""}", "1.01", "1:1.01")]
+        [TestCase(@"{""version"" : ""v1.01"", ""x_netkan_epoch"" : ""9""}", "v1.01", "9:v1.01")]
         public void ApplyEpochNumber(string json, string orig_version, string new_version)
         {
             JObject metadata = JObject.Parse(json);
@@ -51,10 +51,10 @@ namespace Tests.NetKAN
             Assert.AreEqual(new_version, (string) metadata["version"], "Output string as expected");
         }
 
-        [TestCase(@"{""version"" : ""1.01""}", false),
-         TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""a""}", true),
-         TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""-1""}", true),
-         TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""5.5""}", true)]
+        [TestCase(@"{""version"" : ""1.01""}", false)]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""a""}", true)]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""-1""}", true)]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_epoch"" : ""5.5""}", true)]
         public void Invaild(string json, bool expected_to_throw)
         {
             TestDelegate test_delegate = () => MainClass.FixVersionStrings(JObject.Parse(json));


### PR DESCRIPTION
Recursively remove any properties that start with `x_netkan` from the metadata object just before writing the `.ckan` file. Also includes some tests!

Also, reformats some `TestCase` attributes cause they were annoying me. :wink: 

Fixes #1177