### PR TITLE
Implement `x_netkan_override`

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AVC\AVC.cs" />
     <Compile Include="AVC\JsonAvcToKspVersion.cs" />
     <Compile Include="Web.cs" />
+    <Compile Include="NetkanOverride.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Netkan/MainClass.cs
+++ b/Netkan/MainClass.cs
@@ -96,6 +96,9 @@ namespace CKAN.NetKAN
             // Make sure that at the very least this validates against our own
             // internal model.
 
+            // TODO: Given all the other post-processing we do, we should really
+            // be doing these checks at the end (after overrides, vrefs, etc).
+
             CkanModule mod = CkanModule.FromJson(metadata.ToString());
 
             // Make sure our identifiers match.
@@ -113,7 +116,7 @@ namespace CKAN.NetKAN
                 return EXIT_ERROR;
             }
 
-            // Make sure this would actually generate an install
+            // Make sure this would actually generate an install.
             try
             {
                 ModuleInstaller.FindInstallableFiles(mod, file, null);
@@ -190,6 +193,9 @@ namespace CKAN.NetKAN
 
             // Fix our version string, if required.
             metadata = FixVersionStrings(metadata);
+
+            // Apply overrides, if applicable.
+            metadata = new NetkanOverride(metadata).ProcessOverrides();
 
             // Re-inflate our mod, in case our vref or FixVersionString routines have
             // altered it at all.

--- a/Netkan/NetkanOverride.cs
+++ b/Netkan/NetkanOverride.cs
@@ -1,0 +1,182 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CKAN;
+using log4net;
+
+namespace CKAN.NetKAN
+{
+    /// <summary>
+    /// Allow per-version overrides for netkan processing. GH #1160.
+    /// </summary>
+    public class NetkanOverride
+    {
+        private JObject metadata;
+        private CKAN.Version version;
+        private static readonly ILog log = LogManager.GetLogger(typeof (NetkanOverride));
+
+        public NetkanOverride(JObject metadata)
+        {
+            this.metadata = (JObject) metadata.DeepClone();
+            version = new Version(metadata["version"].ToString());
+        }
+
+        /// <summary>
+        /// Processes any x_netkan_override sections in the metadata
+        /// </summary>
+        /// <returns>The metadata after overrides have been processed,
+        /// even if no work was performed.</returns>
+        public JObject ProcessOverrides()
+        {
+            JToken override_list;
+
+            // If there's no override section, then just return our existing metadata.
+            if (! metadata.TryGetValue("x_netkan_override", out override_list))
+                return metadata;
+
+            log.InfoFormat("Found override section: {0}", override_list);
+
+            if (!(override_list is JArray))
+                throw new Kraken(
+                    string.Format(
+                        "x_netkan_override expects a list of overrides, found: {0}",
+                        override_list));
+            
+            // Sweet! We have an override. Let's walk through and see if we can find
+            // an applicable section for us.
+            foreach (JToken override_stanza in override_list)
+            {
+                log.InfoFormat("Processing override: {0}", override_stanza);
+                ProcessOverrideStanza((JObject) override_stanza);
+            }
+
+            return metadata;
+        }
+
+        /// <summary>
+        /// Processes an individual override stanza, altering the object's
+        /// metadata in the process if applicable.
+        /// </summary>
+        private void ProcessOverrideStanza(JObject override_stanza)
+        {
+            JToken stanza_constraints;
+
+            if (!override_stanza.TryGetValue("version", out stanza_constraints))
+            {
+                throw new Kraken(
+                    string.Format(
+                        "Can't find version in override stanza {0}",
+                        override_stanza));
+            }
+
+            IEnumerable<string> constraints;
+
+            // First let's get our constraints into a list of strings.
+
+            if (stanza_constraints is JValue)
+            {
+                constraints = new List<string> { stanza_constraints.ToString() };
+            }
+            else if (stanza_constraints is JArray)
+            {
+                // Pop the constraints in 'constraints'
+                constraints = ((JArray)stanza_constraints).Values().Select(x => x.ToString());
+            }
+            else
+            {
+                throw new Kraken(
+                    string.Format("Totally unexpected x_netkan_override - {0}", stanza_constraints));
+            }
+
+            // If the constraints don't apply, then do nothing.
+            if (!ConstraintsApply(constraints))
+                return;
+
+            // All the constraints pass; let's replace the metadata we have with what's
+            // in the override.
+
+            JToken override_block;
+
+            if (override_stanza.TryGetValue("override", out override_block))
+            {
+                foreach (JProperty property in ((JObject) override_block).Properties())
+                {
+                    metadata[property.Name] = property.Value;
+                }
+            }
+
+            // And let's delete anything that needs deleting.
+
+            JToken delete_list;
+            if (override_stanza.TryGetValue("delete", out delete_list))
+            {
+                foreach (string key in (JArray) delete_list)
+                {
+                    metadata.Remove(key);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Walks through a list of constraints, and returns true if they're all satisifed
+        /// for the mod version we're examining.
+        /// </summary>
+        private bool ConstraintsApply(IEnumerable<string> constraints)
+        {
+            foreach (string constraint in constraints)
+            {
+                Match match = Regex.Match(
+                    constraint,
+                    @"^(?<op> [<>=]*) \s* (?<version> .*)$",
+                    RegexOptions.IgnorePatternWhitespace);
+
+                if (!match.Success)
+                    throw new Kraken(
+                        string.Format("Unable to parse x_netkan_override - {0}", constraint));
+
+                string op = match.Groups["op"].Value;
+                CKAN.Version desired_version = new Version(match.Groups["version"].Value);
+
+                // This contstraint failed. This stanza is not for us.
+                if (!ConstraintPasses(op, desired_version))
+                    return false;
+            }
+
+            // All the constraints passed! We want to apply this stanza!
+            return true;
+        }
+
+        /// <summary>
+        /// Returns whether the given constraint matches the desired version
+        /// for the mod we're processing.
+        /// </summary>
+        private bool ConstraintPasses(string op, CKAN.Version desired_version)
+        {
+            switch (op)
+            {
+                case "":
+                case "=":
+                    return version.IsEqualTo(desired_version);
+
+                case "<":
+                    return version.IsLessThan(desired_version);
+
+                case ">":
+                    return version.IsGreaterThan(desired_version);
+
+                case "<=":
+                    return version.CompareTo(desired_version) <= 0;
+
+                case ">=":
+                    return version.CompareTo(desired_version) >= 0;
+
+                default:
+                    throw new Kraken(
+                        string.Format("Unknown x_netkan_override comparator: {0}", op));
+            }
+        }
+    }
+}
+

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -1,0 +1,130 @@
+﻿using CKAN;
+using CKAN.NetKAN;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Tests.Data;
+
+namespace Tests.NetKAN
+{
+    [TestFixture]
+    public class NetkanOverride
+    {
+        JObject such_metadata;
+
+        [SetUp]
+        public void Setup()
+        {
+            such_metadata = JObject.Parse(TestData.DogeCoinFlag_101());
+        }
+
+        [Test]
+        public void ExactOverride()
+        {
+            // Make sure our author starts as expected.
+            OriginalAuthorUnchanged();
+
+            // Add our override and processs.
+            JObject new_metadata = ProcessOverrides(
+                such_metadata,
+                @"[{
+                    ""version"" : ""1.01"",
+                    ""override"" : {
+                        ""author"" : ""doge""
+                    }
+                }]");
+
+            Assert.AreEqual("doge",new_metadata["author"].ToString(),"Override processed");
+
+            // Make sure our original metadata iddn't change.
+            OriginalAuthorUnchanged();
+        }
+
+        [Test]
+        public void UntriggeredOverride()
+        {
+            JObject new_metadata = ProcessOverrides(
+                such_metadata,
+                @"[{
+                    ""version"" : ""1.02"",
+                    ""override"" : {
+                        ""author"" : ""doge""
+                    }
+                }]");
+
+            Assert.AreEqual("pjf", new_metadata["author"].ToString(), "Untrigged override changes nothing");
+        }
+
+        [Test]
+        [
+            TestCase("range with spaces", "doge",
+                @"[{
+                    ""version"" : [ ""> 1.00"", ""< 1.02"" ],
+                    ""override"" : { ""author"" : ""doge"" }
+                }]"),
+
+            TestCase("exact with spaces", "doge",
+                @"[{
+                    ""version"" : [ ""= 1.01"" ],
+                    ""override"" : { ""author"" : ""doge"" }
+                }]"),
+
+            TestCase("range without spaces", "doge",
+                @"[{
+                    ""version"" : [ "">1.00"", ""<1.02"" ],
+                    ""override"" : { ""author"" : ""doge"" }
+                }]"),
+
+            TestCase("exact without spaces", "doge",
+                @"[{
+                    ""version"" : [ ""=1.01"" ],
+                    ""override"" : { ""author"" : ""doge"" }
+                }]"),
+
+            TestCase("inclusive range", "doge",
+                @"[{
+                    ""version"" : [ "">=1.01"", ""<2.00"" ],
+                    ""override"" : { ""author"" : ""doge"" }
+                }]"),
+
+            TestCase("non-matching", "pjf",
+                @"[{ ""version"" : [ ""< 1.00"", ""> 1.02"" ],
+                    ""override"" : { ""author"" : ""doge"" }
+                }]")
+        ]
+        public void RangedOverride(string label, string expected_author, string override_json)
+        {
+            JObject new_metadata = ProcessOverrides(
+                such_metadata, override_json);
+
+            Assert.AreEqual(expected_author, new_metadata["author"].ToString(), label);
+
+            OriginalAuthorUnchanged();
+        }
+
+        /// <summary>
+        /// Sanity to check to make sure the original metadata hasn't changed during testing.
+        /// </summary>
+        private void OriginalAuthorUnchanged()
+        {
+            Assert.AreEqual("pjf", such_metadata["author"].ToString(), "Sanity check");
+        }
+
+        /// <summary>
+        /// Process overrides (if present)
+        /// </summary>
+        private JObject ProcessOverrides(JObject metadata)
+        {
+            return new CKAN.NetKAN.NetkanOverride(such_metadata).ProcessOverrides();
+        }
+
+        /// <summary>
+        /// Process overrides using the JSON string specified.
+        /// </summary>
+        private JObject ProcessOverrides(JObject metadata, string overrides)
+        {
+            metadata["x_netkan_override"] = JArray.Parse(overrides);
+            return ProcessOverrides(metadata);
+        }
+    }
+}
+

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -101,6 +101,26 @@ namespace Tests.NetKAN
             OriginalAuthorUnchanged();
         }
 
+        [Test]
+        public void DeleteOverride()
+        {
+            JToken token;
+
+            Assert.IsTrue(such_metadata.TryGetValue("abstract", out token));
+            Assert.IsTrue(such_metadata.TryGetValue("author", out token));
+
+            JObject new_metadata = ProcessOverrides(
+                    such_metadata,
+                    @"[{
+                    ""version"" : ""1.01"",
+                    ""delete"" : [ ""abstract"", ""author"" ]
+                }]");
+
+
+            Assert.IsFalse(new_metadata.TryGetValue("abstract", out token));
+            Assert.IsFalse(new_metadata.TryGetValue("author", out token));
+        }
+
         /// <summary>
         /// Sanity to check to make sure the original metadata hasn't changed during testing.
         /// </summary>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="NetKAN\MainClass.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="Core\Types\RelationshipDescriptor.cs" />
+    <Compile Include="NetKAN\NetkanOverride.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Data\CKAN.sln" />


### PR DESCRIPTION
This PR implements the `x_netkan_override` syntax described in #1160.

Includes test cases. Tested on live data.

Closes #1160 and brings in a new age of prosperity. :)