### PR TITLE
Recurse into arrays when removing x_netkan properties

### DIFF
--- a/Netkan/MainClass.cs
+++ b/Netkan/MainClass.cs
@@ -630,9 +630,17 @@ namespace CKAN.NetKAN
                 {
                     propertiesToRemove.Add(property.Name);
                 }
-                else if (property.Value.Type == JTokenType.Object)
+                else switch (property.Value.Type)
                 {
-                    metadata[property.Name] = StripNetkanMetadata((JObject)property.Value);
+                    case JTokenType.Object:
+                        StripNetkanMetadata((JObject)property.Value);
+                        break;
+                    case JTokenType.Array:
+                        foreach (var element in ((JArray)property.Value).Where(i => i.Type == JTokenType.Object))
+                        {
+                            StripNetkanMetadata((JObject)element);
+                        }
+                        break;
                 }
             }
 

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -73,7 +73,7 @@ namespace Tests.NetKAN
             Assert.AreEqual(metadata, expectedMetadata);
         }
 
-        private IEnumerable<object[]> StripNetkanMetadataTestCaseSource
+        private static IEnumerable<object[]> StripNetkanMetadataTestCaseSource
         {
             get
             {
@@ -124,6 +124,29 @@ namespace Tests.NetKAN
     ""baz"": {}
 }
                     "
+                };
+
+                yield return new object[]
+                {
+@"
+{
+    ""foo"": [
+        {
+            ""foo"": ""bar"",
+            ""x_netkan_foo"": ""foobar""
+        }
+    ]
+}
+",
+@"
+{
+    ""foo"": [
+        {
+            ""foo"": ""bar""
+        }
+    ]
+}
+"
                 };
             }
         }


### PR DESCRIPTION
@pjf  Update to the previous PR. This adds recursion into arrays to remove the properties, i.e.:

```json
{
  "foo": [
    {
      "x_netkan": "remove me"
    }
  ]
}
```

Test added for this case.

Changes best viewed when [ignoring whitespace](https://github.com/KSP-CKAN/CKAN/pull/1201/files?w=1).