### PR TITLE
Support MetaNetkans

### DIFF
--- a/Netkan/MainClass.cs
+++ b/Netkan/MainClass.cs
@@ -2,8 +2,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using CommandLine;
@@ -61,31 +63,7 @@ namespace CKAN.NetKAN
 
             JObject json = JsonFromFile(options.File);
             NetKanRemote remote = FindRemote(json);
-
-            JObject metadata;
-            switch (remote.source)
-            {
-                case "kerbalstuff":
-                    metadata = KerbalStuff(json, remote.id, cache);
-                    break;
-                case "jenkins":
-                    metadata = Jenkins(json, remote.id, cache);
-                    break;
-                case "github":
-                    if (options.GitHubToken != null)
-                    {
-                        GithubAPI.SetCredentials(options.GitHubToken);
-                    }
-
-                    metadata = GitHub(json, remote.id, options.PreRelease, cache);
-                    break;
-                case "http":
-                    metadata = HTTP(json, remote.id, cache, user);
-                    break;
-                default:
-                    log.FatalFormat("Unknown remote source: {0}", remote.source);
-                    return EXIT_ERROR;
-            }
+            var metadata = ProcessMetadata(json, remote, options.GitHubToken, options.PreRelease, cache, user, useRecursion: true);
 
             if (metadata == null)
             {
@@ -219,6 +197,55 @@ namespace CKAN.NetKAN
             File.WriteAllText(final_path, sw + Environment.NewLine);
 
             return EXIT_OK;
+        }
+
+        internal static JObject ProcessMetadata(
+            JObject json,
+            NetKanRemote remote,
+            string githubToken,
+            bool prelease,
+            NetFileCache cache,
+            IUser user,
+            bool useRecursion
+        )
+        {
+            JObject metadata;
+            switch (remote.source)
+            {
+                case "kerbalstuff":
+                    metadata = KerbalStuff(json, remote.id, cache);
+                    break;
+                case "jenkins":
+                    metadata = Jenkins(json, remote.id, cache);
+                    break;
+                case "github":
+                    if (githubToken != null)
+                    {
+                        GithubAPI.SetCredentials(githubToken);
+                    }
+
+                    metadata = GitHub(json, remote.id, prelease, cache);
+                    break;
+                case "http":
+                    metadata = HTTP(json, remote.id, cache, user);
+                    break;
+                case "netkan":
+                    if (useRecursion)
+                    {
+                        metadata = MetaNetkan(json, remote.id, githubToken, prelease, cache, user);
+                    }
+                    else
+                    {
+                        log.FatalFormat("Attempted to use a nested recursive netkan");
+                        return null;
+                    }
+                    break;
+                default:
+                    log.FatalFormat("Unknown remote source: {0}", remote.source);
+                    return null;
+            }
+
+            return metadata;
         }
 
         /// <summary>
@@ -440,6 +467,48 @@ namespace CKAN.NetKAN
 
            // metadata["download"] = metadata["download"].ToString() + '#' + metadata["version"].ToString();
             return metadata;
+        }
+
+        internal static JObject MetaNetkan(
+            JObject metadata,
+            string remoteId,
+            string githubToken,
+            bool prelease,
+            NetFileCache cache,
+            IUser user
+        )
+        {
+            var downloadFile = Net.Download(new Uri(remoteId));
+
+            var json = JObject.Parse(File.ReadAllText(downloadFile));
+            var remote = FindRemote(json);
+
+            var processedMetadata = ProcessMetadata(json, remote, githubToken, prelease, cache, user, useRecursion: false);
+
+            var metaSpecVersionJToken = metadata["spec_version"];
+            var processedSpecVersionJToken = processedMetadata["spec_version"];
+
+            var metaSpecVersion = metaSpecVersionJToken.Type == JTokenType.String ?
+                new Version((string)metaSpecVersionJToken) : new Version("v1.0");
+
+            var processedSpecVersion = processedSpecVersionJToken.Type == JTokenType.String ?
+                new Version((string)processedSpecVersionJToken) : new Version("v1.0");
+
+            if (metaSpecVersion > processedSpecVersion)
+            {
+                processedMetadata["spec_version"] = metaSpecVersionJToken;
+            }
+            else
+            {
+                processedMetadata["spec_version"] = processedSpecVersionJToken;
+            }
+
+            foreach (var property in metadata.Properties().Where(property => property.Name != "spec_version" && property.Name != "$kref"))
+            {
+                processedMetadata[property.Name] = property.Value;
+            }
+
+            return processedMetadata;
         }
 
         /// <summary>


### PR DESCRIPTION
This is a rough implementation of #865.

It supports the following:

- Allows you to specify `#/ckan/netkan` `$kref` properties, which are then downloaded and processed automatically.
- The `spec_version` used in the final output `.ckan` is the higher of the two specified in the metanetkan or the target netkan.
- Properties specified in the metanetkan override properties specified in the target netkan.

An example usage:
```json
{
    "spec_version": "v1.6",
    "identifier": "HotSpot",
    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/KSP-CKAN/NetKAN/master/NetKAN/HotSpot.netkan",
    "license": "restricted"
}
```

Produces the following ckan:
```json
{
    "spec_version": "v1.6",
    "identifier": "HotSpot",
    "depends": [
        {
            "name": "ModuleManager",
            "min_version": "2.6.5"
        }
    ],
    "resources": {
        "homepage": "http://forum.kerbalspaceprogram.com/threads/123967",
        "repository": "https://github.com/Apokee/HotSpot",
        "kerbalstuff": "https://kerbalstuff.com/mod/937/Hot%20Spot"
    },
    "ksp_version": "1.0.4",
    "name": "Hot Spot",
    "license": "restricted",
    "abstract": "Display better thermal data.",
    "author": "dbb",
    "version": "0.4.2",
    "download": "https://kerbalstuff.com/mod/937/Hot%20Spot/download/0.4.2",
    "x_generated_by": "netkan",
    "x_screenshot": "https://kerbalstuff.com/content/dbb_49/Hot_Spot/Hot_Spot-1435028274.4356654.png",
    "download_size": 24906
}
```

Notice that the `spec_version` is `v1.6` and the `license` property is overriden.