### PR TITLE
Show missing dependencies

### DIFF
--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -32,7 +32,7 @@ namespace CKAN.CmdLine
             if (installedModuleToShow != null)
             {
                 // Show the installed module.
-                return ShowMod(installedModuleToShow);
+                return ShowMod(installedModuleToShow, ksp);
             }
 
             // Module was not installed, look for an exact match in the available modules,
@@ -121,7 +121,7 @@ namespace CKAN.CmdLine
         /// </summary>
         /// <returns>Success status.</returns>
         /// <param name="module">The module to show.</param>
-        public int ShowMod(CkanModule module)
+        public int ShowMod(CkanModule module, CKAN.KSP ksp)
         {
             #region Abstract and description
             if (!string.IsNullOrEmpty(module.@abstract))
@@ -185,7 +185,17 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("\r\nProvides:");
                 foreach (string prov in module.ProvidesList)
                     user.RaiseMessage("- {0}", prov);
-            } 
+            }
+
+            var missingDeps = ksp.Registry.MissingDependencies((CKAN.CkanModule)module, ksp.Version());
+            if (missingDeps.Count() > 0)
+            {
+                user.RaiseMessage("\nUnsatisfied dependencies:");
+                foreach (string dep in missingDeps.Select(d => d.name))
+                    user.RaiseMessage("- {0}", dep);
+            }
+
+
             #endregion
 
             user.RaiseMessage("\r\nResources:");

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -187,7 +187,7 @@ namespace CKAN.CmdLine
                     user.RaiseMessage("- {0}", prov);
             }
 
-            var missingDeps = ksp.Registry.MissingDependencies((CKAN.CkanModule)module, ksp.Version());
+            var missingDeps = RegistryManager.Instance(ksp).registry.MissingDependencies((CKAN.CkanModule)module, ksp.Version());
             if (missingDeps.Count() > 0)
             {
                 user.RaiseMessage("\nUnsatisfied dependencies:");

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -404,7 +404,7 @@ namespace CKAN
         /// Returns the missing dependencies for a given module.
         /// If this returns an empty list, it's installable.
         /// </summary>
-        public List<RelationshipDescriptor> MissingDependencies(CkanModule mod, KSPVersion ksp_version)
+        public List<RelationshipDescriptor> MissingDependencies(CkanModule mod, KspVersion ksp_version)
         {
             // This mod does not depend on anything, so there are no missing deps
             if (mod.depends == null) return new List<RelationshipDescriptor>();


### PR DESCRIPTION
It would be very cool to know why a module is not compatible (I'm looking at you, RO).
This PR adds a new section to the output of the show command to list the unsatisfied dependencies for a module.

Currently it's incomplete as the search algorithm only searches for the module name in those available for the current version of KSP (which makes it useless to understand missing dependencies), and it turns out that the version lock is almost hardcoded.
