### PR TITLE
Remove spurious and harmless warnings.

### DIFF
--- a/Core/Converters/JsonIgnoreBadUrlConverter.cs
+++ b/Core/Converters/JsonIgnoreBadUrlConverter.cs
@@ -27,7 +27,7 @@ namespace CKAN
             }
             catch
             {
-                log.WarnFormat("{0} is not a valid URL, ignoring", value);
+                log.InfoFormat("{0} is not a valid URL, ignoring", value);
                 return null;
             }
         }

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -111,21 +111,21 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
 
             try
             {
-                data = parser.ReadFile(MimeAppsListPath); //();
+                data = parser.ReadFile(MimeAppsListPath);
             }
             catch (DirectoryNotFoundException ex)
             {
-                log.WarnFormat("Skipping URL handler: {0}", ex.Message);
+                log.InfoFormat("Skipping URL handler: {0}", ex.Message);
                 return;
             }
             catch (FileNotFoundException ex)
             {
-                log.WarnFormat("Skipping URL handler: {0}", ex.Message);
+                log.InfoFormat("Skipping URL handler: {0}", ex.Message);
                 return;
             }
             catch (ParsingException ex)
             {
-                log.WarnFormat("Skipping URL handler: {0}", ex.Message);
+                log.InfoFormat("Skipping URL handler: {0}", ex.Message);
                 return;
             }
 


### PR DESCRIPTION
Users often fixate on the warnings produced by our code, but the most
commonly seen warnings are completely harmless. This PR downgrades
two commonly seen warnings (one regarding URL handlers that's seen in
existing releases, and one regarding bad URLs that would be seen in
future releases) to the info level, as the code works perfectly fine
in the conditions which generate these.

No logic changes. Tested by hand.