### PR TITLE
The RelationshipResolver can now also resolve with InstalledModules

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -139,7 +139,7 @@ namespace CKAN
                     }
                     else
                     {
-                        throw kraken;
+                        throw new ModuleNotFoundKraken(kraken.module, kraken.version, "The module is not available, and it is not installed.", kraken);
                     }
                 }
             }


### PR DESCRIPTION
This is particularly useful for installed .ckan files
Because a InstalledModule can't be a CkanModule, we use Module objects for storage now.
also fixes the issue mentioned in #1223