### PR TITLE
Download cache button fixes

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -760,7 +760,7 @@ namespace CKAN
         private void ContentsDownloadButton_Click(object sender, EventArgs e)
         {
             var module = GetSelectedModule();
-            if (module == null) return;
+            if (module == null || !module.IsCKAN) return;
 
             ResetProgress();
             ShowWaitDialog(false);

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -302,6 +302,10 @@ namespace CKAN
             m_InstallWorker.RunWorkerCompleted += PostInstallMods;
             m_InstallWorker.DoWork += InstallMods;
 
+            m_CacheWorker = new BackgroundWorker { WorkerReportsProgress = true, WorkerSupportsCancellation = true };
+            m_CacheWorker.RunWorkerCompleted += PostModCaching;
+            m_CacheWorker.DoWork += CacheMod;
+
             UpdateModsList();
 
             m_User.displayYesNo = YesNoDialog;
@@ -760,11 +764,7 @@ namespace CKAN
 
             ResetProgress();
             ShowWaitDialog(false);
-            ModuleInstaller.GetInstance(CurrentInstance, m_User).CachedOrDownload(module.ToCkanModule());
-            HideWaitDialog(true);
-
-            UpdateModContentsTree(module);
-            RecreateDialogs();
+            m_CacheWorker.RunWorkerAsync(module.ToCkanModule());
         }
 
         private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -16,6 +17,8 @@ namespace CKAN
 
     public partial class Main : Form
     {
+        private BackgroundWorker m_CacheWorker;
+
         private void UpdateModInfo(GUIMod gui_module)
         {
             Module module = gui_module.ToModule();
@@ -248,7 +251,7 @@ namespace CKAN
 
         private void _UpdateModContentsTree()
         {
-            var module = (CkanModule) ModInfoTabControl.Tag;
+            var module = (CkanModule)ModInfoTabControl.Tag;
             if (Equals(module, current_mod_contents_module))
             {
                 return;
@@ -285,6 +288,25 @@ namespace CKAN
             }
 
             ContentsPreviewTree.Nodes[0].ExpandAll();
+        }
+
+        private void CacheMod(object sender, DoWorkEventArgs e)
+        {
+            ModuleInstaller.GetInstance(CurrentInstance, m_User).CachedOrDownload((CkanModule)e.Argument);
+            e.Result = e.Argument;
+        }
+
+        private void PostModCaching(object sender, RunWorkerCompletedEventArgs e)
+        {
+            Util.Invoke(this, () => _PostModCaching((CkanModule)e.Result));
+        }
+
+        private void _PostModCaching(CkanModule module)
+        {
+            HideWaitDialog(true);
+
+            UpdateModContentsTree(module);
+            RecreateDialogs();
         }
     }
 }

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -251,7 +251,12 @@ namespace CKAN
 
         private void _UpdateModContentsTree(bool force = false)
         {
-            var module = (CkanModule)ModInfoTabControl.Tag;
+            GUIMod guiMod = GetSelectedModule();
+            if (!guiMod.IsCKAN)
+            {
+                return;
+            }
+            CkanModule module = guiMod.ToCkanModule();
             if (Equals(module, current_mod_contents_module) && !force)
             {
                 return;

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -236,23 +236,23 @@ namespace CKAN
                 UpdateModDependencyGraph(null);
         }
 
-        private void UpdateModContentsTree(Module module)
+        private void UpdateModContentsTree(Module module, bool force = false)
         {
             ModInfoTabControl.Tag = module ?? ModInfoTabControl.Tag;
             //Can be costly. For now only update when visible.
-            if (ModInfoTabControl.SelectedIndex != ContentTabPage.TabIndex)
+            if (ModInfoTabControl.SelectedIndex != ContentTabPage.TabIndex && !force)
             {
                 return;
             }
-            Util.Invoke(ContentsPreviewTree, _UpdateModContentsTree);
+            Util.Invoke(ContentsPreviewTree, () => _UpdateModContentsTree(force));
         }
 
         private Module current_mod_contents_module;
 
-        private void _UpdateModContentsTree()
+        private void _UpdateModContentsTree(bool force = false)
         {
             var module = (CkanModule)ModInfoTabControl.Tag;
-            if (Equals(module, current_mod_contents_module))
+            if (Equals(module, current_mod_contents_module) && !force)
             {
                 return;
             }
@@ -305,7 +305,7 @@ namespace CKAN
         {
             HideWaitDialog(true);
 
-            UpdateModContentsTree(module);
+            UpdateModContentsTree(module, true);
             RecreateDialogs();
         }
     }


### PR DESCRIPTION
The download page is now visible during a download.
Refresh the contenttree after a download.