### PR TITLE
Allow installation into subdirectories of Ships

### DIFF
--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -252,6 +252,16 @@ namespace CKAN
             return Path.Combine(GameDir(), "Ships");
         }
 
+        public string ShipsVab()
+        {
+            return Path.Combine(Ships(), "VAB");
+        }
+
+        public string ShipsSph()
+        {
+            return Path.Combine(Ships(), "SPH");
+        }
+
         public string Tutorial()
         {
             return Path.Combine(GameDir(), "saves", "training");

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -426,12 +426,28 @@ namespace CKAN
                 installDir = ksp == null ? null : (KSPPathUtils.NormalizePath(ksp.GameData() + "/" + subDir));
                 makeDirs = true;
             }
+            else if (stanza.install_to.StartsWith("Ships"))
+            {
+                // Don't allow directory creation in ships directory
+                makeDirs = false;
+
+                switch (stanza.install_to)
+                {
+                    case "Ships":
+                        installDir = ksp == null ? null : ksp.Ships();
+                        break;
+                    case "Ships/VAB":
+                        installDir = ksp == null ? null : ksp.ShipsVab();
+                        break;
+                    case "Ships/SPH":
+                        installDir = ksp == null ? null : ksp.ShipsSph();
+                        break;
+                    default:
+                        throw new BadInstallLocationKraken("Unknown install_to " + stanza.install_to);
+                }
+            }
             else switch (stanza.install_to)
             {
-                case "Ships":
-                    installDir = ksp == null ? null : ksp.Ships();
-                    makeDirs = false; // Don't allow directory creation in ships directory
-                    break;
                 case "Tutorial":
                     installDir = ksp == null ? null : ksp.Tutorial();
                     makeDirs = true;

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -484,7 +484,7 @@ namespace Tests.Core
 
             var mod = CkanModule.FromJson(string.Format(@"
             {{
-                ""spec_version"": ""v1.12"",
+                ""spec_version"": 1,
                 ""identifier"": ""AwesomeMod"",
                 ""version"": ""1.0.0"",
                 ""download"": ""https://awesomemod.example/AwesomeMod.zip"",

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -470,6 +470,48 @@ namespace Tests.Core
             );
         }
 
+        [TestCase("Ships")]
+        [TestCase("Ships/VAB")]
+        [TestCase("Ships/SPH")]
+        public void AllowsInstallsToShipsDirectories(string directory)
+        {
+            // Arrange
+            var zip = ZipFile.Create(new MemoryStream());
+            zip.BeginUpdate();
+            zip.AddDirectory("ExampleShips");
+            zip.Add(new ZipEntry("/ExampleShips/AwesomeShip.craft") { Size = 0, CompressedSize = 0 });
+            zip.CommitUpdate();
+
+            var mod = CkanModule.FromJson(string.Format(@"
+            {{
+                ""spec_version"": ""v1.12"",
+                ""identifier"": ""AwesomeMod"",
+                ""version"": ""1.0.0"",
+                ""download"": ""https://awesomemod.example/AwesomeMod.zip"",
+                ""install"": [
+                    {{
+                        ""file"": ""ExampleShips/AwesomeShip.craft"",
+                        ""install_to"": ""{0}""
+                    }}
+                ]
+            }}
+            ", directory));
+
+            // Act
+            List<InstallableFile> results;
+            using (var ksp = new DisposableKSP())
+            {
+                results = CKAN.ModuleInstaller.FindInstallableFiles(mod.install.First(), zip, ksp.KSP);
+            }
+
+
+            // Assert
+            Assert.That(
+                results.Count(i => i.destination.EndsWith(string.Format("/{0}/AwesomeShip.craft", directory))) == 1,
+                Is.True
+            );
+        }
+
         private static void TestDogeCoinStanza(ModuleInstallDescriptor stanza)
         {
             Assert.AreEqual("GameData", stanza.install_to);


### PR DESCRIPTION
Fixes #1134, allowing `install_to` directives to specify `Ships/VAB` or `Ships/SPH` to install into those subdirectories. We still don't allow mods to create directories within `Ships` though.

Still needs:
- [x] Tests
- [x] Documentation Update

This would require a bump to the `spec_version` to `v1.12`.