### PR TITLE
If KerbalStuff doesn't provide a `homepage`, use the KerbalStuff page instead.

### DIFF
--- a/Core/Exporters/DelimeterSeperatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeperatedValueExporter.cs
@@ -101,7 +101,7 @@ namespace CKAN.Exporters
             {
                 return QuoteIfNecessary(resources.homepage.ToString());
             }
-            else if (resources != null && resources.homepage = null && resources.kerbalstuff != null)
+            else if (resources != null && resources.homepage == null && resources.kerbalstuff != null)
             {
                 return QuoteIfNecessary(resources.kerbalstuff.ToString());
             }

--- a/Core/Exporters/DelimeterSeperatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeperatedValueExporter.cs
@@ -105,6 +105,10 @@ namespace CKAN.Exporters
             {
                 return QuoteIfNecessary(resources.kerbalstuff.ToString());
             }
+            else if (resources != null && resources.homepage == null && resources.repository != null)
+            {
+                return QuoteIfNecessary(resources.repository.ToString());
+            }
             
             return string.Empty;
         }

--- a/Core/Exporters/DelimeterSeperatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeperatedValueExporter.cs
@@ -101,7 +101,11 @@ namespace CKAN.Exporters
             {
                 return QuoteIfNecessary(resources.homepage.ToString());
             }
-
+            else if (resources != null && resources.homepage = null && resources.kerbalstuff != null)
+            {
+                return QuoteIfNecessary(resources.kerbalstuff.ToString());
+            }
+            
             return string.Empty;
         }
 


### PR DESCRIPTION
A fair number of mods go through the NetKAN addition process without homepages. While it isn't the biggest deal in the world it would be nice if we could reliably provide users with a way to get more information than what's available in the abstract.

What I think the code I wrote does: If we have a homepage provided use that. If we don't and we have a KerbalStuff page, turn that into the homepage. (First time writing anything in C#).