### PR TITLE
Make better efforts to present users with homepages for mods aka "give homes to the homeless"

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -73,11 +73,11 @@ namespace CKAN
             {
                 Homepage = (object) mod.resources.homepage;
             }
-            else if (mod.resources != null && mod.resources.kerbalstuff != null)
+            else if (mod.resources.kerbalstuff != null)
             {
                 Homepage = (object) mod.resources.kerbalstuff;
             }
-            else if (mod.resources != null && mod.resources.repository != null)
+            else if (mod.resources.repository != null)
             {
                 Homepage = (object) mod.resources.repository;
             }

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -67,10 +67,25 @@ namespace CKAN
             KSPversion = ksp_version != null ? ksp_version.ToString() : "-";
 
             Abstract = mod.@abstract;
-            Homepage = mod.resources != null && mod.resources.homepage != null
-                ? (object) mod.resources.homepage
-                : "N/A";
-
+            
+            // If we have homepage provided use that, otherwise use the kerbalstuff page or the github repo so that users have somewhere to get more info than just the abstract.
+            if (mod.resources != null && mod.resources.homepage != null)
+            {
+                Homepage = (object) mod.resources.homepage;
+            }
+            else if (mod.resources != null && mod.resources.kerbalstuff != null)
+            {
+                Homepage = (object) mod.resources.kerbalstuff;
+            }
+            else if (mod.resources != null && mod.resources.repository != null)
+            {
+                Homepage = (object) mod.resources.repository;
+            }
+            else
+            {
+                Homepage = "N/A";
+            }
+            
             Identifier = mod.identifier;
         }
 

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -69,17 +69,25 @@ namespace CKAN
             Abstract = mod.@abstract;
             
             // If we have homepage provided use that, otherwise use the kerbalstuff page or the github repo so that users have somewhere to get more info than just the abstract.
-            if (mod.resources != null && mod.resources.homepage != null)
+            
+            if (mod.resources != null)
             {
-                Homepage = (object) mod.resources.homepage;
-            }
-            else if (mod.resources.kerbalstuff != null)
-            {
-                Homepage = (object) mod.resources.kerbalstuff;
-            }
-            else if (mod.resources.repository != null)
-            {
-                Homepage = (object) mod.resources.repository;
+                if (mod.resources.homepage != null)
+                {
+                    Homepage = (object) mod.resources.homepage;
+                }
+                else if (mod.resources.kerbalstuff != null)
+                {
+                    Homepage = (object) mod.resources.kerbalstuff;
+                }
+                else if (mod.resources.repository != null)
+                {
+                    Homepage = (object) mod.resources.repository;
+                }
+                else
+                {
+          	      Homepage = "N/A";
+                }
             }
             else
             {

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -24,16 +24,36 @@ namespace CKAN
             Util.Invoke(MetadataModuleAuthorLabel, () => UpdateModInfoAuthor(module));
             Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = module.@abstract);
 
-            if (module.resources != null && module.resources.homepage != null)
+            // If we have homepage provided use that, otherwise use the kerbalstuff page or the github repo so that users have somewhere to get more info than just the abstract.
+            if (module.resources != null)
             {
-                Util.Invoke(MetadataModuleHomePageLinkLabel,
-                    () => MetadataModuleHomePageLinkLabel.Text = module.resources.homepage.ToString());
+                if (module.resources.homepage != null)
+                {
+                    Util.Invoke(MetadataModuleHomePageLinkLabel,
+                        () => MetadataModuleHomePageLinkLabel.Text = module.resources.homepage.ToString());
+                }
+                else if (module.resources.kerbalstuff != null)
+                {
+                    Util.Invoke(MetadataModuleHomePageLinkLabel,
+                        () => MetadataModuleHomePageLinkLabel.Text = module.resources.kerbalstuff.ToString());
+                }
+                else if (module.resources.repository != null)
+                {
+                    Util.Invoke(MetadataModuleHomePageLinkLabel,
+                        () => MetadataModuleHomePageLinkLabel.Text = module.resources.repository.ToString());
+                }
+                else
+                {
+                    Util.Invoke(MetadataModuleHomePageLinkLabel,
+                        () => MetadataModuleHomePageLinkLabel.Text = "N/A");
+                }
             }
             else
             {
                 Util.Invoke(MetadataModuleHomePageLinkLabel,
                     () => MetadataModuleHomePageLinkLabel.Text = "N/A");
             }
+
 
             if (module.resources != null && module.resources.repository != null)
             {


### PR DESCRIPTION
A pet peeve of mine is seeing "N/A" in CKAN and not being able to get more information about a given mod.

This will have the GUI present the KerbalStuff or GitHub page (with the former superceding the latter) when `homepage` isn't provided in the metadata.

I suck at coding, if this can be done more efficiently please let me know.