### PR TITLE
Change default config to launch KSP with -single-instance

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -51,9 +51,9 @@ namespace CKAN
                 var configuration = new Configuration
                 {
                     m_Path = path,
-                    CommandLineArguments = Platform.IsUnix ? "./KSP.x86_64" :
-                                           Platform.IsMac  ? "./KSP.app/Contents/MacOS/KSP" :
-                                                             "KSP.exe"
+                        CommandLineArguments = Platform.IsUnix ? "./KSP.x86_64 -single-instance" :
+                            Platform.IsMac  ? "./KSP.app/Contents/MacOS/KSP -single-instance" :
+                            "KSP.exe -single-instance"
                 };
 
                 SaveConfiguration(configuration, path);

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -52,7 +52,7 @@ namespace CKAN
                 {
                     m_Path = path,
                         CommandLineArguments = Platform.IsUnix ? "./KSP.x86_64 -single-instance" :
-                            Platform.IsMac  ? "./KSP.app/Contents/MacOS/KSP -single-instance" :
+                            Platform.IsMac  ? "./KSP.app/Contents/MacOS/KSP" :
                             "KSP.exe -single-instance"
                 };
 


### PR DESCRIPTION
Partially addresses #1232. This won't help existing (or Mac) users, but new users moving forward will be able to click the launch button to their heart's content.