### PR TITLE
Point the repo master list to CKAN-meta on github

### DIFF
--- a/Core/Types/Repository.cs
+++ b/Core/Types/Repository.cs
@@ -7,7 +7,7 @@ namespace CKAN
     {
         [JsonIgnore] public static readonly string default_ckan_repo_name = "default";
         [JsonIgnore] public static readonly Uri default_ckan_repo_uri = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.zip");
-        [JsonIgnore] public static readonly Uri default_repo_master_list = new Uri("http://api.ksp-ckan.org/mirrors");
+        [JsonIgnore] public static readonly Uri default_repo_master_list = new Uri("https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/repositories.json");
 
         public string name;
         public Uri uri;


### PR DESCRIPTION
api.ksp-ckan.org is not available anymore, put the repo list on github so it enjoys the same availability as our other metada files.