### PR TITLE
Add support for locking the registry.

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -243,7 +243,11 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                     break;
             }
 
-            manager.CurrentInstance.RegistryManager.Dispose();
+            // Release the registry lock file if possible.
+            if (manager.CurrentInstance != null)
+            {
+                manager.CurrentInstance.RegistryManager.Dispose();
+            }
 
             return return_code;
         }

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -109,7 +109,9 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                 user.RaiseMessage("--ksp and --kspdir can't be specified at the same time");
                 return Exit.BADOPT;
             }
+
             KSPManager manager= new KSPManager(user);
+
             if (options.KSP != null)
             {
                 // Set a KSP directory by its alias.
@@ -162,65 +164,88 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
 
             #endregion
 
+            var return_code = Exit.OK;
+
             switch (cmdline.action)
             {
                 case "gui":
-                    return Gui((GuiOptions)options, args);
+                    return_code = Gui((GuiOptions)options, args);
+                    break;
 
                 case "version":
-                    return Version(user);
+                    return_code = Version(user);
+                    break;
 
                 case "update":
-                    return (new Update(user)).RunCommand(manager.CurrentInstance, (UpdateOptions)cmdline.options);
+                    return_code = (new Update(user)).RunCommand(manager.CurrentInstance, (UpdateOptions)cmdline.options);
+                    break;
 
                 case "available":
-                    return Available(manager.CurrentInstance, user);
+                    return_code = Available(manager.CurrentInstance, user);
+                    break;
 
                 case "install":
                     Scan(manager.CurrentInstance, user, cmdline.action);
-                    return (new Install(user)).RunCommand(manager.CurrentInstance, (InstallOptions)cmdline.options);
+                    return_code = (new Install(user)).RunCommand(manager.CurrentInstance, (InstallOptions)cmdline.options);
+                    break;
 
                 case "scan":
-                    return Scan(manager.CurrentInstance,user);
+                    return_code = Scan(manager.CurrentInstance,user);
+                    break;
 
                 case "list":
-                    return (new List(user)).RunCommand(manager.CurrentInstance, (ListOptions)cmdline.options);
+                    return_code = (new List(user)).RunCommand(manager.CurrentInstance, (ListOptions)cmdline.options);
+                    break;
 
                 case "show":
-                    return (new Show(user)).RunCommand(manager.CurrentInstance, (ShowOptions)cmdline.options);
+                    return_code = (new Show(user)).RunCommand(manager.CurrentInstance, (ShowOptions)cmdline.options);
+                    break;
 
                 case "search":
-                    return (new Search(user)).RunCommand(manager.CurrentInstance, options);
+                    return_code = (new Search(user)).RunCommand(manager.CurrentInstance, options);
+                    break;
 
                 case "remove":
-                    return (new Remove(user)).RunCommand(manager.CurrentInstance, cmdline.options);
+                    return_code = (new Remove(user)).RunCommand(manager.CurrentInstance, cmdline.options);
+                    break;
 
                 case "upgrade":
                     Scan(manager.CurrentInstance, user, cmdline.action);
-                    return (new Upgrade(user)).RunCommand(manager.CurrentInstance, cmdline.options);
+                    return_code = (new Upgrade(user)).RunCommand(manager.CurrentInstance, cmdline.options);
+                    break;
 
                 case "clean":
-                    return Clean(manager.CurrentInstance);
+                    return_code = Clean(manager.CurrentInstance);
+                    break;
 
                 case "repair":
                     var repair = new Repair(manager.CurrentInstance,user);
-                    return repair.RunSubCommand((SubCommandOptions) cmdline.options);
+                    return_code = repair.RunSubCommand((SubCommandOptions) cmdline.options);
+                    break;
 
                 case "ksp":
                     var ksp = new KSP(manager, user);
-                    return ksp.RunSubCommand((SubCommandOptions) cmdline.options);
+                    return_code = ksp.RunSubCommand((SubCommandOptions) cmdline.options);
+                    break;
 
                 case "repo":
                     var repo = new Repo (manager, user);
-                    return repo.RunSubCommand((SubCommandOptions) cmdline.options);
+                    return_code = repo.RunSubCommand((SubCommandOptions) cmdline.options);
+                    break;
 
                 case "compare":
-                    return (new Compare(user)).RunCommand(manager.CurrentInstance, cmdline.options);
+                    return_code = (new Compare(user)).RunCommand(manager.CurrentInstance, cmdline.options);
+                    break;
 
                 default:
                     user.RaiseMessage("Unknown command, try --help");
-                    return Exit.BADOPT;
+                    return_code = Exit.BADOPT;
+                    break;
             }
+
+            manager.CurrentInstance.RegistryManager.Dispose();
+
+            return return_code;
         }
 
         private static void CheckMonoVersion(IUser user, int rec_major, int rec_minor, int rec_patch)

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -234,6 +234,9 @@ namespace CKAN
                 throw new InvalidKSPInstanceKraken(name);
             }
 
+            // Dispose of the old registry manager, to release the registry.
+            CurrentInstance.RegistryManager.Dispose();
+
             CurrentInstance = instances[name];
         }
 

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -75,6 +76,11 @@ namespace CKAN
             try
             {
                 lockfile_stream = new FileStream(lockfile_path, FileMode.CreateNew, FileAccess.Write, FileShare.None, 512, FileOptions.DeleteOnClose);
+
+                // Write the current process ID to the file.
+                StreamWriter writer = new StreamWriter(lockfile_stream);
+                writer.Write(Process.GetCurrentProcess().Id);
+                writer.Flush();
             }
             catch (IOException)
             {

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -10,13 +10,17 @@ using Newtonsoft.Json.Linq;
 
 namespace CKAN
 {
-    public class RegistryManager
+    public class RegistryManager : IDisposable
     {
         private static readonly Dictionary<string, RegistryManager> singleton =
             new Dictionary<string, RegistryManager>();
 
         private static readonly ILog log = LogManager.GetLogger(typeof (RegistryManager));
         private readonly string path;
+        private readonly string lock_file_path;
+
+        private bool lock_acquired = false;
+
         private readonly TxFileManager file_transaction = new TxFileManager();
 
         // The only reason we have a KSP field is so we can pass it to the registry
@@ -34,7 +38,14 @@ namespace CKAN
             this.ksp = ksp;
 
             this.path = Path.Combine(path, "registry.json");
+            lock_file_path = Path.Combine(path, "registry.json.locked");
             LoadOrCreate();
+
+            // Create a lock for this registry, so we cannot touch it again.
+            if (!GetLock())
+            {
+                throw new Kraken("Registry is already in use. If this is not the case, then delete the lock file manually." + lock_file_path);
+            }
 
             // We don't cause an inconsistency error to stop the registry from being loaded,
             // because then the user can't do anything to correct it. However we're
@@ -46,6 +57,40 @@ namespace CKAN
             catch (InconsistentKraken kraken)
             {
                 log.ErrorFormat("Loaded registry with inconsistencies:\n\n{0}", kraken.InconsistenciesPretty);
+            }
+        }
+
+        public void Dispose()
+        {
+            // Release the lock.
+            ReleaseLock();
+        }
+
+        /// <summary>
+        /// Tries to lock the registry by creating a lock file.
+        /// </summary>
+        /// <returns><c>true</c>, if lock was gotten, <c>false</c> otherwise.</returns>
+        public bool GetLock()
+        {
+            if (File.Exists(lock_file_path))
+            {
+                return false;
+            }
+
+            File.Create(lock_file_path);
+            lock_acquired = true;
+
+            return true;
+        }
+            
+        /// <summary>
+        /// Release the lock by deleting the file, but only if we managed to create the file.
+        /// </summary>
+        public void ReleaseLock()
+        {
+            if (lock_acquired)
+            {
+                File.Delete(lock_file_path);
             }
         }
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -299,4 +299,20 @@ namespace CKAN
             ;
         }
     }
+
+    public class RegistryInUseKraken : Kraken
+    {
+        readonly string lockfile_path;
+
+        public RegistryInUseKraken(string lockfile_path, string reason = null, Exception inner_exception = null)
+            :base(reason, inner_exception)
+        {
+            this.lockfile_path = lockfile_path;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("\nThe registry is already in use for this instance!\n\nIf you're certain this is not the case, then delete:\n\t\"{0}\"\n", lockfile_path);
+        }
+    }
 }

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -312,7 +312,7 @@ namespace CKAN
 
         public override string ToString()
         {
-            return String.Format("\nThe registry is already in use for this instance!\n\nIf you're certain this is not the case, then delete:\n\t\"{0}\"\n", lockfile_path);
+            return String.Format("The registry is already in use for this instance!\n\nIf you're certain this is not the case, then delete:\n\"{0}\"\n", lockfile_path);
         }
     }
 }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -187,6 +187,21 @@ namespace CKAN
                     Repo.default_ckan_repo.ToString()
                 );
 
+            // Check if there is any other instances already running.
+            // This is not entirely necessary, but we can show a nicer error message this way.
+            try
+            {
+                #pragma warning disable 219
+                Registry registry = RegistryManager.Instance(CurrentInstance).registry;
+                #pragma warning restore 219
+            }
+            catch (RegistryInUseKraken kraken)
+            {
+                m_ErrorDialog.ShowErrorDialog(kraken.ToString());
+
+                return;
+            }
+
             FilterToolButton.MouseHover += (sender, args) => FilterToolButton.ShowDropDown();
             launchKSPToolStripMenuItem.MouseHover += (sender, args) => launchKSPToolStripMenuItem.ShowDropDown();
             ApplyToolButton.MouseHover += (sender, args) => ApplyToolButton.ShowDropDown();

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -221,6 +221,8 @@ namespace CKAN
             }
 
             Application.Run(this);
+
+            Manager.CurrentInstance.RegistryManager.Dispose();
         }
 
         private void ModList_CurrentCellDirtyStateChanged(object sender, EventArgs e)


### PR DESCRIPTION
This change creates a file when the RegistryManager loads a registry. Any other attempts at opening the registry will throw a kraken. Should be implemented in both cmd and gui.

Closes #1259 and #706.