### PR TITLE
Fix bad characters in filename in module.

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -150,16 +150,6 @@ namespace CKAN
 
             string hash = CreateURLHash(url);
 
-            if (description != null)
-            {
-                // Versions can contain ALL SORTS OF WACKY THINGS! Colons, friggin newlines,
-                // slashes, and heaven knows what use mod authors try to smoosh into them.
-                // We'll reduce this down to "friendly" characters, replacing everything else with
-                // dashes. This doesn't change look-ups, as we use the hash prefix for that.
-
-                description = Regex.Replace(description, "[^A-Za-z0-9_.-]", "-");
-            }
-
             description = description ?? Path.GetFileName(path);
 
             string fullName = String.Format("{0}-{1}", hash, Path.GetFileName(description));

--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -565,7 +565,13 @@ namespace CKAN
 
         public static string StandardName(string identifier, Version version)
         {
-            return identifier + "-" + version + ".zip";
+            // Versions can contain ALL SORTS OF WACKY THINGS! Colons, friggin newlines,
+            // slashes, and heaven knows what use mod authors try to smoosh into them.
+            // We'll reduce this down to "friendly" characters, replacing everything else with
+            // dashes. This doesn't change look-ups, as we use the hash prefix for that.
+            string version_string = Regex.Replace(version.ToString(), "[^A-Za-z0-9_.-]", "-");
+
+            return identifier + "-" + version_string + ".zip";
         }
     }
 

--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -56,8 +56,8 @@ namespace Tests.Core
             FileAssert.AreEqual(file, cached_file);
         }
 
-        [Test, TestCase("cheesy.zip","cheesy.zip"), TestCase("Foo-1:2.3","Foo-1-2.3"),
-            TestCase("Foo-1:2:3","Foo-1-2-3"), TestCase("Foo/../etc/passwd","Foo-..-etc-passwd")]
+        [Test, TestCase("cheesy.zip","cheesy.zip"), TestCase("Foo-1-2.3","Foo-1-2.3"),
+            TestCase("Foo-1-2-3","Foo-1-2-3"), TestCase("Foo-..-etc-passwd","Foo-..-etc-passwd")]
         public void NamingHints(string hint, string appendage)
         {
             Uri url = new Uri("http://example.com/");

--- a/Tests/Core/Types/Module.cs
+++ b/Tests/Core/Types/Module.cs
@@ -21,8 +21,10 @@ namespace Tests.Core.Types
         public void StandardName()
         {
             CkanModule module = CkanModule.FromJson(TestData.kOS_014());
-
             Assert.AreEqual(module.StandardName(), "kOS-0.14.zip");
+
+            CkanModule module2 = CkanModule.FromJson(TestData.kOS_014_with_invalid_version_characters());
+            Assert.AreEqual(module2.StandardName(), "kOS-0-14-0.zip");
         }
 
         [Test]

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -298,6 +298,38 @@ namespace Tests.Data
             ;
         }
 
+        public static string kOS_014_with_invalid_version_characters()
+        {
+            return @"
+                {
+                    ""spec_version"": 1,
+                    ""name""     : ""kOS - Kerbal OS"",
+                    ""identifier"" : ""kOS"",
+                    ""abstract"" : ""A programming and automation environment for KSP craft."",
+                    ""download"" : ""https://github.com/KSP-KOS/KOS/releases/download/v0.14/kOS.v14.zip"",
+                    ""license""  : ""GPL-3.0"",
+                    ""version""  : ""0:14^0"",
+                    ""release_status"" : ""stable"",
+                    ""ksp_version"" : ""0.24.2"",
+                    ""resources"" : {
+                        ""homepage"" : ""http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS-Scriptable-Autopilot-System-v0-11-2-13"",
+                        ""manual""   : ""http://ksp-kos.github.io/KOS_DOC/"",
+                        ""bugtracker"": ""https://github.com/KSP-KOS/KOS/issues"",
+                        ""github""   : {
+                            ""url""      : ""https://github.com/KSP-KOS/KOS"",
+                            ""releases"" : true
+                        }
+                    },
+                    ""install"" : [
+                        {
+                            ""file""       : ""GameData/kOS"",
+                            ""install_to"" : ""GameData""
+                        }
+                    ]
+                }"
+            ;
+        }
+
         // AFAIK kOS isn't multi-licensed, but we need somthing for testing. :)
         public static string kOS_014_multilicense()
         {


### PR DESCRIPTION
@pjf reported a slight issue with show in the cli in #1249. This should fix that by moving the renaming code further up the chain. I cannot test with the case @pjf used, since I can't seem to locate it in my registry.

Closes #1249.