### PR TITLE
Small GUI overhaul. Added compatibility column and to right pane, removed homepage column, resized all columns.

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -20,6 +20,7 @@ namespace CKAN
         public string Authors { get; private set; }
         public string InstalledVersion { get; private set; }
         public string LatestVersion { get; private set; }
+        public string KSPCompatibility { get; private set; }
         public string KSPversion { get; private set; }
         public string Abstract { get; private set; }
         public object Homepage { get; private set; }
@@ -64,12 +65,31 @@ namespace CKAN
 
             InstalledVersion = installed_version != null ? installed_version.ToString() : "-";
             LatestVersion = latest_version != null ? latest_version.ToString() : "-";
+
+            // Find the highest compatible KSP version
+            if (!String.IsNullOrEmpty(mod.ksp_version_max.ToString()))
+            {
+                KSPCompatibility = mod.ksp_version_max.ToLongMax().ToString();
+            }
+            else if (!String.IsNullOrEmpty(mod.ksp_version.ToString()))
+            {
+                KSPCompatibility = mod.ksp_version.ToLongMax().ToString();
+            }
+            else if (!String.IsNullOrEmpty(mod.ksp_version_min.ToString()))
+            {
+                KSPCompatibility = "Any above " + mod.ksp_version_min.ToLongMin().ToString();
+            }
+            else
+            {
+                KSPCompatibility = "All versions";
+            }
+
+
             KSPversion = ksp_version != null ? ksp_version.ToString() : "-";
 
             Abstract = mod.@abstract;
             
             // If we have homepage provided use that, otherwise use the kerbalstuff page or the github repo so that users have somewhere to get more info than just the abstract.
-            
             if (mod.resources != null)
             {
                 if (mod.resources.homepage != null)
@@ -93,7 +113,7 @@ namespace CKAN
             {
                 Homepage = "N/A";
             }
-            
+
             Identifier = mod.identifier;
         }
 

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -77,7 +77,7 @@ namespace CKAN
             }
             else if (!String.IsNullOrEmpty(mod.ksp_version_min.ToString()))
             {
-                KSPCompatibility = "Any above " + mod.ksp_version_min.ToLongMin().ToString();
+                KSPCompatibility = mod.ksp_version_min.ToLongMin().ToString() + " and up";
             }
             else
             {

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -68,7 +68,6 @@ namespace CKAN
             this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Homepage = new System.Windows.Forms.DataGridViewLinkColumn();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.ModInfoTabControl = new System.Windows.Forms.TabControl();
             this.MetadataTabPage = new System.Windows.Forms.TabPage();
@@ -409,8 +408,7 @@ namespace CKAN
             this.InstalledVersion,
             this.LatestVersion,
             this.KSPCompatibility,
-            this.Description,
-            this.Homepage});
+            this.Description});
             this.ModList.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ModList.Location = new System.Drawing.Point(0, 0);
             this.ModList.MultiSelect = false;
@@ -486,17 +484,7 @@ namespace CKAN
             this.Description.Name = "Description";
             this.Description.ReadOnly = true;
             this.Description.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Description.Width = 300;
-            // 
-            // Homepage
-            // 
-            this.Homepage.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Homepage.HeaderText = "Homepage";
-            this.Homepage.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
-            this.Homepage.Name = "Homepage";
-            this.Homepage.ReadOnly = true;
-            this.Homepage.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Homepage.Width = 200;
+            this.Description.Width = 821;
             // 
             // splitContainer1
             // 
@@ -1372,7 +1360,6 @@ namespace CKAN
         private DataGridViewTextBoxColumn KSPCompatibility;
         private DataGridViewTextBoxColumn LatestVersion;
         private DataGridViewTextBoxColumn Description;
-        private DataGridViewLinkColumn Homepage;
         private ToolStripMenuItem pluginsToolStripMenuItem;
         public ToolStripMenuItem settingsToolStripMenuItem;
         public DataGridView ModList;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -446,7 +446,7 @@ namespace CKAN
             this.ModName.Name = "ModName";
             this.ModName.ReadOnly = true;
             this.ModName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.ModName.Width = 58;
+            this.ModName.Width = 250;
             // 
             // Author
             // 
@@ -454,7 +454,7 @@ namespace CKAN
             this.Author.Name = "Author";
             this.Author.ReadOnly = true;
             this.Author.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Author.Width = 61;
+            this.Author.Width = 120;
             // 
             // InstalledVersion
             // 
@@ -462,7 +462,7 @@ namespace CKAN
             this.InstalledVersion.Name = "InstalledVersion";
             this.InstalledVersion.ReadOnly = true;
             this.InstalledVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.InstalledVersion.Width = 97;
+            this.InstalledVersion.Width = 70;
             // 
             // LatestVersion
             // 
@@ -470,15 +470,15 @@ namespace CKAN
             this.LatestVersion.Name = "LatestVersion";
             this.LatestVersion.ReadOnly = true;
             this.LatestVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.LatestVersion.Width = 88;
+            this.LatestVersion.Width = 70;
             //
-            // LatestVersion
+            // Highest compatible version of KSP
             // 
-            this.KSPCompatibility.HeaderText = "Highest compat. KSP version";
+            this.KSPCompatibility.HeaderText = "Highest compatible KSP version";
             this.KSPCompatibility.Name = "KSPCompatibility";
             this.KSPCompatibility.ReadOnly = true;
             this.KSPCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.KSPCompatibility.Width = 88;
+            this.KSPCompatibility.Width = 92;
             // 
             // Description
             // 
@@ -486,7 +486,7 @@ namespace CKAN
             this.Description.Name = "Description";
             this.Description.ReadOnly = true;
             this.Description.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Description.Width = 83;
+            this.Description.Width = 300;
             // 
             // Homepage
             // 
@@ -496,7 +496,7 @@ namespace CKAN
             this.Homepage.Name = "Homepage";
             this.Homepage.ReadOnly = true;
             this.Homepage.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Homepage.Width = 84;
+            this.Homepage.Width = 200;
             // 
             // splitContainer1
             // 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -66,6 +66,7 @@ namespace CKAN
             this.Author = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.InstalledVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Homepage = new System.Windows.Forms.DataGridViewLinkColumn();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
@@ -82,6 +83,8 @@ namespace CKAN
             this.GitHubLabel = new System.Windows.Forms.Label();
             this.MetadataModuleReleaseStatusLabel = new System.Windows.Forms.Label();
             this.ReleaseLabel = new System.Windows.Forms.Label();
+            this.KSPCompatibilityLabel = new System.Windows.Forms.Label();
+            this.MetadataModuleKSPCompatibilityLabel = new System.Windows.Forms.Label();
             this.MetadataModuleHomePageLinkLabel = new System.Windows.Forms.LinkLabel();
             this.MetadataModuleGitHubLinkLabel = new System.Windows.Forms.LinkLabel();
             this.MetadataModuleNameLabel = new System.Windows.Forms.Label();
@@ -405,6 +408,7 @@ namespace CKAN
             this.Author,
             this.InstalledVersion,
             this.LatestVersion,
+            this.KSPCompatibility,
             this.Description,
             this.Homepage});
             this.ModList.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -467,6 +471,14 @@ namespace CKAN
             this.LatestVersion.ReadOnly = true;
             this.LatestVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.LatestVersion.Width = 88;
+            //
+            // LatestVersion
+            // 
+            this.KSPCompatibility.HeaderText = "Highest compat. KSP version";
+            this.KSPCompatibility.Name = "KSPCompatibility";
+            this.KSPCompatibility.ReadOnly = true;
+            this.KSPCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.KSPCompatibility.Width = 88;
             // 
             // Description
             // 
@@ -550,6 +562,8 @@ namespace CKAN
             this.MetadataLayoutPanel.Controls.Add(this.MetadataModuleGitHubLinkLabel, 1, 7);
             this.MetadataLayoutPanel.Controls.Add(this.MetadataModuleNameLabel, 0, 0);
             this.MetadataLayoutPanel.Controls.Add(this.MetadataModuleAbstractLabel, 0, 2);
+            this.MetadataLayoutPanel.Controls.Add(this.KSPCompatibilityLabel, 0, 9);
+            this.MetadataLayoutPanel.Controls.Add(this.MetadataModuleKSPCompatibilityLabel, 1, 9);
             this.MetadataLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetadataLayoutPanel.Location = new System.Drawing.Point(3, 3);
             this.MetadataLayoutPanel.Name = "MetadataLayoutPanel";
@@ -676,6 +690,27 @@ namespace CKAN
             this.ReleaseLabel.Size = new System.Drawing.Size(80, 25);
             this.ReleaseLabel.TabIndex = 12;
             this.ReleaseLabel.Text = "Release status:";
+            // 
+            // KSPCompatibilityLabel
+            // 
+            this.KSPCompatibilityLabel.AutoSize = true;
+            this.KSPCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.KSPCompatibilityLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.KSPCompatibilityLabel.Location = new System.Drawing.Point(3, 320);
+            this.KSPCompatibilityLabel.Name = "KSPCompatibilityLabel";
+            this.KSPCompatibilityLabel.Size = new System.Drawing.Size(80, 33);
+            this.KSPCompatibilityLabel.TabIndex = 13;
+            this.KSPCompatibilityLabel.Text = "Highest compatible KSP Version:";
+            // 
+            // MetadataModuleKSPCompatibilityLabel
+            // 
+            this.MetadataModuleKSPCompatibilityLabel.AutoSize = true;
+            this.MetadataModuleKSPCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleKSPCompatibilityLabel.Location = new System.Drawing.Point(89, 354);
+            this.MetadataModuleKSPCompatibilityLabel.Name = "MetadataModuleKSPCompatibilityLabel";
+            this.MetadataModuleKSPCompatibilityLabel.Size = new System.Drawing.Size(257, 33);
+            this.MetadataModuleKSPCompatibilityLabel.TabIndex = 14;
+            this.MetadataModuleKSPCompatibilityLabel.Text = "0.0.0";
             // 
             // MetadataModuleHomePageLinkLabel
             // 
@@ -1287,6 +1322,8 @@ namespace CKAN
         private Label GitHubLabel;
         private Label MetadataModuleReleaseStatusLabel;
         private Label ReleaseLabel;
+        private Label KSPCompatibilityLabel;
+        private Label MetadataModuleKSPCompatibilityLabel;
         private LinkLabel MetadataModuleHomePageLinkLabel;
         private LinkLabel MetadataModuleGitHubLinkLabel;
         private Label MetadataModuleNameLabel;
@@ -1332,6 +1369,7 @@ namespace CKAN
         private DataGridViewTextBoxColumn ModName;
         private DataGridViewTextBoxColumn Author;
         private DataGridViewTextBoxColumn InstalledVersion;
+        private DataGridViewTextBoxColumn KSPCompatibility;
         private DataGridViewTextBoxColumn LatestVersion;
         private DataGridViewTextBoxColumn Description;
         private DataGridViewLinkColumn Homepage;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -476,7 +476,7 @@ namespace CKAN
             this.KSPCompatibility.Name = "KSPCompatibility";
             this.KSPCompatibility.ReadOnly = true;
             this.KSPCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.KSPCompatibility.Width = 92;
+            this.KSPCompatibility.Width = 78;
             // 
             // Description
             // 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -700,7 +700,7 @@ namespace CKAN
             this.KSPCompatibilityLabel.Name = "KSPCompatibilityLabel";
             this.KSPCompatibilityLabel.Size = new System.Drawing.Size(80, 33);
             this.KSPCompatibilityLabel.TabIndex = 13;
-            this.KSPCompatibilityLabel.Text = "Highest compatible KSP Version:";
+            this.KSPCompatibilityLabel.Text = "Max KSP ver.:";
             // 
             // MetadataModuleKSPCompatibilityLabel
             // 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -472,7 +472,7 @@ namespace CKAN
             //
             // Highest compatible version of KSP
             // 
-            this.KSPCompatibility.HeaderText = "Highest compatible KSP version";
+            this.KSPCompatibility.HeaderText = "Max KSP version";
             this.KSPCompatibility.Name = "KSPCompatibility";
             this.KSPCompatibility.ReadOnly = true;
             this.KSPCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -313,7 +313,7 @@ namespace CKAN
             CurrentInstanceUpdated();
 
 
-            ModList.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.AllCells);
+            //ModList.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.AllCells);
             Text = String.Format("CKAN {0} - KSP {1}  --  {2}", Meta.Version(), CurrentInstance.Version(),
                 CurrentInstance.GameDir());
             KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -313,7 +313,6 @@ namespace CKAN
             CurrentInstanceUpdated();
 
 
-            //ModList.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.AllCells);
             Text = String.Format("CKAN {0} - KSP {1}  --  {2}", Meta.Version(), CurrentInstance.Version(),
                 CurrentInstance.GameDir());
             KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -70,6 +70,24 @@ namespace CKAN
             {
                 Util.Invoke(MetadataModuleReleaseStatusLabel, () => MetadataModuleReleaseStatusLabel.Text = module.release_status.ToString());
             }
+
+            // Show mod highest compatible KSP version
+            if (!String.IsNullOrEmpty(module.ksp_version_max.ToString()))
+            {
+                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = module.ksp_version_max.ToLongMax().ToString());
+            }
+            else if (!String.IsNullOrEmpty(module.ksp_version.ToString()))
+            {
+                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = module.ksp_version.ToLongMax().ToString());
+            }
+            else if (!String.IsNullOrEmpty(module.ksp_version_min.ToString()))
+            {
+                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = "Any above " + module.ksp_version_min.ToLongMin().ToString());
+            }
+            else
+            {
+                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = "All versions");
+            }
         }
 
         private void UpdateModInfoAuthor(Module module)

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -82,7 +82,7 @@ namespace CKAN
             }
             else if (!String.IsNullOrEmpty(module.ksp_version_min.ToString()))
             {
-                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = "Any above " + module.ksp_version_min.ToLongMin().ToString());
+                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = module.ksp_version_min.ToLongMin().ToString() + " and up");
             }
             else
             {

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -454,11 +454,13 @@ namespace CKAN
                 var latest_version_cell = new DataGridViewTextBoxCell {Value = mod.LatestVersion};
                 var description_cell = new DataGridViewTextBoxCell {Value = mod.Abstract};
                 var homepage_cell = new DataGridViewLinkCell {Value = mod.Homepage};
+                var KSPCompatibility_cell = new DataGridViewTextBoxCell {Value = mod.KSPCompatibility};
 
                 item.Cells.AddRange(installed_cell, update_cell,
                     name_cell, author_cell,
                     installed_version_cell, latest_version_cell,
-                    description_cell, homepage_cell);
+                    KSPCompatibility_cell, description_cell,
+                    homepage_cell);
 
                 installed_cell.ReadOnly = !mod.IsInstallable();
                 update_cell.ReadOnly = !mod.IsInstallable() || !mod.HasUpdate;

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -453,14 +453,12 @@ namespace CKAN
                 var installed_version_cell = new DataGridViewTextBoxCell {Value = mod.InstalledVersion};
                 var latest_version_cell = new DataGridViewTextBoxCell {Value = mod.LatestVersion};
                 var description_cell = new DataGridViewTextBoxCell {Value = mod.Abstract};
-                var homepage_cell = new DataGridViewLinkCell {Value = mod.Homepage};
                 var KSPCompatibility_cell = new DataGridViewTextBoxCell {Value = mod.KSPCompatibility};
 
                 item.Cells.AddRange(installed_cell, update_cell,
                     name_cell, author_cell,
                     installed_version_cell, latest_version_cell,
-                    KSPCompatibility_cell, description_cell,
-                    homepage_cell);
+                    KSPCompatibility_cell, description_cell);
 
                 installed_cell.ReadOnly = !mod.IsInstallable();
                 update_cell.ReadOnly = !mod.IsInstallable() || !mod.HasUpdate;


### PR DESCRIPTION
Most up to date version: http://imgur.com/a/6oJCS#0

This will allow users to see the highest version of KSP that a mod is compatible with. It lists the information as a column in the main mod listing, and as a field in the mod info pane. I removed the homepage column because it wasn't functional, and also an impractical way to view that information. All columns are resized and auto-resize is disabled. I'm running windows and tested at 1080 as well as 720 and it looked the same. I don't have the ability to check how it looks under other OSes.

All the column width changes can be reverted simply with a revert of d630fee if needed.

Test cases specifically for compatibility addition:
ksp_version set long (1.0.4): [X]Science
ksp_version set short (1.0): Action Groups Extended
ksp_version_max (1.0.99): AGroupOnStage
ksp_version_min with no max (0.25): 6S Service Compartment Tubes
no version information: Active Texture Management - X86

Potential issue I wasn't able to test for:
If an installed mod has a new version, will it show the compatibility for the current version or the upgrade?