### PR TITLE
Consolidate network download code

### DIFF
--- a/Core/Net/Curl.cs
+++ b/Core/Net/Curl.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using CurlSharp;
 using log4net;
 
@@ -11,8 +13,8 @@ namespace CKAN
     /// </summary>
     public static class Curl
     {
-        private static bool init_complete = false;
-        private static readonly ILog log = LogManager.GetLogger(typeof (Curl));
+        private static bool _initComplete;
+        private static readonly ILog Log = LogManager.GetLogger(typeof (Curl));
 
         /// <summary>
         /// Has libcurl do all the work it needs to work correctly.
@@ -20,13 +22,13 @@ namespace CKAN
         /// </summary>
         public static void Init()
         {
-            if (init_complete)
+            if (_initComplete)
             {
-                log.Info("Curl init already performed, not running twice");
+                Log.Info("Curl init already performed, not running twice");
                 return;
             }
             CurlSharp.Curl.GlobalInit(CurlInitFlag.All);
-            init_complete = true;
+            _initComplete = true;
         }
 
         /// <summary>
@@ -36,7 +38,7 @@ namespace CKAN
         public static void CleanUp()
         {
             CurlSharp.Curl.GlobalCleanup();
-            init_complete = false;
+            _initComplete = false;
         }
 
 
@@ -50,9 +52,9 @@ namespace CKAN
         /// Adapted from MultiDemo.cs in the curlsharp repo
         public static CurlEasy CreateEasy(string url, CurlWriteCallback wf)
         {
-            if (!init_complete)
+            if (!_initComplete)
             {
-                log.Warn("Curl environment not pre-initialised, performing non-threadsafe init.");
+                Log.Warn("Curl environment not pre-initialised, performing non-threadsafe init.");
                 Init();
             }
 
@@ -73,6 +75,12 @@ namespace CKAN
             if (url.StartsWith("https://ksp.sarbian.com/"))
             {
                 easy.SslVerifyPeer = false;
+            }
+
+            var caBundle = ResolveCurlCaBundle();
+            if (caBundle != null)
+            {
+                easy.CaInfo = caBundle;
             }
 
             return easy;
@@ -97,6 +105,40 @@ namespace CKAN
             // the original string is used, hence .OriginalString rather than .ToString
             // here.
             return CreateEasy(url.OriginalString, stream);
+        }
+
+        /// <summary>
+        /// Resolves the location of the cURL CA bundle file to use.
+        /// </summary>
+        /// <returns>The absolute file path to the bundle file or null if none is found.</returns>
+        private static string ResolveCurlCaBundle()
+        {
+            const string caBundleFileName = "curl-ca-bundle.crt";
+            const string ckanSubDirectoryName = "CKAN";
+
+            var bundle = new[]
+            {
+                // Working Directory
+                Environment.CurrentDirectory,
+
+                // Executable Directory
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+
+                // %LOCALAPPDATA%/CKAN
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ckanSubDirectoryName),
+
+                // %APPDATA%/CKAN
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ckanSubDirectoryName),
+
+                // %PROGRAMDATA%/CKAN
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ckanSubDirectoryName),
+            }
+            .Select(i => Path.Combine(i, caBundleFileName))
+            .FirstOrDefault(File.Exists);
+
+            Log.InfoFormat("Using curl-ca bundle: {0}", bundle ?? "(none)");
+
+            return bundle;
         }
     }
 }

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -38,31 +38,29 @@ namespace CKAN.NetKAN
 
                     var moduleService = new ModuleService();
                     var fileService = new FileService();
+                    var http = new CachingHttpService(FindCache(new KSPManager(new ConsoleUser(false))));
 
-                    using (var http = new CachingHttpService(FindCache(new KSPManager(new ConsoleUser(false)))))
-                    {
-                        var netkan = ReadNetkan();
-                        Log.Info("Finished reading input");
+                    var netkan = ReadNetkan();
+                    Log.Info("Finished reading input");
 
-                        new NetkanValidator().Validate(netkan);
-                        Log.Info("Input successfully passed pre-validation");
+                    new NetkanValidator().Validate(netkan);
+                    Log.Info("Input successfully passed pre-validation");
 
-                        var transformer = new NetkanTransformer(
-                            http,
-                            fileService,
-                            moduleService,
-                            Options.GitHubToken,
-                            Options.PreRelease
-                        );
+                    var transformer = new NetkanTransformer(
+                        http,
+                        fileService,
+                        moduleService,
+                        Options.GitHubToken,
+                        Options.PreRelease
+                    );
 
-                        var ckan = transformer.Transform(netkan);
-                        Log.Info("Finished transformation");
+                    var ckan = transformer.Transform(netkan);
+                    Log.Info("Finished transformation");
 
-                        new CkanValidator(netkan, http, moduleService).Validate(ckan);
-                        Log.Info("Output successfully passed post-validation");
+                    new CkanValidator(netkan, http, moduleService).Validate(ckan);
+                    Log.Info("Output successfully passed post-validation");
 
-                        WriteCkan(ckan);
-                    }
+                    WriteCkan(ckan);
                 }
                 else
                 {

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -1,39 +1,18 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using CurlSharp;
-using log4net;
 
 namespace CKAN.NetKAN.Services
 {
-    internal sealed partial class CachingHttpService : IHttpService
+    internal sealed class CachingHttpService : IHttpService
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(CachingHttpService));
-
         private readonly NetFileCache _cache;
-        private CurlEasy _curl;
 
         public CachingHttpService(NetFileCache cache)
         {
             _cache = cache;
-
-            CurlSharp.Curl.GlobalInit(CurlInitFlag.All);
-
-            _curl = new CurlEasy { UserAgent = Net.UserAgentString };
-
-            var caBundle = ResolveCurlCaBundle();
-            if (caBundle != null)
-            {
-                _curl.CaInfo = caBundle;
-            }
         }
 
         public string DownloadPackage(Uri url, string identifier)
         {
-            EnsureNotDisposed();
-
             var cachedFile = _cache.GetCachedFilename(url);
 
             if (!string.IsNullOrWhiteSpace(cachedFile))
@@ -79,103 +58,7 @@ namespace CKAN.NetKAN.Services
 
         public string DownloadText(Uri url)
         {
-            EnsureNotDisposed();
-
-            Log.DebugFormat("About to download {0}", url);
-
-            var content = string.Empty;
-
-            _curl.Url = url.ToString();
-            _curl.WriteData = null;
-            _curl.WriteFunction = delegate(byte[] buf, int size, int nmemb, object extraData)
-            {
-                content += Encoding.UTF8.GetString(buf);
-                return size * nmemb;
-            };
-
-            var result = _curl.Perform();
-
-            if (result != CurlCode.Ok)
-            {
-                throw new Exception("Curl download failed with error " + result);
-            }
-
-            Log.DebugFormat("Download from {0}:\n\n{1}", url, content);
-
-            return content;
-        }
-
-        /// <summary>
-        /// Resolves the location of the cURL CA bundle file to use.
-        /// </summary>
-        /// <returns>The absolute file path to the bundle file or null if none is found.</returns>
-        private static string ResolveCurlCaBundle()
-        {
-            const string caBundleFileName = "curl-ca-bundle.crt";
-            const string ckanSubDirectoryName = "CKAN";
-
-            var bundle = new[]
-            {
-                // Working Directory
-                Environment.CurrentDirectory,
-
-                // Executable Directory
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-
-                // %LOCALAPPDATA%/CKAN
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ckanSubDirectoryName),
-
-                // %APPDATA%/CKAN
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ckanSubDirectoryName),
-
-                // %PROGRAMDATA%/CKAN
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), ckanSubDirectoryName),
-            }
-            .Select(i => Path.Combine(i, caBundleFileName))
-            .FirstOrDefault(File.Exists);
-
-            Log.InfoFormat("Using curl-ca bundle: {0}",bundle ?? "(none)");
-
-            return bundle;
-        }
-    }
-
-    internal sealed partial class CachingHttpService
-    {
-        private bool _isDisposed;
-
-        ~CachingHttpService()
-        {
-            Dispose(disposing: false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (_curl != null)
-                {
-                    CurlSharp.Curl.GlobalCleanup();
-                    _curl.Dispose();
-                    _curl = null;
-                }
-            }
-
-            _isDisposed = true;
-        }
-
-        private void EnsureNotDisposed()
-        {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(typeof(CachingHttpService).FullName);
-            }
+            return Net.DownloadText(url);
         }
     }
 }

--- a/Netkan/Services/IHttpService.cs
+++ b/Netkan/Services/IHttpService.cs
@@ -2,7 +2,7 @@
 
 namespace CKAN.NetKAN.Services
 {
-    internal interface IHttpService : IDisposable
+    internal interface IHttpService
     {
         string DownloadPackage(Uri url, string identifier);
         string DownloadText(Uri url);

--- a/Netkan/Sources/Kerbalstuff/KerbalstuffApi.cs
+++ b/Netkan/Sources/Kerbalstuff/KerbalstuffApi.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using System.Text.RegularExpressions;
 using CKAN.NetKAN.Services;
 using log4net;
@@ -82,29 +81,8 @@ namespace CKAN.NetKAN.Sources.Kerbalstuff
             var url = KerbalstuffApiBase + path;
 
             Log.DebugFormat("Calling {0}", url);
-            try
-            {
-                return _http.DownloadText(new Uri(url));
-            }
-            catch (DllNotFoundException)
-            {
-                //Curl is not installed. Curl is a workaround for a mono issue.
-                //TODO Richard - Once repos are merged go and check all Platform calls to see if they are mono checks
-                if (!Platform.IsWindows) throw;
-                //On mircrosft.net so try native code.
-                using (var web = new WebClient())
-                {
-                    try
-                    {
-                        return web.DownloadString(url);
-                    }
-                    catch (WebException webEx)
-                    {
-                        Log.ErrorFormat("WebException while accessing {0}: {1}", url, webEx);
-                        throw;
-                    }
-                }
-            }
+
+            return _http.DownloadText(new Uri(url));
         }
     }
 }


### PR DESCRIPTION
This consolidates much of our network download logic into `Net`, and standardizes behavior such that:

- We always try to use a `WebClient` first
- If that fails, we attempt to use cURL

Also, moves the cURL CA file resolution logic into `Curl` so that everything that uses it benefits from it.