### PR TITLE
GUI: When showing Latest KSP info, do it for the latest mod (for any KSP ver)

### DIFF
--- a/Core/Types/Module.cs
+++ b/Core/Types/Module.cs
@@ -309,6 +309,33 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Returns a human readable string indicating the highest compatible
+        /// version of KSP this module will run with. (Eg: 1.0.2, 1.0.2+,
+        /// "All version", etc).
+        /// 
+        /// This is for *human consumption only*, as the strings may change in the
+        /// future as we support additional locales.
+        /// </summary>
+        public string HighestCompatibleKSP()
+        {
+            // Find the highest compatible KSP version
+            if (!String.IsNullOrEmpty(ksp_version_max.ToString()))
+            {
+                return ksp_version_max.ToLongMax().ToString();
+            }
+            else if (!String.IsNullOrEmpty(ksp_version.ToString()))
+            {
+                return ksp_version.ToLongMax().ToString();
+            }
+            else if (!String.IsNullOrEmpty(ksp_version_min.ToString()))
+            {
+                return ksp_version_min.ToLongMin().ToString() + "+";
+            }
+
+            return "All versions";
+        }
+
+        /// <summary>
         /// Returns true if this module provides the functionality requested.
         /// </summary>
         public bool DoesProvide(string identifier)

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -16,8 +16,10 @@ namespace CKAN
 
     public partial class Main : Form
     {
-        private void UpdateModInfo(Module module)
+        private void UpdateModInfo(GUIMod gui_module)
         {
+            Module module = gui_module.ToModule();
+
             Util.Invoke(MetadataModuleNameLabel, () => MetadataModuleNameLabel.Text = module.name);
             Util.Invoke(MetadataModuleVersionLabel, () => MetadataModuleVersionLabel.Text = module.version.ToString());
             Util.Invoke(MetadataModuleLicenseLabel, () => MetadataModuleLicenseLabel.Text = string.Join(", ",module.license));
@@ -71,23 +73,7 @@ namespace CKAN
                 Util.Invoke(MetadataModuleReleaseStatusLabel, () => MetadataModuleReleaseStatusLabel.Text = module.release_status.ToString());
             }
 
-            // Show mod highest compatible KSP version
-            if (!String.IsNullOrEmpty(module.ksp_version_max.ToString()))
-            {
-                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = module.ksp_version_max.ToLongMax().ToString());
-            }
-            else if (!String.IsNullOrEmpty(module.ksp_version.ToString()))
-            {
-                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = module.ksp_version.ToLongMax().ToString());
-            }
-            else if (!String.IsNullOrEmpty(module.ksp_version_min.ToString()))
-            {
-                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = module.ksp_version_min.ToLongMin().ToString() + " and up");
-            }
-            else
-            {
-                Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = "All versions");
-            }
+            Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = gui_module.KSPCompatibilityLong);
         }
 
         private void UpdateModInfoAuthor(Module module)


### PR DESCRIPTION
Updates #1270.

Includes human-readable MaxKSP functionality in `Module.cs`.

I wasn't sure if flipping `UpdateModInfo` to use a `GuiMod` was the
right idea, but it seems to work, so that's awesome!

I would *love* someone to check this over. It's an improved version of #1270, but I'm not well versed in how the GUI works.