### PR TITLE
More Robust AVC Version Handling

### DIFF
--- a/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
+++ b/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using log4net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -113,6 +114,7 @@ namespace CKAN.NetKAN.Sources.Avc
             var major = "0";
             var minor = "0";
             var patch = "0";
+            string build = null;
 
             var token = JToken.Load(reader);
             Log.DebugFormat("Read Token: {0}, {1}", new Object[] {token.Type, token.ToString()});
@@ -135,17 +137,31 @@ namespace CKAN.NetKAN.Sources.Avc
                     {
                         patch = tokenArray[2];
                     }
+
+                    if (tokenArray.Length >= 3)
+                    {
+                        build = tokenArray[3];
+                    }
+
                     break;
                 case JTokenType.Object:
                     major = (string) token["MAJOR"];
                     minor = (string) token["MINOR"];
                     patch = (string) token["PATCH"];
+                    build = (string) token["BUILD"];
                     break;
                 default:
                     throw new InvalidCastException("Trying to convert non-JSON object to Version object");
             }
 
-            var version = string.Join(".", major, minor, patch);
+            var components = new List<string>() { major, minor, patch };
+
+            if (!string.IsNullOrWhiteSpace(build))
+            {
+                components.Add(build);
+            }
+
+            var version = string.Join(".", components);
             Log.DebugFormat("  extracted version: {0}", version);
             var result = new Version(version);
             Log.DebugFormat("  generated result: {0}", result);

--- a/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
+++ b/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
@@ -34,17 +34,17 @@ namespace CKAN.NetKAN.Sources.Avc
                 case JTokenType.String:
                     var tokenArray = token.ToString().Split('.');
 
-                    if (tokenArray.Length >= 0)
+                    if (tokenArray.Length > 0)
                     {
                         major = tokenArray[0];
                     }
 
-                    if (tokenArray.Length >= 1)
+                    if (tokenArray.Length > 1)
                     {
                         minor = tokenArray[1];
                     }
 
-                    if (tokenArray.Length >= 2)
+                    if (tokenArray.Length > 2)
                     {
                         patch = tokenArray[2];
                     }

--- a/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
+++ b/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
@@ -123,22 +123,22 @@ namespace CKAN.NetKAN.Sources.Avc
                 case JTokenType.String:
                     var tokenArray = token.ToString().Split('.');
 
-                    if (tokenArray.Length >= 0)
+                    if (tokenArray.Length > 0)
                     {
                         major = tokenArray[0];
                     }
 
-                    if (tokenArray.Length >= 1)
+                    if (tokenArray.Length > 1)
                     {
                         minor = tokenArray[1];
                     }
 
-                    if (tokenArray.Length >= 2)
+                    if (tokenArray.Length > 2)
                     {
                         patch = tokenArray[2];
                     }
 
-                    if (tokenArray.Length >= 3)
+                    if (tokenArray.Length > 3)
                     {
                         build = tokenArray[3];
                     }

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
@@ -53,21 +55,72 @@ namespace CKAN.NetKAN.Transformers
                 {
                     Log.Info("Found internal AVC version file");
 
-                    // The CKAN spec states that only a KSP version can be supplied, *or* a min/max can
-                    // be provided. Since min/max are more descriptive, we check and use them first.
-                    if (avc.ksp_version_min != null || avc.ksp_version_max != null)
+                    // Get the minimum and maximum KSP versions that already exist in the metadata.
+                    // Use specific KSP version if min/max don't exist.
+                    var existingKspMinStr = (string)json["ksp_version_min"] ?? (string)json["ksp_version"];
+                    var existingKspMaxStr = (string)json["ksp_version_max"] ?? (string)json["ksp_version"];
+
+                    var existingKspMin = existingKspMinStr == null ? null : new KSPVersion(existingKspMinStr);
+                    var existingKspMax = existingKspMaxStr == null ? null : new KSPVersion(existingKspMaxStr);
+                    
+                    // Get the minimum and maximum KSP versions that are in the AVC file.
+                    // Use specific KSP version if min/max don't exist.
+                    var avcKspMin = avc.ksp_version_min ?? avc.ksp_version;
+                    var avcKspMax = avc.ksp_version_max ?? avc.ksp_version;
+
+                    // Now calculate the minimum and maximum KSP versions between both the existing metadata and the
+                    // AVC file.
+                    var kspMins = new List<KSPVersion>();
+                    var kspMaxes = new List<KSPVersion>();
+
+                    if (existingKspMin != null)
+                        kspMins.Add(existingKspMin);
+
+                    if (avcKspMin != null)
+                        kspMins.Add(avcKspMin);
+
+                    if (existingKspMax != null)
+                        kspMaxes.Add(existingKspMax);
+
+                    if (avcKspMax != null)
+                        kspMaxes.Add(avcKspMax);
+
+                    var kspMin = kspMins.Any() ? kspMins.Min() : null;
+                    var kspMax = kspMaxes.Any() ? kspMaxes.Max() : null;
+
+                    if (kspMin != null || kspMax != null)
                     {
+                        // If we have either a minimum or maximum KSP version, remove all existing KSP version
+                        // information from the metadata.
                         json.Remove("ksp_version");
+                        json.Remove("ksp_version_min");
+                        json.Remove("ksp_version_max");
 
-                        if (avc.ksp_version_min != null)
-                            json["ksp_version_min"] = avc.ksp_version_min.ToString();
+                        if (kspMin != null && kspMax != null)
+                        {
+                            // If we have both a minimum and maximum KSP version...
+                            if (kspMin.CompareTo(kspMax) == 0)
+                            {
+                                // ...and they are equal, then just set ksp_version
+                                json["ksp_version"] = kspMin.ToString();
+                            }
+                            else
+                            {
+                                // ...otherwise set both ksp_version_min and ksp_version_max
+                                json["ksp_version_min"] = kspMin.ToString();
+                                json["ksp_version_max"] = kspMax.ToString();
+                            }
+                        }
+                        else
+                        {
+                            // If we have only one or the other then set which ever is applicable
 
-                        if (avc.ksp_version_max != null)
-                            json["ksp_version_max"] = avc.ksp_version_max.ToString();
-                    }
-                    else if (avc.ksp_version != null)
-                    {
-                        json["ksp_version"] = avc.ksp_version.ToString();
+                            if (kspMin != null)
+                                json["ksp_version_min"] = kspMin.ToString();
+
+                            if (kspMax != null)
+                                json["ksp_version_max"] = kspMax.ToString();
+                        }
                     }
 
                     if (avc.version != null)

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using log4net;
@@ -71,7 +72,10 @@ namespace CKAN.NetKAN.Transformers
 
                     if (avc.version != null)
                     {
-                        json["version"] = avc.version.ToString();
+                        // In practice, the version specified in .version files tends to be unreliable, with authors
+                        // forgetting to update it when new versions are released. Therefore if we have a version
+                        // specified from another source such as KerbalStuff or a GitHub tag, don't overwrite it.
+                        json.SafeAdd("version", avc.version.ToString());
                     }
 
                     // It's cool if we don't have version info at all, it's optional in the AVC spec.

--- a/Tests/NetKAN/Services/ModuleServiceTests.cs
+++ b/Tests/NetKAN/Services/ModuleServiceTests.cs
@@ -83,7 +83,7 @@ namespace Tests.NetKAN.Services
             Assert.That(result, Is.Not.Null,
                 "ModuleService should get an internal AVC file."
             );
-            Assert.That(result.version, Is.EqualTo(new Version("1.1.0")),
+            Assert.That(result.version, Is.EqualTo(new Version("1.1.0.0")),
                 "ModuleService should get correct version from the internal AVC file."
             );
             Assert.That(result.ksp_version, Is.EqualTo(new KSPVersion("0.24.2")),

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -90,29 +90,98 @@ namespace Tests.NetKAN.Transformers
             );
         }
 
-        [TestCase("ksp_version")]
-        [TestCase("ksp_version_min")]
-        [TestCase("ksp_version_max")]
-        public void OverridesExistingKspVersionInfo(string propertyName)
+        [TestCase(
+            "1.0.4", null, null,
+            "1.0.4", null, null,
+            "1.0.4", null, null
+        )]
+        [TestCase(
+            null, "1.0.4", "1.0.4",
+            null, "1.0.4", "1.0.4",
+            "1.0.4", null, null
+        )]
+        [TestCase(
+            "1.0.4", null, null,
+            null, "1.0.4", "1.0.4",
+            "1.0.4", null, null
+        )]
+        [TestCase(
+            null, "1.0.2", "1.0.4",
+            null, "1.0.2", "1.0.4",
+            null, "1.0.2", "1.0.4"
+        )]
+        [TestCase(
+            "1.0.4", null, null,
+            null, "1.0.0", "1.0.2",
+            null, "1.0.0", "1.0.4"
+        )]
+        [TestCase(
+            "1.0.4", null, null,
+            "0.90", null, null,
+            null, "0.90", "1.0.4"
+        )]
+        [TestCase(
+            null, "1.0.4", "1.0.4",
+            "1.0.0", null, null,
+            null, "1.0.0", "1.0.4"
+        )]
+        [TestCase(
+            null, "1.0.0", "1.0.4",
+            "1.0.2", null, null,
+            null, "1.0.0", "1.0.4"
+        )]
+        [TestCase(
+            null, null, null,
+            "1.0.2", null, null,
+            "1.0.2", null, null
+        )]
+        [TestCase(
+            "1.0.2", null, null,
+            null, null, null,
+            "1.0.2", null, null
+        )]
+        [TestCase(
+            null, null, null,
+            null, null, null,
+            null, null, null
+        )]
+        [TestCase(
+            null, "1.0.0", "1.0.1",
+            "1.0.2", "1.0.3", "1.0.4",
+            null, "1.0.0", "1.0.4"
+        )]
+        public void CorrectlyCalculatesKspVersionInfo(
+            string existingKsp, string existingKspMin, string existingKspMax,
+            string avcKsp, string avcKspMin, string avcKspMax,
+            string expectedKsp, string expectedKspMin, string expectedKspMax
+        )
         {
             // Arrange
+            var json = new JObject();
+            json["spec_version"] = 1;
+            json["identifier"] = "AwesomeMod";
+            json["$vref"] = "#/ckan/ksp-avc";
+            json["download"] = "https://awesomemod.example/AwesomeMod.zip";
+
+            if (!string.IsNullOrWhiteSpace(existingKsp))
+                json["ksp_version"] = existingKsp;
+
+            if (!string.IsNullOrWhiteSpace(existingKspMin))
+                json["ksp_version_min"] = existingKspMin;
+
+            if (!string.IsNullOrWhiteSpace(existingKspMax))
+                json["ksp_version_max"] = existingKspMax;
+
             var avcVersion = new AvcVersion();
 
-            switch(propertyName)
-            {
-                case "version":
-                    avcVersion.version = new Version("1.2.3");
-                    break;
-                case "ksp_version":
-                    avcVersion.ksp_version = new KSPVersion("1.2.3");
-                    break;
-                case "ksp_version_min":
-                    avcVersion.ksp_version_min = new KSPVersion("1.2.3");
-                    break;
-                case "ksp_version_max":
-                    avcVersion.ksp_version_max = new KSPVersion("1.2.3");
-                    break;
-            }
+            if (!string.IsNullOrWhiteSpace(avcKsp))
+                avcVersion.ksp_version = new KSPVersion(avcKsp);
+
+            if (!string.IsNullOrWhiteSpace(avcKspMin))
+                avcVersion.ksp_version_min = new KSPVersion(avcKspMin);
+
+            if (!string.IsNullOrWhiteSpace(avcKspMax))
+                avcVersion.ksp_version_max = new KSPVersion(avcKspMax);
 
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
@@ -122,20 +191,21 @@ namespace Tests.NetKAN.Transformers
 
             var sut = new AvcTransformer(mHttp.Object, mModuleService.Object);
 
-            var json = new JObject();
-            json["spec_version"] = 1;
-            json["identifier"] = "AwesomeMod";
-            json["$vref"] = "#/ckan/ksp-avc";
-            json["download"] = "https://awesomemod.example/AwesomeMod.zip";
-            json[propertyName] = "9001";
-
             // Act
             var result = sut.Transform(new Metadata(json));
             var transformedJson = result.Json();
 
             // Assert
-            Assert.That((string)transformedJson[propertyName], Is.EqualTo("1.2.3"),
-                string.Format("AvcTransformer should override an existing {0}.", propertyName)
+            Assert.That((string)transformedJson["ksp_version"], Is.EqualTo(expectedKsp),
+                "AvcTransformer should calculate ksp_version correctly"
+            );
+
+            Assert.That((string)transformedJson["ksp_version_min"], Is.EqualTo(expectedKspMin),
+                "AvcTransformer should calculate ksp_version_min correctly"
+            );
+
+            Assert.That((string)transformedJson["ksp_version_max"], Is.EqualTo(expectedKspMax),
+                "AvcTransformer should calculate ksp_version_max correctly"
             );
         }
 


### PR DESCRIPTION
This PR makes the handling of version information found in internal `.version` files more robust. In practical experience the internal `.version` files aren't remarkably accurate, so we make the two following changes:

- If the metadata already contains a `version` field, such as from KerbalStuff or a GitHub tag, we **do not override** it with the value found in the `.version` file.
- KSP version information is calculated by "merging" the values that are already in the metadata and what we find in the `.version` file. A common example would be if some mod on KerbalStuff indicates that it's compatible with a version of KSP later than what it specifies in its `.version` file. In that case we calculate a minimum version from the `.version` file and a maximum version from the KerbalStuff metadata.
- Add support for "build" component in AVC version, only added if present.

The `CorrectlyCalculatesKspVersionInfo` test contains a lot of cases. Please add any additional cases you think requires testing.
