### PR TITLE
Sort Properties on Final Netkan Output

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -78,6 +78,7 @@
     <Compile Include="CmdLineOptions.cs" />
     <Compile Include="Transformers\OptimusPrimeTransformer.cs" />
     <Compile Include="Transformers\VersionEditTransformer.cs" />
+    <Compile Include="Transformers\PropertySortTransformer.cs" />
     <Compile Include="Transformers\VersionedOverrideTransformer.cs" />
     <Compile Include="Transformers\StripNetkanMetadataTransformer.cs" />
     <Compile Include="Transformers\EpochTransformer.cs" />

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -38,7 +38,8 @@ namespace CKAN.NetKAN.Transformers
                 new DownloadSizeTransformer(http, fileService),
                 new GeneratedByTransformer(),
                 new OptimusPrimeTransformer(),
-                new StripNetkanMetadataTransformer()
+                new StripNetkanMetadataTransformer(),
+                new PropertySortTransformer()
             };
         }
 

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CKAN.NetKAN.Model;
+using Newtonsoft.Json.Linq;
+
+namespace CKAN.NetKAN.Transformers
+{
+    internal sealed class PropertySortTransformer : ITransformer
+    {
+        private const int DefaultSortOrder = 1073741823; // int.MaxValue / 2
+
+        private static readonly Dictionary<string, int> PropertySortOrder = new Dictionary<string, int>
+        {
+            { "spec_version", 0 },
+            { "comment", 1 },
+            { "identifier", 2 },
+            { "$kref", 3 },
+            { "$vref", 4 },
+            { "name", 5 },
+            { "abstract", 6 },
+            { "description", 7 },
+            { "author", 8 },
+            { "license", 9 },
+            { "release_status", 10 },
+            { "resources", 11 },
+            { "version", 12 },
+            { "ksp_version", 13 },
+            { "ksp_version_min", 14 },
+            { "ksp_version_max", 15 },
+            { "download", 16 },
+            { "download_size", 17 },
+            { "provides", 18 },
+            { "depends", 19 },
+            { "recommends", 20 },
+            { "suggests", 21 },
+            { "supports", 22 },
+            { "install", 23 },
+
+            { "x_generated_by", int.MaxValue }
+        };
+
+        public Metadata Transform(Metadata metadata)
+        {
+            var json = metadata.Json();
+            var sortedJson = new JObject();
+
+            var sortedPropertyNames = json
+                .Properties()
+                .Select(i => i.Name)
+                .OrderBy(GetPropertySortOrder)
+                .ThenBy(i => i);
+
+            foreach (var propertyName in sortedPropertyNames)
+            {
+                sortedJson[propertyName] = json[propertyName];
+            }
+
+            return new Metadata(sortedJson);
+        }
+
+        private static double GetPropertySortOrder(string propertyName)
+        {
+            int sortOrder;
+            return PropertySortOrder.TryGetValue(propertyName, out sortOrder) ?
+                sortOrder :
+                propertyName.StartsWith("x_") ?
+                    DefaultSortOrder + 1 :
+                    DefaultSortOrder;
+        }
+    }
+}

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -1,12 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using CKAN.NetKAN.Model;
+using log4net;
 using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN.Transformers
 {
     internal sealed class PropertySortTransformer : ITransformer
     {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(PropertySortTransformer));
+
         private const int DefaultSortOrder = 1073741823; // int.MaxValue / 2
 
         private static readonly Dictionary<string, int> PropertySortOrder = new Dictionary<string, int>
@@ -55,6 +59,9 @@ namespace CKAN.NetKAN.Transformers
             var json = metadata.Json();
             var sortedJson = new JObject();
 
+            Log.InfoFormat("Executing property sort transformation");
+            Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
+
             var sortedPropertyNames = json
                 .Properties()
                 .Select(i => i.Name)
@@ -84,6 +91,8 @@ namespace CKAN.NetKAN.Transformers
 
                 sortedJson["resources"] = sortedResources;
             }
+
+            Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, sortedJson);
 
             return new Metadata(sortedJson);
         }

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -31,14 +31,14 @@ namespace CKAN.NetKAN.Transformers
             { "ksp_version", 13 },
             { "ksp_version_min", 14 },
             { "ksp_version_max", 15 },
-            { "download", 16 },
-            { "download_size", 17 },
-            { "provides", 18 },
-            { "depends", 19 },
-            { "recommends", 20 },
-            { "suggests", 21 },
-            { "supports", 22 },
-            { "install", 23 },
+            { "provides", 16 },
+            { "depends", 17 },
+            { "recommends", 18 },
+            { "suggests", 19 },
+            { "supports", 20 },
+            { "install", 21 },
+            { "download", 22 },
+            { "download_size", 23 },
 
             { "x_generated_by", int.MaxValue }
         };


### PR DESCRIPTION
The order of properties in the final `.ckan` output of Netkan is currently dependent on the order in which code is executed by the various transformers. This PR adds a new `ITransformer`, `PropertySortTransformer` that is added to the very end of the pipeline.

`PropertySortTransformer` has an internal list of known properties and will sort the properties in a well defined order (unknown properties are placed just before the `x_generated_by` property in alphabetical order, with `x_` properties always sorting last).

This means the output of Netkan should remain relatively stable with all sorts of changes.

Sort order was chosen based on what I feel is an intuitive reading order when looking at `.ckan` files, and mirrors the typical order found in handcrafted `.ckan` files.