### PR TITLE
Misc Netkan Fixes

### DIFF
--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -143,6 +143,11 @@ namespace CKAN.NetKAN
 
         private static Metadata ReadNetkan()
         {
+            if (!Options.File.EndsWith(".netkan"))
+            {
+                Log.WarnFormat("Input is not a .netkan file");
+            }
+
             return new Metadata(JObject.Parse(File.ReadAllText(Options.File)));
         }
 

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -35,7 +35,7 @@ namespace CKAN.NetKAN.Services
             EnsureNotDisposed();
 
             return _cache.GetCachedFilename(url) ?? 
-                _cache.Store(url, CKAN.Net.Download(url), string.Format("netkan-{0}", identifier), move: true);
+                _cache.Store(url, CKAN.Net.Download(url), string.Format("netkan-{0}.zip", identifier), move: true);
         }
 
         public string DownloadText(Uri url)


### PR DESCRIPTION
- Makes sure `.zip` is appended to downloaded packages
- Logs a warning if the input file does not end with `.netkan`

Fixes #1307