### PR TITLE
Improve window title when asking yes or no

### DIFF
--- a/GUI/YesNoDialog.Designer.cs
+++ b/GUI/YesNoDialog.Designer.cs
@@ -84,7 +84,7 @@
             this.Controls.Add(this.panel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Name = "YesNoDialog";
-            this.Text = "User input required";
+            this.Text = "CKAN";
             this.panel1.ResumeLayout(false);
             this.ResumeLayout(false);
 


### PR DESCRIPTION
"User input required" looks clunky (not user friendly) on a window. We can stick with "CKAN" and it'll look decent for any application that uses this window.

![Image showing example](http://i.imgur.com/yo672b8.jpg)