### PR TITLE
Fix JObject SafeAdd to make sure underlying value is not null

### DIFF
--- a/Netkan/Extensions/JObjectExtensions.cs
+++ b/Netkan/Extensions/JObjectExtensions.cs
@@ -12,7 +12,7 @@ namespace CKAN.NetKAN.Extensions
         /// <param name="token">The value of the property to write if it does not exist.</param>
         public static void SafeAdd(this JObject jobject, string propertyName, JToken token)
         {
-            if (token != null)
+            if (token != null && token.ToObject<object>() != null)
             {
                 jobject[propertyName] = jobject[propertyName] ?? token;
             }

--- a/Tests/NetKAN/Extensions/JObjectExtensionsTests.cs
+++ b/Tests/NetKAN/Extensions/JObjectExtensionsTests.cs
@@ -53,5 +53,21 @@ namespace Tests.NetKAN.Extensions
                 "SafeAdd() should not add property if value is null."
             );
         }
+
+        // https://github.com/KSP-CKAN/NetKAN-bot/issues/27
+        [Test]
+        public void SafeAddDoesNotAddPropertyWhenValueIsTokenWithNullValue()
+        {
+            // Arrange
+            var sut = new JObject();
+
+            // Act
+            sut.SafeAdd("foo", (string)null);
+
+            // Assert
+            Assert.That((string)sut["foo"], Is.Null,
+                "SafeAdd() should not add property if value is null."
+            );
+        }
     }
 }

--- a/Tests/NetKAN/Extensions/JObjectExtensionsTests.cs
+++ b/Tests/NetKAN/Extensions/JObjectExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using CKAN.NetKAN.Extensions;
+﻿using System.Linq;
+using CKAN.NetKAN.Extensions;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -65,7 +66,7 @@ namespace Tests.NetKAN.Extensions
             sut.SafeAdd("foo", (string)null);
 
             // Assert
-            Assert.That((string)sut["foo"], Is.Null,
+            Assert.That(sut.Properties().Any(i => i.Name == "foo"), Is.False,
                 "SafeAdd() should not add property if value is null."
             );
         }


### PR DESCRIPTION
@techman83 Fix for KSP-CKAN/NetKAN-bot#27

Problem was that converting a `null` to a `JToken` still produces a `JToken` object, but one that represents a `null` value. This makes sure that if the `JToken` is not `null`, that its underlying object is also not `null`.

Adds a regression test that fails prior to the change and passes after the change.