### PR TITLE
GUIMod: Fix spurious protected method warning.

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -199,7 +199,7 @@ namespace CKAN
         }
 
 
-        protected bool Equals(GUIMod other)
+        private bool Equals(GUIMod other)
         {
             return Equals(Name, other.Name);
         }


### PR DESCRIPTION
`protected` methods can only be accessed by the class or its derived classes, but `GUIMod` is a sealed class, which by definition can't be inherited from. Consequently, this generates a warning.

This change flips the method to `private`, which more accurately represents how this method can be accessed.