### PR TITLE
Download default metadata in .tar.gz rather than .zip format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - [GUI] On first start we always refresh the modlist, with an option to do so each time the CKAN is loaded (Postremus, #1285)
 - [Core] KSP instance names now default to the folder in which they're installed (Postremus, #1261)
 - [Core] Processing an updated mod list is now faster, and other speed enhancements (Postremus, #1229)
+- [Core] Metadata is now downloaded in `.tar.gz` rather than `.zip` format, resulting in much faster downloads (pjf, #1344)
 - [Spec] `install_to` can now target `Ships/` subdirectories (dbent and plague006, #1243 #1244)
 
 ### Internal

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -168,10 +168,10 @@ namespace CKAN
             // custom-added by our user.
 
             Repository default_repo;
-            var OldDefaultRepo = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.zip");
-            if (repositories.TryGetValue(Repository.default_ckan_repo_name, out default_repo) && default_repo.uri == OldDefaultRepo)
+            var oldDefaultRepo = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.zip");
+            if (repositories.TryGetValue(Repository.default_ckan_repo_name, out default_repo) && default_repo.uri == oldDefaultRepo)
             {
-                log.InfoFormat("Updating default metadata URL from {0} to {1}", OldDefaultRepo, Repository.default_ckan_repo_uri);
+                log.InfoFormat("Updating default metadata URL from {0} to {1}", oldDefaultRepo, Repository.default_ckan_repo_uri);
                 repositories["default"].uri = Repository.default_ckan_repo_uri;
             }
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -163,6 +163,18 @@ namespace CKAN
                 }
             }
 
+            // If we spot a default repo with the old .zip URL, flip it to the new .tar.gz URL
+            // Any other repo we leave *as-is*, even if it's the github meta-repo, as it's been
+            // custom-added by our user.
+
+            Repository default_repo;
+            var OldDefaultRepo = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.zip");
+            if (repositories.TryGetValue(Repository.default_ckan_repo_name, out default_repo) && default_repo.uri == OldDefaultRepo)
+            {
+                log.InfoFormat("Updating default metadata URL from {0} to {1}", OldDefaultRepo, Repository.default_ckan_repo_uri);
+                repositories["default"].uri = Repository.default_ckan_repo_uri;
+            }
+
             registry_version = LATEST_REGISTRY_VERSION;
         }
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -169,7 +169,7 @@ namespace CKAN
 
             Repository default_repo;
             var oldDefaultRepo = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.zip");
-            if (repositories.TryGetValue(Repository.default_ckan_repo_name, out default_repo) && default_repo.uri == oldDefaultRepo)
+            if (repositories != null && repositories.TryGetValue(Repository.default_ckan_repo_name, out default_repo) && default_repo.uri == oldDefaultRepo)
             {
                 log.InfoFormat("Updating default metadata URL from {0} to {1}", oldDefaultRepo, Repository.default_ckan_repo_uri);
                 repositories["default"].uri = Repository.default_ckan_repo_uri;

--- a/Core/Types/Repository.cs
+++ b/Core/Types/Repository.cs
@@ -6,7 +6,7 @@ namespace CKAN
     public class Repository
     {
         [JsonIgnore] public static readonly string default_ckan_repo_name = "default";
-        [JsonIgnore] public static readonly Uri default_ckan_repo_uri = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.zip");
+        [JsonIgnore] public static readonly Uri default_ckan_repo_uri = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz");
         [JsonIgnore] public static readonly Uri default_repo_master_list = new Uri("https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/repositories.json");
 
         public string name;


### PR DESCRIPTION
At some point, we gained the ability to read `.tar.gz` files, but the client continued to use `.zip` to download metadata. This change flips us to use tarballs, which are *an order of magnitude smaller* than the .zip files. This can make a big difference, especially on slow connections.

This change will affect both new users, and existing users if and only if they're using the default repository settings.