### PR TITLE
We don't show an update, if its assembly is not available

### DIFF
--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -22,6 +22,16 @@ namespace CKAN
 
         public static Version FetchLatestCkanVersion()
         {
+            try
+            {
+                FetchUpdaterUrl();
+                FetchCkanUrl();
+            }
+            catch (Kraken)
+            {
+                return new Version(Meta.Version());
+            }
+
             var response = MakeRequest(latestCKANReleaseApiUrl);
 
             return new CKANVersion(response.tag_name.ToString(), response.name.ToString());
@@ -83,6 +93,10 @@ namespace CKAN
         private static Uri FetchUpdaterUrl()
         {
             var response = MakeRequest(latestUpdaterReleaseApiUrl);
+            if (response.assets.Count == 0)
+            {
+                throw new Kraken("The latest updater isn't uploaded yet.");
+            }
             var assets = response.assets[0];
             return new Uri(assets.browser_download_url.ToString());
         }
@@ -90,6 +104,10 @@ namespace CKAN
         private static Uri FetchCkanUrl()
         {
             var response = MakeRequest(latestCKANReleaseApiUrl);
+            if (response.assets.Count == 0)
+            {
+                throw new Kraken("The latest release isn't uploaded yet.");
+            }
             var assets = response.assets[0];
             return new Uri(assets.browser_download_url.ToString());
         }


### PR DESCRIPTION
that is for example the case, when the build of the assembly takes long,
but the upate post is already published
We just show the currently installed version
also, we don't let the user install anything,
if the autoupdater is not available
fixes #1182