### PR TITLE
Show why a mod was picked for a change

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -525,18 +525,23 @@ namespace CKAN
         /// <returns></returns>
         public string ReasonStringFor(Module mod)
         {
+            var reason = ReasonFor(mod);
+            var is_root_type = reason.GetType() == typeof (SelectionReason.UserRequested)
+                || reason.GetType() == typeof(SelectionReason.Installed);
+            return is_root_type
+                ? reason.Reason
+                : reason.Reason + ReasonStringFor(reason.Parent);
+        }
+
+        public SelectionReason ReasonFor(Module mod)
+        {
             if (mod == null) throw new ArgumentNullException();
             if (!ModList().Contains(mod))
             {
                 throw new ArgumentException("Mod " + mod.identifier + " is not in the list");
             }
 
-            var reason = reasons[mod];
-            var is_root_type = reason.GetType() == typeof (SelectionReason.UserRequested)
-                || reason.GetType() == typeof(SelectionReason.Installed);
-            return is_root_type
-                ? reason.Reason
-                : reason.Reason + ReasonStringFor(reason.Parent);
+            return reasons[mod];
         }
     }
 
@@ -544,7 +549,7 @@ namespace CKAN
     /// Used to keep track of the relationships between modules in the resolver.
     /// Intended to be used for displaying messages to the user.
     /// </summary>
-    internal abstract class SelectionReason
+    public abstract class SelectionReason
     {
         //Currently assumed to exist for any relationship other than useradded or installed
         public virtual CkanModule Parent { get; protected set; }

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -615,7 +615,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  To satisfy dependancy from " + Parent.identifier + ".\n"; }
+                get { return "  To satisfy dependency from " + Parent.identifier + ".\n"; }
             }
         }
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -601,7 +601,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  Suggested by " + Parent.identifier + ".\n"; }
+                get { return "  Suggested by " + Parent.name + ".\n"; }
             }
         }
 
@@ -615,7 +615,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  To satisfy dependency from " + Parent.identifier + ".\n"; }
+                get { return "  To satisfy dependency from " + Parent.name + ".\n"; }
             }
         }
 
@@ -629,7 +629,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  Recommended by " + Parent.identifier + ".\n"; }
+                get { return "  Recommended by " + Parent.name + ".\n"; }
             }
         }
     }

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -107,6 +107,7 @@
     <Compile Include="MainWait.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="ModChange.cs" />
     <Compile Include="NewUpdateDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -61,6 +61,15 @@ namespace CKAN
             this.FilterAllButton = new System.Windows.Forms.ToolStripMenuItem();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.ModList = new CKAN.MainModListGUI();
+            this.Installed = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.Update = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.ModName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Author = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.InstalledVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SizeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModInfoTabControl = new System.Windows.Forms.TabControl();
             this.MetadataTabPage = new System.Windows.Forms.TabPage();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
@@ -102,9 +111,9 @@ namespace CKAN
             this.CancelChangesButton = new System.Windows.Forms.Button();
             this.ConfirmChangesButton = new System.Windows.Forms.Button();
             this.ChangesListView = new System.Windows.Forms.ListView();
-            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.Mod = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChangeType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.Reason = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.WaitTabPage = new System.Windows.Forms.TabPage();
             this.CancelCurrentActionButton = new System.Windows.Forms.Button();
             this.LogTextBox = new System.Windows.Forms.TextBox();
@@ -126,15 +135,6 @@ namespace CKAN
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChooseProvidedModsLabel = new System.Windows.Forms.Label();
-            this.Installed = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.Update = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.ModName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Author = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.InstalledVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SizeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.menuStrip1.SuspendLayout();
             this.menuStrip2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -453,6 +453,75 @@ namespace CKAN
             this.ModList.SelectionChanged += new System.EventHandler(this.ModList_SelectedIndexChanged);
             this.ModList.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ModList_KeyDown);
             this.ModList.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ModList_KeyPress);
+            // 
+            // Installed
+            // 
+            this.Installed.HeaderText = "Installed";
+            this.Installed.Name = "Installed";
+            this.Installed.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.Installed.Width = 50;
+            // 
+            // Update
+            // 
+            this.Update.HeaderText = "Update";
+            this.Update.Name = "Update";
+            this.Update.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.Update.Width = 46;
+            // 
+            // ModName
+            // 
+            this.ModName.HeaderText = "Name";
+            this.ModName.Name = "ModName";
+            this.ModName.ReadOnly = true;
+            this.ModName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.ModName.Width = 250;
+            // 
+            // Author
+            // 
+            this.Author.HeaderText = "Author";
+            this.Author.Name = "Author";
+            this.Author.ReadOnly = true;
+            this.Author.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.Author.Width = 120;
+            // 
+            // InstalledVersion
+            // 
+            this.InstalledVersion.HeaderText = "Installed version";
+            this.InstalledVersion.Name = "InstalledVersion";
+            this.InstalledVersion.ReadOnly = true;
+            this.InstalledVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.InstalledVersion.Width = 70;
+            // 
+            // LatestVersion
+            // 
+            this.LatestVersion.HeaderText = "Latest version";
+            this.LatestVersion.Name = "LatestVersion";
+            this.LatestVersion.ReadOnly = true;
+            this.LatestVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.LatestVersion.Width = 70;
+            // 
+            // KSPCompatibility
+            // 
+            this.KSPCompatibility.HeaderText = "Max KSP version";
+            this.KSPCompatibility.Name = "KSPCompatibility";
+            this.KSPCompatibility.ReadOnly = true;
+            this.KSPCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.KSPCompatibility.Width = 78;
+            // 
+            // SizeCol
+            // 
+            this.SizeCol.HeaderText = "Download (KB)";
+            this.SizeCol.Name = "SizeCol";
+            this.SizeCol.ReadOnly = true;
+            this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            // 
+            // Description
+            // 
+            this.Description.HeaderText = "Description";
+            this.Description.Name = "Description";
+            this.Description.ReadOnly = true;
+            this.Description.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.Description.Width = 821;
             // 
             // ModInfoTabControl
             // 
@@ -948,9 +1017,9 @@ namespace CKAN
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ChangesListView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.ChangesListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.columnHeader1,
+            this.Mod,
             this.ChangeType,
-            this.columnHeader2});
+            this.Reason});
             this.ChangesListView.Location = new System.Drawing.Point(-1, 0);
             this.ChangesListView.Name = "ChangesListView";
             this.ChangesListView.Size = new System.Drawing.Size(1022, 611);
@@ -958,20 +1027,20 @@ namespace CKAN
             this.ChangesListView.UseCompatibleStateImageBehavior = false;
             this.ChangesListView.View = System.Windows.Forms.View.Details;
             // 
-            // columnHeader1
+            // Mod
             // 
-            this.columnHeader1.Text = "Mod";
-            this.columnHeader1.Width = 332;
+            this.Mod.Text = "Mod";
+            this.Mod.Width = 332;
             // 
             // ChangeType
             // 
             this.ChangeType.Text = "Change";
             this.ChangeType.Width = 111;
             // 
-            // columnHeader2
+            // Reason
             // 
-            this.columnHeader2.Text = "Description";
-            this.columnHeader2.Width = 606;
+            this.Reason.Text = "Reason for action";
+            this.Reason.Width = 606;
             // 
             // WaitTabPage
             // 
@@ -1210,75 +1279,6 @@ namespace CKAN
             this.ChooseProvidedModsLabel.TabIndex = 7;
             this.ChooseProvidedModsLabel.Text = "Several mods provide the virtual module Foo, choose one of the following mods:";
             // 
-            // Installed
-            // 
-            this.Installed.HeaderText = "Installed";
-            this.Installed.Name = "Installed";
-            this.Installed.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Installed.Width = 50;
-            // 
-            // Update
-            // 
-            this.Update.HeaderText = "Update";
-            this.Update.Name = "Update";
-            this.Update.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Update.Width = 46;
-            // 
-            // ModName
-            // 
-            this.ModName.HeaderText = "Name";
-            this.ModName.Name = "ModName";
-            this.ModName.ReadOnly = true;
-            this.ModName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.ModName.Width = 250;
-            // 
-            // Author
-            // 
-            this.Author.HeaderText = "Author";
-            this.Author.Name = "Author";
-            this.Author.ReadOnly = true;
-            this.Author.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Author.Width = 120;
-            // 
-            // InstalledVersion
-            // 
-            this.InstalledVersion.HeaderText = "Installed version";
-            this.InstalledVersion.Name = "InstalledVersion";
-            this.InstalledVersion.ReadOnly = true;
-            this.InstalledVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.InstalledVersion.Width = 70;
-            // 
-            // LatestVersion
-            // 
-            this.LatestVersion.HeaderText = "Latest version";
-            this.LatestVersion.Name = "LatestVersion";
-            this.LatestVersion.ReadOnly = true;
-            this.LatestVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.LatestVersion.Width = 70;
-            // 
-            // KSPCompatibility
-            // 
-            this.KSPCompatibility.HeaderText = "Max KSP version";
-            this.KSPCompatibility.Name = "KSPCompatibility";
-            this.KSPCompatibility.ReadOnly = true;
-            this.KSPCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.KSPCompatibility.Width = 78;
-            // 
-            // SizeCol
-            // 
-            this.SizeCol.HeaderText = "Download (KB)";
-            this.SizeCol.Name = "SizeCol";
-            this.SizeCol.ReadOnly = true;
-            this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            // 
-            // Description
-            // 
-            this.Description.HeaderText = "Description";
-            this.Description.Name = "Description";
-            this.Description.ReadOnly = true;
-            this.Description.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Description.Width = 821;
-            // 
             // Main
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1392,9 +1392,9 @@ namespace CKAN
         private Button CancelChangesButton;
         private Button ConfirmChangesButton;
         private ListView ChangesListView;
-        private ColumnHeader columnHeader1;
+        private ColumnHeader Mod;
         private ColumnHeader ChangeType;
-        private ColumnHeader columnHeader2;
+        private ColumnHeader Reason;
         private TabPage ChooseRecommendedModsTabPage;
         private Label RecommendedDialogLabel;
         private ListView RecommendedModsListView;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -73,10 +73,10 @@ namespace CKAN
         private DateTime lastSearchTime;
         private string lastSearchKey;
 
-        private IEnumerable<KeyValuePair<GUIMod, GUIModChangeType>> change_set;
+        private IEnumerable<ModChange> change_set;
         private Dictionary<GUIMod, string> conflicts;
 
-        private IEnumerable<KeyValuePair<GUIMod, GUIModChangeType>> ChangeSet
+        private IEnumerable<ModChange> ChangeSet
         {
             get { return change_set; }
             set
@@ -690,7 +690,7 @@ namespace CKAN
 
         private async Task UpdateChangeSetAndConflicts(IRegistryQuerier registry)
         {
-            IEnumerable<KeyValuePair<GUIMod, GUIModChangeType>> full_change_set = null;
+            IEnumerable<ModChange> full_change_set = null;
             Dictionary<GUIMod, string> new_conflicts = null;
 
             bool too_many_provides_thrown = false;

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -9,9 +9,9 @@ namespace CKAN
     public partial class Main
     {
 
-        private List<KeyValuePair<GUIMod, GUIModChangeType>> m_Changeset;
+        private List<ModChange> m_Changeset;
 
-        public void UpdateChangesDialog(List<KeyValuePair<GUIMod, GUIModChangeType>> changeset, BackgroundWorker installWorker)
+        public void UpdateChangesDialog(List<ModChange> changeset, BackgroundWorker installWorker)
         {
             m_Changeset = changeset;
             m_InstallWorker = installWorker;
@@ -24,14 +24,14 @@ namespace CKAN
 
             foreach (var change in changeset)
             {
-                if (change.Value == GUIModChangeType.None)
+                if (change.ChangeType == GUIModChangeType.None)
                 {
                     continue;
                 }
 
-                var item = new ListViewItem {Text = String.Format("{0} {1}", change.Key.Name, change.Key.Version)};
+                var item = new ListViewItem {Text = String.Format("{0} {1}", change.Mod.Name, change.Mod.Version)};
 
-                var sub_change_type = new ListViewItem.ListViewSubItem {Text = change.Value.ToString()};
+                var sub_change_type = new ListViewItem.ListViewSubItem {Text = change.ChangeType.ToString()};
 
                 item.SubItems.Add(sub_change_type);
                 ChangesListView.Items.Add(item);
@@ -61,7 +61,7 @@ namespace CKAN
             // TODO Work out why this is.
             var user_change_set = mainModList.ComputeUserChangeSet().ToList();
             m_InstallWorker.RunWorkerAsync(
-                new KeyValuePair<List<KeyValuePair<GUIMod, GUIModChangeType>>, RelationshipResolverOptions>(
+                new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                     user_change_set, install_ops));
             m_Changeset = null;
 

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -33,7 +33,16 @@ namespace CKAN
 
                 var sub_change_type = new ListViewItem.ListViewSubItem {Text = change.ChangeType.ToString()};
 
+                ListViewItem.ListViewSubItem description = new ListViewItem.ListViewSubItem();
+                description.Text = change.Reason.Reason.Trim();
+
+                if (change.ChangeType == GUIModChangeType.Update)
+                {
+                    description.Text = String.Format("Update to version {0}", change.Mod.LatestVersion);
+                }
+
                 item.SubItems.Add(sub_change_type);
+                item.SubItems.Add(description);
                 ChangesListView.Items.Add(item);
             }
         }

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -48,7 +48,12 @@ namespace CKAN
 
                 if (change.ChangeType == GUIModChangeType.Update)
                 {
-                    description.Text = String.Format("Update to version {0}", change.Mod.LatestVersion);
+                    description.Text = String.Format("Update selected by user to version {0}.", change.Mod.LatestVersion);
+                }
+
+                if (change.ChangeType == GUIModChangeType.Install && change.Reason is SelectionReason.UserRequested)
+                {
+                    description.Text = "New mod install selected by user.";
                 }
 
                 item.SubItems.Add(sub_change_type);

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -8,7 +8,7 @@ using System.Windows.Forms;
 
 namespace CKAN
 {
-    using ModChanges = List<KeyValuePair<GUIMod, GUIModChangeType>>;
+    using ModChanges = List<ModChange>;
     public partial class Main
     {
         private BackgroundWorker m_InstallWorker;
@@ -39,18 +39,18 @@ namespace CKAN
             var toUpgrade = new HashSet<string>();
 
             // First compose sets of what the user wants installed, upgraded, and removed.
-            foreach (KeyValuePair<GUIMod, GUIModChangeType> change in opts.Key)
+            foreach (ModChange change in opts.Key)
             {
-                switch (change.Value)
+                switch (change.ChangeType)
                 {
                     case GUIModChangeType.Remove:
-                        toUninstall.Add(change.Key.Identifier);
+                        toUninstall.Add(change.Mod.Identifier);
                         break;
                     case GUIModChangeType.Update:
-                        toUpgrade.Add(change.Key.Identifier);
+                        toUpgrade.Add(change.Mod.Identifier);
                         break;
                     case GUIModChangeType.Install:
-                        toInstall.Add(change.Key.Identifier);
+                        toInstall.Add(change.Mod.Identifier);
                         break;
                 }
             }
@@ -62,10 +62,10 @@ namespace CKAN
 
             foreach (var change in opts.Key)
             {
-                if (change.Value == GUIModChangeType.Install)
+                if (change.ChangeType == GUIModChangeType.Install)
                 {
-                    AddMod(change.Key.ToModule().recommends, recommended, change.Key.Identifier, registry);
-                    AddMod(change.Key.ToModule().suggests, suggested, change.Key.Identifier, registry);
+                    AddMod(change.Mod.ToModule().recommends, recommended, change.Mod.Identifier, registry);
+                    AddMod(change.Mod.ToModule().suggests, suggested, change.Mod.Identifier, registry);
                 }
             }
 
@@ -322,7 +322,7 @@ namespace CKAN
                 {
                     foreach (var mod in result.Value)
                     {
-                        modChangedCallback(mod.Key, mod.Value);
+                        modChangedCallback(mod.Mod, mod.ChangeType);
                     }
                 }
 
@@ -343,18 +343,18 @@ namespace CKAN
 
                 var opts = result.Value;
 
-                foreach (KeyValuePair<GUIMod, GUIModChangeType> opt in opts)
+                foreach (ModChange opt in opts)
                 {
-                    switch (opt.Value)
+                    switch (opt.ChangeType)
                     {
                         case GUIModChangeType.Install:
-                            MarkModForInstall(opt.Key.Identifier);
+                            MarkModForInstall(opt.Mod.Identifier);
                             break;
                         case GUIModChangeType.Update:
-                            MarkModForUpdate(opt.Key.Identifier);
+                            MarkModForUpdate(opt.Mod.Identifier);
                             break;
                         case GUIModChangeType.Remove:
-                            MarkModForInstall(opt.Key.Identifier, true);
+                            MarkModForInstall(opt.Mod.Identifier, true);
                             break;
                     }
                 }

--- a/GUI/ModChange.cs
+++ b/GUI/ModChange.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CKAN
+{
+    public class ModChange
+    {
+        public GUIMod Mod { get; private set; }
+        public GUIModChangeType ChangeType { get; private set; }
+        public SelectionReason Reason { get; private set; }
+
+        public ModChange(GUIMod mod, GUIModChangeType changeType, SelectionReason reason)
+        {
+            Mod = mod;
+            ChangeType = changeType;
+            Reason = reason;
+            
+            if (Reason == null)
+            {
+                // Hey, we don't have a Reason
+                // Most likely the user wanted to install it
+                Reason = new SelectionReason.UserRequested();
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return (obj as ModChange).Mod.Identifier == Mod.Identifier;
+        }
+
+        public override int GetHashCode()
+        {
+            return Mod != null ? Mod.Identifier.GetHashCode() : 0;
+        }
+    }
+}

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -147,9 +147,9 @@ namespace Tests.GUI
                 registry.AddAvailable(modb);
                 var installer = ModuleInstaller.GetInstance(tidy.KSP, null);
                 var main_mod_list = new MainModList(null, async kraken => await Task.FromResult(choice_of_provide));
-                var a = new HashSet<KeyValuePair<GUIMod, GUIModChangeType>>
+                var a = new HashSet<ModChange>
                 {
-                    new KeyValuePair<GUIMod, GUIModChangeType>(new GUIMod(mod,registry,ksp_version),GUIModChangeType.Install)
+                    new ModChange(new GUIMod(mod,registry,ksp_version), GUIModChangeType.Install, null)
                 };
 
                 var mod_list = await main_mod_list.ComputeChangeSetFromModList(registry, a, installer, ksp_version);

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -155,8 +155,9 @@ namespace Tests.GUI
                 var mod_list = await main_mod_list.ComputeChangeSetFromModList(registry, a, installer, ksp_version);
                 CollectionAssert.AreEquivalent(
                     new[] {
-                        new KeyValuePair<GUIMod,GUIModChangeType>(new GUIMod(mod,registry,ksp_version), GUIModChangeType.Install),
-                        new KeyValuePair<GUIMod,GUIModChangeType>(new GUIMod(modb,registry,ksp_version),GUIModChangeType.Install)}, mod_list);
+                        new ModChange(new GUIMod(mod,registry,ksp_version), GUIModChangeType.Install, null),
+                        new ModChange(new GUIMod(modb,registry,ksp_version),GUIModChangeType.Install, null)
+                    }, mod_list);
 
             }
         }


### PR DESCRIPTION
The column "Reason for Action" shows why an action was picked for a mod change.
The columns are sorted by action in the order Remove, Update, Install.
Install changes are also sorted based on dependencies.
This pr implements a part of part 1) of #1268. 

How it looks currently:

![ss 2015-08-27 at 06 44 59](https://cloud.githubusercontent.com/assets/1223135/9512787/9a38dd30-4c87-11e5-83dc-a9559658cd9b.png)


