### PR TITLE
NetKAN: Add support for `--version` diagnostic switch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Internal
 
+- [NetKAN] `netkan.exe` will now report its version and exit if run with the `--version` switch.
+
 ## v1.14.0 (Mimas)
 
 ### Bugfixes

--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -31,6 +31,9 @@ namespace CKAN.NetKAN
         [Option("prerelease", HelpText = "Index GitHub Prereleases")]
         public bool PreRelease { get; set; }
 
+        [Option("version", HelpText = "Display the netkan version number and exit.")]
+        public bool Version { get; set; }
+
         // TODO: How do we mark this as required?
         [ValueOption(0)]
         public string File { get; set; }

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -32,6 +32,14 @@ namespace CKAN.NetKAN
             {
                 ProcessArgs(args);
 
+                // If we see the --version flag, then display our build info
+                // and exit.
+                if (Options.Version)
+                {
+                    Console.WriteLine(Meta.Version());
+                    return ExitOk;
+                }
+
                 if (Options.File != null)
                 {
                     Log.InfoFormat("Transforming {0}", Options.File);
@@ -92,7 +100,7 @@ namespace CKAN.NetKAN
             {
                 Debugger.Launch();
             }
-
+                
             Options = new CmdLineOptions();
             Parser.Default.ParseArgumentsStrict(args, Options);
 


### PR DESCRIPTION
This shows the version number we're built from and exits.