### PR TITLE
WIP: changeset recreation redo

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -205,7 +205,11 @@ namespace CKAN
 
             bool value = set_value_to ?? old_value;
             IsUpgradeChecked = value;
-            if (old_value != value) update_cell.Value = value;
+            if (old_value != value)
+            {
+                update_cell.Value = value;
+                Main.Instance.AddUserRequestedChange(this, GUIModChangeType.Update);
+            }
         }
 
         public void SetInstallChecked(DataGridViewRow row, bool? set_value_to = null)
@@ -220,6 +224,8 @@ namespace CKAN
             {
                 IsInstallChecked = changeTo;
                 install_cell.Value = IsInstallChecked;
+                Main.Instance.AddUserRequestedChange(this, 
+                    IsInstallChecked ? GUIModChangeType.Install : GUIModChangeType.Remove);
             }
         }
 

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -208,12 +208,12 @@ namespace CKAN
             var old_value = (bool) update_cell.Value;
 
             bool value = set_value_to ?? old_value;
-            IsUpgradeChecked = value;
-            if (old_value != value)
+            if (IsUpgradeChecked != value)
             {
                 Main.Instance.AddUserRequestedChange(this, GUIModChangeType.Update);
                 update_cell.Value = value;
             }
+            IsUpgradeChecked = value;
         }
 
         public void SetInstallChecked(DataGridViewRow row, bool? set_value_to = null)

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -207,8 +207,8 @@ namespace CKAN
             IsUpgradeChecked = value;
             if (old_value != value)
             {
-                update_cell.Value = value;
                 Main.Instance.AddUserRequestedChange(this, GUIModChangeType.Update);
+                update_cell.Value = value;
             }
         }
 
@@ -223,9 +223,9 @@ namespace CKAN
             if (changeTo != IsInstallChecked)
             {
                 IsInstallChecked = changeTo;
-                install_cell.Value = IsInstallChecked;
-                Main.Instance.AddUserRequestedChange(this, 
+                Main.Instance.AddUserRequestedChange(this,
                     IsInstallChecked ? GUIModChangeType.Install : GUIModChangeType.Remove);
+                install_cell.Value = IsInstallChecked;
             }
         }
 

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -208,11 +208,13 @@ namespace CKAN
             var old_value = (bool) update_cell.Value;
 
             bool value = set_value_to ?? old_value;
+            // Was the value changed by a non gui call to this method?
+            if (old_value != value) update_cell.Value = value;
+
+            // Have we changed the value at all?
             if (IsUpgradeChecked != value)
-            {
                 Main.Instance.AddUserRequestedChange(this, GUIModChangeType.Update);
-                update_cell.Value = value;
-            }
+
             IsUpgradeChecked = value;
         }
 

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -4,6 +4,10 @@ using System.Windows.Forms;
 
 namespace CKAN
 {
+    /// <summary>
+    /// An encapsulation of not just a module, but oodles of additional helpers
+    /// used by the GUI for display.
+    /// </summary>
     public sealed class GUIMod
     {
         private Module Mod { get; set; }

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -173,6 +173,11 @@ namespace CKAN
             return Mod;
         }
 
+        /// <summary>
+        /// Get the requested changetype
+        /// Only supports Install, Remove and Update
+        /// </summary>
+        /// <returns>Either a KeyValuaPair with the change, or null if no change is going to be done</returns>
         public KeyValuePair<GUIMod, GUIModChangeType>? GetRequestedChange()
         {
             if (IsInstalled ^ IsInstallChecked)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -733,9 +733,9 @@ namespace CKAN
             ChangeSet = full_change_set;
         }
 
-        public void AddUserRequestedChange(GUIMod mod, GUIModChangeType type = GUIModChangeType.None)
+        public void AddUserRequestedChange(GUIMod mod, GUIModChangeType type, SelectionReason reason = null)
         {
-            ModChange change = new ModChange(mod, type, null);
+            ModChange change = new ModChange(mod, type, reason);
             ModChange oldChange = userRequestedChangeSet.FirstOrDefault(c => c.Mod.Identifier == mod.Identifier);
             if (oldChange == null || oldChange.ChangeType != type)
             {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -730,7 +730,9 @@ namespace CKAN
             }
             last_mod_to_have_install_toggled.Clear();
             Conflicts = new_conflicts;
-            ChangeSet = full_change_set;
+            // If we would set the changeset to null
+            // it would clear the underlying userchangeset
+            ChangeSet = full_change_set ?? new List<ModChange>();
         }
 
         public void AddUserRequestedChange(GUIMod mod, GUIModChangeType type, SelectionReason reason = null)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -27,6 +27,10 @@ namespace CKAN
         All = 6
     }
 
+    /// <summary>
+    /// An enumeration of changes that can be made to mods,
+    /// including install, remove, update, and no change.
+    /// </summary>
     public enum GUIModChangeType
     {
         None = 0,
@@ -735,13 +739,29 @@ namespace CKAN
             ChangeSet = full_change_set ?? new List<ModChange>();
         }
 
+        /// <summary>
+        /// Intelligently updates userRequestedChangeSet with the change provided.
+        /// </summary>
         public void AddUserRequestedChange(GUIMod mod, GUIModChangeType type, SelectionReason reason = null)
         {
             ModChange change = new ModChange(mod, type, reason);
+
+            // Check to see if we've already got a change scheduled for this mod.
             ModChange oldChange = userRequestedChangeSet.FirstOrDefault(c => c.Mod.Identifier == mod.Identifier);
+
+            // If we didn't previously have a change scheduled, or this change is a different type, then
+            // we need to do extra work.
             if (oldChange == null || oldChange.ChangeType != type)
             {
+                // Clear the existing change. This works because changes are considered 'equal' if their
+                // identifiers are equal. This is a no-op if the change was not already in the list.
                 userRequestedChangeSet.Remove(change);
+
+                // If there was no previous change, or if the change is an update, we add it
+                // back in.
+                //
+                // XXX: If there was a previous change that *wasn't* an update, and we now have
+                // a change that's been request, is it just lost?
                 if (oldChange == null || oldChange.ChangeType == GUIModChangeType.Update)
                 {
                     userRequestedChangeSet.Add(change);

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -116,7 +116,7 @@ namespace CKAN
             //Using the changeset passed in can cause issues with versions.
             // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.
             // TODO Work out why this is.
-            var user_change_set = mainModList.ComputeUserChangeSet().ToList();
+            var user_change_set = Main.Instance.userRequestedChangeSet;
             m_InstallWorker.RunWorkerAsync(
                 new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                     user_change_set, install_ops));

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -331,6 +331,9 @@ namespace CKAN
                 HideWaitDialog(true);
                 m_TabController.HideTab("ChangesetTabPage");
                 ApplyToolButton.Enabled = false;
+                // We have no errors
+                // So we are fine to clear the changeset
+                ChangeSet = null;
             }
             else
             {

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -546,16 +546,5 @@ namespace CKAN
             return resolver.ConflictList.ToDictionary(item => new GUIMod(item.Key, registry, ksp_version),
                 item => item.Value);
         }
-
-        public HashSet<ModChange> ComputeUserChangeSet()
-        {
-            var changes = Modules.Where(mod => mod.IsInstallable()).Select(mod => mod.GetRequestedChange());
-            var changeset = new HashSet<ModChange>(
-                changes.Where(change => change.HasValue).
-                Select(change => change.Value).
-                Select(change => new ModChange(change.Key, change.Value, null))
-                );
-            return changeset;
-        }
     }
 }

--- a/GUI/ModChange.cs
+++ b/GUI/ModChange.cs
@@ -30,6 +30,10 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// Two ModChanges are considered equal if they are the same object, or
+        /// if their mod identifiers match.
+        /// </summary>
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -38,6 +42,9 @@ namespace CKAN
             return (obj as ModChange).Mod.Identifier == Mod.Identifier;
         }
 
+        /// <summary>
+        /// When hashing ModChanges, we hash their identifiers.
+        /// </summary>
         public override int GetHashCode()
         {
             return Mod != null ? Mod.Identifier.GetHashCode() : 0;

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -47,8 +47,8 @@ namespace Tests.GUI
         [Test]
         public void ComputeChangeSetFromModList_WithEmptyList_HasEmptyChangeSet()
         {
-            var item = new MainModList(delegate { }, delegate { return null; });
-            Assert.That(item.ComputeUserChangeSet(), Is.Empty);
+            Main main = new Main();
+            Assert.That(main.UserRequestedChangeSet, Is.Empty);
         }
 
         [Test]
@@ -72,7 +72,9 @@ namespace Tests.GUI
                 mod.IsInstallChecked = true;
                 mod2.IsInstallChecked = true;
 
-                var compute_change_set_from_mod_list = main_mod_list.ComputeChangeSetFromModList(registry, main_mod_list.ComputeUserChangeSet(), null, tidy.KSP.Version());
+                Main main = new Main();
+                var compute_change_set_from_mod_list = main_mod_list.ComputeChangeSetFromModList(registry, 
+                    new HashSet<ModChange>(main.UserRequestedChangeSet), null, tidy.KSP.Version());
                 await UtilStatic.Throws<InconsistentKraken>(async ()=> { await compute_change_set_from_mod_list; });
             }
         }


### PR DESCRIPTION
Currently, once a user wants to install or remove a mod (ticks / unticks it), the whole modlist (event incompatible) is searched for mods the user wants to Change.
When conflicts are present, this search is done a second time.

We now just add or remove the mod from the current user requested changeset.
needed for #1268
