### PR TITLE
Handle double click on the contentTree

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -857,6 +857,7 @@ namespace CKAN
             this.ContentsPreviewTree.Name = "ContentsPreviewTree";
             this.ContentsPreviewTree.Size = new System.Drawing.Size(349, 481);
             this.ContentsPreviewTree.TabIndex = 2;
+            this.ContentsPreviewTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.ContentsPreviewTree_NodeMouseDoubleClick);
             // 
             // ContentsDownloadButton
             // 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1063,15 +1063,20 @@ namespace CKAN
 
         private void RecommendedModsToggleCheckbox_CheckedChanged(object sender, EventArgs e)
         {
-          var state = ((CheckBox)sender).Checked;
-          foreach (ListViewItem item in RecommendedModsListView.Items)
-          {
-            if (item.Checked != state)
+            var state = ((CheckBox)sender).Checked;
+            foreach (ListViewItem item in RecommendedModsListView.Items)
             {
-              item.Checked = state;
+                if (item.Checked != state)
+                {
+                    item.Checked = state;
+                }
             }
-          }
-          RecommendedModsListView.Refresh();
+            RecommendedModsListView.Refresh();
+        }
+
+        private void ContentsPreviewTree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+        {
+            OpenFileBrowser(e.Node);
         }
     }
 

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
+using System.IO;
+using System.Diagnostics;
 
 namespace CKAN
 {
@@ -265,6 +267,33 @@ namespace CKAN
 
             UpdateModContentsTree(module, true);
             RecreateDialogs();
+        }
+
+        /// <summary>
+        /// Opens the file browser of the users system
+        /// with the folder of the clicked node opened
+        /// TODO: Open a file broweser with the file selected
+        /// </summary>
+        /// <param name="node">A node of the ContentsPreviewTree</param>
+        internal void OpenFileBrowser(TreeNode node)
+        {
+            string location = node.Text;
+
+            if (File.Exists(location))
+            {
+                //We need the Folder of the file
+                //Otherwise the OS would try to open the file in it's default application
+                location = Path.GetDirectoryName(location);
+            }
+
+            if (!Directory.Exists(location))
+            {
+                //User either selected the parent node
+                //or he clicked on the tree node of a cached, but not installed mod
+                return;
+            }
+
+            Process.Start(location);
         }
     }
 }


### PR DESCRIPTION
.net opens the windows explorer
mono uses xdg-open to open the directory