### PR TITLE
AutoUpdate makes less calls, has better tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 ### Internal
 
+- [Updater] Checking for updates takes less network resources, and is more resilient to malformed release notes. (Postremus #1410; pjf #1453)
+
 ## v1.14.1 (Eris)
 
 ### Bugfixes

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -38,20 +38,21 @@ namespace CKAN.CmdLine
             if (!options.upgrade_all && options.modules[0] == "ckan")
             {
                 User.RaiseMessage("Querying the latest CKAN version");
-                var latestVersion = AutoUpdate.FetchLatestCkanVersion();
+                AutoUpdate.Instance.FetchLatestReleaseInfo();
+                var latestVersion = AutoUpdate.Instance.LatestVersion;
                 var currentVersion = new Version(Meta.Version());
 
                 if (latestVersion.IsGreaterThan(currentVersion))
                 {
                     User.RaiseMessage("New CKAN version available - " + latestVersion);
-                    var releaseNotes = AutoUpdate.FetchLatestCkanVersionReleaseNotes();
+                    var releaseNotes = AutoUpdate.Instance.ReleaseNotes;
                     User.RaiseMessage(releaseNotes);
                     User.RaiseMessage("\n");
 
                     if (User.RaiseYesNoDialog("Proceed with install?"))
                     {
                         User.RaiseMessage("Upgrading CKAN, please wait..");
-                        AutoUpdate.StartUpdateProcess(false);
+                        AutoUpdate.Instance.StartUpdateProcess(false);
                     }
                 }
                 else

--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -125,6 +125,11 @@ namespace CKAN
             Environment.Exit(0);
         }
 
+        /// <summary>
+        /// Extracts the first downloadable asset (either the ckan.exe or its updater)
+        /// from the provided github API response
+        /// </summary>
+        /// <returns>The URL to the downloadable asset.</returns>
         internal Uri RetrieveUrl(dynamic response)
         {
             if (response.assets.Count == 0)
@@ -135,6 +140,13 @@ namespace CKAN
             return new Uri(assets.browser_download_url.ToString());
         }
 
+        /// <summary>
+        /// Fetches the URL provided, and de-serialises the returned JSON
+        /// data structure into a dynamic object.
+        /// 
+        /// May throw an exception (especially a WebExeption) on failure.
+        /// </summary>
+        /// <returns>A dynamic object representing the JSON we fetched.</returns>
         internal dynamic MakeRequest(Uri url)
         {
             var web = new WebClient();

--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -74,11 +74,16 @@ namespace CKAN
             LatestVersion = new CKANVersion(response.tag_name.ToString(), response.name.ToString());
         }
 
+        /// <summary>
+        /// Downloads the new ckan.exe version, as well as the updater helper,
+        /// and then launches the helper allowing us to upgrade.
+        /// </summary>
+        /// <param name="launchCKANAfterUpdate">If set to <c>true</c> launch CKAN after update.</param>
         public void StartUpdateProcess(bool launchCKANAfterUpdate)
         {
             if (!IsFetched())
             {
-                throw new Kraken("You have not fetched the release info yet. Can't update.");
+                throw new Kraken("We have not fetched the release info yet. Can't update.");
             }
 
             var pid = Process.GetCurrentProcess().Id;

--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -6,10 +6,13 @@ using log4net;
 using Newtonsoft.Json;
 using CKAN.Types;
 
-
 namespace CKAN
 {
 
+    /// <summary>
+    /// CKAN client auto-updating routines. This works in conjunction with the
+    /// auto-update helper to allow users to upgrade.
+    /// </summary>
     public class AutoUpdate
     {
 
@@ -41,6 +44,7 @@ namespace CKAN
             private set { }
         }
 
+        // This is private so we can enforce our class being a singleton.
         private AutoUpdate() { }
 
         public static void ClearCache()
@@ -48,12 +52,20 @@ namespace CKAN
             instance = new AutoUpdate();
         }
 
+        /// <summary>
+        /// Our metadata is considered fetched if we have a latest version, release notes,
+        /// and download URLs for the ckan executable and helper.
+        /// </summary>
         public bool IsFetched()
         {
             return LatestVersion != null && fetchedUpdaterUrl != null &&
                 fetchedCkanUrl != null && ReleaseNotes != null;
         }
 
+        /// <summary>
+        /// Fetches all the latest release info, populating our attributes in
+        /// the process.
+        /// </summary>
         public void FetchLatestReleaseInfo()
         {
             var response = MakeRequest(latestCKANReleaseApiUrl);
@@ -70,6 +82,9 @@ namespace CKAN
             }
 
             string body = response.body.ToString();
+
+            // TODO: What happens if we make a release without three dashes? We should
+            // fall back to using the entire response body.
             ReleaseNotes = body.Split(new string[] { "\r\n---\r\n" }, StringSplitOptions.None)[1];
             LatestVersion = new CKANVersion(response.tag_name.ToString(), response.name.ToString());
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -271,18 +271,19 @@ namespace CKAN
                 try
                 {
                     log.Info("Making autoupdate call");
-                    var latest_version = AutoUpdate.FetchLatestCkanVersion();
+                    AutoUpdate.Instance.FetchLatestReleaseInfo();
+                    var latest_version = AutoUpdate.Instance.LatestVersion;
                     var current_version = new Version(Meta.Version());
 
-                    if (latest_version.IsGreaterThan(current_version))
+                    if (AutoUpdate.Instance.IsFetched() && latest_version.IsGreaterThan(current_version))
                     {
                         log.Debug("Found higher ckan version");
-                        var release_notes = AutoUpdate.FetchLatestCkanVersionReleaseNotes();
+                        var release_notes = AutoUpdate.Instance.ReleaseNotes;
                         var dialog = new NewUpdateDialog(latest_version.ToString(), release_notes);
                         if (dialog.ShowDialog() == DialogResult.OK)
                         {
                             log.Info("Start ckan update");
-                            AutoUpdate.StartUpdateProcess(true);
+                            AutoUpdate.Instance.StartUpdateProcess(true);
                         }
                     }
                 }

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -213,9 +213,10 @@ namespace CKAN
         {
             try
             {
-                var latestVersion = AutoUpdate.FetchLatestCkanVersion();
+                AutoUpdate.Instance.FetchLatestReleaseInfo();
+                var latestVersion = AutoUpdate.Instance.LatestVersion;
 
-                if (latestVersion.IsGreaterThan(new Version(Meta.Version())))
+                if (latestVersion.IsGreaterThan(new Version(Meta.Version())) && AutoUpdate.Instance.IsFetched())
                 {
                     InstallUpdateButton.Enabled = true;
                 }
@@ -234,7 +235,7 @@ namespace CKAN
 
         private void InstallUpdateButton_Click(object sender, EventArgs e)
         {
-            AutoUpdate.StartUpdateProcess(true);
+            AutoUpdate.Instance.StartUpdateProcess(true);
         }
 
         private void CheckUpdateOnLaunchCheckbox_CheckedChanged(object sender, EventArgs e)

--- a/Tests/Core/Net/AutoUpdate.cs
+++ b/Tests/Core/Net/AutoUpdate.cs
@@ -22,6 +22,19 @@ namespace Tests.Core.AutoUpdate
             );
         }
 
+        [Test]
+        [TestCase("aaa\r\n---\r\nbbb", "bbb", "Release note marker included")]
+        [TestCase("aaa\r\nbbb", "aaa\r\nbbb", "No release note marker")]
+        [TestCase("aaa\r\n---\r\nbbb\r\n---\r\nccc", "bbb\r\n---\r\nccc", "Multi release notes markers")]
+        public void ExtractReleaseNotes(string body, string expected, string comment)
+        {
+            Assert.AreEqual(
+                expected,
+                CKAN.AutoUpdate.Instance.ExtractReleaseNotes(body),
+                comment
+            );
+        }
+
         private void Fetch(Uri url)
         {
             CKAN.AutoUpdate.Instance.RetrieveUrl(CKAN.AutoUpdate.Instance.MakeRequest(url));

--- a/Tests/Core/Net/AutoUpdate.cs
+++ b/Tests/Core/Net/AutoUpdate.cs
@@ -17,7 +17,7 @@ namespace Tests.Core.AutoUpdate
         {
             Assert.Throws<CKAN.Kraken>(delegate
                 {
-                    CKAN.AutoUpdate.FetchCkanUrl(test_ckan_release);
+                    Fetch(test_ckan_release);
                 }
             );
         }
@@ -28,9 +28,14 @@ namespace Tests.Core.AutoUpdate
         {
             Assert.Throws<CKAN.Kraken>(delegate
                 {
-                    CKAN.AutoUpdate.FetchUpdaterUrl(test_ckan_release);
+                    Fetch(test_ckan_release);
                 }
             );
+        }
+
+        private void Fetch(Uri url)
+        {
+            CKAN.AutoUpdate.Instance.RetrieveUrl(CKAN.AutoUpdate.Instance.MakeRequest(url));
         }
     }
 }

--- a/Tests/Core/Net/AutoUpdate.cs
+++ b/Tests/Core/Net/AutoUpdate.cs
@@ -22,17 +22,6 @@ namespace Tests.Core.AutoUpdate
             );
         }
 
-        [Test]
-        [Category("Online")]
-        public void FetchUpdaterUrl()
-        {
-            Assert.Throws<CKAN.Kraken>(delegate
-                {
-                    Fetch(test_ckan_release);
-                }
-            );
-        }
-
         private void Fetch(Uri url)
         {
             CKAN.AutoUpdate.Instance.RetrieveUrl(CKAN.AutoUpdate.Instance.MakeRequest(url));

--- a/Tests/Core/Net/AutoUpdate.cs
+++ b/Tests/Core/Net/AutoUpdate.cs
@@ -8,11 +8,12 @@ namespace Tests.Core.AutoUpdate
     [TestFixture]
     public class AutoUpdate
     {
+        // pjf's repo has no releases, so tests on this URL should fail
         private readonly Uri test_ckan_release = new Uri("https://api.github.com/repos/pjf/CKAN/releases/latest");
 
         [Test]
         [Category("Online")]
-        // We should get a kraken if something exists but has no release yet
+        // We expect a kraken when looking at a URL with no releases.
         public void FetchCkanUrl()
         {
             Assert.Throws<CKAN.Kraken>(delegate
@@ -20,6 +21,22 @@ namespace Tests.Core.AutoUpdate
                     Fetch(test_ckan_release);
                 }
             );
+        }
+
+        [Test]
+        [Category("Online")]
+        // This could fail if run during a release, so it's marked as Flaky.
+        [Category("FlakyNetwork")]
+        public void FetchLatestReleaseInfo()
+        {
+            var updater = CKAN.AutoUpdate.Instance;
+
+            // Is is a *really* basic test to just make sure we get release info
+            // if we ask for it.
+            updater.FetchLatestReleaseInfo();
+            Assert.IsTrue(updater.IsFetched());
+            Assert.IsNotNull(updater.ReleaseNotes);
+            Assert.IsNotNull(updater.LatestVersion);
         }
 
         [Test]


### PR DESCRIPTION
This is an extension of #1410, and includes all of its commits. In addition, it:

- Has more documentation
- Has extra tests
- Fixes a bug where we could crash on malformed release notes
- Changes release notes handling so that we use everything after the first line of dashes.

I'm very happy with @Postremus' work, so I'm happy for this to be merged if anyone (including Postremus) is happy with [my extensions](https://github.com/KSP-CKAN/CKAN/compare/ab836f3...eefbdc8).