### PR TITLE
fix a NullReference when opening a .ckan

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -139,6 +139,11 @@ namespace CKAN
         {
             log.DebugFormat("Checking cache for {0}", url);
 
+            if (url == null)
+            {
+                return null;
+            }
+
             string hash = CreateURLHash(url);
 
             // Use our existing list of files, or retrieve and


### PR DESCRIPTION
this prevents a NullReferenceException when importing a .ckan in the gui
The gui does generate a GuiMod when importing a.ckan.
The GuiMod needs to know,if it is cached or not..
Since the .ckan most likely has no download_url, it will crash.
fixes #1465
closes #1464