### PR TITLE
Fixed OS X cmdline not finding a valid KSP install

### DIFF
--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -98,13 +98,12 @@ namespace CKAN
             {
                 // We check both null and "" as we can't write NULL to the registry, so we write an empty string instead
                 // This is neccessary so we can indicate that the user wants to reset the current AutoStartInstance without clearing the windows registry keys!
-                if (AutoStartInstance == "")
+                if (AutoStartInstance != "")
                 {
-                    return null;
-                }
-                if (HasInstance(AutoStartInstance))
-                {
-                    return instances[AutoStartInstance];
+                    if (HasInstance(AutoStartInstance))
+                    {
+                        return instances[AutoStartInstance];
+                    }
                 }
             }
 


### PR DESCRIPTION
I believe this fixes issue #1109 or at least it did on my install of OS X...

Looking at the code I changed, I have a sneaking suspicion this issue may have been more than OS X and impacted every OS, but I have no means of testing that theory currently.

I am not a C# programmer so my bad if I have made some sort of C# faux-pas.