### PR TITLE
Improved steam detection with guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - [All] When installing and uninstalling mods, the mod name and version will be used rather than the internal identifier. (Postremus, #1401)
 - [GUI] The GUI changeset screen now provides explanations as to why changes are being made. (Postremus, #1412)
+- [Core] Better detectio of KSP installs in non-standard Steam locations (LarsOL #1444, pjf #1481)
 
 ### Internal
 

--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -145,23 +145,23 @@ namespace CKAN
                     if (line.Contains("BaseInstallFolder"))
                     {
                         
-                        //TODO: more robust parsing (currently assumes config file is valid)
+                        // This assumes config file is valid, we just skip it if it looks funny.
                         string[] split_line = line.Split('"');
 
-                        log.DebugFormat("Found a Steam Libary Location at {0}", split_line[3]);
-
-                        ksp_path = KSPDirectory(split_line[3]);
-                        if (ksp_path!= null)
+                        if (split_line.Length > 3)
                         {
-                            log.InfoFormat("Found a KSP install at {0}", ksp_path);
-                            return ksp_path;
+                            log.DebugFormat("Found a Steam Libary Location at {0}", split_line[3]);
+
+                            ksp_path = KSPDirectory(split_line[3]);
+                            if (ksp_path != null)
+                            {
+                                log.InfoFormat("Found a KSP install at {0}", ksp_path);
+                                return ksp_path;
+                            }
                         }
-                       
                     }
                 }
-
             }
-            
 
             // Could not locate the folder.
             return null;


### PR DESCRIPTION
This is #1444, but I've added some guards so that if our config file is corrupted we won't throw an exception from running off the end of an array.

I don't have a machine handy with a non-standard install of Steam, but the code looks right to me, so if you're reading this and anyone has reported it's working as intended, then please merge. :)