### PR TITLE
Sort Conflicts Relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Internal
 
+- [NetKAN] `netkan.exe` will now sort `conflicts` relationships next to other relationships. (dbent)
+
 ## v1.14.3 (Haumea)
 
 ### Bugfixes

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -36,9 +36,10 @@ namespace CKAN.NetKAN.Transformers
             { "recommends", 18 },
             { "suggests", 19 },
             { "supports", 20 },
-            { "install", 21 },
-            { "download", 22 },
-            { "download_size", 23 },
+            { "conflicts", 21 },
+            { "install", 22 },
+            { "download", 23 },
+            { "download_size", 24 },
 
             { "x_generated_by", int.MaxValue }
         };


### PR DESCRIPTION
Somehow missed adding an explicit sort for `conflicts` relationships.