### PR TITLE
Rebuild Ships Directory on Load

### DIFF
--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -236,6 +236,20 @@ namespace CKAN
 
             throw new NotKSPDirKraken(directory, "Could not find KSP version in readme.txt");
         }
+        
+        /// <summary>
+        /// Rebuilds the "Ships" directory inside the current KSP instance
+        /// </summary>
+        public void RebuildKSPSubDir()
+        {
+            string[] FoldersToCheck = { "Ships/VAB", "Ships/SPH", "Ships/@thumbs/VAB", "Ships/@thumbs/SPH" };
+            foreach (string sRelativePath in FoldersToCheck)
+            {
+                string sAbsolutePath = ToAbsoluteGameDir(sRelativePath);
+                if (!Directory.Exists(sAbsolutePath))
+                    Directory.CreateDirectory(sAbsolutePath);
+            }
+        }
 
         #endregion
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -356,6 +356,8 @@ namespace CKAN
             }
 
             m_PluginController = new PluginController(pluginsPath, true);
+            
+            CurrentInstance.RebuildKSPSubDir();
 
             log.Info("GUI started");
             ModList.Select();


### PR DESCRIPTION
Small addition that allows CKAN to rebuild any directory structure
within the current KSP game directory on load, if the directory doesn't exist.

Currently only supports Ships/VAB, Ships/SPH, Ships/@thumbs/VAB, and
Ships/@thumbs/SPH, but can be easily extended to other paths.

Fixes #1404