### PR TITLE
Configure FileInitDataParser to omit spaces around '=' when writing config files (#1498)

### DIFF
--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -116,6 +116,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
         private static void RegisterURLHandler_Linux()
         {
             var parser = new FileIniDataParser();
+            parser.Parser.Configuration.AssigmentSpacer = "";
             IniData data;
 
             log.InfoFormat("Trying to register URL handler");


### PR DESCRIPTION
Changed the AssigmentSpacer of the FileIniDataParser instance to the empty string. This removes spaces around the '=' in the kde mimeapps and .desktop files and should enable KDE to parse the files without issues. Fixes #1498 on my system.