### PR TITLE
Restore old displayYesNo instead of setting to null

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -308,9 +308,10 @@ namespace CKAN
             m_CacheWorker.RunWorkerCompleted += PostModCaching;
             m_CacheWorker.DoWork += CacheMod;
 
+            var old_YesNoDialog = m_User.displayYesNo;
             m_User.displayYesNo = YesNoDialog;
             URLHandlers.RegisterURLHandler(m_Configuration, m_User);
-            m_User.displayYesNo = null;
+            m_User.displayYesNo = old_YesNoDialog;
 
             ApplyToolButton.Enabled = false;
 

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -31,13 +31,21 @@ namespace CKAN
 
         public void UpdateRepo()
         {
+            var old_dialog = m_User.displayYesNo;
             m_User.displayYesNo = YesNoDialog;
 
             m_TabController.RenameTab("WaitTabPage", "Updating repositories");
 
             CurrentInstance.ScanGameData();
 
-            m_UpdateRepoWorker.RunWorkerAsync();
+            try
+            {
+                m_UpdateRepoWorker.RunWorkerAsync();
+            }
+            finally
+            {
+                m_User.displayYesNo = old_dialog;
+            }
 
             Util.Invoke(this, SwitchEnabledState);
 


### PR DESCRIPTION
This is a cherry-pick of 8aa8abd from #1290. Instead of assuming the `YesNoDialog` default to null, it instead caches what it previously was and restores it. At the moment this is effectively a no-op, but it may save us hassles in the future.

Code courtesy of @RichardLake, with cherry-picking and integration by me. :)