### PR TITLE
CKAN.schema: Update targeted ship installs.

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -264,8 +264,14 @@
                 {
                     "description" : "Spec v1.12 Ships subfolder paths",
                     "type" : "string",
-                    "pattern" : "^Ships/[SPH|VAB]"
+                    "pattern" : "^Ships/(SPH|VAB)$"
+                },
+                {
+                    "description" : "Spec v1.16 thumbs paths",
+                    "type" : "string",
+                    "pattern" : "^Ships/@thumbs/(SPH|VAB)$"
                 }
+
             ]
         },
         "license" : {


### PR DESCRIPTION
This commit makes two changes to the machine readable schema:

- It fixes v1.12 spec paths to target `Ships/(SPH|VAB)$`. Previously
  there was a character class here, allowing *any* pattern starting
  with `Ships/` followed by any single character from the set `ABHPS|`
  to be considered valid.

- It adds the v1.16 spec that allows for installation into
  Ships subfolders (added in #1448).

Pretty sure this works as all 5,212 unique `.ckan` files I ran it over validated nicely. :)