### PR TITLE
Fixing version sorting of _ vs .

### DIFF
--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -216,13 +216,20 @@ namespace CKAN {
 
             // Then compare the two strings, and return our comparison state.
             // Override sorting of '.' to higher than other characters.
-            if (!str1.StartsWith(".", StringComparison.Ordinal) && str2.StartsWith(".", StringComparison.Ordinal))
+            if (str1.Length > 0 && str2.Length > 0)
             {
-                comp.compare_to = -1;
-            }
-            else if (str1.StartsWith(".", StringComparison.Ordinal) && !str2.StartsWith(".", StringComparison.Ordinal))
-            {
-                comp.compare_to = 1;
+                if (str1[0] != '.' && str2[0] == '.')
+                {
+                    comp.compare_to = -1;
+                }
+                else if (str1[0] == '.' && str2[0] != '.')
+                {
+                    comp.compare_to = 1;
+                }
+                else
+                {
+                    comp.compare_to = String.CompareOrdinal(str1, str2);
+                }
             }
             else
             {

--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -226,13 +226,16 @@ namespace CKAN {
                 {
                     comp.compare_to = 1;
                 }
-                else if (str1.Length == 1 && str2.Length > 1)
+                else if (str1[0] == '.' && str2[0] == '.')
                 {
-                    comp.compare_to = 1;
-                }
-                else if (str1.Length > 1 && str2.Length == 1)
-                {
-                    comp.compare_to = -1;
+                    if (str1.Length == 1 && str2.Length > 1)
+                    {
+                        comp.compare_to = 1;
+                    }
+                    else if (str1.Length > 1 && str2.Length == 1)
+                    {
+                        comp.compare_to = -1;
+                    }
                 }
                 else
                 {

--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -226,6 +226,14 @@ namespace CKAN {
                 {
                     comp.compare_to = 1;
                 }
+                else if (str1.Length == 1 && str2.Length > 1)
+                {
+                    comp.compare_to = 1;
+                }
+                else if (str1.Length > 1 && str2.Length == 1)
+                {
+                    comp.compare_to = -1;
+                }
                 else
                 {
                     comp.compare_to = String.CompareOrdinal(str1, str2);

--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -215,8 +215,19 @@ namespace CKAN {
             }
 
             // Then compare the two strings, and return our comparison state.
-
-            comp.compare_to = String.CompareOrdinal(str1, str2);
+            // Override sorting of '.' to higher than other characters.
+            if (!str1.StartsWith(".", StringComparison.Ordinal) && str2.StartsWith(".", StringComparison.Ordinal))
+            {
+                comp.compare_to = -1;
+            }
+            else if (str1.StartsWith(".", StringComparison.Ordinal) && !str2.StartsWith(".", StringComparison.Ordinal))
+            {
+                comp.compare_to = 1;
+            }
+            else
+            {
+                comp.compare_to = String.CompareOrdinal(str1, str2);
+            }
             return comp;
         }
 

--- a/Tests/Core/Types/Version.cs
+++ b/Tests/Core/Types/Version.cs
@@ -37,6 +37,15 @@ namespace Tests.Core.Types
             Assert.That(v1.IsEqualTo(v0));
         }
 
+        [Test]
+        public void SortAllNonNumbersBeforeDot()
+        {
+            var v0 = new CKAN.Version("1.0_beta");
+            var v1 = new CKAN.Version("1.0.1_beta");
+
+            Assert.That(v0.IsLessThan(v1));
+            Assert.That(v1.IsGreaterThan(v0));
+        }
 
         [Test]
         public void Complex()
@@ -154,6 +163,18 @@ namespace Tests.Core.Types
             Assert.That(str.compare_to, Is.EqualTo(0));
             Assert.AreEqual("25.0", str.remainder1);
             Assert.AreEqual("25.99", str.remainder2);
+
+            str = CKAN.Version.StringComp(".42", "_42");
+
+            Assert.That(str.compare_to, Is.GreaterThan(0));
+            Assert.AreEqual("42", str.remainder1);
+            Assert.AreEqual("42", str.remainder2);
+
+            str = CKAN.Version.StringComp("_42", ".42");
+
+            Assert.That(str.compare_to, Is.LessThan(0));
+            Assert.AreEqual("42", str.remainder1);
+            Assert.AreEqual("42", str.remainder2);
         }
 
         [Test]

--- a/Tests/Core/Types/Version.cs
+++ b/Tests/Core/Types/Version.cs
@@ -48,6 +48,29 @@ namespace Tests.Core.Types
         }
 
         [Test]
+        public void DotSeparatorForExtraData()
+        {
+            var v0 = new CKAN.Version("1.0");
+            var v1 = new CKAN.Version("1.0.repackaged");
+            var v2 = new CKAN.Version("1.0.1");
+
+            Assert.That(v0.IsLessThan(v1));
+            Assert.That(v1.IsLessThan(v2));
+            Assert.That(v1.IsGreaterThan(v0));
+            Assert.That(v2.IsGreaterThan(v1));
+        }
+
+        [Test]
+        public void UnevenVersioning()
+        {
+            var v0 = new CKAN.Version("1.1.0.0");
+            var v1 = new CKAN.Version("1.1.1");
+
+            Assert.That(v0.IsLessThan(v1));
+            Assert.That(v1.IsGreaterThan(v0));
+        }
+
+        [Test]
         public void Complex()
         {
             var v1 = new CKAN.Version("v6a12");


### PR DESCRIPTION
The NavUtilities versions were not being sorted properly. Currently the sort is

- 0.5_RC_3
- 0.5.1_RC_1_repacked
- 0.4.3

It should be

- 0.5.1_RC_1_repacked
- 0.5_RC_3
- 0.4.3

This change modifies the sort so that '.' takes precedence over all other non-digit characters. That way version parts are considered higher than other random characters tacked onto the end of the version.

All the other version tests pass.