### PR TITLE
Added include_only and include_only_regexp

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -192,7 +192,31 @@
                     "filter_regexp" : {
                         "description" : "List of regexps that should filter files from this install",
                         "$ref" : "#/definitions/one_or_more_strings"
+                    },
+                    "include_only" : {
+                        "description" : "List of files and directories that should not be excluded from the install",
+                        "$ref" : "#/definitions/one_or_more_strings"
+                    },
+                    "include_only_regexp" : {
+                        "description" : "List of regexps that should include files in this install",
+                        "$ref" : "#/definitions/one_or_more_strings"
                     }
+                },
+                "not": {
+                    "anyOf": [
+                        {
+                            "required": [ "filter", "include_only" ]
+                        },
+                        {
+                            "required": [ "filter", "include_only_regexp" ]
+                        },
+                        {
+                            "required": [ "filter_regexp", "include_only" ]
+                        },
+                        {
+                            "required": [ "filter_regexp", "include_only_regexp" ]
+                        }
+                    ]
                 },
                 "required" : [ "install_to" ],
                 "comment" : "One must have either file or find, is there a JSON Schema friendly way of specifying that?"

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -197,6 +197,23 @@ namespace Tests.Core
         }
 
         [Test]
+        // Test includes_only and includes_only_regexp
+        public void FindInstallableFilesWithInclude()
+        {
+            string extra_doge = TestData.DogeCoinFlagZipWithExtras();
+            CkanModule mod = TestData.DogeCoinFlag_101_module_include();
+
+            List<InstallableFile> contents = CKAN.ModuleInstaller.FindInstallableFiles(mod, extra_doge, null);
+
+            var files = contents.Select(x => x.source.Name);
+
+            Assert.IsTrue(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/Flags/dogecoin.png"), "dogecoin.png");
+            Assert.IsFalse(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/README.md"), "Filtered README 1");
+            Assert.IsFalse(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/Flags/README.md"), "Filtered README 2");
+            Assert.IsTrue(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/notes.txt.bak"), ".bak file");
+        }
+
+        [Test]
         public void No_Installable_Files()
         {
             // This tests GH #93

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -154,6 +154,22 @@ namespace Tests.Data
             return doge;
         }
 
+        /// <summary>
+        /// The Doge Coin flag using include_only and include_only_regexp.
+        /// Won't install the same files as the other modules and the files don't make sense but I needed some module to test the include_only stuff
+        /// </summary>
+        public static CkanModule DogeCoinFlag_101_module_include()
+        {
+            CkanModule doge = DogeCoinFlag_101_module();
+
+            doge.install[0].filter = null;
+            doge.install[0].filter_regexp = null;
+            doge.install[0].include_only = new List<String> { "dogecoin.png" };
+            doge.install[0].include_only_regexp = new List<string> { "\\.bak$" };
+
+            return doge;
+        }
+
         // Identical to DogeCoinFlag_101, but with a spec version over 9000!
         public static string FutureMetaData()
         {


### PR DESCRIPTION
This PR adds two fields which practically work as negative filter/filter_regexp. 
Also Includes a test and changes to the CKAN.schema to make sure there are only filter or include_only fields but never both. 

I hope I didn't miss anything, don't really know the code-base yet.

Closes #228 
