### PR TITLE
Changed schema to enforce structure of install direcitves

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -195,7 +195,17 @@
                     }
                 },
                 "required" : [ "install_to" ],
-                "comment" : "One must have either file or find, is there a JSON Schema friendly way of specifying that?"
+                "oneOf": [
+                    {
+                        "required": [ "file" ]
+                    },
+                    {
+                        "required": [ "find" ]
+                    },
+                    {
+                        "required": [ "find_regexp" ]
+                    }
+                ]
             }
         }
     },


### PR DESCRIPTION
Found a JSON Schema friendly way of specifying that excactly one of 'file', 'find' and 'find_regexp' must be present. 