### PR TITLE
[NetKAN] Tolerate Malformed Author URLs from KS/SD

### DIFF
--- a/Netkan/Sources/Kerbalstuff/KerbalstuffMod.cs
+++ b/Netkan/Sources/Kerbalstuff/KerbalstuffMod.cs
@@ -12,8 +12,8 @@ namespace CKAN.NetKAN.Sources.Kerbalstuff
         [JsonProperty] public string short_description;
         [JsonProperty] public string author;
         [JsonProperty] public KSVersion[] versions;
-        [JsonProperty] public Uri website;
-        [JsonProperty] public Uri source_code;
+        [JsonProperty] public string website;
+        [JsonProperty] public string source_code;
         [JsonProperty] public int default_version_id;
         [JsonConverter(typeof(KSVersion.JsonConvertFromRelativeKsUri))]
         public Uri background;

--- a/Netkan/Sources/Spacedock/SpacedockMod.cs
+++ b/Netkan/Sources/Spacedock/SpacedockMod.cs
@@ -12,8 +12,8 @@ namespace CKAN.NetKAN.Sources.Spacedock
         [JsonProperty] public string short_description;
         [JsonProperty] public string author;
         [JsonProperty] public SDVersion[] versions;
-        [JsonProperty] public Uri website;
-        [JsonProperty] public Uri source_code;
+        [JsonProperty] public string website;
+        [JsonProperty] public string source_code;
         [JsonProperty] public int default_version_id;
         [JsonConverter(typeof(SDVersion.JsonConvertFromRelativeSdUri))]
         public Uri background;


### PR DESCRIPTION
From KSP-CKAN/NetKAN#2980. This PR changes the datatype of KerbalStuff's `website` and `source_code` properties into `String` from `Uri`, since we have no guarantee that they're actually well-formed `Uri` strings. Now when "normalizing" the URIs (renamed the method from `Escape` to `Normalize` since we were doing a lot more in it than merely escaping characters) we do a final check to make sure the string is a well formed URI. If it is, we proceed as normal, if it isn't we spit out a warning and return `null`, preventing it from being added to the metadata (the `SafeAdd` extension method will ignore `null` inputs).

@politas @plague006 @pjf 