### PR TITLE
Allow NetKAN to use GitHub source archives as download sources

### DIFF
--- a/Netkan/Sources/Github/GithubRef.cs
+++ b/Netkan/Sources/Github/GithubRef.cs
@@ -14,12 +14,13 @@ namespace CKAN.NetKAN.Sources.Github
         public string Project { get; private set; }
         public string Repository { get; private set; }
         public Regex Filter { get; private set; }
+        public bool UseSourceArchive { get; private set; }
         public bool UsePrelease { get; private set; }
 
-        public GithubRef(string remoteRefToken, bool usePrelease = false)
-            : this(new RemoteRef(remoteRefToken), usePrelease) { }
+        public GithubRef(string remoteRefToken, bool useSourceArchive, bool usePrelease)
+            : this(new RemoteRef(remoteRefToken), useSourceArchive, usePrelease) { }
 
-        public GithubRef(RemoteRef remoteRef, bool usePrelease = false)
+        public GithubRef(RemoteRef remoteRef, bool useSourceArchive, bool usePrelease)
             : base(remoteRef)
         {
             var match = Pattern.Match(remoteRef.Id);
@@ -34,6 +35,7 @@ namespace CKAN.NetKAN.Sources.Github
                     new Regex(match.Groups["filter"].Value, RegexOptions.Compiled) :
                     Constants.DefaultAssetMatchPattern;
 
+                UseSourceArchive = useSourceArchive;
                 UsePrelease = usePrelease;
             }
             else

--- a/Netkan/Sources/Github/GithubRelease.cs
+++ b/Netkan/Sources/Github/GithubRelease.cs
@@ -1,80 +1,18 @@
 using System;
-using log4net;
-using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN.Sources.Github
 {
-    public class GithubRelease
+    public sealed class GithubRelease
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(GithubRelease));
-
+        public string Author { get; private set; }
         public Version Version { get; private set; }
         public Uri Download { get; private set; }
-        public long Size { get; private set; }
-        public string Author { get; private set; }
 
-        public GithubRelease(JObject release, JObject asset)
-            : this(ParseArguments(release, asset)) {}
-
-        public GithubRelease(Version version, Uri download, long size, string author)
-            : this(new Arguments(version, download, size, author)) { }
-
-        private GithubRelease(Arguments arguments)
+        public GithubRelease(string author, Version version, Uri download)
         {
-            Version = arguments.Version;
-            Download = arguments.Download;
-            Size = arguments.Size;
-            Author = arguments.Author;
-        }
-
-        private static Arguments ParseArguments(JObject release, JObject asset)
-        {
-            var version = new Version((string)release["tag_name"]);
-            var author = (string)release["author"]["login"];
-
-            if (IsProbablyZip(asset))
-            {
-                var size = (long)asset["size"];
-                var download = new Uri((string)asset["browser_download_url"]);
-
-                Log.DebugFormat("Download {0} is {1} bytes", download, size);
-
-                return new Arguments(version, download, size, author);
-            }
-            else
-            {
-                // TODO: A proper kraken, please!
-                throw new Kraken("Cannot find download");
-            }
-        }
-
-        private static bool IsProbablyZip(JObject asset)
-        {
-            // GH #290, we need to look for the first asset which is a zip, otherwise we
-            // end up picking up manuals, pictures of cats, and all sorts of other things.
-
-            var contentType = (string)asset["content_type"];
-            var name = (string)asset["name"];
-
-            return contentType == "application/x-zip-compressed" ||
-                contentType == "application/zip" ||
-                name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private sealed class Arguments
-        {
-            public Version Version { get; private set; }
-            public Uri Download { get; private set; }
-            public long Size { get; private set; }
-            public string Author { get; private set; }
-
-            public Arguments(Version version, Uri download, long size, string author)
-            {
-                Version = version;
-                Download = download;
-                Size = size;
-                Author = author;
-            }
+            Author = author;
+            Version = version;
+            Download = download;
         }
     }
 }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -35,7 +35,20 @@ namespace CKAN.NetKAN.Transformers
                 Log.InfoFormat("Executing GitHub transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
-                var ghRef = new GithubRef(metadata.Kref, _matchPreleases);
+                var useSourceAchive = false;
+
+                var githubMetadata = (JObject)json["x_netkan_github"];
+                if (githubMetadata != null)
+                {
+                    var githubUseSourceArchive = (bool?)githubMetadata["use_source_archive"];
+
+                    if (githubUseSourceArchive != null)
+                    {
+                        useSourceAchive = githubUseSourceArchive.Value;
+                    }
+                }
+
+                var ghRef = new GithubRef(metadata.Kref, useSourceAchive, _matchPreleases);
 
                 // Find the release on github and download.
                 var ghRelease = _api.GetLatestRelease(ghRef);

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -19,12 +19,11 @@ namespace Tests.NetKAN.Sources.Github
             var sut = new GithubApi();
 
             // Act
-            var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test"));
+            var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test", false, false));
 
             // Assert
             Assert.IsNotNull(githubRelease.Author);
             Assert.IsNotNull(githubRelease.Download);
-            Assert.IsNotNull(githubRelease.Size);
             Assert.IsNotNull(githubRelease.Version);
         }
     }

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -24,10 +24,9 @@ namespace Tests.NetKAN.Transformers
             var mApi = new Mock<IGithubApi>();
             mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>()))
                 .Returns(new GithubRelease(
+                    "ExampleProject",
                     new Version("1.0"),
-                    new Uri("http://github.example/download"),
-                    0,
-                    "ExampleProject"
+                    new Uri("http://github.example/download")
                 ));
 
             var sut = new GithubTransformer(mApi.Object, matchPreleases: false);


### PR DESCRIPTION
@pjf This PR allows GitHub "source code" archives to be used as download sources. Normally, we expect authors to upload a ZIP artifact to their GitHub release, but this can be a redundant step for mods which are pure text files such as `MK2KSPIIntegration` (see: KSP-CKAN/NetKAN#3079).

Now you can specify:
```json
{
    "x_netkan_github": {
        "use_source_archive": true
    }
}
```

And we'll automatically use the "source code" ZIP file as the download source. (`use_source_archive` obviously has a `false` default value).

For example this `.netkan`:
```json
{
    "spec_version": "v1.4",
    "$kref": "#/ckan/github/ABZB/Mk2_Extended_KSPI_Integration",
    "x_netkan_github": {
        "use_source_archive": true
    },
    "license": "CC-BY-NC-SA-4.0",
    "identifier": "MK2KSPIIntegration",
    "ksp_version": "1.0.5",
    "depends": [
        { "name": "InterstellarFuelSwitch"}
    ],
    "recommends": [
        { "name": "B9-PWings-Fork" },
        { "name": "KSPInterstellarExtended"},
        { "name": "Mk2Expansion"}
    ],
    "install": [
        {
            "find"       : "StarLionIndustries",
            "install_to" : "GameData",
            "filter"     : "Deprecated"
        }
    ]
}
```

Produces the following `.ckan`:
```json
{
    "spec_version": "v1.4",
    "identifier": "MK2KSPIIntegration",
    "author": "ABZB",
    "license": "CC-BY-NC-SA-4.0",
    "resources": {
        "repository": "https://github.com/ABZB/Mk2_Extended_KSPI_Integration"
    },
    "version": "8.9.1.T",
    "ksp_version": "1.0.5",
    "depends": [
        {
            "name": "InterstellarFuelSwitch"
        }
    ],
    "recommends": [
        {
            "name": "B9-PWings-Fork"
        },
        {
            "name": "KSPInterstellarExtended"
        },
        {
            "name": "Mk2Expansion"
        }
    ],
    "install": [
        {
            "find": "StarLionIndustries",
            "install_to": "GameData",
            "filter": "Deprecated"
        }
    ],
    "download": "https://api.github.com/repos/ABZB/Mk2_Extended_KSPI_Integration/zipball/8.9.1.T",
    "download_size": 151157,
    "x_generated_by": "netkan"
}
```

Other changes in this PR:

- I've made the `GithubRelease` object less smart, it's now a dumb POCO. All the JSON parsing logic has been moved into `GithubApi`.
- I've gotten rid of the `Size` property from `GithubRelease`, it wasn't used, we calculate the value automatically anyway in the `DownloadSizeTransformer` and GitHub does not provide a value for source code archives.