### PR TITLE
Support SpaceDock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Bugfixes
+
+### Features
+
+- [Core] CKAN will now also work for mods that are hosted on SpaceDock. Use the new `$kref` "spacedock". (Olympic1, #1593)
+- [GUI] Scrolling now works without having to click in the modlist first. (ChucklesTheBeard, #1584)
+
+### Internal
+
 ## v1.16.0
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [Core] CKAN will now also work for mods that are hosted on SpaceDock. Use the new `$kref` "spacedock". (Olympic1, #1593)
-- [GUI] Scrolling now works without having to click in the modlist first. (ChucklesTheBeard, #1584)
+- [Core] CKAN will now also work for mods that are hosted on SpaceDock. Use the new `$kref` "spacedock". (#1593 by: Olympic1)
 
 ### Internal
 

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -152,6 +152,11 @@
                     "type" : "string",
                     "format" : "uri"
                 },
+                "spacedock" : {
+                    "description" : "Project on SpaceDock",
+                    "type" : "string",
+                    "format" : "uri"
+                },
                 "manual" : {
                     "description" : "Mod's manual",
                     "type" : "string",

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -196,6 +196,8 @@ namespace CKAN.CmdLine
                     user.RaiseMessage("- homepage: {0}", Uri.EscapeUriString(module.resources.homepage.ToString()));
                 if (module.resources.kerbalstuff != null)
                     user.RaiseMessage("- kerbalstuff: {0}", Uri.EscapeUriString(module.resources.kerbalstuff.ToString()));
+                if (module.resources.spacedock != null)
+                    user.RaiseMessage("- spacedock: {0}", Uri.EscapeUriString(module.resources.spacedock.ToString()));
                 if (module.resources.repository != null)
                     user.RaiseMessage("- repository: {0}", Uri.EscapeUriString(module.resources.repository.ToString()));
             }

--- a/Core/Exporters/DelimeterSeperatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeperatedValueExporter.cs
@@ -50,7 +50,8 @@ namespace CKAN.Exporters
                     "repository",
                     "homepage",
                     "bugtracker",
-                    "kerbalstuff"
+                    "kerbalstuff",
+                    "spacedock"
                 );
 
                 foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
@@ -74,7 +75,8 @@ namespace CKAN.Exporters
                         WriteRepository(mod.Module.resources),
                         WriteHomepage(mod.Module.resources),
                         WriteBugtracker(mod.Module.resources),
-                        WriteKerbalStuff(mod.Module.resources)
+                        WriteKerbalStuff(mod.Module.resources),
+                        WriteSpaceDock(mod.Module.resources)
                     );
                 }
             }
@@ -120,6 +122,16 @@ namespace CKAN.Exporters
             if (resources != null && resources.kerbalstuff != null)
             {
                 return QuoteIfNecessary(resources.kerbalstuff.ToString());
+            }
+
+            return string.Empty;
+        }
+
+        private string WriteSpaceDock(ResourcesDescriptor resources)
+        {
+            if (resources != null && resources.spacedock != null)
+            {
+                return QuoteIfNecessary(resources.spacedock.ToString());
             }
 
             return string.Empty;

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -83,6 +83,9 @@ namespace CKAN
 
         [JsonConverter(typeof (JsonOldResourceUrlConverter))]
         public Uri kerbalstuff;
+
+        [JsonConverter(typeof(JsonOldResourceUrlConverter))]
+        public Uri spacedock;
     }
 
     public class NameComparer : IEqualityComparer<CkanModule>

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -143,6 +143,10 @@ namespace CKAN
                 {
                     Homepage = mod.resources.kerbalstuff.ToString();
                 }
+                else if (mod.resources.spacedock != null)
+                {
+                    Homepage = mod.resources.spacedock.ToString();
+                }
                 else if (mod.resources.repository != null)
                 {
                     Homepage = mod.resources.repository.ToString();

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -53,6 +53,11 @@
     <Compile Include="Sources\Github\GithubRef.cs" />
     <Compile Include="Sources\Github\GithubRelease.cs" />
     <Compile Include="Sources\Github\IGithubApi.cs" />
+    <Compile Include="Sources\Spacedock\ISpaceDock.cs" />
+    <Compile Include="Sources\Spacedock\SpaceDockApi.cs" />
+    <Compile Include="Sources\Spacedock\SpacedockError.cs" />
+    <Compile Include="Sources\Spacedock\SpacedockMod.cs" />
+    <Compile Include="Sources\Spacedock\SDVersion.cs" />
     <Compile Include="Sources\Kerbalstuff\IKerbalstuffApi.cs" />
     <Compile Include="Sources\Kerbalstuff\KerbalstuffApi.cs" />
     <Compile Include="Sources\Kerbalstuff\KerbalstuffError.cs" />
@@ -69,6 +74,7 @@
     <Compile Include="Model\RemoteRef.cs" />
     <Compile Include="Transformers\InternalCkanTransformer.cs" />
     <Compile Include="Transformers\JenkinsTransformer.cs" />
+    <Compile Include="Transformers\SpacedockTransformer.cs" />
     <Compile Include="Transformers\KerbalstuffTransformer.cs" />
     <Compile Include="Transformers\MetaNetkanTransformer.cs" />
     <Compile Include="Transformers\NetkanTransformer.cs" />

--- a/Netkan/Sources/Spacedock/ISpaceDock.cs
+++ b/Netkan/Sources/Spacedock/ISpaceDock.cs
@@ -1,0 +1,10 @@
+namespace CKAN.NetKAN.Sources.Spacedock
+{
+    internal interface ISpacedockApi
+    {
+        /// <summary>
+        /// Given a mod Id, returns a SDMod with its metadata from the network.
+        /// </summary>
+        SpacedockMod GetMod(int modId);
+    }
+}

--- a/Netkan/Sources/Spacedock/SDVersion.cs
+++ b/Netkan/Sources/Spacedock/SDVersion.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Text.RegularExpressions;
+using log4net;
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Spacedock
+{
+    public class SDVersion
+    {
+        private static readonly ILog log = LogManager.GetLogger(typeof (SDVersion));
+
+        // These all get filled by JSON deserialisation.
+
+        [JsonConverter(typeof(JsonConvertKSPVersion))]
+        public KSPVersion KSP_version;
+        public string changelog;
+
+        [JsonConverter(typeof(JsonConvertFromRelativeSdUri))]
+        public Uri download_path;
+
+        public Version friendly_version;
+        public int id;
+
+        public string Download(string identifier, NetFileCache cache)
+        {
+            log.DebugFormat("Downloading {0}", download_path);
+
+            string filename = ModuleInstaller.CachedOrDownload(identifier, friendly_version, download_path, cache);
+
+            log.Debug("Downloaded.");
+
+            return filename;
+        }
+
+        /// <summary>
+        /// SpaceDock always trims trailing zeros from a three-part version
+        /// (eg: 1.0.0 -> 1.0). This means we could potentially think some mods
+        /// will work with more versions than they actually will. This converter
+        /// puts the .0 back on when appropriate. GH #1156.
+        /// </summary>
+        internal class JsonConvertKSPVersion : JsonConverter
+        {
+            public override object ReadJson(
+                JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer
+            )
+            {
+                if (reader.Value == null)
+                    return null;
+
+                string raw_version = reader.Value.ToString();
+
+                return new KSPVersion( ExpandVersionIfNeeded(raw_version) );
+            }
+
+            /// <summary>
+            /// Actually expand the KSP version. It's way easier to test this than the override. :)
+            /// </summary>
+            public static string ExpandVersionIfNeeded(string version)
+            {
+                if (Regex.IsMatch(version,@"^\d+\.\d+$"))
+                {
+                    // Two part string, add our .0
+                    return version + ".0";
+                }
+
+                return version;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// A simple helper class to prepend SpaceDock URLs.
+        /// </summary>
+        internal class JsonConvertFromRelativeSdUri : JsonConverter
+        {
+            public override object ReadJson(
+                JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer
+            )
+            {
+                if(reader.Value!=null)
+                    return SpacedockApi.ExpandPath(reader.Value.ToString());
+                return null;
+
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Netkan/Sources/Spacedock/SpaceDockApi.cs
+++ b/Netkan/Sources/Spacedock/SpaceDockApi.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using CKAN.NetKAN.Services;
+using log4net;
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Spacedock
+{
+    internal sealed class SpacedockApi : ISpacedockApi
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SpacedockApi));
+
+        private static readonly Uri SpacedockBase = new Uri("https://spacedock.info/");
+        private static readonly Uri SpacedockApiBase = new Uri(SpacedockBase, "/api/");
+
+        private readonly IHttpService _http;
+
+        public SpacedockApi(IHttpService http)
+        {
+            _http = http;
+        }
+
+        public SpacedockMod GetMod(int modId)
+        {
+            var json = Call("/mod/" + modId);
+
+            // Check if the mod has been removed from SD.
+            var error = JsonConvert.DeserializeObject<SpacedockError>(json);
+
+            if (error.error)
+            {
+                var errorMessage = string.Format("Could not get the mod from SD, reason: {0}.", error.reason);
+                throw new Kraken(errorMessage);
+            }
+
+            return SpacedockMod.FromJson(json);
+        }
+
+        // TODO: DBB: Make this private
+        /// <summary>
+        ///     Returns the route with the SpaceDock URI (not the API URI) pre-pended.
+        /// </summary>
+        public static Uri ExpandPath(string route)
+        {
+            Log.DebugFormat("Expanding {0} to full SD URL", route);
+
+            // Alas, this isn't as simple as it may sound. For some reason
+            // some—but not all—SD mods don't work the same way if the path provided
+            // is escaped or un-escaped. Since our curl implementation preserves the
+            // "original" string used to download a mod, we need to jump through some
+            // hoops to make sure this is escaped.
+
+            // Update: The Uri class under mono doesn't un-escape everything when
+            // .ToString() is called, even though the .NET documentation says that it
+            // should. Rather than using it and going through escaping hell, we'll simply
+            // concat our strings together and preserve escaping that way. If SD ever
+            // start returning fully qualified URLs then we should see everyting break
+            // pretty quickly, and we can rejoice because we won't need any of this code
+            // again. -- PJF, KSP-CKAN/CKAN#816.
+
+            // Step 1: Escape any spaces present. SD seems to escape everything else fine.
+            route = Regex.Replace(route, " ", "%20");
+
+            // Step 2: Trim leading slashes and prepend the SD host
+            var urlFixed = new Uri(SpacedockBase + route.TrimStart('/'));
+
+            // Step 3: Profit!
+            Log.DebugFormat("Expanded URL is {0}", urlFixed.OriginalString);
+            return urlFixed;
+        }
+
+        private string Call(string path)
+        {
+            // TODO: There's got to be a better way than using regexps.
+            // new Uri (spacedock_api, path) doesn't work, it only uses the *base* of the first arg,
+            // and hence drops the /api path.
+
+            // Remove leading slashes.
+            path = Regex.Replace(path, "^/+", "");
+
+            var url = SpacedockApiBase + path;
+
+            Log.DebugFormat("Calling {0}", url);
+
+            return _http.DownloadText(new Uri(url));
+        }
+    }
+}

--- a/Netkan/Sources/Spacedock/SpacedockError.cs
+++ b/Netkan/Sources/Spacedock/SpacedockError.cs
@@ -1,0 +1,15 @@
+namespace CKAN.NetKAN.Sources.Spacedock
+{
+    /// <summary>
+    /// Internal class to read errors from SD.
+    /// </summary>
+    internal class SpacedockError
+    {
+        // Currently only used via JsonConvert.DeserializeObject which the compiler
+        // doesn't pick up on.
+#pragma warning disable 0649
+        public string reason;
+        public bool error;
+#pragma warning restore 0649
+    }
+}

--- a/Netkan/Sources/Spacedock/SpacedockMod.cs
+++ b/Netkan/Sources/Spacedock/SpacedockMod.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Spacedock
+{
+    internal class SpacedockMod
+    {
+        [JsonProperty] public int id; // SDID
+        [JsonProperty] public string license;
+        [JsonProperty] public string name;
+        [JsonProperty] public string short_description;
+        [JsonProperty] public string author;
+        [JsonProperty] public SDVersion[] versions;
+        [JsonProperty] public Uri website;
+        [JsonProperty] public Uri source_code;
+        [JsonProperty] public int default_version_id;
+        [JsonConverter(typeof(SDVersion.JsonConvertFromRelativeSdUri))]
+        public Uri background;
+
+        public SDVersion Latest()
+        {
+            // The version we want is specified by `default_version_id`, it's not just
+            // the latest. See GH #214. Thanks to @Starstrider42 for spotting this.
+
+            var latest =
+                from release in versions
+                where release.id == default_version_id
+                select release
+            ;
+
+            // There should only ever be one.
+            return latest.First();
+        }
+
+        /// <summary>
+        /// Returns the path to the mod's home on SpaceDock
+        /// </summary>
+        /// <returns>The home.</returns>
+        public Uri GetPageUrl()
+        {
+            return SpacedockApi.ExpandPath(string.Format("/mod/{0}/{1}", id, name));
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0}", name);
+        }
+
+        public static SpacedockMod FromJson(string json)
+        {
+            return JsonConvert.DeserializeObject<SpacedockMod>(json);
+        }
+    }
+}

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -4,6 +4,7 @@ using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Sources.Github;
 using CKAN.NetKAN.Sources.Kerbalstuff;
+using CKAN.NetKAN.Sources.Spacedock;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -26,6 +27,7 @@ namespace CKAN.NetKAN.Transformers
             {
                 new MetaNetkanTransformer(http),
                 new KerbalstuffTransformer(new KerbalstuffApi(http)),
+                new SpacedockTransformer(new SpacedockApi(http)),
                 new GithubTransformer(new GithubApi(githubToken), prerelease),
                 new HttpTransformer(),
                 new JenkinsTransformer(http),

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -48,11 +48,12 @@ namespace CKAN.NetKAN.Transformers
         {
             { "homepage", 0 },
             { "kerbalstuff", 1 },
-            { "repository", 2 },
-            { "bugtracker", 3 },
-            { "ci", 4 },
-            { "license", 5 },
-            { "manual", 6 }
+            { "spacedock", 2 },
+            { "repository", 3 },
+            { "bugtracker", 4 },
+            { "ci", 5 },
+            { "license", 6 },
+            { "manual", 7 }
         };
 
         public Metadata Transform(Metadata metadata)

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using CKAN.NetKAN.Extensions;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Sources.Spacedock;
+using log4net;
+using Newtonsoft.Json.Linq;
+
+namespace CKAN.NetKAN.Transformers
+{
+    /// <summary>
+    /// An <see cref="ITransformer"/> that looks up data from SpaceDock.
+    /// </summary>
+    internal sealed class SpacedockTransformer : ITransformer
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SpacedockTransformer));
+
+        private readonly ISpacedockApi _api;
+
+        public SpacedockTransformer(ISpacedockApi api)
+        {
+            _api = api;
+        }
+
+        public Metadata Transform(Metadata metadata)
+        {
+            if (metadata.Kref != null && metadata.Kref.Source == "spacedock")
+            {
+                var json = metadata.Json();
+
+                Log.InfoFormat("Executing SpaceDock transformation with {0}", metadata.Kref);
+                Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
+
+                // Look up our mod on SD by its Id.
+                var sdMod = _api.GetMod(Convert.ToInt32(metadata.Kref.Id));
+                var latestVersion = sdMod.Latest();
+
+                Log.InfoFormat("Found SpaceDock Mod: {0} {1}", sdMod.name, latestVersion.friendly_version);
+
+                // Only pre-fill version info if there's none already. GH #199
+                if (json["ksp_version_min"] == null && json["ksp_version_max"] == null && json["ksp_version"] == null)
+                {
+                    Log.DebugFormat("Writing ksp_version from SpaceDock: {0}", latestVersion.KSP_version);
+                    json["ksp_version"] = latestVersion.KSP_version.ToString();
+                }
+
+                json.SafeAdd("name", sdMod.name);
+                json.SafeAdd("abstract", sdMod.short_description);
+                json.SafeAdd("version", latestVersion.friendly_version.ToString());
+                json.SafeAdd("author", sdMod.author);
+                json.SafeAdd("download", latestVersion.download_path.OriginalString);
+
+                // SD provides users with the following default selection of licenses. Let's convert them to CKAN
+                // compatible license strings if possible.
+                //
+                // "MIT" - OK
+                // "BSD" - Specific version is indeterminate
+                // "GPLv2" - Becomes "GPL-2.0"
+                // "GPLv3" - Becomes "GPL-3.0"
+                // "LGPL" - Specific version is indeterminate
+
+                var sdLicense = sdMod.license.Trim();
+
+                switch (sdLicense)
+                {
+                    case "GPLv2":
+                        json.SafeAdd("license", "GPL-2.0");
+                        break;
+                    case "GPLv3":
+                        json.SafeAdd("license", "GPL-3.0");
+                        break;
+                    default:
+                        json.SafeAdd("license", sdLicense);
+                        break;
+                }
+
+                // Make sure resources exist.
+                if (json["resources"] == null)
+                {
+                    json["resources"] = new JObject();
+                }
+
+                var resourcesJson = (JObject)json["resources"];
+
+                resourcesJson.SafeAdd("homepage", Escape(sdMod.website));
+                resourcesJson.SafeAdd("repository", Escape(sdMod.source_code));
+                resourcesJson.SafeAdd("spacedock", sdMod.GetPageUrl().OriginalString);
+
+                if (sdMod.background != null)
+                {
+                    resourcesJson.SafeAdd("x_screenshot", Escape(sdMod.background));
+                }
+
+                Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
+
+                return new Metadata(json);
+            }
+
+            return metadata;
+        }
+
+        /// <summary>
+        /// Provide an escaped version of the given URL, including converting
+        /// square brackets to their escaped forms.
+        /// </summary>
+        private static string Escape(Uri url)
+        {
+            if (url == null)
+            {
+                return null;
+            }
+
+            Log.DebugFormat("Escaping {0}", url);
+
+            var escaped = Uri.EscapeUriString(url.ToString());
+
+            // Square brackets are "reserved characters" that should not appear
+            // in strings to begin with, so C# doesn't try to escape them in case
+            // they're being used in a special way. They're not; some mod authors
+            // just have crazy ideas as to what should be in a URL, and SD doesn't
+            // escape them in its API. There's probably more in RFC 3986.
+
+            escaped = escaped.Replace("[", Uri.HexEscape('['));
+            escaped = escaped.Replace("]", Uri.HexEscape(']'));
+
+            // Make sure we have a "http://" or "https://" start.
+            if (!Regex.IsMatch(escaped, "(?i)^(http|https)://"))
+            {
+                // Prepend "http://", as we do not know if the site supports https.
+                escaped = "http://" + escaped;
+            }
+
+            Log.DebugFormat("Escaped to {0}", escaped);
+
+            return escaped;
+        }
+    }
+}

--- a/Netkan/Transformers/VersionedOverrideTransformer.cs
+++ b/Netkan/Transformers/VersionedOverrideTransformer.cs
@@ -22,7 +22,7 @@ namespace CKAN.NetKAN.Transformers
             JToken overrideList;
             if (json.TryGetValue("x_netkan_override", out overrideList))
             {
-                Log.InfoFormat("Executing SpaceDock transformation with {0}", metadata.Kref);
+                Log.InfoFormat("Executing Override transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
                 // There's an override section, process them

--- a/Netkan/Transformers/VersionedOverrideTransformer.cs
+++ b/Netkan/Transformers/VersionedOverrideTransformer.cs
@@ -22,7 +22,7 @@ namespace CKAN.NetKAN.Transformers
             JToken overrideList;
             if (json.TryGetValue("x_netkan_override", out overrideList))
             {
-                Log.InfoFormat("Executing KerbalStuff transformation with {0}", metadata.Kref);
+                Log.InfoFormat("Executing SpaceDock transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
                 // There's an override section, process them

--- a/Spec.md
+++ b/Spec.md
@@ -549,6 +549,25 @@ When used, the following fields will be auto-filled if not already present:
 - `resources.x_screenshot`
 - `ksp_version`
 
+###### `#/ckan/spacedock/:sdid`
+
+Indicates that data should be fetched from SpaceDock, using the `:sdid` provided. For example: `#/ckan/spacedock/269`.
+
+When used, the following fields will be auto-filled if not already present:
+
+- `name`
+- `license`
+- `abstract`
+- `author`
+- `version`
+- `download`
+- `download_size`
+- `resources.homepage`
+- `resources.kerbalstuff`
+- `resources.repository`
+- `resources.x_screenshot`
+- `ksp_version`
+
 ###### `#/ckan/github/:user/:repo[/asset_match/:filter_regexp]`
 
 Indicates that data should be fetched from GitHub, using the `:user` and `:repo` provided.

--- a/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
+++ b/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.IO;
+using CKAN;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Sources.Spacedock;
+using NUnit.Framework;
+
+namespace Tests.NetKAN.Sources.Spacedock
+{
+    [TestFixture]
+    [Category("FlakyNetwork")]
+    [Category("Online")]
+    public sealed class SpacedockApiTests
+    {
+        private NetFileCache _cache;
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetup()
+        {
+            var tempDirectory = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
+
+            Directory.CreateDirectory(tempDirectory);
+
+            _cache = new NetFileCache(tempDirectory);
+        }
+
+        [TestFixtureTearDown]
+        public void TestFixtureTearDown()
+        {
+            Directory.Delete(_cache.GetCachePath(), recursive: true);
+        }
+
+        [Test]
+        [Category("FlakyNetwork"), Category("Online")]
+        public void GetsModCorrectly()
+        {
+            // Arrange
+            var sut = new SpacedockApi(new CachingHttpService(_cache));
+
+            // Act
+            var result = sut.GetMod(493); // PlaneMode
+
+            // Assert
+            var latestVersion = result.Latest();
+
+            Assert.That(result.id, Is.EqualTo(493));
+            Assert.That(result.author, Is.Not.Null);
+            Assert.That(result.background, Is.Not.Null);
+            Assert.That(result.license, Is.Not.Null);
+            Assert.That(result.name, Is.Not.Null);
+            Assert.That(result.short_description, Is.Not.Null);
+            Assert.That(result.source_code, Is.Not.Null);
+            Assert.That(result.website, Is.Not.Null);
+            Assert.That(result.versions.Length, Is.GreaterThan(0));
+            Assert.That(latestVersion.changelog, Is.Not.Null);
+            Assert.That(latestVersion.download_path, Is.Not.Null);
+            Assert.That(latestVersion.friendly_version, Is.Not.Null);
+            Assert.That(latestVersion.KSP_version, Is.Not.Null);
+        }
+
+        [Test]
+        [Category("FlakyNetwork"), Category("Online")]
+        public void ThrowsWhenModMissing()
+        {
+            // Arrange
+            var sut = new SpacedockApi(new CachingHttpService(_cache));
+
+            // Act
+            TestDelegate act = () => sut.GetMod(-1);
+
+            // Assert
+            Assert.That(act, Throws.Exception.InstanceOf<Kraken>());
+        }
+    }
+}

--- a/Tests/NetKAN/Transformers/HttpTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/HttpTransformerTests.cs
@@ -32,6 +32,7 @@ namespace Tests.NetKAN.Transformers
         [TestCase("#/ckan/github/foo/bar")]
         [TestCase("#/ckan/netkan/http://awesomemod.example/awesomemod.netkan")]
         [TestCase("#/ckan/kerbalstuff/1")]
+        [TestCase("#/ckan/spacedock/1")]
         [TestCase("#/ckan/foo")]
         public void DoesNotAlterMetadataWhenNonMatching(string kref)
         {

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using CKAN.NetKAN;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Sources.Spacedock;
+using CKAN.NetKAN.Transformers;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Tests.NetKAN.Transformers
+{
+    [TestFixture]
+    public sealed class SpacedockTransformerTests
+    {
+        // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
+        [Test]
+        public void DoesNotReplaceKspVersionProperties()
+        {
+            // Arrange
+            var mApi = new Mock<ISpacedockApi>();
+            mApi.Setup(i => i.GetMod(It.IsAny<int>()))
+                .Returns(MakeTestMod());
+
+            var sut = new SpacedockTransformer(mApi.Object);
+
+            var json = new JObject();
+            json["spec_version"] = 1;
+            json["$kref"] = "#/ckan/spacedock/1";
+            json["ksp_version_min"] = "0.23.5";
+
+            // Act
+            var result = sut.Transform(new Metadata(json));
+            var transformedJson = result.Json();
+
+            // Assert
+            Assert.AreEqual(null, (string)transformedJson["ksp_version"]);
+            Assert.AreEqual(null, (string)transformedJson["ksp_version_max"]);
+            Assert.AreEqual("0.23.5", (string)transformedJson["ksp_version_min"]);
+        }
+
+        private static SpacedockMod MakeTestMod()
+        {
+            var sdmod = new SpacedockMod
+            {
+                license = "CC-BY",
+                name = "Dogecoin Flag",
+                short_description = "Such test. Very unit. Wow.",
+                author = "pjf",
+                versions = new SDVersion[1]
+            };
+
+            sdmod.versions[0] = new SDVersion
+            {
+                friendly_version = new CKAN.Version("0.25"),
+                download_path = new Uri("http://example.com/")
+            };
+
+            return sdmod;
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -146,6 +146,7 @@
     <Compile Include="NetKAN\Services\FileServiceTests.cs" />
     <Compile Include="NetKAN\Services\ModuleServiceTests.cs" />
     <Compile Include="NetKAN\Sources\Github\GithubApiTests.cs" />
+    <Compile Include="NetKAN\Sources\Spacedock\SpacedockApiTests.cs" />
     <Compile Include="NetKAN\Sources\Kerbalstuff\KerbalstuffApiTests.cs" />
     <Compile Include="NetKAN\Transformers\AvcTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\DownloadSizeTransformerTests.cs" />
@@ -153,6 +154,7 @@
     <Compile Include="NetKAN\Transformers\GithubTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\HttpTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\InternalCkanTransformerTests.cs" />
+    <Compile Include="NetKAN\Transformers\SpacedockTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\KerbalstuffTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\MetaNetkanTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\StripNetkanMetadataTransformerTests.cs" />


### PR DESCRIPTION
Added `$kref` support for SpaceDock mods. Tested with multiple mods on SpaceDock (new and existing).

`netkan.exe` succesfully transformed `.netkan` files into `.ckan` files. Also compared the existing KS mods with their equivalent on SD.

The new `$kref` also shows up in the GUI.

~~The only thing I'm not sure about is [VersionedOverrideTransformer.cs - L25](https://github.com/KSP-CKAN/CKAN/pull/1593/files#diff-9c0e20a6467ef46703f2a452a0afac1cR25)~~

Closes #1592