### PR TITLE
Extract the GitHub repository name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - [General] General code tidy-up. (#1582 by: ChucklesTheBeard; reviewed: plague006)
 - [GUI] Avoidance of a future bug involving how we query users regarding choices. (#1538 by: pjf, RichardLake; reviewed: Postremus)
 - [Spec] Updated Spec with newer `netkan.exe` features. (#1581 by: dbent; reviewed: Dazpoet)
+- [NetKAN] `netkan.exe` now has support for downloading GitHub sources of a release. (#1587 by: dbent; reviewed: Olympic1)
 
 ## v1.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - [General] General code tidy-up. (#1582 by: ChucklesTheBeard; reviewed: plague006)
 - [GUI] Avoidance of a future bug involving how we query users regarding choices. (#1538 by: pjf, RichardLake; reviewed: Postremus)
 - [Spec] Updated Spec with newer `netkan.exe` features. (#1581 by: dbent; reviewed: Dazpoet)
-- [NetKAN] `netkan.exe` now has support for downloading GitHub sources of a release. (#1587 by: dbent; reviewed: Olympic1)
+- [NetKAN] `netkan.exe` can now extract the GitHub repository name. (#1601 by: Olympic1)
 
 ## v1.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - [General] General code tidy-up. (#1582 by: ChucklesTheBeard; reviewed: plague006)
 - [GUI] Avoidance of a future bug involving how we query users regarding choices. (#1538 by: pjf, RichardLake; reviewed: Postremus)
 - [Spec] Updated Spec with newer `netkan.exe` features. (#1581 by: dbent; reviewed: Dazpoet)
+- [NetKAN] `netkan.exe` now has support for downloading GitHub sources of a release. (#1587 by: dbent; reviewed: Olympic1)
 - [NetKAN] `netkan.exe` can now extract the GitHub repository name. (#1601 by: Olympic1)
 
 ## v1.16.0

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -3,10 +3,10 @@
     "title" : "CKAN JSON Schema",
     "description" : "Schema for validating CKAN meta files",
     "type" : "object",
-    "properties": {
-        "spec_version": {
+    "properties" : {
+        "spec_version" : {
             "description" : "Version of the CKAN spec this document uses",
-            "oneOf"       : [
+            "oneOf" : [
                 {
                     "type"        : "integer",
                     "description" : "The integer '1' is special cased",
@@ -30,7 +30,7 @@
         },
         "kind" : {
             "description" : "Package type, defaults to package.",
-            "enum" : [ "package", "metapackage" ]
+            "enum"        : [ "package", "metapackage" ]
         },
         "abstract" : {
             "description" : "Short description of the mod",
@@ -46,7 +46,7 @@
         },
         "author" : {
             "description" : "Author, or list of authors.",
-            "oneOf"       : [
+            "oneOf" : [
                 { "type" : "string" },
                 {
                     "type"        : "array",
@@ -62,11 +62,11 @@
         },
         "download_size" : {
             "description" : "The size of the download in bytes",
-            "type" : "integer"
+            "type"        : "integer"
         },
         "license" : {
             "description" : "Machine readable license, or array of licenses",
-            "$ref"      : "#/definitions/licenses"
+            "$ref"        : "#/definitions/licenses"
         },
         "version" : {
             "description" : "Version of the mod. Drop the leading v",
@@ -74,7 +74,7 @@
         },
         "release_status" : {
             "description" : "Optional release status",
-            "enum" : [ "stable", "testing", "development" ]
+            "enum"        : [ "stable", "testing", "development" ]
         },
         "ksp_version" : {
             "description" : "Optional target KSP version",
@@ -114,8 +114,8 @@
         },
         "provides" : {
             "description" : "A list of virtual packages this mod provides",
-            "type" : "array",
-            "items" : { "type" : "string" },
+            "type"        : "array",
+            "items"       : { "type" : "string" },
             "uniqueItems" : true
         },
         "resources" : {
@@ -124,43 +124,43 @@
             "properties" : {
                 "homepage" : {
                     "description" : "Mod homepage",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 },
                 "bugtracker" : {
                     "description" : "Mod bugtracker",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 },
                 "license" : {
                     "description" : "Mod license",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 },
                 "repository" : {
                     "description" : "Mod repository",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 },
                 "ci" : {
                     "description" : "Continuous Integration",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 },
                 "kerbalstuff" : {
                     "description" : "Project on KerbalStuff",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 },
                 "spacedock" : {
                     "description" : "Project on SpaceDock",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 },
                 "manual" : {
                     "description" : "Mod's manual",
-                    "type" : "string",
-                    "format" : "uri"
+                    "type"        : "string",
+                    "format"      : "uri"
                 }
             }
         },
@@ -172,31 +172,31 @@
                 "properties" : {
                     "file" : {
                         "description" : "Path to file to install",
-                        "type" : "string"
+                        "type"        : "string"
                     },
                     "find" : {
                         "description" : "A directory to find for installation",
-                        "type" : "string"
+                        "type"        : "string"
                     },
                     "find_regexp" : {
                         "description" : "A regexp that matches the directory to install",
-                        "type" : "string"
+                        "type"        : "string"
                     },
                     "find_matches_files" : {
-                        "description": "If true, find directives match files as well as directories",
-                        "type" : "boolean"
+                        "description" : "If true, find directives match files as well as directories",
+                        "type"        : "boolean"
                     },
                     "install_to" : {
                         "description" : "Where file should be installed to",
-                        "$ref" : "#/definitions/install_to"
+                        "$ref"        : "#/definitions/install_to"
                     },
                     "filter" : {
                         "description" : "List of files and directories that should be filtered from the install",
-                        "$ref" : "#/definitions/one_or_more_strings"
+                        "$ref"        : "#/definitions/one_or_more_strings"
                     },
                     "filter_regexp" : {
                         "description" : "List of regexps that should filter files from this install",
-                        "$ref" : "#/definitions/one_or_more_strings"
+                        "$ref"        : "#/definitions/one_or_more_strings"
                     }
                 },
                 "required" : [ "install_to" ],
@@ -259,24 +259,23 @@
             "oneOf" : [
                 {
                     "description" : "Spec version 1 targets",
-                    "enum" : [ "GameData", "Ships", "GameRoot", "Tutorial", "Scenarios" ]
+                    "enum"        : [ "GameData", "Ships", "GameRoot", "Tutorial", "Scenarios" ]
                 },
                 {
                     "description" : "Spec v1.2 GameData path",
-                    "type" : "string",
-                    "pattern" : "^GameData/"
+                    "type"        : "string",
+                    "pattern"     : "^GameData/"
                 },
                 {
                     "description" : "Spec v1.12 Ships subfolder paths",
-                    "type" : "string",
-                    "pattern" : "^Ships/(SPH|VAB)$"
+                    "type"        : "string",
+                    "pattern"     : "^Ships/(SPH|VAB)$"
                 },
                 {
                     "description" : "Spec v1.16 thumbs paths",
-                    "type" : "string",
-                    "pattern" : "^Ships/@thumbs/(SPH|VAB)$"
+                    "type"        : "string",
+                    "pattern"     : "^Ships/@thumbs/(SPH|VAB)$"
                 }
-
             ]
         },
         "license" : {
@@ -317,15 +316,15 @@
             "anyOf" : [
                 { "$ref" : "#/definitions/license" },
                 {
-                    "type"  : "array",
-                    "items" : { "$ref" : "#/definitions/license" },
+                    "type"        : "array",
+                    "items"       : { "$ref" : "#/definitions/license" },
                     "uniqueItems" : true
                 }
             ]
         },
         "one_or_more_strings" : {
             "description" : "One or more strings",
-            "oneOf"       : [
+            "oneOf" : [
                 { "type" : "string" },
                 {
                     "type"        : "array",

--- a/Netkan/Sources/Github/GithubRef.cs
+++ b/Netkan/Sources/Github/GithubRef.cs
@@ -14,12 +14,13 @@ namespace CKAN.NetKAN.Sources.Github
         public string Project { get; private set; }
         public string Repository { get; private set; }
         public Regex Filter { get; private set; }
+        public bool UseSourceArchive { get; private set; }
         public bool UsePrelease { get; private set; }
 
-        public GithubRef(string remoteRefToken, bool usePrelease = false)
-            : this(new RemoteRef(remoteRefToken), usePrelease) { }
+        public GithubRef(string remoteRefToken, bool useSourceArchive, bool usePrelease)
+            : this(new RemoteRef(remoteRefToken), useSourceArchive, usePrelease) { }
 
-        public GithubRef(RemoteRef remoteRef, bool usePrelease = false)
+        public GithubRef(RemoteRef remoteRef, bool useSourceArchive, bool usePrelease)
             : base(remoteRef)
         {
             var match = Pattern.Match(remoteRef.Id);
@@ -34,6 +35,7 @@ namespace CKAN.NetKAN.Sources.Github
                     new Regex(match.Groups["filter"].Value, RegexOptions.Compiled) :
                     Constants.DefaultAssetMatchPattern;
 
+                UseSourceArchive = useSourceArchive;
                 UsePrelease = usePrelease;
             }
             else

--- a/Netkan/Sources/Github/GithubRelease.cs
+++ b/Netkan/Sources/Github/GithubRelease.cs
@@ -1,80 +1,18 @@
 using System;
-using log4net;
-using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN.Sources.Github
 {
-    public class GithubRelease
+    public sealed class GithubRelease
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(GithubRelease));
-
+        public string Author { get; private set; }
         public Version Version { get; private set; }
         public Uri Download { get; private set; }
-        public long Size { get; private set; }
-        public string Author { get; private set; }
 
-        public GithubRelease(JObject release, JObject asset)
-            : this(ParseArguments(release, asset)) {}
-
-        public GithubRelease(Version version, Uri download, long size, string author)
-            : this(new Arguments(version, download, size, author)) { }
-
-        private GithubRelease(Arguments arguments)
+        public GithubRelease(string author, Version version, Uri download)
         {
-            Version = arguments.Version;
-            Download = arguments.Download;
-            Size = arguments.Size;
-            Author = arguments.Author;
-        }
-
-        private static Arguments ParseArguments(JObject release, JObject asset)
-        {
-            var version = new Version((string)release["tag_name"]);
-            var author = (string)release["author"]["login"];
-
-            if (IsProbablyZip(asset))
-            {
-                var size = (long)asset["size"];
-                var download = new Uri((string)asset["browser_download_url"]);
-
-                Log.DebugFormat("Download {0} is {1} bytes", download, size);
-
-                return new Arguments(version, download, size, author);
-            }
-            else
-            {
-                // TODO: A proper kraken, please!
-                throw new Kraken("Cannot find download");
-            }
-        }
-
-        private static bool IsProbablyZip(JObject asset)
-        {
-            // GH #290, we need to look for the first asset which is a zip, otherwise we
-            // end up picking up manuals, pictures of cats, and all sorts of other things.
-
-            var contentType = (string)asset["content_type"];
-            var name = (string)asset["name"];
-
-            return contentType == "application/x-zip-compressed" ||
-                contentType == "application/zip" ||
-                name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private sealed class Arguments
-        {
-            public Version Version { get; private set; }
-            public Uri Download { get; private set; }
-            public long Size { get; private set; }
-            public string Author { get; private set; }
-
-            public Arguments(Version version, Uri download, long size, string author)
-            {
-                Version = version;
-                Download = download;
-                Size = size;
-                Author = author;
-            }
+            Author = author;
+            Version = version;
+            Download = download;
         }
     }
 }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -59,6 +59,32 @@ namespace CKAN.NetKAN.Transformers
                     json.SafeAdd("author", ghRelease.Author);
                     json.SafeAdd("download", Uri.EscapeUriString(ghRelease.Download.ToString()));
 
+                    if (ghRef.Project.Contains("_"))
+                    {
+                        json.SafeAdd("name", ghRef.Project.Replace("_", " "));
+                    }
+                    else if (ghRef.Project.Contains("-"))
+                    {
+                        json.SafeAdd("name", ghRef.Project.Replace("-", " "));
+                    }
+                    else if (ghRef.Project.Contains("."))
+                    {
+                        json.SafeAdd("name", ghRef.Project.Replace(".", " "));
+                    }
+                    else
+                    {
+                        var repoName = ghRef.Project;
+                        for (var i = 1; i < repoName.Length - 1; ++i)
+                        {
+                            if (char.IsLower(repoName[i - 1]) && char.IsUpper(repoName[i]) || repoName[i - 1] != ' ' && char.IsUpper(repoName[i]) && char.IsLower(repoName[i + 1]))
+                            {
+                                repoName = repoName.Insert(i, " ");
+                            }
+                        }
+
+                        json.SafeAdd("name", repoName);
+                    }
+
                     // Make sure resources exist.
                     if (json["resources"] == null)
                     {

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -35,7 +35,20 @@ namespace CKAN.NetKAN.Transformers
                 Log.InfoFormat("Executing GitHub transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
-                var ghRef = new GithubRef(metadata.Kref, _matchPreleases);
+                var useSourceAchive = false;
+
+                var githubMetadata = (JObject)json["x_netkan_github"];
+                if (githubMetadata != null)
+                {
+                    var githubUseSourceArchive = (bool?)githubMetadata["use_source_archive"];
+
+                    if (githubUseSourceArchive != null)
+                    {
+                        useSourceAchive = githubUseSourceArchive.Value;
+                    }
+                }
+
+                var ghRef = new GithubRef(metadata.Kref, useSourceAchive, _matchPreleases);
 
                 // Find the release on github and download.
                 var ghRelease = _api.GetLatestRelease(ghRef);

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -19,12 +19,11 @@ namespace Tests.NetKAN.Sources.Github
             var sut = new GithubApi();
 
             // Act
-            var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test"));
+            var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test", false, false));
 
             // Assert
             Assert.IsNotNull(githubRelease.Author);
             Assert.IsNotNull(githubRelease.Download);
-            Assert.IsNotNull(githubRelease.Size);
             Assert.IsNotNull(githubRelease.Version);
         }
     }

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -24,10 +24,9 @@ namespace Tests.NetKAN.Transformers
             var mApi = new Mock<IGithubApi>();
             mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>()))
                 .Returns(new GithubRelease(
+                    "ExampleProject",
                     new Version("1.0"),
-                    new Uri("http://github.example/download"),
-                    0,
-                    "ExampleProject"
+                    new Uri("http://github.example/download")
                 ));
 
             var sut = new GithubTransformer(mApi.Object, matchPreleases: false);


### PR DESCRIPTION
Extract the repository name and transform it to a usable `name` for a `.ckan` file.

GitHub supports `_`, `-` and `.`. When a symbol is invalid it changes to a `-`. If the repo name contains any of those symbols it will replace them with a "space", if it doesn't contain any of those symbols it will search for capital letters and split them using a "space".

**For example this `.netkan`:**
```
{
    "spec_version" : "v1.4",
    "identifier"   : "TalisarParts",
    "$kref"        : "#/ckan/github/Olympic1/TalisarParts",
    "license"      : "CC-BY-SA-3.0",
    "ksp_version"  : "1.0.5",
    "install": [
        {
            "find"       : "TalisarParts",
            "install_to" : "GameData"
        }
    ]
}
```
**Generates this `.ckan`:**
```
{
    "spec_version": "v1.4",
    "identifier": "TalisarParts",
    "name": "Talisar Parts",
    "author": "Olympic1",
    "license": "CC-BY-SA-3.0",
    "resources": {
        "repository": "https://github.com/Olympic1/TalisarParts"
    },
    "version": "v0.4.2",
    "ksp_version": "1.0.5",
    "install": [
        {
            "find": "TalisarParts",
            "install_to": "GameData"
        }
    ],
    "download": "https://github.com/Olympic1/TalisarParts/releases/download/v0.4.2/CargoTransportationSolutions_v0.4.2.zip",
    "download_size": 1764922,
    "x_generated_by": "netkan"
}
```