### PR TITLE
SpaceDock Multiple Authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - [Spec] Updated Spec with newer `netkan.exe` features. (#1581 by: dbent; reviewed: Dazpoet)
 - [NetKAN] `netkan.exe` now has support for downloading GitHub sources of a release. (#1587 by: dbent; reviewed: Olympic1)
 - [NetKAN] `netkan.exe` checks for malformed url's and prevents them from being added to the metadata. (#1580 by: dbent; reviewed: Olympic1)
+- [NetKAN] `netkan.exe` will now add all authors listed on SpaceDock (#1600 by: dbent)
 
 ## v1.16.0
 

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Sources\Kerbalstuff\KerbalstuffError.cs" />
     <Compile Include="Sources\Kerbalstuff\KerbalstuffMod.cs" />
     <Compile Include="Sources\Kerbalstuff\KSVersion.cs" />
+    <Compile Include="Sources\Spacedock\SpacedockUser.cs" />
     <Compile Include="Transformers\AvcTransformer.cs" />
     <Compile Include="Transformers\DownloadSizeTransformer.cs" />
     <Compile Include="Transformers\ForcedVTransformer.cs" />

--- a/Netkan/Sources/Spacedock/SpacedockMod.cs
+++ b/Netkan/Sources/Spacedock/SpacedockMod.cs
@@ -15,6 +15,7 @@ namespace CKAN.NetKAN.Sources.Spacedock
         [JsonProperty] public string website;
         [JsonProperty] public string source_code;
         [JsonProperty] public int default_version_id;
+        [JsonProperty] public SpacedockUser[] shared_authors;
         [JsonConverter(typeof(SDVersion.JsonConvertFromRelativeSdUri))]
         public Uri background;
 

--- a/Netkan/Sources/Spacedock/SpacedockUser.cs
+++ b/Netkan/Sources/Spacedock/SpacedockUser.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Spacedock
+{
+    public sealed class SpacedockUser
+    {
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("forumUsername")]
+        public string FormUsername { get; set; }
+
+        [JsonProperty("ircNick")]
+        public string IrcNick { get; set; }
+
+        [JsonProperty("redditUsername")]
+        public string RedditUsername { get; set; }
+
+        [JsonProperty("twitterUsername")]
+        public string TwitterUsername { get; set; }
+
+        [JsonProperty("username")]
+        public string Username { get; set; }
+    }
+}

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
@@ -47,8 +49,14 @@ namespace CKAN.NetKAN.Transformers
                 json.SafeAdd("name", sdMod.name);
                 json.SafeAdd("abstract", sdMod.short_description);
                 json.SafeAdd("version", latestVersion.friendly_version.ToString());
-                json.SafeAdd("author", sdMod.author);
                 json.SafeAdd("download", latestVersion.download_path.OriginalString);
+
+                var authors = GetAuthors(sdMod);
+
+                if (authors.Count == 1)
+                    json.SafeAdd("author", sdMod.author);
+                else if (authors.Count > 1)
+                    json.SafeAdd("author", new JArray(authors));
 
                 // SD provides users with the following default selection of licenses. Let's convert them to CKAN
                 // compatible license strings if possible.
@@ -145,6 +153,16 @@ namespace CKAN.NetKAN.Transformers
                 Log.WarnFormat("Could not normalize URL: {0}", uri);
                 return null;
             }
+        }
+
+        private static List<string> GetAuthors(SpacedockMod mod)
+        {
+            var result = new List<string> { mod.author };
+
+            if (mod.shared_authors != null)
+                result.AddRange(mod.shared_authors.Select(i => i.Username));
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
Fixes #1600.

Now the `SpacedockTransformer` will read the `shared_authors` property from the API (if available) and add the usernames of all those listed to the `author` property in the resultant CKAN as an array.

This `.netkan` (for [kOS](http://spacedock.info/mod/60/kOS:%20Scriptable%20Autopilot%20System)):
```json
{
    "spec_version": 1,
    "identifier": "kOS",
    "$kref": "#/ckan/spacedock/60"
}
```
Produces the following `.ckan`:
```json
{
    "spec_version": 1,
    "identifier": "kOS",
    "name": "kOS: Scriptable Autopilot System",
    "abstract": "Fully programmable autopilot mod for KSP",
    "author": [
        "erendrake",
        "hvacengi",
        "dunbaratu"
    ],
    "license": "GPL-3.0",
    "release_status": "stable",
    "resources": {
        "homepage": "http://ksp-kos.github.io/KOS_DOC/",
        "spacedock": "https://spacedock.info/mod/60/kOS:%20Scriptable%20Autopilot%20System",
        "repository": "https://github.com/KSP-KOS/KOS",
        "x_screenshot": "https://spacedock.info/content/erendrake_184/kOS_Scriptable_Autopilot_System/kOS_Scriptable_Autopilot_System-1455675751.6839738.jpg"
    },
    "version": "0.18.2",
    "ksp_version": "1.0.5",
    "recommends": [
        {
            "name": "ModuleManager",
            "min_version": "2.5.6",
            "comment": "Earlier versions of MM have forward compatibility problems, according to the MM release notes."
        }
    ],
    "suggests": [
        {
            "name": "RemoteTech",
            "min_version": "1.5.1",
            "comment": "RT gives incentive to having local control of craft, even unmanned ones"
        }
    ],
    "install": [
        {
            "file": "GameData/kOS",
            "install_to": "GameData"
        }
    ],
    "download": "https://spacedock.info/mod/60/kOS:%20Scriptable%20Autopilot%20System/download/0.18.2",
    "download_size": 2880080,
    "x_generated_by": "netkan"
}

```