### PR TITLE
Change Mod Info window label for repository

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -700,7 +700,7 @@ namespace CKAN
             this.GitHubLabel.Name = "GitHubLabel";
             this.GitHubLabel.Size = new System.Drawing.Size(83, 30);
             this.GitHubLabel.TabIndex = 10;
-            this.GitHubLabel.Text = "GitHub:";
+            this.GitHubLabel.Text = "Source Code:";
             // 
             // HomePageLabel
             // 


### PR DESCRIPTION
We have sources other than github, and the field definition is not GitHub specific