### PR TITLE
Containerized!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM mono
+RUN apt-get -y update && apt-get -y install libcurl4-openssl-dev
+COPY . /source
+WORKDIR /source
+RUN nuget restore -NonInteractive
+RUN xbuild /property:Configuration=Release /property:OutDir=/build/
+RUN mkdir /kspdir
+VOLUME ["/kspdir"]
+CMD ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "2"
+services:
+    ckan:
+        build: .
+        volumes:
+            - ~/.steam/steam/steamapps/common/Kerbal Space Program/:/kspdir

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+HEAD="mono /build/CmdLine.exe"
+TAIL="--asroot --headless"
+$HEAD ksp add one /kspdir $TAIL
+$HEAD ksp default one $TAIL
+$HEAD update $TAIL
+$HEAD upgrade --all $TAIL
+chown --reference=/kspdir/GameData -R /kspdir

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@ HEAD="mono /build/CmdLine.exe"
 TAIL="--asroot --headless"
 $HEAD ksp add one /kspdir $TAIL
 $HEAD ksp default one $TAIL
+$HEAD scan $TAIL
+$HEAD list $TAIL
 $HEAD update $TAIL
 $HEAD upgrade --all $TAIL
 chown --reference=/kspdir/GameData -R /kspdir

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@ HEAD="mono /build/CmdLine.exe"
 TAIL="--asroot --headless"
 $HEAD ksp add one /kspdir $TAIL
 $HEAD ksp default one $TAIL
+$HEAD update $TAIL
 $HEAD scan $TAIL
 $HEAD list $TAIL
-$HEAD update $TAIL
 $HEAD upgrade --all $TAIL
 chown --reference=/kspdir/GameData -R /kspdir


### PR DESCRIPTION
With Docker, I can now build and run CKAN without needing to maintain a Mono installation.

If you have Docker Compose 1.6.2+ installed (and Docker Engine of course), you can too!

The docker-compose.yml file is written for Linux as that's what I use.  If you're a Mac or Windows user, change the volume to reflect the location of your KSP install.  I have not tested it, but it should work.

To build the software:
`$ docker-compose build ckan`

To check for and install new versions of mods:
`$ docker-compose run --rm ckan`

Due to CKAN's design, it's hard to make one-liners for installing or deleting individual mods.  I can rewrite the entrypoint script to support this feature if there is interest.

There are some minor changes to CKAN itself that would make using it with Docker a little easier (having a configuration file instead of executing multiple commands, disabling the 'as root' warning when running in a container, stuff like that) but I do not believe those changes are worth making at this time.