### PR TITLE
Catch ValueErrors as in KSP-CKAN/CKAN-meta#1035

### DIFF
--- a/bin/ckan-validate.py
+++ b/bin/ckan-validate.py
@@ -45,6 +45,11 @@ def main():
                 print e
                 error = 1
                 continue
+            except ValueError as e:
+                print 'Failed! This error will be cryptic, but often a JSON or property error'
+                print e
+                error = 1
+                continue
             print 'Success!'
 
     sys.exit(error)


### PR DESCRIPTION
A small modification to 'ckan-validate.py' which is used in our testing. Gets rid of the big Traceback, we can probably do more with it.