### PR TITLE
Compare operation should check for negative/positive not -1/+1

### DIFF
--- a/Cmdline/Action/Compare.cs
+++ b/Cmdline/Action/Compare.cs
@@ -24,12 +24,12 @@
                     user.RaiseMessage(
                         "\"{0}\" and \"{1}\" are the same versions.", leftVersion, rightVersion);
                 }
-                else if (compareResult == -1)
+                else if (compareResult < 0)
                 {
                     user.RaiseMessage(
                         "\"{0}\" is lower than \"{1}\".", leftVersion, rightVersion);
                 }
-                else if (compareResult == 1)
+                else if (compareResult > 0)
                 {
                     user.RaiseMessage(
                         "\"{0}\" is higher than \"{1}\".", leftVersion, rightVersion);

--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -69,8 +69,8 @@ namespace CKAN {
 
         private Dictionary<Tuple<Version,Version>, int> cache = new Dictionary<Tuple<Version, Version>, int>();
         /// <summary>
-        /// Returns -1 if this is less than that
-        /// Returns +1 if this is greater than that
+        /// Returns a negative value if this is less than that
+        /// Returns a positive value if this is greater than that
         /// Returns  0 if equal.
         /// </summary>
         public int CompareTo(Version that) {


### PR DESCRIPTION
Otherwise a comparison of `1_0` to `1.0` will fail.