### PR TITLE
Docker support added to CKAN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - [GUI] Added "filter by description" search box. (#1632 by: politas; reviewed: pjf)
+- [CLI] `compare` command now checks positive and negative rather than -1/+1 (#1649 by: dbent; reviewed: Daz)
 
 ### Internal
 
 - [Multiple] Removed various references and code for processing mods on KerbalStuff. Thank you, Sircmpwn, for providing us with such a great service for so long. (#1615 by: Olympic1; reviewed: pjf)
+- [Spec] Updated Spec with the `kind` field which was introduced in v1.6. (#1597 by: plague006; reviewed: Daz)
+- [Netkan] Catch ValueErrors rather than printing the trace (#1648 by: techman83; reviewed: Daz )
 
 ## v1.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - [Multiple] Removed various references and code for processing mods on KerbalStuff. Thank you, Sircmpwn, for providing us with such a great service for so long. (#1615 by: Olympic1; reviewed: pjf)
 - [Spec] Updated Spec with the `kind` field which was introduced in v1.6. (#1597 by: plague006; reviewed: Daz)
+- [spec] ckan.schema now enforces structure of install directives (#1578 by: Zane6888; reviewed: pjf, Daz)
 - [NetKAN] Catch ValueErrors rather than printing the trace (#1648 by: techman83; reviewed: Daz )
 - [NetKAN] Catch ksp_version from SpaceDocks newly implemented game_version (#1655 by: dbent; reviewed: -)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file.
 
 - [Multiple] Removed various references and code for processing mods on KerbalStuff. Thank you, Sircmpwn, for providing us with such a great service for so long. (#1615 by: Olympic1; reviewed: pjf)
 - [Spec] Updated Spec with the `kind` field which was introduced in v1.6. (#1597 by: plague006; reviewed: Daz)
-- [Netkan] Catch ValueErrors rather than printing the trace (#1648 by: techman83; reviewed: Daz )
+- [NetKAN] Catch ValueErrors rather than printing the trace (#1648 by: techman83; reviewed: Daz )
+- [NetKAN] Catch ksp_version from SpaceDocks newly implemented game_version (#1655 by: dbent; reviewed: -)
 
 ## v1.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - [spec] ckan.schema now enforces structure of install directives (#1578 by: Zane6888; reviewed: pjf, Daz)
 - [NetKAN] Catch ValueErrors rather than printing the trace (#1648 by: techman83; reviewed: Daz )
 - [NetKAN] Catch ksp_version from SpaceDocks newly implemented game_version (#1655 by: dbent; reviewed: -)
+- [NetKAN] Allow specifying when an override is executed (#1684 by: dbent; fixes: #1674)
 
 ## v1.16.1
 

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -9,7 +9,7 @@
             "oneOf" : [
                 {
                     "type"        : "integer",
-                    "description" : "The integer '1' is special cased",
+                    "description" : "The integer '1' is special case",
                     "minimum"     : 1,
                     "maximum"     : 1
                 },

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -214,20 +214,9 @@
         "name",
         "abstract",
         "identifier",
+        "download",
         "license",
         "version"
-    ],
-    "oneOf": [
-        {
-            "required": [ "download" ]
-        },
-        {
-            "properties": {
-                "kind": {
-                    "enum": [ "metapackage" ]
-                }
-            }
-        }
     ],
     "definitions" : {
         "identifier" : {

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -214,9 +214,24 @@
         "name",
         "abstract",
         "identifier",
-        "download",
         "license",
         "version"
+    ],
+    "oneOf": [
+        {
+            "required": [ "download" ]
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [ "metapackage" ]
+                }
+            },
+            "not": {
+                "required": [ "download" ]
+            },
+            "required": [ "kind" ]
+        }
     ],
     "definitions" : {
         "identifier" : {

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -204,9 +204,20 @@
         "name",
         "abstract",
         "identifier",
-        "download",
         "license",
         "version"
+    ],
+    "oneOf": [
+        {
+            "required": [ "download" ]
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [ "metapackage" ]
+                }
+            }
+        }
     ],
     "definitions" : {
         "identifier" : {

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -195,7 +195,17 @@
                     }
                 },
                 "required" : [ "install_to" ],
-                "comment" : "One must have either file or find, is there a JSON Schema friendly way of specifying that?"
+                "oneOf": [
+                    {
+                        "required": [ "file" ]
+                    },
+                    {
+                        "required": [ "find" ]
+                    },
+                    {
+                        "required": [ "find_regexp" ]
+                    }
+                ]
             }
         }
     },

--- a/Cmdline/Action/Compare.cs
+++ b/Cmdline/Action/Compare.cs
@@ -24,12 +24,12 @@
                     user.RaiseMessage(
                         "\"{0}\" and \"{1}\" are the same versions.", leftVersion, rightVersion);
                 }
-                else if (compareResult == -1)
+                else if (compareResult < 0)
                 {
                     user.RaiseMessage(
                         "\"{0}\" is lower than \"{1}\".", leftVersion, rightVersion);
                 }
-                else if (compareResult == 1)
+                else if (compareResult > 0)
                 {
                     user.RaiseMessage(
                         "\"{0}\" is higher than \"{1}\".", leftVersion, rightVersion);

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -82,8 +82,8 @@ namespace CKAN.CmdLine
 
             // Processes in Docker containers normally run as root.
             // If we are running in a Docker container, do not require --asroot.
-            // Docker creates a .dockerinit file in the root of each container.
-            if ((Platform.IsUnix || Platform.IsMac) && CmdLineUtil.GetUID() == 0 && !File.Exists("/.dockerinit"))
+            // Docker creates a .dockerenv file in the root of each container.
+            if ((Platform.IsUnix || Platform.IsMac) && CmdLineUtil.GetUID() == 0 && !File.Exists("/.dockerenv"))
             {
                 if (!options.AsRoot)
                 {

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -41,7 +42,7 @@ namespace CKAN.CmdLine
 
             if (args.Length == 1 && args.Any(i => i == "--verbose" || i == "--debug"))
             {
-                // Start the gui with logging enabled #437 
+                // Start the gui with logging enabled #437
                 List<string> guiCommand = args.ToList();
                 guiCommand.Insert(0, "gui");
                 args = guiCommand.ToArray();
@@ -79,7 +80,10 @@ namespace CKAN.CmdLine
             user = new ConsoleUser(options.Headless);
             CheckMonoVersion(user, 3, 1, 0);
 
-            if ((Platform.IsUnix || Platform.IsMac) && CmdLineUtil.GetUID() == 0)
+            // Processes in Docker containers normally run as root.
+            // If we are running in a Docker container, do not require --asroot.
+            // Docker creates a .dockerinit file in the root of each container.
+            if ((Platform.IsUnix || Platform.IsMac) && CmdLineUtil.GetUID() == 0 && !File.Exists("/.dockerinit"))
             {
                 if (!options.AsRoot)
                 {

--- a/Core/Types/Version.cs
+++ b/Core/Types/Version.cs
@@ -69,8 +69,8 @@ namespace CKAN {
 
         private Dictionary<Tuple<Version,Version>, int> cache = new Dictionary<Tuple<Version, Version>, int>();
         /// <summary>
-        /// Returns -1 if this is less than that
-        /// Returns +1 if this is greater than that
+        /// Returns a negative value if this is less than that
+        /// Returns a positive value if this is greater than that
         /// Returns  0 if equal.
         /// </summary>
         public int CompareTo(Version that) {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM mono
+RUN apt-get -y update && apt-get -y install libcurl4-openssl-dev
+RUN mkdir /kspdir
+VOLUME ["/kspdir"]
+COPY . /source
+WORKDIR /source
+RUN nuget restore -NonInteractive
+RUN xbuild /property:Configuration=Release /property:OutDir=/build/
+COPY ./root /root
+CMD ["/root/entrypoint.sh"]

--- a/Netkan/Sources/Spacedock/SDVersion.cs
+++ b/Netkan/Sources/Spacedock/SDVersion.cs
@@ -12,7 +12,9 @@ namespace CKAN.NetKAN.Sources.Spacedock
         // These all get filled by JSON deserialisation.
 
         [JsonConverter(typeof(JsonConvertKSPVersion))]
+        [JsonProperty("game_version")]
         public KSPVersion KSP_version;
+
         public string changelog;
 
         [JsonConverter(typeof(JsonConvertFromRelativeSdUri))]

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -19,6 +19,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IHttpService _http;
         private readonly IModuleService _moduleService;
 
+        public string Name { get { return "avc"; } }
+
         public AvcTransformer(IHttpService http, IModuleService moduleService)
         {
             _http = http;

--- a/Netkan/Transformers/DownloadSizeTransformer.cs
+++ b/Netkan/Transformers/DownloadSizeTransformer.cs
@@ -15,6 +15,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IHttpService _http;
         private readonly IFileService _fileService;
 
+        public string Name { get { return "download_size"; } }
+
         public DownloadSizeTransformer(IHttpService http, IFileService fileService)
         {
             _http = http;

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -12,6 +12,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(EpochTransformer));
 
+        public string Name { get { return "epoch"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             Log.Debug("Fixing version strings (if required)...");

--- a/Netkan/Transformers/ForcedVTransformer.cs
+++ b/Netkan/Transformers/ForcedVTransformer.cs
@@ -12,6 +12,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(ForcedVTransformer));
 
+        public string Name { get { return "forced_v"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/GeneratedByTransformer.cs
+++ b/Netkan/Transformers/GeneratedByTransformer.cs
@@ -12,6 +12,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(GeneratedByTransformer));
 
+        public string Name { get { return "generated_by"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -17,6 +17,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IGithubApi _api;
         private readonly bool _matchPreleases;
 
+        public string Name { get { return "github"; } }
+
         public GithubTransformer(IGithubApi api, bool matchPreleases)
         {
             if (api == null)

--- a/Netkan/Transformers/HttpTransformer.cs
+++ b/Netkan/Transformers/HttpTransformer.cs
@@ -11,6 +11,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(HttpTransformer));
 
+        public string Name { get { return "http"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == "http")

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -8,6 +8,11 @@ namespace CKAN.NetKAN.Transformers
     internal interface ITransformer
     {
         /// <summary>
+        /// A unique name which identifies the transformer.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Transform the given metadata.
         /// </summary>
         /// <param name="metadata">The metadata to transform.</param>

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -16,6 +16,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IHttpService _http;
         private readonly IModuleService _moduleService;
 
+        public string Name { get { return "internal_ckan"; } }
+
         public InternalCkanTransformer(IHttpService http, IModuleService moduleService)
         {
             _http = http;

--- a/Netkan/Transformers/JenkinsTransformer.cs
+++ b/Netkan/Transformers/JenkinsTransformer.cs
@@ -31,6 +31,8 @@ namespace CKAN.NetKAN.Transformers
 
         private readonly IHttpService _http;
 
+        public string Name { get { return "jenkins"; } }
+
         public JenkinsTransformer(IHttpService http)
         {
             _http = http;

--- a/Netkan/Transformers/MetaNetkanTransformer.cs
+++ b/Netkan/Transformers/MetaNetkanTransformer.cs
@@ -18,6 +18,8 @@ namespace CKAN.NetKAN.Transformers
 
         private readonly IHttpService _http;
 
+        public string Name { get { return "metanetkan"; } }
+
         public MetaNetkanTransformer(IHttpService http)
         {
             _http = http;

--- a/Netkan/Transformers/OptimusPrimeTransformer.cs
+++ b/Netkan/Transformers/OptimusPrimeTransformer.cs
@@ -8,6 +8,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(OptimusPrimeTransformer));
 
+        public string Name { get { return "optimus_prime"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -55,6 +55,8 @@ namespace CKAN.NetKAN.Transformers
             { "manual", 6 }
         };
 
+        public string Name { get { return "property_sort"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -19,6 +19,8 @@ namespace CKAN.NetKAN.Transformers
 
         private readonly ISpacedockApi _api;
 
+        public string Name { get { return "spacedock"; } }
+
         public SpacedockTransformer(ISpacedockApi api)
         {
             _api = api;

--- a/Netkan/Transformers/StripNetkanMetadataTransformer.cs
+++ b/Netkan/Transformers/StripNetkanMetadataTransformer.cs
@@ -14,6 +14,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(StripNetkanMetadataTransformer));
 
+        public string Name { get { return "strip_netkan_metadata"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/VersionEditTransformer.cs
+++ b/Netkan/Transformers/VersionEditTransformer.cs
@@ -13,6 +13,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(VersionEditTransformer));
 
+        public string Name { get { return "version_edit"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Spec.md
+++ b/Spec.md
@@ -119,7 +119,7 @@ For compatibility with pre-release clients, and the v1.0 client, the special
 *integer* `1` should be used.
 
 This document describes the CKAN specification 'v1.16'. Changes since spec `1`
-are marked with **v1.2** through to **v1.14** respectively. For maximum
+are marked with **v1.2** through to **v1.16** respectively. For maximum
 compatibility, using older spec versions is preferred when newer features are
 not required.
 
@@ -152,7 +152,7 @@ with any version and the `.dll` suffix removed.
 ##### download
 
 A fully formed URL, indicating where a machine may download the
-described version of the mod.
+described version of the mod. Note: This field is not required if the `kind` is `metapackage`.
 
 ##### license
 
@@ -473,6 +473,10 @@ custom use fields, and will be ignored. For example:
 
 These fields are optional, and should only be used with good reason.
 Typical mods *should not* include these special use fields.
+
+##### kind
+
+Specifies the type of package the .ckan file delivers. This field defaults to `package`, the other option (and presently the only time the field is explicitly declared) is `metapackage`. Metapackages allow for a distributable .ckan file that has relationships to other mods while having no `download` of its own. **v1.6**
 
 ##### provides
 

--- a/Spec.md
+++ b/Spec.md
@@ -152,7 +152,7 @@ with any version and the `.dll` suffix removed.
 ##### download
 
 A fully formed URL, indicating where a machine may download the
-described version of the mod. Note: This field is not required if the `kind` is `metapackage`.
+described version of the mod.
 
 ##### license
 
@@ -473,10 +473,6 @@ custom use fields, and will be ignored. For example:
 
 These fields are optional, and should only be used with good reason.
 Typical mods *should not* include these special use fields.
-
-##### kind
-
-Specifies the type of package the .ckan file delivers. This field defaults to `package`, the other option (and presently the only time the field is explicitly declared) is `metapackage`. Metapackages allow for a distributable .ckan file that has relationships to other mods while having no `download` of its own. **v1.6**
 
 ##### provides
 

--- a/Spec.md
+++ b/Spec.md
@@ -152,7 +152,7 @@ with any version and the `.dll` suffix removed.
 ##### download
 
 A fully formed URL, indicating where a machine may download the
-described version of the mod.
+described version of the mod. Note: This field is not required if the `kind` is `metapackage`.
 
 ##### license
 
@@ -473,6 +473,10 @@ custom use fields, and will be ignored. For example:
 
 These fields are optional, and should only be used with good reason.
 Typical mods *should not* include these special use fields.
+
+##### kind
+
+Specifies the type of package the .ckan file delivers. This field defaults to `package`, the other option (and presently the only time the field is explicitly declared) is `metapackage`. Metapackages allow for a distributable .ckan file that has relationships to other mods while having no `download` of its own. **v1.6**
 
 ##### provides
 

--- a/Spec.md
+++ b/Spec.md
@@ -741,13 +741,39 @@ The `x_netkan_override` field is used to override field values based on the valu
   it is equivalent to specifying `=`. In order for the override to match *all* the comparisons must be true. Therefore
   a range may be specified as such: `[ ">=1.0", "<2.0" ]`. A `string` may also be specified instead of an `array` in
   which case it is treated as an array with a single element equal to the value of the string.
+- `before` (type: `string`, transformation name)<br/>
+  The name of a transformation this override to happen directly before.
+- `after` (type: `string:, transformation name)<br/>
+  The name of a transformation this override to happen directly after.
 - `override` (type: `object`)<br/>
   An object whose fields will override the fields already present if a match occurs. No merging of values occurs, the
   values of the fields are entirely replaced.
 - `delete` (type: `array` of `string`)<br/>
   An array of strings which are the names of fields to remove if a match occurs.
 
-Override objects are processed sequentially and all matching overrides will be used.
+The possible values of `before` and `after` are:
+
+- `$none`
+- `$all`
+- `avc`
+- `download_size`
+- `epoch`
+- `forced_v`
+- `generated_by`
+- `github`
+- `http`
+- `internal_ckan`
+- `jenkins`
+- `metanetkan`
+- `optimus_prime`
+- `property_sort`
+- `spacedock`
+- `strip_netkan_metadata`
+- `version_edit`
+- `versioned_override`
+
+If no `before` or `after` is specified then the override occurs at a "reasonable" point in the transformation process.
+Most overrides should **not** specify a `before` or `after` unless there is a specific need to.
 
 When any metadata changes occur which are version specific, for example a new dependency is added, overrides are the
 recomended means of specifying them. Overrides may also be used to *stage* metadata changes, for example when new

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -1,6 +1,4 @@
-﻿using CKAN;
-using CKAN.NetKAN;
-using CKAN.NetKAN.Model;
+﻿using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Transformers;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -123,6 +121,36 @@ namespace Tests.NetKAN
             Assert.IsFalse(new_metadata.TryGetValue("author", out token));
         }
 
+        [Test]
+        public void LaterOverridesOverrideEarlierOverrides()
+        {
+            var metadata = such_metadata;
+            metadata["x_netkan_override"] = JArray.Parse(@"[
+                {
+                    ""version"": ""1.01"",
+                    ""before"": ""$all"",
+                    ""override"": {
+                        ""name"": ""EARLY""
+                    }
+                },
+                {
+                    ""version"": ""1.01"",
+                    ""after"": ""$all"",
+                    ""override"": {
+                        ""name"": ""LATE""
+                    }
+                }
+            ]");
+
+            var earlyTransformer = new VersionedOverrideTransformer(new[] { "$all" }, new[] { "$none" });
+            var lateTransformer = new VersionedOverrideTransformer(new[] { "$none" }, new[] { "$all" });
+
+            var transformedMetadata1 = earlyTransformer.Transform(new Metadata(metadata)).Json();
+            var transformedMetadata2 = lateTransformer.Transform(new Metadata(transformedMetadata1));
+
+            Assert.AreEqual((string)transformedMetadata2.Json()["name"], "LATE");
+        }
+
         /// <summary>
         /// Sanity to check to make sure the original metadata hasn't changed during testing.
         /// </summary>
@@ -136,7 +164,10 @@ namespace Tests.NetKAN
         /// </summary>
         private JObject ProcessOverrides(JObject metadata)
         {
-            var transformer = new VersionedOverrideTransformer();
+            var transformer = new VersionedOverrideTransformer(
+                before: new string[] { null },
+                after: new string[] { null }
+            );
 
             return transformer.Transform(new Metadata(metadata)).Json();
         }

--- a/bin/ckan-validate.py
+++ b/bin/ckan-validate.py
@@ -45,6 +45,11 @@ def main():
                 print e
                 error = 1
                 continue
+            except ValueError as e:
+                print 'Failed! This error will be cryptic, but often a JSON or property error'
+                print e
+                error = 1
+                continue
             print 'Success!'
 
     sys.exit(error)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "2"
+services:
+    ckan:
+        build: .
+        volumes:
+            - ~/.steam/steam/steamapps/common/Kerbal Space Program/:/kspdir

--- a/quotes.txt
+++ b/quotes.txt
@@ -50,3 +50,18 @@ Sometimes you just don't want to fix things.
 [04:30] (@plague006): politas, Olympic1 you guys around?
 [04:30] (@plague006): y'all [goofed] :p
 [04:32] *** Olympic1 is now known as Olympic1|AWAY
+%
+All netkan indexing stops for a prolonged period (days).
+The errors thrown are non-conclusive and the bots keep
+getting stuck on what appears to be a very standard .netkan
+
+<paraphrase>
+(Daz) So err... I found an extra space in one of the recommends
+(pjf) That's it!
+(Daz) https://github.com/KSP-CKAN/NetKAN/pull/1062
+</paraphrase>
+%
+(Daz) And merged, hoping all goes well this time! Don't wanna be known as that-guy-who-effed-up-netkanindexing-TWICE :p
+(plague006) You say it like it'll only be the second time you've broken everything. :D
+
+-- CKAN#1662

--- a/root/.bashrc
+++ b/root/.bashrc
@@ -1,0 +1,5 @@
+trap /root/cleanup.sh EXIT
+ckan()
+{
+	mono /build/CmdLine.exe "$@" --kspdir /kspdir --headless
+}

--- a/root/cleanup.sh
+++ b/root/cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+chown --reference=/kspdir/GameData -R /kspdir

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+source /root/.bashrc
+ckan update
+ckan scan
+ckan upgrade --all


### PR DESCRIPTION
With Docker, I can now build and run CKAN without needing to maintain a Mono installation.

If you have Docker Compose 1.6.2+ installed (and Docker Engine of course), you can too!

The `docker-compose.yml` file is written for Linux as that's what I use. If you're a Mac or Windows user, change the volume to reflect the location of your KSP install. I have not tested it, but it should work.

All CKAN commands should work.

To build the software:
```
$ docker-compose build ckan
```

To update all mods:
```
$ docker-compose run --rm ckan
```

To install a mod:
```
$ docker-compose run --rm ckan bash
root@<container>:/source# ckan install MechJeb2
```

The minor change to `Cmdline/Main.cs` was to disable the 'as root' warning while running in a Docker container.  It's standard practice to run processes as root in those containers, so the warning was just noisy.