### PR TITLE
Better KSP listing in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - [GUI] In windows launch `KSP_x64.exe` by default rather than `KSP.exe`. (#1711 by plague006; reviewed: dbent)
 - [Core] Unlicense added to CKAN as an option for mods. (#1737 by plague006; reviewed: techman83)
 - [Core] CKAN will now read BuildID.txt for more accurate KSP versions (#1645 by: dbent; reviewed: techman83)
+- [Cmdline] `ckan.exe ksp list` now prints its output as a table and includes the version of the installation and its default status. (#1656 by: dbent)
 
 ### Internal
 


### PR DESCRIPTION
@pjf 

This PR makes the KSP list in the CLI (`ckan ksp list`) prettier by printing it as a table. It also includes two extra bits of information over the previous version: the KSP version of the installation and whether or not it's the default (aka "preferred") KSP installation.

It also explicitly sorts the installations as follows:
- First by whether or not it's the default installation (default first).
- Then by the KSP version of the installation (newer versions first).
- Then by the installation name (A to Z).

The output on my machine looks like:

```
Name             Version  Default  Path
---------------  -------  -------  --------------------------
play-1.1.0.1196  1.1.0    Yes      C:/Bin/KSP/Play/1.1.0.1196
test-1.1.0.1174  1.1.0    No       C:/Bin/KSP/Test/1.1.0.1174
test-1.1.0.1196  1.1.0    No       C:/Bin/KSP/Test/1.1.0.1196
test-1.0.5.1028  1.0.5    No       C:/Bin/KSP/Test/1.0.5.1028
test-1.0.4.861   1.0.4    No       C:/Bin/KSP/Test/1.0.4.861
```

Luckily the Base Class Library includes implementations of `String.PadLeft(int)` and `String.PadRight(int)` so we can [avoid an additional third party dependency](http://www.theregister.co.uk/2016/03/23/npm_left_pad_chaos/).

At some point I may genericize the table-formatting code and use it for other commands like `ckan list` and `ckan available`.