### PR TITLE
Revert "Add `kind` to the spec"

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -214,20 +214,9 @@
         "name",
         "abstract",
         "identifier",
+        "download",
         "license",
         "version"
-    ],
-    "oneOf": [
-        {
-            "required": [ "download" ]
-        },
-        {
-            "properties": {
-                "kind": {
-                    "enum": [ "metapackage" ]
-                }
-            }
-        }
     ],
     "definitions" : {
         "identifier" : {

--- a/Spec.md
+++ b/Spec.md
@@ -152,7 +152,7 @@ with any version and the `.dll` suffix removed.
 ##### download
 
 A fully formed URL, indicating where a machine may download the
-described version of the mod. Note: This field is not required if the `kind` is `metapackage`.
+described version of the mod.
 
 ##### license
 
@@ -473,10 +473,6 @@ custom use fields, and will be ignored. For example:
 
 These fields are optional, and should only be used with good reason.
 Typical mods *should not* include these special use fields.
-
-##### kind
-
-Specifies the type of package the .ckan file delivers. This field defaults to `package`, the other option (and presently the only time the field is explicitly declared) is `metapackage`. Metapackages allow for a distributable .ckan file that has relationships to other mods while having no `download` of its own. **v1.6**
 
 ##### provides
 


### PR DESCRIPTION
Reverts KSP-CKAN/CKAN#1597

I'm heading out + I don't haven't Grok'd how JSON Schema works yet. Reverting this will automatically get NetKAN indexing again.