### PR TITLE
Add Asterisk to legend in CLI list command

### DIFF
--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -111,7 +111,8 @@ namespace CKAN.CmdLine
 
             if (!(options.porcelain) && exportFileType == null)
             {
-                user.RaiseMessage("\nLegend: -: Up to date. X: Incompatible. ^: Upgradable. ?: Unknown ");
+                user.RaiseMessage("\nLegend: -: Up to date. X: Incompatible. ^: Upgradable. ?: Unknown. *: Broken. ");
+                // Broken mods are in a state that CKAN doesn't understand, and therefore can't handle automatically
             }
 
             return Exit.OK;


### PR DESCRIPTION
An * for status shows up whenever a mod falls through all the status tests without matching anything, thus implying an inability for CKAN to intelligently handle the mod. Since "Unknown" has been used to refer to mods that have been installed through CKAN but are now unable to be found in the registry, I have selected "Broken" as a term to describe the status of these mods.