### PR TITLE
Omnipresent VersionedOverrideTransformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - [spec] ckan.schema now enforces structure of install directives (#1578 by: Zane6888; reviewed: pjf, Daz)
 - [NetKAN] Catch ValueErrors rather than printing the trace (#1648 by: techman83; reviewed: Daz )
 - [NetKAN] Catch ksp_version from SpaceDocks newly implemented game_version (#1655 by: dbent; reviewed: -)
+- [NetKAN] Allow specifying when an override is executed (#1684 by: dbent; fixes: #1674)
 
 ## v1.16.1
 

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -19,6 +19,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IHttpService _http;
         private readonly IModuleService _moduleService;
 
+        public string Name { get { return "avc"; } }
+
         public AvcTransformer(IHttpService http, IModuleService moduleService)
         {
             _http = http;

--- a/Netkan/Transformers/DownloadSizeTransformer.cs
+++ b/Netkan/Transformers/DownloadSizeTransformer.cs
@@ -15,6 +15,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IHttpService _http;
         private readonly IFileService _fileService;
 
+        public string Name { get { return "download_size"; } }
+
         public DownloadSizeTransformer(IHttpService http, IFileService fileService)
         {
             _http = http;

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -12,6 +12,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(EpochTransformer));
 
+        public string Name { get { return "epoch"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             Log.Debug("Fixing version strings (if required)...");

--- a/Netkan/Transformers/ForcedVTransformer.cs
+++ b/Netkan/Transformers/ForcedVTransformer.cs
@@ -12,6 +12,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(ForcedVTransformer));
 
+        public string Name { get { return "forced_v"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/GeneratedByTransformer.cs
+++ b/Netkan/Transformers/GeneratedByTransformer.cs
@@ -12,6 +12,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(GeneratedByTransformer));
 
+        public string Name { get { return "generated_by"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -17,6 +17,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IGithubApi _api;
         private readonly bool _matchPreleases;
 
+        public string Name { get { return "github"; } }
+
         public GithubTransformer(IGithubApi api, bool matchPreleases)
         {
             if (api == null)

--- a/Netkan/Transformers/HttpTransformer.cs
+++ b/Netkan/Transformers/HttpTransformer.cs
@@ -11,6 +11,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(HttpTransformer));
 
+        public string Name { get { return "http"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == "http")

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -8,6 +8,11 @@ namespace CKAN.NetKAN.Transformers
     internal interface ITransformer
     {
         /// <summary>
+        /// A unique name which identifies the transformer.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Transform the given metadata.
         /// </summary>
         /// <param name="metadata">The metadata to transform.</param>

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -16,6 +16,8 @@ namespace CKAN.NetKAN.Transformers
         private readonly IHttpService _http;
         private readonly IModuleService _moduleService;
 
+        public string Name { get { return "internal_ckan"; } }
+
         public InternalCkanTransformer(IHttpService http, IModuleService moduleService)
         {
             _http = http;

--- a/Netkan/Transformers/JenkinsTransformer.cs
+++ b/Netkan/Transformers/JenkinsTransformer.cs
@@ -31,6 +31,8 @@ namespace CKAN.NetKAN.Transformers
 
         private readonly IHttpService _http;
 
+        public string Name { get { return "jenkins"; } }
+
         public JenkinsTransformer(IHttpService http)
         {
             _http = http;

--- a/Netkan/Transformers/MetaNetkanTransformer.cs
+++ b/Netkan/Transformers/MetaNetkanTransformer.cs
@@ -18,6 +18,8 @@ namespace CKAN.NetKAN.Transformers
 
         private readonly IHttpService _http;
 
+        public string Name { get { return "metanetkan"; } }
+
         public MetaNetkanTransformer(IHttpService http)
         {
             _http = http;

--- a/Netkan/Transformers/OptimusPrimeTransformer.cs
+++ b/Netkan/Transformers/OptimusPrimeTransformer.cs
@@ -8,6 +8,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(OptimusPrimeTransformer));
 
+        public string Name { get { return "optimus_prime"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -55,6 +55,8 @@ namespace CKAN.NetKAN.Transformers
             { "manual", 6 }
         };
 
+        public string Name { get { return "property_sort"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -19,6 +19,8 @@ namespace CKAN.NetKAN.Transformers
 
         private readonly ISpacedockApi _api;
 
+        public string Name { get { return "spacedock"; } }
+
         public SpacedockTransformer(ISpacedockApi api)
         {
             _api = api;

--- a/Netkan/Transformers/StripNetkanMetadataTransformer.cs
+++ b/Netkan/Transformers/StripNetkanMetadataTransformer.cs
@@ -14,6 +14,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(StripNetkanMetadataTransformer));
 
+        public string Name { get { return "strip_netkan_metadata"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Netkan/Transformers/VersionEditTransformer.cs
+++ b/Netkan/Transformers/VersionEditTransformer.cs
@@ -13,6 +13,8 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(VersionEditTransformer));
 
+        public string Name { get { return "version_edit"; } }
+
         public Metadata Transform(Metadata metadata)
         {
             var json = metadata.Json();

--- a/Spec.md
+++ b/Spec.md
@@ -741,13 +741,39 @@ The `x_netkan_override` field is used to override field values based on the valu
   it is equivalent to specifying `=`. In order for the override to match *all* the comparisons must be true. Therefore
   a range may be specified as such: `[ ">=1.0", "<2.0" ]`. A `string` may also be specified instead of an `array` in
   which case it is treated as an array with a single element equal to the value of the string.
+- `before` (type: `string`, transformation name)<br/>
+  The name of a transformation this override to happen directly before.
+- `after` (type: `string:, transformation name)<br/>
+  The name of a transformation this override to happen directly after.
 - `override` (type: `object`)<br/>
   An object whose fields will override the fields already present if a match occurs. No merging of values occurs, the
   values of the fields are entirely replaced.
 - `delete` (type: `array` of `string`)<br/>
   An array of strings which are the names of fields to remove if a match occurs.
 
-Override objects are processed sequentially and all matching overrides will be used.
+The possible values of `before` and `after` are:
+
+- `$none`
+- `$all`
+- `avc`
+- `download_size`
+- `epoch`
+- `forced_v`
+- `generated_by`
+- `github`
+- `http`
+- `internal_ckan`
+- `jenkins`
+- `metanetkan`
+- `optimus_prime`
+- `property_sort`
+- `spacedock`
+- `strip_netkan_metadata`
+- `version_edit`
+- `versioned_override`
+
+If no `before` or `after` is specified then the override occurs at a "reasonable" point in the transformation process.
+Most overrides should **not** specify a `before` or `after` unless there is a specific need to.
 
 When any metadata changes occur which are version specific, for example a new dependency is added, overrides are the
 recomended means of specifying them. Overrides may also be used to *stage* metadata changes, for example when new

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -1,6 +1,4 @@
-﻿using CKAN;
-using CKAN.NetKAN;
-using CKAN.NetKAN.Model;
+﻿using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Transformers;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -123,6 +121,36 @@ namespace Tests.NetKAN
             Assert.IsFalse(new_metadata.TryGetValue("author", out token));
         }
 
+        [Test]
+        public void LaterOverridesOverrideEarlierOverrides()
+        {
+            var metadata = such_metadata;
+            metadata["x_netkan_override"] = JArray.Parse(@"[
+                {
+                    ""version"": ""1.01"",
+                    ""before"": ""$all"",
+                    ""override"": {
+                        ""name"": ""EARLY""
+                    }
+                },
+                {
+                    ""version"": ""1.01"",
+                    ""after"": ""$all"",
+                    ""override"": {
+                        ""name"": ""LATE""
+                    }
+                }
+            ]");
+
+            var earlyTransformer = new VersionedOverrideTransformer(new[] { "$all" }, new[] { "$none" });
+            var lateTransformer = new VersionedOverrideTransformer(new[] { "$none" }, new[] { "$all" });
+
+            var transformedMetadata1 = earlyTransformer.Transform(new Metadata(metadata)).Json();
+            var transformedMetadata2 = lateTransformer.Transform(new Metadata(transformedMetadata1));
+
+            Assert.AreEqual((string)transformedMetadata2.Json()["name"], "LATE");
+        }
+
         /// <summary>
         /// Sanity to check to make sure the original metadata hasn't changed during testing.
         /// </summary>
@@ -136,7 +164,10 @@ namespace Tests.NetKAN
         /// </summary>
         private JObject ProcessOverrides(JObject metadata)
         {
-            var transformer = new VersionedOverrideTransformer();
+            var transformer = new VersionedOverrideTransformer(
+                before: new string[] { null },
+                after: new string[] { null }
+            );
 
             return transformer.Transform(new Metadata(metadata)).Json();
         }


### PR DESCRIPTION
@pjf @Starstrider42 @Dazpoet

Prompted by #1674. The issue was that the `x_netkan_override` was overriding the `install` stanza. However, the `AvcTransformer` uses the `install` stanza to determine which files in an archive will be installed so that it can pick the correct `.version` file to use. The problem was that the `AvcTransformer` executes before the `VersionedOverrideTransformer` so the `AvcTransformer` didn't think *any* files would be installed because the appropriate override hadn't occurred yet.

What this PR does is basically allow you specify *when* an override should execute, through the use of `before` and `after` properties in the override.

To accomplish this there are three main changes:

- Each `ITransformer` must have a name which identifies it uniquely.
- `VersionedOverrideTransformer` takes a list of names of `ITransformer` implementations that it executes directly before and executes directly after.
- The top-level `NetkanTransformer` has been modified to inject an instance of `VersionedOverrideTransformer` before and after *every other `ITransformer`*.

So now the transformation pipeline looks like:

```
VersionedOverrideTransformer: before: first
FirstTransformer
VersionedOverrideTransformer: before: second, after: first
SecondTransformer
VersionedOverrideTransformer: before third, after: second
ThirdTransformer
VersionedOverrideTransformer: after: third
```

There are also two "psuedo-transformers", `$none` and `$all` (should be self-explanatory) so the pipeline really looks like:

```
VersionedOverrideTransformer: before: first, $all, after: $none
FirstTransformer
VersionedOverrideTransformer: before: second, after: first
SecondTransformer
VersionedOverrideTransformer: before third, after: second
ThirdTransformer
VersionedOverrideTransformer: after: third, $all, before: $none
```

How does this fix #1674?

Well given this `.netkan` (@Starstrider42 changed the archive to workaround the issue in NetKAN#3691 so to make it reproducable I modified from the one given in #1674 by inverting the install stanzas and override condition).

```json
{
    "spec_version": 1,
    "identifier": "CustomAsteroids-Pops-Stock-Inner",
    "$kref": "#/ckan/spacedock/210",
    "$vref" : "#/ckan/ksp-avc",
    "install": [
        {
            "file": "GameData/CustomAsteroids",
            "install_to": "GameData",
            "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
        }
    ],
    "x_netkan_override" : [
        {
            "version": ">=v1.3.0",
            "override" : {
                "install": [
                    {
                        "file": "Standard Setup",
                        "install_to": "GameData",
                        "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
                    }
                ]
            }
        }
    ],
}
```

NetKAN compalains:
```
1076 [1] FATAL CKAN.NetKAN.Program (null) - No files found in GameData/CustomAsteroids to install!
```

However using this `.netkan` (notice the addition of `"before": "avc"`)

```json
{
    "spec_version": 1,
    "identifier": "CustomAsteroids-Pops-Stock-Inner",
    "$kref": "#/ckan/spacedock/210",
    "$vref" : "#/ckan/ksp-avc",
    "install": [
        {
            "file": "GameData/CustomAsteroids",
            "install_to": "GameData",
            "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
        }
    ],
    "x_netkan_override" : [
        {
            "version": ">=v1.3.0",
            "before": "avc",
            "override" : {
                "install": [
                    {
                        "file": "Standard Setup",
                        "install_to": "GameData",
                        "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
                    }
                ]
            }
        }
    ],
}
```

NetKAN successfully produces the following `.ckan`:

```json
{
    "spec_version": 1,
    "identifier": "CustomAsteroids-Pops-Stock-Inner",
    "name": "Custom Asteroids",
    "abstract": "Lets users control where asteroids appear",
    "author": "Starstrider42",
    "license": "MIT",
    "resources": {
        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72785-/",
        "spacedock": "https://spacedock.info/mod/210/Custom%20Asteroids",
        "repository": "https://github.com/Starstrider42/Custom-Asteroids",
        "x_screenshot": "https://spacedock.info/content/Starstrider42_1134/Custom_Asteroids/Custom_Asteroids-1461528691.6712377.png"
    },
    "version": "v1.3.0",
    "ksp_version": "1.1.0",
    "install": [
        {
            "file": "Standard Setup",
            "install_to": "GameData",
            "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
        }
    ],
    "download": "https://spacedock.info/mod/210/Custom%20Asteroids/download/v1.3.0",
    "download_size": 77254,
    "x_generated_by": "netkan"
}
```

To remain backwards compatible with existing overrides, there is a hardcoded `VersionedOverrideTransformer` that occurs `before` and `after` `null`.

The following is the list of all possible values of `before` and `after`. It exposes some of the internal architecture of NetKAN, but I think this is the best possible compromise to solve this particular issue.

```
$none
$all
avc
download_size
epoch
forced_v
generated_by
github
http
internal_ckan
jenkins
metanetkan
optimus_prime
property_sort
spacedock
strip_netkan_metadata
version_edit
versioned_override
```