### PR TITLE
Fixed IOException "Directory is not empty" errors in Test

### DIFF
--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -23,6 +23,7 @@ namespace Tests.Core
         [TearDown]
         public void RemoveCache()
         {
+            cache.Dispose();
             Directory.Delete(cache_dir, true);
         }
 

--- a/Tests/Core/KSP.cs
+++ b/Tests/Core/KSP.cs
@@ -24,6 +24,7 @@ namespace Tests.Core
         [TearDown]
         public void TearDown()
         {
+            ksp.Dispose();
             Directory.Delete(ksp_dir, true);
         }
 

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -25,6 +25,7 @@ namespace Tests.Core
         [TearDown]
         public void TearDown()
         {
+            tidy.DisposeOfAllManagedKSPs(manager);
             tidy.Dispose();
         }
 
@@ -104,6 +105,7 @@ namespace Tests.Core
                 Assert.That(manager.HasInstance(newInstance), Is.False);
                 manager.AddInstance(newInstance, tidy2.KSP);
                 Assert.That(manager.HasInstance(newInstance),Is.True);
+                tidy2.DisposeOfAllManagedKSPs(manager);
             }
         }
 
@@ -122,6 +124,7 @@ namespace Tests.Core
                 manager.LoadInstancesFromRegistry();
                 manager.ClearAutoStart();
                 Assert.That(manager.GetPreferredInstance(), Is.Null);
+                tidy2.DisposeOfAllManagedKSPs(manager);
             }
 
         }
@@ -142,8 +145,12 @@ namespace Tests.Core
         [Test] //37a33
         public void Ctor_InvalidAutoStart_DoesNotThrow()
         {
-            Assert.DoesNotThrow(() => new KSPManager(new NullUser(),new FakeWin32Registry(tidy.KSP, "invalid")
-                ));
+            Assert.DoesNotThrow(() =>
+            {
+                var kspManager = new KSPManager(new NullUser(),new FakeWin32Registry(tidy.KSP, "invalid"));
+                tidy.DisposeOfAllManagedKSPs(kspManager);
+                
+            });
         }
 
 

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -359,7 +359,7 @@ namespace Tests.Core
                     CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, NullUser.User).UninstallList("Foo");
                 });
 
-                manager.CurrentInstance = null; // I weep even more.
+                tidy.DisposeOfAllManagedKSPs(manager);
             }
         }
 
@@ -434,6 +434,9 @@ namespace Tests.Core
 
                 // Check that the module is not installed.
                 Assert.IsFalse(File.Exists(mod_file_path));
+
+                ksp.DisposeOfAllManagedKSPs(manager);
+
             }
         }
 
@@ -464,6 +467,7 @@ namespace Tests.Core
                         string mod_file_path = Path.Combine(ksp.KSP.GameData(), mod_file_name);
 
                         Assert.IsTrue(File.Exists(mod_file_path));
+
                     }
                 }
             }

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -41,9 +41,17 @@ namespace Tests.Data
 
         public void Dispose()
         {
-            Directory.Delete(disposable_dir, true);
             KSP.Dispose();
+            Directory.Delete(disposable_dir, true);
             KSP = null; // In case .Dispose() was called manually.
+        }
+
+        public void DisposeOfAllManagedKSPs(KSPManager kspManager)
+        {
+            foreach (var ksp in kspManager.Instances.Values)
+            {
+                ksp.Dispose();
+            }
         }
     }
 }

--- a/Tests/GUI/GUIMod.cs
+++ b/Tests/GUI/GUIMod.cs
@@ -23,6 +23,7 @@ namespace Tests.GUI
                 registry.AddAvailable(ckan_mod);
                 var mod = new GUIMod(ckan_mod, registry, manager.CurrentInstance.Version());
                 Assert.False(mod.IsUpgradeChecked);
+                tidy.DisposeOfAllManagedKSPs(manager);
             }
         }
         [Test]

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -74,6 +74,7 @@ namespace Tests.GUI
 
                 var compute_change_set_from_mod_list = main_mod_list.ComputeChangeSetFromModList(registry, main_mod_list.ComputeUserChangeSet(), null, tidy.KSP.Version());
                 await UtilStatic.Throws<InconsistentKraken>(async ()=> { await compute_change_set_from_mod_list; });
+                tidy.DisposeOfAllManagedKSPs(manager);
             }
         }
 
@@ -89,6 +90,7 @@ namespace Tests.GUI
                 registry.AddAvailable(ckan_mod);
                 var item = new MainModList(delegate { }, null);
                 Assert.That(item.IsVisible(new GUIMod(ckan_mod, registry, manager.CurrentInstance.Version())));
+                tidy.DisposeOfAllManagedKSPs(manager);
             }
         }
 
@@ -120,6 +122,7 @@ namespace Tests.GUI
                     new GUIMod(TestData.kOS_014_module(), registry, manager.CurrentInstance.Version())
                 });
                 Assert.That(mod_list, Has.Count.EqualTo(2));
+                tidy.DisposeOfAllManagedKSPs(manager);
             }
         }
 


### PR DESCRIPTION
Had issues on my system (win10 VS15 dotCover) with some of the tests due to incorrect disposals. This caused the program to call Directory.Delete(dir, true); with outstanding handles to directories within the dir that was to be deleted. This resulted in an IOException with "Directory is not empty" as the message.