### PR TITLE
HttpTransformer Resolves Redirects

### DIFF
--- a/Tests/NetKAN/Transformers/HttpTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/HttpTransformerTests.cs
@@ -8,27 +8,6 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class HttpTransformerTests
     {
-        [Test]
-        public void AddsDownloadProperty()
-        {
-            // Arrange
-            const string url = "https://awesomemod.example/download/AwesomeMod.zip";
-
-            var sut = new HttpTransformer();
-            var json = new JObject();
-            json["spec_version"] = 1;
-            json["$kref"] = string.Format("#/ckan/http/{0}", url);
-
-            // Act
-            var result = sut.Transform(new Metadata(json));
-            var transformedJson = result.Json();
-
-            // Assert
-            Assert.That((string)transformedJson["download"], Is.EqualTo(url),
-                "HttpTransformer should add a download property equal to the $kref ID."
-            );
-        }
-
         [TestCase("#/ckan/github/foo/bar")]
         [TestCase("#/ckan/netkan/http://awesomemod.example/awesomemod.netkan")]
         [TestCase("#/ckan/spacedock/1")]


### PR DESCRIPTION
@pjf @techman83 @plague006 @Ezriilc

This PR modifies the `HttpTransformer` to resolve redirects and output the resolved URL as the 
`download` property of the `.ckan` file, instead of value specified in the `$kref`.

[Graphotron](https://github.com/KSP-CKAN/NetKAN/blob/33eafb20f717b278e5376847e988dea1d93bfed6/NetKAN/Graphotron.netkan) and [HyperEdit](https://github.com/KSP-CKAN/NetKAN/blob/30241029a0fa7862875b97b37249452ec504222d/NetKAN/HyperEdit.netkan) are the only two `.netkan` files using the `HttpTransformer` at the moment.

Since they use a fixed URL this makes caching problematic. @Ezriilc can make it so that instead of returning the download directly in the response it can produce an HTTP redirect to a version specific URL. This should prevent caching issues (or at least reduce caching issues to the kind we already have to deal with), keep us from having to intervene with updates to Graphotron and HyperEdit, and make sure clients get a version specific URL for backwards compatibility with old versions of KSP.

This example `.netkan` points to some test redirects I setup on my server.

`https://www.bent.io/tmp/redirect1` redirects to `https://www.bent.io/tmp/redirect2` which redirects to `https://www.bent.io/tmp/redirect3` which redirects to `https://www.bent.io/tmp/PlaneMode-1.3.1.zip`. (The code has a hardcoded limit of up to 5 requests before it gives up).

```json
{
    "spec_version": 1,
    "identifier": "PlaneMode",
    "$kref": "#/ckan/http/https://www.bent.io/tmp/redirect1",
    "version": "1.3.1",
    "license": "MIT"
}
```

Produce the following `.ckan`:
```json
{
    "spec_version": 1,
    "identifier": "PlaneMode",
    "license": "MIT",
    "version": "1.3.1",
    "download": "https://www.bent.io/tmp/PlaneMode-1.3.1.zip",
    "download_size": 17530,
    "x_generated_by": "netkan"
}
```

Notice that the `download` property is the final destination of the redirects starting at `https://www.bent.io/tmp/redirect1`.