### PR TITLE
Avoid unexpected null reference exception

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -64,9 +64,18 @@ namespace CKAN
                 // If we haven't handled our exception, then it really was exceptional.
                 if (handled == false)
                 {
-                    // In case whatever's calling us is lazy in error reporting, we'll
-                    // report that we've got an issue here.
-                    log.ErrorFormat("Error processing {0} : {1}", filename, exception.Message);
+                    if (exception == null)
+                    {
+                        // Had exception, walked exception tree, reached leaf, got stuck.
+                        log.ErrorFormat("Error processing {0} (exception tree leaf)", filename); 
+                    }
+                    else
+                    {
+                        // In case whatever's calling us is lazy in error reporting, we'll
+                        // report that we've got an issue here.
+                        log.ErrorFormat("Error processing {0} : {1}", filename, exception.Message);
+                    }
+
                     throw;
                 }
             }
@@ -87,6 +96,7 @@ namespace CKAN
             {
                 log.InfoFormat("About to update {0}", repository.Value.name);
                 UpdateRegistry(repository.Value.uri, registry_manager.registry, ksp, user, false);
+                log.InfoFormat("Updated {0}", repository.Value.name);
             }
 
             // Save our changes.


### PR DESCRIPTION
While traversing possible nested exceptions (added because of #182) it is possible to reach a "leaf" where there are no more `InnerException`s. If at this point the exception hasn't been `handle`d, then `log.ErrorFormat` will try to access `exception.Message`. However, due to the `while` loop just above it, `exception` is `null`.