### PR TITLE
Support reading remote AVC version files

### DIFF
--- a/Netkan/Sources/Avc/AvcVersion.cs
+++ b/Netkan/Sources/Avc/AvcVersion.cs
@@ -6,6 +6,9 @@ namespace CKAN.NetKAN.Sources.Avc
     {
         // Right now we only support KSP versioning info.
 
+        [JsonProperty("URL")]
+        public string Url;
+
         [JsonConverter(typeof(JsonAvcToVersion))]
         public Version version;
 


### PR DESCRIPTION
@pjf @techman83 @BobPalmer
cc: @plague006 @politas @Dazpoet 

This PR modifies the `AvcTransformer` to support reading remote version files. Apparently the last few versions of the AVC addon have supported using the remote `.version` file to determine compatibility in preference to the local `.version` file, if the remote `.version` file specifies the same mod version as the local `.version` file. This PR provides the same behavior.

This should bump the compatibility of CommunityResourcePack as the [download](https://github.com/BobPalmer/CommunityResourcePack/releases/tag/0.5.1.0) specifies a maximum compatibility of KSP 1.1.1 whereas the [remote](https://github.com/BobPalmer/CommunityResourcePack/blob/master/FOR_RELEASE/GameData/CommunityResourcePack/CRP.version) specifies as maximum compatibility of KSP 1.1.2.

This `.netkan`
```json
{
    "spec_version" : "v1.16",
    "identifier" : "CommunityResourcePack",
    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan",
    "x_netkan_license_ok": true
}
```

Produces the following `.ckan`.
```json
{
    "spec_version": "v1.16",
    "identifier": "CommunityResourcePack",
    "name": "Community Resource Pack",
    "abstract": "Common resources for KSP mods",
    "author": "RoverDude",
    "license": "CC-BY-NC-SA-4.0",
    "release_status": "stable",
    "resources": {
        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/83007-105",
        "repository": "https://github.com/BobPalmer/CommunityResourcePack"
    },
    "version": "0.5.1.0",
    "ksp_version_min": "1.0.0",
    "ksp_version_max": "1.1.2",
    "conflicts": [
        {
            "name": "Kerbalism"
        }
    ],
    "install": [
        {
            "file": "GameData/CommunityResourcePack",
            "install_to": "GameData"
        }
    ],
    "download": "https://github.com/BobPalmer/CommunityResourcePack/releases/download/0.5.1.0/CRP_0.5.1.0.zip",
    "download_size": 16098,
    "x_last_revision_by": "harryyoung",
    "x_generated_by": "netkan"
}
```

