### PR TITLE
Remove Mono 3.2.8 from Mono testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: csharp
 mono:
     - latest
     - 3.10.0
-    - 3.2.8
 
 # Travis has problems with nunit on 3.8.0, dunno why.
 #    - 3.8.0


### PR DESCRIPTION
@pjf @techman83 

#1645 is failing in Travis on the Mono 3.2.8 version because of errors like these:
```
System.TypeInitializationException : An exception was thrown by the type initializer for CKAN.Versioning.KspVersionRange
  ----> System.TypeInitializationException : An exception was thrown by the type initializer for CKAN.Versioning.KspVersionBound
  ----> System.NullReferenceException : Object reference not set to an instance of an object
```

There is no reason why a `NullReferenceException` should occur in the type initializer for `KspVersionBound`, this suggests a bug in the Mono 3.2.8 runtime:

- The error does not occur on Mono 3.10.0, Mono 4.2.3, or the .NET runtime.
- A [similar error](https://bugzilla.xamarin.com/show_bug.cgi?id=14977) was fixed in Mono in the 3.2.x era.

Do we even support running CKAN on such an old version of Mono?