### PR TITLE
Reuse changeset logic for .ckan import

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -142,6 +142,8 @@ namespace CKAN
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChooseProvidedModsLabel = new System.Windows.Forms.Label();
+            this.switchToToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.menuStrip1.SuspendLayout();
             this.menuStrip2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -218,6 +220,8 @@ namespace CKAN
             // 
             this.ckanModListsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.importToolStripMenuItem,
+            this.switchToToolStripMenuItem,
+            this.toolStripMenuItem2,
             this.exportCurrentSetToolStripMenuItem});
             this.ckanModListsToolStripMenuItem.Name = "ckanModListsToolStripMenuItem";
             this.ckanModListsToolStripMenuItem.Size = new System.Drawing.Size(214, 26);
@@ -453,7 +457,7 @@ namespace CKAN
             // 
             this.splitContainer1.Panel2.Controls.Add(this.ModInfoTabControl);
             this.splitContainer1.Size = new System.Drawing.Size(1353, 718);
-            this.splitContainer1.SplitterDistance = 987;
+            this.splitContainer1.SplitterDistance = 986;
             this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 7;
             // 
@@ -483,7 +487,7 @@ namespace CKAN
             this.ModList.Name = "ModList";
             this.ModList.RowHeadersVisible = false;
             this.ModList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.ModList.Size = new System.Drawing.Size(987, 718);
+            this.ModList.Size = new System.Drawing.Size(986, 718);
             this.ModList.TabIndex = 3;
             this.ModList.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModList_CellContentClick);
             this.ModList.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModList_CellMouseDoubleClick);
@@ -572,7 +576,7 @@ namespace CKAN
             this.ModInfoTabControl.Margin = new System.Windows.Forms.Padding(4);
             this.ModInfoTabControl.Name = "ModInfoTabControl";
             this.ModInfoTabControl.SelectedIndex = 0;
-            this.ModInfoTabControl.Size = new System.Drawing.Size(361, 718);
+            this.ModInfoTabControl.Size = new System.Drawing.Size(362, 718);
             this.ModInfoTabControl.TabIndex = 0;
             this.ModInfoTabControl.SelectedIndexChanged += new System.EventHandler(this.ModInfoIndexChanged);
             // 
@@ -583,7 +587,7 @@ namespace CKAN
             this.MetadataTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.MetadataTabPage.Name = "MetadataTabPage";
             this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(4);
-            this.MetadataTabPage.Size = new System.Drawing.Size(353, 686);
+            this.MetadataTabPage.Size = new System.Drawing.Size(354, 686);
             this.MetadataTabPage.TabIndex = 0;
             this.MetadataTabPage.Text = "Metadata";
             this.MetadataTabPage.UseVisualStyleBackColor = true;
@@ -604,7 +608,7 @@ namespace CKAN
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.MetaDataLowerLayoutPanel);
-            this.splitContainer2.Size = new System.Drawing.Size(345, 678);
+            this.splitContainer2.Size = new System.Drawing.Size(346, 678);
             this.splitContainer2.SplitterDistance = 325;
             this.splitContainer2.SplitterWidth = 5;
             this.splitContainer2.TabIndex = 0;
@@ -623,7 +627,7 @@ namespace CKAN
             this.MetaDataUpperLayoutPanel.RowCount = 2;
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 80F));
-            this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(343, 323);
+            this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(344, 323);
             this.MetaDataUpperLayoutPanel.TabIndex = 0;
             // 
             // MetadataModuleNameLabel
@@ -634,7 +638,7 @@ namespace CKAN
             this.MetadataModuleNameLabel.Location = new System.Drawing.Point(4, 0);
             this.MetadataModuleNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleNameLabel.Name = "MetadataModuleNameLabel";
-            this.MetadataModuleNameLabel.Size = new System.Drawing.Size(335, 64);
+            this.MetadataModuleNameLabel.Size = new System.Drawing.Size(336, 64);
             this.MetadataModuleNameLabel.TabIndex = 0;
             this.MetadataModuleNameLabel.Text = "Mod Name";
             this.MetadataModuleNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -647,7 +651,7 @@ namespace CKAN
             this.MetadataModuleAbstractLabel.Margin = new System.Windows.Forms.Padding(4);
             this.MetadataModuleAbstractLabel.Name = "MetadataModuleAbstractLabel";
             this.MetadataModuleAbstractLabel.ReadOnly = true;
-            this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(335, 251);
+            this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(336, 251);
             this.MetadataModuleAbstractLabel.TabIndex = 27;
             this.MetadataModuleAbstractLabel.Text = "";
             // 
@@ -687,7 +691,7 @@ namespace CKAN
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.MetaDataLowerLayoutPanel.Size = new System.Drawing.Size(343, 346);
+            this.MetaDataLowerLayoutPanel.Size = new System.Drawing.Size(344, 346);
             this.MetaDataLowerLayoutPanel.TabIndex = 0;
             // 
             // IdentifierLabel
@@ -710,7 +714,7 @@ namespace CKAN
             this.MetadataIdentifierLabel.Location = new System.Drawing.Point(93, 259);
             this.MetadataIdentifierLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataIdentifierLabel.Name = "MetadataIdentifierLabel";
-            this.MetadataIdentifierLabel.Size = new System.Drawing.Size(246, 25);
+            this.MetadataIdentifierLabel.Size = new System.Drawing.Size(247, 25);
             this.MetadataIdentifierLabel.TabIndex = 27;
             this.MetadataIdentifierLabel.Text = "-";
             // 
@@ -793,7 +797,7 @@ namespace CKAN
             this.MetadataModuleVersionLabel.Location = new System.Drawing.Point(93, 0);
             this.MetadataModuleVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleVersionLabel.Name = "MetadataModuleVersionLabel";
-            this.MetadataModuleVersionLabel.Size = new System.Drawing.Size(246, 37);
+            this.MetadataModuleVersionLabel.Size = new System.Drawing.Size(247, 37);
             this.MetadataModuleVersionLabel.TabIndex = 2;
             this.MetadataModuleVersionLabel.Text = "0.0.0";
             // 
@@ -804,7 +808,7 @@ namespace CKAN
             this.MetadataModuleLicenseLabel.Location = new System.Drawing.Point(93, 37);
             this.MetadataModuleLicenseLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleLicenseLabel.Name = "MetadataModuleLicenseLabel";
-            this.MetadataModuleLicenseLabel.Size = new System.Drawing.Size(246, 37);
+            this.MetadataModuleLicenseLabel.Size = new System.Drawing.Size(247, 37);
             this.MetadataModuleLicenseLabel.TabIndex = 4;
             this.MetadataModuleLicenseLabel.Text = "None";
             // 
@@ -815,7 +819,7 @@ namespace CKAN
             this.MetadataModuleAuthorLabel.Location = new System.Drawing.Point(93, 74);
             this.MetadataModuleAuthorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleAuthorLabel.Name = "MetadataModuleAuthorLabel";
-            this.MetadataModuleAuthorLabel.Size = new System.Drawing.Size(246, 37);
+            this.MetadataModuleAuthorLabel.Size = new System.Drawing.Size(247, 37);
             this.MetadataModuleAuthorLabel.TabIndex = 6;
             this.MetadataModuleAuthorLabel.Text = "Nobody";
             // 
@@ -838,7 +842,7 @@ namespace CKAN
             this.MetadataModuleReleaseStatusLabel.Location = new System.Drawing.Point(93, 185);
             this.MetadataModuleReleaseStatusLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleReleaseStatusLabel.Name = "MetadataModuleReleaseStatusLabel";
-            this.MetadataModuleReleaseStatusLabel.Size = new System.Drawing.Size(246, 37);
+            this.MetadataModuleReleaseStatusLabel.Size = new System.Drawing.Size(247, 37);
             this.MetadataModuleReleaseStatusLabel.TabIndex = 11;
             this.MetadataModuleReleaseStatusLabel.Text = "Stable";
             // 
@@ -849,7 +853,7 @@ namespace CKAN
             this.MetadataModuleHomePageLinkLabel.Location = new System.Drawing.Point(93, 111);
             this.MetadataModuleHomePageLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleHomePageLinkLabel.Name = "MetadataModuleHomePageLinkLabel";
-            this.MetadataModuleHomePageLinkLabel.Size = new System.Drawing.Size(246, 37);
+            this.MetadataModuleHomePageLinkLabel.Size = new System.Drawing.Size(247, 37);
             this.MetadataModuleHomePageLinkLabel.TabIndex = 25;
             this.MetadataModuleHomePageLinkLabel.TabStop = true;
             this.MetadataModuleHomePageLinkLabel.Text = "linkLabel1";
@@ -862,7 +866,7 @@ namespace CKAN
             this.MetadataModuleKSPCompatibilityLabel.Location = new System.Drawing.Point(93, 222);
             this.MetadataModuleKSPCompatibilityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleKSPCompatibilityLabel.Name = "MetadataModuleKSPCompatibilityLabel";
-            this.MetadataModuleKSPCompatibilityLabel.Size = new System.Drawing.Size(246, 37);
+            this.MetadataModuleKSPCompatibilityLabel.Size = new System.Drawing.Size(247, 37);
             this.MetadataModuleKSPCompatibilityLabel.TabIndex = 14;
             this.MetadataModuleKSPCompatibilityLabel.Text = "0.0.0";
             // 
@@ -873,7 +877,7 @@ namespace CKAN
             this.MetadataModuleGitHubLinkLabel.Location = new System.Drawing.Point(93, 148);
             this.MetadataModuleGitHubLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleGitHubLinkLabel.Name = "MetadataModuleGitHubLinkLabel";
-            this.MetadataModuleGitHubLinkLabel.Size = new System.Drawing.Size(246, 37);
+            this.MetadataModuleGitHubLinkLabel.Size = new System.Drawing.Size(247, 37);
             this.MetadataModuleGitHubLinkLabel.TabIndex = 26;
             this.MetadataModuleGitHubLinkLabel.TabStop = true;
             this.MetadataModuleGitHubLinkLabel.Text = "linkLabel2";
@@ -887,7 +891,7 @@ namespace CKAN
             this.RelationshipTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.RelationshipTabPage.Name = "RelationshipTabPage";
             this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(4);
-            this.RelationshipTabPage.Size = new System.Drawing.Size(353, 686);
+            this.RelationshipTabPage.Size = new System.Drawing.Size(354, 686);
             this.RelationshipTabPage.TabIndex = 1;
             this.RelationshipTabPage.Text = "Relationships";
             this.RelationshipTabPage.UseVisualStyleBackColor = true;
@@ -907,7 +911,7 @@ namespace CKAN
             this.ModuleRelationshipType.Location = new System.Drawing.Point(8, 9);
             this.ModuleRelationshipType.Margin = new System.Windows.Forms.Padding(4);
             this.ModuleRelationshipType.Name = "ModuleRelationshipType";
-            this.ModuleRelationshipType.Size = new System.Drawing.Size(333, 24);
+            this.ModuleRelationshipType.Size = new System.Drawing.Size(334, 24);
             this.ModuleRelationshipType.TabIndex = 1;
             this.ModuleRelationshipType.SelectedIndexChanged += new System.EventHandler(this.ModuleRelationshipType_SelectedIndexChanged);
             // 
@@ -920,7 +924,7 @@ namespace CKAN
             this.DependsGraphTree.Location = new System.Drawing.Point(4, 42);
             this.DependsGraphTree.Margin = new System.Windows.Forms.Padding(4);
             this.DependsGraphTree.Name = "DependsGraphTree";
-            this.DependsGraphTree.Size = new System.Drawing.Size(342, 629);
+            this.DependsGraphTree.Size = new System.Drawing.Size(343, 629);
             this.DependsGraphTree.TabIndex = 0;
             this.DependsGraphTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.DependsGraphTree_NodeMouseDoubleClick);
             // 
@@ -933,7 +937,7 @@ namespace CKAN
             this.ContentTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ContentTabPage.Name = "ContentTabPage";
             this.ContentTabPage.Padding = new System.Windows.Forms.Padding(4);
-            this.ContentTabPage.Size = new System.Drawing.Size(353, 686);
+            this.ContentTabPage.Size = new System.Drawing.Size(354, 686);
             this.ContentTabPage.TabIndex = 2;
             this.ContentTabPage.Text = "Contents";
             this.ContentTabPage.UseVisualStyleBackColor = true;
@@ -948,7 +952,7 @@ namespace CKAN
             this.ContentsPreviewTree.Location = new System.Drawing.Point(0, 80);
             this.ContentsPreviewTree.Margin = new System.Windows.Forms.Padding(4);
             this.ContentsPreviewTree.Name = "ContentsPreviewTree";
-            this.ContentsPreviewTree.Size = new System.Drawing.Size(346, 595);
+            this.ContentsPreviewTree.Size = new System.Drawing.Size(347, 595);
             this.ContentsPreviewTree.TabIndex = 2;
             this.ContentsPreviewTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.ContentsPreviewTree_NodeMouseDoubleClick);
             // 
@@ -1430,6 +1434,18 @@ namespace CKAN
             this.ChooseProvidedModsLabel.TabIndex = 7;
             this.ChooseProvidedModsLabel.Text = "Several mods provide the virtual module Foo, choose one of the following mods:";
             // 
+            // switchToToolStripMenuItem
+            // 
+            this.switchToToolStripMenuItem.Name = "switchToToolStripMenuItem";
+            this.switchToToolStripMenuItem.Size = new System.Drawing.Size(213, 26);
+            this.switchToToolStripMenuItem.Text = "Switch To...";
+            this.switchToToolStripMenuItem.Click += new System.EventHandler(this.switchToToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem2
+            // 
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(210, 6);
+            // 
             // Main
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -1596,5 +1612,7 @@ namespace CKAN
         private ToolStripMenuItem ckanModListsToolStripMenuItem;
         private ToolStripMenuItem importToolStripMenuItem;
         private ToolStripMenuItem exportCurrentSetToolStripMenuItem;
+        private ToolStripMenuItem switchToToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuItem2;
     }
 }

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -35,8 +35,10 @@ namespace CKAN
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.selectKSPInstallMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openKspDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.installFromckanToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.exportModListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.ckanModListsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportCurrentSetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.ExitToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -55,6 +57,7 @@ namespace CKAN
             this.FilterCompatibleButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterInstalledButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterInstalledUpdateButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.cachedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterNewButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterNotInstalledButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterIncompatibleButton = new System.Windows.Forms.ToolStripMenuItem();
@@ -77,6 +80,8 @@ namespace CKAN
             this.MetadataModuleNameLabel = new System.Windows.Forms.Label();
             this.MetadataModuleAbstractLabel = new System.Windows.Forms.RichTextBox();
             this.MetaDataLowerLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.IdentifierLabel = new System.Windows.Forms.Label();
+            this.MetadataIdentifierLabel = new System.Windows.Forms.Label();
             this.KSPCompatibilityLabel = new System.Windows.Forms.Label();
             this.ReleaseLabel = new System.Windows.Forms.Label();
             this.GitHubLabel = new System.Windows.Forms.Label();
@@ -137,9 +142,6 @@ namespace CKAN
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChooseProvidedModsLabel = new System.Windows.Forms.Label();
-            this.MetadataIdentifierLabel = new System.Windows.Forms.Label();
-            this.IdentifierLabel = new System.Windows.Forms.Label();
-            this.cachedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.menuStrip2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -168,13 +170,15 @@ namespace CKAN
             // 
             // menuStrip1
             // 
+            this.menuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.settingsToolStripMenuItem,
             this.helpToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(1029, 24);
+            this.menuStrip1.Padding = new System.Windows.Forms.Padding(8, 2, 0, 2);
+            this.menuStrip1.Size = new System.Drawing.Size(1372, 28);
             this.menuStrip1.TabIndex = 0;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -183,51 +187,65 @@ namespace CKAN
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.selectKSPInstallMenuItem,
             this.openKspDirectoryToolStripMenuItem,
-            this.installFromckanToolStripMenuItem,
-            this.exportModListToolStripMenuItem,
+            this.toolStripMenuItem1,
+            this.ckanModListsToolStripMenuItem,
             this.toolStripSeparator1,
             this.ExitToolButton});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(44, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // selectKSPInstallMenuItem
             // 
             this.selectKSPInstallMenuItem.Name = "selectKSPInstallMenuItem";
-            this.selectKSPInstallMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.selectKSPInstallMenuItem.Size = new System.Drawing.Size(214, 26);
             this.selectKSPInstallMenuItem.Text = "Select KSP Install...";
             this.selectKSPInstallMenuItem.Click += new System.EventHandler(this.selectKSPInstallMenuItem_Click);
             // 
             // openKspDirectoryToolStripMenuItem
             // 
             this.openKspDirectoryToolStripMenuItem.Name = "openKspDirectoryToolStripMenuItem";
-            this.openKspDirectoryToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.openKspDirectoryToolStripMenuItem.Size = new System.Drawing.Size(214, 26);
             this.openKspDirectoryToolStripMenuItem.Text = "Open KSP Directory";
             this.openKspDirectoryToolStripMenuItem.Click += new System.EventHandler(this.openKspDirectoryToolStripMenuItem_Click);
             // 
-            // installFromckanToolStripMenuItem
+            // toolStripMenuItem1
             // 
-            this.installFromckanToolStripMenuItem.Name = "installFromckanToolStripMenuItem";
-            this.installFromckanToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.installFromckanToolStripMenuItem.Text = "Install from .ckan...";
-            this.installFromckanToolStripMenuItem.Click += new System.EventHandler(this.installFromckanToolStripMenuItem_Click);
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(211, 6);
             // 
-            // exportModListToolStripMenuItem
+            // ckanModListsToolStripMenuItem
             // 
-            this.exportModListToolStripMenuItem.Name = "exportModListToolStripMenuItem";
-            this.exportModListToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.exportModListToolStripMenuItem.Text = "&Export installed mods...";
-            this.exportModListToolStripMenuItem.Click += new System.EventHandler(this.exportModListToolStripMenuItem_Click);
+            this.ckanModListsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.importToolStripMenuItem,
+            this.exportCurrentSetToolStripMenuItem});
+            this.ckanModListsToolStripMenuItem.Name = "ckanModListsToolStripMenuItem";
+            this.ckanModListsToolStripMenuItem.Size = new System.Drawing.Size(214, 26);
+            this.ckanModListsToolStripMenuItem.Text = ".ckan Mod Lists";
+            // 
+            // importToolStripMenuItem
+            // 
+            this.importToolStripMenuItem.Name = "importToolStripMenuItem";
+            this.importToolStripMenuItem.Size = new System.Drawing.Size(213, 26);
+            this.importToolStripMenuItem.Text = "Import...";
+            this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
+            // 
+            // exportCurrentSetToolStripMenuItem
+            // 
+            this.exportCurrentSetToolStripMenuItem.Name = "exportCurrentSetToolStripMenuItem";
+            this.exportCurrentSetToolStripMenuItem.Size = new System.Drawing.Size(213, 26);
+            this.exportCurrentSetToolStripMenuItem.Text = "Export Current Set...";
+            this.exportCurrentSetToolStripMenuItem.Click += new System.EventHandler(this.exportCurrentSetToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(193, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(211, 6);
             // 
             // ExitToolButton
             // 
             this.ExitToolButton.Name = "ExitToolButton";
-            this.ExitToolButton.Size = new System.Drawing.Size(196, 22);
+            this.ExitToolButton.Size = new System.Drawing.Size(214, 26);
             this.ExitToolButton.Text = "Exit";
             this.ExitToolButton.Click += new System.EventHandler(this.ExitToolButton_Click);
             // 
@@ -238,27 +256,27 @@ namespace CKAN
             this.pluginsToolStripMenuItem,
             this.kSPCommandlineToolStripMenuItem});
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(74, 24);
             this.settingsToolStripMenuItem.Text = "Settings";
             // 
             // cKANSettingsToolStripMenuItem
             // 
             this.cKANSettingsToolStripMenuItem.Name = "cKANSettingsToolStripMenuItem";
-            this.cKANSettingsToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
+            this.cKANSettingsToolStripMenuItem.Size = new System.Drawing.Size(210, 26);
             this.cKANSettingsToolStripMenuItem.Text = "CKAN settings";
             this.cKANSettingsToolStripMenuItem.Click += new System.EventHandler(this.CKANSettingsToolStripMenuItem_Click);
             // 
             // pluginsToolStripMenuItem
             // 
             this.pluginsToolStripMenuItem.Name = "pluginsToolStripMenuItem";
-            this.pluginsToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
+            this.pluginsToolStripMenuItem.Size = new System.Drawing.Size(210, 26);
             this.pluginsToolStripMenuItem.Text = "CKAN plugins";
             this.pluginsToolStripMenuItem.Click += new System.EventHandler(this.pluginsToolStripMenuItem_Click);
             // 
             // kSPCommandlineToolStripMenuItem
             // 
             this.kSPCommandlineToolStripMenuItem.Name = "kSPCommandlineToolStripMenuItem";
-            this.kSPCommandlineToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
+            this.kSPCommandlineToolStripMenuItem.Size = new System.Drawing.Size(210, 26);
             this.kSPCommandlineToolStripMenuItem.Text = "KSP command-line";
             this.kSPCommandlineToolStripMenuItem.Click += new System.EventHandler(this.KSPCommandlineToolStripMenuItem_Click);
             // 
@@ -267,21 +285,23 @@ namespace CKAN
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(53, 24);
             this.helpToolStripMenuItem.Text = "Help";
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(125, 26);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
             // statusStrip1
             // 
-            this.statusStrip1.Location = new System.Drawing.Point(0, 696);
+            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 862);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(1029, 22);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 19, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1372, 22);
             this.statusStrip1.TabIndex = 1;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -292,15 +312,17 @@ namespace CKAN
             this.menuStrip2.AutoSize = false;
             this.menuStrip2.BackColor = System.Drawing.SystemColors.Control;
             this.menuStrip2.Dock = System.Windows.Forms.DockStyle.None;
+            this.menuStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.launchKSPToolStripMenuItem,
             this.RefreshToolButton,
             this.UpdateAllToolButton,
             this.ApplyToolButton,
             this.FilterToolButton});
-            this.menuStrip2.Location = new System.Drawing.Point(0, 3);
+            this.menuStrip2.Location = new System.Drawing.Point(0, 4);
             this.menuStrip2.Name = "menuStrip2";
-            this.menuStrip2.Size = new System.Drawing.Size(3917, 40);
+            this.menuStrip2.Padding = new System.Windows.Forms.Padding(8, 2, 0, 2);
+            this.menuStrip2.Size = new System.Drawing.Size(5223, 49);
             this.menuStrip2.TabIndex = 2;
             this.menuStrip2.Text = "menuStrip2";
             // 
@@ -309,7 +331,7 @@ namespace CKAN
             this.launchKSPToolStripMenuItem.Image = global::CKAN.Properties.Resources.ksp;
             this.launchKSPToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.launchKSPToolStripMenuItem.Name = "launchKSPToolStripMenuItem";
-            this.launchKSPToolStripMenuItem.Size = new System.Drawing.Size(113, 36);
+            this.launchKSPToolStripMenuItem.Size = new System.Drawing.Size(128, 45);
             this.launchKSPToolStripMenuItem.Text = "Launch KSP";
             this.launchKSPToolStripMenuItem.Click += new System.EventHandler(this.launchKSPToolStripMenuItem_Click);
             // 
@@ -318,7 +340,7 @@ namespace CKAN
             this.RefreshToolButton.Image = global::CKAN.Properties.Resources.refresh;
             this.RefreshToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.RefreshToolButton.Name = "RefreshToolButton";
-            this.RefreshToolButton.Size = new System.Drawing.Size(90, 36);
+            this.RefreshToolButton.Size = new System.Drawing.Size(102, 45);
             this.RefreshToolButton.Text = "Refresh";
             this.RefreshToolButton.Click += new System.EventHandler(this.RefreshToolButton_Click);
             // 
@@ -327,7 +349,7 @@ namespace CKAN
             this.UpdateAllToolButton.Image = global::CKAN.Properties.Resources.update;
             this.UpdateAllToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.UpdateAllToolButton.Name = "UpdateAllToolButton";
-            this.UpdateAllToolButton.Size = new System.Drawing.Size(167, 36);
+            this.UpdateAllToolButton.Size = new System.Drawing.Size(202, 45);
             this.UpdateAllToolButton.Text = "Add available updates";
             this.UpdateAllToolButton.Click += new System.EventHandler(this.MarkAllUpdatesToolButton_Click);
             // 
@@ -336,7 +358,7 @@ namespace CKAN
             this.ApplyToolButton.Image = global::CKAN.Properties.Resources.apply;
             this.ApplyToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.ApplyToolButton.Name = "ApplyToolButton";
-            this.ApplyToolButton.Size = new System.Drawing.Size(129, 36);
+            this.ApplyToolButton.Size = new System.Drawing.Size(150, 45);
             this.ApplyToolButton.Text = "Apply changes";
             this.ApplyToolButton.Click += new System.EventHandler(this.ApplyToolButton_Click);
             // 
@@ -354,55 +376,62 @@ namespace CKAN
             this.FilterToolButton.Image = global::CKAN.Properties.Resources.search;
             this.FilterToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.FilterToolButton.Name = "FilterToolButton";
-            this.FilterToolButton.Size = new System.Drawing.Size(150, 36);
+            this.FilterToolButton.Size = new System.Drawing.Size(178, 45);
             this.FilterToolButton.Text = "Filter (Compatible)";
             // 
             // FilterCompatibleButton
             // 
             this.FilterCompatibleButton.Name = "FilterCompatibleButton";
-            this.FilterCompatibleButton.Size = new System.Drawing.Size(215, 22);
+            this.FilterCompatibleButton.Size = new System.Drawing.Size(265, 26);
             this.FilterCompatibleButton.Text = "Compatible";
             this.FilterCompatibleButton.Click += new System.EventHandler(this.FilterCompatibleButton_Click);
             // 
             // FilterInstalledButton
             // 
             this.FilterInstalledButton.Name = "FilterInstalledButton";
-            this.FilterInstalledButton.Size = new System.Drawing.Size(215, 22);
+            this.FilterInstalledButton.Size = new System.Drawing.Size(265, 26);
             this.FilterInstalledButton.Text = "Installed";
             this.FilterInstalledButton.Click += new System.EventHandler(this.FilterInstalledButton_Click);
             // 
             // FilterInstalledUpdateButton
             // 
             this.FilterInstalledUpdateButton.Name = "FilterInstalledUpdateButton";
-            this.FilterInstalledUpdateButton.Size = new System.Drawing.Size(215, 22);
+            this.FilterInstalledUpdateButton.Size = new System.Drawing.Size(265, 26);
             this.FilterInstalledUpdateButton.Text = "Installed (update available)";
             this.FilterInstalledUpdateButton.Click += new System.EventHandler(this.FilterInstalledUpdateButton_Click);
+            // 
+            // cachedToolStripMenuItem
+            // 
+            this.cachedToolStripMenuItem.Name = "cachedToolStripMenuItem";
+            this.cachedToolStripMenuItem.Size = new System.Drawing.Size(265, 26);
+            this.cachedToolStripMenuItem.Text = "Cached";
+            this.cachedToolStripMenuItem.Click += new System.EventHandler(this.cachedToolStripMenuItem_Click);
             // 
             // FilterNewButton
             // 
             this.FilterNewButton.Name = "FilterNewButton";
-            this.FilterNewButton.Size = new System.Drawing.Size(215, 22);
+            this.FilterNewButton.Size = new System.Drawing.Size(265, 26);
             this.FilterNewButton.Text = "New in repository";
             this.FilterNewButton.Click += new System.EventHandler(this.FilterNewButton_Click);
             // 
             // FilterNotInstalledButton
             // 
             this.FilterNotInstalledButton.Name = "FilterNotInstalledButton";
-            this.FilterNotInstalledButton.Size = new System.Drawing.Size(215, 22);
+            this.FilterNotInstalledButton.Size = new System.Drawing.Size(265, 26);
             this.FilterNotInstalledButton.Text = "Not installed";
             this.FilterNotInstalledButton.Click += new System.EventHandler(this.FilterNotInstalledButton_Click);
             // 
             // FilterIncompatibleButton
             // 
             this.FilterIncompatibleButton.Name = "FilterIncompatibleButton";
-            this.FilterIncompatibleButton.Size = new System.Drawing.Size(215, 22);
+            this.FilterIncompatibleButton.Size = new System.Drawing.Size(265, 26);
             this.FilterIncompatibleButton.Text = "Incompatible";
             this.FilterIncompatibleButton.Click += new System.EventHandler(this.FilterIncompatibleButton_Click);
             // 
             // FilterAllButton
             // 
             this.FilterAllButton.Name = "FilterAllButton";
-            this.FilterAllButton.Size = new System.Drawing.Size(215, 22);
+            this.FilterAllButton.Size = new System.Drawing.Size(265, 26);
             this.FilterAllButton.Text = "All";
             this.FilterAllButton.Click += new System.EventHandler(this.FilterAllButton_Click);
             // 
@@ -412,7 +441,8 @@ namespace CKAN
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 72);
+            this.splitContainer1.Location = new System.Drawing.Point(0, 89);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -422,31 +452,10 @@ namespace CKAN
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.ModInfoTabControl);
-            this.splitContainer1.Size = new System.Drawing.Size(1015, 578);
-            this.splitContainer1.SplitterDistance = 651;
+            this.splitContainer1.Size = new System.Drawing.Size(1353, 718);
+            this.splitContainer1.SplitterDistance = 987;
+            this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 7;
-            // 
-            // MetadataIdentifierLabel
-            // 
-            this.MetadataIdentifierLabel.AutoSize = true;
-            this.MetadataIdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataIdentifierLabel.ForeColor = System.Drawing.Color.Black;
-            this.MetadataIdentifierLabel.Location = new System.Drawing.Point(92, 210);
-            this.MetadataIdentifierLabel.Name = "MetadataIdentifierLabel";
-            this.MetadataIdentifierLabel.Size = new System.Drawing.Size(249, 66);
-            this.MetadataIdentifierLabel.TabIndex = 27;
-            this.MetadataIdentifierLabel.Text = "-";
-            // 
-            // IdentifierLabel
-            // 
-            this.IdentifierLabel.AutoSize = true;
-            this.IdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.IdentifierLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.IdentifierLabel.Location = new System.Drawing.Point(3, 210);
-            this.IdentifierLabel.Name = "IdentifierLabel";
-            this.IdentifierLabel.Size = new System.Drawing.Size(83, 66);
-            this.IdentifierLabel.TabIndex = 28;
-            this.IdentifierLabel.Text = "Identifier";
             // 
             // ModList
             // 
@@ -469,11 +478,12 @@ namespace CKAN
             this.Description});
             this.ModList.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ModList.Location = new System.Drawing.Point(0, 0);
+            this.ModList.Margin = new System.Windows.Forms.Padding(4);
             this.ModList.MultiSelect = false;
             this.ModList.Name = "ModList";
             this.ModList.RowHeadersVisible = false;
             this.ModList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.ModList.Size = new System.Drawing.Size(651, 578);
+            this.ModList.Size = new System.Drawing.Size(987, 718);
             this.ModList.TabIndex = 3;
             this.ModList.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModList_CellContentClick);
             this.ModList.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModList_CellMouseDoubleClick);
@@ -559,19 +569,21 @@ namespace CKAN
             this.ModInfoTabControl.Controls.Add(this.ContentTabPage);
             this.ModInfoTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ModInfoTabControl.Location = new System.Drawing.Point(0, 0);
+            this.ModInfoTabControl.Margin = new System.Windows.Forms.Padding(4);
             this.ModInfoTabControl.Name = "ModInfoTabControl";
             this.ModInfoTabControl.SelectedIndex = 0;
-            this.ModInfoTabControl.Size = new System.Drawing.Size(360, 578);
+            this.ModInfoTabControl.Size = new System.Drawing.Size(361, 718);
             this.ModInfoTabControl.TabIndex = 0;
             this.ModInfoTabControl.SelectedIndexChanged += new System.EventHandler(this.ModInfoIndexChanged);
             // 
             // MetadataTabPage
             // 
             this.MetadataTabPage.Controls.Add(this.splitContainer2);
-            this.MetadataTabPage.Location = new System.Drawing.Point(4, 25);
+            this.MetadataTabPage.Location = new System.Drawing.Point(4, 28);
+            this.MetadataTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.MetadataTabPage.Name = "MetadataTabPage";
-            this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.MetadataTabPage.Size = new System.Drawing.Size(352, 549);
+            this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.MetadataTabPage.Size = new System.Drawing.Size(353, 686);
             this.MetadataTabPage.TabIndex = 0;
             this.MetadataTabPage.Text = "Metadata";
             this.MetadataTabPage.UseVisualStyleBackColor = true;
@@ -580,7 +592,8 @@ namespace CKAN
             // 
             this.splitContainer2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer2.Location = new System.Drawing.Point(3, 3);
+            this.splitContainer2.Location = new System.Drawing.Point(4, 4);
+            this.splitContainer2.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer2.Name = "splitContainer2";
             this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -591,8 +604,9 @@ namespace CKAN
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.MetaDataLowerLayoutPanel);
-            this.splitContainer2.Size = new System.Drawing.Size(346, 543);
-            this.splitContainer2.SplitterDistance = 261;
+            this.splitContainer2.Size = new System.Drawing.Size(345, 678);
+            this.splitContainer2.SplitterDistance = 325;
+            this.splitContainer2.SplitterWidth = 5;
             this.splitContainer2.TabIndex = 0;
             // 
             // MetaDataUpperLayoutPanel
@@ -604,11 +618,12 @@ namespace CKAN
             this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleAbstractLabel, 0, 1);
             this.MetaDataUpperLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataUpperLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.MetaDataUpperLayoutPanel.Margin = new System.Windows.Forms.Padding(4);
             this.MetaDataUpperLayoutPanel.Name = "MetaDataUpperLayoutPanel";
             this.MetaDataUpperLayoutPanel.RowCount = 2;
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 80F));
-            this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(344, 259);
+            this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(343, 323);
             this.MetaDataUpperLayoutPanel.TabIndex = 0;
             // 
             // MetadataModuleNameLabel
@@ -616,9 +631,10 @@ namespace CKAN
             this.MetadataModuleNameLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetadataModuleNameLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.MetadataModuleNameLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.MetadataModuleNameLabel.Location = new System.Drawing.Point(3, 0);
+            this.MetadataModuleNameLabel.Location = new System.Drawing.Point(4, 0);
+            this.MetadataModuleNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleNameLabel.Name = "MetadataModuleNameLabel";
-            this.MetadataModuleNameLabel.Size = new System.Drawing.Size(338, 56);
+            this.MetadataModuleNameLabel.Size = new System.Drawing.Size(335, 64);
             this.MetadataModuleNameLabel.TabIndex = 0;
             this.MetadataModuleNameLabel.Text = "Mod Name";
             this.MetadataModuleNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -627,10 +643,11 @@ namespace CKAN
             // 
             this.MetadataModuleAbstractLabel.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.MetadataModuleAbstractLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleAbstractLabel.Location = new System.Drawing.Point(3, 59);
+            this.MetadataModuleAbstractLabel.Location = new System.Drawing.Point(4, 68);
+            this.MetadataModuleAbstractLabel.Margin = new System.Windows.Forms.Padding(4);
             this.MetadataModuleAbstractLabel.Name = "MetadataModuleAbstractLabel";
             this.MetadataModuleAbstractLabel.ReadOnly = true;
-            this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(338, 220);
+            this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(335, 251);
             this.MetadataModuleAbstractLabel.TabIndex = 27;
             this.MetadataModuleAbstractLabel.Text = "";
             // 
@@ -658,27 +675,54 @@ namespace CKAN
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleGitHubLinkLabel, 1, 4);
             this.MetaDataLowerLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataLowerLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.MetaDataLowerLayoutPanel.Margin = new System.Windows.Forms.Padding(4);
             this.MetaDataLowerLayoutPanel.Name = "MetaDataLowerLayoutPanel";
             this.MetaDataLowerLayoutPanel.RowCount = 9;
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.MetaDataLowerLayoutPanel.Size = new System.Drawing.Size(344, 276);
+            this.MetaDataLowerLayoutPanel.Size = new System.Drawing.Size(343, 346);
             this.MetaDataLowerLayoutPanel.TabIndex = 0;
+            // 
+            // IdentifierLabel
+            // 
+            this.IdentifierLabel.AutoSize = true;
+            this.IdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.IdentifierLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.IdentifierLabel.Location = new System.Drawing.Point(4, 259);
+            this.IdentifierLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.IdentifierLabel.Name = "IdentifierLabel";
+            this.IdentifierLabel.Size = new System.Drawing.Size(81, 25);
+            this.IdentifierLabel.TabIndex = 28;
+            this.IdentifierLabel.Text = "Identifier";
+            // 
+            // MetadataIdentifierLabel
+            // 
+            this.MetadataIdentifierLabel.AutoSize = true;
+            this.MetadataIdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataIdentifierLabel.ForeColor = System.Drawing.Color.Black;
+            this.MetadataIdentifierLabel.Location = new System.Drawing.Point(93, 259);
+            this.MetadataIdentifierLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.MetadataIdentifierLabel.Name = "MetadataIdentifierLabel";
+            this.MetadataIdentifierLabel.Size = new System.Drawing.Size(246, 25);
+            this.MetadataIdentifierLabel.TabIndex = 27;
+            this.MetadataIdentifierLabel.Text = "-";
             // 
             // KSPCompatibilityLabel
             // 
             this.KSPCompatibilityLabel.AutoSize = true;
             this.KSPCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.KSPCompatibilityLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.KSPCompatibilityLabel.Location = new System.Drawing.Point(3, 180);
+            this.KSPCompatibilityLabel.Location = new System.Drawing.Point(4, 222);
+            this.KSPCompatibilityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.KSPCompatibilityLabel.Name = "KSPCompatibilityLabel";
-            this.KSPCompatibilityLabel.Size = new System.Drawing.Size(83, 73);
+            this.KSPCompatibilityLabel.Size = new System.Drawing.Size(81, 37);
             this.KSPCompatibilityLabel.TabIndex = 13;
             this.KSPCompatibilityLabel.Text = "Max KSP ver.:";
             // 
@@ -687,9 +731,10 @@ namespace CKAN
             this.ReleaseLabel.AutoSize = true;
             this.ReleaseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ReleaseLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.ReleaseLabel.Location = new System.Drawing.Point(3, 150);
+            this.ReleaseLabel.Location = new System.Drawing.Point(4, 185);
+            this.ReleaseLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ReleaseLabel.Name = "ReleaseLabel";
-            this.ReleaseLabel.Size = new System.Drawing.Size(83, 30);
+            this.ReleaseLabel.Size = new System.Drawing.Size(81, 37);
             this.ReleaseLabel.TabIndex = 12;
             this.ReleaseLabel.Text = "Release status:";
             // 
@@ -698,9 +743,10 @@ namespace CKAN
             this.GitHubLabel.AutoSize = true;
             this.GitHubLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.GitHubLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.GitHubLabel.Location = new System.Drawing.Point(3, 120);
+            this.GitHubLabel.Location = new System.Drawing.Point(4, 148);
+            this.GitHubLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.GitHubLabel.Name = "GitHubLabel";
-            this.GitHubLabel.Size = new System.Drawing.Size(83, 30);
+            this.GitHubLabel.Size = new System.Drawing.Size(81, 37);
             this.GitHubLabel.TabIndex = 10;
             this.GitHubLabel.Text = "Source Code:";
             // 
@@ -709,9 +755,10 @@ namespace CKAN
             this.HomePageLabel.AutoSize = true;
             this.HomePageLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.HomePageLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.HomePageLabel.Location = new System.Drawing.Point(3, 90);
+            this.HomePageLabel.Location = new System.Drawing.Point(4, 111);
+            this.HomePageLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.HomePageLabel.Name = "HomePageLabel";
-            this.HomePageLabel.Size = new System.Drawing.Size(83, 30);
+            this.HomePageLabel.Size = new System.Drawing.Size(81, 37);
             this.HomePageLabel.TabIndex = 7;
             this.HomePageLabel.Text = "Homepage:";
             // 
@@ -720,9 +767,10 @@ namespace CKAN
             this.AuthorLabel.AutoSize = true;
             this.AuthorLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AuthorLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.AuthorLabel.Location = new System.Drawing.Point(3, 60);
+            this.AuthorLabel.Location = new System.Drawing.Point(4, 74);
+            this.AuthorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.AuthorLabel.Name = "AuthorLabel";
-            this.AuthorLabel.Size = new System.Drawing.Size(83, 30);
+            this.AuthorLabel.Size = new System.Drawing.Size(81, 37);
             this.AuthorLabel.TabIndex = 5;
             this.AuthorLabel.Text = "Author:";
             // 
@@ -731,9 +779,10 @@ namespace CKAN
             this.LicenseLabel.AutoSize = true;
             this.LicenseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.LicenseLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.LicenseLabel.Location = new System.Drawing.Point(3, 30);
+            this.LicenseLabel.Location = new System.Drawing.Point(4, 37);
+            this.LicenseLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LicenseLabel.Name = "LicenseLabel";
-            this.LicenseLabel.Size = new System.Drawing.Size(83, 30);
+            this.LicenseLabel.Size = new System.Drawing.Size(81, 37);
             this.LicenseLabel.TabIndex = 3;
             this.LicenseLabel.Text = "License:";
             // 
@@ -741,9 +790,10 @@ namespace CKAN
             // 
             this.MetadataModuleVersionLabel.AutoSize = true;
             this.MetadataModuleVersionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleVersionLabel.Location = new System.Drawing.Point(92, 0);
+            this.MetadataModuleVersionLabel.Location = new System.Drawing.Point(93, 0);
+            this.MetadataModuleVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleVersionLabel.Name = "MetadataModuleVersionLabel";
-            this.MetadataModuleVersionLabel.Size = new System.Drawing.Size(249, 30);
+            this.MetadataModuleVersionLabel.Size = new System.Drawing.Size(246, 37);
             this.MetadataModuleVersionLabel.TabIndex = 2;
             this.MetadataModuleVersionLabel.Text = "0.0.0";
             // 
@@ -751,9 +801,10 @@ namespace CKAN
             // 
             this.MetadataModuleLicenseLabel.AutoSize = true;
             this.MetadataModuleLicenseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleLicenseLabel.Location = new System.Drawing.Point(92, 30);
+            this.MetadataModuleLicenseLabel.Location = new System.Drawing.Point(93, 37);
+            this.MetadataModuleLicenseLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleLicenseLabel.Name = "MetadataModuleLicenseLabel";
-            this.MetadataModuleLicenseLabel.Size = new System.Drawing.Size(249, 30);
+            this.MetadataModuleLicenseLabel.Size = new System.Drawing.Size(246, 37);
             this.MetadataModuleLicenseLabel.TabIndex = 4;
             this.MetadataModuleLicenseLabel.Text = "None";
             // 
@@ -761,9 +812,10 @@ namespace CKAN
             // 
             this.MetadataModuleAuthorLabel.AutoSize = true;
             this.MetadataModuleAuthorLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleAuthorLabel.Location = new System.Drawing.Point(92, 60);
+            this.MetadataModuleAuthorLabel.Location = new System.Drawing.Point(93, 74);
+            this.MetadataModuleAuthorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleAuthorLabel.Name = "MetadataModuleAuthorLabel";
-            this.MetadataModuleAuthorLabel.Size = new System.Drawing.Size(249, 30);
+            this.MetadataModuleAuthorLabel.Size = new System.Drawing.Size(246, 37);
             this.MetadataModuleAuthorLabel.TabIndex = 6;
             this.MetadataModuleAuthorLabel.Text = "Nobody";
             // 
@@ -772,9 +824,10 @@ namespace CKAN
             this.VersionLabel.AutoSize = true;
             this.VersionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.VersionLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.VersionLabel.Location = new System.Drawing.Point(3, 0);
+            this.VersionLabel.Location = new System.Drawing.Point(4, 0);
+            this.VersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.VersionLabel.Name = "VersionLabel";
-            this.VersionLabel.Size = new System.Drawing.Size(83, 30);
+            this.VersionLabel.Size = new System.Drawing.Size(81, 37);
             this.VersionLabel.TabIndex = 1;
             this.VersionLabel.Text = "Version:";
             // 
@@ -782,9 +835,10 @@ namespace CKAN
             // 
             this.MetadataModuleReleaseStatusLabel.AutoSize = true;
             this.MetadataModuleReleaseStatusLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleReleaseStatusLabel.Location = new System.Drawing.Point(92, 150);
+            this.MetadataModuleReleaseStatusLabel.Location = new System.Drawing.Point(93, 185);
+            this.MetadataModuleReleaseStatusLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleReleaseStatusLabel.Name = "MetadataModuleReleaseStatusLabel";
-            this.MetadataModuleReleaseStatusLabel.Size = new System.Drawing.Size(249, 30);
+            this.MetadataModuleReleaseStatusLabel.Size = new System.Drawing.Size(246, 37);
             this.MetadataModuleReleaseStatusLabel.TabIndex = 11;
             this.MetadataModuleReleaseStatusLabel.Text = "Stable";
             // 
@@ -792,9 +846,10 @@ namespace CKAN
             // 
             this.MetadataModuleHomePageLinkLabel.AutoEllipsis = true;
             this.MetadataModuleHomePageLinkLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleHomePageLinkLabel.Location = new System.Drawing.Point(92, 90);
+            this.MetadataModuleHomePageLinkLabel.Location = new System.Drawing.Point(93, 111);
+            this.MetadataModuleHomePageLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleHomePageLinkLabel.Name = "MetadataModuleHomePageLinkLabel";
-            this.MetadataModuleHomePageLinkLabel.Size = new System.Drawing.Size(249, 30);
+            this.MetadataModuleHomePageLinkLabel.Size = new System.Drawing.Size(246, 37);
             this.MetadataModuleHomePageLinkLabel.TabIndex = 25;
             this.MetadataModuleHomePageLinkLabel.TabStop = true;
             this.MetadataModuleHomePageLinkLabel.Text = "linkLabel1";
@@ -804,9 +859,10 @@ namespace CKAN
             // 
             this.MetadataModuleKSPCompatibilityLabel.AutoSize = true;
             this.MetadataModuleKSPCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleKSPCompatibilityLabel.Location = new System.Drawing.Point(92, 180);
+            this.MetadataModuleKSPCompatibilityLabel.Location = new System.Drawing.Point(93, 222);
+            this.MetadataModuleKSPCompatibilityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleKSPCompatibilityLabel.Name = "MetadataModuleKSPCompatibilityLabel";
-            this.MetadataModuleKSPCompatibilityLabel.Size = new System.Drawing.Size(249, 73);
+            this.MetadataModuleKSPCompatibilityLabel.Size = new System.Drawing.Size(246, 37);
             this.MetadataModuleKSPCompatibilityLabel.TabIndex = 14;
             this.MetadataModuleKSPCompatibilityLabel.Text = "0.0.0";
             // 
@@ -814,9 +870,10 @@ namespace CKAN
             // 
             this.MetadataModuleGitHubLinkLabel.AutoEllipsis = true;
             this.MetadataModuleGitHubLinkLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleGitHubLinkLabel.Location = new System.Drawing.Point(92, 120);
+            this.MetadataModuleGitHubLinkLabel.Location = new System.Drawing.Point(93, 148);
+            this.MetadataModuleGitHubLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleGitHubLinkLabel.Name = "MetadataModuleGitHubLinkLabel";
-            this.MetadataModuleGitHubLinkLabel.Size = new System.Drawing.Size(249, 30);
+            this.MetadataModuleGitHubLinkLabel.Size = new System.Drawing.Size(246, 37);
             this.MetadataModuleGitHubLinkLabel.TabIndex = 26;
             this.MetadataModuleGitHubLinkLabel.TabStop = true;
             this.MetadataModuleGitHubLinkLabel.Text = "linkLabel2";
@@ -826,10 +883,11 @@ namespace CKAN
             // 
             this.RelationshipTabPage.Controls.Add(this.ModuleRelationshipType);
             this.RelationshipTabPage.Controls.Add(this.DependsGraphTree);
-            this.RelationshipTabPage.Location = new System.Drawing.Point(4, 25);
+            this.RelationshipTabPage.Location = new System.Drawing.Point(4, 28);
+            this.RelationshipTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.RelationshipTabPage.Name = "RelationshipTabPage";
-            this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.RelationshipTabPage.Size = new System.Drawing.Size(352, 549);
+            this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.RelationshipTabPage.Size = new System.Drawing.Size(353, 686);
             this.RelationshipTabPage.TabIndex = 1;
             this.RelationshipTabPage.Text = "Relationships";
             this.RelationshipTabPage.UseVisualStyleBackColor = true;
@@ -846,9 +904,10 @@ namespace CKAN
             "Suggests",
             "Supports",
             "Conflicts"});
-            this.ModuleRelationshipType.Location = new System.Drawing.Point(6, 7);
+            this.ModuleRelationshipType.Location = new System.Drawing.Point(8, 9);
+            this.ModuleRelationshipType.Margin = new System.Windows.Forms.Padding(4);
             this.ModuleRelationshipType.Name = "ModuleRelationshipType";
-            this.ModuleRelationshipType.Size = new System.Drawing.Size(340, 21);
+            this.ModuleRelationshipType.Size = new System.Drawing.Size(333, 24);
             this.ModuleRelationshipType.TabIndex = 1;
             this.ModuleRelationshipType.SelectedIndexChanged += new System.EventHandler(this.ModuleRelationshipType_SelectedIndexChanged);
             // 
@@ -858,9 +917,10 @@ namespace CKAN
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.DependsGraphTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.DependsGraphTree.Location = new System.Drawing.Point(3, 34);
+            this.DependsGraphTree.Location = new System.Drawing.Point(4, 42);
+            this.DependsGraphTree.Margin = new System.Windows.Forms.Padding(4);
             this.DependsGraphTree.Name = "DependsGraphTree";
-            this.DependsGraphTree.Size = new System.Drawing.Size(346, 509);
+            this.DependsGraphTree.Size = new System.Drawing.Size(342, 629);
             this.DependsGraphTree.TabIndex = 0;
             this.DependsGraphTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.DependsGraphTree_NodeMouseDoubleClick);
             // 
@@ -869,10 +929,11 @@ namespace CKAN
             this.ContentTabPage.Controls.Add(this.ContentsPreviewTree);
             this.ContentTabPage.Controls.Add(this.ContentsDownloadButton);
             this.ContentTabPage.Controls.Add(this.NotCachedLabel);
-            this.ContentTabPage.Location = new System.Drawing.Point(4, 25);
+            this.ContentTabPage.Location = new System.Drawing.Point(4, 28);
+            this.ContentTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ContentTabPage.Name = "ContentTabPage";
-            this.ContentTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.ContentTabPage.Size = new System.Drawing.Size(352, 549);
+            this.ContentTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.ContentTabPage.Size = new System.Drawing.Size(353, 686);
             this.ContentTabPage.TabIndex = 2;
             this.ContentTabPage.Text = "Contents";
             this.ContentTabPage.UseVisualStyleBackColor = true;
@@ -884,17 +945,19 @@ namespace CKAN
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ContentsPreviewTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.ContentsPreviewTree.Enabled = false;
-            this.ContentsPreviewTree.Location = new System.Drawing.Point(0, 65);
+            this.ContentsPreviewTree.Location = new System.Drawing.Point(0, 80);
+            this.ContentsPreviewTree.Margin = new System.Windows.Forms.Padding(4);
             this.ContentsPreviewTree.Name = "ContentsPreviewTree";
-            this.ContentsPreviewTree.Size = new System.Drawing.Size(349, 481);
+            this.ContentsPreviewTree.Size = new System.Drawing.Size(346, 595);
             this.ContentsPreviewTree.TabIndex = 2;
             this.ContentsPreviewTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.ContentsPreviewTree_NodeMouseDoubleClick);
             // 
             // ContentsDownloadButton
             // 
-            this.ContentsDownloadButton.Location = new System.Drawing.Point(6, 36);
+            this.ContentsDownloadButton.Location = new System.Drawing.Point(8, 44);
+            this.ContentsDownloadButton.Margin = new System.Windows.Forms.Padding(4);
             this.ContentsDownloadButton.Name = "ContentsDownloadButton";
-            this.ContentsDownloadButton.Size = new System.Drawing.Size(103, 23);
+            this.ContentsDownloadButton.Size = new System.Drawing.Size(137, 28);
             this.ContentsDownloadButton.TabIndex = 1;
             this.ContentsDownloadButton.Text = "Download";
             this.ContentsDownloadButton.UseVisualStyleBackColor = true;
@@ -902,9 +965,10 @@ namespace CKAN
             // 
             // NotCachedLabel
             // 
-            this.NotCachedLabel.Location = new System.Drawing.Point(3, 3);
+            this.NotCachedLabel.Location = new System.Drawing.Point(4, 4);
+            this.NotCachedLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.NotCachedLabel.Name = "NotCachedLabel";
-            this.NotCachedLabel.Size = new System.Drawing.Size(216, 30);
+            this.NotCachedLabel.Size = new System.Drawing.Size(288, 37);
             this.NotCachedLabel.TabIndex = 0;
             this.NotCachedLabel.Text = "This mod is not in the cache, click \'Download\' to preview contents";
             // 
@@ -912,17 +976,19 @@ namespace CKAN
             // 
             this.StatusPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.StatusPanel.Controls.Add(this.StatusLabel);
-            this.StatusPanel.Location = new System.Drawing.Point(0, 698);
+            this.StatusPanel.Location = new System.Drawing.Point(0, 859);
+            this.StatusPanel.Margin = new System.Windows.Forms.Padding(4);
             this.StatusPanel.Name = "StatusPanel";
-            this.StatusPanel.Size = new System.Drawing.Size(797, 19);
+            this.StatusPanel.Size = new System.Drawing.Size(1063, 23);
             this.StatusPanel.TabIndex = 8;
             // 
             // StatusLabel
             // 
             this.StatusLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.StatusLabel.Location = new System.Drawing.Point(0, 0);
+            this.StatusLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(797, 19);
+            this.StatusLabel.Size = new System.Drawing.Size(1063, 23);
             this.StatusLabel.TabIndex = 0;
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -934,10 +1000,11 @@ namespace CKAN
             this.MainTabControl.Controls.Add(this.ChooseRecommendedModsTabPage);
             this.MainTabControl.Controls.Add(this.ChooseProvidedModsTabPage);
             this.MainTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MainTabControl.Location = new System.Drawing.Point(0, 24);
+            this.MainTabControl.Location = new System.Drawing.Point(0, 28);
+            this.MainTabControl.Margin = new System.Windows.Forms.Padding(4);
             this.MainTabControl.Name = "MainTabControl";
             this.MainTabControl.SelectedIndex = 0;
-            this.MainTabControl.Size = new System.Drawing.Size(1029, 672);
+            this.MainTabControl.Size = new System.Drawing.Size(1372, 834);
             this.MainTabControl.TabIndex = 9;
             // 
             // ManageModsTabPage
@@ -952,19 +1019,21 @@ namespace CKAN
             this.ManageModsTabPage.Controls.Add(this.FilterByDescriptionTextBox);
             this.ManageModsTabPage.Controls.Add(this.menuStrip2);
             this.ManageModsTabPage.Controls.Add(this.splitContainer1);
-            this.ManageModsTabPage.Location = new System.Drawing.Point(4, 22);
+            this.ManageModsTabPage.Location = new System.Drawing.Point(4, 25);
+            this.ManageModsTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ManageModsTabPage.Name = "ManageModsTabPage";
-            this.ManageModsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.ManageModsTabPage.Size = new System.Drawing.Size(1021, 646);
+            this.ManageModsTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.ManageModsTabPage.Size = new System.Drawing.Size(1364, 805);
             this.ManageModsTabPage.TabIndex = 0;
             this.ManageModsTabPage.Text = "Manage mods";
             // 
             // FilterByAuthorTextBox
             // 
             this.FilterByAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByAuthorTextBox.Location = new System.Drawing.Point(362, 48);
+            this.FilterByAuthorTextBox.Location = new System.Drawing.Point(483, 59);
+            this.FilterByAuthorTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.FilterByAuthorTextBox.Name = "FilterByAuthorTextBox";
-            this.FilterByAuthorTextBox.Size = new System.Drawing.Size(124, 20);
+            this.FilterByAuthorTextBox.Size = new System.Drawing.Size(165, 22);
             this.FilterByAuthorTextBox.TabIndex = 10;
             this.FilterByAuthorTextBox.TextChanged += new System.EventHandler(this.FilterByAuthorTextBox_TextChanged);
             // 
@@ -972,9 +1041,10 @@ namespace CKAN
             // 
             this.FilterByAuthorLabel.AutoSize = true;
             this.FilterByAuthorLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByAuthorLabel.Location = new System.Drawing.Point(248, 50);
+            this.FilterByAuthorLabel.Location = new System.Drawing.Point(331, 62);
+            this.FilterByAuthorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.FilterByAuthorLabel.Name = "FilterByAuthorLabel";
-            this.FilterByAuthorLabel.Size = new System.Drawing.Size(108, 13);
+            this.FilterByAuthorLabel.Size = new System.Drawing.Size(146, 17);
             this.FilterByAuthorLabel.TabIndex = 11;
             this.FilterByAuthorLabel.Text = "Filter by author name:";
             // 
@@ -982,9 +1052,10 @@ namespace CKAN
             // 
             this.KSPVersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.KSPVersionLabel.AutoSize = true;
-            this.KSPVersionLabel.Location = new System.Drawing.Point(862, 10);
+            this.KSPVersionLabel.Location = new System.Drawing.Point(1149, 12);
+            this.KSPVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.KSPVersionLabel.Name = "KSPVersionLabel";
-            this.KSPVersionLabel.Size = new System.Drawing.Size(146, 13);
+            this.KSPVersionLabel.Size = new System.Drawing.Size(195, 17);
             this.KSPVersionLabel.TabIndex = 8;
             this.KSPVersionLabel.Text = "Kerbal Space Program 0.25.0";
             // 
@@ -992,37 +1063,41 @@ namespace CKAN
             // 
             this.FilterByNameLabel.AutoSize = true;
             this.FilterByNameLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByNameLabel.Location = new System.Drawing.Point(4, 50);
+            this.FilterByNameLabel.Location = new System.Drawing.Point(5, 62);
+            this.FilterByNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.FilterByNameLabel.Name = "FilterByNameLabel";
-            this.FilterByNameLabel.Size = new System.Drawing.Size(98, 13);
+            this.FilterByNameLabel.Size = new System.Drawing.Size(132, 17);
             this.FilterByNameLabel.TabIndex = 10;
             this.FilterByNameLabel.Text = "Filter by mod name:";
             // 
             // FilterByNameTextBox
             // 
             this.FilterByNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByNameTextBox.Location = new System.Drawing.Point(107, 48);
+            this.FilterByNameTextBox.Location = new System.Drawing.Point(143, 59);
+            this.FilterByNameTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.FilterByNameTextBox.Name = "FilterByNameTextBox";
-            this.FilterByNameTextBox.Size = new System.Drawing.Size(124, 20);
+            this.FilterByNameTextBox.Size = new System.Drawing.Size(165, 22);
             this.FilterByNameTextBox.TabIndex = 9;
             this.FilterByNameTextBox.TextChanged += new System.EventHandler(this.FilterByNameTextBox_TextChanged);
-            //
+            // 
             // FilterByDescriptionLabel
             // 
             this.FilterByDescriptionLabel.AutoSize = true;
             this.FilterByDescriptionLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByDescriptionLabel.Location = new System.Drawing.Point(503, 50);
+            this.FilterByDescriptionLabel.Location = new System.Drawing.Point(671, 62);
+            this.FilterByDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.FilterByDescriptionLabel.Name = "FilterByDescriptionLabel";
-            this.FilterByDescriptionLabel.Size = new System.Drawing.Size(93, 13);
+            this.FilterByDescriptionLabel.Size = new System.Drawing.Size(135, 17);
             this.FilterByDescriptionLabel.TabIndex = 10;
             this.FilterByDescriptionLabel.Text = "Filter by description:";
             // 
             // FilterByDescriptionTextBox
             // 
             this.FilterByDescriptionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByDescriptionTextBox.Location = new System.Drawing.Point(608, 48);
+            this.FilterByDescriptionTextBox.Location = new System.Drawing.Point(811, 59);
+            this.FilterByDescriptionTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.FilterByDescriptionTextBox.Name = "FilterByDescriptionTextBox";
-            this.FilterByDescriptionTextBox.Size = new System.Drawing.Size(124, 20);
+            this.FilterByDescriptionTextBox.Size = new System.Drawing.Size(165, 22);
             this.FilterByDescriptionTextBox.TabIndex = 9;
             this.FilterByDescriptionTextBox.TextChanged += new System.EventHandler(this.FilterByDescriptionTextBox_TextChanged);
             // 
@@ -1031,10 +1106,11 @@ namespace CKAN
             this.ChangesetTabPage.Controls.Add(this.CancelChangesButton);
             this.ChangesetTabPage.Controls.Add(this.ConfirmChangesButton);
             this.ChangesetTabPage.Controls.Add(this.ChangesListView);
-            this.ChangesetTabPage.Location = new System.Drawing.Point(4, 22);
+            this.ChangesetTabPage.Location = new System.Drawing.Point(4, 25);
+            this.ChangesetTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ChangesetTabPage.Name = "ChangesetTabPage";
-            this.ChangesetTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.ChangesetTabPage.Size = new System.Drawing.Size(1021, 646);
+            this.ChangesetTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.ChangesetTabPage.Size = new System.Drawing.Size(1364, 805);
             this.ChangesetTabPage.TabIndex = 2;
             this.ChangesetTabPage.Text = "Changeset";
             this.ChangesetTabPage.UseVisualStyleBackColor = true;
@@ -1043,9 +1119,10 @@ namespace CKAN
             // 
             this.CancelChangesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelChangesButton.Location = new System.Drawing.Point(859, 617);
+            this.CancelChangesButton.Location = new System.Drawing.Point(1145, 759);
+            this.CancelChangesButton.Margin = new System.Windows.Forms.Padding(4);
             this.CancelChangesButton.Name = "CancelChangesButton";
-            this.CancelChangesButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelChangesButton.Size = new System.Drawing.Size(100, 28);
             this.CancelChangesButton.TabIndex = 6;
             this.CancelChangesButton.Text = "Clear";
             this.CancelChangesButton.UseVisualStyleBackColor = true;
@@ -1055,9 +1132,10 @@ namespace CKAN
             // 
             this.ConfirmChangesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ConfirmChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ConfirmChangesButton.Location = new System.Drawing.Point(940, 617);
+            this.ConfirmChangesButton.Location = new System.Drawing.Point(1253, 759);
+            this.ConfirmChangesButton.Margin = new System.Windows.Forms.Padding(4);
             this.ConfirmChangesButton.Name = "ConfirmChangesButton";
-            this.ConfirmChangesButton.Size = new System.Drawing.Size(75, 23);
+            this.ConfirmChangesButton.Size = new System.Drawing.Size(100, 28);
             this.ConfirmChangesButton.TabIndex = 5;
             this.ConfirmChangesButton.Text = " Apply";
             this.ConfirmChangesButton.UseVisualStyleBackColor = true;
@@ -1075,8 +1153,9 @@ namespace CKAN
             this.Reason});
             this.ChangesListView.FullRowSelect = true;
             this.ChangesListView.Location = new System.Drawing.Point(-1, 0);
+            this.ChangesListView.Margin = new System.Windows.Forms.Padding(4);
             this.ChangesListView.Name = "ChangesListView";
-            this.ChangesListView.Size = new System.Drawing.Size(1022, 611);
+            this.ChangesListView.Size = new System.Drawing.Size(1362, 752);
             this.ChangesListView.TabIndex = 4;
             this.ChangesListView.UseCompatibleStateImageBehavior = false;
             this.ChangesListView.View = System.Windows.Forms.View.Details;
@@ -1103,10 +1182,11 @@ namespace CKAN
             this.WaitTabPage.Controls.Add(this.LogTextBox);
             this.WaitTabPage.Controls.Add(this.DialogProgressBar);
             this.WaitTabPage.Controls.Add(this.MessageTextBox);
-            this.WaitTabPage.Location = new System.Drawing.Point(4, 22);
+            this.WaitTabPage.Location = new System.Drawing.Point(4, 25);
+            this.WaitTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.WaitTabPage.Name = "WaitTabPage";
-            this.WaitTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.WaitTabPage.Size = new System.Drawing.Size(1021, 646);
+            this.WaitTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.WaitTabPage.Size = new System.Drawing.Size(1364, 805);
             this.WaitTabPage.TabIndex = 1;
             this.WaitTabPage.Text = "Status log";
             // 
@@ -1114,9 +1194,10 @@ namespace CKAN
             // 
             this.CancelCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelCurrentActionButton.Location = new System.Drawing.Point(940, 618);
+            this.CancelCurrentActionButton.Location = new System.Drawing.Point(1253, 761);
+            this.CancelCurrentActionButton.Margin = new System.Windows.Forms.Padding(4);
             this.CancelCurrentActionButton.Name = "CancelCurrentActionButton";
-            this.CancelCurrentActionButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelCurrentActionButton.Size = new System.Drawing.Size(100, 28);
             this.CancelCurrentActionButton.TabIndex = 9;
             this.CancelCurrentActionButton.Text = "Cancel";
             this.CancelCurrentActionButton.UseVisualStyleBackColor = true;
@@ -1128,21 +1209,23 @@ namespace CKAN
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.LogTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.LogTextBox.Location = new System.Drawing.Point(9, 58);
+            this.LogTextBox.Location = new System.Drawing.Point(12, 71);
+            this.LogTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.LogTextBox.Multiline = true;
             this.LogTextBox.Name = "LogTextBox";
             this.LogTextBox.ReadOnly = true;
             this.LogTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.LogTextBox.Size = new System.Drawing.Size(1004, 554);
+            this.LogTextBox.Size = new System.Drawing.Size(1338, 681);
             this.LogTextBox.TabIndex = 8;
             // 
             // DialogProgressBar
             // 
             this.DialogProgressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.DialogProgressBar.Location = new System.Drawing.Point(9, 29);
+            this.DialogProgressBar.Location = new System.Drawing.Point(12, 36);
+            this.DialogProgressBar.Margin = new System.Windows.Forms.Padding(4);
             this.DialogProgressBar.Name = "DialogProgressBar";
-            this.DialogProgressBar.Size = new System.Drawing.Size(1004, 23);
+            this.DialogProgressBar.Size = new System.Drawing.Size(1339, 28);
             this.DialogProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
             this.DialogProgressBar.TabIndex = 7;
             // 
@@ -1153,11 +1236,12 @@ namespace CKAN
             this.MessageTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.MessageTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.MessageTextBox.Enabled = false;
-            this.MessageTextBox.Location = new System.Drawing.Point(8, 6);
+            this.MessageTextBox.Location = new System.Drawing.Point(11, 7);
+            this.MessageTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.MessageTextBox.Multiline = true;
             this.MessageTextBox.Name = "MessageTextBox";
             this.MessageTextBox.ReadOnly = true;
-            this.MessageTextBox.Size = new System.Drawing.Size(1007, 17);
+            this.MessageTextBox.Size = new System.Drawing.Size(1343, 21);
             this.MessageTextBox.TabIndex = 6;
             this.MessageTextBox.Text = "Waiting for operation to complete";
             this.MessageTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
@@ -1169,10 +1253,11 @@ namespace CKAN
             this.ChooseRecommendedModsTabPage.Controls.Add(this.RecommendedModsToggleCheckbox);
             this.ChooseRecommendedModsTabPage.Controls.Add(this.RecommendedDialogLabel);
             this.ChooseRecommendedModsTabPage.Controls.Add(this.RecommendedModsListView);
-            this.ChooseRecommendedModsTabPage.Location = new System.Drawing.Point(4, 22);
+            this.ChooseRecommendedModsTabPage.Location = new System.Drawing.Point(4, 25);
+            this.ChooseRecommendedModsTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ChooseRecommendedModsTabPage.Name = "ChooseRecommendedModsTabPage";
-            this.ChooseRecommendedModsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.ChooseRecommendedModsTabPage.Size = new System.Drawing.Size(1021, 646);
+            this.ChooseRecommendedModsTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.ChooseRecommendedModsTabPage.Size = new System.Drawing.Size(1364, 805);
             this.ChooseRecommendedModsTabPage.TabIndex = 3;
             this.ChooseRecommendedModsTabPage.Text = "Choose recommended mods";
             this.ChooseRecommendedModsTabPage.UseVisualStyleBackColor = true;
@@ -1181,9 +1266,10 @@ namespace CKAN
             // 
             this.RecommendedModsCancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RecommendedModsCancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsCancelButton.Location = new System.Drawing.Point(859, 617);
+            this.RecommendedModsCancelButton.Location = new System.Drawing.Point(1145, 759);
+            this.RecommendedModsCancelButton.Margin = new System.Windows.Forms.Padding(4);
             this.RecommendedModsCancelButton.Name = "RecommendedModsCancelButton";
-            this.RecommendedModsCancelButton.Size = new System.Drawing.Size(75, 23);
+            this.RecommendedModsCancelButton.Size = new System.Drawing.Size(100, 28);
             this.RecommendedModsCancelButton.TabIndex = 8;
             this.RecommendedModsCancelButton.Text = "Cancel";
             this.RecommendedModsCancelButton.UseVisualStyleBackColor = true;
@@ -1193,9 +1279,10 @@ namespace CKAN
             // 
             this.RecommendedModsContinueButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RecommendedModsContinueButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsContinueButton.Location = new System.Drawing.Point(940, 617);
+            this.RecommendedModsContinueButton.Location = new System.Drawing.Point(1253, 759);
+            this.RecommendedModsContinueButton.Margin = new System.Windows.Forms.Padding(4);
             this.RecommendedModsContinueButton.Name = "RecommendedModsContinueButton";
-            this.RecommendedModsContinueButton.Size = new System.Drawing.Size(75, 23);
+            this.RecommendedModsContinueButton.Size = new System.Drawing.Size(100, 28);
             this.RecommendedModsContinueButton.TabIndex = 7;
             this.RecommendedModsContinueButton.Text = "Continue";
             this.RecommendedModsContinueButton.UseVisualStyleBackColor = true;
@@ -1206,9 +1293,10 @@ namespace CKAN
             this.RecommendedModsToggleCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.RecommendedModsToggleCheckbox.AutoSize = true;
             this.RecommendedModsToggleCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsToggleCheckbox.Location = new System.Drawing.Point(8, 620);
+            this.RecommendedModsToggleCheckbox.Location = new System.Drawing.Point(11, 763);
+            this.RecommendedModsToggleCheckbox.Margin = new System.Windows.Forms.Padding(4);
             this.RecommendedModsToggleCheckbox.Name = "RecommendedModsToggleCheckbox";
-            this.RecommendedModsToggleCheckbox.Size = new System.Drawing.Size(92, 17);
+            this.RecommendedModsToggleCheckbox.Size = new System.Drawing.Size(117, 21);
             this.RecommendedModsToggleCheckbox.TabIndex = 9;
             this.RecommendedModsToggleCheckbox.Text = "Toggle * Mods";
             this.RecommendedModsToggleCheckbox.UseVisualStyleBackColor = true;
@@ -1217,9 +1305,10 @@ namespace CKAN
             // RecommendedDialogLabel
             // 
             this.RecommendedDialogLabel.AutoSize = true;
-            this.RecommendedDialogLabel.Location = new System.Drawing.Point(3, 13);
+            this.RecommendedDialogLabel.Location = new System.Drawing.Point(4, 16);
+            this.RecommendedDialogLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.RecommendedDialogLabel.Name = "RecommendedDialogLabel";
-            this.RecommendedDialogLabel.Size = new System.Drawing.Size(422, 13);
+            this.RecommendedDialogLabel.Size = new System.Drawing.Size(564, 17);
             this.RecommendedDialogLabel.TabIndex = 6;
             this.RecommendedDialogLabel.Text = "The following modules have been recommended by one or more of the chosen modules:" +
     "";
@@ -1236,9 +1325,10 @@ namespace CKAN
             this.columnHeader4,
             this.columnHeader5});
             this.RecommendedModsListView.FullRowSelect = true;
-            this.RecommendedModsListView.Location = new System.Drawing.Point(6, 29);
+            this.RecommendedModsListView.Location = new System.Drawing.Point(8, 36);
+            this.RecommendedModsListView.Margin = new System.Windows.Forms.Padding(4);
             this.RecommendedModsListView.Name = "RecommendedModsListView";
-            this.RecommendedModsListView.Size = new System.Drawing.Size(1007, 582);
+            this.RecommendedModsListView.Size = new System.Drawing.Size(1342, 716);
             this.RecommendedModsListView.TabIndex = 5;
             this.RecommendedModsListView.UseCompatibleStateImageBehavior = false;
             this.RecommendedModsListView.View = System.Windows.Forms.View.Details;
@@ -1264,10 +1354,11 @@ namespace CKAN
             this.ChooseProvidedModsTabPage.Controls.Add(this.ChooseProvidedModsContinueButton);
             this.ChooseProvidedModsTabPage.Controls.Add(this.ChooseProvidedModsListView);
             this.ChooseProvidedModsTabPage.Controls.Add(this.ChooseProvidedModsLabel);
-            this.ChooseProvidedModsTabPage.Location = new System.Drawing.Point(4, 22);
+            this.ChooseProvidedModsTabPage.Location = new System.Drawing.Point(4, 25);
+            this.ChooseProvidedModsTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ChooseProvidedModsTabPage.Name = "ChooseProvidedModsTabPage";
-            this.ChooseProvidedModsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.ChooseProvidedModsTabPage.Size = new System.Drawing.Size(1021, 646);
+            this.ChooseProvidedModsTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.ChooseProvidedModsTabPage.Size = new System.Drawing.Size(1364, 805);
             this.ChooseProvidedModsTabPage.TabIndex = 4;
             this.ChooseProvidedModsTabPage.Text = "Choose mods";
             this.ChooseProvidedModsTabPage.UseVisualStyleBackColor = true;
@@ -1276,9 +1367,10 @@ namespace CKAN
             // 
             this.ChooseProvidedModsCancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ChooseProvidedModsCancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChooseProvidedModsCancelButton.Location = new System.Drawing.Point(857, 616);
+            this.ChooseProvidedModsCancelButton.Location = new System.Drawing.Point(1143, 758);
+            this.ChooseProvidedModsCancelButton.Margin = new System.Windows.Forms.Padding(4);
             this.ChooseProvidedModsCancelButton.Name = "ChooseProvidedModsCancelButton";
-            this.ChooseProvidedModsCancelButton.Size = new System.Drawing.Size(75, 23);
+            this.ChooseProvidedModsCancelButton.Size = new System.Drawing.Size(100, 28);
             this.ChooseProvidedModsCancelButton.TabIndex = 10;
             this.ChooseProvidedModsCancelButton.Text = "Cancel";
             this.ChooseProvidedModsCancelButton.UseVisualStyleBackColor = true;
@@ -1288,9 +1380,10 @@ namespace CKAN
             // 
             this.ChooseProvidedModsContinueButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ChooseProvidedModsContinueButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChooseProvidedModsContinueButton.Location = new System.Drawing.Point(938, 616);
+            this.ChooseProvidedModsContinueButton.Location = new System.Drawing.Point(1251, 758);
+            this.ChooseProvidedModsContinueButton.Margin = new System.Windows.Forms.Padding(4);
             this.ChooseProvidedModsContinueButton.Name = "ChooseProvidedModsContinueButton";
-            this.ChooseProvidedModsContinueButton.Size = new System.Drawing.Size(75, 23);
+            this.ChooseProvidedModsContinueButton.Size = new System.Drawing.Size(100, 28);
             this.ChooseProvidedModsContinueButton.TabIndex = 9;
             this.ChooseProvidedModsContinueButton.Text = "Continue";
             this.ChooseProvidedModsContinueButton.UseVisualStyleBackColor = true;
@@ -1308,10 +1401,11 @@ namespace CKAN
             this.columnHeader8});
             this.ChooseProvidedModsListView.FullRowSelect = true;
             this.ChooseProvidedModsListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.ChooseProvidedModsListView.Location = new System.Drawing.Point(6, 28);
+            this.ChooseProvidedModsListView.Location = new System.Drawing.Point(8, 34);
+            this.ChooseProvidedModsListView.Margin = new System.Windows.Forms.Padding(4);
             this.ChooseProvidedModsListView.MultiSelect = false;
             this.ChooseProvidedModsListView.Name = "ChooseProvidedModsListView";
-            this.ChooseProvidedModsListView.Size = new System.Drawing.Size(1007, 582);
+            this.ChooseProvidedModsListView.Size = new System.Drawing.Size(1342, 716);
             this.ChooseProvidedModsListView.TabIndex = 8;
             this.ChooseProvidedModsListView.UseCompatibleStateImageBehavior = false;
             this.ChooseProvidedModsListView.View = System.Windows.Forms.View.Details;
@@ -1329,24 +1423,18 @@ namespace CKAN
             // ChooseProvidedModsLabel
             // 
             this.ChooseProvidedModsLabel.AutoSize = true;
-            this.ChooseProvidedModsLabel.Location = new System.Drawing.Point(6, 12);
+            this.ChooseProvidedModsLabel.Location = new System.Drawing.Point(8, 15);
+            this.ChooseProvidedModsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ChooseProvidedModsLabel.Name = "ChooseProvidedModsLabel";
-            this.ChooseProvidedModsLabel.Size = new System.Drawing.Size(383, 13);
+            this.ChooseProvidedModsLabel.Size = new System.Drawing.Size(511, 17);
             this.ChooseProvidedModsLabel.TabIndex = 7;
             this.ChooseProvidedModsLabel.Text = "Several mods provide the virtual module Foo, choose one of the following mods:";
             // 
-            // cachedToolStripMenuItem
-            // 
-            this.cachedToolStripMenuItem.Name = "cachedToolStripMenuItem";
-            this.cachedToolStripMenuItem.Size = new System.Drawing.Size(215, 22);
-            this.cachedToolStripMenuItem.Text = "Cached";
-            this.cachedToolStripMenuItem.Click += new System.EventHandler(this.cachedToolStripMenuItem_Click);
-            // 
             // Main
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1029, 718);
+            this.ClientSize = new System.Drawing.Size(1372, 884);
             this.Controls.Add(this.MainTabControl);
             this.Controls.Add(this.StatusPanel);
             this.Controls.Add(this.statusStrip1);
@@ -1354,7 +1442,8 @@ namespace CKAN
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
             this.MainMenuStrip = this.menuStrip1;
-            this.MinimumSize = new System.Drawing.Size(878, 664);
+            this.Margin = new System.Windows.Forms.Padding(4);
+            this.MinimumSize = new System.Drawing.Size(1165, 806);
             this.Name = "Main";
             this.Text = "CKAN-GUI";
             this.menuStrip1.ResumeLayout(false);
@@ -1481,12 +1570,10 @@ namespace CKAN
         private RichTextBox MetadataModuleAbstractLabel;
         private ToolStripMenuItem pluginsToolStripMenuItem;
         public ToolStripMenuItem settingsToolStripMenuItem;
-        private ToolStripMenuItem installFromckanToolStripMenuItem;
         private TextBox FilterByAuthorTextBox;
         private Label FilterByAuthorLabel;
         private ToolStripMenuItem FilterAllButton;
         private ToolStripSeparator toolStripSeparator1;
-        private ToolStripMenuItem exportModListToolStripMenuItem;
         private ToolStripMenuItem selectKSPInstallMenuItem;
         private ToolStripMenuItem openKspDirectoryToolStripMenuItem;
         private SplitContainer splitContainer2;
@@ -1505,5 +1592,9 @@ namespace CKAN
         private ToolStripMenuItem cachedToolStripMenuItem;
         private Label IdentifierLabel;
         private Label MetadataIdentifierLabel;
+        private ToolStripSeparator toolStripMenuItem1;
+        private ToolStripMenuItem ckanModListsToolStripMenuItem;
+        private ToolStripMenuItem importToolStripMenuItem;
+        private ToolStripMenuItem exportCurrentSetToolStripMenuItem;
     }
 }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -902,6 +902,7 @@ namespace CKAN
                     }
                 }
                 UpdateChangesetPrecomputed(changeset);
+                m_TabController.ShowTab("ChangesetTabPage");
             }
         }
 
@@ -988,6 +989,7 @@ namespace CKAN
                     }
                 }
                 UpdateChangesetPrecomputed(cc);
+                m_TabController.ShowTab("ChangesetTabPage");
             }
         }
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -888,6 +888,19 @@ namespace CKAN
             if (module != null)
             {
                 var changeset = ComputeImportChangeset(module);
+                if (!changeset.Any())
+                {
+                    MessageBox.Show("You are already using the mods listed in the mod list.", "CKAN Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
+                if (ChangeSet != null && ChangeSet.Any())
+                {
+                    DialogResult dialogResult = MessageBox.Show("Your current changeset is not empty. If you proceed, your changes will be lost.", "CKAN Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                    if (dialogResult == DialogResult.Cancel)
+                    {
+                        return;
+                    }
+                }
                 UpdateChangesetPrecomputed(changeset);
             }
         }
@@ -961,6 +974,19 @@ namespace CKAN
                 var cc = ComputeCleanupChangeset(module);
                 var ic = ComputeImportChangeset(module);
                 cc.UnionWith(ic);
+                if (!cc.Any())
+                {
+                    MessageBox.Show("You are already using the specified mod list.", "CKAN Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
+                if (ChangeSet != null && ChangeSet.Any())
+                {
+                    DialogResult dialogResult = MessageBox.Show("Your current changeset is not empty. If you proceed, your changes will be lost.", "CKAN Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                    if (dialogResult == DialogResult.Cancel)
+                    {
+                        return;
+                    }
+                }
                 UpdateChangesetPrecomputed(cc);
             }
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -888,6 +888,7 @@ namespace CKAN
             if (module != null)
             {
                 var changeset = ComputeImportChangeset(module);
+                ApplyChangesetWithoutRecommends(changeset);
             }
         }
 
@@ -957,9 +958,8 @@ namespace CKAN
             CkanModule module = GetCkanModuleFromFile();
             if (module != null)
             {
-                var cc = ComputeCleanupChangeset(module);
-                var ic = ComputeImportChangeset(module);
-                cc.UnionWith(ic);
+                var changeset = ComputeSwitchChangeset(module);
+                ApplyChangesetWithoutRecommends(changeset);
             }
         }
 
@@ -1010,6 +1010,7 @@ namespace CKAN
             }
         }
 
+        private async void ApplyChangesetWithoutRecommends(HashSet<ModChange> changeset)
         {
             IEnumerable<ModChange> full_change_set = null;
             Dictionary<GUIMod, string> new_conflicts = null;
@@ -1055,6 +1056,41 @@ namespace CKAN
             registry_manager.registry.AddAvailable(module);
 
             var changeset = new HashSet<ModChange>();
+            changeset.Add(new ModChange(
+                new GUIMod(module, registry_manager.registry, CurrentInstance.Version()),
+                GUIModChangeType.Install, null));
+            return changeset;
+        }
+
+        private HashSet<ModChange> ComputeSwitchChangeset(CkanModule module)
+        {
+            RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
+            registry_manager.registry.RemoveAvailable(module);
+            registry_manager.registry.AddAvailable(module);
+
+            var changeset = new HashSet<ModChange>();
+            foreach (InstalledModule im in registry_manager.registry.InstalledModules)
+            {
+                bool keep = false;
+                if (module.recommends != null)
+                    foreach (RelationshipDescriptor rel in module.recommends)
+                    {
+                        if (rel.name == im.identifier) keep = true;
+                    }
+                if (module.depends != null)
+                {
+                    foreach (RelationshipDescriptor rel in module.depends)
+                    {
+                        if (rel.name == im.identifier) keep = true;
+                    }
+                }
+                if (!keep)
+                {
+                    changeset.Add(new ModChange(
+                        new GUIMod(im.Module, registry_manager.registry, CurrentInstance.Version()),
+                        GUIModChangeType.Remove, null));
+                }
+            }
             if (module.recommends != null)
             {
                 foreach (var rel in module.recommends)
@@ -1117,38 +1153,6 @@ namespace CKAN
                             log.WarnFormat("Required module {0} not found in registry.", rel.name);
                         }
                     }
-                }
-            }
-            return changeset;
-        }
-
-        private HashSet<ModChange> ComputeCleanupChangeset(CkanModule module)
-        {
-            RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
-            registry_manager.registry.RemoveAvailable(module);
-            registry_manager.registry.AddAvailable(module);
-
-            var changeset = new HashSet<ModChange>();
-            foreach (InstalledModule im in registry_manager.registry.InstalledModules)
-            {
-                bool keep = false;
-                if (module.recommends != null)
-                    foreach (RelationshipDescriptor rel in module.recommends)
-                    {
-                        if (rel.name == im.identifier) keep = true;
-                    }
-                if (module.depends != null)
-                {
-                    foreach (RelationshipDescriptor rel in module.depends)
-                    {
-                        if (rel.name == im.identifier) keep = true;
-                    }
-                }
-                if (!keep)
-                {
-                    changeset.Add(new ModChange(
-                        new GUIMod(im.Module, registry_manager.registry, CurrentInstance.Version()),
-                        GUIModChangeType.Remove, null));
                 }
             }
             return changeset;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -888,7 +888,6 @@ namespace CKAN
             if (module != null)
             {
                 var changeset = ComputeImportChangeset(module);
-                ApplyChangesetWithoutRecommends(changeset);
             }
         }
 
@@ -958,8 +957,9 @@ namespace CKAN
             CkanModule module = GetCkanModuleFromFile();
             if (module != null)
             {
-                var changeset = ComputeSwitchChangeset(module);
-                ApplyChangesetWithoutRecommends(changeset);
+                var cc = ComputeCleanupChangeset(module);
+                var ic = ComputeImportChangeset(module);
+                cc.UnionWith(ic);
             }
         }
 
@@ -1010,7 +1010,6 @@ namespace CKAN
             }
         }
 
-        private async void ApplyChangesetWithoutRecommends(HashSet<ModChange> changeset)
         {
             IEnumerable<ModChange> full_change_set = null;
             Dictionary<GUIMod, string> new_conflicts = null;
@@ -1056,41 +1055,6 @@ namespace CKAN
             registry_manager.registry.AddAvailable(module);
 
             var changeset = new HashSet<ModChange>();
-            changeset.Add(new ModChange(
-                new GUIMod(module, registry_manager.registry, CurrentInstance.Version()),
-                GUIModChangeType.Install, null));
-            return changeset;
-        }
-
-        private HashSet<ModChange> ComputeSwitchChangeset(CkanModule module)
-        {
-            RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
-            registry_manager.registry.RemoveAvailable(module);
-            registry_manager.registry.AddAvailable(module);
-
-            var changeset = new HashSet<ModChange>();
-            foreach (InstalledModule im in registry_manager.registry.InstalledModules)
-            {
-                bool keep = false;
-                if (module.recommends != null)
-                    foreach (RelationshipDescriptor rel in module.recommends)
-                    {
-                        if (rel.name == im.identifier) keep = true;
-                    }
-                if (module.depends != null)
-                {
-                    foreach (RelationshipDescriptor rel in module.depends)
-                    {
-                        if (rel.name == im.identifier) keep = true;
-                    }
-                }
-                if (!keep)
-                {
-                    changeset.Add(new ModChange(
-                        new GUIMod(im.Module, registry_manager.registry, CurrentInstance.Version()),
-                        GUIModChangeType.Remove, null));
-                }
-            }
             if (module.recommends != null)
             {
                 foreach (var rel in module.recommends)
@@ -1153,6 +1117,38 @@ namespace CKAN
                             log.WarnFormat("Required module {0} not found in registry.", rel.name);
                         }
                     }
+                }
+            }
+            return changeset;
+        }
+
+        private HashSet<ModChange> ComputeCleanupChangeset(CkanModule module)
+        {
+            RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
+            registry_manager.registry.RemoveAvailable(module);
+            registry_manager.registry.AddAvailable(module);
+
+            var changeset = new HashSet<ModChange>();
+            foreach (InstalledModule im in registry_manager.registry.InstalledModules)
+            {
+                bool keep = false;
+                if (module.recommends != null)
+                    foreach (RelationshipDescriptor rel in module.recommends)
+                    {
+                        if (rel.name == im.identifier) keep = true;
+                    }
+                if (module.depends != null)
+                {
+                    foreach (RelationshipDescriptor rel in module.depends)
+                    {
+                        if (rel.name == im.identifier) keep = true;
+                    }
+                }
+                if (!keep)
+                {
+                    changeset.Add(new ModChange(
+                        new GUIMod(im.Module, registry_manager.registry, CurrentInstance.Version()),
+                        GUIModChangeType.Remove, null));
                 }
             }
             return changeset;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -882,40 +882,13 @@ namespace CKAN
             Enabled = true;
         }
 
-
-
         private void importToolStripMenuItem_Click(object sender, EventArgs e)
         {
             CkanModule module = GetCkanModuleFromFile();
-
             if (module != null)
             {
-                // We'll need to make some registry changes to do this.
-                RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
-
-                // Remove this version of the module in the registry, if it exists.
-                registry_manager.registry.RemoveAvailable(module);
-
-                // Sneakily add our version in...
-                registry_manager.registry.AddAvailable(module);
-
-                var changeset = new List<ModChange>();
-                changeset.Add(new ModChange(
-                    new GUIMod(module,registry_manager.registry,CurrentInstance.Version()),
-                    GUIModChangeType.Install, null));
-
-                menuStrip1.Enabled = false;
-
-                RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
-                install_ops.with_recommends = false;
-
-                m_InstallWorker.RunWorkerAsync(
-                    new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                        changeset, install_ops));
-                m_Changeset = null;
-
-                UpdateChangesDialog(null, m_InstallWorker);
-                ShowWaitDialog();
+                var changeset = ComputeImportChangeset(module);
+                ApplyChangesetWithoutRecommends(changeset);
             }
         }
 
@@ -983,57 +956,10 @@ namespace CKAN
         private void switchToToolStripMenuItem_Click(object sender, EventArgs e)
         {
             CkanModule module = GetCkanModuleFromFile();
-
             if (module != null)
             {
-                // We'll need to make some registry changes to do this.
-                RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
-
-                // Remove this version of the module in the registry, if it exists.
-                registry_manager.registry.RemoveAvailable(module);
-
-                // Sneakily add our version in...
-                registry_manager.registry.AddAvailable(module);
-
-                var changeset = new List<ModChange>();
-                foreach (InstalledModule im in registry_manager.registry.InstalledModules)
-                {
-                    bool keep = false;
-                    if (module.recommends != null)
-                        foreach (RelationshipDescriptor rel in module.recommends)
-                        {
-                            if (rel.name == im.identifier) keep = true;
-                        }
-                    if (module.depends != null)
-                    {
-                        foreach (RelationshipDescriptor rel in module.depends)
-                        {
-                            if (rel.name == im.identifier) keep = true;
-                        }
-                    }
-                    if (!keep)
-                    {
-                        changeset.Add(new ModChange(
-                            new GUIMod(im.Module, registry_manager.registry, CurrentInstance.Version()),
-                            GUIModChangeType.Remove, null));
-                    }
-                }
-                changeset.Add(new ModChange(
-                    new GUIMod(module, registry_manager.registry, CurrentInstance.Version()),
-                    GUIModChangeType.Install, null));
-
-                menuStrip1.Enabled = false;
-
-                RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
-                install_ops.with_recommends = false;
-
-                m_InstallWorker.RunWorkerAsync(
-                    new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                        changeset, install_ops));
-                m_Changeset = null;
-
-                UpdateChangesDialog(null, m_InstallWorker);
-                ShowWaitDialog();
+                var changeset = ComputeSwitchChangeset(module);
+                ApplyChangesetWithoutRecommends(changeset);
             }
         }
 
@@ -1085,6 +1011,70 @@ namespace CKAN
                 m_User.RaiseError(ex.Message);
                 return null;
             }
+        }
+
+        private void ApplyChangesetWithoutRecommends(List<ModChange> changeset)
+        {
+            menuStrip1.Enabled = false;
+
+            RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
+            install_ops.with_recommends = false;
+
+            m_InstallWorker.RunWorkerAsync(
+                new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
+                    changeset, install_ops));
+            m_Changeset = null;
+
+            UpdateChangesDialog(null, m_InstallWorker);
+            ShowWaitDialog();
+        }
+
+        private List<ModChange> ComputeImportChangeset(CkanModule module)
+        {
+            RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
+            registry_manager.registry.RemoveAvailable(module);
+            registry_manager.registry.AddAvailable(module);
+
+            var changeset = new List<ModChange>();
+            changeset.Add(new ModChange(
+                new GUIMod(module, registry_manager.registry, CurrentInstance.Version()),
+                GUIModChangeType.Install, null));
+            return changeset;
+        }
+
+        private List<ModChange> ComputeSwitchChangeset(CkanModule module)
+        {
+            RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
+            registry_manager.registry.RemoveAvailable(module);
+            registry_manager.registry.AddAvailable(module);
+
+            var changeset = new List<ModChange>();
+            foreach (InstalledModule im in registry_manager.registry.InstalledModules)
+            {
+                bool keep = false;
+                if (module.recommends != null)
+                    foreach (RelationshipDescriptor rel in module.recommends)
+                    {
+                        if (rel.name == im.identifier) keep = true;
+                    }
+                if (module.depends != null)
+                {
+                    foreach (RelationshipDescriptor rel in module.depends)
+                    {
+                        if (rel.name == im.identifier) keep = true;
+                    }
+                }
+                if (!keep)
+                {
+                    changeset.Add(new ModChange(
+                        new GUIMod(im.Module, registry_manager.registry, CurrentInstance.Version()),
+                        GUIModChangeType.Remove, null));
+                }
+            }
+            changeset.Add(new ModChange(
+                new GUIMod(module, registry_manager.registry, CurrentInstance.Version()),
+                GUIModChangeType.Install, null));
+            return changeset;
         }
 
         private void FocusMod(string key, bool exactMatch, bool showAsFirst=false)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -884,7 +884,7 @@ namespace CKAN
 
 
 
-        private void installFromckanToolStripMenuItem_Click(object sender, EventArgs e)
+        private void importToolStripMenuItem_Click(object sender, EventArgs e)
         {
             OpenFileDialog open_file_dialog = new OpenFileDialog {Filter = Resources.CKANFileFilter};
 
@@ -942,7 +942,7 @@ namespace CKAN
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void exportModListToolStripMenuItem_Click(object sender, EventArgs e)
+        private void exportCurrentSetToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var exportOptions = new List<ExportOption>
             {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -886,28 +886,10 @@ namespace CKAN
 
         private void importToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            OpenFileDialog open_file_dialog = new OpenFileDialog {Filter = Resources.CKANFileFilter};
+            CkanModule module = GetCkanModuleFromFile();
 
-            if (open_file_dialog.ShowDialog() == DialogResult.OK)
+            if (module != null)
             {
-                var path = open_file_dialog.FileName;
-                CkanModule module;
-
-                try
-                {
-                    module = CkanModule.FromFile(path);
-                }
-                catch (Kraken kraken)
-                {
-                    m_User.RaiseError(kraken.Message + ": " + kraken.InnerException.Message);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    m_User.RaiseError(ex.Message);
-                    return;
-                }
-
                 // We'll need to make some registry changes to do this.
                 RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
 
@@ -1000,28 +982,10 @@ namespace CKAN
 
         private void switchToToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            OpenFileDialog open_file_dialog = new OpenFileDialog { Filter = Resources.CKANFileFilter };
+            CkanModule module = GetCkanModuleFromFile();
 
-            if (open_file_dialog.ShowDialog() == DialogResult.OK)
+            if (module != null)
             {
-                var path = open_file_dialog.FileName;
-                CkanModule module;
-
-                try
-                {
-                    module = CkanModule.FromFile(path);
-                }
-                catch (Kraken kraken)
-                {
-                    m_User.RaiseError(kraken.Message + ": " + kraken.InnerException.Message);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    m_User.RaiseError(ex.Message);
-                    return;
-                }
-
                 // We'll need to make some registry changes to do this.
                 RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
 
@@ -1085,6 +1049,35 @@ namespace CKAN
             FilterByNameTextBox.Text = "";
             mainModList.ModNameFilter = "";
             FocusMod(e.Node.Name, true);
+        }
+
+        private CkanModule GetCkanModuleFromFile()
+        {
+            OpenFileDialog open_file_dialog = new OpenFileDialog { Filter = Resources.CKANFileFilter };
+
+            if (open_file_dialog.ShowDialog() != DialogResult.OK)
+            {
+                return null;
+            }
+
+            var path = open_file_dialog.FileName;
+            CkanModule module;
+
+            try
+            {
+                module = CkanModule.FromFile(path);
+                return module;
+            }
+            catch (Kraken kraken)
+            {
+                m_User.RaiseError(kraken.Message + ": " + kraken.InnerException.Message);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                m_User.RaiseError(ex.Message);
+                return null;
+            }
         }
 
         private void FocusMod(string key, bool exactMatch, bool showAsFirst=false)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -987,18 +987,15 @@ namespace CKAN
         private CkanModule GetCkanModuleFromFile()
         {
             OpenFileDialog open_file_dialog = new OpenFileDialog { Filter = Resources.CKANFileFilter };
-
             if (open_file_dialog.ShowDialog() != DialogResult.OK)
             {
                 return null;
             }
 
             var path = open_file_dialog.FileName;
-            CkanModule module;
-
             try
             {
-                module = CkanModule.FromFile(path);
+                CkanModule module = CkanModule.FromFile(path);
                 return module;
             }
             catch (Kraken kraken)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1004,6 +1004,13 @@ namespace CKAN
                         {
                             if (rel.name == im.identifier) keep = true;
                         }
+                    if (module.depends != null)
+                    {
+                        foreach (RelationshipDescriptor rel in module.depends)
+                        {
+                            if (rel.name == im.identifier) keep = true;
+                        }
+                    }
                     if (!keep)
                     {
                         changeset.Add(new ModChange(

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -998,6 +998,74 @@ namespace CKAN
             }
         }
 
+        private void switchToToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog open_file_dialog = new OpenFileDialog { Filter = Resources.CKANFileFilter };
+
+            if (open_file_dialog.ShowDialog() == DialogResult.OK)
+            {
+                var path = open_file_dialog.FileName;
+                CkanModule module;
+
+                try
+                {
+                    module = CkanModule.FromFile(path);
+                }
+                catch (Kraken kraken)
+                {
+                    m_User.RaiseError(kraken.Message + ": " + kraken.InnerException.Message);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    m_User.RaiseError(ex.Message);
+                    return;
+                }
+
+                // We'll need to make some registry changes to do this.
+                RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
+
+                // Remove this version of the module in the registry, if it exists.
+                registry_manager.registry.RemoveAvailable(module);
+
+                // Sneakily add our version in...
+                registry_manager.registry.AddAvailable(module);
+
+                var changeset = new List<ModChange>();
+                foreach (InstalledModule im in registry_manager.registry.InstalledModules)
+                {
+                    bool keep = false;
+                    if (module.recommends != null)
+                        foreach (RelationshipDescriptor rel in module.recommends)
+                        {
+                            if (rel.name == im.identifier) keep = true;
+                        }
+                    if (!keep)
+                    {
+                        changeset.Add(new ModChange(
+                            new GUIMod(im.Module, registry_manager.registry, CurrentInstance.Version()),
+                            GUIModChangeType.Remove, null));
+                    }
+                }
+                changeset.Add(new ModChange(
+                    new GUIMod(module, registry_manager.registry, CurrentInstance.Version()),
+                    GUIModChangeType.Install, null));
+
+                menuStrip1.Enabled = false;
+
+                RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
+                install_ops.with_recommends = false;
+
+                m_InstallWorker.RunWorkerAsync(
+                    new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
+                        changeset, install_ops));
+                m_Changeset = null;
+
+                UpdateChangesDialog(null, m_InstallWorker);
+                ShowWaitDialog();
+            }
+        }
+
         private void selectKSPInstallMenuItem_Click(object sender, EventArgs e)
         {
             Instance.Manager.ClearAutoStart();


### PR DESCRIPTION
Reuse existing functionality around UI changeset processing, and to give the user the possibility to review the changeset after a .ckan import.
