### PR TITLE
GitHubTransformer shouldn't add empty data

### DIFF
--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -63,8 +63,12 @@ namespace CKAN.NetKAN.Transformers
 
                 var resourcesJson = (JObject)json["resources"];
 
-                json.SafeAdd("abstract", ghRepo.Description);
-                resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
+                if (!string.IsNullOrWhiteSpace(ghRepo.Description))
+                    json.SafeAdd("abstract", ghRepo.Description);
+
+                if (!string.IsNullOrWhiteSpace(ghRepo.Homepage))
+                    resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
+
                 resourcesJson.SafeAdd("repository", ghRepo.HtmlUrl);
 
                 if (ghRelease != null)


### PR DESCRIPTION
@pjf @techman83 @KSP-CKAN/wranglers 

GitHub API returns an [empty string for the homepage in some cases](https://github.com/KSP-CKAN/CKAN-meta/commit/9805b7fe4edea89d0c7352d230d66c34d8546956), guard against that and adding empty descriptions as the abstract.