### PR TITLE
install as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- [Core] `install` stanzas can have an `as` property allowing directories and files to be renamed/moved on installation. (#1728 by: dbent)
 - [GUI] Added "filter by description" search box. (#1632 by: politas; reviewed: pjf)
 - [CLI] `compare` command now checks positive and negative rather than -1/+1 (#1649 by: dbent; reviewed: Daz)
 - [GUI] In windows launch KSP_x64.exe by default rather than KSP.exe. (#1711 by plague006; reviewed: )

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -203,6 +203,11 @@
                         "description" : "Where file should be installed to",
                         "$ref"        : "#/definitions/install_to"
                     },
+                    "as": {
+                        "description" : "The name to give the matching directory or file when installed",
+                        "type"        : "string",
+                        "pattern"     : "^[^/\\]+$"
+                    },
                     "filter" : {
                         "description" : "List of files and directories that should be filtered from the install",
                         "$ref"        : "#/definitions/one_or_more_strings"

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -228,6 +228,12 @@ namespace CKAN
                                 break;
                             }
 
+                            if (metadata.install[i].@as != oldMetadata.install[i].@as)
+                            {
+                                same = false;
+                                break;
+                            }
+
                             if ((metadata.install[i].filter == null) != (oldMetadata.install[i].filter == null))
                             {
                                 same = false;

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -31,6 +31,9 @@ namespace CKAN
         [JsonProperty("install_to", Required = Required.Always)]
         public string install_to;
 
+        [JsonProperty("as")]
+        public string @as;
+
         [JsonProperty("filter")]
         [JsonConverter(typeof (JsonSingleOrArrayConverter<string>))]
         public List<string> filter;

--- a/Spec.md
+++ b/Spec.md
@@ -286,6 +286,8 @@ path and abort the install if any attempts to traverse up directories are found
 
 In addition, any number of optional directives *may* be provided:
 
+- `as` : (**v1.18**) The name to give the matching directory or file when installed. Allows renaming directories or
+  files.
 - `filter` : A string, or list of strings, of file parts that should not
   be installed. These are treated as literal things which must match a
   file name or directory. Examples of filters may be `Thumbs.db`,
@@ -294,8 +296,8 @@ In addition, any number of optional directives *may* be provided:
   case-sensitive C# regular expressions which are matched against the
   full paths from the installing zip-file. If a file matches the regular
   expression, it is not installed.
-- `find_matches_files` : If set to `true` then both `find` and
-  `find_regexp` will match files in addition to directories (**v1.16**).
+- `find_matches_files` : (**v1.16**) If set to `true` then both `find` and
+  `find_regexp` will match files in addition to directories.
 
 If no install sections are provided, a CKAN client *must* find the
 top-most directory in the archive that matches the module identifier,

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -322,13 +322,34 @@ namespace Tests.Core
             }
         }
 
-        [Test]
-        public void TransformOutputName()
+        [TestCase("GameData/kOS", "GameData/kOS/Plugins/kOS.dll", "GameData", null, "GameData/kOS/Plugins/kOS.dll")]
+        [TestCase("kOS-1.1/GameData/kOS", "kOS-1.1/GameData/kOS/Plugins/kOS.dll", "GameData", null, "GameData/kOS/Plugins/kOS.dll")]
+        [TestCase("ModuleManager.2.5.1.dll", "ModuleManager.2.5.1.dll", "GameData", null, "GameData/ModuleManager.2.5.1.dll")]
+        [TestCase("Ships", "Ships/SPH/FAR Firehound.craft", "SomeDir/Ships", null, "SomeDir/Ships/SPH/FAR Firehound.craft")]
+        [TestCase("GameData/kOS", "GameData/kOS/Plugins/kOS.dll", "GameData", "kOS-Renamed", "GameData/kOS-Renamed/Plugins/kOS.dll")]
+        [TestCase("kOS-1.1/GameData/kOS", "kOS-1.1/GameData/kOS/Plugins/kOS.dll", "GameData", "kOS-Renamed", "GameData/kOS-Renamed/Plugins/kOS.dll")]
+        [TestCase("ModuleManager.2.5.1.dll", "ModuleManager.2.5.1.dll", "GameData", "ModuleManager-Renamed.dll", "GameData/ModuleManager-Renamed.dll")]
+        public void TransformOutputName(string file, string outputName, string installDir, string @as, string expected)
         {
-            Assert.AreEqual("GameData/kOS/Plugins/kOS.dll", CKAN.ModuleInstaller.TransformOutputName("GameData/kOS", "GameData/kOS/Plugins/kOS.dll", "GameData"));
-            Assert.AreEqual("GameData/kOS/Plugins/kOS.dll", CKAN.ModuleInstaller.TransformOutputName("kOS-1.1/GameData/kOS", "kOS-1.1/GameData/kOS/Plugins/kOS.dll", "GameData"));
-            Assert.AreEqual("GameData/ModuleManager.2.5.1.dll", CKAN.ModuleInstaller.TransformOutputName("ModuleManager.2.5.1.dll", "ModuleManager.2.5.1.dll", "GameData"));
-            Assert.AreEqual("SomeDir/Ships/SPH/FAR Firehound.craft", CKAN.ModuleInstaller.TransformOutputName("Ships", "Ships/SPH/FAR Firehound.craft", "SomeDir/Ships"));
+            // Act
+            var result = CKAN.ModuleInstaller.TransformOutputName(file, outputName, installDir, @as);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [TestCase("GameData", "GameData/kOS/Plugins/kOS.dll", "GameData", "GameData-Renamed")]
+        [TestCase("Ships", "Ships/SPH/FAR Firehound.craft", "SomeDir/Ships", "Ships-Renamed")]
+        [TestCase("GameData/kOS", "GameData/kOS/Plugins/kOS.dll", "GameData", "kOS/Renamed")]
+        [TestCase("kOS-1.1/GameData/kOS", "kOS-1.1/GameData/kOS/Plugins/kOS.dll", "GameData", "kOS/Renamed")]
+        [TestCase("ModuleManager.2.5.1.dll", "ModuleManager.2.5.1.dll", "GameData", "Renamed/ModuleManager.dll")]
+        public void TransformOutputNameThrowsOnInvalidParameters(string file, string outputName, string installDir, string @as)
+        {
+            // Act
+            TestDelegate act = () => CKAN.ModuleInstaller.TransformOutputName(file, outputName, installDir, @as);
+
+            // Assert
+            Assert.That(act, Throws.Exception);
         }
 
         private string CopyDogeFromZip()


### PR DESCRIPTION
@pjf @techman83 @KSP-CKAN/wranglers 

This PR adds supports for a feature similar to the [previously discussed](https://github.com/KSP-CKAN/CKAN/pull/1243#issuecomment-118680302) `install_as` allowing directories or files to be renamed.

Unlike the previously discussed implementation, there is no separate `install_as` which replaces `install_to`. Instead there is an optional extra property `as` which is the name to give to the matching directory or file when installed. This was done to minimize the number of changes required in the code base, especially in an area as sensitive as the install code.

For example, given the following ZIP structure:
- Foo/Bar/File1.dll
- Foo/Bar/File2.dll
- Foo/Bar/Baz/File3.dll

This install structure:
```json
{
  "file": "Foo/Bar",
  "install_to": "GameData/Foo",
  "as": "Bar-Moved"
}
```

Would produce the following installed files relative to the KSP root:
- GameData/Foo/Bar-Moved/File1.dll
- GameData/Foo/Bar-Moved/File2.dll
-  GameData/Foo/Bar-Moved/Baz/File3.dll

Or this install structure:
```json
{
  "file": "Foo/Bar/File1.dll",
  "install_to": "GameData/Foo2/Bar2",
  "as": "FileOne.dll"
}
```
Would produce the following installed files relative to the KSP root:
- GameData/Foo2/Bar2/FileOne.dll

For a more practical example, take this `.ckan` file:
```json
{
    "spec_version": "v1.18",
    "identifier": "Kerbalism-Profile-TAC",
    "name": "Kerbalism - TAC Profile",
    "abstract": "TAC profile for Kerbalism",
    "author": "ShotgunNinja",
    "license": "public-domain",
    "resources": {
        "homepage": "https://github.com/ShotgunNinja/Kerbalism/wiki",
        "spacedock": "https://spacedock.info/mod/533/Kerbalism",
        "repository": "https://github.com/ShotgunNinja/Kerbalism",
        "x_screenshot": "https://spacedock.info/content/ShotgunNinja_2282/Kerbalism/Kerbalism-1460950521.2737155.png"
    },
    "version": "0.9.9.7",
    "ksp_version": "1.1.2",
    "provides": [
        "Kerbalism-Profile"
    ],
    "depends": [
        {
            "name": "Kerbalism"
        },
        {
            "name": "CommunityResourcePack"
        }
    ],
    "conflicts": [
        {
            "name": "Kerbalism-Profile"
        }
    ],
    "install": [
        {
            "file": "GameData/Kerbalism/Profiles/TAC.cfg-disabled",
            "install_to": "GameData/Kerbalism/Profiles",
            "as": "TAC.cfg"
        }
    ],
    "download": "https://spacedock.info/mod/533/Kerbalism/download/0.9.9.7",
    "download_size": 5020915,
    "download_hash": {
        "sha1": "778492A3846D0DC9E87084BD187475D2B3BA3FE3",
        "sha256": "1FBA3441A5A52CBBE7BE09F4C3A407D8CFFF2C87AB8659A77398AAB16B7E0246"
    },
    "download_content_type": "application/zip",
    "x_generated_by": "netkan"
}
```

Which allows use to rename the **TAC.cfg-disabled** file to **TAC.cfg**, enabling it when the `Kerablism-Profile-TAC` package is installed.

**Because this affects installation behavior, using this requires a spec version bump and new release.**