### PR TITLE
Relationship changes should prompt reinstall

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -106,14 +106,14 @@ namespace CKAN.CmdLine
             }
             catch (ModuleNotFoundKraken ex)
             {
-                user.RaiseMessage("Module {0} required, but not listed in index, or not available for your version of KSP", ex.module);
+                user.RaiseMessage("Module {0} required but it is not listed in the index, or not available for your version of KSP.", ex.module);
                 user.RaiseMessage("If you're lucky, you can do a `ckan update` and try again.");
-                user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules");
+                user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules.");
                 return Exit.ERROR;
             }
             catch (BadMetadataKraken ex)
             {
-                user.RaiseMessage("Bad metadata detected for module {0}", ex.module);
+                user.RaiseMessage("Bad metadata detected for module {0}.", ex.module);
                 user.RaiseMessage(ex.Message);
                 return Exit.ERROR;
             }

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -418,7 +418,7 @@ namespace CKAN
                     
                 tx.Complete();
             }
-            RegistryManager.Save();
+            RegistryManager.Save(enforce_consistency: false);
         }
 
         #endregion

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -868,7 +868,7 @@ namespace CKAN
         /// </summary>
         /// <param name="add">Add.</param>
         /// <param name="remove">Remove.</param>
-        public void AddRemove(IEnumerable<CkanModule> add = null, IEnumerable<string> remove = null)
+        public void AddRemove(IEnumerable<CkanModule> add = null, IEnumerable<string> remove = null, bool enforceConsistency = true)
         {
 
             // TODO: We should do a consistency check up-front, rather than relying
@@ -887,7 +887,7 @@ namespace CKAN
                     Install(module);
                 }
 
-                registry_manager.Save();
+                registry_manager.Save(enforceConsistency);
 
                 tx.Complete();
             }
@@ -898,7 +898,7 @@ namespace CKAN
         /// Will *re-install* with warning even if an upgrade is not available.
         /// Throws ModuleNotFoundKraken if module is not installed, or not available.
         /// </summary>
-        public void Upgrade(IEnumerable<string> identifiers, IDownloader netAsyncDownloader)
+        public void Upgrade(IEnumerable<string> identifiers, IDownloader netAsyncDownloader, bool enforceConsistency = true)
         {
             var options = new RelationshipResolverOptions();
 
@@ -909,7 +909,7 @@ namespace CKAN
             var resolver = new RelationshipResolver(identifiers.ToList(), options, registry_manager.registry, ksp.Version());
             List<CkanModule> upgrades = resolver.ModList();
 
-            Upgrade(upgrades, netAsyncDownloader);
+            Upgrade(upgrades, netAsyncDownloader, enforceConsistency);
         }
 
         /// <summary>
@@ -917,7 +917,7 @@ namespace CKAN
         /// Will *re-install* or *downgrade* (with a warning) as well as upgrade.
         /// Throws ModuleNotFoundKraken if a module is not installed.
         /// </summary>
-        public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader)
+        public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader, bool enforceConsistency = true)
         {
             // Start by making sure we've downloaded everything.
             DownloadModules(modules, netAsyncDownloader);
@@ -952,7 +952,7 @@ namespace CKAN
                     CkanModule installed = installed_mod.Module;
                     if (installed.version.IsEqualTo(module.version))
                     {
-                        log.WarnFormat("{0} is already at the latest version, reinstalling", installed.identifier);
+                        log.InfoFormat("{0} is already at the latest version, reinstalling", installed.identifier);
                     }
                     else if (installed.version.IsGreaterThan(module.version))
                     {
@@ -967,7 +967,8 @@ namespace CKAN
 
             AddRemove(
                 modules,
-                to_remove
+                to_remove,
+                enforceConsistency
             );
         }
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -887,6 +887,12 @@ namespace CKAN
             SanityChecker.EnforceConsistency(installed, installed_dlls.Keys);
         }
 
+        public List<string> GetSanityErrors()
+        {
+            var installed = from pair in installed_modules select pair.Value.Module;
+            return SanityChecker.ConsistencyErrors(installed, installed_dlls.Keys).ToList();
+        }
+
         /// <summary>
         /// Finds and returns all modules that could not exist without the listed modules installed, including themselves.
         /// Acts recursively.

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -39,13 +39,18 @@ namespace CKAN
             // We don't cause an inconsistency error to stop the registry from being loaded,
             // because then the user can't do anything to correct it. However we're
             // sure as hell going to complain if we spot one!
-            try
+            var sanityErrors = registry.GetSanityErrors();
+
+            if (sanityErrors.Any())
             {
-                registry.CheckSanity();
-            }
-            catch (InconsistentKraken kraken)
-            {
-                log.ErrorFormat("Loaded registry with inconsistencies:\n\n{0}", kraken.InconsistenciesPretty);
+                log.Info("Loaded registry with inconsistencies:\n\n");
+
+                foreach (var sanityError in sanityErrors)
+                {
+                    log.InfoFormat("- {0}", sanityError);
+                }
+
+                log.Info("\n");
             }
         }
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -333,10 +333,10 @@ namespace CKAN
                 {
                     if (!soft_resolve)
                     {
-                        log.ErrorFormat("Dependency on {0} found, but nothing provides it.", dep_name);
+                        log.ErrorFormat("Dependency on {0} found but it is not listed in the index, or not available for your version of KSP.", dep_name);
                         throw new ModuleNotFoundKraken(dep_name);
                     }
-                    log.InfoFormat("{0} is recommended/suggested, but nothing provides it.", dep_name);
+                    log.InfoFormat("{0} is recommended/suggested but it is not listed in the index, or not available for your version of KSP.", dep_name);
                     continue;
                 }
                 if (candidates.Count > 1)

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -32,7 +32,7 @@ namespace CKAN
             {
                 foreach (CkanModule unhappy_mod in entry.Value)
                 {
-                    errors.Add(string.Format("{0} requires {1} but nothing provides it", unhappy_mod.identifier, entry.Key));
+                    errors.Add(string.Format("{0} depends on {1} but it is not listed in the index, or not available for your version of KSP.", unhappy_mod.identifier, entry.Key));
                 }
             }
 

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -216,7 +216,7 @@ namespace CKAN
             catch (ModuleNotFoundKraken ex)
             {
                 GUI.user.RaiseMessage(
-                    "Module {0} required, but not listed in index, or not available for your version of KSP",
+                    "Module {0} required but it is not listed in the index, or not available for your version of KSP.",
                     ex.module);
                 return false;
             }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -503,13 +503,15 @@ namespace CKAN
             }
 
             // We're only going to update the status of rows that either don't already exist,
-            // or which exist but have changed their latest version.
+            // or which exist but have changed their latest version
+            // or whose installation status has changed
             //
             // TODO: Will this catch a mod where the latest version number remains the same, but
             // another part of the metadata (eg: dependencies or description) has changed?
             IEnumerable<GUIMod> rowsToUpdate = modules.Where(
                 mod => !full_list_of_mod_rows.ContainsKey(mod.Identifier) ||
-                mod.LatestVersion != (full_list_of_mod_rows[mod.Identifier].Tag as GUIMod).LatestVersion);
+                mod.LatestVersion != (full_list_of_mod_rows[mod.Identifier].Tag as GUIMod).LatestVersion ||
+                mod.IsInstalled != (full_list_of_mod_rows[mod.Identifier].Tag as GUIMod).IsInstalled);
 
             // Let's update our list!
             foreach (var mod in rowsToUpdate)


### PR DESCRIPTION
@pjf @techman83 @plague006 @KSP-CKAN/wranglers 

This PR makes it so that changes in `provides`, `conflicts`, `depends`, and `recommends` relationships prompt the user to reinstall the affected packages. This should handle [this case](https://github.com/KSP-CKAN/CKAN/issues/1729#issuecomment-219255719).

The basic change is that when we check for equivalent `install` stanzas we also check for equivalent relationship stanzas.

Because updating metadata can and should be able to put the user's registry in an inconsistent state (e.g. user installs Foo and Bar, later Foo conflicts with Bar, on update their repository is now "inconsistent"), I selectively ignore enforcing consistency checks when updating and just tell the user about the inconsistencies. (Annoyingly the GUI does its own thing in `Core/KSP.cs`).

I've also changed the code that checks old metadata against the new metadata to use the *installed* module as the old metadata, not the *available* module. This means if a user decides *not* to reinstall immediately, they'll be prompted to reinstall until the installed metadata matches the repository metadata. This can be done either by selecting yes at the prompt or by manually upgrading the package. Previously, if a user selected no they would not be prompted to reinstall in the future.