### PR TITLE
Force either `ksp_version` or `ksp_version_max` to be included in .ckans to reduce frequency of promiscuous mods

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -256,6 +256,10 @@
             "required": [ "kind" ]
         }
     ],
+    "oneOf": [
+        { "required": [ "ksp_version" ] },
+        { "required": [ "ksp_version_max" ] }
+    ],
     "definitions" : {
         "identifier" : {
             "description" : "Unique identifier for this mod.",


### PR DESCRIPTION
My best guess at how to do this, I have no method to actually test this.