### PR TITLE
Add download hashes to registry

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -85,7 +85,7 @@ namespace CKAN
         public Uri spacedock;
     }
 
-    public class DownloadHashsDescriptor
+    public class DownloadHashesDescriptor
     {
         [JsonProperty("sha1")]
         public string sha1;
@@ -165,7 +165,7 @@ namespace CKAN
         public long download_size;
 
         [JsonProperty("download_hash")]
-        public DownloadHashsDescriptor download_hash;
+        public DownloadHashesDescriptor download_hash;
 
         [JsonProperty("identifier", Required = Required.Always)]
         public string identifier;

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -85,6 +85,15 @@ namespace CKAN
         public Uri spacedock;
     }
 
+    public class DownloadHashsDescriptor
+    {
+        [JsonProperty("sha1")]
+        public string sha1;
+
+        [JsonProperty("sha256")]
+        public string sha256;
+    }
+
     public class NameComparer : IEqualityComparer<CkanModule>
     {
         public bool Equals(CkanModule x, CkanModule y)
@@ -154,6 +163,9 @@ namespace CKAN
 
         [JsonProperty("download_size")]
         public long download_size;
+
+        [JsonProperty("download_hash")]
+        public DownloadHashsDescriptor download_hash;
 
         [JsonProperty("identifier", Required = Required.Always)]
         public string identifier;

--- a/Tests/Core/Types/Module.cs
+++ b/Tests/Core/Types/Module.cs
@@ -48,6 +48,9 @@ namespace Tests.Core.Types
             Assert.AreEqual("http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS-Scriptable-Autopilot-System-v0-11-2-13", module.resources.homepage.ToString());
             Assert.AreEqual("https://github.com/KSP-KOS/KOS/issues", module.resources.bugtracker.ToString());
             Assert.AreEqual("https://github.com/KSP-KOS/KOS", module.resources.repository.ToString());
+            
+            Assert.AreEqual("C5A224AC4397770C0B19B4A6417F6C5052191608", module.download_hash.sha1.ToString());
+            Assert.AreEqual("E0FB79C81D8FCDA8DB6E38B104106C3B7D078FDC06ACA2BC7834973B43D789CB", module.download_hash.sha256.ToString());
         }
 
         /// <summary>

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -295,7 +295,11 @@ namespace Tests.Data
                             ""file""       : ""GameData/kOS"",
                             ""install_to"" : ""GameData""
                         }
-                    ]
+                    ],
+                    ""download_hash"": {
+                        ""sha1"": ""C5A224AC4397770C0B19B4A6417F6C5052191608"",
+                        ""sha256"": ""E0FB79C81D8FCDA8DB6E38B104106C3B7D078FDC06ACA2BC7834973B43D789CB""
+                    }
                 }"
             ;
         }


### PR DESCRIPTION
At some point they'll probably be needed client-side, and this gave me an excuse to poke around exactly how the registry is created.