### PR TITLE
Remove unused field

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -1452,7 +1452,6 @@ namespace CKAN
         private TextBox LogTextBox;
         private ProgressBar DialogProgressBar;
         private TextBox MessageTextBox;
-        private DataGridViewCheckBoxColumn UpdateCol;
         private TabPage ChangesetTabPage;
         private Button CancelChangesButton;
         private Button ConfirmChangesButton;


### PR DESCRIPTION
From visual studio:

`Warning	1	The field 'CKAN.Main.UpdateCol' is never used	D:\CKAN\GUI\Main.Designer.cs	1455	44	CKAN-GUI`

And indeed a search for any references to it comes up empty.