### PR TITLE
Add LastModified to netkan, registry, and GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - [CLI] `compare` command now checks positive and negative rather than -1/+1 (#1649 by: dbent; reviewed: Daz)
 - [GUI] In windows launch KSP_x64.exe by default rather than KSP.exe. (#1711 by plague006; reviewed: dbent)
 - [Core] Unlicense added to CKAN as an option for mods. (#1737 by plague006; reviewed: techman83)
+- [GUI/NetKAN/Core] Added "Last modified" field and column which allows users to see when a mod was last updated (or had its metadata updated). (#1773 by plague006; reviewed: )
 
 ### Internal
 

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -82,6 +82,10 @@
             "description" : "The content type of the download",
             "type"        : "string"
         },
+        "last_modified" : {
+            "description" : "The UTC time at which metadata was last modified",
+            "type"        : "string"
+        },
         "license" : {
             "description" : "Machine readable license, or array of licenses",
             "$ref"        : "#/definitions/licenses"

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -86,6 +86,12 @@ namespace CKAN
         public Uri spacedock;
     }
 
+    public class LastModified
+    {
+        [JsonProperty("last_modified")]
+        public DateTime last_modified;
+    }
+
     public class NameComparer : IEqualityComparer<CkanModule>
     {
         public bool Equals(CkanModule x, CkanModule y)
@@ -155,6 +161,9 @@ namespace CKAN
 
         [JsonProperty("download_size")]
         public long download_size;
+
+        [JsonProperty("last_modified")]
+        public DateTime last_modified;
 
         [JsonProperty("identifier", Required = Required.Always)]
         public string identifier;

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -23,6 +23,7 @@ namespace CKAN
         public string InstalledVersion { get; private set; }
         public string LatestVersion { get; private set; }
         public string DownloadSize { get; private set; }
+        public string LastModified { get; private set; }
         public bool IsCached { get; private set; }
 
         // These indicate the maximum KSP version that the maximum available
@@ -158,7 +159,17 @@ namespace CKAN
                 DownloadSize = "1<KB";
             else
                 DownloadSize = mod.download_size / 1024+"";
-            
+
+            // Check if last_modified is set
+            if (mod.last_modified != DateTime.MinValue)
+            {
+                LastModified = mod.last_modified.ToLocalTime().ToString();
+            }
+            else
+            {
+                LastModified = "N/A";
+            }
+
             Abbrevation = new string(mod.name.Split(' ').
                 Where(s => s.Length > 0).Select(s => s[0]).ToArray());
 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -69,6 +69,7 @@ namespace CKAN
             this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SizeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.LastModifiedCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModInfoTabControl = new System.Windows.Forms.TabControl();
             this.MetadataTabPage = new System.Windows.Forms.TabPage();
@@ -466,6 +467,7 @@ namespace CKAN
             this.LatestVersion,
             this.KSPCompatibility,
             this.SizeCol,
+            this.LastModifiedCol,
             this.Description});
             this.ModList.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ModList.Location = new System.Drawing.Point(0, 0);
@@ -542,6 +544,15 @@ namespace CKAN
             this.SizeCol.Name = "SizeCol";
             this.SizeCol.ReadOnly = true;
             this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.SizeCol.Width = 60;
+            // 
+            // LastModifiedCol
+            // 
+            this.LastModifiedCol.HeaderText = "Last modified";
+            this.LastModifiedCol.Name = "LastModifiedCol";
+            this.LastModifiedCol.ReadOnly = true;
+            this.LastModifiedCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.LastModifiedCol.Width = 125;
             // 
             // Description
             // 
@@ -1006,7 +1017,7 @@ namespace CKAN
             this.FilterByNameTextBox.Size = new System.Drawing.Size(124, 20);
             this.FilterByNameTextBox.TabIndex = 9;
             this.FilterByNameTextBox.TextChanged += new System.EventHandler(this.FilterByNameTextBox_TextChanged);
-            //
+            // 
             // FilterByDescriptionLabel
             // 
             this.FilterByDescriptionLabel.AutoSize = true;
@@ -1501,6 +1512,7 @@ namespace CKAN
         private DataGridViewTextBoxColumn LatestVersion;
         private DataGridViewTextBoxColumn KSPCompatibility;
         private DataGridViewTextBoxColumn SizeCol;
+        private DataGridViewTextBoxColumn LastModifiedCol;
         private DataGridViewTextBoxColumn Description;
         private ToolStripMenuItem cachedToolStripMenuItem;
         private Label IdentifierLabel;

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -540,13 +540,14 @@ namespace CKAN
                 var latest_version_cell = new DataGridViewTextBoxCell {Value = mod.LatestVersion};
                 var description_cell = new DataGridViewTextBoxCell {Value = mod.Abstract};
                 var KSPCompatibility_cell = new DataGridViewTextBoxCell {Value = mod.KSPCompatibility};
-                var size_cell = new DataGridViewTextBoxCell {Value = mod.DownloadSize};
+                var size_cell = new DataGridViewTextBoxCell { Value = mod.DownloadSize };
+                var last_modified_cell = new DataGridViewTextBoxCell { Value = mod.LastModified };
 
                 item.Cells.AddRange(installed_cell, update_cell,
                     name_cell, author_cell,
                     installed_version_cell, latest_version_cell,
                     KSPCompatibility_cell, size_cell,
-                    description_cell);
+                    last_modified_cell, description_cell);
 
                 installed_cell.ReadOnly = !mod.IsInstallable();
                 update_cell.ReadOnly = !mod.IsInstallable() || !mod.HasUpdate;

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Model\RemoteRef.cs" />
     <Compile Include="Transformers\InternalCkanTransformer.cs" />
     <Compile Include="Transformers\JenkinsTransformer.cs" />
+    <Compile Include="Transformers\LastModifiedTransformer.cs" />
     <Compile Include="Transformers\SpacedockTransformer.cs" />
     <Compile Include="Transformers\MetaNetkanTransformer.cs" />
     <Compile Include="Transformers\NetkanTransformer.cs" />

--- a/Netkan/Transformers/LastModifiedTransformer.cs
+++ b/Netkan/Transformers/LastModifiedTransformer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using CKAN.NetKAN.Model;
+using log4net;
+
+namespace CKAN.NetKAN.Transformers
+{
+    /// <summary>
+    /// An <see cref="ITransformer"/> that adds a property to indicate the program responsible for generating the
+    /// metadata.
+    /// </summary>
+    internal sealed class LastModifiedTransformer : ITransformer
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(LastModifiedTransformer));
+
+        public string Name { get { return "last_modified"; } }
+
+        public Metadata Transform(Metadata metadata)
+        {
+            var json = metadata.Json();
+
+            Log.InfoFormat("Executing Last Updated transformation with {0}", metadata.Kref);
+            Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
+
+            json["last_modified"] = DateTime.UtcNow;
+
+            Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
+
+            return new Metadata(json);
+        }
+    }
+}

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -41,6 +41,7 @@ namespace CKAN.NetKAN.Transformers
                 new VersionedOverrideTransformer(before: new string[] { null }, after: new string[] { null }),
                 new DownloadAttributeTransformer(http, fileService),
                 new GeneratedByTransformer(),
+                new LastModifiedTransformer(),
                 new OptimusPrimeTransformer(),
                 new StripNetkanMetadataTransformer(),
                 new PropertySortTransformer()

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -43,6 +43,7 @@ namespace CKAN.NetKAN.Transformers
             { "download_size", 25 },
             { "download_hash", 26 },
             { "download_content_type", 27 },
+            { "last_modified", 28},
 
             { "x_generated_by", int.MaxValue }
         };

--- a/Spec.md
+++ b/Spec.md
@@ -533,6 +533,12 @@ and not filled in by hand.
 
     "download_content_type": "application/zip"
 
+##### last_updated
+
+If supplied, `last_updated` is the last time the metadata was modified.
+Time is given in UTC. It is recommended that this field is only generated
+by automated tools )where it is encouraged), and not filled in by hand.
+
 #### Extensions
 
 Any field starting with `x_` (an x, followed by an underscore) is considered

--- a/Tests/Core/Types/Module.cs
+++ b/Tests/Core/Types/Module.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using CKAN;
 using NUnit.Framework;
@@ -41,6 +42,7 @@ namespace Tests.Core.Types
             Assert.AreEqual("0.14", module.version.ToString());
             Assert.AreEqual("stable", module.release_status.ToString());
             Assert.AreEqual("0.24.2", module.ksp_version.ToString());
+            Assert.AreEqual(DateTime.Parse("2016-06-02T23:08:48.2829391Z"), module.last_modified);
 
             Assert.That(module.install.First().file, Is.EqualTo("GameData/kOS"));
             Assert.That(module.install.First().install_to, Is.EqualTo("GameData"));
@@ -48,6 +50,8 @@ namespace Tests.Core.Types
             Assert.AreEqual("http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS-Scriptable-Autopilot-System-v0-11-2-13", module.resources.homepage.ToString());
             Assert.AreEqual("https://github.com/KSP-KOS/KOS/issues", module.resources.bugtracker.ToString());
             Assert.AreEqual("https://github.com/KSP-KOS/KOS", module.resources.repository.ToString());
+
+
         }
 
         /// <summary>

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -296,7 +296,8 @@ namespace Tests.Data
                             ""file""       : ""GameData/kOS"",
                             ""install_to"" : ""GameData""
                         }
-                    ]
+                    ],
+                    ""last_modified"": ""2016-06-02T23:08:48.2829391Z""
                 }"
             ;
         }


### PR DESCRIPTION
**DO NOT MERGE** Until @techman83 gives the all-clear as merging this as-is would likely cause some serious indexer-related headaches.

This introduces a new field into the metadata: `last_modified`. `last_modified` represents the most recent inflation of a .ckan by netkan.exe whether it be initial creation for a new release or updating information on a current release. The time is in UTC to avoid timezone related issues but is presented via the GUI in a user's given local time.

I'd love to have a test for the netkan transform, but don't know how to write one. @dbent input?

@techman83 as we discussed on IRC this will probably require the indexer to "ignore" the last_modified property otherwise we would likely end up inflating each .netkan.

Closes https://github.com/KSP-CKAN/CKAN/issues/1116, closes https://github.com/KSP-CKAN/CKAN/issues/1766, closes https://github.com/KSP-CKAN/CKAN/issues/1519, closes https://github.com/KSP-CKAN/CKAN/issues/1155, closes https://github.com/KSP-CKAN/CKAN/issues/1046