### PR TITLE
Column rename "Update" to "UpdateCol" in GUI

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -62,7 +62,7 @@ namespace CKAN
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.ModList = new CKAN.MainModListGUI();
             this.Installed = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.Update = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.UpdateCol = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ModName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Author = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.InstalledVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -459,7 +459,7 @@ namespace CKAN
             this.ModList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.ModList.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Installed,
-            this.Update,
+            this.UpdateCol,
             this.ModName,
             this.Author,
             this.InstalledVersion,
@@ -491,10 +491,10 @@ namespace CKAN
             // 
             // Update
             // 
-            this.Update.HeaderText = "Update";
-            this.Update.Name = "Update";
-            this.Update.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Update.Width = 46;
+            this.UpdateCol.HeaderText = "Update";
+            this.UpdateCol.Name = "Update";
+            this.UpdateCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.UpdateCol.Width = 46;
             // 
             // ModName
             // 
@@ -1452,7 +1452,6 @@ namespace CKAN
         private TextBox LogTextBox;
         private ProgressBar DialogProgressBar;
         private TextBox MessageTextBox;
-        private DataGridViewCheckBoxColumn UpdateCol;
         private TabPage ChangesetTabPage;
         private Button CancelChangesButton;
         private Button ConfirmChangesButton;
@@ -1494,7 +1493,7 @@ namespace CKAN
         public MainModListGUI ModList;
         private TableLayoutPanel MetaDataLowerLayoutPanel;
         private DataGridViewCheckBoxColumn Installed;
-        private DataGridViewCheckBoxColumn Update;
+        private DataGridViewCheckBoxColumn UpdateCol;
         private DataGridViewTextBoxColumn ModName;
         private DataGridViewTextBoxColumn Author;
         private DataGridViewTextBoxColumn InstalledVersion;


### PR DESCRIPTION
Clears both build warnings that have been happening for some time.

    Warning 1 The field 'CKAN.Main.UpdateCol' is never used D:\CKAN\GUI\Main.Designer.cs 1455 44 CKAN-GUI
    Main.Designer.cs(1497,44): warning CS0108: `CKAN.Main.Update' hides inherited member 
    `System.Windows.Forms.Control.Update()'. Use the new keyword if hiding was intended

Replaces #1772 - See there for details of thought processes
Possible solution for #1673 - `System.Windows.Forms.Control.Update()`'s description is "Causes the control to redraw the invalidated regions within its client area."

This orphaned declaration of UpdateCol may have been part of the fix that was implemented last time the MacOSX redraw glitch came up.