### PR TITLE
Cleanse broken KSP version numbers

### DIFF
--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -695,6 +695,14 @@ namespace CKAN.Versioning
                     return KspVersion.Any;
                 default:
                     KspVersion result;
+
+                    // For a little while, AVC files which didn't specify a full three-part
+                    // version number could result in versions like `1.1.`, which cause our
+                    // code to fail. Here we strip any trailing dot from the version number,
+                    // which makes them valid again before parsing. CKAN#1780
+
+                    value = Regex.Replace(value, @"\.$", "");
+
                     if (KspVersion.TryParse(value, out result))
                         return result;
                     else

--- a/Tests/Core/Versioning/KspVersionJsonConverterTests.cs
+++ b/Tests/Core/Versioning/KspVersionJsonConverterTests.cs
@@ -25,6 +25,7 @@ namespace Tests.Core.Versioning
             new object[] { @"{ ""KspVersion"": ""1.2""} ", new KspVersion(1, 2) },
             new object[] { @"{ ""KspVersion"": ""1.2.3""} ", new KspVersion(1, 2, 3) },
             new object[] { @"{ ""KspVersion"": ""1.2.3.4""} ", new KspVersion(1, 2, 3, 4) },
+            new object[] { @"{ ""KspVersion"": ""1.1.""} ", new KspVersion(1,1) }, // #1780
         };
 
         private static readonly object[] ReadJsonFailureCases =


### PR DESCRIPTION
This catches and fixes corrupted version numbers in the form of `1.1.`
that can still persist in registry files (like mine).

Closes #1780, makes #1645 safer.