### PR TITLE
Workaround string.Format() bug in old Mono versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: csharp
 mono:
     - latest
     - 3.10.0
+    - 3.2.8
 
 # Travis has problems with nunit on 3.8.0, dunno why.
 #    - 3.8.0

--- a/Core/Versioning/KspVersionBound.cs
+++ b/Core/Versioning/KspVersionBound.cs
@@ -25,7 +25,11 @@ namespace CKAN.Versioning
             Value = value;
             Inclusive = inclusive;
 
-            _string = inclusive ? string.Format("[{0}]", value) : string.Format("({0})", value);
+            // Workaround an issue in old (<=3.2.x) versions of Mono that does not correctly handle null values
+            // returned from ToString().
+            var valueStr = value.ToString() ?? string.Empty;
+
+            _string = inclusive ? string.Format("[{0}]", valueStr) : string.Format("({0})", valueStr);
         }
 
         public override string ToString()


### PR DESCRIPTION
@pjf 