### PR TITLE
Add work in #1784

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bugfixes
 
 - [Cmdline] Improve legend on `ckan list` functionality. (#1664 by: politas; reviewed: pjf)
+- [Core] Workaround string.Format() bug in old Mono versions (#1784 by: dbent, reviewed postremus)
 
 ### Features
 


### PR DESCRIPTION
Added to the change log. We should also release 18.1 as 16.04 is the oldest version of Ubuntu to have a more recent version of Mono than 3.2.8.