### PR TITLE
Travis/Build: Prevent mozroots from asking for human input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install:
     - sudo apt-get install mono-devel nunit-console libtest-most-perl libipc-system-simple-perl
-    - mozroots --import --ask-remove || true
+    - mozroots --sync --import || true
 
 script:
     - bin/build


### PR DESCRIPTION
This updates travis/mozroots to use the `--sync` option, which requires
no user input, rather than `--ask-remove` which can request input when
removing certificates.