### PR TITLE
Set enforceFIPSPolicy to false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ StyleCop.Cache
 ckan.exe
 ks2ckan.exe
 netkan.exe
-*.exe.config
 *.exe.mdb
 .*.swp
 .fatten.out

--- a/ckan.exe.config
+++ b/ckan.exe.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="yes"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <runtime>
+    <enforceFIPSPolicy enabled="false"/>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Removes *.exe.config from .gitignore in order to include ckan.exe.config with setting to disable enforceFIPSPolicy.
See https://msdn.microsoft.com/en-us/library/hh202806(v=vs.110).aspx for explanation.
Closes #1497