### PR TITLE
Replace \n with \r\n and replace CKAN-meta/issues links

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -163,7 +163,7 @@ namespace CKAN.CmdLine
                         "Please try a `ckan update` and try again.\r\n\r\n"+
                         "If this problem re-occurs, then it maybe a packaging bug.\r\n"+
                         "Please report it at:\r\n\r\n" +
-                        "https://github.com/KSP-CKAN/CKAN-meta/issues/new\r\n\r\n"+
+                        "https://github.com/KSP-CKAN/CKAN/issues/new\r\n\r\n"+
                         "Please including the following information in your report:\r\n\r\n" +
                         "File           : {0}\r\n" +
                         "Installing Mod : {1}\r\n" +

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -127,7 +127,7 @@ namespace CKAN.CmdLine
                     mods[i] = String.Format("{0} ({1})", ex.modules[i].identifier, ex.modules[i].name);
                 }
 
-                string message = String.Format("Too many mods provide {0}. Please pick from the following:\n", ex.requested);
+                string message = String.Format("Too many mods provide {0}. Please pick from the following:\r\n", ex.requested);
 
                 int result;
 
@@ -159,16 +159,16 @@ namespace CKAN.CmdLine
                 if (ex.owning_module != null)
                 {
                     user.RaiseMessage(
-                        "\nOh no! We tried to overwrite a file owned by another mod!\n"+
-                        "Please try a `ckan update` and try again.\n\n"+
-                        "If this problem re-occurs, then it maybe a packaging bug.\n"+
-                        "Please report it at:\n\n" +
-                        "https://github.com/KSP-CKAN/CKAN-meta/issues/new\n\n"+
-                        "Please including the following information in your report:\n\n" +
-                        "File           : {0}\n" +
-                        "Installing Mod : {1}\n" +
-                        "Owning Mod     : {2}\n" +
-                        "CKAN Version   : {3}\n",
+                        "\r\nOh no! We tried to overwrite a file owned by another mod!\r\n"+
+                        "Please try a `ckan update` and try again.\r\n\r\n"+
+                        "If this problem re-occurs, then it maybe a packaging bug.\r\n"+
+                        "Please report it at:\r\n\r\n" +
+                        "https://github.com/KSP-CKAN/CKAN-meta/issues/new\r\n\r\n"+
+                        "Please including the following information in your report:\r\n\r\n" +
+                        "File           : {0}\r\n" +
+                        "Installing Mod : {1}\r\n" +
+                        "Owning Mod     : {2}\r\n" +
+                        "CKAN Version   : {3}\r\n",
                         ex.filename, ex.installing_module, ex.owning_module,
                         Meta.Version()
                     );
@@ -176,19 +176,19 @@ namespace CKAN.CmdLine
                 else
                 {
                     user.RaiseMessage(
-                        "\n\nOh no!\n\n"+
-                        "It looks like you're trying to install a mod which is already installed,\n"+
-                        "or which conflicts with another mod which is already installed.\n\n"+
-                        "As a safety feature, the CKAN will *never* overwrite or alter a file\n"+
-                        "that it did not install itself.\n\n"+
-                        "If you wish to install {0} via the CKAN,\n"+
-                        "then please manually uninstall the mod which owns:\n\n"+
-                        "{1}\n\n"+"and try again.\n",
+                        "\r\n\r\nOh no!\r\n\r\n"+
+                        "It looks like you're trying to install a mod which is already installed,\r\n"+
+                        "or which conflicts with another mod which is already installed.\r\n\r\n"+
+                        "As a safety feature, the CKAN will *never* overwrite or alter a file\r\n"+
+                        "that it did not install itself.\r\n\r\n"+
+                        "If you wish to install {0} via the CKAN,\r\n"+
+                        "then please manually uninstall the mod which owns:\r\n\r\n"+
+                        "{1}\r\n\r\n"+"and try again.\r\n",
                         ex.installing_module, ex.filename
                     );
                 }
 
-                user.RaiseMessage("Your GameData has been returned to its original state.\n");
+                user.RaiseMessage("Your GameData has been returned to its original state.\r\n");
                 return Exit.ERROR;
             }
             catch (InconsistentKraken ex)
@@ -216,7 +216,7 @@ namespace CKAN.CmdLine
             }
             catch (DirectoryNotFoundKraken kraken)
             {
-                user.RaiseMessage("\n{0}", kraken.Message);
+                user.RaiseMessage("\r\n{0}", kraken.Message);
                 return Exit.ERROR;
             }
 

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -41,10 +41,10 @@ namespace CKAN.CmdLine
 
             if (!(options.porcelain) && exportFileType == null)
             {
-                user.RaiseMessage("\nKSP found at {0}\n", ksp.GameDir());
-                user.RaiseMessage("KSP Version: {0}\n", ksp.Version());
+                user.RaiseMessage("\r\nKSP found at {0}\r\n", ksp.GameDir());
+                user.RaiseMessage("KSP Version: {0}\r\n", ksp.Version());
 
-                user.RaiseMessage("Installed Modules:\n");
+                user.RaiseMessage("Installed Modules:\r\n");
             }
 
             if (exportFileType == null)
@@ -111,7 +111,7 @@ namespace CKAN.CmdLine
 
             if (!(options.porcelain) && exportFileType == null)
             {
-                user.RaiseMessage("\nLegend: -: Up to date. X: Incompatible. ^: Upgradable. ?: Unknown. *: Broken. ");
+                user.RaiseMessage("\r\nLegend: -: Up to date. X: Incompatible. ^: Upgradable. ?: Unknown. *: Broken. ");
                 // Broken mods are in a state that CKAN doesn't understand, and therefore can't handle automatically
             }
 

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -106,7 +106,7 @@ namespace CKAN.CmdLine
             ICollection<string> files = module.Files as ICollection<string>;
             if (files == null) throw new InvalidCastException();
 
-            user.RaiseMessage("\nShowing {0} installed files:", files.Count);
+            user.RaiseMessage("\r\nShowing {0} installed files:", files.Count);
             foreach (string file in files)
             {
                 user.RaiseMessage("- {0}", file);
@@ -134,12 +134,12 @@ namespace CKAN.CmdLine
 
             if (!string.IsNullOrEmpty(module.description))
             {
-                user.RaiseMessage("\n{0}\n", module.description);
+                user.RaiseMessage("\r\n{0}\r\n", module.description);
             }
             #endregion
 
             #region General info (author, version...)
-            user.RaiseMessage("\nModule info:");
+            user.RaiseMessage("\r\nModule info:");
             user.RaiseMessage("- version:\t{0}", module.version);
 
             if (module.author != null)
@@ -160,34 +160,34 @@ namespace CKAN.CmdLine
             #region Relationships
             if (module.depends != null && module.depends.Count > 0)
             {
-                user.RaiseMessage("\nDepends:");
+                user.RaiseMessage("\r\nDepends:");
                 foreach (RelationshipDescriptor dep in module.depends)
                     user.RaiseMessage("- {0}", RelationshipToPrintableString(dep));
             }
 
             if (module.recommends != null && module.recommends.Count > 0)
             {
-                user.RaiseMessage("\nRecommends:");
+                user.RaiseMessage("\r\nRecommends:");
                 foreach (RelationshipDescriptor dep in module.recommends)
                     user.RaiseMessage("- {0}", RelationshipToPrintableString(dep));
             }
 
             if (module.suggests != null && module.suggests.Count > 0)
             {
-                user.RaiseMessage("\nSuggests:");
+                user.RaiseMessage("\r\nSuggests:");
                 foreach (RelationshipDescriptor dep in module.suggests)
                     user.RaiseMessage("- {0}", RelationshipToPrintableString(dep));
             }
 
             if (module.ProvidesList != null && module.ProvidesList.Count > 0)
             {
-                user.RaiseMessage("\nProvides:");
+                user.RaiseMessage("\r\nProvides:");
                 foreach (string prov in module.ProvidesList)
                     user.RaiseMessage("- {0}", prov);
             } 
             #endregion
 
-            user.RaiseMessage("\nResources:");
+            user.RaiseMessage("\r\nResources:");
             if (module.resources != null)
             {
                 if (module.resources.bugtracker != null)
@@ -204,7 +204,7 @@ namespace CKAN.CmdLine
             string file_uri_hash = NetFileCache.CreateURLHash(module.download);
             string file_name = CkanModule.StandardName(module.identifier, module.version);
 
-            user.RaiseMessage("\nFilename: {0}", file_uri_hash + "-" + file_name);
+            user.RaiseMessage("\r\nFilename: {0}", file_uri_hash + "-" + file_name);
 
             return Exit.OK;
         }

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -47,7 +47,7 @@ namespace CKAN.CmdLine
                     User.RaiseMessage("New CKAN version available - " + latestVersion);
                     var releaseNotes = AutoUpdate.Instance.ReleaseNotes;
                     User.RaiseMessage(releaseNotes);
-                    User.RaiseMessage("\n");
+                    User.RaiseMessage("\r\n");
 
                     if (User.RaiseYesNoDialog("Proceed with install?"))
                     {
@@ -63,7 +63,7 @@ namespace CKAN.CmdLine
                 return Exit.OK;
             }
 
-            User.RaiseMessage("\nUpgrading modules...\n");
+            User.RaiseMessage("\r\nUpgrading modules...\r\n");
 
             try
             {
@@ -122,7 +122,7 @@ namespace CKAN.CmdLine
                 User.RaiseMessage("Module {0} not found", kraken.module);
                 return Exit.ERROR;
             }
-            User.RaiseMessage("\nDone!\n");
+            User.RaiseMessage("\r\nDone!\r\n");
 
             return Exit.OK;
         }

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -240,7 +240,7 @@ namespace CKAN.CmdLine
                 // The percent looks weird on non-download messages.
                 // The leading newline makes sure we don't end up with a mess from previous
                 // download messages.
-                Console.Write("\n{0}", format);
+                Console.Write("\r\n{0}", format);
             }
         }
         protected override void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -257,11 +257,11 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                         if (major < rec_major || (major == rec_major && minor < rec_minor))
                         {
                             user.RaiseMessage(
-                                "Warning. Detected mono runtime of {0} is less than the recommended version of {1}\n",
+                                "Warning. Detected mono runtime of {0} is less than the recommended version of {1}\r\n",
                                 String.Join(".", major, minor, patch),
                                 String.Join(".", rec_major, rec_minor, rec_patch)
                                 );
-                            user.RaiseMessage("Update recommend\n");
+                            user.RaiseMessage("Update recommend\r\n");
                         }
                     }
                 }
@@ -333,7 +333,7 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                 {
                     user.RaiseMessage("Preliminary scanning shows that the install is in a inconsistent state.");
                     user.RaiseMessage("Use ckan.exe scan for more details");
-                    user.RaiseMessage("Proceeding with {0} in case it fixes it.\n", next_command);
+                    user.RaiseMessage("Proceeding with {0} in case it fixes it.\r\n", next_command);
                 }
 
                 return Exit.ERROR;

--- a/Cmdline/ProgressReporter.cs
+++ b/Cmdline/ProgressReporter.cs
@@ -26,7 +26,7 @@ namespace CKAN.CmdLine
                 // The percent looks weird on non-download messages.
                 // The leading newline makes sure we don't end up with a mess from previous
                 // download messages.
-                user.RaiseMessage("\n{0}", message);
+                user.RaiseMessage("\r\n{0}", message);
             }
         }
     }

--- a/Core/GameVersionProviders/KspBuildMap.cs
+++ b/Core/GameVersionProviders/KspBuildMap.cs
@@ -93,7 +93,7 @@ namespace CKAN.GameVersionProviders
             catch(Exception e)
             {
                 _log.WarnFormat("Could not parse build map");
-                _log.DebugFormat("{0}\n{1}", buildMapJson, e);
+                _log.DebugFormat("{0}\r\n{1}", buildMapJson, e);
                 return false;
             }
         }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -181,7 +181,7 @@ namespace CKAN
             // TODO: All this user-stuff should be happening in another method!
             // We should just be installing mods as a transaction.
 
-            User.RaiseMessage("About to install...\n");
+            User.RaiseMessage("About to install...\r\n");
 
             foreach (CkanModule module in modsToInstall)
             {
@@ -196,7 +196,7 @@ namespace CKAN
                 }
             }
 
-            bool ok = User.RaiseYesNoDialog("\nContinue?");
+            bool ok = User.RaiseYesNoDialog("\r\nContinue?");
 
             if (!ok)
             {
@@ -249,7 +249,7 @@ namespace CKAN
                 ksp.ScanGameData();
             }
 
-            User.RaiseProgress("Done!\n", 100);
+            User.RaiseProgress("Done!\r\n", 100);
         }
 
         /// <summary>
@@ -730,7 +730,7 @@ namespace CKAN
                 return;
             }
 
-            User.RaiseMessage("About to remove:\n");
+            User.RaiseMessage("About to remove:\r\n");
 
             foreach (string mod in goners)
             {
@@ -738,7 +738,7 @@ namespace CKAN
                 User.RaiseMessage(" * {0} {1}", module.Module.name, module.Module.version);
             }
 
-            bool ok = User.RaiseYesNoDialog("\nContinue?");
+            bool ok = User.RaiseYesNoDialog("\r\nContinue?");
 
             if (!ok)
             {
@@ -759,7 +759,7 @@ namespace CKAN
                 transaction.Complete();
             }
 
-            User.RaiseMessage("Done!\n");
+            User.RaiseMessage("Done!\r\n");
         }
 
         public void UninstallList(string mod)
@@ -939,7 +939,7 @@ namespace CKAN
                     //Maybe ModuleNotInstalled ?
                     if (registry_manager.registry.IsAutodetected(ident))
                     {
-                        throw new ModuleNotFoundKraken(ident, module.version.ToString(), String.Format("Can't upgrade {0} as it was not installed by CKAN. \n Please remove manually before trying to install it.", ident));
+                        throw new ModuleNotFoundKraken(ident, module.version.ToString(), String.Format("Can't upgrade {0} as it was not installed by CKAN. \r\n Please remove manually before trying to install it.", ident));
                     }
 
                     User.RaiseMessage("Installing previously uninstalled mod {0}", ident);

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -192,7 +192,7 @@ namespace CKAN
                         throw new Exception("Curl download failed with error " + result);
                     }
 
-                    Log.DebugFormat("Download from {0}:\n\n{1}", url, content);
+                    Log.DebugFormat("Download from {0}:\r\n\r\n{1}", url, content);
 
                     return content;
                 }

--- a/Core/Properties/AssemblyInfo.cs
+++ b/Core/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("https://github.com/KSP-CKAN/CKAN")]
 [assembly: AssemblyProduct ("")]
-[assembly: AssemblyCopyright ("Copyright CKAN Team, https://github.com/KSP-CKAN/CKAN\nCC-BY 4.0, LGPL, or MIT; you choose!")]
+[assembly: AssemblyCopyright ("Copyright CKAN Team, https://github.com/KSP-CKAN/CKAN\r\nCC-BY 4.0, LGPL, or MIT; you choose!")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -45,7 +45,7 @@ namespace CKAN
             }
             catch (InconsistentKraken kraken)
             {
-                log.ErrorFormat("Loaded registry with inconsistencies:\n\n{0}", kraken.InconsistenciesPretty);
+                log.ErrorFormat("Loaded registry with inconsistencies:\r\n\r\n{0}", kraken.InconsistenciesPretty);
             }
         }
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -496,7 +496,7 @@ namespace CKAN
                 foreach (var conflict in conflicts)
                 {
                     var module = conflict.Key;
-                    dict[module] = string.Format("{0} conflicts with {1}\n\n{0}:\n{2}\n{1}:\n{3}",
+                    dict[module] = string.Format("{0} conflicts with {1}\r\n\r\n{0}:\r\n{2}\r\n{1}:\r\n{3}",
                         module.identifier, conflict.Value.identifier,
                         ReasonStringFor(module), ReasonStringFor(conflict.Value));
                     ;
@@ -562,7 +562,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  Currently installed.\n"; }
+                get { return "  Currently installed.\r\n"; }
             }
         }
 
@@ -579,7 +579,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  Requested by user.\n"; }
+                get { return "  Requested by user.\r\n"; }
             }
         }
 
@@ -593,7 +593,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  Suggested by " + Parent.name + ".\n"; }
+                get { return "  Suggested by " + Parent.name + ".\r\n"; }
             }
         }
 
@@ -607,7 +607,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  To satisfy dependency from " + Parent.name + ".\n"; }
+                get { return "  To satisfy dependency from " + Parent.name + ".\r\n"; }
             }
         }
 
@@ -621,7 +621,7 @@ namespace CKAN
 
             public override string Reason
             {
-                get { return "  Recommended by " + Parent.name + ".\n"; }
+                get { return "  Recommended by " + Parent.name + ".\r\n"; }
             }
         }
     }

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -126,8 +126,8 @@ namespace CKAN
 
         internal static string FormatMessage(string requested, List<CkanModule> modules)
         {
-            string oops = string.Format("Too many mods provide {0}:\n", requested);
-            return oops + String.Join("\n* ", modules);
+            string oops = string.Format("Too many mods provide {0}:\r\n", requested);
+            return oops + String.Join("\r\n* ", modules);
         }
     }
 
@@ -143,8 +143,8 @@ namespace CKAN
         {
             get
             {
-                const string message = "The following inconsistencies were found:\n";
-                return message + String.Join("\n * ", inconsistencies);
+                const string message = "The following inconsistencies were found:\r\n";
+                return message + String.Join("\r\n * ", inconsistencies);
             }
         }
 
@@ -203,7 +203,7 @@ namespace CKAN
 
         public override string ToString()
         {
-            return "Uh oh, the following things went wrong when downloading...\n\n" + String.Join("\n", exceptions);
+            return "Uh oh, the following things went wrong when downloading...\r\n\r\n" + String.Join("\r\n", exceptions);
         }
     }
 
@@ -292,10 +292,10 @@ namespace CKAN
         public override string ToString()
         {
             return
-                "\nOh no! Our download failed with a certificate error!\n\n" +
-                "If you're on Linux, try running:\n" +
-                "\tmozroots --import --ask-remove\n" +
-                "on the command-line to update your certificate store, and try again.\n\n"
+                "\r\nOh no! Our download failed with a certificate error!\r\n\r\n" +
+                "If you're on Linux, try running:\r\n" +
+                "\tmozroots --import --ask-remove\r\n" +
+                "on the command-line to update your certificate store, and try again.\r\n\r\n"
             ;
         }
     }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -300,7 +300,7 @@ namespace CKAN
                 }
                 catch (Exception exception)
                 {
-                    m_User.RaiseError("Error in autoupdate: \n\t" + exception.Message + "");
+                    m_User.RaiseError("Error in autoupdate: \r\n\t" + exception.Message + "");
                     log.Error("Error in autoupdate", exception);
                 }
             }

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -234,7 +234,7 @@ namespace CKAN
                         "Please try a `ckan update` and try again.\r\n\r\n" +
                         "If this problem re-occurs, then it maybe a packaging bug.\r\n" +
                         "Please report it at:\r\n\r\n" +
-                        "https://github.com/KSP-CKAN/CKAN-meta/issues/new\r\n\r\n" +
+                        "https://github.com/KSP-CKAN/CKAN/issues/new\r\n\r\n" +
                         "Please including the following information in your report:\r\n\r\n" +
                         "File           : {0}\r\n" +
                         "Installing Mod : {1}\r\n" +

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -230,16 +230,16 @@ namespace CKAN
                 if (ex.owning_module != null)
                 {
                     GUI.user.RaiseMessage(
-                        "\nOh no! We tried to overwrite a file owned by another mod!\n" +
-                        "Please try a `ckan update` and try again.\n\n" +
-                        "If this problem re-occurs, then it maybe a packaging bug.\n" +
-                        "Please report it at:\n\n" +
-                        "https://github.com/KSP-CKAN/CKAN-meta/issues/new\n\n" +
-                        "Please including the following information in your report:\n\n" +
-                        "File           : {0}\n" +
-                        "Installing Mod : {1}\n" +
-                        "Owning Mod     : {2}\n" +
-                        "CKAN Version   : {3}\n",
+                        "\r\nOh no! We tried to overwrite a file owned by another mod!\r\n" +
+                        "Please try a `ckan update` and try again.\r\n\r\n" +
+                        "If this problem re-occurs, then it maybe a packaging bug.\r\n" +
+                        "Please report it at:\r\n\r\n" +
+                        "https://github.com/KSP-CKAN/CKAN-meta/issues/new\r\n\r\n" +
+                        "Please including the following information in your report:\r\n\r\n" +
+                        "File           : {0}\r\n" +
+                        "Installing Mod : {1}\r\n" +
+                        "Owning Mod     : {2}\r\n" +
+                        "CKAN Version   : {3}\r\n",
                         ex.filename, ex.installing_module, ex.owning_module,
                         Meta.Version()
                         );
@@ -247,19 +247,19 @@ namespace CKAN
                 else
                 {
                     GUI.user.RaiseMessage(
-                        "\n\nOh no!\n\n" +
-                        "It looks like you're trying to install a mod which is already installed,\n" +
-                        "or which conflicts with another mod which is already installed.\n\n" +
-                        "As a safety feature, the CKAN will *never* overwrite or alter a file\n" +
-                        "that it did not install itself.\n\n" +
-                        "If you wish to install {0} via the CKAN,\n" +
-                        "then please manually uninstall the mod which owns:\n\n" +
-                        "{1}\n\n" + "and try again.\n",
+                        "\r\n\r\nOh no!\r\n\r\n" +
+                        "It looks like you're trying to install a mod which is already installed,\r\n" +
+                        "or which conflicts with another mod which is already installed.\r\n\r\n" +
+                        "As a safety feature, the CKAN will *never* overwrite or alter a file\r\n" +
+                        "that it did not install itself.\r\n\r\n" +
+                        "If you wish to install {0} via the CKAN,\r\n" +
+                        "then please manually uninstall the mod which owns:\r\n\r\n" +
+                        "{1}\r\n\r\n" + "and try again.\r\n",
                         ex.installing_module, ex.filename
                         );
                 }
 
-                GUI.user.RaiseMessage("Your GameData has been returned to its original state.\n");
+                GUI.user.RaiseMessage("Your GameData has been returned to its original state.\r\n");
                 return false;
             }
             catch (InconsistentKraken ex)
@@ -285,7 +285,7 @@ namespace CKAN
             }
             catch (DirectoryNotFoundKraken kraken)
             {
-                GUI.user.RaiseMessage("\n{0}", kraken.Message);
+                GUI.user.RaiseMessage("\r\n{0}", kraken.Message);
                 return false;
             }
             return true;

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -42,7 +42,7 @@ namespace CKAN
 
             // Provide a stack backtrace, so our users and non-debugging devs can
             // see what's gone wrong.
-            user.RaiseError("Unhandled exception:\n{0} ", exception.ToString());
+            user.RaiseError("Unhandled exception:\r\n{0} ", exception.ToString());
         }
     }
 }

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -232,7 +232,7 @@ namespace CKAN
             }
             catch (Exception ex)
             {
-                log.Warn("Exception caught in CheckForUpdates:\n"+ex);
+                log.Warn("Exception caught in CheckForUpdates:\r\n"+ex);
             }
         }
 

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -69,7 +69,7 @@ namespace CKAN
                 // The percent looks weird on non-download messages.
                 // The leading newline makes sure we don't end up with a mess from previous
                 // download messages.
-                Console.Write("\n{0}", format);
+                Console.Write("\r\n{0}", format);
             }
         }
         protected override void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)


### PR DESCRIPTION
I've replaced all the "\n"s I could find with "\r\n" except in bin/build and bin/build.lean. Should these be changed as well?

I tested with one particular error message ("overwrite a file owned by another mod") in the KSP window, and the linebreaks fine on Windows 10, Ubuntu 16.04, and OS X 10.10. I don't know how to use log4net, so I haven't tested messages printed with that, but it's probably all fine.

The two error messages with links to CKAN-meta/issues now point to CKAN/issues.

Fixes #1835