### PR TITLE
Update CKAN.schema "as" regexp

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -206,7 +206,7 @@
                     "as": {
                         "description" : "The name to give the matching directory or file when installed",
                         "type"        : "string",
-                        "pattern"     : "^[^/\\]+$"
+                        "pattern"     : "^[^\\/]+$"
                     },
                     "filter" : {
                         "description" : "List of files and directories that should be filtered from the install",

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -206,7 +206,7 @@
                     "as": {
                         "description" : "The name to give the matching directory or file when installed",
                         "type"        : "string",
-                        "pattern"     : "^[^\\/]+$"
+                        "pattern"     : "^[^\\\\/]+$"
                     },
                     "filter" : {
                         "description" : "List of files and directories that should be filtered from the install",


### PR DESCRIPTION
The Regexp on install "as" is not being parsed correctly. swapping the escaped \ and the / seems to work, though.
Should enable KSP-CKAN/NetKAN#4487 to build - I think this is the first time we've actually used "as".

Change tested using http://www.jsonschemavalidator.net/