### PR TITLE
Fix issue where CKAN would crash after installing mods if you are sorting by KSP version.

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -526,6 +526,8 @@ namespace CKAN
         /// </summary>
         public string HighestCompatibleKSP()
         {
+            string allVersions = "All versions";
+
             // Find the highest compatible KSP version
             if (ksp_version_max != null)
             {
@@ -533,14 +535,26 @@ namespace CKAN
             }
             else if (ksp_version != null)
             {
-                return ksp_version.ToString();
+                string versionString = ksp_version.ToString();
+                if(versionString == null)
+                {
+                    if(ksp_version.IsAny)
+                    {
+                        return allVersions;
+                    }
+                    else
+                    {
+                        throw new Kraken("No valid version string found, and IsAny is not true.");
+                    }
+                }
+                return versionString;
             }
             else if (ksp_version_min != null )
             {
                 return ksp_version_min + "+";
             }
 
-            return "All versions";
+            return allVersions;
         }
 
         /// <summary>

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -526,8 +526,6 @@ namespace CKAN
         /// </summary>
         public string HighestCompatibleKSP()
         {
-            string allVersions = "All versions";
-
             // Find the highest compatible KSP version
             if (ksp_version_max != null)
             {
@@ -535,26 +533,14 @@ namespace CKAN
             }
             else if (ksp_version != null)
             {
-                string versionString = ksp_version.ToString();
-                if(versionString == null)
-                {
-                    if(ksp_version.IsAny)
-                    {
-                        return allVersions;
-                    }
-                    else
-                    {
-                        throw new Kraken("No valid version string found, and IsAny is not true.");
-                    }
-                }
-                return versionString;
+                return ksp_version.ToString();
             }
             else if (ksp_version_min != null )
             {
                 return ksp_version_min + "+";
             }
 
-            return allVersions;
+            return "All versions";
         }
 
         /// <summary>

--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -690,8 +690,9 @@ namespace CKAN.Versioning
             switch (value)
             {
                 case null:
-                case "any":
                     return null;
+                case "any":
+                    return KspVersion.Any;
                 default:
                     KspVersion result;
 

--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -690,9 +690,8 @@ namespace CKAN.Versioning
             switch (value)
             {
                 case null:
-                    return null;
                 case "any":
-                    return KspVersion.Any;
+                    return null;
                 default:
                     KspVersion result;
 


### PR DESCRIPTION
This was related to mods with ksp_version 'any' in JSON, which is handled differently to mods with no ksp_version field, and the UI code was not knowledgeable about the difference