### PR TITLE
Replace deprecated mozroots command with cert-sync for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
     - "sh -e /etc/init.d/xvfb start"
 
 install:
-    - sudo apt-get install mono-devel nunit-console libtest-most-perl libipc-system-simple-perl
-    - mozroots --sync --import || true
+    - sudo apt-get install mono-devel ca-certificates-mono nunit-console libtest-most-perl libipc-system-simple-perl
+    - cert-sync /etc/ssl/certs/ca-certificates.crt --quiet
 
 script:
     - bin/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install:
     - sudo apt-get install mono-devel ca-certificates-mono nunit-console libtest-most-perl libipc-system-simple-perl
-    - cert-sync /etc/ssl/certs/ca-certificates.crt --quiet
+    - cert-sync --quiet /etc/ssl/certs/ca-certificates.crt
 
 script:
     - bin/build


### PR DESCRIPTION
Explicitly adds ca-certificate-mono package, in case it doesn't get included with mono-complete
@techman83, can you check this?
Closes #1787