### PR TITLE
Fix Windows-only NullReferenceException and add more ModuleInstaller tests

### DIFF
--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Exporters\IExporter.cs" />
     <Compile Include="Exporters\MarkdownExporter.cs" />
     <Compile Include="Exporters\PlainTextExporter.cs" />
+    <Compile Include="Extensions.cs" />
     <Compile Include="GameVersionProviders\IKspBuildMap.cs" />
     <Compile Include="GameVersionProviders\KspBuildIdVersionProvider.cs" />
     <Compile Include="GameVersionProviders\KspVersionSource.cs" />

--- a/Core/Extensions.cs
+++ b/Core/Extensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CKAN
+{
+    public static class Extensions
+    {
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
+        {
+            return new HashSet<T>(source);
+        }
+    }
+}

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -919,7 +919,9 @@ namespace CKAN
                     var dirInfo = new DirectoryInfo(dir);
 
                     // this is a system root, do not touch it
-                    if (dirInfo.Parent == null)
+                    // the first check returns true on Windows
+                    // the second check returns true in Mono
+                    if (dirInfo.Parent == null || dirInfo.Parent == dirInfo)
                     {
                         return results;
                     }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -895,10 +895,10 @@ namespace CKAN
             var newDirectories = new HashSet<string>();
             foreach (string directory in directories)
             {
-                if ( directory.Contains(ksp.GameData()))
+                if (directory.Contains(ksp.GameData()))
                 {
                     var path = directory;
-                    while ((path != ksp.GameData()) & (path != null) & !newDirectories.Contains(path) )
+                    while ((path != ksp.GameData()) && !newDirectories.Contains(path))
                     {
                         newDirectories.Add(path);
                         DirectoryInfo parent = Directory.GetParent(path);

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -909,19 +909,20 @@ namespace CKAN
             var gameDir = KSPPathUtils.NormalizePath(ksp.GameDir());
             return directories
                 .Where(dir => !string.IsNullOrWhiteSpace(dir))
-                // make all directory expressions absolute from the GameDir
+                // normalize all paths before deduplicate
                 .Select(KSPPathUtils.NormalizePath)
                 // remove any duplicate paths
                 .Distinct()
                 .SelectMany(dir =>
                 {
                     var results = new HashSet<string>();
-                    var dirInfo = new DirectoryInfo(dir);
+                    // adding in the DirectorySeparatorChar fixes attempts on Windows
+                    // to parse "X:" which resolves to Environment.CurrentDirectory
+                    var dirInfo = new DirectoryInfo(dir + Path.DirectorySeparatorChar);
 
-                    // this is a system root, do not touch it
-                    // the first check returns true on Windows
-                    // the second check returns true in Mono
-                    if (dirInfo.Parent == null || dirInfo.Parent == dirInfo)
+                    // if this is a parentless directory (Windows)
+                    // or if the Root equals the current directory (Mono)
+                    if (dirInfo.Parent == null || dirInfo.Root == dirInfo)
                     {
                         return results;
                     }

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CKAN;
+using log4net.Core;
+using NUnit.Framework;
+using Tests.Data;
+
+namespace Tests.Core
+{
+    /// <summary>
+    /// Tests the AddParentDirectories method in CKAN.ModuleInstaller
+    /// </summary>
+    [TestFixture]
+    public class ModuleInstallerDirTest
+    {
+        private DisposableKSP _instance;
+        private CKAN.Registry _registry;
+        private CKAN.ModuleInstaller _installer;
+        private CKAN.CkanModule _testModule;
+        private string _gameDataDir;
+
+        /// <summary>
+        /// Prep environment by setting up a single mod in
+        /// a disposable KSP instance.
+        /// </summary>
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            _testModule = TestData.DogeCoinFlag_101_module();
+
+            _instance = new DisposableKSP();
+            _registry = CKAN.RegistryManager.Instance(_instance.KSP).registry;
+            _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, NullUser.User);
+
+            _gameDataDir = _instance.KSP.GameData();
+            _registry.AddAvailable(_testModule);
+            var testModFile = TestData.DogeCoinFlagZip();
+            _instance.KSP.Cache.Store(_testModule.download, testModFile);
+            _installer.InstallList(
+                new List<string>() { _testModule.identifier },
+                new RelationshipResolverOptions()
+            );
+        }
+
+        /// <summary>
+        /// Make sure that the GameData directory is not included.
+        /// </summary>
+        [Test]
+        public void TestGameData()
+        {
+            var result = _installer
+                .AddParentDirectories(new HashSet<string>() { _gameDataDir })
+                .ToList();
+
+            Assert.IsEmpty(result);
+        }
+
+        /// <summary>
+        /// These are sanity tests that attempt to throw exceptions
+        /// when invoking AddParentDirectories()
+        /// </summary>
+        [Test]
+        public void TestNullPath()
+        {
+            Assert.DoesNotThrow(delegate ()
+            {
+                _installer.AddParentDirectories(null);
+                _installer.AddParentDirectories(new HashSet<string>());
+                _installer.AddParentDirectories(new HashSet<string>() { string.Empty });
+                var sysRoot = Path.GetPathRoot(Environment.CurrentDirectory);
+                _installer.AddParentDirectories(new HashSet<string>() { sysRoot });
+            });
+        }
+
+        /// <summary>
+        /// Make sure that the list of directories is
+        /// always normalized and deduplicated.
+        /// </summary>
+        [Test]
+        public void TestSlashVariants()
+        {
+            var rawInstallDir = Path.Combine(_gameDataDir, _testModule.identifier);
+            var normalizedInstallDir = CKAN.KSPPathUtils.NormalizePath(rawInstallDir);
+            var windowsInstallDir = normalizedInstallDir.Replace('/', '\\');
+
+            Assert.DoesNotThrow(delegate ()
+            {
+                var result = _installer.AddParentDirectories(new HashSet<string>()
+                {
+                    rawInstallDir,
+                    windowsInstallDir,
+                    normalizedInstallDir
+                }).ToList();
+
+                // should only contain one path
+                Assert.AreEqual(result.Count, 1);
+                Assert.Contains(normalizedInstallDir, result);
+            });
+        }
+    }
+}

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -71,7 +71,7 @@ namespace Tests.Core
                 _installer.AddParentDirectories(null);
                 _installer.AddParentDirectories(new HashSet<string>());
                 _installer.AddParentDirectories(new HashSet<string>() { string.Empty });
-                var sysRoot = Path.GetPathRoot(Environment.CurrentDirectory);
+                var sysRoot = Path.GetPathRoot(Environment.CurrentDirectory) + Environment.NewLine;
                 _installer.AddParentDirectories(new HashSet<string>() { sysRoot });
             });
         }

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -97,7 +97,7 @@ namespace Tests.Core
                 }).ToList();
 
                 // should only contain one path
-                Assert.AreEqual(result.Count, 1);
+                Assert.AreEqual(1, result.Count);
                 Assert.Contains(normalizedInstallDir, result);
             });
         }

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -71,8 +71,7 @@ namespace Tests.Core
                 _installer.AddParentDirectories(null);
                 _installer.AddParentDirectories(new HashSet<string>());
                 _installer.AddParentDirectories(new HashSet<string>() { string.Empty });
-                var sysRoot = Path.GetPathRoot(Environment.CurrentDirectory) + Environment.NewLine;
-                _installer.AddParentDirectories(new HashSet<string>() { sysRoot });
+                _installer.AddParentDirectories(new HashSet<string>() { Path.GetPathRoot(Environment.CurrentDirectory) });
             });
         }
 

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using CKAN;
+using NUnit.Framework;
 
 namespace Tests.Data
 {
@@ -10,6 +11,7 @@ namespace Tests.Data
     /// </summary>
     public class DisposableKSP : IDisposable
     {
+        private readonly string _failureMessage = "Unexpected exception trying to delete disposable test container.";
         private readonly string _goodKsp = TestData.good_ksp_dir();
         private readonly string _disposableDir;
 
@@ -47,8 +49,23 @@ namespace Tests.Data
                 registry.Dispose();
             }
 
-            //Now that the loickfile is closed, we can remove the directory
-            Directory.Delete(_disposableDir, true);
+            var i = 6;
+            while (--i < 0)
+            {
+                try
+                {
+                    // Now that the lockfile is closed, we can remove the directory
+                    Directory.Delete(_disposableDir, true);
+                }
+                catch (IOException)
+                {
+                    // We silently catch this exception because we expect failures
+                }
+                catch (Exception ex)
+                {
+                    throw new AssertionException(_failureMessage, ex);
+                }
+            }
 
             //proceed to dispose our wrapped KSP object
             KSP.Dispose();

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -112,6 +112,7 @@
   <ItemGroup>
     <Compile Include="Core\Cache.cs" />
     <Compile Include="Core\FileIdentifier.cs" />
+    <Compile Include="Core\ModuleInstallerDirTest.cs" />
     <Compile Include="Core\KSP.cs" />
     <Compile Include="Core\KSPManager.cs" />
     <Compile Include="Core\KSPPathUtils.cs" />


### PR DESCRIPTION
If the user attempts to uninstall a mod in Windows, there is a NullReferenceException where AddParentDirectories tries to compare a null to a string. It is also continuing to walk up above the GameData directory, adding my Program Files directory to the list of directories to delete.

The new code normalizes all compared paths and checks for several edge cases, improving its reliability.

I added new tests to ensure the Windows path oddities I saw don't creep back in.