### PR TITLE
Add log4net.xml, refactor logging init and log to file by default

### DIFF
--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -68,4 +68,9 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="log4net.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -48,8 +48,7 @@ namespace CKAN.CmdLine
                 args = guiCommand.ToArray();
             }
 
-            BasicConfigurator.Configure();
-            LogManager.GetRepository().Threshold = Level.Warn;
+            Logging.Initialize();
             log.Debug("CKAN started");
 
             Options cmdline;

--- a/Cmdline/log4net.xml
+++ b/Cmdline/log4net.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="CkanConsole" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%5level (%file:%line) %message%newline" />
+    </layout>
+  </appender>
+
+  <appender name="CkanFile" type="log4net.Appender.RollingFileAppender">
+    <file value="./CKAN.log" />
+    <appendToFile value="true" />
+    <rollingStyle value="Size" />
+    <maximumFileSize value="1MB" />
+    <maxSizeRollBackups value="30" />
+    <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date{yyyy-MM-dd HH:mm:ss} %level %logger - %message%newline" />
+    </layout>
+  </appender>
+
+  <root>
+    <level value="INFO" />
+    <appender-ref ref="CkanFile" />
+    <appender-ref ref="CkanConsole" />
+  </root>
+</log4net>

--- a/Cmdline/log4net.xml
+++ b/Cmdline/log4net.xml
@@ -22,6 +22,5 @@
   <root>
     <level value="INFO" />
     <appender-ref ref="CkanFile" />
-    <appender-ref ref="CkanConsole" />
   </root>
 </log4net>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -56,6 +56,7 @@
     <Compile Include="GameVersionProviders\KspVersionSource.cs" />
     <Compile Include="GameVersionProviders\IGameVersionProvider.cs" />
     <Compile Include="GameVersionProviders\KspBuildMap.cs" />
+    <Compile Include="Logging.cs" />
     <Compile Include="Net\AutoUpdate.cs" />
     <Compile Include="Net\IDownloader.cs" />
     <Compile Include="Net\NetAsyncDownloader.cs" />

--- a/Core/Logging.cs
+++ b/Core/Logging.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using log4net;
+using log4net.Config;
+using log4net.Core;
+using log4net.Repository.Hierarchy;
+
+namespace CKAN
+{
+    public class Logging
+    {
+        public static void Initialize()
+        {
+            if (LogManager.GetRepository().Configured)
+            {
+                return;
+            }
+
+            // if the log4net.xml file does not exist, then fall back to the existing
+            // configuration process
+            var logConfig = new FileInfo(Path.Combine(Environment.CurrentDirectory, "log4net.xml"));
+            if (!logConfig.Exists)
+            {
+                BasicConfigurator.Configure();
+            }
+            else
+            {
+                // when the XML file exists, attempt to set up log4net using it
+                try
+                {
+                    XmlConfigurator.ConfigureAndWatch(logConfig);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("Exception trying to configure logging!", e);
+                }
+            }
+        }
+    }
+}

--- a/Core/Logging.cs
+++ b/Core/Logging.cs
@@ -36,6 +36,9 @@ namespace CKAN
                 catch (Exception e)
                 {
                     Console.WriteLine("Exception trying to configure logging!", e);
+
+                    // attempt to fall back to basic
+                    BasicConfigurator.Configure();
                 }
             }
         }

--- a/Core/Logging.cs
+++ b/Core/Logging.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using log4net;
 using log4net.Config;
-using log4net.Core;
-using log4net.Repository.Hierarchy;
 
 namespace CKAN
 {

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -288,6 +288,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="log4net.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Resources\backward.png" />
     <Content Include="Resources\forward.png" />
   </ItemGroup>

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -19,6 +19,8 @@ namespace CKAN
 
         public static void Main_(string[] args, bool showConsole = false)
         {
+            Logging.Initialize();
+
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/GUI/log4net.xml
+++ b/GUI/log4net.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="CkanConsole" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%5level (%file:%line) %message%newline" />
+    </layout>
+  </appender>
+
+  <appender name="CkanFile" type="log4net.Appender.RollingFileAppender">
+    <file value="./CKAN.log" />
+    <appendToFile value="true" />
+    <rollingStyle value="Size" />
+    <maximumFileSize value="1MB" />
+    <maxSizeRollBackups value="30" />
+    <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date{yyyy-MM-dd HH:mm:ss} %level %logger - %message%newline" />
+    </layout>
+  </appender>
+
+  <root>
+    <level value="WARN" />
+    <appender-ref ref="CkanFile" />
+  </root>
+</log4net>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -102,7 +102,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="curl-ca-bundle.crt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -8,15 +8,12 @@
     <RootNamespace>CKAN.NetKAN</RootNamespace>
     <AssemblyName>NetKAN</AssemblyName>
     <StartupObject>CKAN.NetKAN.Program</StartupObject>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine">

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -8,12 +8,15 @@
     <RootNamespace>CKAN.NetKAN</RootNamespace>
     <AssemblyName>NetKAN</AssemblyName>
     <StartupObject>CKAN.NetKAN.Program</StartupObject>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine">
@@ -99,6 +102,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="curl-ca-bundle.crt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -104,7 +104,7 @@ namespace CKAN.NetKAN
             Options = new CmdLineOptions();
             Parser.Default.ParseArgumentsStrict(args, Options);
 
-            BasicConfigurator.Configure();
+            Logging.Initialize();
             LogManager.GetRepository().Threshold = Level.Warn;
 
             if (Options.Verbose)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [Click here to go to the CKAN wiki][5]
 
-**The CKAN Spec can be found [here](Spec.md)**.
+[Click here to view the CKAN metadata specification](Spec.md)
 
 ## What's the CKAN?
 
@@ -28,7 +28,7 @@ We very much welcome contributions, discussions, and especially pull-requests.
 ## The CKAN spec
 
 At the core of the CKAN is the **[metadata specification](Spec.md)**,
-which comes with a corresponding [JSON Schema](CKAN.schema) which you can also find in the [Schema Store][8]
+which comes with a corresponding [JSON Schema](CKAN.schema) that you can also find in the [Schema Store][8]
 
 This repository includes a validator that you can use to [validate your files][3].
 

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -57,9 +57,6 @@ namespace Tests.Core.Net
         [Explicit]
         public void SingleDownload()
         {
-            // Force log4net on.
-            // BasicConfigurator.Configure();
-            // LogManager.GetRepository().Threshold = Level.Debug;
             log.Info("Performing single download test.");
 
             // We know kOS is in the TestKAN data, and hosted in KS. Let's get it.

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -37,6 +37,7 @@ namespace Tests.Data
             }
 
             KSP = new KSP(_disposableDir, NullUser.User);
+            Logging.Initialize();
         }
 
         public void Dispose()


### PR DESCRIPTION
The logging initialization has been condensed into one class which will either load config from a log4net.xml in the app startup directory, or failing to find one tries to initialize the existing basic logging system. All of the logging entry points have been refactored to call this `Logging.Initialize()` method.

Tests are passing in the Windows/VS environment, review and feedback appreciated.

This would resolve #1452, which unfortunately has some project changes that are risky and needs a rebase.