### PR TITLE
Add Curse to resources

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -170,6 +170,11 @@
                     "type"        : "string",
                     "format"      : "uri"
                 },
+                "curse" : {
+                    "description" : "Project on Curse",
+                    "type"        : "string",
+                    "format"      : "uri"
+                },
                 "manual" : {
                     "description" : "Mod's manual",
                     "type"        : "string",
@@ -325,7 +330,10 @@
             "description" : "A license.",
             "enum" : [
                 "public-domain",
+                "AFL-3.0",
+                "AGPL-3.0",
                 "Apache", "Apache-1.0", "Apache-2.0",
+                "APSL-2.0",
                 "Artistic", "Artistic-1.0", "Artistic-2.0",
                 "BSD-2-clause", "BSD-3-clause", "BSD-4-clause",
                 "ISC",
@@ -343,7 +351,8 @@
                 "GFDL-1.0", "GFDL-1.1", "GFDL-1.2", "GFDL-1.3",
                 "GFDL-NIV-1.0", "GFDL-NIV-1.1", "GFDL-NIV-1.2", "GFDL-NIV-1.3",
                 "LPPL-1.0", "LPPL-1.1", "LPPL-1.2", "LPPL-1.3c",
-                "MPL-1.1",
+                "MPL-1.0", "MPL-1.1",
+                "Ms-PL", "Ms-RL",
                 "Perl",
                 "Python-2.0",
                 "QPL-1.0",

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -199,6 +199,8 @@ namespace CKAN.CmdLine
                     user.RaiseMessage("- spacedock: {0}", Uri.EscapeUriString(module.resources.spacedock.ToString()));
                 if (module.resources.repository != null)
                     user.RaiseMessage("- repository: {0}", Uri.EscapeUriString(module.resources.repository.ToString()));
+                if (module.resources.curse != null)
+                    user.RaiseMessage("- curse: {0}", Uri.EscapeUriString(module.resources.curse.ToString()));
             }
 
             // Compute the CKAN filename.

--- a/Core/Exporters/DelimeterSeperatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeperatedValueExporter.cs
@@ -50,7 +50,8 @@ namespace CKAN.Exporters
                     "repository",
                     "homepage",
                     "bugtracker",
-                    "spacedock"
+                    "spacedock",
+                    "curse"
                 );
 
                 foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
@@ -74,7 +75,8 @@ namespace CKAN.Exporters
                         WriteRepository(mod.Module.resources),
                         WriteHomepage(mod.Module.resources),
                         WriteBugtracker(mod.Module.resources),
-                        WriteSpaceDock(mod.Module.resources)
+                        WriteSpaceDock(mod.Module.resources),
+                        WriteCurse(mod.Module.resources)
                     );
                 }
             }
@@ -120,6 +122,16 @@ namespace CKAN.Exporters
             if (resources != null && resources.spacedock != null)
             {
                 return QuoteIfNecessary(resources.spacedock.ToString());
+            }
+
+            return string.Empty;
+        }
+
+        private string WriteCurse(ResourcesDescriptor resources)
+        {
+            if (resources != null && resources.curse != null)
+            {
+                return QuoteIfNecessary(resources.curse.ToString());
             }
 
             return string.Empty;

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -84,6 +84,9 @@ namespace CKAN
 
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri spacedock;
+
+        [JsonConverter(typeof(JsonOldResourceUrlConverter))]
+        public Uri curse;
     }
 
     public class DownloadHashesDescriptor

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -131,7 +131,7 @@ namespace CKAN
 
             Abstract = mod.@abstract;
             
-            // If we have homepage provided use that, otherwise use the spacedock page or the github repo so that users have somewhere to get more info than just the abstract.
+            // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
 
             Homepage = "N/A";
             if (mod.resources != null)
@@ -143,6 +143,10 @@ namespace CKAN
                 else if (mod.resources.spacedock != null)
                 {
                     Homepage = mod.resources.spacedock.ToString();
+                }
+                else if (mod.resources.curse != null)
+                {
+                    Homepage = mod.resources.curse.ToString();
                 }
                 else if (mod.resources.repository != null)
                 {

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -32,7 +32,7 @@ namespace CKAN
             Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = module.@abstract);
             Util.Invoke(MetadataIdentifierLabel, () => MetadataIdentifierLabel.Text = module.identifier);
 
-            // If we have homepage provided use that, otherwise use the spacedock page or the github repo so that users have somewhere to get more info than just the abstract.
+            // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
             Util.Invoke(MetadataModuleHomePageLinkLabel,
                        () => MetadataModuleHomePageLinkLabel.Text = gui_module.Homepage.ToString());
 

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -155,7 +155,7 @@ namespace CKAN.NetKAN.Transformers
                     {
                         // In practice, the version specified in .version files tends to be unreliable, with authors
                         // forgetting to update it when new versions are released. Therefore if we have a version
-                        // specified from another source such as SpaceDock or a GitHub tag, don't overwrite it.
+                        // specified from another source such as SpaceDock, curse or a GitHub tag, don't overwrite it.
                         json.SafeAdd("version", avc.version.ToString());
                     }
 

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -51,11 +51,12 @@ namespace CKAN.NetKAN.Transformers
         {
             { "homepage", 0 },
             { "spacedock", 1 },
-            { "repository", 2 },
-            { "bugtracker", 3 },
-            { "ci", 4 },
-            { "license", 5 },
-            { "manual", 6 }
+            { "curse", 2 },
+            { "repository", 3 },
+            { "bugtracker", 4 },
+            { "ci", 5 },
+            { "license", 6 },
+            { "manual", 7 }
         };
 
         public string Name { get { return "property_sort"; } }

--- a/Spec.md
+++ b/Spec.md
@@ -118,8 +118,8 @@ reference CKAN client that will read this file.
 For compatibility with pre-release clients, and the v1.0 client, the special
 *integer* `1` should be used.
 
-This document describes the CKAN specification 'v1.16'. Changes since spec `1`
-are marked with **v1.2** through to **v1.16** respectively. For maximum
+This document describes the CKAN specification 'v1.20'. Changes since spec `1`
+are marked with **v1.2** through to **v1.20** respectively. For maximum
 compatibility, using older spec versions is preferred when newer features are
 not required.
 
@@ -451,7 +451,7 @@ are described. Unless specified otherwise, these are URLs:
 - `repository` : The repository where the module source can be found.
 - `ci` :  (**v1.6**) Continuous Integration (e.g. Jenkins) Server where the module is being built. `x_ci` is an alias used in netkan.
 - `spacedock` : The mod on SpaceDock.
-- `curse` : The mod on Curse.
+- `curse` :  (**v1.20**) The mod on Curse.
 - `manual` : The mod's manual, if it exists.
 
 Example resources:
@@ -603,6 +603,8 @@ For example: `#/ckan/github/pjf/DogeCoinFlag`.
 
 When used, the following fields will be auto-filled if not already present:
 
+- `name`
+- `abstract`
 - `author`
 - `version`
 - `download`
@@ -824,6 +826,7 @@ The possible values of `before` and `after` are:
 - `optimus_prime`
 - `property_sort`
 - `spacedock`
+- `curse`
 - `strip_netkan_metadata`
 - `version_edit`
 - `versioned_override`

--- a/Spec.md
+++ b/Spec.md
@@ -451,16 +451,18 @@ are described. Unless specified otherwise, these are URLs:
 - `repository` : The repository where the module source can be found.
 - `ci` :  (**v1.6**) Continuous Integration (e.g. Jenkins) Server where the module is being built. `x_ci` is an alias used in netkan.
 - `spacedock` : The mod on SpaceDock.
+- `curse` : The mod on Curse.
 - `manual` : The mod's manual, if it exists.
 
 Example resources:
 
     "resources" : {
-        "homepage"     : "http://tinyurl.com/DogeCoinFlag",
+        "homepage"     : "https://tinyurl.com/DogeCoinFlag",
         "bugtracker"   : "https://github.com/pjf/DogeCoinFlag/issues",
-        "repository"   : "http://github.com/pjf/DogeCoinFlag",
+        "repository"   : "https://github.com/pjf/DogeCoinFlag",
         "ci"           : "https://ksp.sarbian.com/jenkins/DogecoinFlag"
         "spacedock"    : "https://spacedock.info/mod/269/Dogecoin%20Flag"
+        "curse"        : "https://kerbal.curseforge.com/projects/220221"
     }
 
 While all currently defined resources are all URLs, future revisions of the spec may provide for more complex types.
@@ -575,6 +577,23 @@ When used, the following fields will be auto-filled if not already present:
 - `resources.spacedock`
 - `resources.repository`
 - `resources.x_screenshot`
+- `ksp_version`
+
+###### `#/ckan/curse/:cid`
+
+Indicates that data should be fetched from Curse, using the `:cid` provided. For example: `#/ckan/curse/220221`.
+
+When used, the following fields will be auto-filled if not already present:
+
+- `name`
+- `license`
+- `author`
+- `version`
+- `download`
+- `download_size`
+- `download_hash`
+- `download_content_type`
+- `resources.curse`
 - `ksp_version`
 
 ###### `#/ckan/github/:user/:repo[/asset_match/:filter_regexp]`


### PR DESCRIPTION
Adds the Curse Uri to the `"resources"` stanza together with curse licenses.

```
"resources": {
    "curse": "http://kerbal.curseforge.com/projects/220221"
}
```

