### PR TITLE
Make sure we're updating the build mappings on repository update

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -4,7 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Autofac;
 using ChinhDo.Transactions;
+using CKAN.GameVersionProviders;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
@@ -124,6 +126,9 @@ namespace CKAN
         /// </summary>
         internal static void UpdateRegistry(Uri repo, Registry registry, KSP ksp, IUser user, Boolean clear = true)
         {
+            // Use this opportunity to also update the build mappings... kind of hacky
+            ServiceLocator.Container.Resolve<IKspBuildMap>().Refresh();
+
             log.InfoFormat("Downloading {0}", repo);
 
             string repo_file = String.Empty;


### PR DESCRIPTION
Fix issue brought up in #1900 that @Olympic1 subsequently deleted?

Looks like this [rebase](https://github.com/KSP-CKAN/CKAN/commit/94335381e274cb07fe77ae1fa6183a2513131b8f#diff-a5b6137749fb38bca7e80257e4e5b158L144) accidentally deleted the line that updates the build mapping, thus leading to stale build mappings.