### PR TITLE
Add regexp second test for vref filespecs

### DIFF
--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -117,12 +117,8 @@ namespace CKAN.NetKAN.Services
                 for (var i = 0; i < files.Count; i++)
                 {
                     Log.DebugFormat("Testing file '{0}' against path '{1}'", files[i].Name,internalFilePath);
-                    if (files[i].Name == internalFilePath) 
-                    {
-                        remoteIndex = i;
-                        break;
-                    }
-                    else if (Regex.IsMatch(files[i].Name, internalFilePath))
+                    // Test for either an exact match or using the filespec as a regexp
+                    if (files[i].Name == internalFilePath) || (Regex.IsMatch(files[i].Name, internalFilePath))
                     {
                         remoteIndex = i;
                         break;

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -116,7 +116,13 @@ namespace CKAN.NetKAN.Services
 
                 for (var i = 0; i < files.Count; i++)
                 {
-                    if (files[i].Name == internalFilePath)
+                    Log.DebugFormat("Testing file '{0}' against path '{1}'", files[i].Name,internalFilePath);
+                    if (files[i].Name == internalFilePath) 
+                    {
+                        remoteIndex = i;
+                        break;
+                    }
+                    else if (Regex.IsMatch(files[i].Name, internalFilePath))
                     {
                         remoteIndex = i;
                         break;

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -118,7 +118,7 @@ namespace CKAN.NetKAN.Services
                 {
                     Log.DebugFormat("Testing file '{0}' against path '{1}'", files[i].Name,internalFilePath);
                     // Test for either an exact match or using the filespec as a regexp
-                    if (files[i].Name == internalFilePath) || (Regex.IsMatch(files[i].Name, internalFilePath))
+                    if (internalFilePath.Equals(files[i]?.Name) || Regex.IsMatch(files[i]?.Name, internalFilePath))
                     {
                         remoteIndex = i;
                         break;


### PR DESCRIPTION
Closes #1918
Shouldn't impact any existing $vref filespecs, as they all have complete paths.