### PR TITLE
Fix default logging on fallback when no XML file

### DIFF
--- a/Core/Logging.cs
+++ b/Core/Logging.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using log4net;
 using log4net.Config;
+using log4net.Core;
 
 namespace CKAN
 {
@@ -20,6 +21,7 @@ namespace CKAN
             if (!logConfig.Exists)
             {
                 BasicConfigurator.Configure();
+                LogManager.GetRepository().Threshold = Level.Warn;
             }
             else
             {


### PR DESCRIPTION
Closes #1913, ref #1881 
This should get our builds working again. "prove" works on this build.