### PR TITLE
Update UI state when download cache is cleared

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -86,7 +86,7 @@ namespace CKAN
         /// When our cache dirctory changes, we just clear the list of
         /// files we know about.
         /// </summary>
-        private void OnCacheChanged()
+        public void OnCacheChanged()
         {
             cachedFiles = null;   
         }

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -166,8 +166,17 @@ namespace CKAN
             Abbrevation = new string(mod.name.Split(' ').
                 Where(s => s.Length > 0).Select(s => s[0]).ToArray());
 
-            if (Main.Instance != null)
-                IsCached = Main.Instance.CurrentInstance.Cache.IsMaybeCachedZip(mod.download);
+            UpdateIsCached();
+        }
+
+        public void UpdateIsCached()
+        {
+            if (Main.Instance.CurrentInstance == null)
+            {
+                return;
+            }
+
+            IsCached = Main.Instance.CurrentInstance.Cache.IsMaybeCachedZip(Mod.download);
         }
 
         public CkanModule ToCkanModule()

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -171,7 +171,7 @@ namespace CKAN
 
         public void UpdateIsCached()
         {
-            if (Main.Instance.CurrentInstance == null)
+            if (Main.Instance?.CurrentInstance?.Cache == null || Mod?.download == null)
             {
                 return;
             }

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -192,7 +192,7 @@ namespace CKAN
                 UpdateModDependencyGraph(null);
         }
 
-        private void UpdateModContentsTree(CkanModule module, bool force = false)
+        public void UpdateModContentsTree(CkanModule module, bool force = false)
         {
             ModInfoTabControl.Tag = module ?? ModInfoTabControl.Tag;
             //Can be costly. For now only update when visible.
@@ -262,7 +262,7 @@ namespace CKAN
             e.Result = e.Argument;
         }
 
-        private void PostModCaching(object sender, RunWorkerCompletedEventArgs e)
+        public void PostModCaching(object sender, RunWorkerCompletedEventArgs e)
         {
             Util.Invoke(this, () => _PostModCaching((CkanModule)e.Result));
         }
@@ -271,6 +271,7 @@ namespace CKAN
         {
             HideWaitDialog(true);
 
+            GetSelectedModule()?.UpdateIsCached();;
             UpdateModContentsTree(module, true);
             RecreateDialogs();
         }

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -69,8 +69,7 @@ namespace CKAN
         {
             m_cacheSize = 0;
             m_cacheFileCount = 0;
-            var cachePath = Path.Combine(Main.Instance.CurrentInstance.CkanDir(), "downloads");
-
+            var cachePath = Main.Instance.CurrentInstance.DownloadCacheDir();
             var cacheDirectory = new DirectoryInfo(cachePath);
             foreach (var file in cacheDirectory.GetFiles())
             {
@@ -98,8 +97,7 @@ namespace CKAN
 
             if (deleteConfirmationDialog.ShowYesNoDialog(confirmationText) == System.Windows.Forms.DialogResult.Yes)
             {
-                var cachePath = Path.Combine(Main.Instance.CurrentInstance.CkanDir(), "downloads");
-                foreach (var file in Directory.GetFiles(cachePath))
+                foreach (var file in Directory.GetFiles(Main.Instance.CurrentInstance.DownloadCacheDir()))
                 {
                     try
                     {
@@ -109,6 +107,19 @@ namespace CKAN
                     {
                     }
                 }
+
+                // tell the cache object to nuke itself
+                Main.Instance.CurrentInstance.Cache.OnCacheChanged();
+
+                // forcibly tell all mod rows to re-check cache state
+                foreach (DataGridViewRow row in Main.Instance.ModList.Rows)
+                {
+                    var mod = row.Tag as GUIMod;
+                    mod?.UpdateIsCached();
+                }
+
+                // finally, clear the preview contents list
+                Main.Instance.UpdateModContentsTree(null, true);
 
                 UpdateCacheInfo();
             }


### PR DESCRIPTION
Fixes #1928 by adding a method to GUIMod which allows the IsCached property to be updated, then calling it once when we finish caching after clicking Download and once when the cache is cleared.