### PR TITLE
Use OpenFileDialog instead of FolderBrowserDialog in instance selector

### DIFF
--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -84,14 +84,24 @@ namespace CKAN
 
         private void UseSelectedInstance()
         {
-            var instance = (string)KSPInstancesListView.SelectedItems[0].Tag;
+            if (KSPInstancesListView.SelectedItems.Count == 0)
+            {
+                return;
+            }
+
+            var selected = KSPInstancesListView.SelectedItems[0];
+            var instName = selected?.Tag as string;
+            if (instName == null)
+            {
+                return;
+            }
 
             if (SetAsDefaultCheckbox.Checked)
             {
-                _manager.SetAutoStart(instance);
+                _manager.SetAutoStart(instName);
             }
 
-            _manager.SetCurrentInstance(instance);
+            _manager.SetCurrentInstance(instName);
             DialogResult = DialogResult.OK;
             Close();
         }

--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -15,7 +15,7 @@ namespace CKAN
             CheckFileExists = false,
             CheckPathExists = false,
             InitialDirectory = Environment.CurrentDirectory,
-            Filter = "KSP binaries (KSP*.exe)|KSP*.exe",
+            Filter = "KSP binaries (KSP*.*)|KSP*.*",
             Multiselect = false
         };
 

--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -15,7 +15,7 @@ namespace CKAN
             CheckFileExists = false,
             CheckPathExists = false,
             InitialDirectory = Environment.CurrentDirectory,
-            Filter = "KSP binaries (KSP*.*)|KSP*.*",
+            Filter = "Build metadata file (buildID*.txt)|buildID*.txt",
             Multiselect = false
         };
 


### PR DESCRIPTION
This would resolve #1017 by changing the selection behavior for new instances. Instead of the `FolderBrowserDialog` we would be asking the user to select a KSP executable as a way of indicating the game root directory.

I'd like input on how safe that is - I believe that the KSP binaries are still suffixed in .exe when run in Mac/Linux environments but I haven't seen one of these installs.

The actual filter is `KSP*.exe` - so users will see 32- and 64-bit versions but can only select one.

There are also style changes in this file, variable names and changing `SetButtonsEnabled` because "Set*/Get*" methods are not C# style.