### PR TITLE
Change name of Registry lock file

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -39,7 +39,7 @@ namespace CKAN
             this.ksp = ksp;
 
             this.path = Path.Combine(path, "registry.json");
-            lockfilePath = Path.Combine(path, "registry.json.locked");
+            lockfilePath = Path.Combine(path, "registry.locked");
 
             // Create a lock for this registry, so we cannot touch it again.
             if (!GetLock())


### PR DESCRIPTION
I'm not sure why the original change appended the word "locked" to create a file with "json" in the name that isn't a JSON file.

This is a tiny, tiny change from "registry.json.locked" to "registry.locked". Anyone have any reason not to make this change?

Closes #1943
