### PR TITLE
Support modifying KSP compatibility on the command line

### DIFF
--- a/Cmdline/Action/CompatSubCommand.cs
+++ b/Cmdline/Action/CompatSubCommand.cs
@@ -145,10 +145,10 @@ namespace CKAN.CmdLine.Action
             [VerbOption("list", HelpText = "List compatible KSP versions")]
             public CompatListOptions List { get; set; }
 
-            [VerbOption("add", HelpText = "List compatible KSP versions")]
+            [VerbOption("add", HelpText = "Add version to KSP compatibility list")]
             public CompatAddOptions Add { get; set; }
 
-            [VerbOption("forget", HelpText = "List compatible KSP versions")]
+            [VerbOption("forget", HelpText = "Forget version on KSP compatibility list")]
             public CompatForgetOptions Forget { get; set; }
         }
 

--- a/Cmdline/Action/CompatSubCommand.cs
+++ b/Cmdline/Action/CompatSubCommand.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CKAN.Versioning;
+using CommandLine;
+
+namespace CKAN.CmdLine.Action
+{
+    public class CompatSubCommand : ISubCommand
+    {
+        private readonly KSPManager _kspManager;
+        private readonly IUser _user;
+
+        public CompatSubCommand(KSPManager kspManager, IUser user)
+        {
+            _kspManager = kspManager;
+            _user = user;
+        }
+
+        public int RunSubCommand(SubCommandOptions options)
+        {
+            var exitCode = 0;
+
+            Parser.Default.ParseArgumentsStrict(options.options.ToArray(), new CompatOptions(), (option, suboptions) =>
+            {
+                switch (option)
+                {
+                    case "list":
+                        {
+                            var ksp = _kspManager.CurrentInstance;
+
+                            const string versionHeader = "Version";
+                            const string actualHeader = "Actual";
+
+                            var output = ksp
+                                .GetCompatibleVersions()
+                                .Select(i => new
+                                {
+                                    Version = i,
+                                    Actual = false
+                                })
+                                .ToList();
+
+                            output.Add(new
+                            {
+                                Version = ksp.Version(),
+                                Actual = true
+                            });
+
+                            output = output
+                                .OrderByDescending(i => i.Actual)
+                                .ThenByDescending(i => i.Version)
+                                .ToList();
+
+                            var versionWidth = Enumerable
+                                .Repeat(versionHeader, 1)
+                                .Concat(output.Select(i => i.Version.ToString()))
+                                .Max(i => i.Length);
+
+                            var actualWidth = Enumerable
+                                .Repeat(actualHeader, 1)
+                                .Concat(output.Select(i => i.Actual.ToString()))
+                                .Max(i => i.Length);
+
+                            const string columnFormat = "{0}  {1}";
+
+                            _user.RaiseMessage(string.Format(columnFormat,
+                                versionHeader.PadRight(versionWidth),
+                                actualHeader.PadRight(actualWidth)
+                            ));
+
+                            _user.RaiseMessage(string.Format(columnFormat,
+                                new string('-', versionWidth),
+                                new string('-', actualWidth)
+                            ));
+
+                            foreach (var line in output)
+                            {
+                                _user.RaiseMessage(string.Format(columnFormat,
+                                   line.Version.ToString().PadRight(versionWidth),
+                                   line.Actual.ToString().PadRight(actualWidth)
+                               ));
+                            }
+                        }
+                        break;
+                    case "add":
+                        {
+                            var ksp = _kspManager.CurrentInstance;
+                            var addOptions = (CompatAddOptions)suboptions;
+
+                            KspVersion kspVersion;
+                            if (KspVersion.TryParse(addOptions.Version, out kspVersion))
+                            {
+                                var newCompatibleVersion = ksp.GetCompatibleVersions();
+                                newCompatibleVersion.Add(kspVersion);
+                                ksp.SetCompatibleVersions(newCompatibleVersion);
+                            }
+                            else
+                            {
+                                _user.RaiseError("ERROR: Invalid KSP version.");
+                                exitCode = Exit.ERROR;
+                            }
+                        }
+                        break;
+                    case "forget":
+                        {
+                            var ksp = _kspManager.CurrentInstance;
+                            var addOptions = (CompatForgetOptions)suboptions;
+
+                            KspVersion kspVersion;
+                            if (KspVersion.TryParse(addOptions.Version, out kspVersion))
+                            {
+                                if (kspVersion != ksp.Version())
+                                {
+                                    var newCompatibleVersion = ksp.GetCompatibleVersions();
+                                    newCompatibleVersion.RemoveAll(i => i == kspVersion);
+                                    ksp.SetCompatibleVersions(newCompatibleVersion);
+                                }
+                                else
+                                {
+                                    _user.RaiseError("ERROR: Cannot forget actual KSP version.");
+                                    exitCode = Exit.ERROR;
+                                }
+                            }
+                            else
+                            {
+                                _user.RaiseError("ERROR: Invalid KSP version.");
+                                exitCode = Exit.ERROR;
+                            }
+                        }
+                        break;
+                    default:
+                        exitCode = Exit.BADOPT;
+                        break;
+                }
+            });
+
+            return exitCode;
+        }
+
+        private class CompatOptions : CommonOptions
+        {
+            [VerbOption("list", HelpText = "List compatible KSP versions")]
+            public CompatListOptions List { get; set; }
+
+            [VerbOption("add", HelpText = "List compatible KSP versions")]
+            public CompatAddOptions Add { get; set; }
+
+            [VerbOption("forget", HelpText = "List compatible KSP versions")]
+            public CompatForgetOptions Forget { get; set; }
+        }
+
+        private class CompatListOptions : CommonOptions { }
+
+        private class CompatAddOptions : CommonOptions
+        {
+            [ValueOption(0)]
+            public string Version { get; set; }
+        }
+
+        private class CompatForgetOptions : CommonOptions
+        {
+            [ValueOption(0)]
+            public string Version { get; set; }
+        }
+    }
+}

--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using CKAN.CmdLine.Action;
 using CommandLine;
 
 namespace CKAN.CmdLine

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Action\Compare.cs" />
+    <Compile Include="Action\CompatSubCommand.cs" />
     <Compile Include="ConsoleUser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Main.cs" />

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using CKAN.CmdLine.Action;
 using log4net;
 using log4net.Config;
 using log4net.Core;
@@ -252,6 +253,10 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                 case "ksp":
                     var ksp = new KSP(manager, user);
                     return ksp.RunSubCommand((SubCommandOptions) cmdline.options);
+
+                case "compat":
+                    var compat = new CompatSubCommand(manager, user);
+                    return compat.RunSubCommand((SubCommandOptions)cmdline.options);
 
                 case "repo":
                     var repo = new Repo (manager, user);

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -79,6 +79,9 @@ namespace CKAN.CmdLine
         [VerbOption("ksp", HelpText = "Manage KSP installs")]
         public SubCommandOptions Repo { get; set; }
 
+        [VerbOption("compat", HelpText = "Manager KSP version compatibility")]
+        public SubCommandOptions Compat { get; set; }
+
         [VerbOption("compare", HelpText = "Compare version strings")]
         public CompareOptions Compare { get; set; }
 

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -383,9 +383,9 @@ namespace CKAN
         }
 
 
-        public KspVersionCriteria VersionCriteria ()
+        public KspVersionCriteria VersionCriteria()
         {
-            return new KspVersionCriteria(version, _compatibleVersions);
+            return new KspVersionCriteria(Version(), _compatibleVersions);
         }
 
         #endregion


### PR DESCRIPTION
@politas Support modifying KSP compatibility from the CLI.

Also fixes a bug where compatibility would be too permissive due to unitialized `version` field in `KSP`.