### PR TITLE
Remove non-functioning code on available command

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CKAN.Exporters;
+using CKAN.Types;
+using log4net;
+
+namespace CKAN.CmdLine
+{
+    public class Available : ICommand
+    {
+        private static readonly ILog log = LogManager.GetLogger(typeof(List));
+
+        public IUser user { get; set; }
+
+        public Available(IUser user)
+        {
+            this.user = user;
+        }
+
+        private int ConsoleWidth()
+        {
+            try
+            {
+                var width = user.WindowWidth;
+                return width;
+            }
+            catch (Kraken)
+            {
+                var width = 80;
+                log.InfoFormat("Could not find console width, defaulting to {0}", width);
+                return width;
+            }
+        }
+
+        public int RunCommand(CKAN.KSP ksp, object raw_options)
+        {
+            IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
+
+            var width = ConsoleWidth();
+
+            List<CkanModule> available = registry.Available(ksp.VersionCriteria());
+
+            user.RaiseMessage("Mods available for KSP {0}", ksp.Version());
+            user.RaiseMessage("");
+
+            foreach (CkanModule module in available)
+            {
+                    string entry = String.Format("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
+                    user.RaiseMessage(width > 0 ? entry.PadRight(width).Substring(0, width - 1) : entry);
+            }
+
+            return Exit.OK;
+        }
+    }
+}
+

--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -1,18 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using CKAN.Exporters;
-using CKAN.Types;
-using log4net;
+//using System.Linq;
+//using System.Text.RegularExpressions;
+//using CKAN.Exporters;
+//using CKAN.Types;
+//using log4net;
 
 namespace CKAN.CmdLine
 {
     public class Available : ICommand
     {
-        private static readonly ILog log = LogManager.GetLogger(typeof(List));
-
         public IUser user { get; set; }
 
         public Available(IUser user)
@@ -20,27 +18,9 @@ namespace CKAN.CmdLine
             this.user = user;
         }
 
-        private int ConsoleWidth()
-        {
-            try
-            {
-                var width = user.WindowWidth;
-                log.InfoFormat("Found console width {0}", width);
-                return width;
-            }
-            catch (Kraken)
-            {
-                var width = 80;
-                log.InfoFormat("Could not find console width, defaulting to {0}", width);
-                return width;
-            }
-        }
-
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
             IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
-
-            var width = ConsoleWidth();
 
             List<CkanModule> available = registry.Available(ksp.VersionCriteria());
 
@@ -49,8 +29,7 @@ namespace CKAN.CmdLine
 
             foreach (CkanModule module in available)
             {
-                    string entry = String.Format("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
-                    user.RaiseMessage(width > 0 ? entry.PadRight(width).Substring(0, width - 1) : entry);
+                user.RaiseMessage(String.Format("* {0} ({1}) - {2}", module.identifier, module.version, module.name));
             }
 
             return Exit.OK;

--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -25,6 +25,7 @@ namespace CKAN.CmdLine
             try
             {
                 var width = user.WindowWidth;
+                log.InfoFormat("Found console width {0}", width);
                 return width;
             }
             catch (Kraken)

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -23,16 +23,14 @@
     <Reference Include="CommandLine">
       <HintPath>..\Core\packages\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
+      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Action\Compare.cs" />
@@ -55,6 +53,7 @@
     <Compile Include="Action\Show.cs" />
     <Compile Include="Action\Update.cs" />
     <Compile Include="Action\Upgrade.cs" />
+    <Compile Include="Action\Available.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -218,7 +218,8 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                     return (new Update(user)).RunCommand(manager.CurrentInstance, (UpdateOptions)cmdline.options);
 
                 case "available":
-                    return Available(manager.CurrentInstance, user);
+                    return (new Available(user)).RunCommand(manager.CurrentInstance, (AvailableOptions)cmdline.options);
+                    //return Available(manager.CurrentInstance, user);
 
                 case "install":
                     Scan(manager.CurrentInstance, user, cmdline.action);
@@ -321,24 +322,6 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
         private static int Version(IUser user)
         {
             user.RaiseMessage(Meta.Version());
-
-            return Exit.OK;
-        }
-
-        private static int Available(CKAN.KSP current_instance, IUser user)
-        {
-            List<CkanModule> available = RegistryManager.Instance(current_instance).registry.Available(current_instance.VersionCriteria());
-
-            user.RaiseMessage("Mods available for KSP {0}", current_instance.Version());
-            user.RaiseMessage("");
-
-            var width = user.WindowWidth;
-
-            foreach (CkanModule module in available)
-            {
-                string entry = String.Format("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
-                user.RaiseMessage(width > 0 ? entry.PadRight(width).Substring(0, width - 1) : entry);
-            }
 
             return Exit.OK;
         }


### PR DESCRIPTION
Console.WindiwWidth command was throwing an exception. Right-padding was not utilised on any other command, so code removed.

Moved available command into its own Action/Available.cs to match other commands.
Closes #359