### PR TITLE
Fix for black rows in GUI on conflicting mods.

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -125,14 +125,14 @@ namespace CKAN
                 }
                 else
                 {
-                    if (row.DefaultCellStyle.BackColor != SystemColors.ControlText)
+                    if (row.DefaultCellStyle.BackColor != Color.Empty)
                     {
                         foreach (DataGridViewCell cell in row.Cells)
                         {
                             cell.ToolTipText = null;
                         }
 
-                        row.DefaultCellStyle.BackColor = SystemColors.ControlText;
+                        row.DefaultCellStyle.BackColor = Color.Empty;
                         ModList.InvalidateRow(row.Index);
                     }
                 }


### PR DESCRIPTION
Fixes issue #1967 by setting row background color to "Color.Empty" - the default color value for this object.