### PR TITLE
Always provide a string error message for ModuleNotFoundKraken

### DIFF
--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -57,7 +57,7 @@ namespace CKAN
 
         // TODO: Is there a way to set the stringify version of this?
         public ModuleNotFoundKraken(string module, string version = null, string reason = null, Exception innerException = null)
-            : base(reason, innerException)
+            : base(reason ?? string.Format("Module {0} of version {1} is not available", module, version), innerException)
         {
             this.module = module;
             this.version = version;


### PR DESCRIPTION
As per issue #1992.