### PR TITLE
Switch to all C# native mod downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/packages/
 /_build/
 /.vs/
 Screenshots/

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -83,7 +83,14 @@ namespace CKAN
                 downloads.Add(download);
             }
 
-            DownloadNative();
+            // adding chicken bits
+            if (Platform.IsWindows || System.Environment.GetEnvironmentVariable("KSP_CKAN_USE_CURL") != null) {
+                DownloadNative();
+            }
+            else
+            {
+                DownloadCurl();
+            }
 
         }
 

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -83,14 +83,8 @@ namespace CKAN
                 downloads.Add(download);
             }
 
-            if (Platform.IsWindows)
-            {
-                DownloadNative();
-            }
-            else
-            {
-                DownloadCurl();
-            }
+            DownloadNative();
+
         }
 
         /// <summary>


### PR DESCRIPTION
Improvements in Mono and the downfall of kerbalstuff appears to have removed the necessity for curl downloads.
Closes #840 