### PR TITLE
Update build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ env:
     - BUILD_CONFIGURATION=Release
 
 mono:
+    - 4.8.0
     - 4.6.2
-    - 4.2.4
+    - 4.4.2
     - 4.0.5
 
 addons:
@@ -38,7 +39,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         tags: true
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 4.6.2
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 4.8.0
         # all_branches needed as a workaround for travis-ci#1675
         all_branches: true
 
@@ -55,7 +56,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         branch: master
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 4.6.2
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 4.8.0
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 
 script:
     - ./build --configuration=$BUILD_CONFIGURATION
-    - ./build test+only --configuration=$BUILD_CONFIGURATION --exclude=FlakyNetwork
+    - ./build test+only --configuration=$BUILD_CONFIGURATION --where="cat!=FlakyNetwork"
 
 deploy:
     # Releases (which are tagged) go to github

--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -36,9 +36,8 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/AutoUpdate/packages.config
+++ b/AutoUpdate/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/AutoUpdate/packages.config
+++ b/AutoUpdate/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
 </packages>

--- a/CKAN.sln.DotSettings
+++ b/CKAN.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -40,12 +40,11 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -37,13 +37,11 @@
     <Reference Include="CommandLine">
       <HintPath>..\_build\lib\nuget\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
-      <HintPath>..\_build\lib\nuget\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a">
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/Cmdline/packages.config
+++ b/Cmdline/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/Cmdline/packages.config
+++ b/Cmdline/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
 </packages>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -33,6 +33,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=4.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Autofac.4.4.0\lib\net45\Autofac.dll</HintPath>
+    </Reference>
     <Reference Include="CommandLine">
       <HintPath>..\_build\lib\nuget\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
     </Reference>
@@ -55,9 +58,6 @@
     </Reference>
     <Reference Include="CurlSharp">
       <HintPath>..\lib\curlsharp-v0.5.1-2-gd2d5699\CurlSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Autofac">
-      <HintPath>..\_build\lib\nuget\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -40,9 +40,8 @@
       <HintPath>..\_build\lib\nuget\ICSharpCode.SharpZipLib.Patched.0.86.5\lib\net20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\log4net.2.0.5\lib\net40-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -46,9 +46,8 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -10,6 +10,8 @@
     <AssemblyName>CKAN</AssemblyName>
     <OutputPath>..\_build\out\$(AssemblyName)\$(Configuration)\bin\</OutputPath>
     <IntermediateOutputPath>..\_build\out\$(AssemblyName)\$(Configuration)\obj\</IntermediateOutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -19,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -27,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine">

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -4,6 +4,6 @@
   <package id="ChinhDo.Transactions.FileManager" version="1.2.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="TxFileManager" version="1.3" targetFramework="net40" />
 </packages>

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net40" />
+  <package id="Autofac" version="4.4.0" targetFramework="net45" />
   <package id="ChinhDo.Transactions.FileManager" version="1.2.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -3,7 +3,7 @@
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
   <package id="ChinhDo.Transactions.FileManager" version="1.2.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
-  <package id="log4net" version="2.0.5" targetFramework="net40" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
   <package id="TxFileManager" version="1.3" targetFramework="net40" />
 </packages>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -56,9 +56,8 @@
     <Reference Include="INIFileParser">
       <HintPath>..\_build\lib\nuget\ini-parser.2.1.1\lib\INIFileParser.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -50,8 +50,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Autofac.4.4.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="INIFileParser, Version=2.4.0.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\ini-parser.3.4.0\lib\net20\INIFileParser.dll</HintPath>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -59,9 +59,8 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -53,8 +53,8 @@
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="INIFileParser">
-      <HintPath>..\_build\lib\nuget\ini-parser.2.1.1\lib\INIFileParser.dll</HintPath>
+    <Reference Include="INIFileParser, Version=2.4.0.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\ini-parser.3.4.0\lib\net20\INIFileParser.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -3,5 +3,5 @@
   <package id="Autofac" version="4.4.0" targetFramework="net45" />
   <package id="ini-parser" version="3.4.0" targetFramework="net45" userInstalled="true" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
 </packages>

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="ini-parser" version="2.1.1" targetFramework="net4" userInstalled="true" />
+  <package id="ini-parser" version="3.4.0" targetFramework="net45" userInstalled="true" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
+  <package id="Autofac" version="4.4.0" targetFramework="net45" />
   <package id="ini-parser" version="3.4.0" targetFramework="net45" userInstalled="true" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="ini-parser" version="2.1.1" targetFramework="net4" userInstalled="true" />
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -47,9 +47,8 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -44,9 +44,8 @@
       <HintPath>..\_build\lib\nuget\ICSharpCode.SharpZipLib.Patched.0.86.5\lib\net20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Netkan/packages.config
+++ b/Netkan/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/Netkan/packages.config
+++ b/Netkan/packages.config
@@ -3,5 +3,5 @@
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
 </packages>

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -27,7 +27,7 @@ namespace Tests.Core
         /// Prep environment by setting up a single mod in
         /// a disposable KSP instance.
         /// </summary>
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SetUp()
         {
             _testModule = TestData.DogeCoinFlag_101_module();

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -16,7 +16,7 @@ namespace Tests.Core.Relationships
         private CKAN.Registry registry;
         private DisposableKSP ksp;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             ksp = new DisposableKSP();

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Reflection;
 using CKAN;
 using CKAN.Versioning;
 using Version = CKAN.Version;
@@ -12,12 +13,14 @@ namespace Tests.Data
     {
         public static string DataDir()
         {
-            // TODO: Have this actually walk our directory structure and find
-            // t/data. This means we can relocate our test executable and
-            // things will still work.
-            string current = Directory.GetCurrentDirectory();
-
-            return Path.Combine(current, "../../../../../Tests/Data");
+            // FIXME: Come up with a better solution for test data
+            // 1. This is fragile with respect to changes in directory structure.
+            // 2. This forces us to disable ReSharper's test assembly shadow copying
+            // 3. "Quick" solution is to embed test data as an archive and extract it on demand to a known temporary location.
+            //    But this makes updates hard.
+            // 4. A better, but much harder solution, is to not require harded files on disk for any of our tests, but that's
+            //    a lot of work.
+            return Path.Combine(Directory.GetParent(Assembly.GetExecutingAssembly().Location).FullName, "../../../../../Tests/Data");
         }
 
         public static string DataDir(string file)

--- a/Tests/GUI/Configuration.cs
+++ b/Tests/GUI/Configuration.cs
@@ -10,13 +10,13 @@ namespace Tests.GUI
     {
         string tempDir;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             tempDir = TestData.NewTempDir();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             Directory.Delete(tempDir, true);

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -47,7 +47,7 @@ namespace Tests.GUI
             new NetAsyncModulesDownloader(main.currentUser)
         );*/
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Up()
         {
             _instance = new DisposableKSP();
@@ -84,7 +84,7 @@ namespace Tests.GUI
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void Down()
         {
             _instance.Dispose();

--- a/Tests/GUI/NavigationHistoryTests.cs
+++ b/Tests/GUI/NavigationHistoryTests.cs
@@ -39,7 +39,7 @@
             Assert.IsFalse(nav.CanNavigateForward);
         }
 
-        [Test, ExpectedException(typeof(InvalidOperationException))]
+        [Test]
         public void NavigatingBackward_WhenUnable_ThrowsException()
         {
             // arrange
@@ -48,14 +48,14 @@
 
             // act
 
-            nav.NavigateBackward();
+            TestDelegate act = () => nav.NavigateBackward();
 
             // assert
 
-            Assert.Fail();
+            Assert.Throws<InvalidOperationException>(act);
         }
 
-        [Test, ExpectedException(typeof(InvalidOperationException))]
+        [Test]
         public void NavigatingForward_WhenUnable_ThrowsException()
         {
             // arrange
@@ -64,11 +64,11 @@
 
             // act
 
-            nav.NavigateForward();
+            TestDelegate act = () => nav.NavigateForward();
 
             // assert
 
-            Assert.Fail();
+            Assert.Throws<InvalidOperationException>(act);
         }
 
         [Test]

--- a/Tests/NetKAN/SDMod.cs
+++ b/Tests/NetKAN/SDMod.cs
@@ -26,10 +26,10 @@ namespace Tests.NetKAN
         }
 
         [Test]
-        [TestCase("/mod/42/Example/download/1.23", Result="https://spacedock.info/mod/42/Example/download/1.23")]
-        [TestCase("/mod/42/Example%20With%20Spaces/download/1.23", Result="https://spacedock.info/mod/42/Example%20With%20Spaces/download/1.23")]
-        [TestCase("/mod/42/Example With Spaces/download/1.23", Result="https://spacedock.info/mod/42/Example%20With%20Spaces/download/1.23")]
-        [TestCase("/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93",Result="https://spacedock.info/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93")]
+        [TestCase("/mod/42/Example/download/1.23", ExpectedResult="https://spacedock.info/mod/42/Example/download/1.23")]
+        [TestCase("/mod/42/Example%20With%20Spaces/download/1.23", ExpectedResult = "https://spacedock.info/mod/42/Example%20With%20Spaces/download/1.23")]
+        [TestCase("/mod/42/Example With Spaces/download/1.23", ExpectedResult = "https://spacedock.info/mod/42/Example%20With%20Spaces/download/1.23")]
+        [TestCase("/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93", ExpectedResult = "https://spacedock.info/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93")]
         // GH #816: Ensure URLs with & are encoded correctly.
         public string SD_URL_encode_816(string path)
         {

--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Sources.Curse
     {
         private NetFileCache _cache;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetup()
         {
             var tempDirectory = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
@@ -24,7 +24,7 @@ namespace Tests.NetKAN.Sources.Curse
             _cache = new NetFileCache(tempDirectory);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
             Directory.Delete(_cache.GetCachePath(), recursive: true);

--- a/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
+++ b/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Sources.Spacedock
     {
         private NetFileCache _cache;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetup()
         {
             var tempDirectory = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
@@ -24,7 +24,7 @@ namespace Tests.NetKAN.Sources.Spacedock
             _cache = new NetFileCache(tempDirectory);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
             Directory.Delete(_cache.GetCachePath(), recursive: true);

--- a/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
@@ -21,7 +21,7 @@ namespace Tests.NetKAN.Transformers
             var transformedJson = result.Json();
 
             // Assert
-            Assert.That((string)transformedJson["x_generated_by"], Is.StringContaining("netkan"),
+            Assert.That((string)transformedJson["x_generated_by"], Does.Contain("netkan"),
                 "GeneratedByTransformer should add an x_generated_by property containing the string 'netkan'"
             );
         }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -35,9 +35,8 @@
     <RootNamespace>Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="CurlSharp">
       <HintPath>..\lib\curlsharp-v0.5.1-2-gd2d5699\CurlSharp.dll</HintPath>
@@ -68,6 +67,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Data\CKAN-meta-badkan.zip" />
     <None Include="Data\CKAN-meta-testkan.tar.gz" />
     <None Include="Data\CKAN-meta-testkan.zip" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -52,9 +52,8 @@
     <Reference Include="Moq, Version=4.7.8.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Moq.4.7.8\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -46,9 +46,8 @@
       <HintPath>..\_build\lib\nuget\ICSharpCode.SharpZipLib.Patched.0.86.5\lib\net20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -49,9 +49,8 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.7.8.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Moq.4.7.8\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -56,9 +56,8 @@
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Tests/app.config
+++ b/Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Moq" version="4.5.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Moq" version="4.5.21" targetFramework="net45" />
+  <package id="Moq" version="4.7.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -5,5 +5,5 @@
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Moq" version="4.7.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -4,6 +4,6 @@
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Moq" version="4.7.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Moq" version="4.5.21" targetFramework="net45" />

--- a/build
+++ b/build
@@ -19,7 +19,7 @@ if [ $# -gt 1 ]; then
     done
 fi
 
-nugetVersion="2.8.6"
+nugetVersion="4.0.0"
 useExperimental=false
 rootDir=$(dirname $0)
 buildDir="$rootDir/_build"

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#addin "nuget:?package=Cake.SemVer&version=1.0.6"
+#addin "nuget:?package=Cake.SemVer&version=1.0.14"
 #tool "nuget:?package=ILRepack&version=2.0.12"
 #tool "nuget:?package=NUnit.Runners&version=2.6.4"
 

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 #addin "nuget:?package=Cake.SemVer&version=1.0.14"
 #tool "nuget:?package=ILRepack&version=2.0.12"
-#tool "nuget:?package=NUnit.Runners&version=2.6.4"
+#tool "nuget:?package=NUnit.ConsoleRunner&version=3.6.1"
 
 using System.Text.RegularExpressions;
 using Semver;
@@ -112,7 +112,7 @@ Task("Test+Only")
 Task("Test-UnitTests+Only")
     .Does(() =>
 {
-    var exclude = Argument<string>("exclude", null);
+    var where = Argument<string>("where", null);
 
     var testFile = outDirectory
         .Combine("CKAN.Tests")
@@ -127,9 +127,9 @@ Task("Test-UnitTests+Only")
 
     CreateDirectory(nunitOutputDirectory);
 
-    NUnit(testFile.FullPath, new NUnitSettings {
-        Exclude = exclude,
-        ResultsFile = nunitOutputDirectory.CombineWithFilePath("TestResult.xml")
+    NUnit3(testFile.FullPath, new NUnit3Settings {
+        Where = where,
+        Results = nunitOutputDirectory.CombineWithFilePath("TestResult.xml")
     });
 });
 

--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ Param (
 )
 
 # Globals
-$NugetVersion       = "2.8.6"
+$NugetVersion       = "4.0.0"
 $UseExperimental    = $false
 $RootDir            = "${PSScriptRoot}"
 $BuildDir           = "${RootDir}/_build"

--- a/nuget.config
+++ b/nuget.config
@@ -3,4 +3,8 @@
   <config>
     <add key="repositoryPath" value="_build/lib/nuget" />
   </config>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
 </configuration>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.17.0" />
+  <package id="Cake" version="0.19.2" />
 </packages>


### PR DESCRIPTION
@politas @Olympic1 

Update build

- Update NuGet from 2.8.6 to 4.0.0
- Ensure all projects target .NET 4.5 (previously only CKAN.Core) wasn't
- Ensure all projects have `Prefer32Bit` set to false (makes sure program runs as 64-bit application on 64-bit platforms)
- Update Cake from 0.17.0 to 0.19.2
- Update Cake.SemVer from 1.0.6 to 1.0.14
- Explicitly specify NuGet repository in `nuget.config` to workaround Linux-specific issue
- Update libraries:
  - Update log4net from 2.0.5 to 2.0.8
  - Update Castle.Core from 3.3.3 to 4.0.0
  - Update Moq from 4.5.21 to 4.7.8
  - Update NUnit from 2.6.4 to 3.6.1
    - Breaking changes, updated source for NUnit 3 API.
    - Changed from NUnit.Runners 2.6.4 to NUnit.ConsoleRunner 3.6.1
  - Update ini-parser from 2.1.1 to 3.4.0
  - Update Autofac from 3.5.2 to 4.4.0
  - Update Newtonsoft.Json (JSON.NET) from 9.0.1 to 10.0.2
- Added Mono 4.8.0 and 4.4.2 to Travis build matrix
  - Updated deployments to only deploy on Mono 4.8.0 builds
- Removed Mono 4.2.4 from Travis, was causing NuGet to timeout consistently attempting to download packages