### PR TITLE
Convert spaces to %20 in Curse URLs

### DIFF
--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -86,7 +86,7 @@ namespace CKAN.NetKAN.Transformers
                 else                         json.SafeAdd("version", latestVersion.GetFileVersion());
 
                 json.SafeAdd("author", JToken.FromObject(curseMod.authors));
-                json.SafeAdd("download", latestVersion.GetDownloadUrl());
+                json.SafeAdd("download", Regex.Replace(latestVersion.GetDownloadUrl(), " ", "%20"));
 
                 // Curse provides users with the following default selection of licenses. Let's convert them to CKAN
                 // compatible license strings if possible.


### PR DESCRIPTION
This should allow KSP-CKAN/NetKAN#5471 to work, and will make all our Curse transforms more reliable.