### PR TITLE
Update build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - BUILD_CONFIGURATION=Release
 
 mono:
+    - 5.0.0
     - 4.8.0
     - 4.6.2
     - 4.4.2
@@ -39,7 +40,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         tags: true
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 4.8.0
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.0.0
         # all_branches needed as a workaround for travis-ci#1675
         all_branches: true
 
@@ -56,7 +57,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         branch: master
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 4.8.0
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.0.0
 
 notifications:
   irc:

--- a/CKAN.sln
+++ b/CKAN.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CKAN-core", "Core\CKAN-core.csproj", "{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}"
 EndProject

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -33,8 +33,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Autofac.4.4.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="CommandLine">
       <HintPath>..\_build\lib\nuget\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.4.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="ChinhDo.Transactions.FileManager" version="1.2.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -50,8 +50,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Autofac.4.4.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="INIFileParser, Version=2.4.0.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\ini-parser.3.4.0\lib\net20\INIFileParser.dll</HintPath>

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.4.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="ini-parser" version="3.4.0" targetFramework="net45" userInstalled="true" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -49,8 +49,8 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.7.8.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Moq.4.7.8\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.10.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Moq.4.7.10\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Moq" version="4.7.8" targetFramework="net45" />
+  <package id="Moq" version="4.7.10" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/build
+++ b/build
@@ -19,7 +19,7 @@ if [ $# -gt 1 ]; then
     done
 fi
 
-nugetVersion="4.0.0"
+nugetVersion="4.1.0"
 useExperimental=false
 rootDir=$(dirname $0)
 buildDir="$rootDir/_build"

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #addin "nuget:?package=Cake.SemVer&version=1.0.14"
-#tool "nuget:?package=ILRepack&version=2.0.12"
+#tool "nuget:?package=ILRepack&version=2.0.13"
 #tool "nuget:?package=NUnit.ConsoleRunner&version=3.6.1"
 
 using System.Text.RegularExpressions;

--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ Param (
 )
 
 # Globals
-$NugetVersion       = "4.0.0"
+$NugetVersion       = "4.1.0"
 $UseExperimental    = $false
 $RootDir            = "${PSScriptRoot}"
 $BuildDir           = "${RootDir}/_build"
@@ -29,7 +29,7 @@ if (!(Test-Path $NugetExe)) {
 }
 
 # Install build packages
-Invoke-Expression "${NugetExe} install `"${PackagesConfigFile}`" -OutputDirectory `"${PackagesDir}`"" 
+Invoke-Expression "${NugetExe} install `"${PackagesConfigFile}`" -OutputDirectory `"${PackagesDir}`""
 
 # Build args
 $cakeArgs = @()

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.19.2" />
+  <package id="Cake" version="0.19.5" />
 </packages>


### PR DESCRIPTION
Depends on #2049

#2049 is the minimum changes needed to support building on Mono 5.0.0. This also takes the opportunity to upgrade to the latest versions of all tools/libraries.

- Update NuGet from 4.0.0 to 4.1.0
- Update Cake from 0.19.2 to 0.19.5
- Update Moq from 4.7.8 to 4.7.10
- Update Autofac from 4.4.0 to 4.5.0
- Update solution file to VS15/VS2017