### PR TITLE
Move downloads outside of gui transaction

### DIFF
--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Types\CKANVersion.cs" />
     <Compile Include="Registry\IRegistryQuerier.cs" />
     <Compile Include="Types\ExportFileType.cs" />
+    <Compile Include="Types\ModuleResolution.cs" />
     <Compile Include="User.cs" />
     <Compile Include="Types\Version.cs" />
     <Compile Include="Types\Kraken.cs" />

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -28,7 +28,7 @@ namespace CKAN
         private static SortedList<string, ModuleInstaller> instances = new SortedList<string, ModuleInstaller>();
 
         private static readonly ILog log = LogManager.GetLogger(typeof(ModuleInstaller));
-        private static readonly TxFileManager file_transaction = new TxFileManager ();
+        private static readonly TxFileManager file_transaction = new TxFileManager();
 
         private RegistryManager registry_manager;
         private KSP ksp;
@@ -144,8 +144,6 @@ namespace CKAN
             return full_path;
         }
 
-
-
         public void InstallList(
             List<string> modules,
             RelationshipResolverOptions options,
@@ -175,7 +173,7 @@ namespace CKAN
         {
             var resolver = new RelationshipResolver(modules, options, registry_manager.registry, ksp.VersionCriteria());
             var modsToInstall = resolver.ModList().ToList();
-            List<CkanModule> downloads = new List<CkanModule> ();
+            List<CkanModule> downloads = new List<CkanModule>();
 
             // TODO: All this user-stuff should be happening in another method!
             // We should just be installing mods as a transaction.
@@ -300,7 +298,7 @@ namespace CKAN
             }
 
             // Find our in the cache if we don't already have it.
-            filename = filename ?? Cache.GetCachedZip(module.download,true);
+            filename = filename ?? Cache.GetCachedZip(module.download, true);
 
             // If we *still* don't have a file, then kraken bitterly.
             if (filename == null)
@@ -415,7 +413,7 @@ namespace CKAN
         {
             string installDir;
             bool makeDirs;
-            var files = new List<InstallableFile> ();
+            var files = new List<InstallableFile>();
 
             // Normalize the path before doing everything else
             // TODO: This really should happen in the ModuleInstallDescriptor itself.
@@ -469,25 +467,28 @@ namespace CKAN
                         throw new BadInstallLocationKraken("Unknown install_to " + stanza.install_to);
                 }
             }
-            else switch (stanza.install_to)
+            else 
             {
-                case "Tutorial":
-                    installDir = ksp == null ? null : ksp.Tutorial();
-                    makeDirs = true;
-                    break;
+                switch (stanza.install_to)
+                {
+                    case "Tutorial":
+                        installDir = ksp == null ? null : ksp.Tutorial();
+                        makeDirs = true;
+                        break;
 
-                case "Scenarios":
-                    installDir = ksp == null ? null : ksp.Scenarios();
-                    makeDirs = true;
-                    break;
+                    case "Scenarios":
+                        installDir = ksp == null ? null : ksp.Scenarios();
+                        makeDirs = true;
+                        break;
 
-                case "GameRoot":
-                    installDir = ksp == null ? null : ksp.GameDir();
-                    makeDirs = false;
-                    break;
+                    case "GameRoot":
+                        installDir = ksp == null ? null : ksp.GameDir();
+                        makeDirs = false;
+                        break;
 
-                default:
-                    throw new BadInstallLocationKraken("Unknown install_to " + stanza.install_to);
+                    default:
+                        throw new BadInstallLocationKraken("Unknown install_to " + stanza.install_to);
+                }
             }
 
             // O(N^2) solution, as we're walking the zipfile for each stanza.
@@ -496,7 +497,8 @@ namespace CKAN
             foreach (ZipEntry entry in zipfile)
             {
                 // Skips things not prescribed by our install stanza.
-                if (! stanza.IsWanted(entry.Name)) {
+                if (!stanza.IsWanted(entry.Name))
+                {
                     continue;
                 }
 
@@ -612,7 +614,7 @@ namespace CKAN
         /// </summary>
         public static List<InstallableFile> FindInstallableFiles(CkanModule module, ZipFile zipfile, KSP ksp)
         {
-            var files = new List<InstallableFile> ();
+            var files = new List<InstallableFile>();
 
             try
             {
@@ -672,7 +674,7 @@ namespace CKAN
                 // Skip if we're not making directories for this install.
                 if (!makeDirs)
                 {
-                    log.DebugFormat ("Skipping {0}, we don't make directories for this path", fullPath);
+                    log.DebugFormat("Skipping {0}, we don't make directories for this path", fullPath);
                     return;
                 }
 
@@ -693,7 +695,7 @@ namespace CKAN
                 }
 
                 // We don't allow for the overwriting of files. See #208.
-                if (File.Exists (fullPath))
+                if (File.Exists(fullPath))
                 {
                     throw new FileExistsKraken(fullPath, string.Format("Trying to write {0} but it already exists.", fullPath));
                 }
@@ -778,7 +780,7 @@ namespace CKAN
 
         public void UninstallList(string mod)
         {
-            var list = new List<string> {mod};
+            var list = new List<string> { mod };
             UninstallList(list);
         }
 
@@ -824,7 +826,7 @@ namespace CKAN
                         // This is the fastest way to do this test.
                         if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
                         {
-                            if ( !(directoriesToDelete.Contains(path)))
+                            if (!directoriesToDelete.Contains(path))
                             {
                                 directoriesToDelete.Add(path);
                             }
@@ -836,7 +838,7 @@ namespace CKAN
                             // Since we check for directory contents when deleting, this should purge empty
                             // dirs, making less ModuleManager headaches for people.
                             var directoryName = Path.GetDirectoryName(path);
-                            if ( !(directoriesToDelete.Contains(directoryName)))
+                            if (!(directoriesToDelete.Contains(directoryName)))
                             {
                                 directoriesToDelete.Add(directoryName);
                             }

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -288,11 +288,6 @@ namespace CKAN
         {
             _comparator = comparator;
 
-            if (!validate_json_against_schema(json))
-            {
-                throw new BadMetadataKraken(null, "Validation against spec failed");
-            }
-
             try
             {
                 // Use the json string to populate our object
@@ -362,54 +357,6 @@ namespace CKAN
                 throw new InvalidModuleAttributesException("ksp_version mixed with ksp_version_(min|max)", this);
             }
 
-            if (license == null)
-            {
-                license = new List<License> { new License("unknown") };
-            }
-
-            if (@abstract == null)
-            {
-                @abstract = "";
-            }
-
-            if (name == null)
-            {
-                name = "";
-            }
-        }
-
-        private static bool validate_json_against_schema(string json)
-        {
-
-            log.Debug("In-client JSON schema validation unimplemented.");
-            return true;
-            // due to Newtonsoft Json not supporting v4 of the standard, we can't actually do this :(
-
-            //            if (metadata_schema == null)
-            //            {
-            //                string schema = "";
-            //
-            //                try
-            //                {
-            //                    schema = File.ReadAllText(metadata_schema_path);
-            //                }
-            //                catch (Exception)
-            //                {
-            //                    if (!metadata_schema_missing_warning_fired)
-            //                    {
-            //                        User.Error("Couldn't open metadata schema at \"{0}\", will not validate metadata files",
-            //                            metadata_schema_path);
-            //                        metadata_schema_missing_warning_fired = true;
-            //                    }
-            //
-            //                    return true;
-            //                }
-            //
-            //                metadata_schema = JsonSchema.Parse(schema);
-            //            }
-            //
-            //            JObject obj = JObject.Parse(json);
-            //            return obj.IsValid(metadata_schema);
             license = license ?? new List<License> { License.UnknownLicense };
             @abstract = @abstract ?? string.Empty;
             name = name ?? string.Empty;

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -410,6 +410,9 @@ namespace CKAN
             //
             //            JObject obj = JObject.Parse(json);
             //            return obj.IsValid(metadata_schema);
+            license = license ?? new List<License> { License.UnknownLicense };
+            @abstract = @abstract ?? string.Empty;
+            name = name ?? string.Empty;
         }
 
         /// <summary>

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -4,11 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
-using log4net;
-using Newtonsoft.Json;
-using System.Transactions;
 using Autofac;
 using CKAN.Versioning;
+using log4net;
+using Newtonsoft.Json;
 
 namespace CKAN
 {

--- a/Core/Types/License.cs
+++ b/Core/Types/License.cs
@@ -9,6 +9,9 @@ namespace CKAN
     [JsonConverter(typeof(JsonSimpleStringConverter))]
     public class License
     {
+        static License _unknownLicense;
+        public static License UnknownLicense => _unknownLicense ?? (_unknownLicense = new License("unknown"));
+
         // TODO: It would be lovely for our build system to write these for us.
         private static readonly HashSet<string> valid_licenses = new HashSet<string> {
             "public-domain",

--- a/Core/Types/ModuleResolution.cs
+++ b/Core/Types/ModuleResolution.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CKAN.Types
+{
+    public class ModuleResolution : IEnumerable<CkanModule>
+    {
+        public List<CkanModule> CachedModules { get; set; }
+        public List<CkanModule> UncachedModules { get; set; }
+
+        public IEnumerable<CkanModule> All => CachedModules.Concat(UncachedModules);
+
+        public int Count => CachedModules.Count + UncachedModules.Count;
+
+        public ModuleResolution(IEnumerable<CkanModule> modules, Func<CkanModule, bool> isCached)
+        {
+            CachedModules = new List<CkanModule>();
+            UncachedModules = new List<CkanModule>();
+
+            foreach (var module in modules)
+            {
+                if (isCached(module))
+                {
+                    CachedModules.Add(module);
+                }
+                else
+                {
+                    UncachedModules.Add(module);
+                }
+            }
+        }
+
+        public IEnumerator<CkanModule> GetEnumerator()
+        {
+            return All.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
#1935 mentions a timeout exception impacting only the GUI on large and/or slow downloads (taking longer than ten minutes). I believe this can be solved by moving the download process outside of the transaction begun in the GUI (there are additional transactions started inside Core which are not impacted by download times).

Of course, this is a terrible idea if changes to the cache are intended to be covered by the transaction, but I have not dug into the cache code deeply enough to know if this is the case. Thoughts?

To minimize the changes required (and thereby maximize my odds of not breaking anything), I have created the new download workflow *in addition to* the old one rather than replacing the old one. This is largely because the old one is in use in lots of different places throughout the GUI code--for additions and updates as well as bulk installs. This PR pretty much just overhauls bulk installs, since they exhibited the problem for me when I tried to update for 1.3 the other day.

I have just used a build based on this to update my KSP install, so it works. On my machine. We all know what that's worth, surely. :)

First PR here. If I have goofed on anything, I apologize.