### PR TITLE
Fix crash in "ckan available" with curly braces in mod name

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -29,7 +29,7 @@ namespace CKAN.CmdLine
 
             foreach (CkanModule module in available)
             {
-                user.RaiseMessage(String.Format("* {0} ({1}) - {2}", module.identifier, module.version, module.name));
+                user.RaiseMessage("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
             }
 
             return Exit.OK;


### PR DESCRIPTION
`mono ckan available` currently errors out halfway through the list:

```
...
* KSPDev-LogConsole (1:0.15) - KSPDev LogConsole

Unhandled Exception:
System.FormatException: Input string was not in a correct format.
  at System.Text.StringBuilder.AppendFormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) [0x000e9] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.String.FormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) [0x00026] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.String.Format (System.IFormatProvider provider, System.String format, System.Object[] args) [0x00029] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.IO.TextWriter.WriteLine (System.String format, System.Object[] arg) [0x00007] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.IO.TextWriter+SyncTextWriter.WriteLine (System.String format, System.Object[] arg) [0x00000] in <8f2c484307284b51944a1a13a14c0266>:0 
  at (wrapper synchronized) System.IO.TextWriter+SyncTextWriter:WriteLine (string,object[])
  at System.Console.WriteLine (System.String format, System.Object[] arg) [0x00016] in <8f2c484307284b51944a1a13a14c0266>:0 
  at CKAN.CmdLine.ConsoleUser.DisplayMessage (System.String message, System.Object[] args) [0x00001] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.NullUser.RaiseMessage (System.String message, System.Object[] url) [0x00001] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.CmdLine.Available.RunCommand (CKAN.KSP ksp, System.Object raw_options) [0x0008b] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.CmdLine.MainClass.RunAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user, CKAN.KSPManager manager) [0x001b3] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x003b7] in <b3a003dfcca84e4386996f3968e550bd>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.FormatException: Input string was not in a correct format.
  at System.Text.StringBuilder.AppendFormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) [0x000e9] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.String.FormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) [0x00026] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.String.Format (System.IFormatProvider provider, System.String format, System.Object[] args) [0x00029] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.IO.TextWriter.WriteLine (System.String format, System.Object[] arg) [0x00007] in <8f2c484307284b51944a1a13a14c0266>:0 
  at System.IO.TextWriter+SyncTextWriter.WriteLine (System.String format, System.Object[] arg) [0x00000] in <8f2c484307284b51944a1a13a14c0266>:0 
  at (wrapper synchronized) System.IO.TextWriter+SyncTextWriter:WriteLine (string,object[])
  at System.Console.WriteLine (System.String format, System.Object[] arg) [0x00016] in <8f2c484307284b51944a1a13a14c0266>:0 
  at CKAN.CmdLine.ConsoleUser.DisplayMessage (System.String message, System.Object[] args) [0x00001] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.NullUser.RaiseMessage (System.String message, System.Object[] url) [0x00001] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.CmdLine.Available.RunCommand (CKAN.KSP ksp, System.Object raw_options) [0x0008b] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.CmdLine.MainClass.RunAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user, CKAN.KSPManager manager) [0x001b3] in <b3a003dfcca84e4386996f3968e550bd>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x003b7] in <b3a003dfcca84e4386996f3968e550bd>:0 
```

The next mod listed in `registry.json` is KSPFrenchTranslation, which has a "name" value of "KSP 1.3 Full Game French Transaltion {BETA}". Hmm, those curly braces make it look like a malformed string format parameter. Maybe someone's passing that string where a format string is expected?

... Yup. `RaiseMessage` has a format/args parameter pattern, and is used that way throughout CKAN, except in `CmdLine.Available.RunCommand`, where the return value of a `String.Format` call is passed as the format parameter, which means trouble if any of the `args` contain curly braces:

https://github.com/KSP-CKAN/CKAN/blob/1fe599741ec79a6fb0c92bcf1c0e62435f45a69a/Cmdline/Action/Available.cs#L30-L33

The attached change fixes the issue in my testing.