### PR TITLE
Handle cases where there are no available_modules but there are installed_modules

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -200,10 +200,14 @@ namespace CKAN
                     )
             };
 
-            
-
-            string json = File.ReadAllText(path);
+            var json = File.ReadAllText(path);
             registry = JsonConvert.DeserializeObject<Registry>(json, settings);
+
+            if (registry.available_modules.Count == 0 && registry.InstalledModules.Any())
+            {
+                throw new ArgumentOutOfRangeException("available_modules", "Mods are installed, yet there are no available modules.");
+            }
+
             log.DebugFormat("Loaded CKAN registry at {0}", path);
         }
 
@@ -213,12 +217,7 @@ namespace CKAN
             {
                 Load();
             }
-            catch (FileNotFoundException)
-            {
-                Create();
-                Load();
-            }
-            catch (DirectoryNotFoundException)
+            catch (Exception)
             {
                 Create();
                 Load();


### PR DESCRIPTION
If the registry.json does not contain available_modules, but there are installed modules, we should re-create the registry. Relates to #1994 #1992 and supercedes #1993.