### PR TITLE
Check grandparent+ directories for find and find_regexp

### DIFF
--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -167,8 +167,8 @@ namespace CKAN
             // don't include entries for directories, but still include entries
             // for the files they contain.
             Regex inst_filt = this.find != null
-                ? new Regex(@"(?:^|/)" + Regex.Escape(this.find) + @"$")
-                : new Regex(this.find_regexp);
+                ? new Regex(@"(?:^|/)" + Regex.Escape(this.find) + @"$", RegexOptions.IgnoreCase)
+                : new Regex(this.find_regexp, RegexOptions.IgnoreCase);
 
             // Find the shortest directory path that matches our filter,
             // including all parent directories of all entries.


### PR DESCRIPTION
ZIP files can contain entries for directories, but it's optional. Currently, CKAN behaves differently depending on whether these entries are present, which is probably bad since it may not be controllable by or even apparent to the user.

`find` and `find_regexp` currently loop through each entry in the ZIP and check whether they match against the search pattern. If file matching is turned on, the names of file entries are checked, otherwise their immediate parent folders are checked. If there are multiple matches, the shortest one is used.

This algorithm only works in two cases:

1. The directory being searched for is present as a directory entry
2. The directory being searched for does not have a directory entry but is the immediate parent directory of a file

It fails for an important third case:

- The directory being searched for does not have a directory entry but is a grandparent, great-grandparent, etc. directory of one of the other entries

For example, take a look at [PlanetCerillion](https://github.com/KSP-CKAN/NetKAN/blob/master/NetKAN/PlanetCerillion.netkan) (many files omitted for brevity):

https://github.com/KSP-CKAN/NetKAN/blob/f6a054d20ca962da0f11bb5e2abf47616996b3a1/NetKAN/PlanetCerillion.netkan#L3-L7

```
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2017-09-23 13:57   Planet_Cerillion/Cache/
   706632  2017-09-23 13:57   Planet_Cerillion/Cache/1-Cerillion.bin
   706632  2017-09-23 13:57   Planet_Cerillion/Cache/2-Mavis.bin
        0  2017-09-23 11:57   Planet_Cerillion/Configs/
    69702  2017-09-23 14:08   Planet_Cerillion/Configs/atmo.cfg
    23211  2017-09-23 13:27   Planet_Cerillion/Configs/Cerillion_1.cfg
        0  2017-09-23 13:22   Planet_Cerillion/Data/
    17970  2017-07-12 11:18   Planet_Cerillion/Data/Arch.obj
    94598  2017-04-16 12:58   Planet_Cerillion/Data/Artifact1.obj
        0  2017-09-23 11:55   Planet_Cerillion/Data/Cerillion/
  8388608  2017-07-13 11:35   Planet_Cerillion/Data/Cerillion/inscatter.half
     8192  2017-07-13 11:35   Planet_Cerillion/Data/Cerillion/irradiance.half
        0  2017-09-23 13:22   Planet_Cerillion/Data/Disparia/
  8388608  2017-09-23 13:11   Planet_Cerillion/Data/Disparia/inscatter.half
     8192  2017-09-23 13:11   Planet_Cerillion/Data/Disparia/irradiance.half
        0  2017-09-23 13:53   Planet_Cerillion/PluginData/
  8388736  2016-03-29 22:28   Planet_Cerillion/PluginData/Cerillion_biome.dds
  4113460  2016-03-27 15:41   Planet_Cerillion/PluginData/Cerillion_color.png
      317  2017-09-23 14:29   License.txt
      701  2017-04-11 17:47   README.txt
```

The `find` clause is trying to find the `Planet_Cerillion` directory, but it is not present as a directory entry, and all the files are contained within sub-subfolders rather than directly under `Planet_Cerillion`. This causes ["Could not find Planet_Cerillion entry in zipfile to install"](http://status.ksp-ckan.org/).

With the attached code changes, the algorithm will check all grandparent, great-grandparent, etc. directories. This fixes the Planet_Cerillion case above, as well as the problem found in https://github.com/KSP-CKAN/NetKAN/pull/5841 and probably others.