### PR TITLE
Fix build.ps1 script failing when spaces exist in source path

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -19,17 +19,17 @@ $CakeVersion        = (Select-Xml -Xml ([xml](Get-Content $PackagesConfigFile)) 
 $CakeExe            = "${PackagesDir}/Cake.${CakeVersion}/Cake.exe"
 
 # Download NuGet
-$nugetDir = Split-Path $NugetExe -Parent
-if (!(Test-Path $nugetDir)) {
+$NugetDir = Split-Path "$NugetExe" -Parent
+if (!(Test-Path "$NugetDir")) {
     mkdir $nugetDir > $null
 }
 
-if (!(Test-Path $NugetExe)) {
+if (!(Test-Path "$NugetExe")) {
     (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v${NugetVersion}/nuget.exe", $NugetExe)
 }
 
 # Install build packages
-Invoke-Expression "${NugetExe} install `"${PackagesConfigFile}`" -OutputDirectory `"${PackagesDir}`""
+Invoke-Expression "& '${NugetExe}' install `"${PackagesConfigFile}`" -OutputDirectory `"${PackagesDir}`""
 
 # Build args
 $cakeArgs = @()
@@ -47,5 +47,5 @@ if ($UseExperimental) {
 }
 
 # Run Cake
-Invoke-Expression "${CakeExe} ${cakeArgs} ${RemainingArgs}"
+Invoke-Expression "& '${CakeExe}' ${cakeArgs} ${RemainingArgs}"
 exit $LASTEXITCODE


### PR DESCRIPTION
Currently, if there are spaces in the path to the CKAN source (e.g. `C:\Users\First Last\CKAN`), running build.ps1 fails with:

```
C:\Users\First : The term 'C:\Users\First' is not recognized as the name of a cmdlet, function, script file, or
operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and tr
again.
At line:1 char:1
+ C:\Users\First Last\CKAN/_build/tools/NuGet/4.1.0/nuget.exe instal ...
+ ~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\First:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

Adding an ampersand to the nuget and cake invocations fixes these errors.