### PR TITLE
Perform directory root comparison in case-insensitive way

### DIFF
--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -266,7 +266,10 @@ namespace CKAN
 
             if (Path.IsPathRooted(path))
             {
-                return path;
+                throw new PathErrorKraken(
+                    path,
+                    String.Format("{0} is already absolute", path)
+                );
             }
 
             if (!Path.IsPathRooted(root))

--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -232,7 +232,7 @@ namespace CKAN
                 );
             }
 
-            if (! path.StartsWith(root))
+            if (!path.StartsWith(root, StringComparison.CurrentCultureIgnoreCase))
             {
                 throw new PathErrorKraken(
                     path,
@@ -266,10 +266,7 @@ namespace CKAN
 
             if (Path.IsPathRooted(path))
             {
-                throw new PathErrorKraken(
-                    path,
-                    String.Format("{0} is already absolute", path)
-                );
+                return path;
             }
 
             if (!Path.IsPathRooted(root))

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -969,7 +969,7 @@ namespace CKAN
                         return results;
                     }
 
-                    if (!dir.StartsWith(gameDir))
+                    if (!dir.StartsWith(gameDir, StringComparison.CurrentCultureIgnoreCase))
                     {
                         dir = KSPPathUtils.ToAbsolute(dir, gameDir);
                     }

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -100,5 +100,28 @@ namespace Tests.Core
                 Assert.Contains(normalizedInstallDir, result);
             });
         }
+
+        /// <summary>
+        /// Try to add the same path with multiple casings, ensure no PathErrorKraken
+        /// </summary>
+        [Test]
+        public void TestCaseSensitivity()
+        {
+            var paths = new HashSet<string>();
+            // add in all-uppercase and all-lowercase version
+            paths.Add(Path.Combine(_gameDataDir.ToUpper(), _testModule.identifier));
+            paths.Add(Path.Combine(_gameDataDir.ToLower(), _testModule.identifier));
+            // here we are looking for no PathErrorKraken
+            Assert.DoesNotThrow(delegate()
+            {
+                var size = _installer.AddParentDirectories(paths).Count;
+                // each directory adds two directories to the result
+                // two directorie sets { GAMEDATA and gamedata } = 4 objects in result array
+                if (size != 4)
+                {
+                    throw new InvalidOperationException("Directories have case-sensitive differences");
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
This should resolve most cases of #1940 without sacrificing case-sensitivity for the actual path creation/manipulation. The issue arises when ToAbsolute is called on an already-absolute path that did not have the same casing as the mod path. The StartsWith() should return false if the two directories are both absolute but have different casing.