### PR TITLE
Loop to find max KSP version instead of assuming ordering

### DIFF
--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -132,14 +132,14 @@ namespace CKAN
         public KspVersion LatestCompatibleKSP()
         {
             KspVersion best = null;
-            foreach (var pair in module_version) {
+            foreach (var pair in module_version)
+            {
                 KspVersion v = pair.Value.LatestCompatibleKSP();
-                if (v.IsAny) {
+                if (v.IsAny)
                     // Can't get later than Any, so stop
                     return v;
-                } else if (best == null || best < v) {
+                else if (best == null || best < v)
                     best = v;
-                }
             }
             return best;
         }

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -67,17 +67,17 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Return the most recent release of a module with a optional ksp version to target and a RelationshipDescriptor to satisfy. 
+        /// Return the most recent release of a module with a optional ksp version to target and a RelationshipDescriptor to satisfy.
         /// </summary>
         /// <param name="ksp_version">If not null only consider mods which match this ksp version.</param>
         /// <param name="relationship">If not null only consider mods which satisfy the RelationshipDescriptor.</param>
         /// <returns></returns>
         public CkanModule Latest(KspVersionCriteria ksp_version = null, RelationshipDescriptor relationship=null)
-        {            
+        {
             var available_versions = new List<Version>(module_version.Keys);
             CkanModule module;
             log.DebugFormat("Our dictionary has {0} keys", module_version.Keys.Count);
-            log.DebugFormat("Choosing between {0} available versions", available_versions.Count);            
+            log.DebugFormat("Choosing between {0} available versions", available_versions.Count);
 
             // Uh oh, nothing available. Maybe this existed once, but not any longer.
             if (available_versions.Count == 0)
@@ -117,20 +117,38 @@ namespace CKAN
                 return version == null ? null : module_version[version];
             }
             else
-            {                
+            {
                 var version = available_versions.FirstOrDefault(v =>
                     relationship.version_within_bounds(v) &&
                     module_version[v].IsCompatibleKSP(ksp_version));
-                return version == null ? null : module_version[version];                
+                return version == null ? null : module_version[version];
             }
-            
+        }
+
+        /// <summary>
+        /// Returns the latest game version that is compatible with this mod.
+        /// Checks all versions of the mod.
+        /// </summary>
+        public KspVersion LatestCompatibleKSP()
+        {
+            KspVersion best = null;
+            foreach (var pair in module_version) {
+                KspVersion v = pair.Value.LatestCompatibleKSP();
+                if (v.IsAny) {
+                    // Can't get later than Any, so stop
+                    return v;
+                } else if (best == null || best < v) {
+                    best = v;
+                }
+            }
+            return best;
         }
 
         /// <summary>
         /// Returns the module with the specified version, or null if that does not exist.
         /// </summary>
         public CkanModule ByVersion(Version v)
-        {            
+        {
             CkanModule module;
             module_version.TryGetValue(v, out module);
             return module;

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -28,6 +28,12 @@ namespace CKAN
         CkanModule LatestAvailable(string identifier, KspVersionCriteria ksp_version, RelationshipDescriptor relationship_descriptor = null);
 
         /// <summary>
+        /// Returns the max game version that is compatible with the given mod.
+        /// </summary>
+        /// <param name="identifier">Name of mod to check</param>
+        KspVersion LatestCompatibleKSP(string identifier);
+
+        /// <summary>
         ///     Returns all available version of a module.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
@@ -146,7 +152,7 @@ namespace CKAN
                 return false;
             }
             if (newest_version == null) return false;
-            return !new List<string>(querier.InstalledDlls).Contains(identifier) && querier.IsInstalled(identifier, false) 
+            return !new List<string>(querier.InstalledDlls).Contains(identifier) && querier.IsInstalled(identifier, false)
                 && newest_version.version.IsGreaterThan(querier.InstalledVersion(identifier));
         }
     }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -523,6 +523,14 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// Return the latest game version compatible with the given mod.
+        /// </summary>
+        /// <param name="identifier">Name of mod to check</param>
+        public KspVersion LatestCompatibleKSP(string identifier)
+        {
+            return available_modules[identifier].LatestCompatibleKSP();
+        }
 
 
         /// <summary>

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -113,7 +113,7 @@ namespace CKAN
     /// <summary>
     ///     Describes a CKAN module (ie, what's in the CKAN.schema file).
     /// </summary>
-    
+
     // Base class for both modules (installed via the CKAN) and bundled
     // modules (which are more lightweight)
     [JsonObject(MemberSerialization.OptIn)]
@@ -447,7 +447,7 @@ namespace CKAN
                 mod1.conflicts.Any(
                     conflict =>
                         mod2.ProvidesList.Contains(conflict.name) && conflict.version_within_bounds(mod2.version));
-        }       
+        }
 
         /// <summary>
         /// Returns true if our mod is compatible with the KSP version specified.
@@ -462,29 +462,37 @@ namespace CKAN
 
         /// <summary>
         /// Returns a human readable string indicating the highest compatible
-        /// version of KSP this module will run with. (Eg: 1.0.2, 1.0.2+,
-        /// "All version", etc).
-        /// 
+        /// version of KSP this module will run with. (Eg: 1.0.2,
+        /// "All versions", etc).
+        ///
         /// This is for *human consumption only*, as the strings may change in the
         /// future as we support additional locales.
         /// </summary>
         public string HighestCompatibleKSP()
         {
-            // Find the highest compatible KSP version
-            if (ksp_version_max != null)
-            {
-                return ksp_version_max.ToString();
+            KspVersion v = LatestCompatibleKSP();
+            if (v.IsAny) {
+                return "All versions";
+            } else {
+                return v.ToString();
             }
-            else if (ksp_version != null)
-            {
-                return ksp_version.ToString();
-            }
-            else if (ksp_version_min != null )
-            {
-                return ksp_version_min + "+";
-            }
+        }
 
-            return "All versions";
+        /// <summary>
+        /// Returns machine readable object indicating the highest compatible
+        /// version of KSP this module will run with.
+        /// </summary>
+        public KspVersion LatestCompatibleKSP()
+        {
+            // Find the highest compatible KSP version
+            if (ksp_version_max != null) {
+                return ksp_version_max;
+            } else if (ksp_version != null) {
+                return ksp_version;
+            } else {
+                // No upper limit.
+                return KspVersion.Any;
+            }
         }
 
         /// <summary>
@@ -601,4 +609,3 @@ namespace CKAN
         }
     }
 }
-

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -471,11 +471,10 @@ namespace CKAN
         public string HighestCompatibleKSP()
         {
             KspVersion v = LatestCompatibleKSP();
-            if (v.IsAny) {
+            if (v.IsAny)
                 return "All versions";
-            } else {
+            else
                 return v.ToString();
-            }
         }
 
         /// <summary>
@@ -485,14 +484,13 @@ namespace CKAN
         public KspVersion LatestCompatibleKSP()
         {
             // Find the highest compatible KSP version
-            if (ksp_version_max != null) {
+            if (ksp_version_max != null)
                 return ksp_version_max;
-            } else if (ksp_version != null) {
+            else if (ksp_version != null)
                 return ksp_version;
-            } else {
+            else
                 // No upper limit.
                 return KspVersion.Any;
-            }
         }
 
         /// <summary>

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -89,14 +89,13 @@ namespace CKAN
                 // use that.
                 if (IsCKAN)
                     latestAvailableForAnyVersion = (CkanModule) mod;
-                
             }
 
             // If there's known information for this mod in any form, calculate the highest compatible
             // KSP.
             if (latestAvailableForAnyVersion != null)
             {
-                KSPCompatibility = KSPCompatibilityLong = latestAvailableForAnyVersion.HighestCompatibleKSP();
+                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "";
 
                 // If the mod we have installed is *not* the mod we have installed, or we don't know
                 // what we have installed, indicate that an upgrade would be needed.
@@ -128,7 +127,7 @@ namespace CKAN
             KSPversion = kspVersion != null ? kspVersion.ToString() : "-";
 
             Abstract = mod.@abstract;
-            
+
             // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
 
             Homepage = "N/A";
@@ -160,7 +159,7 @@ namespace CKAN
                 DownloadSize = "1<KB";
             else
                 DownloadSize = mod.download_size / 1024+"";
-            
+
             Abbrevation = new string(mod.name.Split(' ').
                 Where(s => s.Length > 0).Select(s => s[0]).ToArray());
 


### PR DESCRIPTION
As per https://github.com/KSP-CKAN/NetKAN/issues/5945, the "Max KSP version" column is inaccurate for 3-4% of indexed mods:
- if the wrong version is chosen as "latest"
- if the compatible scope of the versions isn't coherent over time

This can discourage users from trusting this column, which is a problem because it should be a main tool for a common task: Determining whether it's safe to update the game.

This code change updates the column to show the actual maximum KSP version across all versions of each mod. The simplest possible strategy is used: loop over the versions and compare. The version ordering problems, accumulated bad metadata, and a few other related issues should still be addressed, so I don't consider this to be a complete fix for that issue, but now at least the column will be reliable.

Additional change to call out for transparency: The "min_version+" format is dropped and displayed the same as the unbounded case. If there's a use case for this, it would be best addressed by showing a true range or list rather than making the code and display confusing for maximums.