### PR TITLE
Quit on ctrl-q and alt-f,x

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -195,8 +195,9 @@ namespace CKAN
             //
             this.ExitToolButton.Name = "ExitToolButton";
             this.ExitToolButton.Size = new System.Drawing.Size(281, 30);
-            this.ExitToolButton.Text = "Exit";
+            this.ExitToolButton.Text = "E&xit";
             this.ExitToolButton.Click += new System.EventHandler(this.ExitToolButton_Click);
+            this.ExitToolButton.ShortcutKeys = Keys.Control | Keys.Q;
             //
             // settingsToolStripMenuItem
             //


### PR DESCRIPTION
This change provides a Ctrl-Q hotkey for the File->Exit option, as well as an 'x' hotkey while the menu is being displayed. This makes exiting the GUI a bit more convenient for keyboard users.