### PR TITLE
Fix exception installing some mods (fixes #2135)

### DIFF
--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -179,7 +179,7 @@ namespace CKAN
                 // Normalize path before searching (path separator as '/', no trailing separator)
                 for (string path = Regex.Replace(entry.Name.Replace('\\', '/'), "/$", "");
                         !string.IsNullOrEmpty(path);
-                        path = Path.GetDirectoryName(path), is_file = false)
+                        path = Path.GetDirectoryName(path).Replace('\\', '/'), is_file = false)
                 {
 
                     // Skip file paths if not allowed


### PR DESCRIPTION
`Path.GetDirectoryName("/a/b/c")` returns `"\a\b"` on windows, but the regexp assumes forward slashes.
On Linux it returns "/a/b", so the problem is platform-specific.

Since the regexp didn't match on Windows, the loop would fail to find the path and raise a file not found exception, as reported in #2135. I believe only `find`-based netkans were affected, but unfortunately that includes `DefaultInstallStanza`.

Renormalizing back to forward slashes ensures the regexp will match as it should.