### PR TITLE
Fix crash on startup (fixes #2134)

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -529,7 +529,9 @@ namespace CKAN
         /// <param name="identifier">Name of mod to check</param>
         public KspVersion LatestCompatibleKSP(string identifier)
         {
-            return available_modules[identifier].LatestCompatibleKSP();
+            return available_modules.ContainsKey(identifier)
+                ? available_modules[identifier].LatestCompatibleKSP()
+                : null;
         }
 
 

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -95,7 +95,7 @@ namespace CKAN
             // KSP.
             if (latestAvailableForAnyVersion != null)
             {
-                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "";
+                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? mod.LatestCompatibleKSP().ToString();
 
                 // If the mod we have installed is *not* the mod we have installed, or we don't know
                 // what we have installed, indicate that an upgrade would be needed.


### PR DESCRIPTION
If a mod isn't in the registry, return null instead of raising an exception when looking for its max KSP version

When I tested this code change, I had a very recent registry, so the code only ran with identifiers that were in the dictionary. Users updating to 1.22.4 encountered newly added mods, which caused an exception as reported in #2134. Checking `ContainsKey` first will avoid this, and returning `null` signals that the mod is not in the registry, which will cause the column to default to max version of the newly added mod object.