### PR TITLE
Improve exceptions and error messages

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -294,7 +294,7 @@ namespace CKAN
             }
             catch (JsonException ex)
             {
-                throw new BadMetadataKraken(null, "JSON deserialization error", ex);
+                throw new BadMetadataKraken(null, string.Format("JSON deserialization error: {0}", ex.Message), ex);
             }
 
             // NOTE: Many of these tests may be better in our Deserialisation handler.
@@ -580,6 +580,15 @@ namespace CKAN
         public override string ToString()
         {
             return string.Format("{0} {1}", identifier, version);
+        }
+
+        public string DescribeInstallStanzas()
+        {
+            List<string> descriptions = new List<string>();
+            foreach (ModuleInstallDescriptor mid in install) {
+                descriptions.Add(mid.DescribeMatch());
+            }
+            return string.Join(", ", descriptions);
         }
     }
 

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text;
 using System.Text.RegularExpressions;
 using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json;
@@ -49,7 +50,7 @@ namespace CKAN
             // this check now that we're doing better json-fu above.
             if (install_to == null)
             {
-                throw new BadMetadataKraken(null, "Install stanzas must have a file an install_to");
+                throw new BadMetadataKraken(null, "Install stanzas must have an install_to");
             }
 
             var setCount = new[] { file, find, find_regexp }.Count(i => i != null);
@@ -206,6 +207,21 @@ namespace CKAN
             stanza.find        = null;
             stanza.find_regexp = null;
             return stanza;
+        }
+
+        public string DescribeMatch()
+        {
+            StringBuilder sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(file)) {
+                sb.AppendFormat("file=\"{0}\"", file);
+            }
+            if (!string.IsNullOrEmpty(find)) {
+                sb.AppendFormat("find=\"{0}\"", find);
+            }
+            if (!string.IsNullOrEmpty(find_regexp)) {
+                sb.AppendFormat("find_regexp=\"{0}\"", find_regexp);
+            }
+            return sb.ToString();
         }
     }
 }

--- a/Netkan/Sources/Spacedock/SpaceDockApi.cs
+++ b/Netkan/Sources/Spacedock/SpaceDockApi.cs
@@ -29,7 +29,7 @@ namespace CKAN.NetKAN.Sources.Spacedock
 
             if (error.error)
             {
-                var errorMessage = string.Format("Could not get the mod from SD, reason: {0}.", error.reason);
+                var errorMessage = string.Format("Could not get the mod from SpaceDock, reason: {0}", error.reason);
                 throw new Kraken(errorMessage);
             }
 
@@ -42,7 +42,7 @@ namespace CKAN.NetKAN.Sources.Spacedock
         /// </summary>
         public static Uri ExpandPath(string route)
         {
-            Log.DebugFormat("Expanding {0} to full SD URL", route);
+            Log.DebugFormat("Expanding {0} to full SpaceDock URL", route);
 
             // Alas, this isn't as simple as it may sound. For some reason
             // some—but not all—SD mods don't work the same way if the path provided

--- a/Netkan/Transformers/VersionEditTransformer.cs
+++ b/Netkan/Transformers/VersionEditTransformer.cs
@@ -31,9 +31,13 @@ namespace CKAN.NetKAN.Transformers
                     json["version"] = new Regex(versionEditInfo.Find)
                         .Replace(versionEditInfo.Version, versionEditInfo.Replace);
                 }
-                else if(versionEditInfo.Strict)
+                else if (versionEditInfo.Strict)
                 {
-                    throw new Kraken("Could not match version with find pattern");
+                    throw new Kraken(string.Format(
+                        "Could not match version {0} with find pattern {1}",
+                        versionEditInfo.Version,
+                        versionEditInfo.Find
+                    ));
                 }
 
                 Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -20,10 +20,13 @@ namespace CKAN.NetKAN.Validators
             var file = _http.DownloadPackage(metadata.Download, metadata.Identifier);
 
             // Make sure this would actually generate an install.
-            
+
             if (!_moduleService.HasInstallableFiles(mod, file))
             {
-                throw new Kraken("Module contains no files to install.");
+                throw new Kraken(string.Format(
+                    "Module contains no files matching: {0}",
+                    mod.DescribeInstallStanzas()
+                ));
             }
         }
     }


### PR DESCRIPTION
`netkan.exe`'s error outputs are not always as clear as they could be. In some cases important details of the error are omitted, and very rarely a sentence is simply unclear.

This code change updates the following error strings to help with investigating issues.

| Error | Change |
| --- | --- |
| JSON deserialization error | Add the `Exception.Message` property produced by `PopulateObject` |
| Install stanzas must have a file an install_to | Remove "a file" since it looks non-grammatical |
| Could not get the mod from SD, reason: {upstream error}. | Change SD to SpaceDock, remove trailing period |
| Expanding {url} to full SD URL | Change SD to SpaceDock |
| Could not normalize URL: {non URL} | Add mod identifier |
| Could not match version with find pattern | Add the version and the find pattern |
| Module contains no files to install. | Explain the install stanzas that did not match rather than suggesting the download is empty |