### PR TITLE
Add skip_deploy to GitHub release deploy provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
 deploy:
     # Releases (which are tagged) go to github
     - provider: releases
+      skip_cleanup: true
       api_key:
         secure: AjwbRLStNJZb9hAOLfRLK85KlFo2q2Dr1NKCoDS4elek1nqSiOjL1hH0kDgUMx/PJqQVnFU8tbJPL30t9Pj7jcJhp0LhbbPipQE3TCSpafTneSEbdz5HT+OdghWCZhUhfs07wGNTFUwcAO4WBZ7wv1AnfdfogHdA5RMdykiIl38=
       file:
@@ -47,12 +48,12 @@ deploy:
     # Any merge to master gets sent to
     # http://ckan-travis.s3-website-us-east-1.amazonaws.com/
     - provider: s3
+      skip_cleanup: true
       access_key_id: AKIAI5JWAEFPFK6GH3XA
       secret_access_key:
         secure: b0PPlD7auqysK2LHA8N1US03dE/VKH2rOTwIqpIh50l/gURuXEl7Nd8S7qlf2dpEmz+8D5pIWD+J9scfrdD8Uuakhi3sQbqcV26UiR6+Ye06eGQfmIzqzAECt2naqEy7VJ/xrqq5aaaf8QhcOQMba3qVvwDSzkB2fJeh7+D6EY8=
       bucket: ckan-travis
       acl: public_read
-      skip_cleanup: true
       local_dir: _build/repack/$BUILD_CONFIGURATION
       on:
         repo: KSP-CKAN/CKAN


### PR DESCRIPTION
Potential fix for #2133 

The failure in #2133 has nothing to do with our build process, but is a Ruby error generated by Travis itself:
```
No such file or directory @ rb_sysopen - _build/repack/Release/ckan.exe
```

Meaning it can't find the file to deploy. The `skip_deploy` option is necessary to prevent Travis from cleaning out the working directory according to [this](https://docs.travis-ci.com/user/deployment/#Uploading-Files). The GitHub release provider did not have yet, although the Amazon S3 provider did. My assumption is that previously *any* provider having `skip_cleanup` meant that no cleanup was done and that some change was made in Travis which causes cleanup to be done if any provider *doesn't* have it. Only way to really test this is to try another release @politas 
