### PR TITLE
Permanent fix for UpdateCol build errors

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -474,7 +474,7 @@ namespace CKAN
             // UpdateCol
             //
             this.UpdateCol.HeaderText = "Update";
-            this.UpdateCol.Name = "Update";
+            this.UpdateCol.Name = "UpdateCol";
             this.UpdateCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.UpdateCol.Width = 46;
             //


### PR DESCRIPTION
This particular issue crops up whenever anyone tries to modify the Main Designer under Visual Studio. It's just a minor build issue that results. I worked out a little while ago that this change will fix this permanently.
This was part of #2018, which was a dead end for other reasons.