### PR TITLE
Build Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ env:
     - BUILD_CONFIGURATION=Release
 
 mono:
-    - 5.0.0
-    - 4.8.0
+    - 5.4.0
+    - 5.2.0
+    - 5.0.1
+    - 4.8.1
     - 4.6.2
     - 4.4.2
-    - 4.0.5
 
 addons:
     apt:
@@ -41,7 +42,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         tags: true
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.0.0
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.4.0
         # all_branches needed as a workaround for travis-ci#1675
         all_branches: true
 
@@ -58,7 +59,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         branch: master
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.0.0
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.4.0
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ language: csharp
 sudo: required
 
 env:
-    - BUILD_CONFIGURATION=Debug
-    - BUILD_CONFIGURATION=Release
+    global:
+        - BUILD_RELEASE_MONO_VERSION=5.4.0
+    matrix:
+        - BUILD_CONFIGURATION=Debug
+        - BUILD_CONFIGURATION=Release
 
 mono:
     - 5.4.0
@@ -42,7 +45,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         tags: true
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.4.0
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
         # all_branches needed as a workaround for travis-ci#1675
         all_branches: true
 
@@ -59,7 +62,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         branch: master
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = 5.4.0
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
 
 notifications:
   irc:

--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -58,11 +58,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -37,7 +37,7 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,9 +59,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">
-    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/AutoUpdate/packages.config
+++ b/AutoUpdate/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>

--- a/CKAN.sln
+++ b/CKAN.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CKAN-core", "Core\CKAN-core.csproj", "{3B9AEA22-FA3B-4E43-9283-EABDD81CF271}"
 EndProject
@@ -48,6 +48,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9CF1B259-3AA8-428D-85C6-51996134BB34}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -41,7 +41,7 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
@@ -96,9 +96,7 @@
     </Content>
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -95,4 +95,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <Target Name="BeforeBuild">
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+  </Target>
 </Project>

--- a/Cmdline/packages.config
+++ b/Cmdline/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -47,7 +47,7 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -140,9 +140,7 @@
     <EmbeddedResource Include="builds.json" />
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -139,7 +139,10 @@
     <None Include="packages.config" />
     <EmbeddedResource Include="builds.json" />
   </ItemGroup>
-  <ItemGroup />
-  <ItemGroup />
-  <ItemGroup />
+  <Target Name="BeforeBuild">
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+  </Target>
 </Project>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -33,8 +33,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="CommandLine">
       <HintPath>..\_build\lib\nuget\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
@@ -51,6 +51,11 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Transactions" />
     <Reference Include="ChinhDo.Transactions">
       <HintPath>..\_build\lib\nuget\TxFileManager.1.3\lib\net20\ChinhDo.Transactions.dll</HintPath>
@@ -58,6 +63,8 @@
     <Reference Include="CurlSharp">
       <HintPath>..\lib\curlsharp-v0.5.1-2-gd2d5699\CurlSharp.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -150,7 +150,7 @@ namespace CKAN
                         // is running, and it's not safe to delete the lock file.
                         // We are done.
                     }
-                    catch (ArgumentException ex)
+                    catch (ArgumentException)
                     {
                         // ArgumentException means the process doesn't exist,
                         // so the lock file is stale and we can delete it.

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="Autofac" version="4.6.2" targetFramework="net45" />
   <package id="ChinhDo.Transactions.FileManager" version="1.2.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -4,6 +4,6 @@
   <package id="ChinhDo.Transactions.FileManager" version="1.2.0" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="TxFileManager" version="1.3" targetFramework="net40" />
 </packages>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -350,4 +350,10 @@
     <Content Include="Resources\forward.png" />
     <Content Include="Resources\textClear.png" />
   </ItemGroup>
+  <Target Name="BeforeBuild">
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+  </Target>
 </Project>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -50,8 +50,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="INIFileParser, Version=2.4.0.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\ini-parser.3.4.0\lib\net20\INIFileParser.dll</HintPath>
@@ -65,6 +65,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -60,7 +60,7 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -351,9 +351,7 @@
     <Content Include="Resources\textClear.png" />
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="Autofac" version="4.6.2" targetFramework="net45" />
   <package id="ini-parser" version="3.4.0" targetFramework="net45" userInstalled="true" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -3,5 +3,5 @@
   <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="ini-parser" version="3.4.0" targetFramework="net45" userInstalled="true" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -48,7 +48,7 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -136,9 +136,7 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -135,4 +135,10 @@
       <Name>CKAN-core</Name>
     </ProjectReference>
   </ItemGroup>
+  <Target Name="BeforeBuild">
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+  </Target>
 </Project>

--- a/Netkan/packages.config
+++ b/Netkan/packages.config
@@ -3,5 +3,5 @@
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\_build\lib\nuget\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="CurlSharp">
       <HintPath>..\lib\curlsharp-v0.5.1-2-gd2d5699\CurlSharp.dll</HintPath>
@@ -59,6 +59,7 @@
       <HintPath>..\_build\lib\nuget\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -210,4 +210,10 @@
   <ProjectExtensions>
     <VisualStudio AllowExistingFolder="true" />
   </ProjectExtensions>
+  <Target Name="BeforeBuild">
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
+          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+  </Target>
 </Project>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -49,8 +49,8 @@
       <HintPath>..\_build\lib\nuget\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.7.10.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Moq.4.7.10\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.142.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\Moq.4.7.142\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\_build\lib\nuget\Moq.4.7.10\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
@@ -211,9 +211,7 @@
     <VisualStudio AllowExistingFolder="true" />
   </ProjectExtensions>
   <Target Name="BeforeBuild">
-    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo"
-          Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'"/>
+    <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
+    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -55,8 +55,8 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\_build\lib\nuget\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\_build\lib\nuget\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
-  <package id="Moq" version="4.7.10" targetFramework="net45" />
+  <package id="Moq" version="4.7.142" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -5,5 +5,5 @@
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Moq" version="4.7.142" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="NUnit" version="3.8.1" targetFramework="net45" />
 </packages>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net45" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Moq" version="4.7.10" targetFramework="net45" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -4,6 +4,6 @@
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Moq" version="4.7.10" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/build
+++ b/build
@@ -22,6 +22,7 @@ fi
 nugetVersion="4.1.0"
 useExperimental=false
 rootDir=$(dirname $0)
+scriptFile="$rootDir/build.cake"
 buildDir="$rootDir/_build"
 toolsDir="$buildDir/tools"
 packagesDir="$buildDir/lib/nuget"
@@ -58,5 +59,5 @@ if $useExperimental; then
     cakeArgs="$cakeArgs --experimental"
 fi
 
-mono "$cakeExe" $cakeArgs $remainingArgs
+mono "$cakeExe" "$scriptFile" $cakeArgs $remainingArgs
 exit $?

--- a/build
+++ b/build
@@ -19,7 +19,7 @@ if [ $# -gt 1 ]; then
     done
 fi
 
-nugetVersion="4.1.0"
+nugetVersion="4.4.0"
 useExperimental=false
 rootDir=$(dirname $0)
 scriptFile="$rootDir/build.cake"

--- a/build
+++ b/build
@@ -40,7 +40,7 @@ if [ ! -f "$nugetExe" ]; then
     curl -L "https://dist.nuget.org/win-x86-commandline/v${nugetVersion}/nuget.exe" --output "$nugetExe"
 fi
 
-mono "$nugetExe" install "$packagesConfigFile" -OutputDirectory "$packagesDir"
+mono "$nugetExe" restore "$packagesConfigFile" -OutputDirectory "$packagesDir"
 
 cakeArgs=""
 

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,5 @@
-#addin "nuget:?package=Cake.SemVer&version=1.0.14"
+#addin "nuget:?package=Cake.SemVer&version=2.0.0"
+#addin "nuget:?package=semver&version=2.0.4"
 #tool "nuget:?package=ILRepack&version=2.0.13"
 #tool "nuget:?package=NUnit.ConsoleRunner&version=3.6.1"
 

--- a/build.cake
+++ b/build.cake
@@ -21,6 +21,13 @@ Task("Default")
     .IsDependentOn("Ckan")
     .IsDependentOn("Netkan");
 
+
+Task("Debug")
+    .IsDependentOn("Default");
+
+Task("Release")
+    .IsDependentOn("Default");
+
 Task("Ckan")
     .IsDependentOn("Repack-Ckan");
 
@@ -156,6 +163,26 @@ Task("Version")
     .Does(() =>
 {
     Information(GetVersion().ToString());
+});
+
+Setup(context =>
+{
+    var argConfiguration = Argument<string>("configuration");
+
+    if (string.Equals(target, "Release", StringComparison.OrdinalIgnoreCase))
+    {
+        if (argConfiguration != null)
+            Warning($"Ignoring configuration argument: '{argConfiguration}'");
+
+        configuration = "Release";
+    }
+    else if (string.Equals(target, "Debug", StringComparison.OrdinalIgnoreCase))
+    {
+        if (argConfiguration != null)
+            Warning($"Ignoring configuration argument: '{argConfiguration}'");
+
+        configuration = "Debug";
+    }
 });
 
 Teardown(context =>

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 #addin "nuget:?package=Cake.SemVer&version=2.0.0"
 #addin "nuget:?package=semver&version=2.0.4"
 #tool "nuget:?package=ILRepack&version=2.0.13"
-#tool "nuget:?package=NUnit.ConsoleRunner&version=3.6.1"
+#tool "nuget:?package=NUnit.ConsoleRunner&version=3.7.0"
 
 using System.Text.RegularExpressions;
 using Semver;

--- a/build.cake
+++ b/build.cake
@@ -77,7 +77,7 @@ Task("Repack-Ckan")
     ILRepack(ckanFile, cmdLineBinDirectory.CombineWithFilePath("CmdLine.exe"), assemblyPaths,
         new ILRepackSettings
         {
-            Libs = new List<FilePath> { cmdLineBinDirectory.ToString() },
+            Libs = new List<DirectoryPath> { cmdLineBinDirectory.ToString() },
             TargetPlatform = TargetPlatformVersion.v4
         }
     );
@@ -95,7 +95,7 @@ Task("Repack-Netkan")
     ILRepack(netkanFile, netkanBinDirectory.CombineWithFilePath("NetKAN.exe"), assemblyPaths,
         new ILRepackSettings
         {
-            Libs = new List<FilePath> { netkanBinDirectory.ToString() },
+            Libs = new List<DirectoryPath> { netkanBinDirectory.ToString() },
         }
     );
 
@@ -130,7 +130,7 @@ Task("Test-UnitTests+Only")
 
     NUnit3(testFile.FullPath, new NUnit3Settings {
         Where = where,
-        Results = nunitOutputDirectory.CombineWithFilePath("TestResult.xml")
+        Work = nunitOutputDirectory
     });
 });
 

--- a/build.cake
+++ b/build.cake
@@ -167,7 +167,7 @@ Task("Version")
 
 Setup(context =>
 {
-    var argConfiguration = Argument<string>("configuration");
+    var argConfiguration = Argument<string>("configuration", null);
 
     if (string.Equals(target, "Release", StringComparison.OrdinalIgnoreCase))
     {

--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ Param (
 )
 
 # Globals
-$NugetVersion       = "4.1.0"
+$NugetVersion       = "4.4.0"
 $UseExperimental    = $false
 $RootDir            = "${PSScriptRoot}"
 $ScriptFile         = "${RootDir}/build.cake"

--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ if (!(Test-Path "$NugetExe")) {
 }
 
 # Install build packages
-Invoke-Expression "& '${NugetExe}' install `"${PackagesConfigFile}`" -OutputDirectory `"${PackagesDir}`""
+Invoke-Expression "& '${NugetExe}' restore `"${PackagesConfigFile}`" -OutputDirectory `"${PackagesDir}`""
 
 # Build args
 $cakeArgs = @()

--- a/build.ps1
+++ b/build.ps1
@@ -10,6 +10,7 @@ Param (
 $NugetVersion       = "4.1.0"
 $UseExperimental    = $false
 $RootDir            = "${PSScriptRoot}"
+$ScriptFile         = "${RootDir}/build.cake"
 $BuildDir           = "${RootDir}/_build"
 $ToolsDir           = "${BuildDir}/tools"
 $PackagesDir        = "${BuildDir}/lib/nuget"
@@ -47,5 +48,5 @@ if ($UseExperimental) {
 }
 
 # Run Cake
-Invoke-Expression "& '${CakeExe}' ${cakeArgs} ${RemainingArgs}"
+Invoke-Expression "& '${CakeExe}' '${ScriptFile}' ${cakeArgs} ${RemainingArgs}"
 exit $LASTEXITCODE

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.19.5" />
+  <package id="Cake" version="0.23.0" />
 </packages>


### PR DESCRIPTION
General update to the build. Important new feature: The csproj files have been updated to generate the GlobalAssemblyVersionInfo file if it doesn't already exist. This should allow the project to build out-of-the-box in IDEs like Visual Studio without having to go to the command line first.

Other updates:
- Add `Release` and `Debug` targets
- Remove unused variable to fix warning
- Update Mono versions used for build
  - Remove Mono 4.0.5 (breaking with newest Cake)
  - Upgrade Mono 4.8.0 to 4.8.1
  - Upgrade Mono 5.0.0 to 5.0.1
  - Add Mono 5.2.0
  - Add Mono 5.4.0
- Upgrade NuGet from 4.1.0 to 4.4.0 (and use `restore` instead of `install`)
- Upgrade Cake from 0.19.5 to 0.23.0 (and fix new breaks script)
- Upgrade Cake.SemVer from 1.0.14 to 2.0.0
- Upgrade NUnit.ConsoleRunner from 3.6.1 to 3.7.0
- Upgrade JSON.NET from 10.0.2 to 10.0.3
- Upgrade Autofac from 4.5.0 to 4.6.2
- Upgrade Castle.Core from 4.0.0 to 4.2.1
- Upgrade Moq from 4.7.10 to 4.7.142
- Upgrade NUnit from 3.6.1 to 3.8.1