### PR TITLE
Simplify IUser

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -246,10 +246,6 @@ namespace CKAN.CmdLine
         protected override void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)
         {
         }
-        public override int WindowWidth
-        {
-            get { return Console.WindowWidth; }
-        }
 
     }
 }

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -243,9 +243,6 @@ namespace CKAN.CmdLine
                 Console.Write("\r\n{0}", format);
             }
         }
-        protected override void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)
-        {
-        }
 
     }
 }

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -238,7 +238,7 @@ namespace CKAN
                 );
             }
         }
-        
+
         public void DownloadAndWait(ICollection<KeyValuePair<Uri, long>> urls)
         {
             // Start the download!
@@ -319,7 +319,6 @@ namespace CKAN
             }
             // Signal that we're done.
             complete_or_canceled.Set();
-            User.RaiseDownloadsCompleted(file_urls, file_paths, errors);
         }
 
         /// <summary>

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -16,7 +16,6 @@ namespace CKAN
 
         void RaiseProgress(string message, int percent);
         void RaiseMessage(string message, params object[] url);
-        void RaiseDownloadsCompleted(Uri[] file_urls, string[] file_paths, Exception[] errors);
     }
 
     //Can be used in tests to supress output or as a base class for other types of user.
@@ -37,10 +36,6 @@ namespace CKAN
             return true;
         }
 
-        protected virtual void DisplayMessage(string message, params object[] args)
-        {
-        }
-
         protected virtual int DisplaySelectionDialog(string message, params object[] args)
         {
             return 0;
@@ -54,18 +49,8 @@ namespace CKAN
         {
         }
 
-        protected virtual void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)
+        protected virtual void DisplayMessage(string message, params object[] args)
         {
-        }
-
-        public void RaiseMessage(string message, params object[] args)
-        {
-            DisplayMessage(message, args);
-        }
-
-        public void RaiseProgress(string message, int percent)
-        {
-            ReportProgress(message, percent);
         }
 
         public bool RaiseYesNoDialog(string question)
@@ -83,9 +68,15 @@ namespace CKAN
             DisplayError(message, args);
         }
 
-        public void RaiseDownloadsCompleted(Uri[] file_urls, string[] file_paths, Exception[] errors)
+        public void RaiseProgress(string message, int percent)
         {
-            ReportDownloadsComplete(file_urls, file_paths, errors);
+            ReportProgress(message, percent);
         }
+
+        public void RaiseMessage(string message, params object[] args)
+        {
+            DisplayMessage(message, args);
+        }
+
     }
 }

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -5,54 +5,27 @@ using System;
 
 namespace CKAN
 {
-    public delegate int DisplaySelectionDialog(string message, params object[] args);
-    public delegate void DisplayMessage(string message, params object[] args);
-    public delegate bool DisplayYesNoDialog(string message);
-    public delegate void DisplayError(string message, params object[] args);
-    public delegate void ReportProgress(string format, int percent);
-    public delegate void DownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors);
 
     public interface IUser
     {
-        event DisplayYesNoDialog AskUser;
-        event DisplaySelectionDialog AskUserForSelection;
-        event DisplayMessage Message;
-        event DisplayError Error;
-        event ReportProgress Progress;
-        event DownloadsComplete DownloadsComplete;
-        int WindowWidth { get; }
         bool Headless { get; }
 
-        int RaiseSelectionDialog(string message, params object[] args);
-        void RaiseMessage(string message, params object[] url);
-        void RaiseProgress(string message, int percent);
         bool RaiseYesNoDialog(string question);
+        int  RaiseSelectionDialog(string message, params object[] args);
         void RaiseError(string message, params object[] args);
+
+        void RaiseProgress(string message, int percent);
+        void RaiseMessage(string message, params object[] url);
         void RaiseDownloadsCompleted(Uri[] file_urls, string[] file_paths, Exception[] errors);
     }
 
     //Can be used in tests to supress output or as a base class for other types of user.
-    //It supplies no opp event handlers so that subclasses can avoid null checks. 
+    //It supplies no op event handlers so that subclasses can avoid null checks.
     public class NullUser : IUser
     {
         public static readonly IUser User = new NullUser();
 
-        public NullUser()
-        {
-            AskUser += DisplayYesNoDialog;
-            AskUserForSelection += DisplaySelectionDialog;
-            Message += DisplayMessage;
-            Error += DisplayError;
-            Progress += ReportProgress;
-            DownloadsComplete += ReportDownloadsComplete;
-        }
-
-        public event DisplayYesNoDialog AskUser;
-        public event DisplaySelectionDialog AskUserForSelection;
-        public event DisplayMessage Message;
-        public event DisplayError Error;
-        public event ReportProgress Progress;
-        public event DownloadsComplete DownloadsComplete;
+        public NullUser() { }
 
         public virtual bool Headless
         {
@@ -80,44 +53,39 @@ namespace CKAN
         protected virtual void ReportProgress(string format, int percent)
         {
         }
+
         protected virtual void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)
         {
         }
 
-        public virtual int WindowWidth
+        public void RaiseMessage(string message, params object[] args)
         {
-            get { return -1; }
-        }
-
-        public void RaiseMessage(string message, params object[] url)
-        {
-            Message(message, url);
+            DisplayMessage(message, args);
         }
 
         public void RaiseProgress(string message, int percent)
         {
-            Progress(message, percent);
+            ReportProgress(message, percent);
         }
 
         public bool RaiseYesNoDialog(string question)
         {
-            //Return value will be from last handler added.
-            return AskUser(question);
+            return DisplayYesNoDialog(question);
         }
 
         public int RaiseSelectionDialog(string message, params object[] args)
         {
-            return AskUserForSelection(message, args);
+            return DisplaySelectionDialog(message, args);
         }
 
         public void RaiseError(string message, params object[] args)
         {
-            Error(message, args);
+            DisplayError(message, args);
         }
 
         public void RaiseDownloadsCompleted(Uri[] file_urls, string[] file_paths, Exception[] errors)
         {
-            DownloadsComplete(file_urls, file_paths, errors);
+            ReportDownloadsComplete(file_urls, file_paths, errors);
         }
     }
 }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -335,7 +335,7 @@ namespace CKAN
 
             installWorker = new BackgroundWorker { WorkerReportsProgress = true, WorkerSupportsCancellation = true };
             installWorker.RunWorkerCompleted += PostInstallMods;
-            installWorker.DoWork += InstallMods;          
+            installWorker.DoWork += InstallMods;
 
             var old_YesNoDialog = currentUser.displayYesNo;
             currentUser.displayYesNo = YesNoDialog;
@@ -385,7 +385,7 @@ namespace CKAN
             }
 
             pluginController = new PluginController(pluginsPath, true);
-            
+
             CurrentInstance.RebuildKSPSubDir();
 
             NavInit();  // initialize navigation. this should be called as late
@@ -1077,7 +1077,7 @@ namespace CKAN
                 }
                 else
                 {
-                    row_match = mod.Name.StartsWith(key, StringComparison.OrdinalIgnoreCase) || 
+                    row_match = mod.Name.StartsWith(key, StringComparison.OrdinalIgnoreCase) ||
                         mod.Abbrevation.StartsWith(key, StringComparison.OrdinalIgnoreCase) ||
                         mod.Identifier.StartsWith(key, StringComparison.OrdinalIgnoreCase);
                 }
@@ -1237,9 +1237,5 @@ namespace CKAN
             Main.Instance.SetProgress(percent);
         }
 
-        public override int WindowWidth
-        {
-            get { return -1; }
-        }
     }
 }

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -75,10 +75,6 @@ namespace CKAN
         protected override void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)
         {
         }
-        public override int WindowWidth
-        {
-            get { return Console.WindowWidth; }
-        }
 
     }
 }

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -72,9 +72,6 @@ namespace CKAN
                 Console.Write("\r\n{0}", format);
             }
         }
-        protected override void ReportDownloadsComplete(Uri[] urls, string[] filenames, Exception[] errors)
-        {
-        }
 
     }
 }


### PR DESCRIPTION
Currently `IUser` has 6 public events, which makes it awkward to implement this interface. These events are only used inside `NullUser`, so at first blush, they belong inside `NullUser` as an implementation detail. However, all `NullUser` does with them is wire up the interface's functions to `NullUser`'s own equivalent `virtual` functions. This is an unnecessary and cumbersome step of indirection with no advantages over simply calling those functions directly. (Technically this structure could allow third-party classes to inject listeners to various events in other places, but no code currently does this, so the need/advantage is debatable.)

This PR replaces this structure with a much simpler one and does some additional minor clean-up:

- Remove the events from the interface, making it much simpler to implement in new classes, such as a new UI
- Remove the events from `NullUser`
  - Make `NullUser` simply call the virtual functions from inside the interface functions
- Remove the delegate definitions now that they're no longer used
- Remove `WindowWidth` (not used even before this)
- Rearrange the remaining members of `IUser` into a general-purpose group and a progress/updates group
- (My editor auto-deletes trailing whitespace)

After these changes, `Core\User.cs` is much easier to understand, the `IUser` interface is much simpler to implement in new code, and existing code still works.