### PR TITLE
Move AskForAutoUpdates dialog to centre of screen

### DIFF
--- a/GUI/AskUserForAutoUpdatesDialog.Designer.cs
+++ b/GUI/AskUserForAutoUpdatesDialog.Designer.cs
@@ -77,6 +77,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "AskUserForAutoUpdatesDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Check for updates";
             this.ResumeLayout(false);
             this.PerformLayout();


### PR DESCRIPTION
Unlike the main CKAN window, the AskforUpdates dialog that appears on initial launch of CKAN does not raise a taskbar entry. Moving this dialog to the centre of the screen minimises opportunities for the dialog to appear off-screen due to multi-monitor setups.
Closes #2164