### PR TITLE
Add include_only fields

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -228,7 +228,31 @@
                     "filter_regexp" : {
                         "description" : "List of regexps that should filter files from this install",
                         "$ref"        : "#/definitions/one_or_more_strings"
+                    },
+                    "include_only" : {
+                        "description" : "List of files and directories that should not be excluded from the install",
+                        "type"        : "#/definitions/one_or_more_strings"
+                    },
+                    "include_only_regexp" : {
+                        "description" : "List of regexps that should include files in this install",
+                        "type"        : "#/definitions/one_or_more_strings"
                     }
+                },
+                "not": {
+                    "anyOf": [
+                        {
+                            "required": [ "filter", "include_only" ]
+                        },
+                        {
+                            "required": [ "filter", "include_only_regexp" ]
+                        },
+                        {
+                            "required": [ "filter_regexp", "include_only" ]
+                        },
+                        {
+                            "required": [ "filter_regexp", "include_only_regexp" ]
+                        }
+                    ]
                 },
                 "required" : [ "install_to" ],
                 "oneOf": [

--- a/Spec.md
+++ b/Spec.md
@@ -295,14 +295,22 @@ In addition, any number of optional directives *may* be provided:
 
 - `as` : (**v1.18**) The name to give the matching directory or file when installed. Allows renaming directories or
   files.
-- `filter` : A string, or list of strings, of file parts that should not
+- `filter` : A string, or list of strings, of file parts that should *not*
   be installed. These are treated as literal things which must match a
   file name or directory. Examples of filters may be `Thumbs.db`,
   or `Source`. Filters are considered case-insensitive.
 - `filter_regexp` : A string, or list of strings, which are treated as
   case-sensitive C# regular expressions which are matched against the
   full paths from the installing zip-file. If a file matches the regular
-  expression, it is not installed.
+  expression, it is *not* installed.
+- `include_only` : (**v1.24**) A string, or list of strings, of file parts that should
+  be installed. These are treated as literal things which must match a
+  file name or directory. Examples of this may be `Settings.cfg`,
+  or `Plugin`. These are considered case-insensitive.
+- `include_only_regexp` : (**v1.24**) A string, or list of strings, which are treated as
+  case-sensitive C# regular expressions which are matched against the
+  full paths from the installing zip-file. If a file matches the regular
+  expression, it is installed.
 - `find_matches_files` : (**v1.16**) If set to `true` then both `find` and
   `find_regexp` will match files in addition to directories.
 
@@ -755,8 +763,8 @@ file downloaded by the `download` field. The following conditions apply:
   [the KSP-AVC spec](http://ksp.cybutek.net/kspavc/Documents/README.htm).
 * The `KSP_VERSION` field for the `.version` file will be ignored if the
   `KSP_VERSION_MIN` and `KSP_VERSION_MAX` fields are set.
-* Netkan will first attempt to use anything after `ksp-avc` as a literal 
-   path within the zip file, and if that fails, will use the string as a 
+* Netkan will first attempt to use anything after `ksp-avc` as a literal
+   path within the zip file, and if that fails, will use the string as a
    regexp to search for a matching file to use.
 
 When used, the following fields are auto-generated:

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -88,7 +88,8 @@ namespace Tests.Core
                 TestData.DogeCoinFlag_101_module_find()
             };
 
-        [Test][TestCaseSource("doge_mods")]
+        [Test]
+        [TestCaseSource("doge_mods")]
         public void FindInstallableFiles(CkanModule mod)
         {
             List<InstallableFile> contents = CKAN.ModuleInstaller.FindInstallableFiles(mod, dogezip, null);
@@ -117,7 +118,8 @@ namespace Tests.Core
             Assert.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/Flags/dogecoin.png", filenames);
         }
 
-        [Test][TestCaseSource("doge_mods")]
+        [Test]
+        [TestCaseSource("doge_mods")]
         public void FindInstallableFilesWithKSP(CkanModule mod)
         {
             using (var tidy = new DisposableKSP())
@@ -180,7 +182,8 @@ namespace Tests.Core
             }
         }
 
-        [Test][TestCaseSource("doge_mods")]
+        [Test]
+        [TestCaseSource("doge_mods")]
         // Make sure all our filters work.
         public void FindInstallableFilesWithFilter(CkanModule mod)
         {
@@ -194,6 +197,23 @@ namespace Tests.Core
             Assert.IsFalse(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/README.md"), "Filtered README 1");
             Assert.IsFalse(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/Flags/README.md"), "Filtered README 2");
             Assert.IsFalse(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/notes.txt.bak"), "Filtered .bak file");
+        }
+
+        [Test]
+        // Test includes_only and includes_only_regexp
+        public void FindInstallableFilesWithInclude()
+        {
+            string extra_doge = TestData.DogeCoinFlagZipWithExtras();
+            CkanModule mod = TestData.DogeCoinFlag_101_module_include();
+
+            List<InstallableFile> contents = CKAN.ModuleInstaller.FindInstallableFiles(mod, extra_doge, null);
+
+            var files = contents.Select(x => x.source.Name);
+
+            Assert.IsTrue(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/Flags/dogecoin.png"), "dogecoin.png");
+            Assert.IsFalse(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/README.md"), "Filtered README 1");
+            Assert.IsFalse(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/Flags/README.md"), "Filtered README 2");
+            Assert.IsTrue(files.Contains("DogeCoinFlag-1.01/GameData/DogeCoinFlag/notes.txt.bak"), ".bak file");
         }
 
         [Test]
@@ -372,7 +392,7 @@ namespace Tests.Core
         {
             using (var tidy = new DisposableKSP())
             {
-                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(tidy.KSP)){CurrentInstance = tidy.KSP};
+                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(tidy.KSP)) { CurrentInstance = tidy.KSP };
 
                 Assert.Throws<ModNotInstalledKraken>(delegate
                 {
@@ -414,7 +434,7 @@ namespace Tests.Core
                 Assert.AreEqual(1, registry.Available(ksp.KSP.VersionCriteria()).Count());
 
                 // Attempt to install it.
-                List<string> modules = new List<string> {TestData.DogeCoinFlag_101_module().identifier};
+                List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
                 CKAN.ModuleInstaller.GetInstance(ksp.KSP, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
 
@@ -431,7 +451,7 @@ namespace Tests.Core
             // Create a new disposable KSP instance to run the test on.
             using (var ksp = new DisposableKSP())
             {
-                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(ksp.KSP)){CurrentInstance = ksp.KSP};
+                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(ksp.KSP)) { CurrentInstance = ksp.KSP };
 
                 Assert.IsTrue(Directory.Exists(ksp.KSP.DownloadCacheDir()));
 
@@ -442,7 +462,7 @@ namespace Tests.Core
                 ksp.KSP.Cache.Store(TestData.DogeCoinFlag_101_module().download, TestData.DogeCoinFlagZip());
                 registry.AddAvailable(TestData.DogeCoinFlag_101_module());
 
-                List<string> modules = new List<string> {TestData.DogeCoinFlag_101_module().identifier};
+                List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
                 CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
 
@@ -465,7 +485,7 @@ namespace Tests.Core
             // Create a new disposable KSP instance to run the test on.
             using (var ksp = new DisposableKSP())
             {
-                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(ksp.KSP)){CurrentInstance = ksp.KSP};
+                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(ksp.KSP)) { CurrentInstance = ksp.KSP };
 
                 Assert.IsTrue(Directory.Exists(ksp.KSP.DownloadCacheDir()));
 
@@ -477,7 +497,7 @@ namespace Tests.Core
                 ksp.KSP.Cache.Store(TestData.DogeCoinFlag_101_module().download, TestData.DogeCoinFlagZip());
                 registry.AddAvailable(TestData.DogeCoinFlag_101_module());
 
-                List<string> modules = new List<string> {TestData.DogeCoinFlag_101_module().identifier};
+                List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
                 CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
 
@@ -522,19 +542,19 @@ namespace Tests.Core
                     {
                         // Copy the zip file to the cache directory.
                         ksp.KSP.Cache.Store(TestData.DogeCoinFlag_101_module().download, TestData.DogeCoinFlagZip());
-                        
+
                         // Mark it as available in the registry.
                         var registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
                         registry.AddAvailable(TestData.DogeCoinFlag_101_module());
-                        
+
                         // Attempt to install it.
-                        List<string> modules = new List<string> {TestData.DogeCoinFlag_101_module().identifier};
-                        
+                        List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
+
                         CKAN.ModuleInstaller.GetInstance(ksp.KSP, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
-                        
+
                         // Check that the module is installed.
                         string mod_file_path = Path.Combine(ksp.KSP.GameData(), mod_file_name);
-                        
+
                         Assert.IsTrue(File.Exists(mod_file_path));
                     }
                 }

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -167,6 +167,22 @@ namespace Tests.Data
             return doge;
         }
 
+        /// <summary>
+        /// The Doge Coin flag using include_only and include_only_regexp.
+        /// Won't install the same files as the other modules and the files don't make sense but I needed some module to test the include_only stuff
+        /// </summary>
+        public static CkanModule DogeCoinFlag_101_module_include()
+        {
+            CkanModule doge = DogeCoinFlag_101_module();
+
+            doge.install[0].filter = null;
+            doge.install[0].filter_regexp = null;
+            doge.install[0].include_only = new List<String> { "dogecoin.png" };
+            doge.install[0].include_only_regexp = new List<string> { "\\.bak$" };
+
+            return doge;
+        }
+
         // Identical to DogeCoinFlag_101, but with a spec version over 9000!
         public static string FutureMetaData()
         {
@@ -540,7 +556,7 @@ namespace Tests.Data
             {
                 name = Generator.Next().ToString(CultureInfo.InvariantCulture),
                 @abstract = Generator.Next().ToString(CultureInfo.InvariantCulture),
-                identifier = identifier??Generator.Next().ToString(CultureInfo.InvariantCulture),
+                identifier = identifier ?? Generator.Next().ToString(CultureInfo.InvariantCulture),
                 spec_version = new Version(1.ToString(CultureInfo.InvariantCulture)),
                 ksp_version = ksp_version ?? KspVersion.Parse("0." + Generator.Next()),
                 version = version ?? new Version(Generator.Next().ToString(CultureInfo.InvariantCulture))


### PR DESCRIPTION
This PR adds two fields which practically work as negative filter/filter_regexp.
Also includes a test and changes to the schema to make sure there are only filter or include_only fields but never both.
Also added the new "filters" to the spec.

Closes #228
Closes #1577