### PR TITLE
Fix schema validation errors

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -231,26 +231,26 @@
                     },
                     "include_only" : {
                         "description" : "List of files and directories that should not be excluded from the install",
-                        "type"        : "#/definitions/one_or_more_strings"
+                        "$ref"        : "#/definitions/one_or_more_strings"
                     },
                     "include_only_regexp" : {
                         "description" : "List of regexps that should include files in this install",
-                        "type"        : "#/definitions/one_or_more_strings"
+                        "$ref"        : "#/definitions/one_or_more_strings"
                     }
                 },
-                "not": {
-                    "anyOf": [
+                "not" : {
+                    "anyOf" : [
                         {
-                            "required": [ "filter", "include_only" ]
+                            "required" : [ "filter", "include_only" ]
                         },
                         {
-                            "required": [ "filter", "include_only_regexp" ]
+                            "required" : [ "filter", "include_only_regexp" ]
                         },
                         {
-                            "required": [ "filter_regexp", "include_only" ]
+                            "required" : [ "filter_regexp", "include_only" ]
                         },
                         {
-                            "required": [ "filter_regexp", "include_only_regexp" ]
+                            "required" : [ "filter_regexp", "include_only_regexp" ]
                         }
                     ]
                 },


### PR DESCRIPTION
NetKAN pull requests and the bot are currently failing at the schema validation step, and the output suggests it's something from #2170. This command can be used to reproduce the issue locally:

```
python ./bin/ckan-validate.py /path/to/existing/valid/file.ckan
```

I tried running `CKAN.schema` through the validator at https://www.jsonschemavalidator.net/ , and it flagged two places where `"type"` was used that should have been `"$ref"`. After fixing this, the validation script runs successfully.