### PR TITLE
Clean up registry lock file after parse failure

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -47,7 +47,13 @@ namespace CKAN
                 throw new RegistryInUseKraken(lockfilePath);
             }
 
-            LoadOrCreate();
+            try {
+                LoadOrCreate();
+            } catch {
+                // Clean up the lock file
+                Dispose(false);
+                throw;
+            }
 
             // We don't cause an inconsistency error to stop the registry from being loaded,
             // because then the user can't do anything to correct it. However we're

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -47,9 +47,12 @@ namespace CKAN
                 throw new RegistryInUseKraken(lockfilePath);
             }
 
-            try {
+            try
+            {
                 LoadOrCreate();
-            } catch {
+            }
+            catch
+            {
                 // Clean up the lock file
                 Dispose(false);
                 throw;


### PR DESCRIPTION
I have an old KSP 0.90 install that has a corrupted `registry.json` file (truncated in the middle of a string in the section about the installed files). If I try to access this instance with `RegistryManager.Instance()`, an appropriate `JsonReaderException` is thrown in the constructor of `RegistryManager` and no access is possible, but the `registry.locked` file is still in the folder (it is created by `GetLock` immediately before the parsing is attempted). Depending on exactly what the process does after that, additional exceptions can occur at random when various of the object's partially constructed resources are destroyed by the garbage collector. The lock file _does_ disappear later when the process exits.

When a constructor throws an exception, this means the requested object cannot be created, so it should first clean up any resources it has allocated up to that point, including things like lock files, so the program is in a consistent state.

This change intercepts parsing exceptions in the constructor and calls `Dispose` to clean up, just like the destructor does, before re-throwing the exception. This causes the lock file to be cleaned up if the registry can't be parsed, while still alerting the calling code to the problem. It also fixes the seemingly random exceptions that I was seeing afterwards.