### PR TITLE
Purge 6 MB of bloat from `registry.json`

### DIFF
--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -13,7 +13,8 @@ namespace CKAN
         // TODO: This class should also record file paths as well.
         // It's just sha1 now for registry compatibility.
 
-        [JsonProperty] private string sha1_sum;
+        [JsonProperty("sha1_sum", NullValueHandling = NullValueHandling.Ignore)]
+        private string sha1_sum;
 
         public string Sha1
         {
@@ -64,7 +65,7 @@ namespace CKAN
     /// <summary>
     /// A simple class that represents an installed module. Includes the time of installation,
     /// the module itself, and a list of files installed with it.
-    /// 
+    ///
     /// Primarily used by the Registry class.
     /// </summary>
 
@@ -89,7 +90,7 @@ namespace CKAN
         // registry format compatibility.
         [JsonProperty] private Dictionary<string, InstalledModuleFile> installed_files;
 
-        public IEnumerable<string> Files 
+        public IEnumerable<string> Files
         {
             get { return installed_files.Keys; }
         }

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -72,18 +72,23 @@ namespace CKAN
 
     public class ResourcesDescriptor
     {
+        [JsonProperty("repository", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri repository;
 
+        [JsonProperty("homepage", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri homepage;
 
+        [JsonProperty("bugtracker", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri bugtracker;
 
+        [JsonProperty("spacedock", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri spacedock;
 
+        [JsonProperty("curse", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri curse;
     }
@@ -141,24 +146,24 @@ namespace CKAN
         [JsonProperty("abstract")]
         public string @abstract;
 
-        [JsonProperty("description")]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string description;
 
         // Package type: in spec v1.6 can be either "package" or "metapackage"
-        [JsonProperty("kind")]
+        [JsonProperty("kind", NullValueHandling = NullValueHandling.Ignore)]
         public string kind;
 
-        [JsonProperty("author")]
+        [JsonProperty("author", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public List<string> author;
 
-        [JsonProperty("comment")]
+        [JsonProperty("comment", NullValueHandling = NullValueHandling.Ignore)]
         public string comment;
 
-        [JsonProperty("conflicts")]
+        [JsonProperty("conflicts", NullValueHandling = NullValueHandling.Ignore)]
         public List<RelationshipDescriptor> conflicts;
 
-        [JsonProperty("depends")]
+        [JsonProperty("depends", NullValueHandling = NullValueHandling.Ignore)]
         public List<RelationshipDescriptor> depends;
 
         [JsonProperty("download")]
@@ -167,19 +172,19 @@ namespace CKAN
         [JsonProperty("download_size")]
         public long download_size;
 
-        [JsonProperty("download_hash")]
+        [JsonProperty("download_hash", NullValueHandling = NullValueHandling.Ignore)]
         public DownloadHashesDescriptor download_hash;
 
         [JsonProperty("identifier", Required = Required.Always)]
         public string identifier;
 
-        [JsonProperty("ksp_version")]
+        [JsonProperty("ksp_version", NullValueHandling = NullValueHandling.Ignore)]
         public KspVersion ksp_version;
 
-        [JsonProperty("ksp_version_max")]
+        [JsonProperty("ksp_version_max", NullValueHandling = NullValueHandling.Ignore)]
         public KspVersion ksp_version_max;
 
-        [JsonProperty("ksp_version_min")]
+        [JsonProperty("ksp_version_min", NullValueHandling = NullValueHandling.Ignore)]
         public KspVersion ksp_version_min;
 
         [JsonProperty("ksp_version_strict")]
@@ -192,28 +197,28 @@ namespace CKAN
         [JsonProperty("name")]
         public string name;
 
-        [JsonProperty("provides")]
+        [JsonProperty("provides", NullValueHandling = NullValueHandling.Ignore)]
         public List<string> provides;
 
-        [JsonProperty("recommends")]
+        [JsonProperty("recommends", NullValueHandling = NullValueHandling.Ignore)]
         public List<RelationshipDescriptor> recommends;
 
-        [JsonProperty("release_status")]
+        [JsonProperty("release_status", NullValueHandling = NullValueHandling.Ignore)]
         public ReleaseStatus release_status;
 
-        [JsonProperty("resources")]
+        [JsonProperty("resources", NullValueHandling = NullValueHandling.Ignore)]
         public ResourcesDescriptor resources;
 
-        [JsonProperty("suggests")]
+        [JsonProperty("suggests", NullValueHandling = NullValueHandling.Ignore)]
         public List<RelationshipDescriptor> suggests;
 
         [JsonProperty("version", Required = Required.Always)]
         public Version version;
 
-        [JsonProperty("supports")]
+        [JsonProperty("supports", NullValueHandling = NullValueHandling.Ignore)]
         public List<RelationshipDescriptor> supports;
 
-        [JsonProperty("install")]
+        [JsonProperty("install", NullValueHandling = NullValueHandling.Ignore)]
         public ModuleInstallDescriptor[] install;
 
         // Used to see if we're compatible with a given game/KSP version or not.

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -17,13 +17,13 @@ namespace CKAN
         #region Properties
 
         // Either file, find, or find_regexp is required, we check this manually at deserialise.
-        [JsonProperty("file")]
+        [JsonProperty("file", NullValueHandling = NullValueHandling.Ignore)]
         public string file;
 
-        [JsonProperty("find")]
+        [JsonProperty("find", NullValueHandling = NullValueHandling.Ignore)]
         public string find;
 
-        [JsonProperty("find_regexp")]
+        [JsonProperty("find_regexp", NullValueHandling = NullValueHandling.Ignore)]
         public string find_regexp;
 
         [JsonProperty("find_matches_files")]
@@ -32,22 +32,22 @@ namespace CKAN
         [JsonProperty("install_to", Required = Required.Always)]
         public string install_to;
 
-        [JsonProperty("as")]
+        [JsonProperty("as", NullValueHandling = NullValueHandling.Ignore)]
         public string @as;
 
-        [JsonProperty("filter")]
+        [JsonProperty("filter", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public List<string> filter;
 
-        [JsonProperty("filter_regexp")]
+        [JsonProperty("filter_regexp", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public List<string> filter_regexp;
 
-        [JsonProperty("include_only")]
+        [JsonProperty("include_only", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public List<string> include_only;
 
-        [JsonProperty("include_only_regexp")]
+        [JsonProperty("include_only_regexp", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public List<string> include_only_regexp;
 


### PR DESCRIPTION
The `registry.json` file must be loaded and parsed before CKAN can do anything (CLI, GUI, etc.). Currently this file is about 21 MB and takes about 2 seconds to load on an SSD. Nearly 6 MB of it just sets assorted properties to `null`. But guess what value the deserializer uses if the property is absent? Yep: `null`. So those properties don't need to be there.

This pull request marks all the `JsonProperty` attributes that have at least one `null` value in `registry.json` with `NullValueHandling = NullValueHandling.Ignore`, which means that if the value is `null`, it will not be printed to the file. When the properties are not `null`, they will be saved and loaded normally. The file will load the same and CKAN will work the same either way.

```
$ ls -gG

-rw-r--r-- 1 21217174 Nov  9 16:58 before.json
-rw-r--r-- 1 15360478 Nov  9 17:22 debloat.json
```

Total change: 5856696 bytes, or 5.86 MB, or 27.6% of the current file size. This may yield a noticeable performance improvement on systems where `registry.json` is stored on a slower disk. (I don't think it's a straight 25% speed-up because the deserializer still needs to create the same objects and so on.)

There are still `"ksp_version":null` properties in my registry for a few mods with no version requirements. I think this is due to some custom deserialization code adjusting things independently of the attributes. It seems harmless for now.

Inspired by code review of #1888.