### PR TITLE
Remove unnecessary using directives

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -1,11 +1,4 @@
-﻿using System;
 using System.Collections.Generic;
-using System.IO;
-//using System.Linq;
-//using System.Text.RegularExpressions;
-//using CKAN.Exporters;
-//using CKAN.Types;
-//using log4net;
 
 namespace CKAN.CmdLine
 {
@@ -36,4 +29,3 @@ namespace CKAN.CmdLine
         }
     }
 }
-

--- a/Cmdline/Action/CompatSubCommand.cs
+++ b/Cmdline/Action/CompatSubCommand.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CKAN.Versioning;
 using CommandLine;
 

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 using log4net;
 
 namespace CKAN.CmdLine

--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Linq;
-using System.Text;
-using CKAN.CmdLine.Action;
 using CommandLine;
 
 namespace CKAN.CmdLine

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 using CKAN.Exporters;
 using CKAN.Types;
 using log4net;
@@ -140,4 +137,3 @@ namespace CKAN.CmdLine
         }
     }
 }
-

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net;
 using Newtonsoft.Json;
 using CommandLine;
-using CKAN;
 using log4net;
 
 namespace CKAN.CmdLine
@@ -316,4 +315,3 @@ namespace CKAN.CmdLine
         }
     }
 }
-

--- a/Cmdline/Action/Search.cs
+++ b/Cmdline/Action/Search.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace CKAN.CmdLine
 {
@@ -73,4 +72,3 @@ namespace CKAN.CmdLine
         }
     }
 }
-

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -1,7 +1,5 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace CKAN.CmdLine
 {

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
 using log4net;
 
 namespace CKAN.CmdLine
@@ -22,7 +20,7 @@ namespace CKAN.CmdLine
             UpgradeOptions options = (UpgradeOptions) raw_options;
 
             if (options.ckan_file != null)
-            {                
+            {
                 options.modules.Add(LoadCkanFromFile(ksp, options.ckan_file).identifier);
             }
 
@@ -148,4 +146,3 @@ namespace CKAN.CmdLine
         }
     }
 }
-

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -4,7 +4,6 @@
 // License: CC-BY 4.0, LGPL, or MIT (your choice)
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -13,7 +12,6 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using CKAN.CmdLine.Action;
 using log4net;
-using log4net.Config;
 using log4net.Core;
 
 namespace CKAN.CmdLine

--- a/Core/CkanTransaction.cs
+++ b/Core/CkanTransaction.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Transactions;
 
 namespace CKAN

--- a/Core/CompatibleKspVersionsDto.cs
+++ b/Core/CompatibleKspVersionsDto.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace CKAN
 {

--- a/Core/Converters/JsonIgnoreBadUrlConverter.cs
+++ b/Core/Converters/JsonIgnoreBadUrlConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using log4net;
 
 namespace CKAN
@@ -55,4 +54,3 @@ namespace CKAN
         }
     }
 }
-

--- a/Core/Extensions.cs
+++ b/Core/Extensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace CKAN
 {

--- a/Core/FileIdentifier.cs
+++ b/Core/FileIdentifier.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.IO;
 using System.Linq;
 

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using CKAN;
 using log4net;
 
 namespace CKAN
@@ -36,7 +35,7 @@ namespace CKAN
 
         public SortedList<string, KSP> Instances
         {
-            get { return new SortedList<string, KSP>(instances); }            
+            get { return new SortedList<string, KSP>(instances); }
         }
 
 
@@ -50,17 +49,17 @@ namespace CKAN
 
         /// <summary>
         /// Returns the prefered KSP instance, or null if none can be found.
-        /// 
+        ///
         /// This works by checking to see if we're in a KSP dir first, then the
         /// registry for an autostart instance, then will try to auto-populate
         /// by scanning for the game.
-        /// 
+        ///
         /// This *will not* touch the registry if we find a portable install.
-        /// 
+        ///
         /// This *will* run KSP instance autodetection if the registry is empty.
-        /// 
+        ///
         /// This *will* set the current instance, or throw an exception if it's already set.
-        /// 
+        ///
         /// Returns null if we have multiple instances, but none of them are preferred.
         /// </summary>
         public KSP GetPreferredInstance()
@@ -116,7 +115,7 @@ namespace CKAN
         /// <summary>
         /// Find and register a default instance by running
         /// game autodetection code.
-        /// 
+        ///
         /// Returns the resulting KSP object if found.
         /// </summary>
         public KSP FindAndRegisterDefaultInstance()
@@ -134,12 +133,12 @@ namespace CKAN
             {
                 return null;
             }
-            catch (NotKSPDirKraken)//Todo check carefully if this is nessesary. 
+            catch (NotKSPDirKraken)//Todo check carefully if this is nessesary.
             {
                 return null;
             }
 
-            
+
         }
 
         /// <summary>
@@ -149,7 +148,7 @@ namespace CKAN
         public KSP AddInstance(string name, KSP ksp_instance)
         {
             instances.Add(name, ksp_instance);
-            Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);                
+            Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);
             return ksp_instance;
         }
 
@@ -209,7 +208,7 @@ namespace CKAN
         /// <summary>
         /// Renames an instance in the registry and saves.
         /// </summary>
-        /// 
+        ///
         // TODO: What should we do if our target name already exists?
         public void RenameInstance(string from, string to)
         {
@@ -294,13 +293,13 @@ namespace CKAN
                 }
                 else
                 {
-                    log.WarnFormat("{0} at {1} is not a vaild install", name, path);                    
+                    log.WarnFormat("{0} at {1} is not a vaild install", name, path);
                 }
 
                 //var ksp = new KSP(path, User);
                 //instances.Add(name, ksp);
 
-                
+
             }
 
             try

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -2,10 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Text.RegularExpressions;
-using System.Threading;
-using CurlSharp;
 using log4net;
 
 namespace CKAN
@@ -22,7 +18,7 @@ namespace CKAN
         }
 
         private static readonly ILog log = LogManager.GetLogger(typeof (NetAsyncModulesDownloader));
-        
+
         private List<CkanModule> modules;
         private readonly NetAsyncDownloader downloader;
 

--- a/Core/Types/CKANVersion.cs
+++ b/Core/Types/CKANVersion.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace CKAN.Types
 {

--- a/Core/Types/FileType.cs
+++ b/Core/Types/FileType.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace CKAN
 {

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -1,8 +1,6 @@
 // Communicate with the user (status messages, yes/no questions, etc)
 // This class will proxy to either the GUI or cmdline functionality.
 
-using System;
-
 namespace CKAN
 {
 

--- a/GUI/AskUserForAutoUpdatesDialog.cs
+++ b/GUI/AskUserForAutoUpdatesDialog.cs
@@ -1,10 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace CKAN

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Linq;
 using CKAN.Versioning;

--- a/GUI/MainAllModVersions.cs
+++ b/GUI/MainAllModVersions.cs
@@ -1,11 +1,7 @@
-﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
 using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace CKAN
@@ -14,7 +10,7 @@ namespace CKAN
     {
         public MainAllModVersions()
         {
-            InitializeComponent();            
+            InitializeComponent();
         }
 
         public GUIMod SelectedModule {

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -2,10 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.IO;
 using System.Diagnostics;

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Reflection;

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Net;
-using System.Windows.Forms;
 using Newtonsoft.Json;
 
 namespace CKAN
@@ -15,7 +14,7 @@ namespace CKAN
     public partial class Main
     {
         private BackgroundWorker m_UpdateRepoWorker;
-        
+
         public static RepositoryList FetchMasterRepositoryList(Uri master_uri = null)
         {
             WebClient client = new WebClient();
@@ -60,7 +59,7 @@ namespace CKAN
             _enabled = !_enabled;
             menuStrip1.Enabled = _enabled;
             MainTabControl.Enabled = _enabled;
-            /* Windows (7 & 8 only?) bug #1548 has extra facets. 
+            /* Windows (7 & 8 only?) bug #1548 has extra facets.
              * parent.childcontrol.Enabled = false seems to disable the parent,
              * if childcontrol had focus. Depending on optimization steps,
              * parent.childcontrol.Enabled = true does not necessarily

--- a/GUI/ModChange.cs
+++ b/GUI/ModChange.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CKAN
 {
@@ -21,7 +16,7 @@ namespace CKAN
             Mod = mod;
             ChangeType = changeType;
             Reason = reason;
-            
+
             if (Reason == null)
             {
                 // Hey, we don't have a Reason

--- a/GUI/NewRepoDialog.cs
+++ b/GUI/NewRepoDialog.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
 using System.Windows.Forms;
 
 namespace CKAN

--- a/GUI/NewUpdateDialog.cs
+++ b/GUI/NewUpdateDialog.cs
@@ -1,10 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace CKAN

--- a/GUI/PluginsDialog.cs
+++ b/GUI/PluginsDialog.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using System.Windows.Forms;
 
 namespace CKAN

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -27,10 +26,10 @@ namespace CKAN
 
             if (args.Contains(URLHandlers.UrlRegistrationArgument))
             {
-                //Passing in null will cause a NullRefrenceException if it tries to show the dialog 
-                //asking for elevation permission, but we want that to happen. Doing that keeps us 
+                //Passing in null will cause a NullRefrenceException if it tries to show the dialog
+                //asking for elevation permission, but we want that to happen. Doing that keeps us
                 //from getting in to a infinite loop of trying to register.
-                URLHandlers.RegisterURLHandler(null, null); 
+                URLHandlers.RegisterURLHandler(null, null);
             }
             else
             {

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 using log4net;
-using log4net.Repository.Hierarchy;
 
 namespace CKAN
 {

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -9,7 +9,6 @@ using CKAN.NetKAN.Transformers;
 using CKAN.NetKAN.Validators;
 using CommandLine;
 using log4net;
-using log4net.Config;
 using log4net.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -100,7 +99,7 @@ namespace CKAN.NetKAN
             {
                 Debugger.Launch();
             }
-                
+
             Options = new CmdLineOptions();
             Parser.Default.ParseArgumentsStrict(args, Options);
 

--- a/Netkan/Sources/Curse/CurseFile.cs
+++ b/Netkan/Sources/Curse/CurseFile.cs
@@ -1,5 +1,4 @@
 using CKAN.Versioning;
-using log4net;
 using Newtonsoft.Json;
 using System;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
My editor got [an upgrade](https://github.com/atom/ide-csharp/issues/7#issuecomment-343563804) today, which to my surprise included the ability to detect when a `using` directive in a C# file isn't needed. To celebrate, here's a pull request!

Most of these are because nothing from that assembly is being used.
Some of them (`using CKAN;` mainly) are because the file's code is already in that namespace.

In theory this might speed up compile times (since the compiler doesn't have to load as many references to parse a file), but that would probably be imperceptible in practice.