### PR TITLE
Fix null-reference exception on failed mod upgrade

### DIFF
--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -75,6 +75,7 @@ namespace CKAN
         public CkanModule Latest(KspVersionCriteria ksp_version = null, RelationshipDescriptor relationship=null)
         {
             var available_versions = new List<Version>(module_version.Keys);
+            available_versions.Sort(new RecentVersionComparer());
             CkanModule module;
             log.DebugFormat("Our dictionary has {0} keys", module_version.Keys.Count);
             log.DebugFormat("Choosing between {0} available versions", available_versions.Count);

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -237,14 +237,16 @@ namespace CKAN
 
         public void _MarkModForUpdate(string identifier)
         {
-            foreach (DataGridViewRow row in ModList.Rows)
+            if (!mainModList.full_list_of_mod_rows.ContainsKey(identifier))
             {
-                var mod = (GUIMod) row.Tag;
-                if (mod.Identifier == identifier)
-                {
-                    (row.Cells[1] as DataGridViewCheckBoxCell).Value = true;
-                    break;
-                }
+                return;
+            }
+            DataGridViewRow row = mainModList.full_list_of_mod_rows[identifier];
+
+            var mod = (GUIMod)row.Tag;
+            if (mod.Identifier == identifier)
+            {
+                mod.SetUpgradeChecked(row, true);
             }
         }
     }


### PR DESCRIPTION
Fixes #2162 

THIS IS A HACK!  I can't work out why the SortedDictionary "module_version" reverses it's sort-order after a module update has failed; someone more familiar with the codebase may be able to work out the actual bug.
