### PR TITLE
Initialize checkboxes to desired value at creation

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -41,6 +41,24 @@ namespace CKAN
         public bool IsCKAN { get; private set; }
         public string Abbrevation { get; private set; }
 
+        /// <summary>
+        /// Return whether this mod is installable.
+        /// Used for determining whether to show a checkbox in the leftmost column.
+        /// </summary>
+        /// <returns>
+        /// False if the mod is auto detected,
+        /// otherwise true if it's compatible or already installed,
+        /// otherwise false.
+        /// </returns>
+        public bool IsInstallable()
+        {
+            // Auto detected mods are never installable
+            if (IsAutodetected)
+                return false;
+            // Compatible mods are installable, but so are mods that are already installed
+            return !IsIncompatible || IsInstalled;
+        }
+
         public string Version
         {
             get { return IsInstalled ? InstalledVersion : LatestVersion; }
@@ -253,5 +271,6 @@ namespace CKAN
         {
             return (Name != null ? Name.GetHashCode() : 0);
         }
+
     }
 }

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -341,10 +341,11 @@ namespace CKAN
 
         private void PostInstallMods(object sender, RunWorkerCompletedEventArgs e)
         {
-            UpdateModsList();
-            tabController.SetTabLock(false);
+            KeyValuePair<bool, ModChanges> result = (KeyValuePair<bool, ModChanges>) e.Result;
 
-            var result = (KeyValuePair<bool, ModChanges>) e.Result;
+            UpdateModsList(false, result.Value);
+
+            tabController.SetTabLock(false);
 
             if (result.Key)
             {
@@ -370,24 +371,6 @@ namespace CKAN
                 SetDescription("An error occurred, check the log for information");
                 Util.Invoke(DialogProgressBar, () => DialogProgressBar.Style = ProgressBarStyle.Continuous);
                 Util.Invoke(DialogProgressBar, () => DialogProgressBar.Value = 0);
-
-                var opts = result.Value;
-
-                foreach (ModChange opt in opts)
-                {
-                    switch (opt.ChangeType)
-                    {
-                        case GUIModChangeType.Install:
-                            MarkModForInstall(opt.Mod.Identifier);
-                            break;
-                        case GUIModChangeType.Update:
-                            MarkModForUpdate(opt.Mod.Identifier);
-                            break;
-                        case GUIModChangeType.Remove:
-                            MarkModForInstall(opt.Mod.Identifier, true);
-                            break;
-                    }
-                }
             }
 
             Util.Invoke(this, () => Enabled = true);

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -529,8 +529,7 @@ namespace CKAN
                             : myChange.ChangeType == GUIModChangeType.Remove  ? false
                             : mod.IsInstalled
                     } : new DataGridViewTextBoxCell() {
-                        Value    = mod.IsAutodetected ? "AD" : "-",
-                        ReadOnly = true
+                        Value    = mod.IsAutodetected ? "AD" : "-"
                     };
 
                 var updating = mod.IsInstallable() && mod.HasUpdate
@@ -539,8 +538,7 @@ namespace CKAN
                             : myChange.ChangeType == GUIModChangeType.Update ? true
                             : false
                     } : new DataGridViewTextBoxCell() {
-                        Value    = "-",
-                        ReadOnly = true
+                        Value    = "-"
                     };
 
                 var name = new DataGridViewTextBoxCell {Value = mod.Name};
@@ -552,6 +550,9 @@ namespace CKAN
                 var size = new DataGridViewTextBoxCell {Value = mod.DownloadSize};
 
                 item.Cells.AddRange(selecting, updating, name, author, installVersion, latestVersion, compat, size, desc);
+
+                selecting.ReadOnly = selecting is DataGridViewTextBoxCell;
+                updating.ReadOnly = updating is  DataGridViewTextBoxCell;
 
                 full_list_of_mod_rows.Add(mod.Identifier, item);
             }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -137,12 +137,12 @@ namespace CKAN
             }
         }
 
-        public void UpdateModsList(Boolean repo_updated = false)
+        public void UpdateModsList(Boolean repo_updated = false, List<ModChange> mc = null)
         {
-            Util.Invoke(this, () => _UpdateModsList(repo_updated));
+            Util.Invoke(this, () => _UpdateModsList(repo_updated, mc ?? new List<ModChange>()));
         }
 
-        private void _UpdateModsList(bool repo_updated)
+        private void _UpdateModsList(bool repo_updated, List<ModChange> mc)
         {
             log.Debug("Updating the mod list");
 
@@ -182,7 +182,7 @@ namespace CKAN
 
             // Update our mod listing. If we're doing a repo update, then we don't refresh
             // all (in case the user has selected changes they wish to apply).
-            mainModList.ConstructModList(gui_mods.ToList(), refreshAll: !repo_updated, hideEpochs: configuration.HideEpochs);
+            mainModList.ConstructModList(gui_mods.ToList(), mc, !repo_updated, configuration.HideEpochs);
             mainModList.Modules = new ReadOnlyCollection<GUIMod>(
                 mainModList.full_list_of_mod_rows.Values.Select(row => row.Tag as GUIMod).ToList());
 
@@ -495,7 +495,7 @@ namespace CKAN
         /// <param name="modules">A list of modules that may require updating</param>
         /// <param name="refreshAll">If set to <c>true</c> then always rebuild the list from scratch</param>
         /// <param name="hideEpochs">If true, remove epochs from the displayed versions</param>
-        public IEnumerable<DataGridViewRow> ConstructModList(IEnumerable<GUIMod> modules, bool refreshAll = false, bool hideEpochs = false)
+        public IEnumerable<DataGridViewRow> ConstructModList(IEnumerable<GUIMod> modules, List<ModChange> mc = null, bool refreshAll = false, bool hideEpochs = false)
         {
 
             if (refreshAll || full_list_of_mod_rows == null)
@@ -520,21 +520,28 @@ namespace CKAN
                 full_list_of_mod_rows.Remove(mod.Identifier);
                 var item = new DataGridViewRow {Tag = mod};
 
+                ModChange myChange = mc?.Find((ModChange ch) => ch.Mod.Identifier == mod.Identifier);
+
                 var selecting = mod.IsInstallable()
-                    ? (DataGridViewCell) new DataGridViewCheckBoxCell()
-                    : new DataGridViewTextBoxCell();
+                    ? (DataGridViewCell) new DataGridViewCheckBoxCell() {
+                        Value = myChange == null ? mod.IsInstalled
+                            : myChange.ChangeType == GUIModChangeType.Install ? true
+                            : myChange.ChangeType == GUIModChangeType.Remove  ? false
+                            : mod.IsInstalled
+                    } : new DataGridViewTextBoxCell() {
+                        Value    = mod.IsAutodetected ? "AD" : "-",
+                        ReadOnly = true
+                    };
 
-                selecting.Value = mod.IsInstallable()
-                    ? (object) mod.IsInstalled
-                    : (mod.IsAutodetected ? "AD" : "-");
-
-                var updating = mod.HasUpdate && !mod.IsAutodetected
-                    ? new DataGridViewCheckBoxCell()
-                    : (DataGridViewCell) new DataGridViewTextBoxCell();
-
-                updating.Value = !mod.IsInstallable() || !mod.HasUpdate
-                    ? "-"
-                    : (object) false;
+                var updating = mod.IsInstallable() && mod.HasUpdate
+                    ? (DataGridViewCell) new DataGridViewCheckBoxCell() {
+                        Value = myChange == null ? false
+                            : myChange.ChangeType == GUIModChangeType.Update ? true
+                            : false
+                    } : new DataGridViewTextBoxCell() {
+                        Value    = "-",
+                        ReadOnly = true
+                    };
 
                 var name = new DataGridViewTextBoxCell {Value = mod.Name};
                 var author = new DataGridViewTextBoxCell {Value = mod.Authors};
@@ -545,9 +552,6 @@ namespace CKAN
                 var size = new DataGridViewTextBoxCell {Value = mod.DownloadSize};
 
                 item.Cells.AddRange(selecting, updating, name, author, installVersion, latestVersion, compat, size, desc);
-
-                selecting.ReadOnly = !mod.IsInstallable();
-                updating.ReadOnly = !mod.IsInstallable() || !mod.HasUpdate;
 
                 full_list_of_mod_rows.Add(mod.Identifier, item);
             }

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -10,7 +10,7 @@ namespace CKAN
     using System.Windows.Forms;
 
     public static class Util
-    {                
+    {
         /// <summary>
         /// Invokes an action on the UI thread, or directly if we're
         /// on the UI thread.
@@ -114,18 +114,6 @@ namespace CKAN
                 // We tried all prefixes, and still no luck.
                 return false;
             }
-        }
-    }
-}
-
-namespace CKAN
-{    
-    public static class UtilWithoutWinForm
-    {
-        public static bool IsInstallable(this GUIMod mod)
-        {
-            if(mod==null) throw new ArgumentNullException();
-            return !(mod.IsAutodetected || mod.IsIncompatible) || (!mod.IsAutodetected && mod.IsInstalled);
         }
     }
 }

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -70,7 +70,7 @@ namespace Tests.GUI
                 var mod = new GUIMod(module, registry, tidy.KSP.VersionCriteria());
                 var mod2 = new GUIMod(TestData.kOS_014_module(), registry, tidy.KSP.VersionCriteria());
                 var mods = new List<GUIMod>() { mod, mod2 };
-                mainList.ConstructModList(mods, true);
+                mainList.ConstructModList(mods, null, true);
                 mainList.Modules = new ReadOnlyCollection<GUIMod>(mods);
                 mod2.IsInstallChecked = true;
                 var computeTask = mainList.ComputeChangeSetFromModList(registry, mainList.ComputeUserChangeSet(), null,


### PR DESCRIPTION
This is a possible fix for #2162, and an alternative to #2183.

That issue happens because after a failed install/upgrade attempt, `Main.PostInstallMods` rebuilds the mod list and then re-applies the `ModChanges` object's changes to the checkboxes. But one of the checkboxes may no longer be a checkbox, and trying to access it as one causes a null reference exception.

This pull request eliminates the possibility of this happening. Rather than generating the check boxes in a default state and then applying a `ModChanges` after the fact, we now pass the `ModChanges` directly to `Main.ConstructModList` and use it to control the initial checkbox state, so the row object starts out consistent with the `ModChanges`.

`ConstructModList` is cleaned up a bit to make this happen. Previously it created the checkbox cells, set their values, and potentially set them as read-only in three separate statements per checkbox. Each of those lines has to have its own Boolean check for whether to show a checkbox or a "-" for actions that aren't allowed (incompatible mods, for example). If those checks ever got out of sync, we would risk the same kind of exceptions that were happening in this issue by treating a non-checkbox as a checkbox. And they sort of were out of sync! The creation of the Update checkbox depended on `mod.HasUpdate && !mod.IsAutodetected`, but the setting of its value used `!mod.Isinstallable() || !mod.HasUpdate`, which, in addition to being confusing, is not exactly the same condition.

Now each checkbox is set up in one single step; we create the checkbox and set its value property simultaneously using the {Property=value} syntax, under one single Boolean check, so there is no risk of them executing out of sync. (`ReadOnly` still has to be set separately due to .NET raising an exception, see review comments for details.)

As for the reason why the update checkbox was no longer a checkbox, @mwerle reports that `AvailableModule.module_versions` sometimes flipped its sort order, which caused it to consider the wrong mod version as the most recent, and therefore miss an available upgrade. This object is a `SortedDictionary` initialized to sort in descending order, but it's also an `internal [JsonProperty]`, so it's possible that the deserializer (or some other object) might replace it with a `SortedDictionary` that uses ascending order instead (which is the default), which could cause such issues.

Since we can't force all objects everywhere to initialize their `SortedDictionary` objects to descending order before assigning them to `AvailableModule.module_versions`, `AvailableModule` is updated to use an ascending order sort instead. This way it will work even if some other object replaces the dictionary.

In addition, some weird or confusing things are cleaned up:

- `GUIMod.IsInstalled()` was implemented as an extension method in `Util.cs`, which made it harder to find without doing a find-in-files, and is not necessary because we own the `GUIMod` class and can do whatever we like with it. This method is now moved to being a normal public instance method of `GUIMod`.
- `GUIMod.IsInstalled()` was also fairly hard to understand, consisting of an OR of an OR expression and an AND expression, sharing one term, one of which had a NOT on the outside, and the other had a NOT on the inside. If you could tell what it did by glancing at it, I salute you. Now it's simplified to an equivalent sequence of checks that I think is much easier to read, with explanatory comments and XML documentation.