### PR TITLE
Avoid crash with unavailable installed mod, improve error messages

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -250,7 +250,7 @@ namespace CKAN
             User.RaiseProgress("Done!\r\n", 100);
         }
 
-        public ModuleResolution ResolveModules(IEnumerable<string> modules, RelationshipResolverOptions options)
+        public ModuleResolution ResolveModules(IEnumerable<CkanModule> modules, RelationshipResolverOptions options)
         {
             var resolver = new RelationshipResolver(modules, options, registry_manager.registry, ksp.VersionCriteria());
             return new ModuleResolution(resolver.ModList(), m => ksp.Cache.IsCachedZip(m.download));

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -32,7 +32,16 @@ namespace CKAN
             {
                 foreach (CkanModule unhappy_mod in entry.Value)
                 {
-                    errors.Add(string.Format("{0} depends on {1} but it is not listed in the index, or not available for your version of KSP.", unhappy_mod.identifier, entry.Key));
+                    // This error can fire if a dependency
+                    // IS listed in the index AND IS available for our version,
+                    // but not installed.
+                    // This happens when `dlls` is Registry.installed_dlls.Keys,
+                    // as in Registry.GetSanityErrors.
+                    errors.Add(string.Format(
+                        "{0} has an unmet dependency: {1} is not installed",
+                        unhappy_mod.identifier,
+                        entry.Key
+                    ));
                 }
             }
 

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -378,23 +378,25 @@ namespace CKAN
 
             if (match.Success)
             {
-                string ident = match.Groups["mod"].Value;
+                string ident   = match.Groups["mod"].Value;
                 string version = match.Groups["version"].Value;
 
                 module = registry.GetModuleByVersion(ident, version);
 
                 if (module == null)
-                        throw new ModuleNotFoundKraken(ident, version,
-                            string.Format("Cannot install {0}, version {1} not available", ident, version));
+                    throw new ModuleNotFoundKraken(ident, version,
+                        string.Format("Module {0} version {1} not available", ident, version));
             }
             else
-                module = registry.LatestAvailable(mod, ksp_version);
+            {
+                module = registry.LatestAvailable(mod, ksp_version)
+                      ?? registry.InstalledModule(mod)?.Module;
 
-            if (module == null)
+                if (module == null)
                     throw new ModuleNotFoundKraken(mod, null,
-                        string.Format("Cannot install {0}, module not available", mod));
-            else
-                return module;
+                        string.Format("Module {0} not installed or available", mod));
+            }
+            return module;
         }
 
         /// <summary> Generates a CKAN.Meta object given a filename</summary>

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -20,7 +20,7 @@ namespace CKAN
         private volatile bool installCanceled;
 
         // this will be the final list of mods we want to install
-        private HashSet<string> toInstall = new HashSet<string>();
+        private HashSet<CkanModule> toInstall = new HashSet<CkanModule>();
 
         private void InstallMods(object sender, DoWorkEventArgs e) // this probably needs to be refactored
         {
@@ -35,7 +35,7 @@ namespace CKAN
             ModuleInstaller installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
             // setup progress callback
 
-            toInstall = new HashSet<string>();
+            toInstall = new HashSet<CkanModule>();
             var toUninstall = new HashSet<string>();
             var toUpgrade = new HashSet<string>();
 
@@ -51,7 +51,7 @@ namespace CKAN
                         toUpgrade.Add(change.Mod.Identifier);
                         break;
                     case GUIModChangeType.Install:
-                        toInstall.Add(change.Mod.Identifier);
+                        toInstall.Add(change.Mod.ToModule());
                         break;
                 }
             }
@@ -183,9 +183,9 @@ namespace CKAN
                     // if the mod is available for the current KSP version _and_
                     // the mod is not installed _and_
                     // the mod is not already in the install list
-                    if (
-                        registry.LatestAvailable(mod.name, CurrentInstance.VersionCriteria()) != null &&
-                        !registry.IsInstalled(mod.name) && !toInstall.Contains(mod.name))
+                    if (registry.LatestAvailable(mod.name, CurrentInstance.VersionCriteria()) != null
+                        && !registry.IsInstalled(mod.name)
+                        && !toInstall.Any(m => m.identifier == mod.name))
                     {
                         // add it to the list of chooseAble mods we display to the user
                         if (!chooseAble.ContainsKey(mod.name))
@@ -211,7 +211,7 @@ namespace CKAN
             // recommended list, since they can't de-select it anyway.
             foreach (var item in toInstall)
             {
-                selectable.Remove(item);
+                selectable.Remove(item.identifier);
             }
 
             Dictionary<CkanModule, string> mods = GetShowableMods(selectable);
@@ -551,8 +551,7 @@ namespace CKAN
             {
                 if (item.Checked)
                 {
-                    var identifier = ((CkanModule) item.Tag).identifier;
-                    toInstall.Add(identifier);
+                    toInstall.Add((CkanModule) item.Tag);
                 }
             }
 

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -640,14 +640,19 @@ namespace CKAN
                 }
             }
 
-            var installed =
-                registry.Installed()
-                    .Where(pair => pair.Value.CompareTo(new ProvidesVersion("")) != 0)
-                    .Select(pair => pair.Key);
+            // Only check mods that would exist after the changes are made.
+            IEnumerable<CkanModule> installed = registry.InstalledModules.Where(
+                im => !modules_to_remove.Contains(im.Module.identifier)
+            ).Select(im => im.Module);
 
-            //We wish to only check mods that would exist after the changes are made.
-            var mods_to_check = installed.Union(modules_to_install).Except(modules_to_remove);
-            var resolver = new RelationshipResolver(mods_to_check.ToList(), options, registry, ksp_version);
+            // Convert ONLY modules_to_install with CkanModule.FromIDandVersion,
+            // because it may not find already-installed modules.
+            IEnumerable<CkanModule> mods_to_check = installed.Union(
+                modules_to_install.Except(modules_to_remove).Select(
+                    name => CkanModule.FromIDandVersion(registry, name, ksp_version)
+                )
+            );
+            var resolver = new RelationshipResolver(mods_to_check, options, registry, ksp_version);
             return resolver.ConflictList.ToDictionary(item => new GUIMod(item.Key, registry, ksp_version),
                 item => item.Value);
         }


### PR DESCRIPTION
KSP-CKAN/NetKAN#6044 highlighted some issues with how dependencies are handled currently:

- If you have a mod that's installed but not available (TextureReplacer in the initial report, which is available in 1.3.0 and not in 1.3.1, and the user had upgraded), `RelationshipResolver` can cause an unhandled exception when trying to compute conflicts, which happens whenever you try to install a new mod.
- That exception says "Cannot install XYZ, module not available", which is partially correct and partially misleading; it is not available, but we were **not** trying to install it.
- If you manually delete a mod that CKAN installed, the message contains "ModuleManager but it is not listed in the index, or not available for your version of KSP", which is incorrect and misleading because ModuleManager **is** in the index and available for your version of KSP, it's just not installed on disk.

The error messages are fixed by rewriting them (as far as I could tell from searching the code, there was no scenario in which the old phrasing was more accurate). The unhandled exception is fixed from two directions:
1. `CkanModule.FromIDandVersion` will now fall back to checking the installed modules if the requested mod isn't found in the available modules.
2. Instead of passing a list of only identifiers to `RelationshipResolver`, `MainModList` will now pass a list of `CkanModules`, retrieved from `Registry.InstalledModules` for the already installed modules and `CkanModule.FromIDandVersion` for the mods to install. This avoids the need for the lookup that was raising the exception.

After these changes, the app should be more well-behaved in these circumstances, and users should receive more useful feedback when things go wrong.