### PR TITLE
Adapt Curse API to new widget

### DIFF
--- a/Netkan/Sources/Curse/CurseApi.cs
+++ b/Netkan/Sources/Curse/CurseApi.cs
@@ -8,10 +8,10 @@ namespace CKAN.NetKAN.Sources.Curse
 {
     internal sealed class CurseApi : ICurseApi
     {
-        private static readonly ILog Log = LogManager.GetLogger(typeof (CurseApi));
+        private static readonly ILog Log = LogManager.GetLogger(typeof(CurseApi));
 
-        public static string CurseApiBase = "https://widget.mcf.li/project/";
-        public static string CurseApiEnd = ".json";
+        private static string CurseApiBase = "https://api.cfwidget.com/project/";
+        private static string CurseApiEnd = "";
 
         private readonly IHttpService _http;
 
@@ -26,18 +26,15 @@ namespace CKAN.NetKAN.Sources.Curse
 
             // Check if the mod has been removed from Curse and if it corresponds to a KSP mod.
             var error = JsonConvert.DeserializeObject<CurseError>(json);
-
-            if (error.code != 0)
+            if (!string.IsNullOrEmpty(error.error))
             {
-                var errorMessage = string.Format("Could not get the mod from Curse, reason: {0}.", error.message);
-                throw new Kraken(errorMessage);
-            }
-            else if (!error.game.Equals("Kerbal Space Program"))
-            {
-                throw new Kraken("Could not get the mod from Curse, reason: Specified id is not a KSP mod");
+                throw new Kraken(string.Format(
+                    "Could not get the mod from Curse, reason: {0}.",
+                    error.message
+                ));
             }
 
-            return CurseMod.FromJson(modId, json);
+            return CurseMod.FromJson(json);
         }
 
         public static Uri ResolveRedirect(Uri url)
@@ -52,7 +49,8 @@ namespace CKAN.NetKAN.Sources.Curse
             while (response.Headers["Location"] != null)
             {
                 redirects++;
-                if(redirects > 6) throw new Kraken("More than 6 redirects when resolving the following url: " + url);
+                if (redirects > 6)
+                    throw new Kraken("More than 6 redirects when resolving the following url: " + url);
                 redirUrl = new Uri(redirUrl, response.Headers["Location"]);
                 request = (HttpWebRequest) WebRequest.Create(redirUrl);
                 request.AllowAutoRedirect = false;
@@ -63,9 +61,9 @@ namespace CKAN.NetKAN.Sources.Curse
             return redirUrl;
         }
 
-        private string Call(int modid)
+        private string Call(int modId)
         {
-            var url = CurseApiBase + modid + CurseApiEnd;
+            var url = CurseApiBase + modId + CurseApiEnd;
 
             Log.DebugFormat("Calling {0}", url);
 

--- a/Netkan/Sources/Curse/CurseApi.cs
+++ b/Netkan/Sources/Curse/CurseApi.cs
@@ -11,7 +11,6 @@ namespace CKAN.NetKAN.Sources.Curse
         private static readonly ILog Log = LogManager.GetLogger(typeof(CurseApi));
 
         private static string CurseApiBase = "https://api.cfwidget.com/project/";
-        private static string CurseApiEnd = "";
 
         private readonly IHttpService _http;
 
@@ -26,7 +25,7 @@ namespace CKAN.NetKAN.Sources.Curse
 
             // Check if the mod has been removed from Curse and if it corresponds to a KSP mod.
             var error = JsonConvert.DeserializeObject<CurseError>(json);
-            if (!string.IsNullOrEmpty(error.error))
+            if (!string.IsNullOrWhiteSpace(error.error))
             {
                 throw new Kraken(string.Format(
                     "Could not get the mod from Curse, reason: {0}.",
@@ -63,7 +62,7 @@ namespace CKAN.NetKAN.Sources.Curse
 
         private string Call(int modId)
         {
-            var url = CurseApiBase + modId + CurseApiEnd;
+            var url = CurseApiBase + modId;
 
             Log.DebugFormat("Calling {0}", url);
 

--- a/Netkan/Sources/Curse/CurseError.cs
+++ b/Netkan/Sources/Curse/CurseError.cs
@@ -8,10 +8,8 @@ namespace CKAN.NetKAN.Sources.Curse
         // Currently only used via JsonConvert.DeserializeObject which the compiler
         // doesn't pick up on.
 #pragma warning disable 0649
-        public int code;
         public string error;
         public string message;
-        public string game;
 #pragma warning restore 0649
     }
 }

--- a/Netkan/Sources/Curse/CurseFile.cs
+++ b/Netkan/Sources/Curse/CurseFile.cs
@@ -7,21 +7,13 @@ namespace CKAN.NetKAN.Sources.Curse
 {
     public class CurseFile
     {
-        //Not currently writing anything to the log in this collection.
-        //private static readonly ILog log = LogManager.GetLogger(typeof (CurseFile));
-
-        internal CurseMod Mod;
-
         [JsonConverter(typeof(JsonConvertKSPVersion))]
         [JsonProperty] public KspVersion version;
-
-        //[JsonProperty] public string changelog;
-
-        //[JsonProperty] public Version friendly_version;
-
-        [JsonProperty] public string name;
+        [JsonProperty] public string name = "";
         [JsonProperty] public string type;
         [JsonProperty] public int id;
+        [JsonProperty] public DateTime uploaded_at;
+        [JsonProperty] public string url;
 
         private string _downloadUrl;
         private string _filename;
@@ -30,22 +22,24 @@ namespace CKAN.NetKAN.Sources.Curse
         /// <summary>
         /// Returns the direct path to the file
         /// </summary>
-        /// <returns>The download url</returns>
-        public String GetDownloadUrl()
+        /// <returns>
+        /// The download URL
+        /// </returns>
+        public string GetDownloadUrl()
         {
-            if (_downloadUrl == null)
+            if (string.IsNullOrEmpty(_downloadUrl))
             {
-                _downloadUrl = CurseApi.ResolveRedirect(new Uri(Mod.GetPageUrl() + "/files/" + id + "/download")).ToString();
+                _downloadUrl = url + "/file";
             }
             return _downloadUrl;
         }
 
         /// <summary>
-        /// Sets the download url of the file
+        /// Sets the download URL of the file
         /// </summary>
-        public void SetDownloadUrl(String url)
+        public void SetDownloadUrl(string u)
         {
-            _downloadUrl = url;
+            _downloadUrl = u;
         }
 
         /// <summary>
@@ -65,7 +59,7 @@ namespace CKAN.NetKAN.Sources.Curse
         {
             if (_filename == null)
             {
-                Match match = Regex.Match(GetDownloadUrl(), "[^/]*\\.zip");
+                Match match = Regex.Match(url, "[^/]*\\.zip");
                 if (match.Groups.Count > 0) _filename = match.Groups[0].Value;
                 else _filename = GetCurseIdVersion();
             }
@@ -80,13 +74,11 @@ namespace CKAN.NetKAN.Sources.Curse
         {
             if (_fileVersion == null)
             {
-                // Matches the last group of numbers letters and dots before the .zip extension, staring at a number or a 'v' and a number
-                Match match = Regex.Match(GetDownloadUrl(), "(v?[0-9][0-9a-z.]*[0-9a-z])[^0-9]*\\.zip");
-                if (match.Groups.Count > 1) _fileVersion = match.Groups[1].Value;
-
-                // The id is unique across all files, and is always incrementing.
-                // This format also assures, that any "real" version precedes them.
-                else _fileVersion = GetCurseIdVersion();
+                Match match = Regex.Match(name, "(v?[0-9][0-9a-z.]*[0-9a-z])[^0-9]*\\.zip");
+                if (match.Groups.Count > 1)
+                    _fileVersion = match.Groups[1].Value;
+                else
+                    _fileVersion = GetCurseIdVersion();
             }
             return _fileVersion;
         }
@@ -98,17 +90,6 @@ namespace CKAN.NetKAN.Sources.Curse
         {
             _fileVersion = version;
         }
-
-        //public string Download(string identifier, NetFileCache cache)
-        //{
-        //    log.DebugFormat("Downloading {0}", download_path);
-        //
-        //    string filename = ModuleInstaller.CachedOrDownload(identifier, friendly_version, download_path, cache);
-        //
-        //    log.Debug("Downloaded.");
-        //
-        //    return filename;
-        //}
 
         /// <summary>
         /// Curse has versions that don't play nicely with CKAN, for example "1.1-prerelease".

--- a/Netkan/Sources/Curse/CurseFile.cs
+++ b/Netkan/Sources/Curse/CurseFile.cs
@@ -18,6 +18,7 @@ namespace CKAN.NetKAN.Sources.Curse
         private string _downloadUrl;
         private string _filename;
         private string _fileVersion;
+        public  string ModPageUrl = "";
 
         /// <summary>
         /// Returns the direct path to the file
@@ -29,7 +30,7 @@ namespace CKAN.NetKAN.Sources.Curse
         {
             if (string.IsNullOrEmpty(_downloadUrl))
             {
-                _downloadUrl = url + "/file";
+                _downloadUrl = CurseApi.ResolveRedirect(new Uri(ModPageUrl + "/files/" + id + "/download")).ToString();
             }
             return _downloadUrl;
         }
@@ -59,7 +60,7 @@ namespace CKAN.NetKAN.Sources.Curse
         {
             if (_filename == null)
             {
-                Match match = Regex.Match(url, "[^/]*\\.zip");
+                Match match = Regex.Match(GetDownloadUrl(), "[^/]*\\.zip");
                 if (match.Groups.Count > 0) _filename = match.Groups[0].Value;
                 else _filename = GetCurseIdVersion();
             }

--- a/Netkan/Sources/Curse/CurseFile.cs
+++ b/Netkan/Sources/Curse/CurseFile.cs
@@ -75,7 +75,7 @@ namespace CKAN.NetKAN.Sources.Curse
         {
             if (_fileVersion == null)
             {
-                Match match = Regex.Match(name, "(v?[0-9][0-9a-z.]*[0-9a-z])[^0-9]*\\.zip");
+                Match match = Regex.Match(GetDownloadUrl(), "(v?[0-9][0-9a-z.]*[0-9a-z])[^0-9]*\\.zip");
                 if (match.Groups.Count > 1)
                     _fileVersion = match.Groups[1].Value;
                 else

--- a/Netkan/Sources/Curse/CurseMod.cs
+++ b/Netkan/Sources/Curse/CurseMod.cs
@@ -10,22 +10,24 @@ namespace CKAN.NetKAN.Sources.Curse
     {
         [JsonProperty] public string license;
         [JsonProperty] public string title;
-        //[JsonProperty] public string short_description;
-        [JsonProperty] public string[] authors;
-        [JsonProperty] public Dictionary<int, CurseFile> files;
-        //[JsonProperty] public string website;
-        //[JsonProperty] public string source_code;
-        //[JsonProperty] public int default_version_id;
+        [JsonProperty] public List<CurseFile> files;
         [JsonProperty] public string thumbnail;
+        [JsonProperty] public int id;
+        [JsonProperty] public string game;
+        [JsonProperty] public List<CurseModMember> members;
 
-        public int ModId;
+        public string[] authors {
+            get {
+                return members.Select(m => m.username).ToArray();
+            }
+        }
 
         private string _pageUrl;
         private string _name;
 
         public CurseFile Latest()
         {
-            return files.Values.First();
+            return files.First();
         }
 
         /// <summary>
@@ -34,7 +36,7 @@ namespace CKAN.NetKAN.Sources.Curse
         /// <returns>The home</returns>
         public string GetProjectUrl()
         {
-            return "http://kerbal.curseforge.com/projects/" + ModId;
+            return "https://www.curseforge.com/project/" + id;
         }
 
         /// <summary>
@@ -69,19 +71,21 @@ namespace CKAN.NetKAN.Sources.Curse
 
         public override string ToString()
         {
-            //return string.Format("{0}", name);
             return string.Format("{0}", title);
         }
 
-        public static CurseMod FromJson(int modId, string json)
+        public static CurseMod FromJson(string json)
         {
             CurseMod mod = JsonConvert.DeserializeObject<CurseMod>(json);
-            mod.ModId = modId;
-            foreach (CurseFile file in mod.files.Values)
-            {
-                file.Mod = mod;
-            }
             return mod;
         }
+    }
+
+    internal class CurseModMember
+    {
+
+        [JsonProperty] public string title;
+        [JsonProperty] public string username;
+
     }
 }

--- a/Netkan/Sources/Curse/CurseMod.cs
+++ b/Netkan/Sources/Curse/CurseMod.cs
@@ -10,6 +10,7 @@ namespace CKAN.NetKAN.Sources.Curse
     {
         [JsonProperty] public string license;
         [JsonProperty] public string title;
+        [JsonProperty] public string description;
         [JsonProperty] public List<CurseFile> files;
         [JsonProperty] public string thumbnail;
         [JsonProperty] public int id;
@@ -36,7 +37,7 @@ namespace CKAN.NetKAN.Sources.Curse
         /// <returns>The home</returns>
         public string GetProjectUrl()
         {
-            return "https://www.curseforge.com/project/" + id;
+            return "https://kerbal.curseforge.com/projects/" + id;
         }
 
         /// <summary>
@@ -77,6 +78,10 @@ namespace CKAN.NetKAN.Sources.Curse
         public static CurseMod FromJson(string json)
         {
             CurseMod mod = JsonConvert.DeserializeObject<CurseMod>(json);
+            foreach (CurseFile file in mod.files)
+            {
+                file.ModPageUrl = mod.GetPageUrl();
+            }
             return mod;
         }
     }

--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -78,7 +78,7 @@ namespace CKAN.NetKAN.Transformers
                 }
 
                 json.SafeAdd("name", curseMod.GetName());
-                //json.SafeAdd("abstract", cMod.short_description);
+                json.SafeAdd("abstract", curseMod.description);
 
                 if (useDownloadNameVersion)  json.SafeAdd("version", latestVersion.name);
                 else if (useFilenameVersion) json.SafeAdd("version", latestVersion.GetFilename());
@@ -194,8 +194,8 @@ namespace CKAN.NetKAN.Transformers
 
                 var resourcesJson = (JObject)json["resources"];
 
-                //resourcesJson.SafeAdd("homepage", Normalize(cMod.website));
-                //resourcesJson.SafeAdd("repository", Normalize(cMod.source_code));
+                //resourcesJson.SafeAdd("homepage", Normalize(curseMod.website));
+                //resourcesJson.SafeAdd("repository", Normalize(curseMod.source_code));
                 resourcesJson.SafeAdd("curse", curseMod.GetProjectUrl());
 
                 if (curseMod.thumbnail != null)

--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -43,16 +43,12 @@ namespace Tests.NetKAN.Sources.Curse
             // Assert
             var latestVersion = result.Latest();
 
-            Assert.That(result.ModId, Is.EqualTo(220221));
-            Assert.That(result.authors, Is.Not.Null);
+            Assert.That(result.members, Is.Not.Null);
+            Assert.That(result.id, Is.EqualTo(220221));
             Assert.That(result.thumbnail, Is.Not.Null);
             Assert.That(result.license, Is.Not.Null);
             Assert.That(result.title, Is.Not.Null);
-            //Assert.That(result.short_description, Is.Not.Null);
-            //Assert.That(result.source_code, Is.Not.Null);
-            //Assert.That(result.website, Is.Not.Null);
             Assert.That(result.files.Count, Is.GreaterThan(0));
-            //Assert.That(latestVersion.changelog, Is.Not.Null);
             Assert.That(latestVersion.GetDownloadUrl(), Is.Not.Null);
             Assert.That(latestVersion.GetFileVersion(), Is.Not.Null);
             Assert.That(latestVersion.version, Is.Not.Null); // KSP Version

--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -43,8 +43,8 @@ namespace Tests.NetKAN.Sources.Curse
             // Assert
             var latestVersion = result.Latest();
 
-            Assert.That(result.members, Is.Not.Null);
             Assert.That(result.id, Is.EqualTo(220221));
+            Assert.That(result.members, Is.Not.Null);
             Assert.That(result.thumbnail, Is.Not.Null);
             Assert.That(result.license, Is.Not.Null);
             Assert.That(result.title, Is.Not.Null);

--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -48,6 +48,7 @@ namespace Tests.NetKAN.Sources.Curse
             Assert.That(result.thumbnail, Is.Not.Null);
             Assert.That(result.license, Is.Not.Null);
             Assert.That(result.title, Is.Not.Null);
+            Assert.That(result.description, Is.Not.Null);
             Assert.That(result.files.Count, Is.GreaterThan(0));
             Assert.That(latestVersion.GetDownloadUrl(), Is.Not.Null);
             Assert.That(latestVersion.GetFileVersion(), Is.Not.Null);

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -43,13 +43,10 @@ namespace Tests.NetKAN.Transformers
             {
                 license = "CC-BY",
                 title = "Dogecoin Flag",
-                //short_description = "Such test. Very unit. Wow.",
-                authors = new string[] {"pjf"}
-                //versions = new SDVersion[1]
+                members = new List<CurseModMember>{ new CurseModMember { username = "pjf" } }
             };
 
-            cmod.files = new Dictionary<int, CurseFile>();
-            cmod.files[0] = new CurseFile();
+            cmod.files = new List<CurseFile>() { new CurseFile() };
             cmod.files[0].SetFileVersion("0.25");
             cmod.files[0].SetDownloadUrl("http://example.com/download.zip");
 

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -43,6 +43,7 @@ namespace Tests.NetKAN.Transformers
             {
                 license = "CC-BY",
                 title = "Dogecoin Flag",
+                description = "Such test. Very unit. Wow.",
                 members = new List<CurseModMember>{ new CurseModMember { username = "pjf" } }
             };
 


### PR DESCRIPTION
Closes #2178.

This pull request updates the Curse API code to work with the latest changes to the widget.

- The base URL is changed
- No longer need json suffix in URL
- `files` is now an array rather than a dictionary
- `authors` is now moved into `members` array with `username` as property name
- The version is now embedded in `name`

After these changes, the tests all pass and `netkan.exe` generates files that match previous versions except for specifics of URLs.