### PR TITLE
Only check first three segments of version in ci (fixes #2191)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         branch: master
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\d+\.\d+\.\d+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
 
 notifications:
   irc:


### PR DESCRIPTION
See my comment on #2191; the `mono --version` check is now printing 5.4.0.201 instead of just 5.4.0, and our perl regex extracts that whole string. This pull request changes the perl regex to match just the 5.4.0 part, so it should match BUILD_RELEASE_MONO_VERSION again.

This should get builds deploying to S3 again, which should fix the Curse errors on the status page.