### PR TITLE
Update version regex for release builds as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ deploy:
       on:
         repo: KSP-CKAN/CKAN
         tags: true
-        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\S+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\d+\.\d+\.\d+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
         # all_branches needed as a workaround for travis-ci#1675
         all_branches: true
 


### PR DESCRIPTION
Applying the fix from #2192 to release builds in addition to per-merge builds. The same condition was used in both places, so it would have stopped a release from building as well.