### PR TITLE
Fix cmdline help text problems (fixes #445, fixes #1490, fixes #2105)

### DIFF
--- a/Cmdline/Action/Compare.cs
+++ b/Cmdline/Action/Compare.cs
@@ -1,6 +1,7 @@
 ﻿namespace CKAN.CmdLine
 {
-    public class Compare : ICommand
+    // Does not need an instance, so this is not an ICommand
+    public class Compare
     {
         private IUser user;
 
@@ -9,7 +10,7 @@
             this.user = user;
         }
 
-        public int RunCommand(CKAN.KSP ksp, object rawOptions)
+        public int RunCommand(object rawOptions)
         {
             var options = (CompareOptions)rawOptions;
 

--- a/Cmdline/Action/CompatSubCommand.cs
+++ b/Cmdline/Action/CompatSubCommand.cs
@@ -1,142 +1,15 @@
 using System.Linq;
 using CKAN.Versioning;
 using CommandLine;
+using CommandLine.Text;
 
 namespace CKAN.CmdLine.Action
 {
     public class CompatSubCommand : ISubCommand
     {
-        private readonly KSPManager _kspManager;
-        private readonly IUser _user;
+        public CompatSubCommand() { }
 
-        public CompatSubCommand(KSPManager kspManager, IUser user)
-        {
-            _kspManager = kspManager;
-            _user = user;
-        }
-
-        public int RunSubCommand(SubCommandOptions options)
-        {
-            var exitCode = 0;
-
-            Parser.Default.ParseArgumentsStrict(options.options.ToArray(), new CompatOptions(), (option, suboptions) =>
-            {
-                switch (option)
-                {
-                    case "list":
-                        {
-                            var ksp = _kspManager.CurrentInstance;
-
-                            const string versionHeader = "Version";
-                            const string actualHeader = "Actual";
-
-                            var output = ksp
-                                .GetCompatibleVersions()
-                                .Select(i => new
-                                {
-                                    Version = i,
-                                    Actual = false
-                                })
-                                .ToList();
-
-                            output.Add(new
-                            {
-                                Version = ksp.Version(),
-                                Actual = true
-                            });
-
-                            output = output
-                                .OrderByDescending(i => i.Actual)
-                                .ThenByDescending(i => i.Version)
-                                .ToList();
-
-                            var versionWidth = Enumerable
-                                .Repeat(versionHeader, 1)
-                                .Concat(output.Select(i => i.Version.ToString()))
-                                .Max(i => i.Length);
-
-                            var actualWidth = Enumerable
-                                .Repeat(actualHeader, 1)
-                                .Concat(output.Select(i => i.Actual.ToString()))
-                                .Max(i => i.Length);
-
-                            const string columnFormat = "{0}  {1}";
-
-                            _user.RaiseMessage(string.Format(columnFormat,
-                                versionHeader.PadRight(versionWidth),
-                                actualHeader.PadRight(actualWidth)
-                            ));
-
-                            _user.RaiseMessage(string.Format(columnFormat,
-                                new string('-', versionWidth),
-                                new string('-', actualWidth)
-                            ));
-
-                            foreach (var line in output)
-                            {
-                                _user.RaiseMessage(string.Format(columnFormat,
-                                   line.Version.ToString().PadRight(versionWidth),
-                                   line.Actual.ToString().PadRight(actualWidth)
-                               ));
-                            }
-                        }
-                        break;
-                    case "add":
-                        {
-                            var ksp = _kspManager.CurrentInstance;
-                            var addOptions = (CompatAddOptions)suboptions;
-
-                            KspVersion kspVersion;
-                            if (KspVersion.TryParse(addOptions.Version, out kspVersion))
-                            {
-                                var newCompatibleVersion = ksp.GetCompatibleVersions();
-                                newCompatibleVersion.Add(kspVersion);
-                                ksp.SetCompatibleVersions(newCompatibleVersion);
-                            }
-                            else
-                            {
-                                _user.RaiseError("ERROR: Invalid KSP version.");
-                                exitCode = Exit.ERROR;
-                            }
-                        }
-                        break;
-                    case "forget":
-                        {
-                            var ksp = _kspManager.CurrentInstance;
-                            var addOptions = (CompatForgetOptions)suboptions;
-
-                            KspVersion kspVersion;
-                            if (KspVersion.TryParse(addOptions.Version, out kspVersion))
-                            {
-                                if (kspVersion != ksp.Version())
-                                {
-                                    var newCompatibleVersion = ksp.GetCompatibleVersions();
-                                    newCompatibleVersion.RemoveAll(i => i == kspVersion);
-                                    ksp.SetCompatibleVersions(newCompatibleVersion);
-                                }
-                                else
-                                {
-                                    _user.RaiseError("ERROR: Cannot forget actual KSP version.");
-                                    exitCode = Exit.ERROR;
-                                }
-                            }
-                            else
-                            {
-                                _user.RaiseError("ERROR: Invalid KSP version.");
-                                exitCode = Exit.ERROR;
-                            }
-                        }
-                        break;
-                    default:
-                        exitCode = Exit.BADOPT;
-                        break;
-                }
-            });
-
-            return exitCode;
-        }
-
-        private class CompatOptions : CommonOptions
+        public class CompatOptions : VerbCommandOptions
         {
             [VerbOption("list", HelpText = "List compatible KSP versions")]
             public CompatListOptions List { get; set; }
@@ -146,20 +19,188 @@ namespace CKAN.CmdLine.Action
 
             [VerbOption("forget", HelpText = "Forget version on KSP compatibility list")]
             public CompatForgetOptions Forget { get; set; }
+
+            [HelpVerbOption]
+            public string GetUsage(string verb)
+            {
+                HelpText ht = HelpText.AutoBuild(this, verb);
+                // Add a usage prefix line
+                ht.AddPreOptionsLine(" ");
+                if (string.IsNullOrEmpty(verb))
+                {
+                    ht.AddPreOptionsLine("ckan compat - Manage KSP version compatibility");
+                    ht.AddPreOptionsLine($"Usage: ckan compat <command> [options]");
+                }
+                else
+                {
+                    ht.AddPreOptionsLine("compat " + verb + " - " + GetDescription(verb));
+                    switch (verb)
+                    {
+                        // First the commands with one string argument
+                        case "add":
+                        case "forget":
+                            ht.AddPreOptionsLine($"Usage: ckan compat {verb} [options] version");
+                            break;
+
+                        // Now the commands with only --flag type options
+                        case "list":
+                        default:
+                            ht.AddPreOptionsLine($"Usage: ckan compat {verb} [options]");
+                            break;
+                    }
+                }
+                return ht;
+            }
         }
 
-        private class CompatListOptions : CommonOptions { }
+        public class CompatListOptions : InstanceSpecificOptions { }
 
-        private class CompatAddOptions : CommonOptions
+        public class CompatAddOptions : InstanceSpecificOptions
         {
-            [ValueOption(0)]
-            public string Version { get; set; }
+            [ValueOption(0)] public string Version { get; set; }
         }
 
-        private class CompatForgetOptions : CommonOptions
+        public class CompatForgetOptions : InstanceSpecificOptions
         {
-            [ValueOption(0)]
-            public string Version { get; set; }
+            [ValueOption(0)] public string Version { get; set; }
         }
+
+        public int RunSubCommand(SubCommandOptions options)
+        {
+            var exitCode = Exit.OK;
+
+            Parser.Default.ParseArgumentsStrict(options.options.ToArray(), new CompatOptions(), (string option, object suboptions) =>
+            {
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions comOpts = (CommonOptions)suboptions;
+                    _user = new ConsoleUser(comOpts.Headless);
+                    _kspManager = new KSPManager(_user);
+                    exitCode = comOpts.Handle(_kspManager, _user);
+                    if (exitCode != Exit.OK)
+                        return;
+
+                    switch (option)
+                    {
+                        case "list":
+                            {
+                                var ksp = MainClass.GetGameInstance(_kspManager);
+
+                                const string versionHeader = "Version";
+                                const string actualHeader = "Actual";
+
+                                var output = ksp
+                                    .GetCompatibleVersions()
+                                    .Select(i => new
+                                    {
+                                        Version = i,
+                                        Actual = false
+                                    })
+                                    .ToList();
+
+                                output.Add(new
+                                {
+                                    Version = ksp.Version(),
+                                    Actual = true
+                                });
+
+                                output = output
+                                    .OrderByDescending(i => i.Actual)
+                                    .ThenByDescending(i => i.Version)
+                                    .ToList();
+
+                                var versionWidth = Enumerable
+                                    .Repeat(versionHeader, 1)
+                                    .Concat(output.Select(i => i.Version.ToString()))
+                                    .Max(i => i.Length);
+
+                                var actualWidth = Enumerable
+                                    .Repeat(actualHeader, 1)
+                                    .Concat(output.Select(i => i.Actual.ToString()))
+                                    .Max(i => i.Length);
+
+                                const string columnFormat = "{0}  {1}";
+
+                                _user.RaiseMessage(string.Format(columnFormat,
+                                    versionHeader.PadRight(versionWidth),
+                                    actualHeader.PadRight(actualWidth)
+                                ));
+
+                                _user.RaiseMessage(string.Format(columnFormat,
+                                    new string('-', versionWidth),
+                                    new string('-', actualWidth)
+                                ));
+
+                                foreach (var line in output)
+                                {
+                                    _user.RaiseMessage(string.Format(columnFormat,
+                                       line.Version.ToString().PadRight(versionWidth),
+                                       line.Actual.ToString().PadRight(actualWidth)
+                                   ));
+                                }
+                            }
+                            break;
+
+                        case "add":
+                            {
+                                var ksp = MainClass.GetGameInstance(_kspManager);
+                                var addOptions = (CompatAddOptions)suboptions;
+
+                                KspVersion kspVersion;
+                                if (KspVersion.TryParse(addOptions.Version, out kspVersion))
+                                {
+                                    var newCompatibleVersion = ksp.GetCompatibleVersions();
+                                    newCompatibleVersion.Add(kspVersion);
+                                    ksp.SetCompatibleVersions(newCompatibleVersion);
+                                }
+                                else
+                                {
+                                    _user.RaiseError("ERROR: Invalid KSP version.");
+                                    exitCode = Exit.ERROR;
+                                }
+                            }
+                            break;
+
+                        case "forget":
+                            {
+                                var ksp = MainClass.GetGameInstance(_kspManager);
+                                var addOptions = (CompatForgetOptions)suboptions;
+
+                                KspVersion kspVersion;
+                                if (KspVersion.TryParse(addOptions.Version, out kspVersion))
+                                {
+                                    if (kspVersion != ksp.Version())
+                                    {
+                                        var newCompatibleVersion = ksp.GetCompatibleVersions();
+                                        newCompatibleVersion.RemoveAll(i => i == kspVersion);
+                                        ksp.SetCompatibleVersions(newCompatibleVersion);
+                                    }
+                                    else
+                                    {
+                                        _user.RaiseError("ERROR: Cannot forget actual KSP version.");
+                                        exitCode = Exit.ERROR;
+                                    }
+                                }
+                                else
+                                {
+                                    _user.RaiseError("ERROR: Invalid KSP version.");
+                                    exitCode = Exit.ERROR;
+                                }
+                            }
+                            break;
+
+                        default:
+                            exitCode = Exit.BADOPT;
+                            break;
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+
+            return exitCode;
+        }
+
+        private KSPManager _kspManager;
+        private IUser      _user;
     }
 }

--- a/Cmdline/Action/ICommand.cs
+++ b/Cmdline/Action/ICommand.cs
@@ -5,4 +5,3 @@
         int RunCommand(CKAN.KSP ksp, object options);
     }
 }
-

--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -1,87 +1,101 @@
 using System;
 using System.Linq;
 using CommandLine;
+using CommandLine.Text;
 
 namespace CKAN.CmdLine
 {
     public class KSP : ISubCommand
     {
-        public KSPManager Manager { get; set; }
-        public IUser User { get; set; }
-        public string option;
-        public object suboptions;
+        public KSP() { }
 
-        public KSP(KSPManager manager, IUser user)
+        internal class KSPSubOptions : VerbCommandOptions
         {
-            Manager = manager;
-            User = user;
-        }
-
-        internal class KSPSubOptions : CommonOptions
-        {
-            [VerbOption("list", HelpText="List KSP installs")]
+            [VerbOption("list",    HelpText = "List KSP installs")]
             public CommonOptions ListOptions { get; set; }
 
-            [VerbOption("add", HelpText="Add a KSP install")]
+            [VerbOption("add",     HelpText = "Add a KSP install")]
             public AddOptions AddOptions { get; set; }
 
-            [VerbOption("rename", HelpText="Rename a KSP install")]
+            [VerbOption("rename",  HelpText = "Rename a KSP install")]
             public RenameOptions RenameOptions { get; set; }
 
-            [VerbOption("forget", HelpText="Forget a KSP install")]
+            [VerbOption("forget",  HelpText = "Forget a KSP install")]
             public ForgetOptions ForgetOptions { get; set; }
 
-            [VerbOption("default", HelpText="Set the default KSP install")]
+            [VerbOption("default", HelpText = "Set the default KSP install")]
             public DefaultOptions DefaultOptions { get; set; }
+
+            [HelpVerbOption]
+            public string GetUsage(string verb)
+            {
+                HelpText ht = HelpText.AutoBuild(this, verb);
+                // Add a usage prefix line
+                ht.AddPreOptionsLine(" ");
+                if (string.IsNullOrEmpty(verb))
+                {
+                    ht.AddPreOptionsLine("ckan ksp - Manage KSP installs");
+                    ht.AddPreOptionsLine($"Usage: ckan ksp <command> [options]");
+                }
+                else
+                {
+                    ht.AddPreOptionsLine("ksp " + verb + " - " + GetDescription(verb));
+                    switch (verb)
+                    {
+                        // First the commands with two string arguments
+                        case "add":
+                            ht.AddPreOptionsLine($"Usage: ckan ksp {verb} [options] name url");
+                            break;
+                        case "rename":
+                            ht.AddPreOptionsLine($"Usage: ckan ksp {verb} [options] oldname newname");
+                            break;
+
+                        // Now the commands with one string argument
+                        case "remove":
+                        case "forget":
+                        case "use":
+                        case "default":
+                            ht.AddPreOptionsLine($"Usage: ckan ksp {verb} [options] name");
+                            break;
+
+                        // Now the commands with only --flag type options
+                        case "list":
+                        default:
+                            ht.AddPreOptionsLine($"Usage: ckan ksp {verb} [options]");
+                            break;
+
+                    }
+                }
+                return ht;
+            }
         }
 
         internal class AddOptions : CommonOptions
         {
-            [ValueOption(0)]
-            public string name { get; set; }
-
-            [ValueOption(1)]
-            public string path { get; set; }
+            [ValueOption(0)] public string name { get; set; }
+            [ValueOption(1)] public string path { get; set; }
         }
 
         internal class RenameOptions : CommonOptions
         {
-            [ValueOption(0)]
-            public string old_name { get; set; }
-
-            [ValueOption(1)]
-            public string new_name { get; set; }
+            [ValueOption(0)] public string old_name { get; set; }
+            [ValueOption(1)] public string new_name { get; set; }
         }
 
         internal class ForgetOptions : CommonOptions
         {
-            [ValueOption(0)]
-            public string name { get; set; }
+            [ValueOption(0)] public string name { get; set; }
         }
 
         internal class DefaultOptions : CommonOptions
         {
-            [ValueOption(0)]
-            public string name { get; set; }
-        }
-
-        internal void Parse(string option, object suboptions)
-        {
-            this.option = option;
-            this.suboptions = suboptions;
+            [ValueOption(0)] public string name { get; set; }
         }
 
         // This is required by ISubCommand
         public int RunSubCommand(SubCommandOptions unparsed)
         {
             string[] args = unparsed.options.ToArray();
-
-            if (args.Length == 0)
-            {
-                // There's got to be a better way of showing help...
-                args = new string[1];
-                args[0] = "help";
-            }
 
             #region Aliases
 
@@ -100,33 +114,55 @@ namespace CKAN.CmdLine
 
             #endregion
 
+            int exitCode = Exit.OK;
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new KSPSubOptions (), Parse);
-
-            // That line above will have set our 'option' and 'suboption' fields.
-
-            switch (option)
+            Parser.Default.ParseArgumentsStrict(args, new KSPSubOptions(), (string option, object suboptions) =>
             {
-                case "list":
-                    return ListInstalls();
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions options = (CommonOptions)suboptions;
+                    User = new ConsoleUser(options.Headless);
+                    Manager = new KSPManager(User);
+                    exitCode = options.Handle(Manager, User);
+                    if (exitCode != Exit.OK)
+                        return;
 
-                case "add":
-                    return AddInstall((AddOptions)suboptions);
+                    switch (option)
+                    {
+                        case "list":
+                            exitCode = ListInstalls();
+                            break;
 
-                case "rename":
-                    return RenameInstall((RenameOptions)suboptions);
+                        case "add":
+                            exitCode = AddInstall((AddOptions)suboptions);
+                            break;
 
-                case "forget":
-                    return ForgetInstall((ForgetOptions)suboptions);
+                        case "rename":
+                            exitCode = RenameInstall((RenameOptions)suboptions);
+                            break;
 
-                case "default":
-                    return SetDefaultInstall((DefaultOptions)suboptions);
+                        case "forget":
+                            exitCode = ForgetInstall((ForgetOptions)suboptions);
+                            break;
 
-                default:
-                    User.RaiseMessage("Unknown command: ksp {0}", option);
-                    return Exit.BADOPT;
-            }
+                        case "use":
+                        case "default":
+                            exitCode = SetDefaultInstall((DefaultOptions)suboptions);
+                            break;
+
+                        default:
+                            User.RaiseMessage("Unknown command: ksp {0}", option);
+                            exitCode = Exit.BADOPT;
+                            break;
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+            return exitCode;
         }
+
+        private KSPManager Manager { get; set; }
+        private IUser      User    { get; set; }
 
         private int ListInstalls()
         {

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -23,7 +23,6 @@ namespace CKAN.CmdLine
 
             IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
 
-
             ExportFileType? exportFileType = null;
 
             if (!string.IsNullOrWhiteSpace(options.export))
@@ -121,18 +120,12 @@ namespace CKAN.CmdLine
 
             switch (export)
             {
-                case "text":
-                    return ExportFileType.PlainText;
-                case "markdown":
-                    return ExportFileType.Markdown;
-                case "bbcode":
-                    return ExportFileType.BbCode;
-                case "csv":
-                    return ExportFileType.Csv;
-                case "tsv":
-                    return ExportFileType.Tsv;
-                default:
-                    return null;
+                case "text":     return ExportFileType.PlainText;
+                case "markdown": return ExportFileType.Markdown;
+                case "bbcode":   return ExportFileType.BbCode;
+                case "csv":      return ExportFileType.Csv;
+                case "tsv":      return ExportFileType.Tsv;
+                default:         return null;
             }
         }
     }

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -1,61 +1,84 @@
 ﻿using CommandLine;
+using CommandLine.Text;
 
 namespace CKAN.CmdLine
 {
     public class Repair : ISubCommand
     {
-        public CKAN.KSP CurrentInstance { get; set; }
-        public IUser User { get; set; }
-        public string option;
-        public object suboptions;
+        public Repair() { }
 
-        internal class RepairSubOptions : CommonOptions
+        internal class RepairSubOptions : VerbCommandOptions
         {
-            [VerbOption("registry", HelpText="Try to repair the CKAN registry")]
-            public CommonOptions Registry { get; set; }
-        }
+            [VerbOption("registry", HelpText = "Try to repair the CKAN registry")]
+            public InstanceSpecificOptions Registry { get; set; }
 
-        public Repair(CKAN.KSP current_instance,IUser user)
-        {
-            CurrentInstance = current_instance;
-            User = user;
+            [HelpVerbOption]
+            public string GetUsage(string verb)
+            {
+                HelpText ht = HelpText.AutoBuild(this, verb);
+                // Add a usage prefix line
+                ht.AddPreOptionsLine(" ");
+                if (string.IsNullOrEmpty(verb))
+                {
+                    ht.AddPreOptionsLine("ckan repair - Attempt various automatic repairs");
+                    ht.AddPreOptionsLine($"Usage: ckan repair <command> [options]");
+                }
+                else
+                {
+                    ht.AddPreOptionsLine("repair " + verb + " - " + GetDescription(verb));
+                    switch (verb)
+                    {
+                        // Commands with only --flag type options
+                        case "registry":
+                        default:
+                            ht.AddPreOptionsLine($"Usage: ckan repair {verb} [options]");
+                            break;
+                    }
+                }
+                return ht;
+            }
         }
 
         public int RunSubCommand(SubCommandOptions unparsed)
         {
-            string[] args = unparsed.options.ToArray();
-
-            if (args.Length == 0)
-            {
-                // There's got to be a better way of showing help...
-                args = new string[1];
-                args[0] = "help";
-            }
-
+            int exitCode = Exit.OK;
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new RepairSubOptions (), Parse);
-
-            switch (option)
+            Parser.Default.ParseArgumentsStrict(unparsed.options.ToArray(), new RepairSubOptions(), (string option, object suboptions) =>
             {
-                case "registry":
-                    return Registry();
-            }
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions options = (CommonOptions)suboptions;
+                    User = new ConsoleUser(options.Headless);
+                    KSPManager manager = new KSPManager(User);
+                    exitCode = options.Handle(manager, User);
+                    if (exitCode != Exit.OK)
+                        return;
 
-            throw new BadCommandKraken("Unknown command: repair " + option);
+                    switch (option)
+                    {
+                        case "registry":
+                            exitCode = Registry(MainClass.GetGameInstance(manager));
+                            break;
+
+                        default:
+                            User.RaiseMessage("Unknown command: repair {0}", option);
+                            exitCode = Exit.BADOPT;
+                            break;
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+            return exitCode;
         }
 
-        public void Parse(string option, object suboptions)
-        {
-            this.option = option;
-            this.suboptions = suboptions;
-        }
+        private IUser User { get; set; }
 
         /// <summary>
         /// Try to repair our registry.
         /// </summary>
-        private int Registry()
+        private int Registry(CKAN.KSP ksp)
         {
-            var manager = RegistryManager.Instance(CurrentInstance);
+            var manager = RegistryManager.Instance(ksp);
             manager.registry.Repair();
             manager.Save();
             User.RaiseMessage("Registry repairs attempted. Hope it helped.");
@@ -63,4 +86,3 @@ namespace CKAN.CmdLine
         }
     }
 }
-

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -4,95 +4,95 @@ using System.Linq;
 using System.Net;
 using Newtonsoft.Json;
 using CommandLine;
+using CommandLine.Text;
 using log4net;
 
 namespace CKAN.CmdLine
 {
-    public struct RepositoryList
-    {
-        public Repository[] repositories;
-    }
-
     public class Repo : ISubCommand
     {
-        private static readonly ILog log = LogManager.GetLogger(typeof (Repo));
+        public Repo() { }
 
-        public KSPManager Manager { get; set; }
-        public IUser User { get; set; }
-        public string option;
-        public object suboptions;
-
-
-        public Repo(KSPManager manager, IUser user)
+        internal class RepoSubOptions : VerbCommandOptions
         {
-            Manager = manager;
-            User = user;
-        }
+            [VerbOption("available", HelpText = "List (canonical) available repositories")]
+            public AvailableOptions AvailableOptions { get; set; }
 
-        internal class RepoSubOptions : CommonOptions
-        {
-            [VerbOption("available", HelpText="List (canonical) available repositories")]
-            public CommonOptions AvailableOptions { get; set; }
+            [VerbOption("list",      HelpText = "List repositories")]
+            public ListOptions ListOptions { get; set; }
 
-            [VerbOption("list", HelpText="List repositories")]
-            public CommonOptions ListOptions { get; set; }
-
-            [VerbOption("add", HelpText="Add a repository")]
+            [VerbOption("add",       HelpText = "Add a repository")]
             public AddOptions AddOptions { get; set; }
 
-            [VerbOption("forget", HelpText="Forget a repository")]
+            [VerbOption("forget",    HelpText = "Forget a repository")]
             public ForgetOptions ForgetOptions { get; set; }
 
-            [VerbOption("default", HelpText="Set the default repository")]
+            [VerbOption("default",   HelpText = "Set the default repository")]
             public DefaultOptions DefaultOptions { get; set; }
+
+            [HelpVerbOption]
+            public string GetUsage(string verb)
+            {
+                HelpText ht = HelpText.AutoBuild(this, verb);
+                // Add a usage prefix line
+                ht.AddPreOptionsLine(" ");
+                if (string.IsNullOrEmpty(verb))
+                {
+                    ht.AddPreOptionsLine("ckan repo - Manage CKAN repositories");
+                    ht.AddPreOptionsLine($"Usage: ckan repo <command> [options]");
+                }
+                else
+                {
+                    ht.AddPreOptionsLine("repo " + verb + " - " + GetDescription(verb));
+                    switch (verb)
+                    {
+                        // First the commands with two arguments
+                        case "add":
+                            ht.AddPreOptionsLine($"Usage: ckan repo {verb} [options] name url");
+                            break;
+
+                        // Then the commands with one argument
+                        case "remove":
+                        case "forget":
+                        case "default":
+                            ht.AddPreOptionsLine($"Usage: ckan repo {verb} [options] name");
+                            break;
+
+                        // Now the commands with only --flag type options
+                        case "available":
+                        case "list":
+                        default:
+                            ht.AddPreOptionsLine($"Usage: ckan repo {verb} [options]");
+                            break;
+                    }
+                }
+                return ht;
+            }
         }
 
-        internal class AvailableOptions : CommonOptions
+        internal class AvailableOptions : CommonOptions { }
+        internal class ListOptions      : InstanceSpecificOptions { }
+
+        internal class AddOptions : InstanceSpecificOptions
         {
+            [ValueOption(0)] public string name { get; set; }
+            [ValueOption(1)] public string uri { get; set; }
         }
 
-        internal class ListOptions : CommonOptions
+        internal class DefaultOptions : InstanceSpecificOptions
         {
+            [ValueOption(0)] public string uri { get; set; }
         }
 
-        internal class AddOptions : CommonOptions
+        internal class ForgetOptions : InstanceSpecificOptions
         {
-            [ValueOption(0)]
-            public string name { get; set; }
-
-            [ValueOption(1)]
-            public string uri { get; set; }
-        }
-
-        internal class DefaultOptions : CommonOptions
-        {
-            [ValueOption(0)]
-            public string uri { get; set; }
-        }
-
-        internal class ForgetOptions : CommonOptions
-        {
-            [ValueOption(0)]
-            public string name { get; set; }
-        }
-
-        internal void Parse(string option, object suboptions)
-        {
-            this.option = option;
-            this.suboptions = suboptions;
+            [ValueOption(0)] public string name { get; set; }
         }
 
         // This is required by ISubCommand
         public int RunSubCommand(SubCommandOptions unparsed)
         {
             string[] args = unparsed.options.ToArray();
-
-            if (args.Length == 0)
-            {
-                // There's got to be a better way of showing help...
-                args = new string[1];
-                args[0] = "help";
-            }
 
             #region Aliases
 
@@ -107,35 +107,56 @@ namespace CKAN.CmdLine
             }
 
             #endregion
+
+            int exitCode = Exit.OK;
+
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new RepoSubOptions (), Parse);
-
-            // That line above will have set our 'option' and 'suboption' fields.
-
-            switch (option)
+            Parser.Default.ParseArgumentsStrict(args, new RepoSubOptions(), (string option, object suboptions) =>
             {
-                case "available":
-                    return AvailableRepositories();
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions options = (CommonOptions)suboptions;
+                    User = new ConsoleUser(options.Headless);
+                    Manager = new KSPManager(User);
+                    exitCode = options.Handle(Manager, User);
+                    if (exitCode != Exit.OK)
+                        return;
 
-                case "list":
-                    return ListRepositories();
+                    switch (option)
+                    {
+                        case "available":
+                            exitCode = AvailableRepositories();
+                            break;
 
-                case "add":
-                    return AddRepository((AddOptions)suboptions);
+                        case "list":
+                            exitCode = ListRepositories();
+                            break;
 
-                case "forget":
-                    return ForgetRepository((ForgetOptions)suboptions);
+                        case "add":
+                            exitCode = AddRepository((AddOptions)suboptions);
+                            break;
 
-                case "default":
-                    return DefaultRepository((DefaultOptions)suboptions);
+                        case "remove":
+                        case "forget":
+                            exitCode = ForgetRepository((ForgetOptions)suboptions);
+                            break;
 
-                default:
-                    User.RaiseMessage("Unknown command: repo {0}", option);
-                    return Exit.BADOPT;
-            }
+                        case "default":
+                            exitCode = DefaultRepository((DefaultOptions)suboptions);
+                            break;
+
+                        default:
+                            User.RaiseMessage("Unknown command: repo {0}", option);
+                            exitCode = Exit.BADOPT;
+                            break;
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+            return exitCode;
         }
 
-        public static RepositoryList FetchMasterRepositoryList(Uri master_uri = null)
+        private static RepositoryList FetchMasterRepositoryList(Uri master_uri = null)
         {
             WebClient client = new WebClient();
 
@@ -179,8 +200,8 @@ namespace CKAN.CmdLine
 
         private int ListRepositories()
         {
+            var manager = RegistryManager.Instance(MainClass.GetGameInstance(Manager));
             User.RaiseMessage("Listing all known repositories:");
-            var manager = RegistryManager.Instance(Manager.CurrentInstance);
             SortedDictionary<string, Repository> repositories = manager.registry.Repositories;
 
             int maxNameLen = 0;
@@ -199,7 +220,7 @@ namespace CKAN.CmdLine
 
         private int AddRepository(AddOptions options)
         {
-            RegistryManager manager = RegistryManager.Instance(Manager.CurrentInstance);
+            RegistryManager manager = RegistryManager.Instance(MainClass.GetGameInstance(Manager));
 
             if (options.name == null)
             {
@@ -263,7 +284,7 @@ namespace CKAN.CmdLine
                 return Exit.BADOPT;
             }
 
-            RegistryManager manager = RegistryManager.Instance(Manager.CurrentInstance);
+            RegistryManager manager = RegistryManager.Instance(MainClass.GetGameInstance(Manager));
             var registry = manager.registry;
             log.DebugFormat("About to forget repository '{0}'", options.name);
 
@@ -290,7 +311,7 @@ namespace CKAN.CmdLine
 
         private int DefaultRepository(DefaultOptions options)
         {
-            RegistryManager manager = RegistryManager.Instance(Manager.CurrentInstance);
+            RegistryManager manager = RegistryManager.Instance(MainClass.GetGameInstance(Manager));
 
             if (options.uri == null)
             {
@@ -313,5 +334,16 @@ namespace CKAN.CmdLine
 
             return Exit.OK;
         }
+
+        private KSPManager Manager { get; set; }
+        private IUser      User    { get; set; }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof (Repo));
     }
+
+    public struct RepositoryList
+    {
+        public Repository[] repositories;
+    }
+
 }

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -50,261 +50,149 @@ namespace CKAN.CmdLine
             Logging.Initialize();
             log.Debug("CKAN started");
 
-            Options cmdline;
-
             // If we're starting with no options then invoke the GUI instead.
             if (args.Length == 0)
             {
                 return Gui(new GuiOptions(), args);
             }
 
-            IUser user;
+            // We shouldn't instantiate Options if it's a subcommand.
+            // It breaks command-specific help, for starters.
+            try
+            {
+                switch (args[0])
+                {
+                    case "repair":
+                        var repair = new Repair();
+                        return repair.RunSubCommand(new SubCommandOptions(args));
+
+                    case "ksp":
+                        var ksp = new KSP();
+                        return ksp.RunSubCommand(new SubCommandOptions(args));
+
+                    case "compat":
+                        var compat = new CompatSubCommand();
+                        return compat.RunSubCommand(new SubCommandOptions(args));
+
+                    case "repo":
+                        var repo = new Repo();
+                        return repo.RunSubCommand(new SubCommandOptions(args));
+                }
+            }
+            catch (NoGameInstanceKraken)
+            {
+                return printMissingInstanceError(new ConsoleUser(false));
+            }
+
+            Options cmdline;
             try
             {
                 cmdline = new Options(args);
             }
             catch (BadCommandKraken)
             {
-                // Our help screen will already be shown. Let's add some extra data.
-                user = new ConsoleUser(false);
-                user.RaiseMessage("You are using CKAN version {0}", Meta.GetVersion(VersionFormat.Full));
-
-                return Exit.BADOPT;
+                return AfterHelp();
             }
 
             // Process commandline options.
+            CommonOptions options = (CommonOptions)cmdline.options;
+            IUser user = new ConsoleUser(options.Headless);
+            KSPManager manager = new KSPManager(user);
 
-            var options = (CommonOptions)cmdline.options;
-            user = new ConsoleUser(options.Headless);
-            CheckMonoVersion(user, 3, 1, 0);
+            int exitCode = options.Handle(manager, user);
+            if (exitCode != Exit.OK)
+                return exitCode;
+            // Don't bother with instances or registries yet because some commands don't need them.
+            return RunSimpleAction(cmdline, options, args, user, manager);
+        }
 
-            // Processes in Docker containers normally run as root.
-            // If we are running in a Docker container, do not require --asroot.
-            // Docker creates a .dockerenv file in the root of each container.
-            if ((Platform.IsUnix || Platform.IsMac) && CmdLineUtil.GetUID() == 0 && !File.Exists("/.dockerenv"))
+        public static int AfterHelp()
+        {
+            // Our help screen will already be shown. Let's add some extra data.
+            new ConsoleUser(false).RaiseMessage("You are using CKAN version {0}", Meta.GetVersion(VersionFormat.Full));
+            return Exit.BADOPT;
+        }
+
+        public static CKAN.KSP GetGameInstance(KSPManager manager)
+        {
+            CKAN.KSP ksp = manager.CurrentInstance
+                ?? manager.GetPreferredInstance();
+            if (ksp == null)
             {
-                if (!options.AsRoot)
-                {
-                    user.RaiseError(@"You are trying to run CKAN as root.
-This is a bad idea and there is absolutely no good reason to do it. Please run CKAN from a user account (or use --asroot if you are feeling brave).");
-                    return Exit.ERROR;
-                }
-                else
-                {
-                    user.RaiseMessage("Warning: Running CKAN as root!");
-                }
+                throw new NoGameInstanceKraken();
             }
-
-            if (options.Debug)
-            {
-                LogManager.GetRepository().Threshold = Level.Debug;
-                log.Info("Debug logging enabled");
-            }
-            else if (options.Verbose)
-            {
-                LogManager.GetRepository().Threshold = Level.Info;
-                log.Info("Verbose logging enabled");
-            }
-
-            // Assign user-agent string if user has given us one
-            if (options.NetUserAgent != null)
-            {
-                Net.UserAgentString = options.NetUserAgent;
-            }
-
-            // User provided KSP instance
-
-            if (options.KSPdir != null && options.KSP != null)
-            {
-                user.RaiseMessage("--ksp and --kspdir can't be specified at the same time");
-                return Exit.BADOPT;
-            }
-
-            var manager = new KSPManager(user);
-
-            if (options.KSP != null)
-            {
-                // Set a KSP directory by its alias.
-
-                try
-                {
-                    manager.SetCurrentInstance(options.KSP);
-                }
-                catch (InvalidKSPInstanceKraken)
-                {
-                    user.RaiseMessage("Invalid KSP installation specified \"{0}\", use '--kspdir' to specify by path, or 'list-installs' to see known KSP installations", options.KSP);
-                    return Exit.BADOPT;
-                }
-            }
-            else if (options.KSPdir != null)
-            {
-                // Set a KSP directory by its path
-                manager.SetCurrentInstanceByPath(options.KSPdir);
-            }
-            else if (! (cmdline.action == "ksp" || cmdline.action == "version" || cmdline.action == "gui"))
-            {
-                // Find whatever our preferred instance is.
-                // We don't do this on `ksp/version/gui` commands, they don't need it.
-                CKAN.KSP ksp = manager.GetPreferredInstance();
-
-                if (ksp == null)
-                {
-                    user.RaiseMessage("I don't know where KSP is installed.");
-                    user.RaiseMessage("Use 'ckan ksp help' for assistance on setting this.");
-                    return Exit.ERROR;
-                }
-                else
-                {
-                    log.InfoFormat("Using KSP install at {0}", ksp.GameDir());
-                }
-            }
-
-            #region Aliases
-
-            switch (cmdline.action)
-            {
-                case "add":
-                    cmdline.action = "install";
-                    break;
-
-                case "uninstall":
-                    cmdline.action = "remove";
-                    break;
-            }
-
-            #endregion
-
-            //If we have found a preferred KSP instance, try to lock the registry
-            if (manager.CurrentInstance != null)
-            {
-                try
-                {
-                    using (var registry = RegistryManager.Instance(manager.CurrentInstance))
-                    {
-                        log.InfoFormat("About to run action {0}", cmdline.action);
-                        return RunAction(cmdline, options, args, user, manager);
-                    }
-                }
-                catch (RegistryInUseKraken kraken)
-                {
-                    log.Info("Registry in use detected");
-                    user.RaiseMessage(kraken.ToString());
-                    return Exit.ERROR;
-                }
-            }
-            else // we have no preferred KSP instance, so no need to lock the registry
-            {
-                return RunAction(cmdline, options, args, user, manager);
-            }
+            return ksp;
         }
 
         /// <summary>
         /// Run whatever action the user has provided
         /// </summary>
         /// <returns>The exit status that should be returned to the system.</returns>
-        private static int RunAction(Options cmdline, CommonOptions options, string[] args, IUser user, KSPManager manager)
-        {
-            switch (cmdline.action)
-            {
-                case "gui":
-                    return Gui((GuiOptions)options, args);
-
-                case "version":
-                    return Version(user);
-
-                case "update":
-                    return (new Update(user)).RunCommand(manager.CurrentInstance, (UpdateOptions)cmdline.options);
-
-                case "available":
-                    return (new Available(user)).RunCommand(manager.CurrentInstance, (AvailableOptions)cmdline.options);
-                    //return Available(manager.CurrentInstance, user);
-
-                case "install":
-                    Scan(manager.CurrentInstance, user, cmdline.action);
-                    return (new Install(user)).RunCommand(manager.CurrentInstance, (InstallOptions)cmdline.options);
-
-                case "scan":
-                    return Scan(manager.CurrentInstance,user);
-
-                case "list":
-                    return (new List(user)).RunCommand(manager.CurrentInstance, (ListOptions)cmdline.options);
-
-                case "show":
-                    return (new Show(user)).RunCommand(manager.CurrentInstance, (ShowOptions)cmdline.options);
-
-                case "search":
-                    return (new Search(user)).RunCommand(manager.CurrentInstance, options);
-
-                case "remove":
-                    return (new Remove(user)).RunCommand(manager.CurrentInstance, cmdline.options);
-
-                case "upgrade":
-                    Scan(manager.CurrentInstance, user, cmdline.action);
-                    return (new Upgrade(user)).RunCommand(manager.CurrentInstance, cmdline.options);
-
-                case "clean":
-                    return Clean(manager.CurrentInstance);
-
-                case "repair":
-                    var repair = new Repair(manager.CurrentInstance,user);
-                    return repair.RunSubCommand((SubCommandOptions) cmdline.options);
-
-                case "ksp":
-                    var ksp = new KSP(manager, user);
-                    return ksp.RunSubCommand((SubCommandOptions) cmdline.options);
-
-                case "compat":
-                    var compat = new CompatSubCommand(manager, user);
-                    return compat.RunSubCommand((SubCommandOptions)cmdline.options);
-
-                case "repo":
-                    var repo = new Repo (manager, user);
-                    return repo.RunSubCommand((SubCommandOptions) cmdline.options);
-
-                case "compare":
-                    return (new Compare(user)).RunCommand(manager.CurrentInstance, cmdline.options);
-
-                default:
-                    user.RaiseMessage("Unknown command, try --help");
-                    return Exit.BADOPT;
-            }
-        }
-
-        private static void CheckMonoVersion(IUser user, int rec_major, int rec_minor, int rec_patch)
+        private static int RunSimpleAction(Options cmdline, CommonOptions options, string[] args, IUser user, KSPManager manager)
         {
             try
             {
-                Type type = Type.GetType("Mono.Runtime");
-                if (type == null) return;
-
-                MethodInfo display_name = type.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
-                if (display_name != null)
+                switch (cmdline.action)
                 {
-                    var version_string = (string) display_name.Invoke(null, null);
-                    var match = Regex.Match(version_string, @"^\D*(?<major>[\d]+)\.(?<minor>\d+)\.(?<revision>\d+).*$");
+                    case "gui":
+                        return Gui((GuiOptions)options, args);
 
-                    if (match.Success)
-                    {
-                        int major = Int32.Parse(match.Groups["major"].Value);
-                        int minor = Int32.Parse(match.Groups["minor"].Value);
-                        int patch = Int32.Parse(match.Groups["revision"].Value);
+                    case "version":
+                        return Version(user);
 
-                        if (major < rec_major || (major == rec_major && minor < rec_minor))
-                        {
-                            user.RaiseMessage(
-                                "Warning. Detected mono runtime of {0} is less than the recommended version of {1}\r\n",
-                                String.Join(".", major, minor, patch),
-                                String.Join(".", rec_major, rec_minor, rec_patch)
-                                );
-                            user.RaiseMessage("Update recommend\r\n");
-                        }
-                    }
+                    case "update":
+                        return (new Update(user)).RunCommand(GetGameInstance(manager), (UpdateOptions)cmdline.options);
+
+                    case "available":
+                        return (new Available(user)).RunCommand(GetGameInstance(manager), (AvailableOptions)cmdline.options);
+
+                    case "add":
+                    case "install":
+                        Scan(GetGameInstance(manager), user, cmdline.action);
+                        return (new Install(user)).RunCommand(GetGameInstance(manager), (InstallOptions)cmdline.options);
+
+                    case "scan":
+                        return Scan(GetGameInstance(manager), user);
+
+                    case "list":
+                        return (new List(user)).RunCommand(GetGameInstance(manager), (ListOptions)cmdline.options);
+
+                    case "show":
+                        return (new Show(user)).RunCommand(GetGameInstance(manager), (ShowOptions)cmdline.options);
+
+                    case "search":
+                        return (new Search(user)).RunCommand(GetGameInstance(manager), options);
+
+                    case "uninstall":
+                    case "remove":
+                        return (new Remove(user)).RunCommand(GetGameInstance(manager), cmdline.options);
+
+                    case "upgrade":
+                        Scan(GetGameInstance(manager), user, cmdline.action);
+                        return (new Upgrade(user)).RunCommand(GetGameInstance(manager), cmdline.options);
+
+                    case "clean":
+                        return Clean(GetGameInstance(manager));
+
+                    case "compare":
+                        return (new Compare(user)).RunCommand(cmdline.options);
+
+                    default:
+                        user.RaiseMessage("Unknown command, try --help");
+                        return Exit.BADOPT;
                 }
             }
-            catch (Exception)
+            catch (NoGameInstanceKraken)
             {
-                // Ignored. This may be fragile and is just a warning method
+                return printMissingInstanceError(user);
             }
+        }
+
+        private static int printMissingInstanceError(IUser user)
+        {
+            user.RaiseMessage("I don't know where KSP is installed.");
+            user.RaiseMessage("Use 'ckan ksp help' for assistance in setting this.");
+            return Exit.ERROR;
         }
 
         private static int Gui(GuiOptions options, string[] args)
@@ -331,7 +219,7 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
         /// <param name="user"></param>
         /// <param name="next_command">Changes the output message if set.</param>
         /// <returns>Exit.OK if instance is consistent, Exit.ERROR otherwise </returns>
-        private static int Scan(CKAN.KSP ksp_instance, IUser user, string next_command=null)
+        private static int Scan(CKAN.KSP ksp_instance, IUser user, string next_command = null)
         {
             try
             {
@@ -341,7 +229,7 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
             catch (InconsistentKraken kraken)
             {
 
-                if (next_command==null)
+                if (next_command == null)
                 {
                     user.RaiseError(kraken.InconsistenciesPretty);
                     user.RaiseError("The repo has not been saved.");
@@ -362,6 +250,11 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
             current_instance.CleanCache();
             return Exit.OK;
         }
+    }
+
+    public class NoGameInstanceKraken : Kraken
+    {
+        public NoGameInstanceKraken() { }
     }
 
     public class CmdLineUtil

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -1,5 +1,12 @@
+using System;
+using System.IO;
+using System.Reflection;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using log4net;
+using log4net.Core;
 using CommandLine;
+using CommandLine.Text;
 
 namespace CKAN.CmdLine
 {
@@ -26,16 +33,15 @@ namespace CKAN.CmdLine
                 },
                 delegate
                 {
-                    throw (new BadCommandKraken());
+                    throw new BadCommandKraken();
                 }
             );
         }
     }
 
     // Actions supported by our client go here.
-    // TODO: Figure out how to do per action help screens.
 
-    internal class Actions
+    internal class Actions : VerbCommandOptions
     {
         [VerbOption("gui", HelpText = "Start the CKAN GUI")]
         public GuiOptions GuiOptions { get; set; }
@@ -74,10 +80,10 @@ namespace CKAN.CmdLine
         public SubCommandOptions Repair { get; set; }
 
         [VerbOption("repo", HelpText = "Manage CKAN repositories")]
-        public SubCommandOptions KSP { get; set; }
+        public SubCommandOptions Repo { get; set; }
 
         [VerbOption("ksp", HelpText = "Manage KSP installs")]
-        public SubCommandOptions Repo { get; set; }
+        public SubCommandOptions KSP { get; set; }
 
         [VerbOption("compat", HelpText = "Manage KSP version compatibility")]
         public SubCommandOptions Compat { get; set; }
@@ -87,6 +93,75 @@ namespace CKAN.CmdLine
 
         [VerbOption("version", HelpText = "Show the version of the CKAN client being used.")]
         public VersionOptions Version { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            HelpText ht = HelpText.AutoBuild(this, verb);
+
+            // Add a usage prefix line
+            ht.AddPreOptionsLine(" ");
+            if (string.IsNullOrEmpty(verb))
+            {
+                ht.AddPreOptionsLine($"Usage: ckan <command> [options]");
+            }
+            else
+            {
+                ht.AddPreOptionsLine(verb + " - " + GetDescription(verb));
+                switch (verb)
+                {
+                    // First the commands that deal with mods
+                    case "add":
+                    case "install":
+                    case "remove":
+                    case "uninstall":
+                    case "upgrade":
+                        ht.AddPreOptionsLine($"Usage: ckan {verb} [options] modules");
+                        break;
+                    case "show":
+                        ht.AddPreOptionsLine($"Usage: ckan {verb} [options] module");
+                        break;
+
+                    // Now the commands with other string arguments
+                    case "search":
+                        ht.AddPreOptionsLine($"Usage: ckan {verb} [options] substring");
+                        break;
+                    case "compare":
+                        ht.AddPreOptionsLine($"Usage: ckan {verb} [options] version1 version2");
+                        break;
+
+                    // Now the commands with only --flag type options
+                    case "gui":
+                    case "available":
+                    case "list":
+                    case "update":
+                    case "scan":
+                    case "clean":
+                    case "version":
+                    default:
+                        ht.AddPreOptionsLine($"Usage: ckan {verb} [options]");
+                        break;
+                }
+            }
+            return ht;
+        }
+
+    }
+
+    public abstract class VerbCommandOptions
+    {
+        protected string GetDescription(string verb)
+        {
+            var info = this.GetType().GetProperties();
+            foreach (var property in info)
+            {
+                BaseOptionAttribute attrib = (BaseOptionAttribute)Attribute.GetCustomAttribute(
+                    property, typeof(BaseOptionAttribute), false);
+                if (attrib != null && attrib.LongName == verb)
+                    return attrib.HelpText;
+            }
+            return "";
+        }
     }
 
     // Options common to all classes.
@@ -102,20 +177,143 @@ namespace CKAN.CmdLine
         [Option("debugger", DefaultValue = false, HelpText = "Launch debugger at start")]
         public bool Debugger { get; set; }
 
-        [Option("ksp", DefaultValue = null, HelpText = "KSP install to use")]
-        public string KSP { get; set; }
-
-        [Option("kspdir", DefaultValue = null, HelpText = "KSP dir to use")]
-        public string KSPdir { get; set; }
-
-        [Option("net-useragent", DefaultValue = null, HelpText = "Set the default user-agent string for HTTP requests")]
+        [Option("net-useragent", HelpText = "Set the default user-agent string for HTTP requests")]
         public string NetUserAgent { get; set; }
 
-        [Option("headless", DefaultValue = null, HelpText = "Set to disable all prompts")]
+        [Option("headless", DefaultValue = false, HelpText = "Set to disable all prompts")]
         public bool Headless { get; set; }
 
-        [Option("asroot", DefaultValue = null, HelpText = "Allows CKAN to run as root on Linux-based systems")]
+        [Option("asroot", DefaultValue = false, HelpText = "Allows CKAN to run as root on Linux-based systems")]
         public bool AsRoot { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            return HelpText.AutoBuild(this, verb);
+        }
+
+        public virtual int Handle(KSPManager manager, IUser user)
+        {
+            CheckMonoVersion(user, 3, 1, 0);
+
+            // Processes in Docker containers normally run as root.
+            // If we are running in a Docker container, do not require --asroot.
+            // Docker creates a .dockerenv file in the root of each container.
+            if ((Platform.IsUnix || Platform.IsMac) && CmdLineUtil.GetUID() == 0 && !File.Exists("/.dockerenv"))
+            {
+                if (!AsRoot)
+                {
+                    user.RaiseError("You are trying to run CKAN as root.\r\nThis is a bad idea and there is absolutely no good reason to do it. Please run CKAN from a user account (or use --asroot if you are feeling brave).");
+                    return Exit.ERROR;
+                }
+                else
+                {
+                    user.RaiseMessage("Warning: Running CKAN as root!");
+                }
+            }
+
+            if (Debug)
+            {
+                LogManager.GetRepository().Threshold = Level.Debug;
+                log.Info("Debug logging enabled");
+            }
+            else if (Verbose)
+            {
+                LogManager.GetRepository().Threshold = Level.Info;
+                log.Info("Verbose logging enabled");
+            }
+
+            // Assign user-agent string if user has given us one
+            if (NetUserAgent != null)
+            {
+                Net.UserAgentString = NetUserAgent;
+            }
+
+            return Exit.OK;
+        }
+
+        private static void CheckMonoVersion(IUser user, int rec_major, int rec_minor, int rec_patch)
+        {
+            try
+            {
+                Type type = Type.GetType("Mono.Runtime");
+                if (type == null) return;
+
+                MethodInfo display_name = type.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
+                if (display_name != null)
+                {
+                    var version_string = (string) display_name.Invoke(null, null);
+                    var match = Regex.Match(version_string, @"^\D*(?<major>[\d]+)\.(?<minor>\d+)\.(?<revision>\d+).*$");
+
+                    if (match.Success)
+                    {
+                        int major = Int32.Parse(match.Groups["major"].Value);
+                        int minor = Int32.Parse(match.Groups["minor"].Value);
+                        int patch = Int32.Parse(match.Groups["revision"].Value);
+
+                        if (major < rec_major || (major == rec_major && minor < rec_minor))
+                        {
+                            user.RaiseMessage(
+                                "Warning. Detected mono runtime of {0} is less than the recommended version of {1}\r\n",
+                                String.Join(".", major, minor, patch),
+                                String.Join(".", rec_major, rec_minor, rec_patch)
+                                );
+                            user.RaiseMessage("Update recommend\r\n");
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Ignored. This may be fragile and is just a warning method
+            }
+        }
+
+        protected static readonly ILog log = LogManager.GetLogger(typeof(CommonOptions));
+    }
+
+    public class InstanceSpecificOptions : CommonOptions
+    {
+        [Option("ksp", HelpText = "KSP install to use")]
+        public string KSP { get; set; }
+
+        [Option("kspdir", HelpText = "KSP dir to use")]
+        public string KSPdir { get; set; }
+
+        public override int Handle(KSPManager manager, IUser user)
+        {
+            int exitCode = base.Handle(manager, user);
+            if (exitCode == Exit.OK)
+            {
+                // User provided KSP instance
+                if (KSPdir != null && KSP != null)
+                {
+                    user.RaiseMessage("--ksp and --kspdir can't be specified at the same time");
+                    return Exit.BADOPT;
+                }
+
+                if (KSP != null)
+                {
+                    // Set a KSP directory by its alias.
+
+                    try
+                    {
+                        manager.SetCurrentInstance(KSP);
+                    }
+                    catch (InvalidKSPInstanceKraken)
+                    {
+                        user.RaiseMessage("Invalid KSP installation specified \"{0}\", use '--kspdir' to specify by path, or 'ksp list' to see known KSP installations", KSP);
+                        return Exit.BADOPT;
+                    }
+                }
+                else if (KSPdir != null)
+                {
+                    // Set a KSP directory by its path
+                    manager.SetCurrentInstanceByPath(KSPdir);
+                }
+            }
+            return exitCode;
+        }
     }
 
     /// <summary>
@@ -126,12 +324,19 @@ namespace CKAN.CmdLine
     {
         [ValueList(typeof(List<string>))]
         public List<string> options { get; set; }
+
+        public SubCommandOptions() { }
+
+        public SubCommandOptions(string[] args)
+        {
+            options = new System.Collections.Generic.List<string>(args).GetRange(1, args.Length - 1);
+        }
     }
 
     // Each action defines its own options that it supports.
     // Don't forget to cast to this type when you're processing them later on.
 
-    internal class InstallOptions : CommonOptions
+    internal class InstallOptions : InstanceSpecificOptions
     {
         [OptionArray('c', "ckanfiles", HelpText = "Local CKAN files to process")]
         public string[] ckan_files { get; set; }
@@ -145,12 +350,11 @@ namespace CKAN.CmdLine
         [Option("with-all-suggests", HelpText = "Install suggested modules all the way down")]
         public bool with_all_suggests { get; set; }
 
-        // TODO: How do we provide helptext on this?
-        [ValueList(typeof (List<string>))]
+        [ValueList(typeof(List<string>))]
         public List<string> modules { get; set; }
     }
 
-    internal class UpgradeOptions : CommonOptions
+    internal class UpgradeOptions : InstanceSpecificOptions
     {
         [Option('c', "ckanfile", HelpText = "Local CKAN file to process")]
         public string ckan_file { get; set; }
@@ -167,16 +371,13 @@ namespace CKAN.CmdLine
         [Option("all", HelpText = "Upgrade all available updated modules")]
         public bool upgrade_all { get; set; }
 
-        // TODO: How do we provide helptext on this?
         [ValueList(typeof (List<string>))]
         public List<string> modules { get; set; }
     }
 
-    internal class ScanOptions : CommonOptions
-    {
-    }
+    internal class ScanOptions : InstanceSpecificOptions { }
 
-    internal class ListOptions : CommonOptions
+    internal class ListOptions : InstanceSpecificOptions
     {
         [Option("porcelain", HelpText = "Dump raw list of modules, good for shell scripting")]
         public bool porcelain { get; set; }
@@ -185,25 +386,17 @@ namespace CKAN.CmdLine
         public string export { get; set; }
     }
 
-    internal class VersionOptions : CommonOptions
-    {
-    }
+    internal class VersionOptions   : CommonOptions { }
+    internal class CleanOptions     : InstanceSpecificOptions { }
+    internal class AvailableOptions : InstanceSpecificOptions { }
 
-    internal class CleanOptions : CommonOptions
-    {
-    }
-
-    internal class AvailableOptions : CommonOptions
-    {
-    }
-
-    internal class GuiOptions : CommonOptions
+    internal class GuiOptions : InstanceSpecificOptions
     {
         [Option("show-console", HelpText = "Shows the console while running the GUI")]
         public bool ShowConsole { get; set; }
     }
 
-    internal class UpdateOptions : CommonOptions
+    internal class UpdateOptions : InstanceSpecificOptions
     {
         // This option is really meant for devs testing their CKAN-meta forks.
         [Option('r', "repo", HelpText = "CKAN repository to use (experimental!)")]
@@ -216,7 +409,7 @@ namespace CKAN.CmdLine
         public bool list_changes { get; set; }
     }
 
-    internal class RemoveOptions : CommonOptions
+    internal class RemoveOptions : InstanceSpecificOptions
     {
         [Option("re", HelpText = "Parse arguments as regular expressions")]
         public bool regex { get; set; }
@@ -228,28 +421,19 @@ namespace CKAN.CmdLine
         public bool rmall { get; set; }
     }
 
-    internal class ShowOptions : CommonOptions
+    internal class ShowOptions : InstanceSpecificOptions
     {
-        [ValueOption(0)]
-        public string Modname { get; set; }
+        [ValueOption(0)] public string Modname { get; set; }
     }
 
-    internal class ClearCacheOptions : CommonOptions
+    internal class SearchOptions : InstanceSpecificOptions
     {
-    }
-
-    internal class SearchOptions : CommonOptions
-    {
-        [ValueOption(0)]
-        public string search_term { get; set; }
+        [ValueOption(0)] public string search_term { get; set; }
     }
 
     internal class CompareOptions : CommonOptions
     {
-        [ValueOption(0)]
-        public string Left { get; set; }
-
-        [ValueOption(1)]
-        public string Right { get; set; }
+        [ValueOption(0)] public string Left  { get; set; }
+        [ValueOption(1)] public string Right { get; set; }
     }
 }


### PR DESCRIPTION
This pull request resolves several problems with CmdLine help text, first noted in #445 and again in #1490.

- Before, only the main listing of commands was shown when the `--help` parameter was used, regardless of the rest of the command line. Now, command-specific help is shown if you enter a partial command.
- When accessing help for a command, two extra lines are printed at the top, first the description from the command listing, then the format of the command.
- Subcommands' commands also have their own help listings.
- The `--ksp` and `--kspdir` options are omitted for commands that don't need an instance, such as `version`, `ksp`, or `repo available`
   - Similarly, such commands now don't load the registry. This was done partially before by hard-coding a few such command names; now it's consistent and not hard-coded.
- Assorted other clean-up, such as the help attributes for `repo` and `ksp` being swapped.

This should make the command line options more easily discoverable.
(Especially `ckan update --list-changes`, which I only discovered when I set out to re-implement it from scratch!)

Help text of all commands captured with [shell script](https://github.com/HebaruSan/KSP_Tools/blob/master/ckan-help-test):

- [before.txt](https://github.com/KSP-CKAN/CKAN/files/1511767/before.txt) - What it looks like with the released version for comparison
- [after.txt](https://github.com/KSP-CKAN/CKAN/files/1511766/after.txt) - What it looks like after this pull request

The exceptions in #2105 also no longer seem to happen.