### PR TITLE
Revise issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,13 +1,43 @@
+<!--
+
 Thanks for wanting to bring an issue to our attention!
 
 Before you open a ticket, please do a quick search of the existing issues to see if it's already been brought up.
 
+https://github.com/KSP-CKAN/CKAN/issues
+
+-->
+
+Background
+----------
+
 **CKAN Version:** 
+
+
+**KSP Version:** 
+
 
 **Operating System:** 
 
-**The issue you are experiencing:** 
 
-**How to recreate this issue:** 
+**Have you made any manual changes to your GameData folder (i.e., not via CKAN)?** 
+
+
+Problem
+-------
+
+**What steps did you take in CKAN?**
+
+
+**What did you expect to happen?**
+
+
+**What happened instead?**
+
+
+**Screenshots:**
+<!-- You can copy an image of a window in Windows with Alt-PrtScr, then paste it in GitHub with ctrl-V -->
+
 
 **CKAN error codes (if applicable):** 
+


### PR DESCRIPTION
Monitoring the new issue queue, a few patterns are apparent. There are some questions we don't ask in the issue template that we should, as well as some questions that don't generally receive productive responses. And a lot of people don't delete the instructional text at the top.

This pull request modifies the issue template:

- Put the introductory text in a comment since it's not needed after the issue is submitted
- Added link to where you can do a search of open issues
- Split into background/problem sections
- Added space between questions to encourage more consistent formatting :crossed_fingers: 
- Added question about KSP version since many issues are version-specific
- Added question about manual modifications to GameData since this is a frequent cause of issues
- "Issue you are experiencing" and "How to recreate" replaced by steps taken, expected result, and actual outcome
- Added screenshots section with instructional comment in case the reader doesn't know how
