### PR TITLE
Dispose registry managers before exit to prevent exceptions

### DIFF
--- a/Cmdline/Action/CompatSubCommand.cs
+++ b/Cmdline/Action/CompatSubCommand.cs
@@ -196,7 +196,7 @@ namespace CKAN.CmdLine.Action
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
-
+            RegistryManager.DisposeAll();
             return exitCode;
         }
 

--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -158,6 +158,7 @@ namespace CKAN.CmdLine
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
+            RegistryManager.DisposeAll();
             return exitCode;
         }
 

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -68,6 +68,7 @@ namespace CKAN.CmdLine
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
+            RegistryManager.DisposeAll();
             return exitCode;
         }
 

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -153,6 +153,7 @@ namespace CKAN.CmdLine
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
+            RegistryManager.DisposeAll();
             return exitCode;
         }
 

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -186,6 +186,10 @@ namespace CKAN.CmdLine
             {
                 return printMissingInstanceError(user);
             }
+            finally
+            {
+                RegistryManager.DisposeAll();
+            }
         }
 
         private static int printMissingInstanceError(IUser user)

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -244,6 +244,19 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Call Dispose on all the registry managers in the cache.
+        /// Useful for exiting without Dispose-related exceptions.
+        /// Note that this also REMOVES these entries from the cache.
+        /// </summary>
+        public static void DisposeAll()
+        {
+            foreach (RegistryManager rm in new List<RegistryManager>(registryCache.Values))
+            {
+                rm.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Returns the currently installed modules in json format suitable for outputting to a ckan file.
         /// Defaults to using depends and with version numbers.
         /// </summary>


### PR DESCRIPTION
Since #2197 got merged, NetKAN validation is failing with `System.ObjectDisposedException`.

```
Running ckan update
Downloading updates...
Updated information on 687 available modules

Unhandled Exception:
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Stream has been closed'.
  at System.IO.FileStream.Flush () [0x0000d] in <62f5937022004555807e6c57c33f6684>:0 
  at System.IO.StreamWriter.Flush (System.Boolean flushStream, System.Boolean flushEncoder) [0x00094] in <62f5937022004555807e6c57c33f6684>:0 
  at System.IO.StreamWriter.Dispose (System.Boolean disposing) [0x00022] in <62f5937022004555807e6c57c33f6684>:0 
  at System.IO.TextWriter.Dispose () [0x00000] in <62f5937022004555807e6c57c33f6684>:0 
  at (wrapper remoting-invoke-with-check) System.IO.TextWriter:Dispose ()
  at CKAN.RegistryManager.ReleaseLock () [0x00008] in <1ee145d5510f4f75b7126acddfc45dc9>:0 
  at CKAN.RegistryManager.Dispose (System.Boolean safeToAlsoFreeManagedObjects) [0x00000] in <1ee145d5510f4f75b7126acddfc45dc9>:0 
  at CKAN.RegistryManager.Finalize () [0x00000] in <1ee145d5510f4f75b7126acddfc45dc9>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Stream has been closed'.
  at System.IO.FileStream.Flush () [0x0000d] in <62f5937022004555807e6c57c33f6684>:0 
  at System.IO.StreamWriter.Flush (System.Boolean flushStream, System.Boolean flushEncoder) [0x00094] in <62f5937022004555807e6c57c33f6684>:0 
  at System.IO.StreamWriter.Dispose (System.Boolean disposing) [0x00022] in <62f5937022004555807e6c57c33f6684>:0 
  at System.IO.TextWriter.Dispose () [0x00000] in <62f5937022004555807e6c57c33f6684>:0 
  at (wrapper remoting-invoke-with-check) System.IO.TextWriter:Dispose ()
  at CKAN.RegistryManager.ReleaseLock () [0x00008] in <1ee145d5510f4f75b7126acddfc45dc9>:0 
  at CKAN.RegistryManager.Dispose (System.Boolean safeToAlsoFreeManagedObjects) [0x00000] in <1ee145d5510f4f75b7126acddfc45dc9>:0 
  at CKAN.RegistryManager.Finalize () [0x00000] in <1ee145d5510f4f75b7126acddfc45dc9>:0 
Build step 'Execute shell' marked build as failure
```

This happens because as part of making registry access entirely on-demand by commands rather than predetermined upstream, I removed the `using (registry) { /* code */ }` block that Main.cs previously used to manage access to the registry, and in C# a `using` block calls `Dispose` on its argument when the code block exits. Now `Dispose` isn't being called because the registry is just accessed like a normal object, which leads the garbage collector to sometimes clean things up in the wrong order. (I had the same problem for a while in #2177.)

(A brief aside: `using` wasn't really being used correctly here previously. If you really want your object to be properly managed, you should be passing the reference you acquire with `using` to the functions that need it, and only using it that way. Instead, this code was acquiring one reference to the object in the `using` statement, then not using that reference at all and instead re-acquiring other references to it separately in independent code. Often this happened deep inside private `Core` code, such as ModuleInstaller.cs:53, where ModuleInstaller's constructor acquires a reference to the registry manager with no trace of a `using` block. In essence, this code relied on the coincidence that the called code would only access that particular instance of the registry, and would have failed had it done otherwise.)

This pull request fixes this issue by adding a static cleanup function `RegistryManager.DisposeAll` and calling it from the end of Cmdline. This will work regardless of which or how many registries are accessed or when/where or even if none are accessed at all.