### PR TITLE
Deploy AutoUpdater.exe to S3 and use it to auto-update (fixes #2140)

### DIFF
--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -21,10 +21,8 @@ namespace CKAN
 
         private readonly Uri latestCKANReleaseApiUrl = new Uri("https://api.github.com/repos/KSP-CKAN/CKAN/releases/latest");
 
-        private readonly Uri latestUpdaterReleaseApiUrl = new Uri(
-            "https://api.github.com/repos/KSP-CKAN/CKAN-autoupdate/releases/latest");
+        private readonly Uri lastestUpdaterUrl = new Uri("https://ckan-travis.s3.amazonaws.com/AutoUpdater.exe");
 
-        private Tuple<Uri, long> fetchedUpdaterUrl;
         private Tuple<Uri, long> fetchedCkanUrl;
 
         public Version LatestVersion { get; private set; }
@@ -59,7 +57,7 @@ namespace CKAN
         /// </summary>
         public bool IsFetched()
         {
-            return LatestVersion != null && fetchedUpdaterUrl != null &&
+            return LatestVersion != null &&
                 fetchedCkanUrl != null && ReleaseNotes != null;
         }
 
@@ -73,7 +71,6 @@ namespace CKAN
 
             try
             {
-                fetchedUpdaterUrl = RetrieveUrl(MakeRequest(latestUpdaterReleaseApiUrl));
                 fetchedCkanUrl = RetrieveUrl(response);
             }
             catch (Kraken)
@@ -126,7 +123,7 @@ namespace CKAN
             string updaterFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
             string ckanFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
             Net.DownloadWithProgress(new[]{
-                new Net.DownloadTarget(fetchedUpdaterUrl.Item1, updaterFilename, fetchedUpdaterUrl.Item2),
+                new Net.DownloadTarget(lastestUpdaterUrl, updaterFilename),
                 new Net.DownloadTarget(fetchedCkanUrl.Item1, ckanFilename, fetchedCkanUrl.Item2),
             }, user);
 
@@ -151,7 +148,7 @@ namespace CKAN
         /// </summary>
         /// <returns>The URL to the downloadable asset.</returns>
         internal Tuple<Uri, long> RetrieveUrl(dynamic response)
-        { 
+        {
             if (response.assets.Count == 0)
             {
                 throw new Kraken("The latest release isn't uploaded yet.");
@@ -164,7 +161,7 @@ namespace CKAN
         /// <summary>
         /// Fetches the URL provided, and de-serialises the returned JSON
         /// data structure into a dynamic object.
-        /// 
+        ///
         /// May throw an exception (especially a WebExeption) on failure.
         /// </summary>
         /// <returns>A dynamic object representing the JSON we fetched.</returns>

--- a/build.cake
+++ b/build.cake
@@ -16,10 +16,12 @@ var outDirectory = buildDirectory.Combine("out");
 var repackDirectory = buildDirectory.Combine("repack");
 var ckanFile = repackDirectory.Combine(configuration).CombineWithFilePath("ckan.exe");
 var netkanFile = repackDirectory.Combine(configuration).CombineWithFilePath("netkan.exe");
+var autoUpdateFile = repackDirectory.Combine(configuration).CombineWithFilePath("AutoUpdater.exe");
 
 Task("Default")
     .IsDependentOn("Ckan")
-    .IsDependentOn("Netkan");
+    .IsDependentOn("Netkan")
+    .IsDependentOn("AutoUpdater");
 
 
 Task("Debug")
@@ -33,6 +35,9 @@ Task("Ckan")
 
 Task("Netkan")
     .IsDependentOn("Repack-Netkan");
+
+Task("AutoUpdater")
+    .IsDependentOn("Repack-AutoUpdater");
 
 Task("Restore-Nuget")
     .Does(() =>
@@ -64,7 +69,7 @@ Task("Generate-GlobalAssemblyVersionInfo")
     var metaDirectory = buildDirectory.Combine("meta");
 
     CreateDirectory(metaDirectory);
-    
+
     CreateAssemblyInfo(metaDirectory.CombineWithFilePath("GlobalAssemblyVersionInfo.cs"), new AssemblyInfoSettings
     {
         Version = versionStr2,
@@ -107,6 +112,13 @@ Task("Repack-Netkan")
     );
 
     CopyFile(netkanFile, buildDirectory.CombineWithFilePath("netkan.exe"));
+});
+
+Task("Repack-AutoUpdater")
+    .IsDependentOn("Build-DotNet")
+    .Does(() =>
+{
+    CopyFile(outDirectory.Combine("AutoUpdater").Combine(configuration).Combine("bin").CombineWithFilePath("AutoUpdater.exe"), autoUpdateFile);
 });
 
 Task("Test")


### PR DESCRIPTION
The auto-updater is, ironically enough, not up to date.

`Core/Net/AutoUpdate.cs` tries to download the latest autoupdater exe file. It does this by looking up the latest release on the CKAN-autoupdate repo. This release was published on June 30, 2015, after which that repo was merged into the main CKAN repo and marked as retired. So a 2-year-old file is used instead of the latest code.

A few days after that release was published, on July 2, 2015, [a fix was made to the auto-updater](https://github.com/KSP-CKAN/CKAN/commit/8b882ceb460cffdd3dd08359c7311988a3ba3aad), but it did not take effect. #2140 reports the exact symptoms that that commit was trying to fix.

This pull request tries to bring the latest auto-update code into active service:

- The build process is updated to copy AutoUpdater.exe into the repack directory
  - Which means the deploy process in .travis.yml will copy it to ckan-travis.s3.amazonaws.com
  - This should mean that the latest auto-updater will be available on the internet to clients
- The autoupdate code in `Core/Net/AutoUpdate.cs` is updated to no longer deal with the retired CKAN-autoupdate repository
  - Instead, it downloads AutoUpdater.exe directly from where the build process puts it on the S3 site, like NetKAN-bot does
  - This should mean that the latest auto-updater will be used instead of the one from June 2015

Fixes #2140.