### PR TITLE
Avoid NRE in install-from-ckan (fixes #2171)

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -65,7 +65,16 @@ namespace CKAN.CmdLine
                     }
 
                     // Parse the JSON file.
-                    options.modules.Add(LoadCkanFromFile(ksp, filename).identifier);
+                    try
+                    {
+                        options.modules.Add(LoadCkanFromFile(ksp, filename).identifier);
+                    }
+                    catch (Kraken kraken)
+                    {
+                        user.RaiseError(kraken.InnerException == null
+                            ? kraken.Message
+                            : $"{kraken.Message}: {kraken.InnerException.Message}");
+                    }
                 }
 
                 // At times RunCommand() calls itself recursively - in this case we do

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -934,7 +934,9 @@ namespace CKAN
                 }
                 catch (Kraken kraken)
                 {
-                    currentUser.RaiseError(kraken.Message + ": " + kraken.InnerException.Message);
+                    currentUser.RaiseError(kraken.InnerException == null
+                        ? kraken.Message
+                        : $"{kraken.Message}: {kraken.InnerException.Message}");
                     return;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Fixes #2171; see that issue for details. To sum up, loading a .ckan file can raise exceptions, and currently they're not handled well. In Cmdline they are caught by the uncaught exception handler, and in GUI the exception handler itself causes a null reference exception.

Now in both cases we properly print out the error using an IUser reference.