### PR TITLE
Avoid NRE in TooManyModsProvide (fixes #2207)

### DIFF
--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -54,21 +54,19 @@ namespace CKAN
             });
             var module = await task.Task;
 
-            if (module == null)
+            if (module == null
+                    && last_mod_to_have_install_toggled.TryPeek(out mod))
             {
-                last_mod_to_have_install_toggled.TryPeek(out mod);
-                MarkModForInstall(mod.Identifier,uncheck:true);
+                MarkModForInstall(mod.Identifier, true);
             }
             Util.Invoke(this, () =>
             {
                 tabController.SetTabLock(false);
-
                 tabController.HideTab("ChooseProvidedModsTabPage");
-
                 tabController.ShowTab("ManageModsTabPage");
             });
 
-            if(module!=null)
+            if (module != null)
                 MarkModForInstall(module.identifier);
 
             last_mod_to_have_install_toggled.TryPop(out mod);


### PR DESCRIPTION
#2207 pointed out that a null reference exception can occur in GUI's `TooManyModsProvide`. Auditing this function, all object references but one are either checked for null before use or initialized with `new` and never set again.

The one unsafe line is supposed to be set by a `TryPeek` call, which returns true if it sets the reference and false otherwise, but currently that return value is being ignored. Now we will use that return value to guard the remaining unsafe reference.

Fixes #2207.