### PR TITLE
Install version from file when installing from file (fixes #1356)

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -67,7 +67,8 @@ namespace CKAN.CmdLine
                     // Parse the JSON file.
                     try
                     {
-                        options.modules.Add(LoadCkanFromFile(ksp, filename).identifier);
+                        CkanModule m = LoadCkanFromFile(ksp, filename);
+                        options.modules.Add($"{m.identifier}={m.version}");
                     }
                     catch (Kraken kraken)
                     {


### PR DESCRIPTION
The `ckan install -c GreatMod.ckan` command loads the file into the registry, and then installs the latest version of GreatMod. This is fine if the file contains the latest version, but if it is an older version, then the command doesn't actually install what's specified in the file.

This pull request updates the install command to include the version from the file when adding to the install list.

Fixes #1356.