### PR TITLE
Provide fresh auto updater in releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ deploy:
         - _build/repack/$BUILD_CONFIGURATION/ckan.exe
         - _build/osx/CKAN.dmg
         - _build/deb/ckan_*.deb
+        - _build/out/AutoUpdater/$BUILD_CONFIGURATION/bin/AutoUpdater.exe
       on:
         repo: KSP-CKAN/CKAN
         tags: true

--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -88,10 +88,17 @@ namespace CKAN
             {
                 fetchedCkanUrl = RetrieveUrl(response, 0);
                 // Check whether the release includes the auto updater
-                if (response.assets.Count >= 4) {
-                    // Last asset is AutoUpdater.exe
-                    fetchedUpdaterUrl = RetrieveUrl(response, 3);
-                } else {
+                foreach (var asset in response.assets)
+                {
+                    string url = asset.browser_download_url.ToString();
+                    if (url.EndsWith("AutoUpdater.exe"))
+                    {
+                        fetchedUpdaterUrl = new Tuple<Uri, long>(new Uri(url), (long)asset.size);
+                        break;
+                    }
+                }
+                if (fetchedUpdaterUrl == null)
+                {
                     // Older releases don't include the auto updater
                     fetchedUpdaterUrl = RetrieveUrl(MakeRequest(oldLatestUpdaterReleaseApiUrl), 0);
                 }

--- a/Tests/Core/Net/AutoUpdate.cs
+++ b/Tests/Core/Net/AutoUpdate.cs
@@ -18,10 +18,9 @@ namespace Tests.Core.AutoUpdate
         public void FetchCkanUrl()
         {
             Assert.Throws<CKAN.Kraken>(delegate
-                {
-                    Fetch(test_ckan_release);
-                }
-            );
+            {
+                Fetch(test_ckan_release, 0);
+            });
         }
 
         [Test]
@@ -53,9 +52,9 @@ namespace Tests.Core.AutoUpdate
             );
         }
 
-        private void Fetch(Uri url)
+        private void Fetch(Uri url, int whichOne)
         {
-            CKAN.AutoUpdate.Instance.RetrieveUrl(CKAN.AutoUpdate.Instance.MakeRequest(url));
+            CKAN.AutoUpdate.Instance.RetrieveUrl(CKAN.AutoUpdate.Instance.MakeRequest(url), whichOne);
         }
     }
 }


### PR DESCRIPTION
This pull request replaces #2204, which was closed because its approach wasn't appropriate. See that PR for details of the problem being solved.

New approach:

- Add AutoUpdater.exe to the list of downloadable files when creating a new release on GitHub
- Update client to look for this file and use it, falling back to the old URL if it's missing

This change assumes that the list of assets in the release will be in the same order as they are in the `.travis.yml` file. I believe this would be the case because it's an array rather than a dictionary, and the easiest way for Travis to implement it would be a simple `foreach` loop, but I was not able to find documentation or a concrete example to confirm this.

We should mention in the next release notes that users do _not_ need to download AutoUpdater.exe manually.

Partially fixes #2140. The error will still occur when updating _to_ this release, because the old clients will still use the 2-year-old auto updater exe, but updating from this release to the next release will use the latest auto update code. If we publish one last manual release to https://github.com/KSP-CKAN/CKAN-autoupdate/releases , then the current clients will update properly as well.