### PR TITLE
Remove invalid installs from registry at load

### DIFF
--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -279,6 +279,7 @@ namespace CKAN
         {
             log.Debug("Loading KSP instances from registry");
 
+            bool needSave = false;
             instances.Clear();
 
             foreach (Tuple<string, string> instance in Win32Registry.GetInstances())
@@ -293,13 +294,9 @@ namespace CKAN
                 }
                 else
                 {
-                    log.WarnFormat("{0} at {1} is not a vaild install", name, path);
+                    log.WarnFormat("{0} at {1} is not a valid install, removing", name, path);
+                    needSave = true;
                 }
-
-                //var ksp = new KSP(path, User);
-                //instances.Add(name, ksp);
-
-
             }
 
             try
@@ -310,6 +307,12 @@ namespace CKAN
             {
                 log.WarnFormat("Auto-start instance was invalid: {0}", e.Message);
                 AutoStartInstance = null;
+            }
+
+            if (needSave)
+            {
+                // Save the list without the invalid entries
+                Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);
             }
         }
     }


### PR DESCRIPTION
If a KSP instance that CKAN knows about is removed manually, an error message is printed at startup:

> 194 [1] WARN CKAN.KSPManager (null) - rss at /Users/lamont/ksp_rss is not a vaild install

But it's impossible to remove it from the list of known installs, because it's not actually added to the list that is manipulated to make that happen.

This pull request updates the loading code to save the list of (valid) instances to the registry again if there were any that were invalid. To alert the user that this is happening, the message now says "removing" at the end:

> 194 [1] WARN CKAN.KSPManager (null) - rss at /Users/lamont/ksp_rss is not a valid install, removing

Fixes #896.
Fixes #1836.