### PR TITLE
Add depending mod to missing dependency exception

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -111,6 +111,13 @@ namespace CKAN.CmdLine
                 var installer = ModuleInstaller.GetInstance(ksp, user);
                 installer.InstallList(options.modules, install_ops);
             }
+            catch (DependencyNotSatisfiedKraken ex)
+            {
+                user.RaiseMessage("{0} requires {1} but it is not listed in the index, or not available for your version of KSP.", ex.parent, ex.module);
+                user.RaiseMessage("If you're lucky, you can do a `ckan update` and try again.");
+                user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules.");
+                return Exit.ERROR;
+            }
             catch (ModuleNotFoundKraken ex)
             {
                 user.RaiseMessage("Module {0} required but it is not listed in the index, or not available for your version of KSP.", ex.module);

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -120,8 +120,10 @@ namespace CKAN.ConsoleUI {
 
                     } catch (BadMetadataKraken ex) {
                         RaiseError($"Bad metadata detected for {ex.module}: {ex.Message}");
+                    } catch (DependencyNotSatisfiedKraken ex) {
+                        RaiseError($"{ex.parent} requires {ex.module}, but it is not listed in the index, or not available for your version of KSP.\r\n{ex.Message}");
                     } catch (ModuleNotFoundKraken ex) {
-                        RaiseError($"Module {ex.module} required but it is not listed in the index, or not available for your version of KSP. {ex.Message}");
+                        RaiseError($"Module {ex.module} required but it is not listed in the index, or not available for your version of KSP.\r\n{ex.Message}");
                     } catch (ModNotInstalledKraken ex) {
                         RaiseError($"{ex.mod} is not installed, can't remove");
                     }

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -334,8 +334,8 @@ namespace CKAN
                 {
                     if (!soft_resolve)
                     {
-                        log.ErrorFormat("Dependency on {0} found but it is not listed in the index, or not available for your version of KSP.", dep_name);
-                        throw new ModuleNotFoundKraken(dep_name);
+                        log.InfoFormat("Dependency on {0} found but it is not listed in the index, or not available for your version of KSP.", dep_name);
+                        throw new DependencyNotSatisfiedKraken(reason.Parent, dep_name);
                     }
                     log.InfoFormat("{0} is recommended/suggested but it is not listed in the index, or not available for your version of KSP.", dep_name);
                     continue;

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -64,6 +64,31 @@ namespace CKAN
         }
     }
 
+    /// <summary>
+    /// Exception describing a missing dependency
+    /// </summary>
+    public class DependencyNotSatisfiedKraken : ModuleNotFoundKraken
+    {
+        /// <summary>
+        /// The mod with an unmet dependency
+        /// </summary>
+        public readonly CkanModule parent;
+
+        /// <summary>
+        /// Initialize the exceptions
+        /// </summary>
+        /// <param name="parentModule">The module with the unmet dependency</param>
+        /// <param name="module">The name of the missing dependency</param>
+        /// <param name="reason">Message parameter for base class</param>
+        /// <param name="innerException">Originating exception parameter for base class</param>
+        public DependencyNotSatisfiedKraken(CkanModule parentModule,
+            string module, string version = null, string reason = null, Exception innerException = null)
+            : base(module, version, reason, innerException)
+        {
+            parent = parentModule;
+        }
+    }
+
     public class NotKSPDirKraken : Kraken
     {
         public string path;

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -244,6 +244,13 @@ namespace CKAN
             {
                 action();
             }
+            catch (DependencyNotSatisfiedKraken ex)
+            {
+                GUI.user.RaiseMessage(
+                    "{0} requires {1} but it is not listed in the index, or not available for your version of KSP.",
+                    ex.parent, ex.module);
+                return false;
+            }
             catch (ModuleNotFoundKraken ex)
             {
                 GUI.user.RaiseMessage(

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -53,7 +53,7 @@ namespace Tests.Core.Relationships
             list.Add(mod_a.identifier);
             list.Add(mod_b.identifier);
             AddToRegistry(mod_a, mod_b);
-            
+
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
                 options,
@@ -473,7 +473,7 @@ namespace Tests.Core.Relationships
             list.Add(depender.identifier);
             registry.AddAvailable(depender);
 
-            Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
+            Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                 list,
                 options,
                 registry,
@@ -495,10 +495,10 @@ namespace Tests.Core.Relationships
             {
                 new RelationshipDescriptor {name = dependant.identifier, version = new Version(dep)}
             });
-            list.Add(depender.identifier);            
+            list.Add(depender.identifier);
             AddToRegistry(depender, dependant);
 
-            Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
+            Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                 list,
                 options,
                 registry,
@@ -517,10 +517,10 @@ namespace Tests.Core.Relationships
             {
                 new RelationshipDescriptor {name = dependant.identifier, min_version = new Version(dep_min)}
             });
-            list.Add(depender.identifier);            
+            list.Add(depender.identifier);
             AddToRegistry(depender, dependant);
 
-            Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
+            Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                 list,
                 options,
                 registry,
@@ -599,7 +599,7 @@ namespace Tests.Core.Relationships
                 new RelationshipDescriptor {name = dependant.identifier, version = new Version(dep)}
             });
 
-            list.Add(depender.identifier);            
+            list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
@@ -608,7 +608,7 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
-            
+
         }
 
         [Test]
@@ -721,16 +721,16 @@ namespace Tests.Core.Relationships
             var relationship_resolver = new RelationshipResolver(list, options, registry, null);
 
             var mod_not_in_resolver_list = generator.GeneratorRandomModule();
-            CollectionAssert.DoesNotContain(relationship_resolver.ModList(),mod_not_in_resolver_list);            
+            CollectionAssert.DoesNotContain(relationship_resolver.ModList(),mod_not_in_resolver_list);
             Assert.Throws<ArgumentException>(() => relationship_resolver.ReasonFor(mod_not_in_resolver_list));
-            
+
         }
 
         [Test]
         public void ReasonFor_WithUserAddedMods_GivesReasonUserAdded()
         {
             var list = new List<string>();
-            var mod = generator.GeneratorRandomModule();                        
+            var mod = generator.GeneratorRandomModule();
             list.Add(mod.identifier);
             registry.AddAvailable(mod);
             AddToRegistry(mod);
@@ -748,7 +748,7 @@ namespace Tests.Core.Relationships
             var mod =
                 generator.GeneratorRandomModule(sugests:
                     new List<RelationshipDescriptor> {new RelationshipDescriptor {name = sugested.identifier}});
-            list.Add(mod.identifier);            
+            list.Add(mod.identifier);
             AddToRegistry(mod, sugested);
 
             options.with_all_suggests = true;
@@ -762,7 +762,7 @@ namespace Tests.Core.Relationships
         [Test]
         public void ReasonFor_WithTreeOfMods_GivesCorrectParents()
         {
-            var list = new List<string>();            
+            var list = new List<string>();
             var sugested = generator.GeneratorRandomModule();
             var recommendedA = generator.GeneratorRandomModule();
             var recommendedB = generator.GeneratorRandomModule();


### PR DESCRIPTION
Currently `ModuleNotFoundKraken` is thrown if a dependency isn't met, but this only specifies the mod that can't be installed, not the one that depends on it. This means that if the depending mod is specified indirectly somehow, the user is not told how to avoid the error.

This pull request adds a new Kraken-inheriting class that specifies both the unavailable mod as well as the depending mod, and throws it from the relationship resolver. To maintain backwards compatibility, this new class inherits from `ModuleNotFoundKraken`. We also catch this Kraken in Cmdline, ConsoleUI, and GUI, and extend the messages to the user accordingly. And an identical error-level log message is moved to verbose-level, because we're already throwing an exception.

Before (using KSP 1.3.1):

```
$ mono ckan.exe install FASA --ksp steam
2989 [1] ERROR CKAN.RelationshipResolver (null) - Dependency on TextureReplacer found but it is not listed in the index, or not available for your version of KSP.
Module TextureReplacer required but it is not listed in the index, or not available for your version of KSP.
If you're lucky, you can do a `ckan update` and try again.
Try `ckan install --no-recommends` to skip installation of recommended modules.
```

After:

```
$ mono ckan.exe install FASA --ksp steam
FASA 1:v7.2 requires TextureReplacer but it is not listed in the index, or not available for your version of KSP.
If you're lucky, you can do a `ckan update` and try again.
Try `ckan install --no-recommends` to skip installation of recommended modules.
```