### PR TITLE
Available ∪ Incompatible = All

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -64,7 +64,7 @@ namespace CKAN
             get { return IsInstalled ? InstalledVersion : LatestVersion; }
         }
 
-        public GUIMod(CkanModule mod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version)
+        public GUIMod(CkanModule mod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool incompatible = false)
         {
             IsCKAN = mod is CkanModule;
             //Currently anything which could alter these causes a full reload of the modlist
@@ -73,7 +73,7 @@ namespace CKAN
             IsInstalled = registry.IsInstalled(mod.identifier, false);
             IsInstallChecked = IsInstalled;
             HasUpdate = registry.HasUpdate(mod.identifier, current_ksp_version);
-            IsIncompatible = !mod.IsCompatibleKSP(current_ksp_version);
+            IsIncompatible = incompatible || !mod.IsCompatibleKSP(current_ksp_version);
             IsAutodetected = registry.IsAutodetected(mod.identifier);
             Authors = mod.author == null ? "N/A" : String.Join(",", mod.author);
 

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -151,7 +151,7 @@ namespace CKAN
             var gui_mods = new HashSet<GUIMod>(registry.Available(versionCriteria)
                 .Select(m => new GUIMod(m, registry, versionCriteria)));
             gui_mods.UnionWith(registry.Incompatible(versionCriteria)
-                .Select(m => new GUIMod(m, registry, versionCriteria)));
+                .Select(m => new GUIMod(m, registry, versionCriteria, true)));
             var installed = registry.InstalledModules
                 .Select(m => new GUIMod(m.Module, registry, versionCriteria));
 


### PR DESCRIPTION
Previously, `Registry.Available` checked for the availability/compatibility of mods' dependencies, but `Registry.Incompatible` only looked at the KSP versions. This meant that mods with compatible KSP versions but with incompatible dependencies were excluded from both of those lists. Since these two lists of mods are used to generate the full list of mods to show in the All filter of GUI, such mods would simply vanish and be completely invisible to the user.

Now the dependency checking logic is refactored into a private helper function called by both `Registry.Available` and `Registry.Incompatible`. Mods with incompatible dependencies will themselves appear in `Registry.Incompatible`, and GUI's All filter will actually show all mods, as expected.

Fixes #1695.