### PR TITLE
Make Cmdline modules case insensitive

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -82,6 +82,10 @@ namespace CKAN.CmdLine
                 // not want to be doing this again, so "consume" the option
                 options.ckan_files = null;
             }
+            else
+            {
+                Search.AdjustModulesCase(ksp, options.modules);
+            }
 
             if (options.modules.Count == 0)
             {

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -65,6 +65,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     var installer = ModuleInstaller.GetInstance(ksp, user);
+                    Search.AdjustModulesCase(ksp, options.modules);
                     installer.UninstallList(options.modules);
                 }
                 catch (ModNotInstalledKraken kraken)
@@ -84,4 +85,3 @@ namespace CKAN.CmdLine
         }
     }
 }
-

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -116,6 +116,7 @@ namespace CKAN.CmdLine
                 else
                 {
                     // TODO: These instances all need to go.
+                    Search.AdjustModulesCase(ksp, options.modules);
                     ModuleInstaller.GetInstance(ksp, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User));
                 }
             }

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -374,7 +374,7 @@ namespace CKAN
         {
             CkanModule module;
 
-            Match match = Regex.Match(mod, @"^(?<mod>[^=]*)=(?<version>.*)$");
+            Match match = idAndVersionMatcher.Match(mod);
 
             if (match.Success)
             {
@@ -398,6 +398,11 @@ namespace CKAN
             }
             return module;
         }
+
+        public static readonly Regex idAndVersionMatcher = new Regex(
+            @"^(?<mod>[^=]*)=(?<version>.*)$",
+            RegexOptions.Compiled
+        );
 
         /// <summary> Generates a CKAN.Meta object given a filename</summary>
         public static CkanModule FromFile(string filename)


### PR DESCRIPTION
Previously, Cmdline users had to type the exact capitalization of each mod identifier in the `install`, `remove`, and `upgrade` commands. This pull request adds a lookup step to convert "incorrectly"-capitalized identifiers to their correct capitalization, based on what is indexed in the registry. This allows users to type any capitalization they like as long as the letters are all the same.

Before:

```
$ mono ckan.exe install astroGATOR
Module astroGATOR required but it is not listed in the index, or not available for your version of KSP.
If you're lucky, you can do a `ckan update` and try again.
Try `ckan install --no-recommends` to skip installation of recommended modules.
```

After:

```
$ mono ckan.exe install astroGATOR
About to install...

 * Astrogator v0.7.8(cached)

Continue? [Y/n] 
```

The `identifier=version` format code is refactored slightly to create a reusable/shared compiled Regex object, then used in `CkanModule.FromIDandVersion` as well as the new lookup code.

Fixes #889.