### PR TITLE
Check game version compatibility when installing specific version

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -120,7 +120,14 @@ namespace CKAN.CmdLine
             }
             catch (ModuleNotFoundKraken ex)
             {
-                user.RaiseMessage("Module {0} required but it is not listed in the index, or not available for your version of KSP.", ex.module);
+                if (ex.version == null)
+                {
+                    user.RaiseMessage("Module {0} required but it is not listed in the index, or not available for your version of KSP.", ex.module);
+                }
+                else
+                {
+                    user.RaiseMessage("Module {0} {1} required but it is not listed in the index, or not available for your version of KSP.", ex.module, ex.version);
+                }
                 user.RaiseMessage("If you're lucky, you can do a `ckan update` and try again.");
                 user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules.");
                 return Exit.ERROR;

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -94,9 +94,10 @@ namespace CKAN.CmdLine
             // Prepare options. Can these all be done in the new() somehow?
             var install_ops = new RelationshipResolverOptions
             {
-                with_all_suggests = options.with_all_suggests,
-                with_suggests = options.with_suggests,
-                with_recommends = !options.no_recommends
+                with_all_suggests  = options.with_all_suggests,
+                with_suggests      = options.with_suggests,
+                with_recommends    = !options.no_recommends,
+                allow_incompatible = options.allow_incompatible
             };
 
             if (user.Headless)
@@ -113,9 +114,17 @@ namespace CKAN.CmdLine
             }
             catch (DependencyNotSatisfiedKraken ex)
             {
-                user.RaiseMessage("{0} requires {1} but it is not listed in the index, or not available for your version of KSP.", ex.parent, ex.module);
+                if (ex.version == null)
+                {
+                    user.RaiseMessage("{0} requires {1} but it is not listed in the index, or not available for your version of KSP.", ex.parent, ex.module);
+                }
+                else
+                {
+                    user.RaiseMessage("{0} requires {1} {2} but it is not listed in the index, or not available for your version of KSP.", ex.parent, ex.module, ex.version);
+                }
                 user.RaiseMessage("If you're lucky, you can do a `ckan update` and try again.");
                 user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules.");
+                user.RaiseMessage("Or `ckan install --allow-incompatible` to ignore module compatibility.");
                 return Exit.ERROR;
             }
             catch (ModuleNotFoundKraken ex)
@@ -130,6 +139,7 @@ namespace CKAN.CmdLine
                 }
                 user.RaiseMessage("If you're lucky, you can do a `ckan update` and try again.");
                 user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules.");
+                user.RaiseMessage("Or `ckan install --allow-incompatible` to ignore module compatibility.");
                 return Exit.ERROR;
             }
             catch (BadMetadataKraken ex)

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -344,14 +344,17 @@ namespace CKAN.CmdLine
         [OptionArray('c', "ckanfiles", HelpText = "Local CKAN files to process")]
         public string[] ckan_files { get; set; }
 
-        [Option("no-recommends", HelpText = "Do not install recommended modules")]
+        [Option("no-recommends", DefaultValue = false, HelpText = "Do not install recommended modules")]
         public bool no_recommends { get; set; }
 
-        [Option("with-suggests", HelpText = "Install suggested modules")]
+        [Option("with-suggests", DefaultValue = false, HelpText = "Install suggested modules")]
         public bool with_suggests { get; set; }
 
-        [Option("with-all-suggests", HelpText = "Install suggested modules all the way down")]
+        [Option("with-all-suggests", DefaultValue = false, HelpText = "Install suggested modules all the way down")]
         public bool with_all_suggests { get; set; }
+
+        [Option("allow-incompatible", DefaultValue = false, HelpText = "Install modules that are not compatible with the current game version")]
+        public bool allow_incompatible { get; set; }
 
         [ValueList(typeof(List<string>))]
         public List<string> modules { get; set; }
@@ -362,16 +365,16 @@ namespace CKAN.CmdLine
         [Option('c', "ckanfile", HelpText = "Local CKAN file to process")]
         public string ckan_file { get; set; }
 
-        [Option("no-recommends", HelpText = "Do not install recommended modules")]
+        [Option("no-recommends", DefaultValue = false, HelpText = "Do not install recommended modules")]
         public bool no_recommends { get; set; }
 
-        [Option("with-suggests", HelpText = "Install suggested modules")]
+        [Option("with-suggests", DefaultValue = false, HelpText = "Install suggested modules")]
         public bool with_suggests { get; set; }
 
-        [Option("with-all-suggests", HelpText = "Install suggested modules all the way down")]
+        [Option("with-all-suggests", DefaultValue = false, HelpText = "Install suggested modules all the way down")]
         public bool with_all_suggests { get; set; }
 
-        [Option("all", HelpText = "Upgrade all available updated modules")]
+        [Option("all", DefaultValue = false, HelpText = "Upgrade all available updated modules")]
         public bool upgrade_all { get; set; }
 
         [ValueList(typeof (List<string>))]
@@ -407,7 +410,7 @@ namespace CKAN.CmdLine
         [Option('r', "repo", HelpText = "CKAN repository to use (experimental!)")]
         public string repo { get; set; }
 
-        [Option("all", HelpText = "Upgrade all available updated modules")]
+        [Option("all", DefaultValue = false, HelpText = "Upgrade all available updated modules")]
         public bool update_all { get; set; }
 
         [Option("list-changes", DefaultValue = false, HelpText = "List new and removed modules")]
@@ -422,7 +425,7 @@ namespace CKAN.CmdLine
         [ValueList(typeof(List<string>))]
         public List<string> modules { get; set; }
 
-        [Option("all", HelpText = "Remove all installed mods.")]
+        [Option("all", DefaultValue = false, HelpText = "Remove all installed mods.")]
         public bool rmall { get; set; }
     }
 

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -383,7 +383,8 @@ namespace CKAN
 
                 module = registry.GetModuleByVersion(ident, version);
 
-                if (module == null)
+                if (module == null
+                        || (ksp_version != null && !module.IsCompatibleKSP(ksp_version)))
                     throw new ModuleNotFoundKraken(ident, version,
                         string.Format("Module {0} version {1} not available", ident, version));
             }


### PR DESCRIPTION
## Problem

`ckan install identifier=version` currently bypasses game version compatibility checks. This means that an incompatible module that you normally couldn't install at all, can be installed just by specifying any version:

```
$ mono ckan.exe install AvisorforValentina
Module AvisorforValentina required but it is not listed in the index, or not available for your version of KSP.
If you're lucky, you can do a `ckan update` and try again.
Try `ckan install --no-recommends` to skip installation of recommended modules.
```

```
$ mono ckan.exe install AvisorforValentina=1.01
About to install...

 * A visor for Valentina 1.01

Continue? [Y/n] 
```

This makes the `identifier=version` format unsafe by default, since compatibility checking is just turned off; this could be a problem if I intend to install an older _compatible_ version but make a typo in the version number.

It also isn't documented anywhere that it works this way, so a user might not even realize that he's installing incompatible versions once he discovers this argument format.

## Changes

This pull request checks that the version the user specified is compatible with the game version. It also adds the module version to the error message:

```
$ mono ckan.exe install AvisorforValentina=1.01
Module AvisorforValentina 1.01 required but it is not listed in the index, or not available for your version of KSP.
If you're lucky, you can do a `ckan update` and try again.
Try `ckan install --no-recommends` to skip installation of recommended modules.
Or `ckan install --allow-incompatible` to ignore module compatibility.
```

To avoid losing the ability to install incompatible mods if the user so chooses, a new explicit Cmdline option `--allow-incompatible` is added:

```
$ mono ckan.exe install --help
CKAN 1.24.0-PRE+5cf8b5017bc5
Copyright © 2014-2017
 
install - Install a KSP mod
Usage: ckan install [options] modules

  --allow-incompatible    (Default: False) Install modules that are not 
                          compatible with the current game version
```

This works for _both_ the `identifier=version` format and the simpler `identifier` format, so you now don't have to know the version number to install the latest incompatible version of a mod:

```
$ mono ckan.exe install AvisorforValentina=1.01 --allow-incompatible
About to install...

 * A visor for Valentina 1.01

Continue? [Y/n] 
```

```
$ mono ckan.exe install AvisorforValentina --allow-incompatible
About to install...

 * A visor for Valentina 1.01

Continue? [Y/n] 
```