### PR TITLE
Include invalid instances in KSPManager

### DIFF
--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -295,24 +295,28 @@ namespace CKAN.CmdLine
                     return Exit.BADOPT;
                 }
 
-                if (KSP != null)
+                try
                 {
-                    // Set a KSP directory by its alias.
-
-                    try
+                    if (!string.IsNullOrEmpty(KSP))
                     {
+                        // Set a KSP directory by its alias.
                         manager.SetCurrentInstance(KSP);
                     }
-                    catch (InvalidKSPInstanceKraken)
+                    else if (!string.IsNullOrEmpty(KSPdir))
                     {
-                        user.RaiseMessage("Invalid KSP installation specified \"{0}\", use '--kspdir' to specify by path, or 'ksp list' to see known KSP installations", KSP);
-                        return Exit.BADOPT;
+                        // Set a KSP directory by its path
+                        manager.SetCurrentInstanceByPath(KSPdir);
                     }
                 }
-                else if (KSPdir != null)
+                catch (NotKSPDirKraken k)
                 {
-                    // Set a KSP directory by its path
-                    manager.SetCurrentInstanceByPath(KSPdir);
+                    user.RaiseMessage("Sorry, {0} does not appear to be a KSP directory", k.path);
+                    return Exit.BADOPT;
+                }
+                catch (InvalidKSPInstanceKraken k)
+                {
+                    user.RaiseMessage("Invalid KSP installation specified \"{0}\", use '--kspdir' to specify by path, or 'ksp list' to see known KSP installations", k.instance);
+                    return Exit.BADOPT;
                 }
             }
             return exitCode;

--- a/ConsoleUI/KSPListScreen.cs
+++ b/ConsoleUI/KSPListScreen.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.ComponentModel;
+using CKAN.Versioning;
 using CKAN.ConsoleUI.Toolkit;
 
 namespace CKAN.ConsoleUI {
@@ -40,8 +41,8 @@ namespace CKAN.ConsoleUI {
                     }, new ConsoleListBoxColumn<KSP>() {
                         Header   = "Version",
                         Width    = 12,
-                        Renderer = k => k.Version().ToString(),
-                        Comparer = (a, b) => a.Version().CompareTo(b.Version())
+                        Renderer = k => k.Version()?.ToString() ?? noVersion,
+                        Comparer = (a, b) => a.Version()?.CompareTo(b.Version() ?? KspVersion.Any) ?? 1
                     }, new ConsoleListBoxColumn<KSP>() {
                         Header   = "Path",
                         Width    = 70,
@@ -115,7 +116,15 @@ namespace CKAN.ConsoleUI {
                 if (name == manager.AutoStartInstance) {
                     manager.ClearAutoStart();
                 } else {
-                    manager.SetAutoStart(name);
+                    try {
+                        manager.SetAutoStart(name);
+                    } catch (NotKSPDirKraken k) {
+                        ConsoleMessageDialog errd = new ConsoleMessageDialog(
+                            $"Error loading {k.path}:\n{k.Message}",
+                            new List<string>() {"OK"}
+                        );
+                        errd.Run();
+                    }
                 }
                 return true;
             });
@@ -184,6 +193,15 @@ namespace CKAN.ConsoleUI {
                         return false;
                     }
 
+                } catch (NotKSPDirKraken k) {
+
+                    ConsoleMessageDialog errd = new ConsoleMessageDialog(
+                        $"Error loading {ksp.GameDir()}:\n{k.Message}",
+                        new List<string>() {"OK"}
+                    );
+                    errd.Run();
+                    return false;
+
                 } catch (Exception e) {
 
                     ConsoleMessageDialog errd = new ConsoleMessageDialog(
@@ -211,6 +229,7 @@ namespace CKAN.ConsoleUI {
         private KSPManager          manager;
         private ConsoleListBox<KSP> kspList;
 
+        private const string noVersion = "<NONE>";
         private static readonly string defaultMark = Symbols.checkmark;
     }
 

--- a/GUI/ChooseKSPInstance.Designer.cs
+++ b/GUI/ChooseKSPInstance.Designer.cs
@@ -43,11 +43,11 @@
             this.SetAsDefaultCheckbox = new System.Windows.Forms.CheckBox();
             this.ForgetButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
-            // 
+            //
             // KSPInstancesListView
-            // 
-            this.KSPInstancesListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.KSPInstancesListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.KSPInstancesListView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.KSPInstancesListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
@@ -67,26 +67,25 @@
             this.KSPInstancesListView.View = System.Windows.Forms.View.Details;
             this.KSPInstancesListView.SelectedIndexChanged += new System.EventHandler(this.KSPInstancesListView_SelectedIndexChanged);
             this.KSPInstancesListView.DoubleClick += new System.EventHandler(this.KSPInstancesListView_DoubleClick);
-            // 
+            //
             // KSPInstallName
-            // 
+            //
             this.KSPInstallName.Text = "Name";
             this.KSPInstallName.Width = 161;
-            // 
+            //
             // KSPInstallVersion
-            // 
+            //
             this.KSPInstallVersion.Text = "Version";
-            this.KSPInstallVersion.Width = 54;
-            // 
+            this.KSPInstallVersion.Width = 100;
+            //
             // KSPInstallPath
-            // 
+            //
             this.KSPInstallPath.Text = "Path";
-            this.KSPInstallPath.Width = 232;
-            // 
+            this.KSPInstallPath.Width = 400;
+            //
             // SelectButton
-            // 
+            //
             this.SelectButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.SelectButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.SelectButton.Enabled = false;
             this.SelectButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.SelectButton.Location = new System.Drawing.Point(399, 320);
@@ -96,9 +95,9 @@
             this.SelectButton.Text = "Select";
             this.SelectButton.UseVisualStyleBackColor = true;
             this.SelectButton.Click += new System.EventHandler(this.SelectButton_Click);
-            // 
+            //
             // AddNewButton
-            // 
+            //
             this.AddNewButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.AddNewButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.AddNewButton.Location = new System.Drawing.Point(318, 320);
@@ -108,9 +107,9 @@
             this.AddNewButton.Text = "Add new";
             this.AddNewButton.UseVisualStyleBackColor = true;
             this.AddNewButton.Click += new System.EventHandler(this.AddNewButton_Click);
-            // 
+            //
             // RenameButton
-            // 
+            //
             this.RenameButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RenameButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.RenameButton.Location = new System.Drawing.Point(237, 320);
@@ -120,9 +119,9 @@
             this.RenameButton.Text = "Rename";
             this.RenameButton.UseVisualStyleBackColor = true;
             this.RenameButton.Click += new System.EventHandler(this.RenameButton_Click);
-            // 
+            //
             // SetAsDefaultCheckbox
-            // 
+            //
             this.SetAsDefaultCheckbox.AutoSize = true;
             this.SetAsDefaultCheckbox.Location = new System.Drawing.Point(12, 324);
             this.SetAsDefaultCheckbox.Name = "SetAsDefaultCheckbox";
@@ -130,9 +129,9 @@
             this.SetAsDefaultCheckbox.TabIndex = 4;
             this.SetAsDefaultCheckbox.Text = "Set as default";
             this.SetAsDefaultCheckbox.UseVisualStyleBackColor = true;
-            // 
+            //
             // ForgetButton
-            // 
+            //
             this.ForgetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ForgetButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ForgetButton.Location = new System.Drawing.Point(156, 320);
@@ -142,9 +141,9 @@
             this.ForgetButton.Text = "Forget";
             this.ForgetButton.UseVisualStyleBackColor = true;
             this.ForgetButton.Click += new System.EventHandler(this.Forget_Click);
-            // 
+            //
             // ChooseKSPInstance
-            // 
+            //
             this.AcceptButton = this.SelectButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -194,7 +194,7 @@ namespace CKAN
 
             configuration = Configuration.LoadOrCreateConfiguration
                 (
-                    Path.Combine(CurrentInstance.GameDir(), "CKAN/GUIConfig.xml"),
+                    Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml"),
                     Repo.default_ckan_repo.ToString()
                 );
 
@@ -428,7 +428,7 @@ namespace CKAN
 
             configuration = Configuration.LoadOrCreateConfiguration
             (
-                Path.Combine(CurrentInstance.GameDir(), "CKAN/GUIConfig.xml"),
+                Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml"),
                 Repo.default_ckan_repo.ToString()
             );
 


### PR DESCRIPTION
## Problems

If a KSP instance that CKAN knows about is removed manually (i.e., the user deletes the folder), an error message is printed at startup:

```
194 [1] WARN CKAN.KSPManager (null) - rss at /Users/lamont/ksp_rss is not a vaild install
```

But it's impossible to remove it from the list of known installs, because it's not added to the list that is manipulated to make that happen. However, if the user _adds_ another instance, then any currently invalid instances are automatically removed.

None of this is particularly desirable. It should always be possible for the user to remove any instance, but no instance should be removed without the user choosing it.

## Changes

Now invalid instances are added to the list of known instances at startup; they appear in the instance selection list in Cmdline, ConsoleUI, and GUI. But if the user tries to use an invalid instance or set it as default, an error message appears indicating that the install is not valid.

This is achieved by defining a new `CKAN.KSP.Valid` property, which guards `CKAN.KSP.CkanDir()` and a few other spots. If `Valid` is `false` when we need it to be `true` to perform an operation, then `NotKSPDirKraken` is thrown and (hopefully) caught by the appropriate UI component. An invalid instance also has a null `Version` property, because you need a valid instance to get the version, so we have to handle that in the instance listing code now.

## Linkages

This is the replacement for #2214. (It's actually attempt <span>#</span>3. With any luck, no one will ever see attempt <span>#</span>2, which involved defining a `Tuple<string, string, KSP>` type and converting `KSPManager.Instances` to return it. Allowing KSP objects to be invalid is much more straightforward and less ugly.)

Fixes #896.
Fixes #1836.
Fixes #1859.

Merry Christmas, Happy Hannukah, and Happy New Year!