### PR TITLE
Don't try to remove autodetected DLLs

### DIFF
--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -34,11 +34,10 @@ namespace CKAN.CmdLine
 
                 // Get the list of installed modules
                 IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
-                var installed = new SortedDictionary<string, Version>(registry.Installed(false));
 
                 // Try every regex on every installed module:
                 // if it matches, select for removal
-                foreach (string mod in installed.Keys)
+                foreach (string mod in registry.InstalledModules.Select(mod => mod.identifier))
                 {
                     if (justins.Any(re => re.IsMatch(mod)))
                         selectedModules.Add(mod);
@@ -52,12 +51,11 @@ namespace CKAN.CmdLine
             if (options.rmall)
             {
                 log.Debug("Removing all mods");
-                // Get the list of installed modules
+                // Add the list of installed modules to the list that should be uninstalled
                 IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
-                var installed = new SortedDictionary<string, Version>(registry.Installed(false));
-
-                // Add it to the list that should be uninstalled.
-                options.modules.AddRange(installed.Keys);
+                options.modules.AddRange(
+                    registry.InstalledModules.Select(mod => mod.identifier)
+                );
             }
 
             if (options.modules != null && options.modules.Count > 0)


### PR DESCRIPTION
## Problem

`ckan remove --all` currently tries to remove autodetected DLLs, which fails. This makes this command unusable on Steam installs, which always have two extra DLLs, `KSPSteamCtrlr` and `Steamworks`.

`ckan remove --re regularexpression` has the same problem if the regular expressions match any autodetected DLL.

## Cause

`Cmdline/Action/Remove.cs` loops over `Registry.Installed`, which includes autodetected DLLs:

```
Installed: KSPSteamCtrlr autodetected dll
Installed: Steamworks autodetected dll
Installed: StockVisualEnhancements 3:1.2.7.0
Installed: SVE-LowResolution 3:1.0.2
Installed: Scatterer-sunflare 2:v0.0320b
Installed: Scatterer-config 2:v0.0320b
Installed: DistantObject-default v1.9.1
Installed: Scatterer 2:v0.0320b
Installed: EnvironmentalVisualEnhancements 2:EVE-1.2.2-1
Installed: ModuleManager 3.0.1
Installed: DistantObject v1.9.1
```

## Changes

Now it uses `Registry.InstalledModules`, which does not include autodetected DLLs:

```
InstalledModule: StockVisualEnhancements 3:1.2.7.0
InstalledModule: SVE-LowResolution 3:1.0.2
InstalledModule: Scatterer-sunflare 2:v0.0320b
InstalledModule: Scatterer-config 2:v0.0320b
InstalledModule: DistantObject-default v1.9.1
InstalledModule: Scatterer 2:v0.0320b
InstalledModule: EnvironmentalVisualEnhancements 2:EVE-1.2.2-1
InstalledModule: ModuleManager 3.0.1
InstalledModule: DistantObject v1.9.1
```

## Before

```
$ mono ckan.exe remove --all
I can't do that, KSPSteamCtrlr isn't installed.
Try `ckan list` for a list of installed mods.
```

## After

```
$ mono ckan.exe remove --all
About to remove:

 * Stock Visual Enhancements 3:1.2.7.0
 * Stock Visual Enhancements-Low Resolution Textures 3:1.0.2
 * scatterer - sunflare 2:v0.0320b
 * scatterer - default config 2:v0.0320b
 * Distant Object Enhancement default config v1.9.1
 * scatterer 2:v0.0320b
 * Environmental Visual Enhancements 2:EVE-1.2.2-1
 * Module Manager 3.0.1
 * Distant Object Enhancement v1.9.1

Continue? [Y/n] 
```

## Linkages

Fixes #1553.