### PR TITLE
Use shared installer code in GUI and fix reinstall problems

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -190,12 +190,12 @@ namespace CKAN
             {
                 if (!ksp.Cache.IsCachedZip(module.download))
                 {
-                    User.RaiseMessage(" * {0} {1}", module.name, module.version);
+                    User.RaiseMessage(" * {0} {1} ({2})", module.name, module.version, module.download.Host);
                     downloads.Add(module);
                 }
                 else
                 {
-                    User.RaiseMessage(" * {0} {1}(cached)", module.name, module.version);
+                    User.RaiseMessage(" * {0} {1} (cached)", module.name, module.version);
                 }
             }
 
@@ -253,23 +253,6 @@ namespace CKAN
             }
 
             User.RaiseProgress("Done!\r\n", 100);
-        }
-
-        public ModuleResolution ResolveModules(IEnumerable<CkanModule> modules, RelationshipResolverOptions options)
-        {
-            var resolver = new RelationshipResolver(modules, options, registry_manager.registry, ksp.VersionCriteria());
-            return new ModuleResolution(resolver.ModList(), m => ksp.Cache.IsCachedZip(m.download));
-        }
-
-        public void EnsureCache(List<CkanModule> modules, IDownloader downloader = null)
-        {
-            if (!modules.Any())
-            {
-                return;
-            }
-
-            downloader = downloader ?? new NetAsyncModulesDownloader(User);
-            downloader.DownloadModules(ksp.Cache, modules);
         }
 
         public void InstallList(ModuleResolution modules, RelationshipResolverOptions options)
@@ -1037,7 +1020,7 @@ namespace CKAN
         /// Will *re-install* with warning even if an upgrade is not available.
         /// Throws ModuleNotFoundKraken if module is not installed, or not available.
         /// </summary>
-        public void Upgrade(IEnumerable<string> identifiers, NetAsyncModulesDownloader netAsyncDownloader, bool enforceConsistency = true)
+        public void Upgrade(IEnumerable<string> identifiers, IDownloader netAsyncDownloader, bool enforceConsistency = true)
         {
             var options = new RelationshipResolverOptions();
 
@@ -1054,7 +1037,7 @@ namespace CKAN
         /// Will *re-install* or *downgrade* (with a warning) as well as upgrade.
         /// Throws ModuleNotFoundKraken if a module is not installed.
         /// </summary>
-        public void Upgrade(IEnumerable<CkanModule> modules, NetAsyncModulesDownloader netAsyncDownloader, bool enforceConsistency = true)
+        public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader, bool enforceConsistency = true)
         {
             // Start by making sure we've downloaded everything.
             DownloadModules(modules, netAsyncDownloader);
@@ -1114,7 +1097,7 @@ namespace CKAN
         /// <summary>
         /// Makes sure all the specified mods are downloaded.
         /// </summary>
-        private void DownloadModules(IEnumerable<CkanModule> mods, NetAsyncModulesDownloader downloader)
+        private void DownloadModules(IEnumerable<CkanModule> mods, IDownloader downloader)
         {
             List<CkanModule> downloads = mods.Where(module => !ksp.Cache.IsCachedZip(module.download)).ToList();
 

--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -193,7 +193,7 @@ namespace CKAN
         internal dynamic MakeRequest(Uri url)
         {
             var web = new WebClient();
-            web.Headers.Add("user-agent", Net.UserAgentString);
+            web.Headers.Add("User-Agent", Net.UserAgentString);
 
             try
             {

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -39,7 +39,7 @@ namespace CKAN
                 size = expectedSize;
                 lastProgressUpdateTime = DateTime.Now;
 
-                agent.Headers.Add("user-agent", Net.UserAgentString);
+                agent.Headers.Add("User-Agent", Net.UserAgentString);
             }
         }
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1143,7 +1143,7 @@ namespace CKAN
 
         private void reinstallToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var module = ModInfoTabControl.SelectedModule;
+            GUIMod module = ModInfoTabControl.SelectedModule;
             if (module == null || !module.IsCKAN)
                 return;
 
@@ -1158,7 +1158,7 @@ namespace CKAN
             // Build the list of changes, first the mod to remove:
             List<ModChange> toReinstall = new List<ModChange>()
             {
-                new ModChange(module, GUIModChangeType.Remove,  null)
+                new ModChange(module, GUIModChangeType.Remove, null)
             };
             // Then everything we need to re-install:
             HashSet<string> goners = registry.FindReverseDependencies(
@@ -1167,11 +1167,7 @@ namespace CKAN
             foreach (string id in goners)
             {
                 toReinstall.Add(new ModChange(
-                    new GUIMod(
-                        registry.LatestAvailable(id, versCrit, null),
-                        registry,
-                        versCrit
-                    ),
+                    mainModList.full_list_of_mod_rows[id]?.Tag as GUIMod,
                     GUIModChangeType.Install,
                     null
                 ));

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -31,6 +31,8 @@ namespace CKAN
 
             IRegistryQuerier registry  = RegistryManager.Instance(manager.CurrentInstance).registry;
             ModuleInstaller  installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
+            // Avoid accumulating multiple event handlers
+            installer.onReportModInstalled -= OnModInstalled;
             installer.onReportModInstalled += OnModInstalled;
             // setup progress callback
 

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -14,7 +14,6 @@ namespace CKAN
     {
         private BackgroundWorker installWorker;
 
-
         // used to signal the install worker that the user canceled the install process
         // this may happen on the recommended/suggested mods dialogs
         private volatile bool installCanceled;
@@ -28,16 +27,16 @@ namespace CKAN
 
             ClearLog();
 
-            var opts =
-                (KeyValuePair<ModChanges, RelationshipResolverOptions>) e.Argument;
+            var opts = (KeyValuePair<ModChanges, RelationshipResolverOptions>) e.Argument;
 
-            IRegistryQuerier registry = RegistryManager.Instance(manager.CurrentInstance).registry;
-            ModuleInstaller installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
+            IRegistryQuerier registry  = RegistryManager.Instance(manager.CurrentInstance).registry;
+            ModuleInstaller  installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
+            installer.onReportModInstalled += OnModInstalled;
             // setup progress callback
 
-            toInstall = new HashSet<CkanModule>();
+            toInstall       = new HashSet<CkanModule>();
             var toUninstall = new HashSet<string>();
-            var toUpgrade = new HashSet<string>();
+            var toUpgrade   = new HashSet<string>();
 
             // First compose sets of what the user wants installed, upgraded, and removed.
             foreach (ModChange change in opts.Key)
@@ -59,14 +58,14 @@ namespace CKAN
             // Now work on satisifying dependencies.
 
             var recommended = new Dictionary<string, List<string>>();
-            var suggested = new Dictionary<string, List<string>>();
+            var suggested   = new Dictionary<string, List<string>>();
 
             foreach (var change in opts.Key)
             {
                 if (change.ChangeType == GUIModChangeType.Install)
                 {
                     AddMod(change.Mod.ToModule().recommends, recommended, change.Mod.Identifier, registry);
-                    AddMod(change.Mod.ToModule().suggests, suggested, change.Mod.Identifier, registry);
+                    AddMod(change.Mod.ToModule().suggests,   suggested,   change.Mod.Identifier, registry);
                 }
             }
 
@@ -89,86 +88,121 @@ namespace CKAN
             tabController.ShowTab("WaitTabPage");
             tabController.SetTabLock(true);
 
-
-            var downloader = new NetAsyncModulesDownloader(GUI.user);
+            IDownloader downloader = new NetAsyncModulesDownloader(GUI.user);
             cancelCallback = () =>
             {
                 downloader.CancelDownload();
                 installCanceled = true;
             };
 
-            GUI.user.RaiseMessage("About to install...\r\n");
-
-            // FIXME: here we should heat up the cache with any mods we're going to install, because
-            // when this transaction types out it messes up everything else.
-            var resolvedMods = installer.ResolveModules(toInstall, opts.Value);
-
-            foreach (var module in resolvedMods.CachedModules)
+            bool resolvedAllProvidedMods = false;
+            while (!resolvedAllProvidedMods)
             {
-                GUI.user.RaiseMessage(" * {0} {1}(cached)", module.name, module.version);
-            }
-
-            foreach (var module in resolvedMods.UncachedModules)
-            {
-                GUI.user.RaiseMessage(" * {0} {1}", module.name, module.version);
-            }
-
-            if (!GUI.user.RaiseYesNoDialog("\r\nContinue?"))
-            {
-                throw new CancelledActionKraken("User declined install list");
-            }
-
-            GUI.user.RaiseMessage(String.Empty); // Just to look tidy.
-
-            installer.EnsureCache(resolvedMods.UncachedModules);
-
-            //Transaction is needed here to revert changes when an installation is cancelled
-            //TODO: Cancellation should be handled in the ModuleInstaller
-            using (var transaction = CkanTransaction.CreateTransactionScope())
-            {
-
-                //Set the result to false/failed in case we return
-                e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
-                SetDescription("Uninstalling selected mods");
-                if (!WasSuccessful(() => installer.UninstallList(toUninstall)))
-                    return;
-                if (installCanceled) return;
-
-                SetDescription("Updating selected mods");
-                if (!WasSuccessful(() => installer.Upgrade(toUpgrade, downloader)))
-                    return;
-                if (installCanceled) return;
-
-                // TODO: We should be able to resolve all our provisioning conflicts
-                // before we start installing anything. CKAN.SanityChecker can be used to
-                // pre-check if our changes are going to be consistent.
-
-                bool resolvedAllProvidedMods = false;
-
-                while (!resolvedAllProvidedMods)
+                try
                 {
+                    e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
+                    if (!installCanceled && toUninstall.Count > 0)
+                    {
+                        installer.UninstallList(toUninstall);
+                    }
+                    if (!installCanceled && toUpgrade.Count > 0)
+                    {
+                        installer.Upgrade(toUpgrade, downloader);
+                    }
+                    if (!installCanceled && toInstall.Count > 0)
+                    {
+                        installer.InstallList(toInstall, opts.Value, downloader);
+                    }
+                    e.Result = new KeyValuePair<bool, ModChanges>(!installCanceled, opts.Key);
                     if (installCanceled)
                     {
-                        e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
-                        return;
-                    }
-                    var ret = InstallList(resolvedMods, opts.Value);
-                    if (!ret)
-                    {
-                        // install failed for some reason, error message is already displayed to the user
-                        e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
                         return;
                     }
                     resolvedAllProvidedMods = true;
                 }
-
-                if (!installCanceled)
+                catch (DependencyNotSatisfiedKraken ex)
                 {
-                    transaction.Complete();
+                    GUI.user.RaiseMessage(
+                        "{0} requires {1} but it is not listed in the index, or not available for your version of KSP.",
+                        ex.parent, ex.module);
+                    return;
+                }
+                catch (ModuleNotFoundKraken ex)
+                {
+                    GUI.user.RaiseMessage(
+                        "Module {0} required but it is not listed in the index, or not available for your version of KSP.",
+                        ex.module);
+                    return;
+                }
+                catch (BadMetadataKraken ex)
+                {
+                    GUI.user.RaiseMessage("Bad metadata detected for module {0}: {1}", ex.module, ex.Message);
+                    return;
+                }
+                catch (FileExistsKraken ex)
+                {
+                    if (ex.owningModule != null)
+                    {
+                        GUI.user.RaiseMessage(
+                            "\r\nOh no! We tried to overwrite a file owned by another mod!\r\n" +
+                            "Please try a `ckan update` and try again.\r\n\r\n" +
+                            "If this problem re-occurs, then it maybe a packaging bug.\r\n" +
+                            "Please report it at:\r\n\r\n" +
+                            "https://github.com/KSP-CKAN/NetKAN/issues/new\r\n\r\n" +
+                            "Please including the following information in your report:\r\n\r\n" +
+                            "File           : {0}\r\n" +
+                            "Installing Mod : {1}\r\n" +
+                            "Owning Mod     : {2}\r\n" +
+                            "CKAN Version   : {3}\r\n",
+                            ex.filename, ex.installingModule, ex.owningModule,
+                            Meta.GetVersion()
+                        );
+                    }
+                    else
+                    {
+                        GUI.user.RaiseMessage(
+                            "\r\n\r\nOh no!\r\n\r\n" +
+                            "It looks like you're trying to install a mod which is already installed,\r\n" +
+                            "or which conflicts with another mod which is already installed.\r\n\r\n" +
+                            "As a safety feature, the CKAN will *never* overwrite or alter a file\r\n" +
+                            "that it did not install itself.\r\n\r\n" +
+                            "If you wish to install {0} via the CKAN,\r\n" +
+                            "then please manually uninstall the mod which owns:\r\n\r\n" +
+                            "{1}\r\n\r\n" + "and try again.\r\n",
+                            ex.installingModule, ex.filename
+                        );
+                    }
+
+                    GUI.user.RaiseMessage("Your GameData has been returned to its original state.\r\n");
+                    return;
+                }
+                catch (InconsistentKraken ex)
+                {
+                    // The prettiest Kraken formats itself for us.
+                    GUI.user.RaiseMessage(ex.InconsistenciesPretty);
+                    return;
+                }
+                catch (CancelledActionKraken)
+                {
+                    return;
+                }
+                catch (MissingCertificateKraken kraken)
+                {
+                    // Another very pretty kraken.
+                    GUI.user.RaiseMessage(kraken.ToString());
+                    return;
+                }
+                catch (DownloadErrorsKraken)
+                {
+                    // User notified in InstallList
+                    return;
+                }
+                catch (DirectoryNotFoundKraken kraken)
+                {
+                    GUI.user.RaiseMessage("\r\n{0}", kraken.Message);
+                    return;
                 }
             }
-
-            e.Result = new KeyValuePair<bool, ModChanges>(!installCanceled, opts.Key);
         }
 
         private void AddMod(IEnumerable<RelationshipDescriptor> relations, Dictionary<string, List<string>> chooseAble,
@@ -232,113 +266,6 @@ namespace CKAN
 
                 tabController.SetTabLock(false);
             }
-        }
-
-        /// <summary>
-        /// Helper function to wrap around calls to ModuleInstaller.
-        /// Handles some of the possible krakens and displays user friendly messages for them.
-        /// </summary>
-        private static bool WasSuccessful(Action action)
-        {
-            try
-            {
-                action();
-            }
-            catch (DependencyNotSatisfiedKraken ex)
-            {
-                GUI.user.RaiseMessage(
-                    "{0} requires {1} but it is not listed in the index, or not available for your version of KSP.",
-                    ex.parent, ex.module);
-                return false;
-            }
-            catch (ModuleNotFoundKraken ex)
-            {
-                GUI.user.RaiseMessage(
-                    "Module {0} required but it is not listed in the index, or not available for your version of KSP.",
-                    ex.module);
-                return false;
-            }
-            catch (BadMetadataKraken ex)
-            {
-                GUI.user.RaiseMessage("Bad metadata detected for module {0}: {1}", ex.module, ex.Message);
-                return false;
-            }
-            catch (FileExistsKraken ex)
-            {
-                if (ex.owningModule != null)
-                {
-                    GUI.user.RaiseMessage(
-                        "\r\nOh no! We tried to overwrite a file owned by another mod!\r\n" +
-                        "Please try a `ckan update` and try again.\r\n\r\n" +
-                        "If this problem re-occurs, then it maybe a packaging bug.\r\n" +
-                        "Please report it at:\r\n\r\n" +
-                        "https://github.com/KSP-CKAN/NetKAN/issues/new\r\n\r\n" +
-                        "Please including the following information in your report:\r\n\r\n" +
-                        "File           : {0}\r\n" +
-                        "Installing Mod : {1}\r\n" +
-                        "Owning Mod     : {2}\r\n" +
-                        "CKAN Version   : {3}\r\n",
-                        ex.filename, ex.installingModule, ex.owningModule,
-                        Meta.GetVersion()
-                        );
-                }
-                else
-                {
-                    GUI.user.RaiseMessage(
-                        "\r\n\r\nOh no!\r\n\r\n" +
-                        "It looks like you're trying to install a mod which is already installed,\r\n" +
-                        "or which conflicts with another mod which is already installed.\r\n\r\n" +
-                        "As a safety feature, the CKAN will *never* overwrite or alter a file\r\n" +
-                        "that it did not install itself.\r\n\r\n" +
-                        "If you wish to install {0} via the CKAN,\r\n" +
-                        "then please manually uninstall the mod which owns:\r\n\r\n" +
-                        "{1}\r\n\r\n" + "and try again.\r\n",
-                        ex.installingModule, ex.filename
-                        );
-                }
-
-                GUI.user.RaiseMessage("Your GameData has been returned to its original state.\r\n");
-                return false;
-            }
-            catch (InconsistentKraken ex)
-            {
-                // The prettiest Kraken formats itself for us.
-                GUI.user.RaiseMessage(ex.InconsistenciesPretty);
-                return false;
-            }
-            catch (CancelledActionKraken)
-            {
-                return false;
-            }
-            catch (MissingCertificateKraken kraken)
-            {
-                // Another very pretty kraken.
-                GUI.user.RaiseMessage(kraken.ToString());
-                return false;
-            }
-            catch (DownloadErrorsKraken)
-            {
-                // User notified in InstallList
-                return false;
-            }
-            catch (DirectoryNotFoundKraken kraken)
-            {
-                GUI.user.RaiseMessage("\r\n{0}", kraken.Message);
-                return false;
-            }
-            return true;
-        }
-        private bool InstallList(ModuleResolution modules, RelationshipResolverOptions options)
-        {
-            if (toInstall.Any())
-            {
-                // actual magic happens here, we run the installer with our mod list
-                var module_installer = ModuleInstaller.GetInstance(manager.CurrentInstance, GUI.user);
-                module_installer.onReportModInstalled = OnModInstalled;
-                return WasSuccessful(() => module_installer.InstallList(modules, options));
-            }
-
-            return true;
         }
 
         private void OnModInstalled(CkanModule mod)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -186,7 +186,7 @@ namespace CKAN
             mainModList.Modules = new ReadOnlyCollection<GUIMod>(
                 mainModList.full_list_of_mod_rows.Values.Select(row => row.Tag as GUIMod).ToList());
 
-            //TODO Consider using smart enum pattern so stuff like this is easier
+            //TODO Consider using smart enumeration pattern so stuff like this is easier
             FilterToolButton.DropDownItems[0].Text = String.Format("Compatible ({0})",
                 mainModList.CountModsByFilter(GUIModFilter.Compatible));
             FilterToolButton.DropDownItems[1].Text = String.Format("Installed ({0})",
@@ -520,7 +520,7 @@ namespace CKAN
                 full_list_of_mod_rows.Remove(mod.Identifier);
                 var item = new DataGridViewRow {Tag = mod};
 
-                ModChange myChange = mc?.Find((ModChange ch) => ch.Mod.Identifier == mod.Identifier);
+                ModChange myChange = mc?.FindLast((ModChange ch) => ch.Mod.Identifier == mod.Identifier);
 
                 var selecting = mod.IsInstallable()
                     ? (DataGridViewCell) new DataGridViewCheckBoxCell() {

--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -25,7 +25,7 @@ namespace CKAN.NetKAN
         [Option("github-token", HelpText = "GitHub OAuth token for API access")]
         public string GitHubToken { get; set; }
 
-        [Option("net-useragent", DefaultValue = null, HelpText = "Set the default user-agent string for HTTP requests")]
+        [Option("net-useragent", DefaultValue = null, HelpText = "Set the default User-Agent string for HTTP requests")]
         public string NetUserAgent { get; set; }
 
         [Option("prerelease", HelpText = "Index GitHub prereleases")]


### PR DESCRIPTION
## Install messages in `ModuleInstaller.InstallList`

- For cached modules, added a space between version and "(cached)"
- For non-cached modules, added indication of download host so the user can make a more informed decision about whether to continue with the downloads

```
$ mono ckan.exe install GPP
1) DistantObject-RealSolarSystem (Distant Object Enhancement Real Solar System config)
2) DistantObject-default (Distant Object Enhancement default config)
Enter a number between 1 and 2 (To cancel press "c" or "n".): 
2
About to install...

 * Galileo's Planet Pack 1.5.88 (github.com)
 * Distant Object Enhancement default config v1.9.1 (cached)
 * Kopernicus Planetary System Modifier 2:release-1.3.1-3 (github.com)
 * ModularFlightIntegrator 1.2.4.0 (cached)
 * scatterer 2:v0.0320b (cached)
 * scatterer - default config 2:v0.0320b (cached)
 * GPP Textures 3.0.0 (github.com)
 * Strategia 1.6.0 (github.com)
 * Custom Barn Kit 1.1.16.0 (ksp.sarbian.com)
 * Contract Configurator 1.23.3 (github.com)
 * Waypoint Manager 2.7.0 (github.com)
 * Final Frontier 1.3.6-3189 (spacedock.info)
 * Distant Object Enhancement v1.9.1 (cached)
 * OPM Galileo 1.2.4 (github.com)
 * Community Terrain Texture Pack 1:1.0.1 (github.com)
 * Kerbal-Konstructs 1.2.0.1 (spacedock.info)
 * Sigma Replacements: Heads H_v0.1.8 (github.com)
 * Sigma Replacements: Suits S_v0.1.5 (github.com)
 * Sigma Replacements: Navigation N_v0.1.3 (github.com)

Continue? [Y/n] 
```

The same changes are visible in ConsoleUI and GUI.

## Code style/refactoring

In addition, some improvements are made to the organization of the code. This should have no visible impact.

- Duplicated installation code in GUI `MainInstaller` removed
  - Replaced with calls to equivalent logic in Core `ModuleInstaller` (modeled after similar function in `ConsoleUI`)
  - Makes the logic consistent in all UIs and easier to maintain (for example, the above change to messages)
  - `ModuleInstaller.ResolveModules` and `ModuleInstaller.EnsureCache` removed because they were only used by the removed redundant GUI code
- `ModuleInstaller.Upgrade` functions accept `IDownloader` reference instead of `NetAsyncModulesDodwnloader`, to make it easier to create alternate downloaders in the future
- All occurrences of HTTP `User-Agent` header properly capitalized