### PR TITLE
Save and restore panel position

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -46,6 +46,8 @@ namespace CKAN
 
         public Size WindowSize = new Size(1024, 500);
 
+        public int PanelPosition = new int(650);
+
         public void Save()
         {
             SaveConfiguration(this, path);

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -26,6 +26,13 @@ namespace CKAN
         public bool SortDescending = false;
 
         private string path = "";
+
+        /// <summary>
+        /// Stores whether main window was maximised or not
+        /// <para> Value is the default - window not maximised</para>
+        /// </summary>
+        public bool IsWindowMaximised = false;
+
         private Point windowLocation = new Point(0,0);
         //Workaround for bug which mis-sets the window location.
         // Here instead of in Main_FormClosing due to the mistaken
@@ -44,10 +51,22 @@ namespace CKAN
             set { windowLocation = value; }
         }
 
+        /// <summary>
+        /// Stores size of unmaximised main window
+        /// <para> value is the default window size used where there is no GUIConfig.xml file</para>
+        /// </summary>
         public Size WindowSize = new Size(1024, 500);
 
+        /// <summary>
+        /// Stores distance from left of the split between the Main Mod List and the metadata panels
+        /// <para> value is the default position used where there is no GUIConfig.xml file</para>
+        /// </summary>
         public int PanelPosition = 650;
 
+        /// <summary>
+        /// Stores distance from top of the split in the first metadata panel between the Name/description, and the mod details
+        /// <para> value is the default position used where there is no GUIConfig.xml file</para>
+        /// </summary>
         public int ModInfoPosition = 235;
 
         public void Save()

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -48,6 +48,8 @@ namespace CKAN
 
         public int PanelPosition = 650;
 
+        public int ModInfoPosition = 235;
+
         public void Save()
         {
             SaveConfiguration(this, path);

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -46,7 +46,7 @@ namespace CKAN
 
         public Size WindowSize = new Size(1024, 500);
 
-        public int PanelPosition = new int(650);
+        public int PanelPosition = 650;
 
         public void Save()
         {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -285,6 +285,7 @@ namespace CKAN
         {
             Location = configuration.WindowLoc;
             Size = configuration.WindowSize;
+            splitContainer1.SplitterDistance = configuration.PanelPosition;
 
             if (!configuration.CheckForUpdatesOnLaunchNoNag && AutoUpdate.CanUpdate)
             {
@@ -405,10 +406,14 @@ namespace CKAN
                 return;
             }
 
+            // Copy window location to app settings
             configuration.WindowLoc = Location;
 
             // Copy window size to app settings
             configuration.WindowSize = WindowState == FormWindowState.Normal ? Size : RestoreBounds.Size;
+
+            // Copy panel position to app settings
+            configuration.PanelPosition = splitContainer1.SplitterDistance;
 
             // Save the active filter
             configuration.ActiveFilter = (int)mainModList.ModFilter;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -285,6 +285,7 @@ namespace CKAN
         {
             Location = configuration.WindowLoc;
             Size = configuration.WindowSize;
+            WindowState = configuration.IsWindowMaximised ? FormWindowState.Maximized : FormWindowState.Normal;
             splitContainer1.SplitterDistance = configuration.PanelPosition;
             ModInfoTabControl.ModMetaSplitPosition = configuration.ModInfoPosition;
 
@@ -410,13 +411,16 @@ namespace CKAN
             // Copy window location to app settings
             configuration.WindowLoc = Location;
 
-            // Copy window size to app settings
+            // Copy window size to app settings if not maximized
             configuration.WindowSize = WindowState == FormWindowState.Normal ? Size : RestoreBounds.Size;
+
+            //copy window maximized state to app settings
+            configuration.IsWindowMaximised = WindowState == FormWindowState.Maximized ? true : false;
 
             // Copy panel position to app settings
             configuration.PanelPosition = splitContainer1.SplitterDistance;
 
-            // Copy window location to app settings
+            // Copy metadata panel split height to app settings
             configuration.ModInfoPosition = ModInfoTabControl.ModMetaSplitPosition;
 
             // Save the active filter

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -286,6 +286,7 @@ namespace CKAN
             Location = configuration.WindowLoc;
             Size = configuration.WindowSize;
             splitContainer1.SplitterDistance = configuration.PanelPosition;
+            ModInfoTabControl.ModMetaSplitPosition = configuration.ModInfoPosition;
 
             if (!configuration.CheckForUpdatesOnLaunchNoNag && AutoUpdate.CanUpdate)
             {
@@ -414,6 +415,9 @@ namespace CKAN
 
             // Copy panel position to app settings
             configuration.PanelPosition = splitContainer1.SplitterDistance;
+
+            // Copy window location to app settings
+            configuration.ModInfoPosition = ModInfoTabControl.ModMetaSplitPosition;
 
             // Save the active filter
             configuration.ActiveFilter = (int)mainModList.ModFilter;

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -61,6 +61,18 @@ namespace CKAN
             }
         }
 
+        public int ModMetaSplitPosition
+        {
+            get
+            {
+                return splitContainer2.SplitterDistance;
+            }
+            set
+            {
+                this.splitContainer2.SplitterDistance = value;
+            }
+        }
+
         private KSPManager manager
         {
             get


### PR DESCRIPTION
Stores the SplitterDistance of the main window in GUIConfig.xml as PanelPosition when closing the window and restores it on opening.

Closes #2208