### PR TITLE
Check version of PowerShell in build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -6,6 +6,16 @@ Param (
     [Object[]]$RemainingArgs
 )
 
+# PSScriptRoot isn't set in PowerShell 2
+$minPSVer = [version]"3.0"
+if (($PSVersionTable.PSVersion -lt $minPSVer)) {
+    [Console]::ForegroundColor = 'red'
+    [Console]::Error.WriteLine("This script does not support PowerShell $($PSVersionTable.PSVersion).")
+    [Console]::Error.WriteLine("Please upgrade to PowerShell $minPSVer or later.")
+    [Console]::ResetColor()
+    exit
+}
+
 # Globals
 $NugetVersion       = "4.4.0"
 $UseExperimental    = $false


### PR DESCRIPTION
## Problem

If you run the current `build.ps1` script with PowerShell 2 or earlier, [the `$PSScriptRoot` variable isn't set](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1), which means several of the build script's variables are set to either the empty string or incomplete values. This has many consequences, for example the `_build` directory is created in the root of the drive.

https://github.com/KSP-CKAN/CKAN/blob/700f70951dfaa352a288b1a70bbf5132379239bc/build.ps1#L12-L18

## Changes

This pull request checks the currently running version of PowerShell and prints an error if it's less than 3.0:

![image](https://user-images.githubusercontent.com/1559108/34390395-7d48d706-eb37-11e7-92f3-fa1b5e3bdb5b.png)

We could try to make the script backwards compatible with PowerShell 2.0, but PowerShell is up to 5.1 now, so it's probably better just to upgrade.

I wanted to use `Write-Error`, but apparently there's no way to turn off its (in this case useless) stack trace output.