### PR TITLE
Add and change logging to make INFO readable

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -48,7 +48,7 @@ namespace CKAN.CmdLine
             }
 
             Logging.Initialize();
-            log.Debug("CKAN started");
+            log.Info("CKAN started.");
 
             // If we're starting with no options then invoke the GUI instead.
             if (args.Length == 0)
@@ -83,6 +83,10 @@ namespace CKAN.CmdLine
             {
                 return printMissingInstanceError(new ConsoleUser(false));
             }
+            finally
+            {
+                log.Info("CKAN exiting.");
+            }
 
             Options cmdline;
             try
@@ -93,17 +97,28 @@ namespace CKAN.CmdLine
             {
                 return AfterHelp();
             }
+            finally
+            {
+                log.Info("CKAN exiting.");
+            }
 
             // Process commandline options.
             CommonOptions options = (CommonOptions)cmdline.options;
             IUser user = new ConsoleUser(options.Headless);
             KSPManager manager = new KSPManager(user);
 
-            int exitCode = options.Handle(manager, user);
-            if (exitCode != Exit.OK)
-                return exitCode;
-            // Don't bother with instances or registries yet because some commands don't need them.
-            return RunSimpleAction(cmdline, options, args, user, manager);
+            try
+            {
+                int exitCode = options.Handle(manager, user);
+                if (exitCode != Exit.OK)
+                    return exitCode;
+                // Don't bother with instances or registries yet because some commands don't need them.
+                return RunSimpleAction(cmdline, options, args, user, manager);
+            }
+            finally
+            {
+                log.Info("CKAN exiting.");
+            }
         }
 
         public static int AfterHelp()

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json;
 
 namespace CKAN
 {
-    
+
     /// <summary>
     ///     Everything for dealing with KSP itself.
     /// </summary>
@@ -55,7 +55,7 @@ namespace CKAN
             {
                 throw new NotKSPDirKraken(gameDir);
             }
-            
+
             this.gameDir = gameDir;
             Init();
             Cache = new NetFileCache(DownloadCacheDir());
@@ -66,7 +66,7 @@ namespace CKAN
         /// </summary>
         private void Init()
         {
-            log.DebugFormat("Initialising {0}", CkanDir());
+            log.InfoFormat("Initialising {0}", CkanDir());
 
             if (! Directory.Exists(CkanDir()))
             {
@@ -98,7 +98,7 @@ namespace CKAN
 
             LoadCompatibleVersions();
 
-            log.DebugFormat("Initialised {0}", CkanDir());
+            log.InfoFormat("Initialised {0}", CkanDir());
         }
 
         public void SetCompatibleVersions(List<KspVersion> compatibleVersions)
@@ -264,7 +264,7 @@ namespace CKAN
                 return readmeVersionProvider.TryGetVersion(directory, out version) ? version : null;
             }
         }
-        
+
         /// <summary>
         /// Rebuilds the "Ships" directory inside the current KSP instance
         /// </summary>
@@ -399,8 +399,8 @@ namespace CKAN
         {
             // TODO: We really should be asking our Cache object to do the
             // cleaning, rather than doing it ourselves.
-            
-            log.Debug("Cleaning cache directory");
+
+            log.Info("Cleaning cache directory");
 
             string[] files = Directory.GetFiles(DownloadCacheDir(), "*", SearchOption.AllDirectories);
 
@@ -450,7 +450,7 @@ namespace CKAN
                 {
                     manager.registry.RegisterDll(this, dll);
                 }
-                    
+
                 tx.Complete();
             }
             manager.Save(enforce_consistency: false);
@@ -468,7 +468,7 @@ namespace CKAN
 
         /// <summary>
         /// Given a path relative to this KSP's GameDir, returns the
-        /// absolute path on the system. 
+        /// absolute path on the system.
         /// </summary>
         public string ToAbsoluteGameDir(string path)
         {

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -277,7 +277,7 @@ namespace CKAN
 
         public void LoadInstancesFromRegistry()
         {
-            log.Debug("Loading KSP instances from registry");
+            log.Info("Loading KSP instances from registry");
 
             instances.Clear();
 

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -411,9 +411,10 @@ namespace CKAN
                 {
                     foreach (InstallableFile file in files)
                     {
-                        log.InfoFormat("Copying {0}", file.source.Name);
+                        log.DebugFormat("Copying {0}", file.source.Name);
                         CopyZipEntry(zipfile, file.source, file.destination, file.makedir);
                     }
+                    log.InfoFormat("Installed {0}", module);
                 }
                 catch (FileExistsKraken kraken)
                 {
@@ -889,7 +890,7 @@ namespace CKAN
                                 directoriesToDelete.Add(directoryName);
                             }
 
-                            log.InfoFormat("Removing {0}", file);
+                            log.DebugFormat("Removing {0}", file);
                             file_transaction.Delete(path);
 
 
@@ -932,7 +933,7 @@ namespace CKAN
                         // This works around GH #251.
                         // The filesystem boundry bug is described in https://transactionalfilemgr.codeplex.com/workitem/20
 
-                        log.InfoFormat("Removing {0}", directory);
+                        log.DebugFormat("Removing {0}", directory);
                         Directory.Delete(directory);
                     }
                     else
@@ -940,6 +941,7 @@ namespace CKAN
                         log.InfoFormat("Not removing directory {0}, it's not empty", directory);
                     }
                 }
+                log.InfoFormat("Removed {0}", modName);
                 transaction.Complete();
             }
         }

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -49,7 +49,7 @@ namespace CKAN
             Log.DebugFormat("Downloading {0} to {1}", url, filename);
 
             var agent = MakeDefaultHttpClient();
-           
+
             try
             {
                 agent.DownloadFile(url, filename);
@@ -228,7 +228,7 @@ namespace CKAN
                 }
                 else
                 {
-                    Log.DebugFormat("{0} redirected to {1}", currentUri, location);
+                    Log.InfoFormat("{0} redirected to {1}", currentUri, location);
 
                     if (Uri.IsWellFormedUriString(location, UriKind.Absolute))
                     {

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -47,7 +47,7 @@ namespace CKAN
 
             watcher.NotifyFilter =
                 NotifyFilters.LastWrite | NotifyFilters.LastAccess | NotifyFilters.DirectoryName | NotifyFilters.FileName;
-            
+
             // If we spot any changes, we fire our event handler.
             watcher.Changed += new FileSystemEventHandler(OnCacheChanged);
             watcher.Created += new FileSystemEventHandler(OnCacheChanged);
@@ -88,7 +88,7 @@ namespace CKAN
         /// </summary>
         public void OnCacheChanged()
         {
-            cachedFiles = null;   
+            cachedFiles = null;
         }
 
         public string GetCachePath()
@@ -124,7 +124,7 @@ namespace CKAN
         /// <summary>
         /// Returns true if a file matching the given URL is cached, but makes no
         /// attempts to check if it's even valid. This is very fast.
-        /// 
+        ///
         /// Use IsCachedZip() for a slower but more reliable method.
         /// </summary>
         public bool IsMaybeCachedZip(Uri url)
@@ -243,7 +243,7 @@ namespace CKAN
             string fullName = String.Format("{0}-{1}", hash, Path.GetFileName(description));
             string targetPath = Path.Combine(cachePath, fullName);
 
-            log.DebugFormat("Storing {0} in {1}", path, targetPath);
+            log.InfoFormat("Storing {0} in {1}", path, targetPath);
 
             if (move)
             {

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -32,7 +32,7 @@ namespace CKAN
             try
             {
                 CkanModule module = CkanModule.FromJson(metadata);
-                log.InfoFormat("Found {0} version {1}", module.identifier, module.version);
+                log.DebugFormat("Found {0} version {1}", module.identifier, module.version);
                 registry.AddAvailable(module);
             }
             catch (Exception exception)

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -285,7 +285,7 @@ namespace CKAN
 
             string json = File.ReadAllText(path);
             registry = JsonConvert.DeserializeObject<Registry>(json, settings);
-            log.DebugFormat("Loaded CKAN registry at {0}", path);
+            log.InfoFormat("Loaded CKAN registry at {0}", path);
         }
 
         private void LoadOrCreate()
@@ -311,7 +311,7 @@ namespace CKAN
         private void Create()
         {
             registry = Registry.Empty();
-            log.DebugFormat("Creating new CKAN registry at {0}", path);
+            log.InfoFormat("Creating new CKAN registry at {0}", path);
             Save();
         }
 
@@ -391,7 +391,7 @@ namespace CKAN
 
         public void Save(bool enforce_consistency = true, bool recommmends = false, bool with_versions = true)
         {
-            log.DebugFormat("Saving CKAN registry at {0}", path);
+            log.InfoFormat("Saving CKAN registry at {0}", path);
 
             if (enforce_consistency)
             {

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -230,7 +230,7 @@ namespace CKAN
 
             foreach (var module in user_requested_mods)
             {
-                log.InfoFormat("Resolving relationships for {0}", module.identifier);
+                log.DebugFormat("Resolving relationships for {0}", module.identifier);
                 Resolve(module, options);
             }
 
@@ -272,7 +272,7 @@ namespace CKAN
             var sub_options = (RelationshipResolverOptions) options.Clone();
             sub_options.with_suggests = false;
 
-            log.InfoFormat("Resolving dependencies for {0}", module.identifier);
+            log.DebugFormat("Resolving dependencies for {0}", module.identifier);
             ResolveStanza(module.depends, new SelectionReason.Depends(module), sub_options, false, old_stanza);
 
             if (options.with_recommends)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -144,7 +144,7 @@ namespace CKAN
 
         private void _UpdateModsList(bool repo_updated, List<ModChange> mc)
         {
-            log.Debug("Updating the mod list");
+            log.Info("Updating the mod list");
 
             KspVersionCriteria versionCriteria = CurrentInstance.VersionCriteria();
             IRegistryQuerier registry = RegistryManager.Instance(CurrentInstance).registry;


### PR DESCRIPTION
## Background

Unbeknownst to many, including myself until today, [CKAN has log file capabilities](https://github.com/KSP-CKAN/CKAN/wiki/User-guide#logging). It can use several different levels of verbosity, with DEBUG being way too slow and verbose (dozens of megabytes of excruciating detail about nothing), and WARN saying little to nothing (errors only, essentially). For purposes of this pull request, assume we're always talking about INFO, which represents a happy medium in between.

## Problems

Currently the INFO log isn't as useful as it could be. It contains many details that users would not care about, and leaves out other important information about what's happening. A typical session generates a very long log file, but it's hard to figure out what actually happened from it.

## Changes

This pull request aims to make the INFO log useful and readable for typical usage. Each high level step that CKAN takes ought to be logged, while each low level operation should be relegated to DEBUG unless there's a problem.

Moved from INFO to DEBUG (decreased visibility):

- Per-file install/remove messages
- Resolving relationships for modname
- Resolving dependencies for modname
- Found modname version v (when updating registry)

Moved from DEBUG to INFO (increased visibility):

- CKAN started.
- Initialising KSP/CKAN
- Initialised KSP/CKAN
- Cleaning cache directory
- Loading KSP instances from registry
- URL redirected to URL
- Updating the mod list
- Creating / Saving / Loading CKAN registry
- Stored file to cachename

Added to INFO:

- Installed modname
- Removed modname
- CKAN exiting.

After these changes, my INFO logs are a lot easier to make sense of.