### PR TITLE
Don't clear available modules till after the new list is ready

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -136,7 +136,7 @@ namespace CKAN.CmdLine
 
             var updated = repository == null
                 ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, user)
-                : CKAN.Repo.Update(registry_manager, ksp, user, true, repository);
+                : CKAN.Repo.Update(registry_manager, ksp, user, repository);
 
             user.RaiseMessage("Updated information on {0} available modules", updated);
         }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -347,13 +347,16 @@ namespace CKAN
 
         #endregion
 
-        /// <summary>
-        /// Clears all available modules from the registry.
-        /// </summary>
-        public void ClearAvailable()
+        public void SetAllAvailable(IEnumerable<CkanModule> newAvail)
         {
             SealionTransaction();
+            // Clear current modules
             available_modules = new Dictionary<string, AvailableModule>();
+            // Add the new modules
+            foreach (CkanModule module in newAvail)
+            {
+                AddAvailable(module);
+            }
         }
 
         /// <summary>
@@ -365,7 +368,7 @@ namespace CKAN
 
             var identifier = module.identifier;
             // If we've never seen this module before, create an entry for it.
-            if (! available_modules.ContainsKey(identifier))
+            if (!available_modules.ContainsKey(identifier))
             {
                 log.DebugFormat("Adding new available module {0}", identifier);
                 available_modules[identifier] = new AvailableModule(identifier);

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -14,6 +14,7 @@ namespace Tests.Core.Net
     public class NetAsyncModulesDownloader
     {
 
+        private CKAN.RegistryManager manager;
         private CKAN.Registry registry;
         private DisposableKSP ksp;
         private CKAN.IDownloader async;
@@ -29,13 +30,12 @@ namespace Tests.Core.Net
 
             // Give us a registry to play with.
             ksp = new DisposableKSP();
-            registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
-            registry.ClearAvailable();
+            manager = CKAN.RegistryManager.Instance(ksp.KSP);
+            registry = manager.registry;
             registry.ClearDlls();
             registry.Installed().Clear();
-
             // Make sure we have a registry we can use.
-            CKAN.Repo.UpdateRegistry(TestData.TestKANZip(), registry, ksp.KSP, new NullUser());
+            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
 
             // Ready our downloader.
             async = new CKAN.NetAsyncModulesDownloader(new NullUser());
@@ -128,4 +128,3 @@ namespace Tests.Core.Net
 
     }
 }
-

--- a/Tests/Core/Net/Repo.cs
+++ b/Tests/Core/Net/Repo.cs
@@ -8,6 +8,7 @@ namespace Tests.Core.Net
     [TestFixture]
     public class Repo
     {
+        private CKAN.RegistryManager manager;
         private CKAN.Registry registry;
         private DisposableKSP ksp;
 
@@ -15,8 +16,8 @@ namespace Tests.Core.Net
         public void Setup()
         {
             ksp = new DisposableKSP();
-            registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
-            registry.ClearAvailable();
+            manager = CKAN.RegistryManager.Instance(ksp.KSP);
+            registry = manager.registry;
             registry.ClearDlls();
             registry.Installed().Clear();
         }
@@ -30,7 +31,7 @@ namespace Tests.Core.Net
         [Test]
         public void UpdateRegistryTarGz()
         {
-            CKAN.Repo.UpdateRegistry(TestData.TestKANTarGz(), registry, ksp.KSP, new NullUser());
+            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANTarGz());
 
             // Test we've got an expected module.
             CkanModule far = registry.LatestAvailable("FerramAerospaceResearch", new KspVersionCriteria(KspVersion.Parse("0.25.0")));
@@ -41,10 +42,10 @@ namespace Tests.Core.Net
         [Test]
         public void UpdateRegistryZip()
         {
-            CKAN.Repo.UpdateRegistry(TestData.TestKANZip(), registry, ksp.KSP, new NullUser());
+            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
 
             // Test we've got an expected module.
-                CkanModule far = registry.LatestAvailable("FerramAerospaceResearch", new KspVersionCriteria (KspVersion.Parse("0.25.0")));
+            CkanModule far = registry.LatestAvailable("FerramAerospaceResearch", new KspVersionCriteria(KspVersion.Parse("0.25.0")));
 
             Assert.AreEqual("v0.14.3.2", far.version.ToString());
         }
@@ -54,7 +55,7 @@ namespace Tests.Core.Net
         {
             Assert.DoesNotThrow(delegate
             {
-                CKAN.Repo.UpdateRegistry(TestData.BadKANTarGz(), registry, ksp.KSP, new NullUser());
+                CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.BadKANTarGz());
             });
         }
 
@@ -62,9 +63,9 @@ namespace Tests.Core.Net
         public void BadKanZip()
         {
             Assert.DoesNotThrow(delegate
-                {
-                    CKAN.Repo.UpdateRegistry(TestData.BadKANZip(), registry, ksp.KSP, new NullUser());
-                });
+            {
+                CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.BadKANZip());
+            });
         }
     }
 }

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -13,6 +13,7 @@ namespace Tests.Core.Relationships
     [TestFixture]
     public class SanityChecker
     {
+        private CKAN.RegistryManager manager;
         private CKAN.Registry registry;
         private DisposableKSP ksp;
 
@@ -21,12 +22,11 @@ namespace Tests.Core.Relationships
         {
             ksp = new DisposableKSP();
 
-            registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
-            registry.ClearAvailable();
+            manager = CKAN.RegistryManager.Instance(ksp.KSP);
+            registry = manager.registry;
             registry.ClearDlls();
             registry.Installed().Clear();
-
-            Repo.UpdateRegistry(TestData.TestKANZip(), registry, ksp.KSP, new NullUser());
+            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
         }
 
         [Test]
@@ -191,4 +191,3 @@ namespace Tests.Core.Relationships
         }
     }
 }
-


### PR DESCRIPTION
## Problem

There are sporadic but repeated reports of `ModuleNotFoundKraken` being thrown in `Registry.AllAvailable`. This happens when `available_modules` is empty.

See #1994 and KSP-CKAN/NetKAN#5907 for examples.

## Cause

Currently when we update the registry, we clear `available_modules` first, then request the remote repo data and parse it. If anything goes wrong with those network requests or the parsing, we can't un-clear `available_modules`; it's gone, and that's that, and we have nothing to replace it with.

## Changes

This pull request refactors the relevant code to avoid clearing `available_modules` until the full new list of available modules is retrieved and non-empty. The low-level retrieval and parsing functions are changed to return the new values rather than setting them into a `Registry` object. The higher level functions are updated to receive these return values and pass them to a new `Registry.SetAllAvailable` function, which replaces `Registry.ClearAvailable`. If any exceptions are thrown or if we finish the update process without finding any available modules, then the registry will not be changed.

Fixes #1994.
Fixes KSP-CKAN/NetKAN#5907.
Fixes KSP-CKAN/NetKAN#5963.