### PR TITLE
Save timestamped .ckan files after we save the registry

### DIFF
--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -246,8 +246,7 @@ namespace CKAN.CmdLine
             try
             {
                 string path = options.path;
-                CKAN.KSP ksp = new CKAN.KSP(path, User);
-                Manager.AddInstance(options.name, ksp);
+                Manager.AddInstance(new CKAN.KSP(path, options.name, User));
                 User.RaiseMessage("Added \"{0}\" with root \"{1}\" to known installs", options.name, options.path);
                 return Exit.OK;
             }

--- a/ConsoleUI/KSPAddScreen.cs
+++ b/ConsoleUI/KSPAddScreen.cs
@@ -28,7 +28,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override void Save()
         {
-            manager.AddInstance(name.Value, new KSP(path.Value, new NullUser()));
+            manager.AddInstance(new KSP(path.Value, name.Value, new NullUser()));
         }
     }
 

--- a/ConsoleUI/KSPEditScreen.cs
+++ b/ConsoleUI/KSPEditScreen.cs
@@ -17,7 +17,7 @@ namespace CKAN.ConsoleUI {
         /// <param name="mgr">KSP manager containing the instances</param>
         /// <param name="k">Instance to edit</param>
         public KSPEditScreen(KSPManager mgr, KSP k)
-            : base(mgr, KSPListScreen.InstallName(mgr, k), k.GameDir())
+            : base(mgr, k.Name, k.GameDir())
         {
             ksp = k;
             try {
@@ -158,7 +158,7 @@ namespace CKAN.ConsoleUI {
                 // Notify the user that the registry doesn't parse
                 AddObject(new ConsoleLabel(
                     1, repoFrameTop, -1,
-                    () => $"Failed to extract mod list sources from {KSPListScreen.InstallName(manager, ksp)}."
+                    () => $"Failed to extract mod list sources from {ksp.Name}."
                 ));
 
             }
@@ -180,7 +180,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override bool Valid()
         {
-            if (name.Value != KSPListScreen.InstallName(manager, ksp)
+            if (name.Value != ksp.Name
                     && !nameValid()) {
                 return false;
             }
@@ -207,15 +207,15 @@ namespace CKAN.ConsoleUI {
                 ksp.SetCompatibleVersions(compatEditList);
             }
 
-            string oldName = KSPListScreen.InstallName(manager, ksp);
+            string oldName = ksp.Name;
             if (path.Value != ksp.GameDir()) {
                 // If the path is changed, then we have to remove the old instance
                 // and replace it with a new one, whether or not the name is changed.
                 manager.RemoveInstance(oldName);
-                manager.AddInstance(name.Value, new KSP(path.Value, new NullUser()));
+                manager.AddInstance(new KSP(path.Value, name.Value, new NullUser()));
             } else if (name.Value != oldName) {
                 // If only the name changed, there's an API for that.
-                manager.RenameInstance(KSPListScreen.InstallName(manager, ksp), name.Value);
+                manager.RenameInstance(ksp.Name, name.Value);
             }
         }
 

--- a/ConsoleUI/KSPListScreen.cs
+++ b/ConsoleUI/KSPListScreen.cs
@@ -37,7 +37,7 @@ namespace CKAN.ConsoleUI {
                     }, new ConsoleListBoxColumn<KSP>() {
                         Header   = "Name",
                         Width    = 20,
-                        Renderer = k => InstallName(manager, k)
+                        Renderer = k => k.Name
                     }, new ConsoleListBoxColumn<KSP>() {
                         Header   = "Version",
                         Width    = 12,
@@ -65,13 +65,13 @@ namespace CKAN.ConsoleUI {
             AddBinding(Keys.Enter, (object sender) => {
 
                 ConsoleMessageDialog d = new ConsoleMessageDialog(
-                    $"Loading instance {InstallName(manager, kspList.Selection)}...",
+                    $"Loading instance {kspList.Selection.Name}...",
                     new List<string>()
                 );
 
                 if (TryGetInstance(kspList.Selection, () => { d.Run(() => {}); })) {
                     try {
-                        manager.SetCurrentInstance(InstallName(manager, kspList.Selection));
+                        manager.SetCurrentInstance(kspList.Selection.Name);
                     } catch (Exception ex) {
                         // This can throw if the previous current instance had an error,
                         // since it gets destructed when it's replaced.
@@ -91,7 +91,7 @@ namespace CKAN.ConsoleUI {
             });
             kspList.AddTip("R", "Remove");
             kspList.AddBinding(Keys.R, (object sender) => {
-                manager.RemoveInstance(InstallName(manager, kspList.Selection));
+                manager.RemoveInstance(kspList.Selection.Name);
                 kspList.SetData(manager.Instances.Values);
                 return true;
             });
@@ -99,7 +99,7 @@ namespace CKAN.ConsoleUI {
             kspList.AddBinding(Keys.E, (object sender) => {
 
                 ConsoleMessageDialog d = new ConsoleMessageDialog(
-                    $"Loading instance {InstallName(manager, kspList.Selection)}...",
+                    $"Loading instance {kspList.Selection.Name}...",
                     new List<string>()
                 );
                 TryGetInstance(kspList.Selection, () => { d.Run(() => {}); });
@@ -112,7 +112,7 @@ namespace CKAN.ConsoleUI {
 
             kspList.AddTip("D", "Default");
             kspList.AddBinding(Keys.D, (object sender) => {
-                string name = InstallName(manager, kspList.Selection);
+                string name = kspList.Selection.Name;
                 if (name == manager.AutoStartInstance) {
                     manager.ClearAutoStart();
                 } else {
@@ -134,25 +134,6 @@ namespace CKAN.ConsoleUI {
             LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
             CenterHeader = () => "KSP Instances";
             mainMenu     = kspList.SortMenu();
-        }
-
-        /// <summary>
-        /// Return the name of an instance of the game.
-        /// It's not in an object because it's the key of the main dictionary holding them.
-        /// </summary>
-        /// <param name="manager">KSP manager object containing the instances</param>
-        /// <param name="ksp">Game instance to look up</param>
-        /// <returns>
-        /// Name of the instance
-        /// </returns>
-        public static string InstallName(KSPManager manager, KSP ksp)
-        {
-            foreach (var kvp in manager.Instances) {
-                if (kvp.Value == ksp) {
-                    return kvp.Key;
-                }
-            }
-            return null;
         }
 
         /// <summary>
@@ -221,7 +202,7 @@ namespace CKAN.ConsoleUI {
 
         private string StatusSymbol(KSP k)
         {
-            return InstallName(manager, k) == manager.AutoStartInstance
+            return k.Name == manager.AutoStartInstance
                 ? defaultMark
                 : " ";
         }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -274,7 +274,7 @@ namespace CKAN.ConsoleUI {
             mainMenu = new ConsolePopupMenu(opts);
 
             LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => $"KSP {manager.CurrentInstance.Version().ToString()} ({KSPListScreen.InstallName(manager, manager.CurrentInstance)})";
+            CenterHeader = () => $"KSP {manager.CurrentInstance.Version().ToString()} ({manager.CurrentInstance.Name})";
         }
 
         // Alt+H doesn't work on Mac, but F1 does, and we need
@@ -466,8 +466,12 @@ namespace CKAN.ConsoleUI {
             try {
                 // Save the mod list as "depends" without the installed versions.
                 // Beacause that's supposed to work.
-                RegistryManager.Instance(manager.CurrentInstance).Save(true, false, false);
-                RaiseError($"Mod list exported to {Path.Combine(manager.CurrentInstance.CkanDir(), "installed-default.ckan")}");
+                RegistryManager.Instance(manager.CurrentInstance).Save(true);
+                string path = Path.Combine(
+                    manager.CurrentInstance.CkanDir(),
+                    $"installed-{manager.CurrentInstance.Name}.ckan"
+                );
+                RaiseError($"Mod list exported to {path}");
             } catch (Exception ex) {
                 RaiseError($"Export failed: {ex.Message}");
             }

--- a/Core/CkanTransaction.cs
+++ b/Core/CkanTransaction.cs
@@ -10,12 +10,14 @@ namespace CKAN
 
         public static TransactionScope CreateTransactionScope()
         {
-            var transactionOptions = new TransactionOptions
-            {
-                Timeout = TransactionManager.MaximumTimeout
-            };
-            return  new TransactionScope(TransactionScopeOption.Required, transactionOptions);
+            return new TransactionScope(TransactionScopeOption.Required, transOpts);
         }
+
+        private static TransactionOptions transOpts = new TransactionOptions()
+        {
+            IsolationLevel = IsolationLevel.ReadCommitted,
+            Timeout        = TransactionManager.MaximumTimeout
+        };
 
     }
 }

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -18,7 +18,7 @@ namespace CKAN
 {
 
     /// <summary>
-    ///     Everything for dealing with KSP itself.
+    /// Everything for dealing with KSP itself.
     /// </summary>
     public class KSP : IDisposable
     {
@@ -31,6 +31,8 @@ namespace CKAN
         private readonly string gameDir;
         private KspVersion version;
         private List<KspVersion> _compatibleVersions = new List<KspVersion>();
+
+        public string Name { get; internal set; }
         public KspVersion VersionOfKspWhenCompatibleVersionsWereStored { get; private set; }
         public bool CompatibleVersionsAreFromDifferentKsp { get { return _compatibleVersions.Count > 0 && VersionOfKspWhenCompatibleVersionsWereStored != Version(); } }
 
@@ -40,12 +42,13 @@ namespace CKAN
         #region Construction and Initialisation
 
         /// <summary>
-        /// Returns a KSP object, insisting that directory contains a valid KSP install.
-        /// Will initialise a CKAN instance in the KSP dir if it does not already exist.
-        /// Throws a NotKSPDirKraken if directory is not a KSP install.
+        /// Returns a KSP object.
+        /// Will initialise a CKAN instance in the KSP dir if it does not already exist,
+        /// if the directory contains a valid KSP install.
         /// </summary>
-        public KSP(string gameDir, IUser user)
+        public KSP(string gameDir, string name, IUser user)
         {
+            Name = name;
             User = user;
             // Make sure our path is absolute and has normalised slashes.
             this.gameDir = KSPPathUtils.NormalizePath(Path.GetFullPath(gameDir));
@@ -60,7 +63,7 @@ namespace CKAN
         public bool Valid { get { return IsKspDir(gameDir); } }
 
         /// <summary>
-        ///     Create the CKAN directory and any supporting files.
+        /// Create the CKAN directory and any supporting files.
         /// </summary>
         private void SetupCkanDirectories()
         {
@@ -80,6 +83,11 @@ namespace CKAN
             {
                 User.RaiseMessage("Creating {0}", DownloadCacheDir());
                 Directory.CreateDirectory(DownloadCacheDir());
+            }
+            if (!Directory.Exists(InstallHistoryDir()))
+            {
+                User.RaiseMessage("Creating {0}", InstallHistoryDir());
+                Directory.CreateDirectory(InstallHistoryDir());
             }
 
             // Clear any temporary files we find. If the directory
@@ -177,8 +185,6 @@ namespace CKAN
 
             log.DebugFormat("Checking if KSP is in my exe dir: {0}", exe_dir);
 
-            // Checking for a GameData directory probably isn't the best way to
-            // detect KSP, but it works. More robust implementations welcome.
             if (IsKspDir(exe_dir))
             {
                 log.InfoFormat("KSP found at {0}", exe_dir);
@@ -215,6 +221,8 @@ namespace CKAN
         /// <summary>
         /// Checks if the specified directory looks like a KSP directory.
         /// Returns true if found, false if not.
+        /// Checking for a GameData directory probably isn't the best way to
+        /// detect KSP, but it works. More robust implementations welcome.
         /// </summary>
         internal static bool IsKspDir(string directory)
         {
@@ -306,6 +314,13 @@ namespace CKAN
         {
             return KSPPathUtils.NormalizePath(
                 Path.Combine(CkanDir(), "downloads")
+            );
+        }
+
+        public string InstallHistoryDir()
+        {
+            return KSPPathUtils.NormalizePath(
+                Path.Combine(CkanDir(), "history")
             );
         }
 

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -75,7 +75,7 @@ namespace CKAN
 
             if (path != null)
             {
-                return new KSP(path, User);
+                return new KSP(path, "portable", User);
             }
 
             // If we only know of a single instance, return that.
@@ -114,7 +114,7 @@ namespace CKAN
             try
             {
                 string gamedir = KSP.FindGameDir();
-                return AddInstance("auto", new KSP(gamedir, User));
+                return AddInstance(new KSP(gamedir, "auto", User));
             }
             catch (DirectoryNotFoundException)
             {
@@ -130,10 +130,11 @@ namespace CKAN
         /// Adds a KSP instance to registry.
         /// Returns the resulting KSP object.
         /// </summary>
-        public KSP AddInstance(string name, KSP ksp_instance)
+        public KSP AddInstance(KSP ksp_instance)
         {
             if (ksp_instance.Valid)
             {
+                string name = ksp_instance.Name;
                 instances.Add(name, ksp_instance);
                 Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);
             }
@@ -203,16 +204,15 @@ namespace CKAN
         /// <summary>
         /// Renames an instance in the registry and saves.
         /// </summary>
-        ///
-        // TODO: What should we do if our target name already exists?
         public void RenameInstance(string from, string to)
         {
-            var ksp = instances[from];
+            // TODO: What should we do if our target name already exists?
+            KSP ksp = instances[from];
             instances.Remove(from);
+            ksp.Name = to;
             instances.Add(to, ksp);
             Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);
         }
-
 
         /// <summary>
         /// Sets the current instance.
@@ -245,7 +245,7 @@ namespace CKAN
 
         public void SetCurrentInstanceByPath(string path)
         {
-            KSP ksp = new KSP(path, User);
+            KSP ksp = new KSP(path, "custom", User);
             if (ksp.Valid)
             {
                 CurrentInstance = ksp;
@@ -294,7 +294,7 @@ namespace CKAN
                 var path = instance.Item2;
                 log.DebugFormat("Loading {0} from {1}", name, path);
                 // Add unconditionally, sort out invalid instances downstream
-                instances.Add(name, new KSP(path, User));
+                instances.Add(name, new KSP(path, name, User));
             }
 
             try
@@ -307,6 +307,7 @@ namespace CKAN
                 AutoStartInstance = null;
             }
         }
+
     }
 
     public class KSPManagerKraken : Kraken

--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -72,10 +72,10 @@ namespace CKAN
             var path = Path.GetDirectoryName(_instanceDialog.FileName);
             try
             {
-                KSP instance = new KSP(path, GUI.user);                
                 var instanceName = Path.GetFileName(path);
+                KSP instance = new KSP(path, instanceName, GUI.user);
                 instanceName = _manager.GetNextValidInstanceName(instanceName);
-                _manager.AddInstance(instanceName, instance);
+                _manager.AddInstance(instance);
                 UpdateInstancesList();
             }
             catch (NotKSPDirKraken k)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -998,10 +998,9 @@ namespace CKAN
                     }
 
                     // Save, just to be certain that the installed-*.ckan metapackage is generated.
-                    RegistryManager.Instance(CurrentInstance).Save(true, recommends, versions);
-
-                    // TODO: The core might eventually save as something other than 'installed-default.ckan'
-                    File.Copy(Path.Combine(CurrentInstance.CkanDir(), "installed-default.ckan"), dlg.FileName, true);
+                    RegistryManager mgr = RegistryManager.Instance(CurrentInstance);
+                    mgr.Save(true);
+                    mgr.ExportInstalled(dlg.FileName, recommends, versions);
                 }
                 else
                 {
@@ -1152,8 +1151,7 @@ namespace CKAN
             if (reinstallDialog.ShowYesNoDialog(confirmationText) == DialogResult.No)
                 return;
 
-            IRegistryQuerier   registry = RegistryManager.Instance(CurrentInstance).registry;
-            KspVersionCriteria versCrit = CurrentInstance.VersionCriteria();
+            IRegistryQuerier registry = RegistryManager.Instance(CurrentInstance).registry;
 
             // Build the list of changes, first the mod to remove:
             List<ModChange> toReinstall = new List<ModChange>()

--- a/Tests/Core/KSP.cs
+++ b/Tests/Core/KSP.cs
@@ -18,7 +18,7 @@ namespace Tests.Core
         {
             ksp_dir = TestData.NewTempDir();
             TestData.CopyDirectory(TestData.good_ksp_dir(), ksp_dir);
-            ksp = new CKAN.KSP(ksp_dir,NullUser.User);
+            ksp = new CKAN.KSP(ksp_dir, "test", NullUser.User);
         }
 
         [TearDown]
@@ -32,7 +32,7 @@ namespace Tests.Core
                 CKAN.RegistryManager.Instance(ksp).Dispose();
                 ksp.Dispose();
             }
-            
+
             Directory.Delete(ksp_dir, true);
         }
 

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -101,8 +101,9 @@ namespace Tests.Core
             using (var tidy2 = new DisposableKSP())
             {
                 const string newInstance = "tidy2";
+                tidy2.KSP.Name = newInstance;
                 Assert.That(manager.HasInstance(newInstance), Is.False);
-                manager.AddInstance(newInstance, tidy2.KSP);
+                manager.AddInstance(tidy2.KSP);
                 Assert.That(manager.HasInstance(newInstance),Is.True);
             }
         }

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -38,7 +38,7 @@ namespace Tests.Data
                 File.Copy(registryFile, registryPath, true);
             }
 
-            KSP = new KSP(_disposableDir, NullUser.User);
+            KSP = new KSP(_disposableDir, "disposable", NullUser.User);
             Logging.Initialize();
         }
 
@@ -74,4 +74,3 @@ namespace Tests.Data
         }
     }
 }
-


### PR DESCRIPTION
## Motivation

Currently if users install and uninstall lots of mods, they have no record of the changes. This can be a problem if one of the mods they install is not compatible, since they have no easy way to return to an older state or even know what the older states were.

We do create a `CKAN/installed-default.ckan` file containing the list of installed mods, but this is overwritten each time the mod list changes.

## Changes

Now each CKAN folder will have a `history` subfolder created, and when the list of installed mods is changed, a new file with a name like this is created:

- `installed-steam-2018-01-02_22-21-37.ckan`

This contains the same info as the `installed-default.ckan` file, but it will not be overwritten by later changes, because the file name contains the change timestamp. This allows the user to quietly accumulate a history of all their mod lists over time, and if they post a problem on the forum, we can tell them, "Check the CKAN/history folder for your older installs."

Also a few code cleanup changes:

- There was a TODO about changing the "default" part of "installed-default" to be the name of the instance. This is now done.
  - To make that happen, the `KSP` class now has a public `Name` property.
  - The existence of `KSP.Name` makes `ModListScreen.InstallName` obsolete, so it is removed.
- There is now a public function specifically for generating custom .ckan files, and that option in GUI no longer depends on making a copy of `installed-default.ckan` after the fact.

Fixes #1504, unless you think it should include a first-class rollback UI.