### PR TITLE
Check provides for optional dependencies in GUI

### DIFF
--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -231,7 +231,29 @@ namespace CKAN
                         chooseAble[mod.name].Add(identifier);
                     }
                 }
-                // XXX - Don't ignore all krakens! Those things are important!
+                catch (ModuleNotFoundKraken)
+                {
+                    List<CkanModule> providers = registry.LatestAvailableWithProvides(
+                        mod.name,
+                        CurrentInstance.VersionCriteria(),
+                        mod
+                    );
+                    foreach (CkanModule provider in providers)
+                    {
+                        if (!registry.IsInstalled(provider.identifier)
+                            && !toInstall.Any(m => m.identifier == provider.identifier))
+                        {
+                            // We want to show this mod to the user. Add it.
+                            if (!chooseAble.ContainsKey(provider.identifier))
+                            {
+                                // Add a new entry if this provider isn't listed yet.
+                                chooseAble.Add(provider.identifier, new List<string>());
+                            }
+                            // Add the dependent mod to the list of reasons this dependency is shown.
+                            chooseAble[provider.identifier].Add(identifier);
+                        }
+                    }
+                }
                 catch (Kraken)
                 {
                 }


### PR DESCRIPTION
## Problem

In GUI, `provides` relationships are only checked for `depends`; if a mod suggests or recommends a virtual package, it's not shown.

One example is ProceduralFairings in KSP 1.2.2; it `suggests` a virtual package called `PFTextures`, which is provided by another module. Currently this module doesn't appear in GUI as a suggestion when installing ProceduralFairings.

![image](https://user-images.githubusercontent.com/1559108/34510533-35963b64-f01a-11e7-803d-460244496170.png)

## Changes

Now if we don't find the exact name of an optional dependency, we check for mods that provide it and add them to the recommendation/suggestion lists for the user to choose.

![image](https://user-images.githubusercontent.com/1559108/34510504-fce4ae18-f019-11e7-8d1a-f214dbdbd6e3.png)

Fixes #1234.