### PR TITLE
Update registry at start of GUI if available_modules is empty

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -360,6 +360,17 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Check whether the available_modules list is empty
+        /// </summary>
+        /// <returns>
+        /// True if we have at least one available mod, false otherwise.
+        /// </returns>
+        public bool HasAnyAvailable()
+        {
+            return available_modules.Count > 0;
+        }
+
+        /// <summary>
         /// Mark a given module as available.
         /// </summary>
         public void AddAvailable(CkanModule module)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -341,9 +341,15 @@ namespace CKAN
 
             CurrentInstanceUpdated();
 
-            // If we're auto-updating then we shouldn't interfere progress tab
-            if (configuration.RefreshOnStartup && !autoUpdating)
+            // We would like to refresh if we're configured to refresh on startup,
+            // or if we have no currently available modules.
+            bool repoUpdateNeeded = configuration.RefreshOnStartup
+                || !RegistryManager.Instance(CurrentInstance).registry.HasAnyAvailable();
+            // If we're auto-updating the client then we shouldn't interfere with the progress tab
+            if (!autoUpdating && repoUpdateNeeded)
+            {
                 UpdateRepo();
+            }
 
             Text = $"CKAN {Meta.GetVersion()} - KSP {CurrentInstance.Version()}  --  {CurrentInstance.GameDir()}";
 


### PR DESCRIPTION
## Problem

If the registry's `available_modules` list is empty while GUI is trying to use it, null reference exceptions can occur.
See #1994 and KSP-CKAN/NetKAN#5907 for examples.

## Relevant side notes

The GUI already auto-refreshes the `available_modules` list at startup if `configuration.RefreshOnStartup` is true.

`available_modules` is empty by default when first adding a new instance, which we handle by setting `configuration.RefreshOnStartup` to true for such a newly added instance, so the registry will be loaded when we get to that part of the initialization.

## Changes

Now the GUI performs its registry auto-refresh in one more situation: when `available_modules` is empty. This ensures that we will re-download the registry if we need to.

## Linkages

Closes #2115. After looking at that pull request, I don't think the approach is workable; `Create` resets the registry completely, which we do not want in this case because information about installed modules and source repositories is lost. And it doesn't solve the problem; if `configuration.RefreshOnStartup` is false, then `available_modules` would stay empty and the app would still crash.