### PR TITLE
Allow uninstallation of mods while Incompatible filter is selected

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -701,46 +701,44 @@ namespace CKAN
 
         private async void ModList_CellValueChanged(object sender, DataGridViewCellEventArgs e)
         {
-            if (mainModList.ModFilter == GUIModFilter.Incompatible)
-                return;
-
-            var row_index = e.RowIndex;
-            var column_index = e.ColumnIndex;
+            int row_index    = e.RowIndex;
+            int column_index = e.ColumnIndex;
 
             if (row_index < 0 || column_index < 0)
                 return;
 
-            var registry_manager = RegistryManager.Instance(CurrentInstance);
+            DataGridView     grid     = sender as DataGridView;
+            DataGridViewRow  row      = grid?.Rows[row_index];
+            DataGridViewCell gridCell = row?.Cells[column_index];
 
-            var grid = sender as DataGridView;
-
-            var row = grid.Rows[row_index];
-            var grid_view_cell = row.Cells[column_index];
-
-            if (grid_view_cell is DataGridViewLinkCell)
+            if (gridCell is DataGridViewLinkCell)
             {
-                var cell = grid_view_cell as DataGridViewLinkCell;
-                Process.Start(cell.Value.ToString());
+                // Launch URLs if found in grid
+                DataGridViewLinkCell cell = gridCell as DataGridViewLinkCell;
+                string cmd = cell?.Value.ToString();
+                if (!string.IsNullOrEmpty(cmd))
+                    Process.Start(cmd);
             }
             else if (column_index < 2)
             {
-                var gui_mod = (GUIMod)row.Tag;
-                switch (column_index)
+                GUIMod gui_mod = row?.Tag as GUIMod;
+                if (gui_mod != null)
                 {
-                    case 0:
-                        gui_mod.SetInstallChecked(row);
-                        if (gui_mod.IsInstallChecked)
-                            last_mod_to_have_install_toggled.Push(gui_mod);
-
-                        break;
-
-                    case 1:
-                        gui_mod.SetUpgradeChecked(row);
-                        break;
+                    switch (column_index)
+                    {
+                        case 0:
+                            gui_mod.SetInstallChecked(row);
+                            if (gui_mod.IsInstallChecked)
+                                last_mod_to_have_install_toggled.Push(gui_mod);
+                            break;
+                        case 1:
+                            gui_mod.SetUpgradeChecked(row);
+                            break;
+                    }
+                    await UpdateChangeSetAndConflicts(
+                        RegistryManager.Instance(CurrentInstance).registry
+                    );
                 }
-
-                var registry = registry_manager.registry;
-                await UpdateChangeSetAndConflicts(registry);
             }
         }
 


### PR DESCRIPTION
## Problem

1. Install some mods
2. Either upgrade your game or modify your compatible KSP versions so that some of the mods from step <span>#</span>1 become incompatible
3. Change GUI filter to Incompatible
4. Try to uninstall some of your incompatible mods. The apply changes button does not become enabled.

Note that this is not an architectural limitation of Core; if you use the All filter instead, you can uninstall incompatible mods.

## Changes

There was an explicit check for the Incompatible filter in `ModList_CellValueChanged`, presumably to prevent the user from _installing_ incompatible mods. However, such mods won't have checkboxes anyway. This check is removed.

Also added a few null checks to the function to be on the safe side.

Fixes #1842.
Replaces #1929, which was reverted in #2150 due to issues like #2148.
Re-tested #2148 with this change applied, and it worked for me. See my comment on that issue for my ideas about what caused it.