### PR TITLE
Show status bar text, add progress bar

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -78,8 +78,8 @@
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ModInfoTabControl = new CKAN.MainModInfo();
-            this.StatusPanel = new System.Windows.Forms.Panel();
-            this.StatusLabel = new System.Windows.Forms.Label();
+            this.StatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.StatusProgress = new System.Windows.Forms.ToolStripProgressBar();
             this.MainTabControl = new CKAN.MainTabControl();
             this.ManageModsTabPage = new System.Windows.Forms.TabPage();
             this.FilterByAuthorTextBox = new CKAN.HintTextBox();
@@ -124,7 +124,6 @@
             this.splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).BeginInit();
             this.ModListContextMenuStrip.SuspendLayout();
-            this.StatusPanel.SuspendLayout();
             this.MainTabControl.SuspendLayout();
             this.ManageModsTabPage.SuspendLayout();
             this.ChangesetTabPage.SuspendLayout();
@@ -263,16 +262,17 @@
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
+            //
             // statusStrip1
-            // 
-            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
-            this.statusStrip1.Location = new System.Drawing.Point(0, 1016);
+            //
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 21, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(1544, 22);
             this.statusStrip1.TabIndex = 1;
-            this.statusStrip1.Text = "statusStrip1";
-            // 
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
+            {
+                this.StatusLabel, this.StatusProgress
+            });
+            //
             // menuStrip2
             // 
             this.menuStrip2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -581,27 +581,22 @@
             this.ModInfoTabControl.Name = "ModInfoTabControl";
             this.ModInfoTabControl.Size = new System.Drawing.Size(360, 836);
             this.ModInfoTabControl.TabIndex = 0;
-            // 
-            // StatusPanel
-            // 
-            this.StatusPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.StatusPanel.Controls.Add(this.StatusLabel);
-            this.StatusPanel.Location = new System.Drawing.Point(0, 1074);
-            this.StatusPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.StatusPanel.Name = "StatusPanel";
-            this.StatusPanel.Size = new System.Drawing.Size(1196, 29);
-            this.StatusPanel.TabIndex = 8;
-            // 
+            //
             // StatusLabel
-            // 
-            this.StatusLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.StatusLabel.Location = new System.Drawing.Point(0, 0);
-            this.StatusLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            //
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(1050, 29);
-            this.StatusLabel.TabIndex = 0;
+            this.StatusLabel.Spring = true;
+            this.StatusLabel.Text = "";
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
+            //
+            // StatusProgress
+            //
+            this.StatusProgress.Enabled = true;
+            this.StatusProgress.Visible = false;
+            this.StatusProgress.Minimum = 0;
+            this.StatusProgress.Maximum = 100;
+            this.StatusProgress.Size = new System.Drawing.Size(300, 20);
+            this.StatusProgress.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             // MainTabControl
             // 
             this.MainTabControl.Controls.Add(this.ManageModsTabPage);
@@ -1034,7 +1029,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1544, 1038);
             this.Controls.Add(this.MainTabControl);
-            this.Controls.Add(this.StatusPanel);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -1054,7 +1048,6 @@
             this.splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).EndInit();
             this.ModListContextMenuStrip.ResumeLayout(false);
-            this.StatusPanel.ResumeLayout(false);
             this.MainTabControl.ResumeLayout(false);
             this.ManageModsTabPage.ResumeLayout(false);
             this.ManageModsTabPage.PerformLayout();
@@ -1120,8 +1113,8 @@
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
         private CKAN.MainModInfo ModInfoTabControl;
-        private System.Windows.Forms.Panel StatusPanel;
-        private System.Windows.Forms.Label StatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel StatusLabel;
+        private System.Windows.Forms.ToolStripProgressBar StatusProgress;
         private CKAN.MainTabControl MainTabControl;
         private System.Windows.Forms.TabPage ManageModsTabPage;
         private CKAN.HintTextBox FilterByAuthorTextBox;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -124,6 +124,7 @@
             this.splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).BeginInit();
             this.ModListContextMenuStrip.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
             this.MainTabControl.SuspendLayout();
             this.ManageModsTabPage.SuspendLayout();
             this.ChangesetTabPage.SuspendLayout();
@@ -266,6 +267,8 @@
             // statusStrip1
             //
             this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Location = new System.Drawing.Point(0, 1016);
+            this.statusStrip1.Size = new System.Drawing.Size(1544, 22);
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 21, 0);
             this.statusStrip1.TabIndex = 1;
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
@@ -585,12 +588,14 @@
             // StatusLabel
             //
             this.StatusLabel.Name = "StatusLabel";
+            this.StatusLabel.Size = new System.Drawing.Size(1050, 29);
             this.StatusLabel.Spring = true;
             this.StatusLabel.Text = "";
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             //
             // StatusProgress
             //
+            this.StatusProgress.Name = "StatusProgress";
             this.StatusProgress.Enabled = true;
             this.StatusProgress.Visible = false;
             this.StatusProgress.Minimum = 0;
@@ -1048,6 +1053,8 @@
             this.splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).EndInit();
             this.ModListContextMenuStrip.ResumeLayout(false);
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
             this.MainTabControl.ResumeLayout(false);
             this.ManageModsTabPage.ResumeLayout(false);
             this.ManageModsTabPage.PerformLayout();

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -22,7 +22,7 @@ namespace CKAN
 
         public void AddStatusMessage(string text, params object[] args)
         {
-            Util.Invoke(StatusLabel, () => StatusLabel.Text = String.Format(text, args));
+            Util.Invoke(statusStrip1, () => StatusLabel.Text = String.Format(text, args));
             AddLogMessage(String.Format(text, args));
         }
 

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -22,6 +22,9 @@ namespace CKAN
             DialogProgressBar.Maximum = 100;
             DialogProgressBar.Style = ProgressBarStyle.Marquee;
             MessageTextBox.Text = "Please wait";
+            StatusProgress.Value = 0;
+            StatusProgress.Style = ProgressBarStyle.Marquee;
+            StatusProgress.Visible = true;
         }
 
         public void HideWaitDialog(bool success)
@@ -29,6 +32,8 @@ namespace CKAN
             MessageTextBox.Text = "All done!";
             DialogProgressBar.Value = 100;
             DialogProgressBar.Style = ProgressBarStyle.Continuous;
+            StatusProgress.Value = 100;
+            StatusProgress.Style = ProgressBarStyle.Continuous;
             RecreateDialogs();
 
             tabController.SetActiveTab("ManageModsTabPage");
@@ -36,6 +41,9 @@ namespace CKAN
             CancelCurrentActionButton.Enabled = false;
             DialogProgressBar.Value = 0;
             DialogProgressBar.Style = ProgressBarStyle.Continuous;
+            StatusProgress.Value = 0;
+            StatusProgress.Style = ProgressBarStyle.Continuous;
+            StatusProgress.Visible = false;
         }
 
         public void SetProgress(int progress)
@@ -49,13 +57,22 @@ namespace CKAN
                 progress = 100;
             }
 
-            Util.Invoke(DialogProgressBar, () => DialogProgressBar.Value = progress);
-            Util.Invoke(DialogProgressBar, () => DialogProgressBar.Style = ProgressBarStyle.Continuous);
+            Util.Invoke(DialogProgressBar, () =>
+            {
+                DialogProgressBar.Value = progress;
+                DialogProgressBar.Style = ProgressBarStyle.Continuous;
+                StatusProgress.Value = progress;
+                StatusProgress.Style = ProgressBarStyle.Continuous;
+            });
         }
 
         public void ResetProgress()
         {
-            Util.Invoke(DialogProgressBar, () => DialogProgressBar.Style = ProgressBarStyle.Marquee);
+            Util.Invoke(DialogProgressBar, () =>
+            {
+                DialogProgressBar.Style = ProgressBarStyle.Marquee;
+                StatusProgress.Style    = ProgressBarStyle.Marquee;
+            });
         }
 
         public void SetDescription(string message)


### PR DESCRIPTION
## Problems

CKAN's GUI has a status bar that is always empty:

![image](https://user-images.githubusercontent.com/1559108/34695168-bb260e20-f4c1-11e7-95f0-610c0ebacb59.png)

And some code that tries to set it:

https://github.com/KSP-CKAN/CKAN/blob/378d12818ade7831e27a953096f531cc546a9b11/GUI/MainDialogs.cs#L23-L27

Currently they aren't connected.

## Causes

Two different status bar controls are in use at the moment: the one that is visible, and the one that receives the status messages from code.

- `statusStrip1` is the control that's actually visible. It has no contained controls and none of its properties are set by code during downloads/installs.
- `StatusPanel` is a panel which is technically added to the form but not visible. `StatusLabel` is a label which is added to this and which receives the status messages from the application, but again is not visible.

## Changes

The status bar code is rewritten according to the [documentation for StatusStrip](https://msdn.microsoft.com/en-us/library/system.windows.forms.statusstrip(v=vs.110).aspx#Examples).

- `StatusPanel` is removed
- `StatusLabel` is changed to type `System.Windows.Forms.ToolStripStatusLabel` and added to `statuStrip1` instead
- A new `ToolStripProgressBar` control is added to mirror the behavior of the progress bar on the install screen

Together, these changes make the status bar work as intended:

![image](https://user-images.githubusercontent.com/1559108/34695128-8efcde46-f4c1-11e7-9510-51a12ba406c4.png)