### PR TITLE
Add import downloads menu item to GUI

### DIFF
--- a/ConsoleUI/DownloadImportDialog.cs
+++ b/ConsoleUI/DownloadImportDialog.cs
@@ -29,7 +29,7 @@ namespace CKAN.ConsoleUI {
             if (files.Count > 0) {
                 ProgressScreen  ps   = new ProgressScreen("Importing Downloads", "Calculating...");
                 ModuleInstaller inst = ModuleInstaller.GetInstance(gameInst, ps);
-                ps.Run(() => ImportFiles(gameInst, files, ps, inst,
+                ps.Run(() => inst.ImportFiles(files, ps,
                     (string identifier) => cp.Install.Add(identifier)));
                 // Don't let the installer re-use old screen references
                 inst.User = null;
@@ -49,63 +49,6 @@ namespace CKAN.ConsoleUI {
                 }
             }
             return gameInst.GameDir();
-        }
-
-        /// <summary>
-        /// Import a list of files into the download cache, with progress bar and
-        /// interactive prompts for installation and deletion.
-        /// </summary>
-        /// <param name="gameInst">Game instance to install into</param>
-        /// <param name="files">Set of files to import</param>
-        /// <param name="user">Object for user interaction</param>
-        /// <param name="inst">Module installer object</param>
-        /// <param name="installMod">Function to call to mark a mod for installation</param>
-        public static void ImportFiles(KSP gameInst, HashSet<FileInfo> files,
-                IUser user, ModuleInstaller inst, Action<string> installMod)
-        {
-            Registry         registry    = RegistryManager.Instance(gameInst).registry;
-            HashSet<string>  installable = new HashSet<string>();
-            List<FileInfo>   deletable   = new List<FileInfo>();
-            // Get the mapping of known hashes to modules
-            Dictionary<string, List<CkanModule>> index = registry.GetSha1Index();
-            int i = 0;
-            foreach (FileInfo f in files) {
-                int percent = i * 100 / files.Count;
-                user.RaiseProgress($"Importing {f.Name}... ({percent}%)", percent);
-                // Calc SHA-1 sum
-                string sha1 = NetModuleCache.GetFileHashSha1(f.FullName);
-                // Find SHA-1 sum in registry (potentially multiple)
-                if (index.ContainsKey(sha1)) {
-                    deletable.Add(f);
-                    List<CkanModule> matches = index[sha1];
-                    foreach (CkanModule mod in matches) {
-                        if (mod.IsCompatibleKSP(gameInst.VersionCriteria())) {
-                            installable.Add(mod.identifier);
-                        }
-                        if (inst.Cache.IsMaybeCachedZip(mod)) {
-                            user.RaiseMessage("Already cached: {0}", f.Name);
-                        } else {
-                            user.RaiseMessage($"Importing {mod.identifier} {Formatting.StripEpoch(mod.version)}...");
-                            inst.Cache.Store(mod, f.FullName);
-                        }
-                    }
-                } else {
-                    user.RaiseMessage("Not found in index: {0}", f.Name);
-                }
-                ++i;
-            }
-            if (installable.Count > 0 && user.RaiseYesNoDialog($"Install {installable.Count} compatible imported mods?")) {
-                // Install the imported mods
-                foreach (string identifier in installable) {
-                    installMod(identifier);
-                }
-            }
-            if (user.RaiseYesNoDialog($"Import complete. Delete {deletable.Count} old files?")) {
-                // Delete old files
-                foreach (FileInfo f in deletable) {
-                    f.Delete();
-                }
-            }
         }
 
     }

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -133,7 +133,7 @@ namespace CKAN.ConsoleUI {
 
         private void OnModInstalled(CkanModule mod)
         {
-            RaiseMessage($"{Symbols.checkmark} Successfully installed {mod.name} {Formatting.StripEpoch(mod.version)}");
+            RaiseMessage($"{Symbols.checkmark} Successfully installed {mod.name} {ModuleInstaller.StripEpoch(mod.version)}");
         }
 
         private static readonly RelationshipResolverOptions resolvOpts = new RelationshipResolverOptions() {

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -391,8 +391,8 @@ namespace CKAN.ConsoleUI {
                 AddObject(new ConsoleLabel(
                     l + 2, t + 1, r - 2,
                     () => minMod == maxMod
-                        ? $"{Formatting.WithAndWithoutEpoch(minMod.ToString())}"
-                        : $"{Formatting.WithAndWithoutEpoch(minMod.ToString())} - {Formatting.WithAndWithoutEpoch(maxMod.ToString())}",
+                        ? $"{ModuleInstaller.WithAndWithoutEpoch(minMod.ToString())}"
+                        : $"{ModuleInstaller.WithAndWithoutEpoch(minMod.ToString())} - {ModuleInstaller.WithAndWithoutEpoch(maxMod.ToString())}",
                     null,
                     color
                 ));

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -37,7 +37,7 @@ namespace CKAN.ConsoleUI {
                     }, new ConsoleListBoxColumn<CkanModule>() {
                         Header   = "Version",
                         Width    = 10,
-                        Renderer = m => Formatting.StripEpoch(m.version?.ToString() ?? ""),
+                        Renderer = m => ModuleInstaller.StripEpoch(m.version?.ToString() ?? ""),
                         Comparer = (a, b) => a.version.CompareTo(b.version)
                     }, new ConsoleListBoxColumn<CkanModule>() {
                         Header   = "Max KSP version",

--- a/ConsoleUI/Toolkit/Formatting.cs
+++ b/ConsoleUI/Toolkit/Formatting.cs
@@ -120,42 +120,6 @@ namespace CKAN.ConsoleUI.Toolkit {
             }
         }
 
-        /// <summary>
-        /// Returns a version string shorn of any leading epoch as delimited by a single colon
-        /// </summary>
-        /// <param name="version">A version that might contain an epoch</param>
-        public static string StripEpoch(Version version)
-        {
-            return StripEpoch(version.ToString());
-        }
-
-        /// <summary>
-        /// Returns a version string shorn of any leading epoch as delimited by a single colon
-        /// </summary>
-        /// <param name="version">A version string that might contain an epoch</param>
-        public static string StripEpoch(string version)
-        {
-            // If our version number starts with a string of digits, followed by
-            // a colon, and then has no more colons, we're probably safe to assume
-            // the first string of digits is an epoch
-            return epochMatch.IsMatch(version)
-                ? epochReplace.Replace(version, @"$2")
-                : version;
-        }
-
-        /// <summary>
-        /// As above, but includes the original in parentheses
-        /// </summary>
-        /// <param name="version">A version string that might contain an epoch</param>
-        public static string WithAndWithoutEpoch(string version)
-        {
-            return epochMatch.IsMatch(version)
-                ? $"{epochReplace.Replace(version, @"$2")} ({version})"
-                : version;
-        }
-
-        private static readonly Regex epochMatch   = new Regex(@"^[0-9][0-9]*:[^:]+$", RegexOptions.Compiled);
-        private static readonly Regex epochReplace = new Regex(@"^([^:]+):([^:]+)$",   RegexOptions.Compiled);
     }
 
 }

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -146,6 +146,8 @@
     <Compile Include="MainDialogs.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="MainImport.cs">
+    </Compile>
     <Compile Include="MainInstall.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -242,14 +242,17 @@ namespace CKAN
         {
             //Contract.Requires<ArgumentException>(row.Cells[0] is DataGridViewCheckBoxCell);
             var install_cell = row.Cells[0] as DataGridViewCheckBoxCell;
-            bool changeTo = set_value_to != null ? (bool)set_value_to : (bool)install_cell.Value;
-            //Need to do this check here to prevent an infinite loop
-            //which is at least happening on Linux
-            //TODO: Eliminate the cause
-            if (changeTo != IsInstallChecked)
+            if (install_cell != null)
             {
-                IsInstallChecked = changeTo;
-                install_cell.Value = IsInstallChecked;
+                bool changeTo = set_value_to ?? (bool)install_cell.Value;
+                //Need to do this check here to prevent an infinite loop
+                //which is at least happening on Linux
+                //TODO: Eliminate the cause
+                if (changeTo != IsInstallChecked)
+                {
+                    IsInstallChecked = changeTo;
+                    install_cell.Value = IsInstallChecked;
+                }
             }
         }
 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -36,6 +36,7 @@
             this.openKspDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.installFromckanToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportModListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importDownloadsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.ExitToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -152,7 +153,10 @@
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.selectKSPInstallMenuItem,
             this.openKspDirectoryToolStripMenuItem,
+            new System.Windows.Forms.ToolStripSeparator(),
             this.installFromckanToolStripMenuItem,
+            this.importDownloadsToolStripMenuItem,
+            new System.Windows.Forms.ToolStripSeparator(),
             this.exportModListToolStripMenuItem,
             this.toolStripSeparator1,
             this.ExitToolButton});
@@ -188,6 +192,14 @@
             this.exportModListToolStripMenuItem.Text = "&Export installed mods...";
             this.exportModListToolStripMenuItem.Click += new System.EventHandler(this.exportModListToolStripMenuItem_Click);
             // 
+            //
+            // importDownloadsToolStripMenuItem
+            //
+            this.importDownloadsToolStripMenuItem.Name = "importDownloadsToolStripMenuItem";
+            this.importDownloadsToolStripMenuItem.Size = new System.Drawing.Size(281, 30);
+            this.importDownloadsToolStripMenuItem.Text = "&Import downloaded mods...";
+            this.importDownloadsToolStripMenuItem.Click += new System.EventHandler(this.importDownloadsToolStripMenuItem_Click);
+            //
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
@@ -1078,6 +1090,7 @@
         private System.Windows.Forms.ToolStripMenuItem openKspDirectoryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem installFromckanToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportModListToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importDownloadsToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem ExitToolButton;
         public System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;

--- a/GUI/MainImport.cs
+++ b/GUI/MainImport.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+
+    public partial class Main
+    {
+
+        private void importDownloadsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ImportModules();
+        }
+
+        private void ImportModules()
+        {
+            // Prompt the user to select one or more ZIP files
+            OpenFileDialog dlg = new OpenFileDialog()
+            {
+                Title            = "Import Mods",
+                AddExtension     = true,
+                CheckFileExists  = true,
+                CheckPathExists  = true,
+                InitialDirectory = FindDownloadsPath(CurrentInstance),
+                DefaultExt       = "zip",
+                Filter           = "Mods (*.zip)|*.zip",
+                Multiselect      = true
+            };
+            if (dlg.ShowDialog() == DialogResult.OK
+                    && dlg.FileNames.Length > 0)
+            {
+
+                // Set up GUI to respond to IUser calls...
+                GUIUser.DisplayYesNo old_YesNoDialog = currentUser.displayYesNo;
+                currentUser.displayYesNo = YesNoDialog;
+                tabController.RenameTab("WaitTabPage", "Status log");
+                tabController.ShowTab("WaitTabPage");
+                tabController.SetTabLock(true);
+
+                try
+                {
+                    ModuleInstaller.GetInstance(CurrentInstance, currentUser).ImportFiles(
+                        GetFiles(dlg.FileNames),
+                        currentUser,
+                        (string id) => MarkModForInstall(id, false)
+                    );
+                }
+                finally
+                {
+                    // Put GUI back the way we found it
+                    currentUser.displayYesNo = old_YesNoDialog;
+                    tabController.SetTabLock(false);
+                    tabController.HideTab("WaitTabPage");
+                }
+            }
+        }
+
+        private HashSet<FileInfo> GetFiles(string[] filenames)
+        {
+            HashSet<FileInfo> files = new HashSet<FileInfo>();
+            foreach (string fn in filenames)
+            {
+                files.Add(new FileInfo(fn));
+            }
+            return files;
+        }
+
+        private static readonly string[] downloadPaths = new string[] {
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads"),
+            Environment.GetFolderPath(Environment.SpecialFolder.Desktop)
+        };
+
+        private static string FindDownloadsPath(KSP gameInst)
+        {
+            foreach (string p in downloadPaths) {
+                if (!string.IsNullOrEmpty(p) && Directory.Exists(p)) {
+                    return p;
+                }
+            }
+            return gameInst.GameDir();
+        }
+
+    }
+
+}

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -543,8 +543,8 @@ namespace CKAN
 
                 var name = new DataGridViewTextBoxCell {Value = mod.Name};
                 var author = new DataGridViewTextBoxCell {Value = mod.Authors};
-                var installVersion = new DataGridViewTextBoxCell {Value = hideEpochs ? StripEpoch(mod.InstalledVersion) : mod.InstalledVersion };
-                var latestVersion = new DataGridViewTextBoxCell {Value = hideEpochs ? StripEpoch(mod.LatestVersion) : mod.LatestVersion };
+                var installVersion = new DataGridViewTextBoxCell {Value = hideEpochs ? ModuleInstaller.StripEpoch(mod.InstalledVersion) : mod.InstalledVersion };
+                var latestVersion = new DataGridViewTextBoxCell {Value = hideEpochs ? ModuleInstaller.StripEpoch(mod.LatestVersion) : mod.LatestVersion };
                 var desc = new DataGridViewTextBoxCell {Value = mod.Abstract};
                 var compat = new DataGridViewTextBoxCell {Value = mod.KSPCompatibility};
                 var size = new DataGridViewTextBoxCell {Value = mod.DownloadSize};
@@ -557,17 +557,6 @@ namespace CKAN
                 full_list_of_mod_rows.Add(mod.Identifier, item);
             }
             return full_list_of_mod_rows.Values;
-        }
-
-        /// <summary>
-        /// Returns a version string shorn of any leading epoch as delimited by a single colon
-        /// </summary>
-        public string StripEpoch(string version)
-        {
-            // If our version number starts with a string of digits, followed by
-            // a colon, and then has no more colons, we're probably safe to assume
-            // the first string of digits is an epoch
-            return Regex.IsMatch(version, @"^[0-9][0-9]*:[^:]+$") ? Regex.Replace(version, @"^([^:]+):([^:]+)$", @"$2") : version;
         }
 
         private bool IsNameInNameFilter(GUIMod mod)


### PR DESCRIPTION
## Problem

Issues with downloading sometimes lead users to download files with a browser, but if it works, there's no way to make CKAN use the files. There should be, because they're the same files regardless of who downloads them.

## Changes

This pull request adds a new "Import downloaded mods..." option to GUI's (slightly reorganized) File menu:

![image](https://user-images.githubusercontent.com/1559108/34789804-93b853a8-f637-11e7-95a8-e870f46946b5.png)

Clicking it brings up a file selection dialog where the user can select multiple ZIP files, starting in their profile's Downloads folder:

![image](https://user-images.githubusercontent.com/1559108/34789821-a5b84194-f637-11e7-8de3-240393486869.png)

If the user accepts that popup, CKAN switches to the progress bar tab and displays messages about its progress in importing the files. At the end, if any of the mods are compatible and not yet installed, the user is asked whether to install them:

![image](https://user-images.githubusercontent.com/1559108/34789828-aa1ba190-f637-11e7-97b9-534ce53f410a.png)

If the user clicks Yes, then they're taken to the install flow for those selected mods:

![image](https://user-images.githubusercontent.com/1559108/34789840-aec3ce02-f637-11e7-9352-be0e96570b47.png)

![image](https://user-images.githubusercontent.com/1559108/34789846-b3b3e780-f637-11e7-8395-945774bf1c32.png)

Finally, they're given another yes/no prompt asking whether to delete the original copies of the files that were successfully imported, now that they're in the cache. The idea is that some downloads are large and would waste space if kept in multiple copies. Apparently I did not capture a screenshot of this.

## Code 

ConsoleUI's download importing function is moved to be an instance method of ModuleInstaller, along with some mod formatting helper functions. This is then shared between ConsoleUI and GUI.

A new file MainImport.cs is added to GUI to contain all the GUI-specific importing logic. It mainly deals with showing the popup and calls the importing function of its ModuleInstaller.

Fixes #1788.