### PR TITLE
Print fewer download updates in headless mode

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -231,9 +231,15 @@ namespace CKAN.CmdLine
         {
             if (Regex.IsMatch(format, "download", RegexOptions.IgnoreCase))
             {
-                Console.Write(
+                // In headless mode, only print a new message if the percent has changed,
+                // to reduce clutter in Jenkins for large downloads
+                if (!m_Headless || percent != previousPercent)
+                {
                     // The \r at the front here causes download messages to *overwrite* each other.
-                    "\r{0} - {1}%           ", format, percent);
+                    Console.Write(
+                        "\r{0} - {1}%           ", format, percent);
+                    previousPercent = percent;
+                }
             }
             else
             {
@@ -244,5 +250,6 @@ namespace CKAN.CmdLine
             }
         }
 
+        private int previousPercent = -1;
     }
 }

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -60,9 +60,15 @@ namespace CKAN
         {
             if (Regex.IsMatch(format, "download", RegexOptions.IgnoreCase))
             {
-                Console.Write(
+                // In headless mode, only print a new message if the percent has changed,
+                // to reduce clutter in Jenkins for large downloads
+                if (!m_Headless || percent != previousPercent)
+                {
                     // The \r at the front here causes download messages to *overwrite* each other.
-                    "\r{0} - {1}%           ", format, percent);
+                    Console.Write(
+                        "\r{0} - {1}%           ", format, percent);
+                    previousPercent = percent;
+                }
             }
             else
             {
@@ -73,5 +79,6 @@ namespace CKAN
             }
         }
 
+        private int previousPercent = -1;
     }
 }


### PR DESCRIPTION
## Problem

When GPP updates, Jenkins has to download 181 MB of files. Since Cmdline currently prints a download status every 3 seconds, this results in most of the log looking like this:

https://ci.ksp-ckan.org/job/NetKAN/6759/consoleText

```
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
1615 kbps - downloading - 98 MB left - 45%           
```

This time it went on for 15060 lines, and a total of 827 kilobytes, almost all of which is just clutter.

## Changes

Now when netkan or ckan are running in headless mode, which Jenkins uses, they will only print a download progress update when the percentage changes (or less often, for very fast downloads). This will limit the number of lines to at most 100 while still logging the download.

I didn't reduce the number of updates coming from Core because these can be appropriate for making it clear that the GUI is still running.