### PR TITLE
Leave out children already shown in ancestor node

### DIFF
--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -184,6 +184,22 @@ namespace CKAN
             Cursor.Current = prevCur;
         }
 
+        private bool ImMyOwnGrandpa(TreeNode node)
+        {
+            CkanModule module = node.Tag as CkanModule;
+            if (module != null)
+            {
+                for (TreeNode other = node.Parent; other != null; other = other.Parent)
+                {
+                    if (module == other.Tag)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         private void UpdateModDependencyGraph(CkanModule module)
         {
             ModInfoTabControl.Tag = module ?? ModInfoTabControl.Tag;
@@ -224,6 +240,10 @@ namespace CKAN
 
         private void AddChildren(IRegistryQuerier registry, TreeNode node)
         {
+            // Skip children of nodes from circular dependencies
+            if (ImMyOwnGrandpa(node))
+                return;
+
             // Load one layer of grandchildren on demand
             CkanModule module = node.Tag as CkanModule;
             // Tag is null for non-indexed nodes


### PR DESCRIPTION
## Problem

Many mod relationships are mutual/circular, so mod X conflicts with Y, and Y also conflicts with X.

In the 1.24 pre-release version of the GUI relationships tab, this means you can expand them in an infinite chain if you want to, back and forth forever. This causes visual clutter and is a bit silly looking. Example from #2257:

![image](https://user-images.githubusercontent.com/1559108/35064053-abad91f6-fbc0-11e7-927e-54f1bb0348aa.png)

## Changes

Now we omit the children of nodes that already have their children shown as part of their own ancestry. The user will have seen them already when they expanded the identical ancestor node.

![image](https://user-images.githubusercontent.com/1559108/35063970-7ec4ef54-fbc0-11e7-8b4d-24d9bc54bcb2.png)

This is done by walking the tree via `TreeNode.Parent` up to the root and comparing the `CkanModule` objects located in the `.Tag` property.

Fixes #2257.