### PR TITLE
Resolve provides for install-from-ckan-file

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -395,15 +395,15 @@ namespace CKAN
             var installed_modules =
                 registry.InstalledModules.Select(imod => imod.Module).ToDictionary(mod => mod.identifier, mod => mod);
 
-            bool handled_all_to_many_provides = false;
-            while (!handled_all_to_many_provides)
+            bool handled_all_too_many_provides = false;
+            while (!handled_all_too_many_provides)
             {
                 //Can't await in catch clause - doesn't seem to work in mono. Hence this flag
                 TooManyModsProvideKraken kraken;
                 try
                 {
                     new RelationshipResolver(modules_to_install.ToList(), options, registry, version);
-                    handled_all_to_many_provides = true;
+                    handled_all_too_many_provides = true;
                     continue;
                 }
                 catch (TooManyModsProvideKraken k)


### PR DESCRIPTION
## Problem

If you install a .ckan file with dependencies that are virtual modules (provided by multiple mods via the `provides` metadata property), you would get one of these exceptions, depending on whether you were using CKAN 1.22 or earlier, or 1.24:

```
CKAN.TooManyModsProvideKraken: Too many mods provide Scatterer-sunflare:
Scatterer-sunflare 2:v0.0320
* AstronikiSunflareforScatterer 1.2
* CepheusSunflare 1.2
* EdenSunflare 1.2
* SVE-Sunflare 2:1.1.6
   bei CKAN.RelationshipResolver.ResolveStanza(IEnumerable`1 stanza, SelectionReason reason, RelationshipResolverOptions options, Boolean soft_resolve, IEnumerable`1 old_stanza)
   bei CKAN.RelationshipResolver.Resolve(CkanModule module, RelationshipResolverOptions options, IEnumerable`1 old_stanza)
   bei CKAN.RelationshipResolver.ResolveStanza(IEnumerable`1 stanza, SelectionReason reason, RelationshipResolverOptions options, Boolean soft_resolve, IEnumerable`1 old_stanza)
   bei CKAN.RelationshipResolver.Resolve(CkanModule module, RelationshipResolverOptions options, IEnumerable`1 old_stanza)
   bei CKAN.RelationshipResolver.AddModulesToInstall(IEnumerable`1 modules)
   bei CKAN.RelationshipResolver..ctor(IEnumerable`1 module_names, RelationshipResolverOptions options, IRegistryQuerier registry, KspVersionCriteria kspversion)
   bei CKAN.ModuleInstaller.ResolveModules(IEnumerable`1 modules, RelationshipResolverOptions options)
   bei CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   bei System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   bei System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

![image](https://user-images.githubusercontent.com/1559108/35134854-0be417e6-fcd1-11e7-95ac-0336e6b7482f.png)

## Cause

GUI resolves provides-relationships in `mainModList.ComputeChangeSetFromModList`. Currently this is only called from grid code's checkbox handler. The user is only prompted to select a providing mod as a result of clicking the Install/Upgrade checkboxes, and through no other route.

Installing from a .ckan file doesn't go through the grid code, so provides-resolution was not available to it. If your .ckan file depended on a virtual mod, the TooManyModsProvideKraken would be thrown and not caught by anything, and thus shown to the user.

## Changes

Now the .ckan file handling code calls `mainModList.ComputeChangeSetFromModList` before installing to force resolution of provides relationships.

Fixes #2254.