### PR TITLE
Accept header and infrastructure for auth tokens

### DIFF
--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -144,10 +144,14 @@ namespace CKAN
             // download updater app and new ckan.exe
             string updaterFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
             string ckanFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
-            Net.DownloadWithProgress(new[]{
-                new Net.DownloadTarget(fetchedUpdaterUrl.Item1, updaterFilename, fetchedUpdaterUrl.Item2),
-                new Net.DownloadTarget(fetchedCkanUrl.Item1, ckanFilename, fetchedCkanUrl.Item2),
-            }, user);
+            Net.DownloadWithProgress(
+                new[]
+                {
+                    new Net.DownloadTarget(fetchedUpdaterUrl.Item1, updaterFilename, fetchedUpdaterUrl.Item2),
+                    new Net.DownloadTarget(fetchedCkanUrl.Item1,    ckanFilename,    fetchedCkanUrl.Item2),
+                },
+                user
+            );
 
             // run updater
             SetExecutable(updaterFilename);

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -17,6 +17,7 @@ namespace CKAN
 
     public class Net
     {
+        // The user agent that we report to web sites
         public static string UserAgentString = "Mozilla/4.0 (compatible; CKAN)";
 
         private static readonly ILog Log = LogManager.GetLogger(typeof (Net));
@@ -112,20 +113,19 @@ namespace CKAN
 
         public class DownloadTarget
         {
-            public Uri uri { get; private set; }
+            public Uri    url      { get; private set; }
             public string filename { get; private set; }
-            public long size { get; private set; }
+            public long   size     { get; private set; }
+            public string mimeType { get; private set; }
 
-            public DownloadTarget(Uri uri, string filename = null, long size = 0)
+            public DownloadTarget(Uri url, string filename = null, long size = 0, string mimeType = "")
             {
-                if (filename == null)
-                {
-                    filename = FileTransaction.GetTempFileName();
-                }
-
-                this.uri = uri;
-                this.filename = filename;
-                this.size = size;
+                this.url      = url;
+                this.filename = string.IsNullOrEmpty(filename)
+                    ? FileTransaction.GetTempFileName()
+                    : filename;
+                this.size     = size;
+                this.mimeType = mimeType;
             }
         }
 
@@ -150,10 +150,10 @@ namespace CKAN
                     if (filenames == null || urls == null) return;
                     for (var i = 0; i < Math.Min(urls.Length, filenames.Length); i++)
                     {
-                        File.Move(filenames[i], downloadTargets.First(p => p.uri == urls[i]).filename);
+                        File.Move(filenames[i], downloadTargets.First(p => p.url == urls[i]).filename);
                     }
                 }
-            }.DownloadAndWait(downloadTargets.ToDictionary(p => p.uri, p => p.size));
+            }.DownloadAndWait(downloadTargets);
         }
 
         public static string DownloadText(Uri url)

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -116,7 +116,7 @@ namespace CKAN
     /// Helpers for <see cref="IRegistryQuerier"/>
     /// </summary>
     public static class IRegistryQuerierHelpers
-{
+    {
         /// <summary>
         /// Helper to call <see cref="IRegistryQuerier.GetModuleByVersion(string, Version)"/>
         /// </summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -242,7 +242,7 @@ namespace CKAN
                 new Dictionary<string, AvailableModule>(),
                 new Dictionary<string, string>(),
                 new SortedDictionary<string, Repository>()
-                );
+            );
         }
 
         #endregion

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -175,6 +175,9 @@ namespace CKAN
         [JsonProperty("download_hash", NullValueHandling = NullValueHandling.Ignore)]
         public DownloadHashesDescriptor download_hash;
 
+        [JsonProperty("download_content_type", NullValueHandling = NullValueHandling.Ignore)]
+        public string download_content_type;
+
         [JsonProperty("identifier", Required = Required.Always)]
         public string identifier;
 

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -407,9 +407,9 @@ namespace CKAN
             Main.Instance.ResetProgress();
             Main.Instance.ClearLog();
 
-            NetAsyncModulesDownloader dowloader = new NetAsyncModulesDownloader(Main.Instance.currentUser);
+            NetAsyncModulesDownloader downloader = new NetAsyncModulesDownloader(Main.Instance.currentUser);
 
-            dowloader.DownloadModules(Main.Instance.CurrentInstance.Cache, new List<CkanModule> { (CkanModule)e.Argument });
+            downloader.DownloadModules(Main.Instance.CurrentInstance.Cache, new List<CkanModule> { (CkanModule)e.Argument });
             e.Result = e.Argument;
         }
 

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -75,10 +75,7 @@ namespace Tests.Core.Net
             log.InfoFormat("Downloading kOS from {0}",kOS.download);
 
             // Download our module.
-            async.DownloadModules(
-                ksp.KSP.Cache,
-                modules
-            );
+            async.DownloadModules(ksp.KSP.Cache, modules);
 
             // Assert that we have it, and it passes zip validation.
             Assert.IsTrue(cache.IsCachedZip(kOS));


### PR DESCRIPTION
## Problems

CKAN's GitHub downloads fail with an HTTP 403 status fairly frequently. We do not know the exact details that trigger it, but it mostly affects large downloads.

It also turns out that the URLs we're using are supposed to be for users and browsers only, not applications. We should migrate to using the GitHub API.

See #2210 for details.

## Cause

GitHub's normal download links are throttled to prevent abuse, and CKAN's use of them is sometimes affected by this.

GitHub prefers applications to use the GitHub API for programmatic access, which requires support for two new HTTP headers, one that specifies the MIME type of the download (without this, the API returns a JSON description of the file instead of the actual download):

```http
Accept: application/octet-stream
```

And one that contains the user's GitHub API authentication token (this one is technically optional, but downloads will still fail frequently without it, because the limit is 60 per hour):

```http
Authentication: token <OAuth token here>
```

## Changes

### MIME types

The `Accept` header is now set for all module downloads. The default is `application/octet-stream`, but we will use a multi-value format as well when `download_content_type` is set for a module:

```http
Accept: {CkanModule.download_content_type};q=1.0,application/octet-stream;q=0.9
```

`CkanModule` has a new property `download_content_type` that maps to the same value in CKAN-meta (this was absent from the registry previously but stored to the metadata repo for all modules by netkan). This allows us to get the MIME type of a download.

`NetAsyncDownloader` now uses `Net.DownloadTarget` objects instead of `KeyValuePair<Uri, int>` to describe requested downloads, as does all of its calling code.

`Net.DownloadTarget` now has a `mimeType` property storing the MIME type of the download.

The value from `CkanModule.download_content_type` is passed to `Net.DownloadTarget.mimeType` when it's available.

The value from `Net.DownloadTarget.mimeType` is used to set the `Accept` header when it's available.

### Auth tokens

The Windows/Mono registry now has a new `AuthTokens` key (secret value in screenshot deleted in post-processing):

![image](https://user-images.githubusercontent.com/1559108/35291076-168e4d92-0064-11e8-8ab7-cf23951bdbeb.png)

When a download is initiated, its `Uri.Host` property is looked up as a key of this key, and if it's found, then the corresponding value is plugged in to the `Authentication` header.

## Still To Be Done In Future Pull Requests

Partial fix for #2210. Will be complete after:

- Cmdline commands for editing the auth token table
- ConsoleUI screen for editing the auth token table
- GUI window for editing the auth token table
- netkan update to use `asset.url` instead of `asset.browser_download_url`
- Conversion of existing URLs to use the API

Note that you can set up auth tokens without UI components by using the registry editor in Windows or an equivalent tool for Mono. When this is done, this version of the client will be able to access GitHub API download URLs with that auth token.

Many thanks to @dbent for wise feedback and ideas that guided these changes in the comments of #2210.