### PR TITLE
Add Cmdline import command

### DIFF
--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -34,7 +34,8 @@ namespace CKAN.CmdLine
         {
             try
             {
-                HashSet<FileInfo> toImport = GetFiles((ImportOptions)options);
+                ImportOptions opts = options as ImportOptions;
+                HashSet<FileInfo> toImport = GetFiles(opts);
                 if (toImport.Count < 1)
                 {
                     user.RaiseMessage("Usage: ckan import path [path2, ...]");
@@ -45,7 +46,7 @@ namespace CKAN.CmdLine
                     log.InfoFormat("Importing {0} files", toImport.Count);
                     List<string>    toInstall = new List<string>();
                     ModuleInstaller inst      = ModuleInstaller.GetInstance(ksp, user);
-                    inst.ImportFiles(toImport, user, id => toInstall.Add(id));
+                    inst.ImportFiles(toImport, user, id => toInstall.Add(id), !opts.Headless);
                     if (toInstall.Count > 0)
                     {
                         inst.InstallList(

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using log4net;
+
+namespace CKAN.CmdLine
+{
+
+    /// <summary>
+    /// Handler for "ckan import" command.
+    /// Imports manually downloaded ZIP files into the cache.
+    /// </summary>
+    public class Import : ICommand
+    {
+
+        /// <summary>
+        /// Initialize the command
+        /// </summary>
+        /// <param name="user">IUser object for user interaction</param>
+        public Import(IUser user)
+        {
+            this.user = user;
+        }
+
+        /// <summary>
+        /// Execute an import command
+        /// </summary>
+        /// <param name="ksp">Game instance into which to import</param>
+        /// <param name="options">Command line parameters from the user</param>
+        /// <returns>
+        /// Process exit code
+        /// </returns>
+        public int RunCommand(CKAN.KSP ksp, object options)
+        {
+            try
+            {
+                HashSet<FileInfo> toImport = GetFiles((ImportOptions)options);
+                if (toImport.Count < 1)
+                {
+                    user.RaiseMessage("Usage: ckan import path [path2, ...]");
+                    return Exit.ERROR;
+                }
+                else
+                {
+                    log.InfoFormat("Importing {0} files", toImport.Count);
+                    List<string>    toInstall = new List<string>();
+                    ModuleInstaller inst      = ModuleInstaller.GetInstance(ksp, user);
+                    inst.ImportFiles(toImport, user, id => toInstall.Add(id));
+                    if (toInstall.Count > 0)
+                    {
+                        inst.InstallList(
+                            toInstall,
+                            new RelationshipResolverOptions()
+                        );
+                    }
+                    return Exit.OK;
+                }
+            }
+            catch (Exception ex)
+            {
+                user.RaiseError("Import error: {0}", ex.Message);
+                return Exit.ERROR;
+            }
+        }
+
+        private HashSet<FileInfo> GetFiles(ImportOptions options)
+        {
+            HashSet<FileInfo> files = new HashSet<FileInfo>();
+            foreach (string filename in options.paths)
+            {
+                if (Directory.Exists(filename))
+                {
+                    // Import everything in this folder
+                    log.InfoFormat("{0} is a directory", filename);
+                    foreach (string dirfile in Directory.EnumerateFiles(filename))
+                    {
+                        AddFile(files, dirfile);
+                    }
+                }
+                else
+                {
+                    AddFile(files, filename);
+                }
+            }
+            return files;
+        }
+
+        private void AddFile(HashSet<FileInfo> files, string filename)
+        {
+            if (File.Exists(filename))
+            {
+                log.InfoFormat("Attempting import of {0}", filename);
+                files.Add(new FileInfo(filename));
+            }
+            else
+            {
+                user.RaiseMessage("File not found: {0}", filename);
+            }
+        }
+
+        private        readonly IUser user;
+        private static readonly ILog  log = LogManager.GetLogger(typeof(Import));
+    }
+
+}

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Action\Compare.cs" />
     <Compile Include="Action\CompatSubCommand.cs" />
     <Compile Include="Action\ICommand.cs" />
+    <Compile Include="Action\Import.cs" />
     <Compile Include="Action\Install.cs" />
     <Compile Include="Action\ISubCommand.cs" />
     <Compile Include="Action\KSP.cs" />

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -189,6 +189,9 @@ namespace CKAN.CmdLine
                         Scan(GetGameInstance(manager), user, cmdline.action);
                         return (new Upgrade(user)).RunCommand(GetGameInstance(manager), cmdline.options);
 
+                    case "import":
+                        return (new Import(user)).RunCommand(GetGameInstance(manager), options);
+
                     case "clean":
                         return Clean(GetGameInstance(manager));
 

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -67,6 +67,9 @@ namespace CKAN.CmdLine
         [VerbOption("remove", HelpText = "Remove an installed mod")]
         public RemoveOptions Remove { get; set; }
 
+        [VerbOption("import", HelpText = "Import manually downloaded mods")]
+        public ImportOptions Import { get; set; }
+
         [VerbOption("scan", HelpText = "Scan for manually installed KSP mods")]
         public ScanOptions Scan { get; set; }
 
@@ -131,6 +134,9 @@ namespace CKAN.CmdLine
                         break;
                     case "compare":
                         ht.AddPreOptionsLine($"Usage: ckan {verb} [options] version1 version2");
+                        break;
+                    case "import":
+                        ht.AddPreOptionsLine($"Usage: ckan {verb} [options] paths");
                         break;
 
                     // Now the commands with only --flag type options
@@ -431,6 +437,12 @@ namespace CKAN.CmdLine
 
         [Option("all", DefaultValue = false, HelpText = "Remove all installed mods.")]
         public bool rmall { get; set; }
+    }
+
+    internal class ImportOptions : InstanceSpecificOptions
+    {
+        [ValueList(typeof(List<string>))]
+        public List<string> paths { get; set; }
     }
 
     internal class ShowOptions : InstanceSpecificOptions

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1092,7 +1092,8 @@ namespace CKAN
         /// <param name="files">Set of files to import</param>
         /// <param name="user">Object for user interaction</param>
         /// <param name="installMod">Function to call to mark a mod for installation</param>
-        public void ImportFiles(HashSet<FileInfo> files, IUser user, Action<string> installMod)
+        /// <param name="allowDelete">True to ask user whether to delete imported files, false to leave the files as is</param>
+        public void ImportFiles(HashSet<FileInfo> files, IUser user, Action<string> installMod, bool allowDelete = true)
         {
             Registry         registry    = registry_manager.registry;
             HashSet<string>  installable = new HashSet<string>();
@@ -1142,7 +1143,7 @@ namespace CKAN
                     installMod(identifier);
                 }
             }
-            if (user.RaiseYesNoDialog($"Import complete. Delete {deletable.Count} old files?"))
+            if (allowDelete && deletable.Count > 0 && user.RaiseYesNoDialog($"Import complete. Delete {deletable.Count} old files?"))
             {
                 // Delete old files
                 foreach (FileInfo f in deletable)

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1134,7 +1134,7 @@ namespace CKAN
                 }
                 ++i;
             }
-            if (installable.Count > 0 && user.RaiseYesNoDialog($"Install {installable.Count} compatible imported mods?"))
+            if (installable.Count > 0 && user.RaiseYesNoDialog($"Install {installable.Count} compatible imported mods in game instance {ksp.Name} ({ksp.GameDir()})?"))
             {
                 // Install the imported mods
                 foreach (string identifier in installable)

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -142,7 +142,7 @@ namespace CKAN
             }
 
             // If no exceptions, then everything is fine
-            return cache.Store(module.download, path, description, move);
+            return cache.Store(module.download, path, description ?? module.StandardName(), move);
         }
 
         private NetFileCache cache;


### PR DESCRIPTION
## Background

#2177 created the ability to import manually downloaded files to the cache, as part of ConsoleUI.

#2246 added it for GUI.

## Changes

This pull request adds the same import functionality for Cmdline.

```
$ ckan import --help
CKAN 1.24.0-PRE2+d6a802f8a78c
Copyright © 2014-2017
 
import - Import manually downloaded mods
Usage: ckan import [options] paths

  --ksp              KSP install to use

  --kspdir           KSP dir to use

  -v, --verbose      (Default: False) Show more of what's going on when 
                     running.

  -d, --debug        (Default: False) Show debugging level messages. Implies 
                     verbose

  --debugger         (Default: False) Launch debugger at start

  --net-useragent    Set the default user-agent string for HTTP requests

  --headless         (Default: False) Set to disable all prompts

  --asroot           (Default: False) Allows CKAN to run as root on Linux-based
                     systems

You are using CKAN version v1.24.0-PRE2+d6a802f8a78c
```

```
$ ckan import /tmp/B8CF009D-Astrogator-v0.7.8.zip 

Importing B8CF009D-Astrogator-v0.7.8.zip... (0%)Importing Astrogator v0.7.8...
Install 1 compatible imported mods? [Y/n] 
Import complete. Delete 1 old files? [Y/n] 
About to install...

 * Astrogator v0.7.8 (cached)
 * Module Manager 3.0.1 (cached)
 * LoadingTipsPlus V1.5 (cached)

Continue? [Y/n]
```

If you specify a directory, it'll attempt to import all files in it.

The core function `NetModuleCache.Store` is also updated to populate a default cache filename of `CkanModule.StandardName()`, to make them consistent with normally downloaded filenames.