### PR TITLE
Use arch=32 for OSX

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -19,5 +19,5 @@ else
 	export DYLD_FALLBACK_LIBRARY_PATH=$APP_PATH/Contents/MacOS:$MONO_FRAMEWORK_PATH/lib:/lib:/usr/lib
 
 	cd "$APP_PATH/Contents/MacOS"
-	exec -a "CKAN" "$MONO" --debug $ASSEMBLY $@
+	exec -a "CKAN" "$MONO" --arch=32 $ASSEMBLY $@
 fi


### PR DESCRIPTION
CKAN's GUI apparently does not work in 64-bit on OSX (see #2269 and [the wiki](https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-OSX)).

This pull request adds `--arch=32` to the command line of mono in the `CKAN.app` bundle, and removes `--debug` because it's not recommended on the wiki.

(This doesn't fix #2269 because that user isn't using the app bundle.)