### PR TITLE
Add a read-execute-print-loop prompt for Cmdline

### DIFF
--- a/Cmdline/Action/AuthToken.cs
+++ b/Cmdline/Action/AuthToken.cs
@@ -23,7 +23,7 @@ namespace CKAN.CmdLine
         /// <returns>
         /// Exit code
         /// </returns>
-        public int RunSubCommand(SubCommandOptions unparsed)
+        public int RunSubCommand(KSPManager manager, CommonOptions opts, SubCommandOptions unparsed)
         {
             string[] args     = unparsed.options.ToArray();
             int      exitCode = Exit.OK;
@@ -33,8 +33,12 @@ namespace CKAN.CmdLine
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
                 {
                     CommonOptions options = (CommonOptions)suboptions;
+                    options.Merge(opts);
                     user                  = new ConsoleUser(options.Headless);
-                    manager               = new KSPManager(user);
+                    if (manager == null)
+                    {
+                        manager           = new KSPManager(user);
+                    }
                     exitCode              = options.Handle(manager, user);
                     if (exitCode == Exit.OK)
                     {
@@ -115,7 +119,6 @@ namespace CKAN.CmdLine
         private const string tokenHeader = "Token";
 
         private IUser      user;
-        private KSPManager manager;
         private static readonly ILog log = LogManager.GetLogger(typeof(AuthToken));
     }
 

--- a/Cmdline/Action/Compat.cs
+++ b/Cmdline/Action/Compat.cs
@@ -5,9 +5,9 @@ using CommandLine.Text;
 
 namespace CKAN.CmdLine.Action
 {
-    public class CompatSubCommand : ISubCommand
+    public class Compat : ISubCommand
     {
-        public CompatSubCommand() { }
+        public Compat() { }
 
         public class CompatOptions : VerbCommandOptions
         {
@@ -65,7 +65,7 @@ namespace CKAN.CmdLine.Action
             [ValueOption(0)] public string Version { get; set; }
         }
 
-        public int RunSubCommand(SubCommandOptions options)
+        public int RunSubCommand(KSPManager manager, CommonOptions opts, SubCommandOptions options)
         {
             var exitCode = Exit.OK;
 
@@ -75,9 +75,10 @@ namespace CKAN.CmdLine.Action
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
                 {
                     CommonOptions comOpts = (CommonOptions)suboptions;
-                    _user = new ConsoleUser(comOpts.Headless);
-                    _kspManager = new KSPManager(_user);
-                    exitCode = comOpts.Handle(_kspManager, _user);
+                    comOpts.Merge(opts);
+                    _user       = new ConsoleUser(comOpts.Headless);
+                    _kspManager = manager ?? new KSPManager(_user);
+                    exitCode    = comOpts.Handle(_kspManager, _user);
                     if (exitCode != Exit.OK)
                         return;
 
@@ -88,7 +89,7 @@ namespace CKAN.CmdLine.Action
                                 var ksp = MainClass.GetGameInstance(_kspManager);
 
                                 const string versionHeader = "Version";
-                                const string actualHeader = "Actual";
+                                const string actualHeader  = "Actual";
 
                                 var output = ksp
                                     .GetCompatibleVersions()
@@ -196,7 +197,6 @@ namespace CKAN.CmdLine.Action
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
-            RegistryManager.DisposeAll();
             return exitCode;
         }
 

--- a/Cmdline/Action/ISubCommand.cs
+++ b/Cmdline/Action/ISubCommand.cs
@@ -2,7 +2,6 @@
 {
     internal interface ISubCommand
     {
-        int RunSubCommand(SubCommandOptions options);
+        int RunSubCommand(KSPManager manager, CommonOptions opts, SubCommandOptions options);
     }
 }
-

--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -13,16 +13,16 @@ namespace CKAN.CmdLine
         internal class KSPSubOptions : VerbCommandOptions
         {
             [VerbOption("list",    HelpText = "List KSP installs")]
-            public CommonOptions ListOptions { get; set; }
+            public CommonOptions ListOptions     { get; set; }
 
             [VerbOption("add",     HelpText = "Add a KSP install")]
-            public AddOptions AddOptions { get; set; }
+            public AddOptions    AddOptions      { get; set; }
 
             [VerbOption("rename",  HelpText = "Rename a KSP install")]
-            public RenameOptions RenameOptions { get; set; }
+            public RenameOptions RenameOptions   { get; set; }
 
             [VerbOption("forget",  HelpText = "Forget a KSP install")]
-            public ForgetOptions ForgetOptions { get; set; }
+            public ForgetOptions ForgetOptions   { get; set; }
 
             [VerbOption("default", HelpText = "Set the default KSP install")]
             public DefaultOptions DefaultOptions { get; set; }
@@ -94,7 +94,7 @@ namespace CKAN.CmdLine
         }
 
         // This is required by ISubCommand
-        public int RunSubCommand(SubCommandOptions unparsed)
+        public int RunSubCommand(KSPManager manager, CommonOptions opts, SubCommandOptions unparsed)
         {
             string[] args = unparsed.options.ToArray();
 
@@ -123,8 +123,9 @@ namespace CKAN.CmdLine
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
                 {
                     CommonOptions options = (CommonOptions)suboptions;
-                    User = new ConsoleUser(options.Headless);
-                    Manager = new KSPManager(User);
+                    options.Merge(opts);
+                    User     = new ConsoleUser(options.Headless);
+                    Manager  = manager ?? new KSPManager(User);
                     exitCode = options.Handle(Manager, User);
                     if (exitCode != Exit.OK)
                         return;
@@ -159,7 +160,6 @@ namespace CKAN.CmdLine
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
-            RegistryManager.DisposeAll();
             return exitCode;
         }
 

--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -1,0 +1,47 @@
+using System;
+using CommandLine;
+using CommandLine.Text;
+using log4net;
+
+namespace CKAN.CmdLine
+{
+
+    public class Prompt
+    {
+        public Prompt() { }
+
+        public int RunCommand(KSPManager manager, object raw_options)
+        {
+            CommonOptions opts = raw_options as CommonOptions;
+            bool done = false;
+            while (!done)
+            {
+                // Prompt if not in headless mode
+                if (!(opts?.Headless ?? false))
+                {
+                    Console.Write(
+                        manager.CurrentInstance != null
+                            ? $"CKAN {Meta.GetVersion()}: KSP {manager.CurrentInstance.Version().ToString()} ({manager.CurrentInstance.Name})> "
+                            : $"CKAN {Meta.GetVersion()}> "
+                    );
+                }
+                // Get input
+                string command = Console.ReadLine();
+                if (command == null || command == exitCommand)
+                {
+                    done = true;
+                }
+                else if (command != "")
+                {
+                    // Parse input as if it was a normal command line,
+                    // but with a persistent KSPManager object.
+                    MainClass.Execute(manager, opts, command.Split(' '));
+                }
+            }
+            return Exit.OK;
+        }
+
+        private const string exitCommand = "exit";
+    }
+
+}

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -39,7 +39,7 @@ namespace CKAN.CmdLine
             }
         }
 
-        public int RunSubCommand(SubCommandOptions unparsed)
+        public int RunSubCommand(KSPManager manager, CommonOptions opts, SubCommandOptions unparsed)
         {
             int exitCode = Exit.OK;
             // Parse and process our sub-verbs
@@ -49,8 +49,12 @@ namespace CKAN.CmdLine
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
                 {
                     CommonOptions options = (CommonOptions)suboptions;
+                    options.Merge(opts);
                     User = new ConsoleUser(options.Headless);
-                    KSPManager manager = new KSPManager(User);
+                    if (manager == null)
+                    {
+                        manager = new KSPManager(User);
+                    }
                     exitCode = options.Handle(manager, User);
                     if (exitCode != Exit.OK)
                         return;
@@ -68,7 +72,6 @@ namespace CKAN.CmdLine
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
-            RegistryManager.DisposeAll();
             return exitCode;
         }
 
@@ -79,7 +82,7 @@ namespace CKAN.CmdLine
         /// </summary>
         private int Registry(CKAN.KSP ksp)
         {
-            var manager = RegistryManager.Instance(ksp);
+            RegistryManager manager = RegistryManager.Instance(ksp);
             manager.registry.Repair();
             manager.Save();
             User.RaiseMessage("Registry repairs attempted. Hope it helped.");

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -91,7 +91,7 @@ namespace CKAN.CmdLine
         }
 
         // This is required by ISubCommand
-        public int RunSubCommand(SubCommandOptions unparsed)
+        public int RunSubCommand(KSPManager manager, CommonOptions opts, SubCommandOptions unparsed)
         {
             string[] args = unparsed.options.ToArray();
 
@@ -118,8 +118,9 @@ namespace CKAN.CmdLine
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
                 {
                     CommonOptions options = (CommonOptions)suboptions;
-                    User = new ConsoleUser(options.Headless);
-                    Manager = new KSPManager(User);
+                    options.Merge(opts);
+                    User     = new ConsoleUser(options.Headless);
+                    Manager  = manager ?? new KSPManager(User);
                     exitCode = options.Handle(Manager, User);
                     if (exitCode != Exit.OK)
                         return;
@@ -154,7 +155,6 @@ namespace CKAN.CmdLine
                     }
                 }
             }, () => { exitCode = MainClass.AfterHelp(); });
-            RegistryManager.DisposeAll();
             return exitCode;
         }
 

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -56,7 +56,7 @@
     <Compile Include="Action\AuthToken.cs" />
     <Compile Include="Action\Available.cs" />
     <Compile Include="Action\Compare.cs" />
-    <Compile Include="Action\CompatSubCommand.cs" />
+    <Compile Include="Action\Compat.cs" />
     <Compile Include="Action\ICommand.cs" />
     <Compile Include="Action\Import.cs" />
     <Compile Include="Action\Install.cs" />
@@ -64,6 +64,7 @@
     <Compile Include="Action\KSP.cs" />
     <Compile Include="Action\List.cs" />
     <Compile Include="Action\Remove.cs" />
+    <Compile Include="Action\Prompt.cs" />
     <Compile Include="Action\Repair.cs" />
     <Compile Include="Action\Repo.cs" />
     <Compile Include="Action\Search.cs" />

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -15,7 +15,7 @@ namespace CKAN.CmdLine
 
     public class Options
     {
-        public string action { get; set; }
+        public string action  { get; set; }
         public object options { get; set; }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace CKAN.CmdLine
             (
                 args, new Actions(), (verb, suboptions) =>
                 {
-                    action = verb;
+                    action  = verb;
                     options = suboptions;
                 },
                 delegate
@@ -48,6 +48,9 @@ namespace CKAN.CmdLine
 
         [VerbOption("consoleui", HelpText = "Start the CKAN console UI")]
         public ConsoleUIOptions ConsoleUIOptions { get; set; }
+
+        [VerbOption("prompt", HelpText = "Run CKAN prompt for executing multiple commands in a row")]
+        public CommonOptions PromptOptions { get; set; }
 
         [VerbOption("search", HelpText = "Search for mods")]
         public SearchOptions SearchOptions { get; set; }
@@ -100,7 +103,7 @@ namespace CKAN.CmdLine
         [VerbOption("compare", HelpText = "Compare version strings")]
         public CompareOptions Compare { get; set; }
 
-        [VerbOption("version", HelpText = "Show the version of the CKAN client being used.")]
+        [VerbOption("version", HelpText = "Show the version of the CKAN client being used")]
         public VersionOptions Version { get; set; }
 
         [HelpVerbOption]
@@ -242,6 +245,24 @@ namespace CKAN.CmdLine
             }
 
             return Exit.OK;
+        }
+
+        /// <summary>
+        /// Combine two options objects.
+        /// This is mainly to ensure that --headless carries through for prompt.
+        /// </summary>
+        /// <param name="otherOpts">Options object to merge into this one</param>
+        public void Merge(CommonOptions otherOpts)
+        {
+            if (otherOpts != null)
+            {
+                Verbose      = Verbose      || otherOpts.Verbose;
+                Debug        = Debug        || otherOpts.Debug;
+                Debugger     = Debugger     || otherOpts.Debugger;
+                NetUserAgent = NetUserAgent ?? otherOpts.NetUserAgent;
+                Headless     = Headless     || otherOpts.Headless;
+                AsRoot       = AsRoot       || otherOpts.AsRoot;
+            }
         }
 
         private static void CheckMonoVersion(IUser user, int rec_major, int rec_minor, int rec_patch)

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -213,7 +213,7 @@ namespace CKAN
 
                 registry_manager.Save(!options.without_enforce_consistency);
 
-                User.RaiseProgress("Commiting filesystem changes", 80);
+                User.RaiseProgress("Committing filesystem changes", 80);
 
                 transaction.Complete();
 
@@ -250,7 +250,7 @@ namespace CKAN
 
                 registry_manager.Save(!options.without_enforce_consistency);
 
-                User.RaiseProgress("Commiting filesystem changes", 80);
+                User.RaiseProgress("Committing filesystem changes", 80);
 
                 transaction.Complete();
             }


### PR DESCRIPTION
Fixes #2161.

## Background

CKAN's Cmdline interface executes one command and then exits. Scripts can be written with CKAN, but they require CKAN to be executed once per command, with the cost of parsing `registry.json` incurred for each command.

## Changes

A new `ckan prompt` command is created that:
- Prompts the user for commands as input, displaying the CKAN version and the name and game version of the active instance, if any
- Interprets them as Cmdline commands and subcommands
- Only parses `registry.json` once for a given instance across multiple commands, so you don't have to wait several seconds between operations
- Carries its `CommonOptions` flags over to the commands it runs (mainly to make a top-level `--headless` work properly)

Line break added before the `install` command to simulate having the screen pause for input:

```
$ ckan.exe prompt
CKAN v1.24.0-PRE2> list

KSP found at C:/Program Files (x86)/Steam/steamapps/common/Kerbal Space Program

KSP Version: 1.3.1.1891

Installed Modules:

- KSPSteamCtrlr autodetected dll
- LoadingTipsPlus V1.5
- ModuleManager 3.0.1
- Steamworks autodetected dll

Legend: -: Up to date. X: Incompatible. ^: Upgradable. ?: Unknown. *: Broken.

CKAN v1.24.0-PRE2: KSP 1.3.1.1891 (Steam)> install astrogator
About to install...

 * Astrogator v0.7.8 (cached)

Continue? [Y/n]


Installing mod "Astrogator v0.7.8"
Updating registry
Commiting filesystem changes
Rescanning GameData
Done!
CKAN v1.24.0-PRE2: KSP 1.3.1.1891 (Steam)> exit
```

`ckan prompt --headless` now works kind of like a CKAN scripting language:

```
$ cat ~/Documents/ckan-script.txt
ksp list
list
repo list
authtoken list
update
upgrade --all

$ ckan prompt --headless < ~/Documents/ckan-script.txt
Name   Version     Default  Path
-----  ----------  -------  ------------------------------------------------------------------
Steam  1.3.1.1891  Yes      C:/Program Files (x86)/Steam/steamapps/common/Kerbal Space Program
Fake2  1.3.1       No       c:/users/user/downloads/fakeksp2
Fake   1.2.2       No       C:/Users/user/Downloads/FakeKSP

KSP found at C:/Program Files (x86)/Steam/steamapps/common/Kerbal Space Program

KSP Version: 1.3.1.1891

Installed Modules:

- KSPSteamCtrlr autodetected dll
- LoadingTipsPlus V1.5
- ModuleManager 3.0.1
- Steamworks autodetected dll

Legend: -: Up to date. X: Incompatible. ^: Upgradable. ?: Unknown. *: Broken.
Listing all known repositories:
  default: 0: https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz
Host            Token
--------------  ------------------------------------
api.github.com  abcdefghijklmnopqrstuvwxyz0123456789
Downloading updates...
Updated information on 802 available modules

Upgrading modules...


Done!
```

### Other changes

- The command-running code is refactored into an `Execute` function to make it easier to parse and run commands from other commands. This also allowed us to centralize the `DisposeAll` calls that each subcommand previously had to handle itself.
- `CompatSubCommand` is renamed to `Compat` for consistency with other subcommands

## Not Done Yet

Tab completion as in #888 and #2174 is not implemented. It should be possible to add it to `Prompt.cs`'s input driver. (Or it might be cleaner to do bash completion instead.)