### PR TITLE
Retry of failed downloads

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -244,6 +244,12 @@ namespace CKAN.CmdLine
                 user.RaiseMessage(kraken.ToString());
                 return Exit.ERROR;
             }
+            catch (DownloadThrottledKraken kraken)
+            {
+                user.RaiseMessage(kraken.ToString());
+                user.RaiseMessage($"Try the authtoken command. See {kraken.infoUrl} for details.");
+                return Exit.ERROR;
+            }
             catch (DownloadErrorsKraken)
             {
                 user.RaiseMessage("One or more files failed to download, stopped.");

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -249,6 +249,11 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("One or more files failed to download, stopped.");
                 return Exit.ERROR;
             }
+            catch (ModuleDownloadErrorsKraken kraken)
+            {
+                user.RaiseMessage(kraken.ToString());
+                return Exit.ERROR;
+            }
             catch (DirectoryNotFoundKraken kraken)
             {
                 user.RaiseMessage("\r\n{0}", kraken.Message);

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -96,6 +96,13 @@ namespace CKAN.ConsoleUI {
                         RaiseError(ex.ToString());
                     } catch (ModuleDownloadErrorsKraken ex) {
                         RaiseError(ex.ToString());
+                    } catch (DownloadThrottledKraken ex) {
+                        if (RaiseYesNoDialog($"{ex.ToString()}\n\nEdit authentication tokens now?")) {
+                            if (ex.infoUrl != null) {
+                                ModInfoScreen.LaunchURL(ex.infoUrl);
+                            }
+                            LaunchSubScreen(new AuthTokenScreen());
+                        }
                     } catch (MissingCertificateKraken ex) {
                         RaiseError(ex.ToString());
                     } catch (InconsistentKraken ex) {

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -94,6 +94,8 @@ namespace CKAN.ConsoleUI {
                         RaiseError("Game files reverted.");
                     } catch (DownloadErrorsKraken ex) {
                         RaiseError(ex.ToString());
+                    } catch (ModuleDownloadErrorsKraken ex) {
+                        RaiseError(ex.ToString());
                     } catch (MissingCertificateKraken ex) {
                         RaiseError(ex.ToString());
                     } catch (InconsistentKraken ex) {

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -65,7 +65,7 @@ namespace CKAN.ConsoleUI {
             ));
             AddObject(new ConsoleLabel(
                 13, 5, midL - 2,
-                () => Formatting.FmtSize(mod.download_size)
+                () => CkanModule.FmtSize(mod.download_size)
             ));
             AddObject(new ConsoleLabel(
                 3, 6, midL - 2,

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -203,7 +203,7 @@ namespace CKAN.ConsoleUI {
             // Show total download size of all installed mods
             AddObject(new ConsoleLabel(
                 1, -1, searchWidth,
-                () => $"{Formatting.FmtSize(totalInstalledDownloadSize())} installed",
+                () => $"{CkanModule.FmtSize(totalInstalledDownloadSize())} installed",
                 null,
                 () => ConsoleTheme.Current.DimLabelFg
             ));

--- a/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
@@ -48,7 +48,7 @@ namespace CKAN.ConsoleUI.Toolkit {
 
             AddObject(new ConsoleLabel(
                 left + 2, bottom - 1, right - 2,
-                () => $"{chosenFiles.Count} selected, {Formatting.FmtSize(totalChosenSize())}",
+                () => $"{chosenFiles.Count} selected, {CkanModule.FmtSize(totalChosenSize())}",
                 () => ConsoleTheme.Current.PopupBg,
                 () => ConsoleTheme.Current.PopupFg
             ));
@@ -231,7 +231,7 @@ namespace CKAN.ConsoleUI.Toolkit {
             } else {
                 FileInfo file = fi as FileInfo;
                 if (file != null) {
-                    return Formatting.FmtSize(file.Length);
+                    return CkanModule.FmtSize(file.Length);
                 } else {
                     return dirSize;
                 }

--- a/ConsoleUI/Toolkit/Formatting.cs
+++ b/ConsoleUI/Toolkit/Formatting.cs
@@ -99,27 +99,6 @@ namespace CKAN.ConsoleUI.Toolkit {
             return messageLines;
         }
 
-        /// <summary>
-        /// Format a byte count into readable file size
-        /// </summary>
-        /// <param name="bytes">Number of bytes in a file</param>
-        /// <returns>
-        /// ### bytes or ### KB or ### MB or ### GB
-        /// </returns>
-        public static string FmtSize(long bytes)
-        {
-            const double K = 1024;
-            if (bytes < K) {
-                return $"{bytes} B";
-            } else if (bytes < K * K) {
-                return $"{bytes / K :N1} KB";
-            } else if (bytes < K * K * K) {
-                return $"{bytes / K / K :N1} MB";
-            } else {
-                return $"{bytes / K / K / K :N1} GB";
-            }
-        }
-
     }
 
 }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -168,7 +168,12 @@ namespace CKAN
             {
                 if (!ksp.Cache.IsCachedZip(module))
                 {
-                    User.RaiseMessage(" * {0} {1} ({2})", module.name, module.version, module.download.Host);
+                    User.RaiseMessage(" * {0} {1} ({2}, {3})",
+                        module.name,
+                        module.version,
+                        module.download.Host,
+                        CkanModule.FmtSize(module.download_size)
+                    );
                     downloads.Add(module);
                 }
                 else

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -23,6 +23,14 @@ namespace CKAN
         private static readonly ILog Log = LogManager.GetLogger(typeof (Net));
         private static readonly TxFileManager FileTransaction = new TxFileManager();
 
+        public static readonly Dictionary<string, Uri> ThrottledHosts = new Dictionary<string, Uri>()
+        {
+            {
+                "api.github.com",
+                new Uri("https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-GitHub-API-authtoken")
+            }
+        };
+
         /// <summary>
         ///     Downloads the specified url, and stores it in the filename given.
         ///     If no filename is supplied, a temporary file will be generated.

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -395,9 +395,9 @@ namespace CKAN
             {
                 // Math.Ceiling was added to avoid showing 0 MiB left when finishing
                 User.RaiseProgress(
-                    String.Format("{0} kbps - downloading - {1:f0} MB left",
-                        totalBytesPerSecond/1024,
-                        Math.Ceiling((double)totalBytesLeft/1024/1024)),
+                    String.Format("{0}/sec - downloading - {1} left",
+                        CkanModule.FmtSize(totalBytesPerSecond),
+                        CkanModule.FmtSize(totalBytesLeft)),
                     totalPercentage);
             }
         }

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -622,6 +622,27 @@ namespace CKAN
             }
             return string.Join(", ", descriptions);
         }
+
+        /// <summary>
+        /// Format a byte count into readable file size
+        /// </summary>
+        /// <param name="bytes">Number of bytes in a file</param>
+        /// <returns>
+        /// ### bytes or ### KB or ### MB or ### GB
+        /// </returns>
+        public static string FmtSize(long bytes)
+        {
+            const double K = 1024;
+            if (bytes < K) {
+                return $"{bytes} B";
+            } else if (bytes < K * K) {
+                return $"{bytes / K :N1} KB";
+            } else if (bytes < K * K * K) {
+                return $"{bytes / K / K :N1} MB";
+            } else {
+                return $"{bytes / K / K / K :N1} GB";
+            }
+        }
     }
 
     public class InvalidModuleAttributesException : Exception

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Text;
 using System.Collections.Generic;
 
@@ -377,6 +378,23 @@ namespace CKAN
                 "\tmozroots --import --ask-remove\r\n" +
                 "on the command-line to update your certificate store, and try again.\r\n\r\n"
             ;
+        }
+    }
+
+    public class DownloadThrottledKraken : Kraken
+    {
+        public readonly Uri throttledUrl;
+        public readonly Uri infoUrl;
+
+        public DownloadThrottledKraken(Uri url, Uri info) : base()
+        {
+            throttledUrl = url;
+            infoUrl      = info;
+        }
+
+        public override string ToString()
+        {
+            return $"Download from {throttledUrl.Host} was throttled.\r\nConsider adding an authentication token to increase the throtting limit.";
         }
     }
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Collections.Generic;
 
 namespace CKAN
@@ -218,18 +219,72 @@ namespace CKAN
     /// </summary>
     public class DownloadErrorsKraken : Kraken
     {
-        public List<Exception> exceptions;
+        public readonly List<KeyValuePair<int, Exception>> exceptions
+            = new List<KeyValuePair<int, Exception>>();
 
-        public DownloadErrorsKraken(IEnumerable<Exception> errors, string reason = null, Exception innerException = null)
-            : base(reason, innerException)
+        public DownloadErrorsKraken(List<KeyValuePair<int, Exception>> errors) : base()
         {
-            exceptions = new List<Exception>(errors);
+            exceptions = new List<KeyValuePair<int, Exception>>(errors);
         }
 
         public override string ToString()
         {
             return "Uh oh, the following things went wrong when downloading...\r\n\r\n" + String.Join("\r\n", exceptions);
         }
+
+    }
+
+    /// <summary>
+    /// A download errors exception that knows about modules,
+    /// to make the error message nicer.
+    /// </summary>
+    public class ModuleDownloadErrorsKraken : Kraken
+    {
+        /// <summary>
+        /// Initialize the exception.
+        /// </summary>
+        /// <param name="modules">List of modules that we tried to download</param>
+        /// <param name="kraken">Download errors from URL-level downloader</param>
+        public ModuleDownloadErrorsKraken(IList<CkanModule> modules, DownloadErrorsKraken kraken)
+            : base()
+        {
+            foreach (var kvp in kraken.exceptions)
+            {
+                exceptions.Add(new KeyValuePair<CkanModule, Exception>(
+                    modules[kvp.Key], kvp.Value
+                ));
+            }
+        }
+
+        /// <summary>
+        /// Generate a user friendly description of this error.
+        /// </summary>
+        /// <returns>
+        /// One or more downloads were unsuccessful:
+        ///
+        /// Error downloading Astrogator v0.7.8: The remote server returned an error: (404) Not Found.
+        /// Etc.
+        /// </returns>
+        public override string ToString()
+        {
+            if (builder == null)
+            {
+                builder = new StringBuilder();
+                builder.AppendLine("One or more downloads were unsuccessful:");
+                builder.AppendLine("");
+                foreach (KeyValuePair<CkanModule, Exception> kvp in exceptions)
+                {
+                    builder.AppendLine(
+                        $"Error downloading {kvp.Key.ToString()}: {kvp.Value.Message}"
+                    );
+                }
+            }
+            return builder.ToString();
+        }
+
+        private readonly List<KeyValuePair<CkanModule, Exception>> exceptions
+            = new List<KeyValuePair<CkanModule, Exception>>();
+        private StringBuilder builder = null;
     }
 
     /// <summary>

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -173,12 +173,9 @@ namespace CKAN
 
             Identifier = mod.identifier;
 
-            if (mod.download_size == 0)
-                DownloadSize = "N/A";
-            else if (mod.download_size / 1024.0 < 1)
-                DownloadSize = "1<KB";
-            else
-                DownloadSize = mod.download_size / 1024+"";
+            DownloadSize = (mod.download_size == 0)
+                ? "N/A"
+                : CkanModule.FmtSize(mod.download_size);
 
             Abbrevation = new string(mod.name.Split(' ').
                 Where(s => s.Length > 0).Select(s => s[0]).ToArray());

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -554,7 +554,7 @@
             // 
             // SizeCol
             // 
-            this.SizeCol.HeaderText = "Download (KB)";
+            this.SizeCol.HeaderText = "Download";
             this.SizeCol.Name = "SizeCol";
             this.SizeCol.ReadOnly = true;
             this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -98,6 +98,7 @@
             this.Reason = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.WaitTabPage = new System.Windows.Forms.TabPage();
             this.CancelCurrentActionButton = new System.Windows.Forms.Button();
+            this.RetryCurrentActionButton = new System.Windows.Forms.Button();
             this.LogTextBox = new System.Windows.Forms.TextBox();
             this.DialogProgressBar = new System.Windows.Forms.ProgressBar();
             this.MessageTextBox = new System.Windows.Forms.TextBox();
@@ -769,26 +770,27 @@
             this.ChangesListView.TabIndex = 4;
             this.ChangesListView.UseCompatibleStateImageBehavior = false;
             this.ChangesListView.View = System.Windows.Forms.View.Details;
-            // 
+            //
             // Mod
-            // 
+            //
             this.Mod.Text = "Mod";
             this.Mod.Width = 332;
-            // 
+            //
             // ChangeType
-            // 
+            //
             this.ChangeType.Text = "Change";
             this.ChangeType.Width = 111;
-            // 
+            //
             // Reason
-            // 
+            //
             this.Reason.Text = "Reason for action";
             this.Reason.Width = 606;
-            // 
+            //
             // WaitTabPage
-            // 
+            //
             this.WaitTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.WaitTabPage.Controls.Add(this.CancelCurrentActionButton);
+            this.WaitTabPage.Controls.Add(this.RetryCurrentActionButton);
             this.WaitTabPage.Controls.Add(this.LogTextBox);
             this.WaitTabPage.Controls.Add(this.DialogProgressBar);
             this.WaitTabPage.Controls.Add(this.MessageTextBox);
@@ -812,11 +814,25 @@
             this.CancelCurrentActionButton.Text = "Cancel";
             this.CancelCurrentActionButton.UseVisualStyleBackColor = true;
             this.CancelCurrentActionButton.Click += new System.EventHandler(this.CancelCurrentActionButton_Click);
-            // 
+            //
+            // RetryCurrentActionButton
+            //
+            this.RetryCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.RetryCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.RetryCurrentActionButton.Location = new System.Drawing.Point(1290, 951);
+            this.RetryCurrentActionButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.RetryCurrentActionButton.Name = "RetryCurrentActionButton";
+            this.RetryCurrentActionButton.Size = new System.Drawing.Size(112, 35);
+            this.RetryCurrentActionButton.TabIndex = 8;
+            this.RetryCurrentActionButton.Text = "Retry";
+            this.RetryCurrentActionButton.UseVisualStyleBackColor = true;
+            this.RetryCurrentActionButton.Visible = false;
+            this.RetryCurrentActionButton.Click += new System.EventHandler(this.RetryCurrentActionButton_Click);
+            //
             // LogTextBox
-            // 
-            this.LogTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.LogTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.LogTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.LogTextBox.Location = new System.Drawing.Point(14, 89);
@@ -1152,6 +1168,7 @@
         private System.Windows.Forms.ColumnHeader Reason;
         private System.Windows.Forms.TabPage WaitTabPage;
         private System.Windows.Forms.Button CancelCurrentActionButton;
+        private System.Windows.Forms.Button RetryCurrentActionButton;
         private System.Windows.Forms.TextBox LogTextBox;
         private System.Windows.Forms.ProgressBar DialogProgressBar;
         private System.Windows.Forms.TextBox MessageTextBox;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -974,7 +974,6 @@ namespace CKAN
                                 install_ops
                             )
                         );
-                        UpdateChangesDialog(null, installWorker);
                         ShowWaitDialog();
                     }
                 }

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -46,7 +46,12 @@ namespace CKAN
                     continue;
                 }
 
-                var item = new ListViewItem {Text = String.Format("{0} {1}", change.Mod.Name, change.Mod.Version)};
+                ListViewItem item = new ListViewItem()
+                {
+                    Text = CurrentInstance.Cache.IsCachedZip(change.Mod.ToModule())
+                        ? $"{change.Mod.Name} {change.Mod.Version} (cached)"
+                        : $"{change.Mod.Name} {change.Mod.Version} ({change.Mod.ToModule()?.download.Host ?? ""}, {change.Mod.DownloadSize})"
+                };
 
                 var sub_change_type = new ListViewItem.ListViewSubItem {Text = change.ChangeType.ToString()};
 

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -110,6 +110,7 @@ namespace CKAN
                 return;
 
             menuStrip1.Enabled = false;
+            RetryCurrentActionButton.Visible = false;
 
             RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
             install_ops.with_recommends = false;

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -32,7 +32,7 @@ namespace CKAN
 
             IEnumerable<ModChange> leftOver = changeset.Where(change => change.ChangeType != GUIModChangeType.Remove
                                                 && change.ChangeType != GUIModChangeType.Update);
-            
+
             // Now make our list more human-friendly (dependencies for a mod are listed directly
             // after it.)
             CreateSortedModList(leftOver);
@@ -74,7 +74,7 @@ namespace CKAN
         /// It arranges the changeset in a human-friendly order
         /// The requested mod is listed first, it's dependencies right after it
         /// So we get for example "ModuleRCSFX" directly after "USI Exploration Pack"
-        /// 
+        ///
         /// It is very likely that this is forward-compatible with new ChangeTypes's,
         /// like a a "reconfigure" changetype, but only the future will tell
         /// </summary>
@@ -116,13 +116,12 @@ namespace CKAN
             //Using the changeset passed in can cause issues with versions.
             // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.
             // TODO Work out why this is.
-            var user_change_set = mainModList.ComputeUserChangeSet().ToList();
             installWorker.RunWorkerAsync(
                 new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                    user_change_set, install_ops));
-            changeSet = null;
-
-            UpdateChangesDialog(null, installWorker);
+                    mainModList.ComputeUserChangeSet().ToList(),
+                    install_ops
+                )
+            );
             ShowWaitDialog();
         }
 

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -22,8 +22,12 @@ namespace CKAN
 
         public void AddStatusMessage(string text, params object[] args)
         {
-            Util.Invoke(statusStrip1, () => StatusLabel.Text = String.Format(text, args));
-            AddLogMessage(String.Format(text, args));
+            string msg = String.Format(text, args);
+            // No newlines in status bar
+            Util.Invoke(statusStrip1, () =>
+                StatusLabel.Text = msg.Replace("\r\n", " ").Replace("\n", " ")
+            );
+            AddLogMessage(msg);
         }
 
         public void ErrorDialog(string text, params object[] args)

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -192,6 +193,28 @@ namespace CKAN
                 {
                     // Another very pretty kraken.
                     GUI.user.RaiseMessage(kraken.ToString());
+                    return;
+                }
+                catch (DownloadThrottledKraken kraken)
+                {
+                    string msg = kraken.ToString();
+                    GUI.user.RaiseMessage(msg);
+                    if (YesNoDialog($"{msg}\r\n\r\nOpen settings now?"))
+                    {
+                        // Launch the URL describing this host's throttling practices, if any
+                        if (kraken.infoUrl != null)
+                        {
+                            Process.Start(new ProcessStartInfo()
+                            {
+                                UseShellExecute = true,
+                                FileName        = kraken.infoUrl.ToString()
+                            });
+                        }
+                        // Now pretend they clicked the menu option for the settings
+                        Enabled = false;
+                        settingsDialog.ShowDialog();
+                        Enabled = true;
+                    }
                     return;
                 }
                 catch (ModuleDownloadErrorsKraken kraken)

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -194,9 +194,10 @@ namespace CKAN
                     GUI.user.RaiseMessage(kraken.ToString());
                     return;
                 }
-                catch (DownloadErrorsKraken)
+                catch (ModuleDownloadErrorsKraken kraken)
                 {
-                    // User notified in InstallList
+                    GUI.user.RaiseMessage(kraken.ToString());
+                    GUI.user.RaiseError(kraken.ToString());
                     return;
                 }
                 catch (DirectoryNotFoundKraken kraken)

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -477,8 +477,14 @@ namespace CKAN
             foreach (var pair in mods)
             {
                 CkanModule module = pair.Key;
-                ListViewItem item = new ListViewItem {Tag = module, Checked = !suggested, Text = pair.Key.name};
-
+                ListViewItem item = new ListViewItem()
+                {
+                    Tag = module,
+                    Checked = !suggested,
+                    Text = CurrentInstance.Cache.IsCachedZip(pair.Key)
+                        ? $"{pair.Key.name} {pair.Key.version} (cached)"
+                        : $"{pair.Key.name} {pair.Key.version} ({pair.Key.download.Host ?? ""}, {CkanModule.FmtSize(pair.Key.download_size)})"
+                };
 
                 ListViewItem.ListViewSubItem recommendedBy = new ListViewItem.ListViewSubItem() { Text = pair.Value };
 

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -322,6 +322,7 @@ namespace CKAN
                 HideWaitDialog(true);
                 tabController.HideTab("ChangesetTabPage");
                 ApplyToolButton.Enabled = false;
+                RetryCurrentActionButton.Visible = false;
                 UpdateChangesDialog(null, installWorker);
             }
             else
@@ -331,6 +332,7 @@ namespace CKAN
                 AddStatusMessage("Error!");
                 SetDescription("An error occurred, check the log for information");
                 UpdateChangesDialog(result.Value, installWorker);
+                RetryCurrentActionButton.Visible = true;
                 Util.Invoke(DialogProgressBar, () => DialogProgressBar.Style = ProgressBarStyle.Continuous);
                 Util.Invoke(DialogProgressBar, () => DialogProgressBar.Value = 0);
             }

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -301,12 +301,13 @@ namespace CKAN
         {
             KeyValuePair<bool, ModChanges> result = (KeyValuePair<bool, ModChanges>) e.Result;
 
-            UpdateModsList(false, result.Value);
-
             tabController.SetTabLock(false);
 
             if (result.Key)
             {
+                // Rebuilds the list of GUIMods
+                UpdateModsList(false, result.Value);
+
                 if (modChangedCallback != null)
                 {
                     foreach (var mod in result.Value)
@@ -320,13 +321,15 @@ namespace CKAN
                 HideWaitDialog(true);
                 tabController.HideTab("ChangesetTabPage");
                 ApplyToolButton.Enabled = false;
+                UpdateChangesDialog(null, installWorker);
             }
             else
             {
-                // there was an error
-                // rollback user's choices but stay on the log dialog
+                // There was an error
+                // Stay on the log dialog and re-apply the user's change set to allow retry
                 AddStatusMessage("Error!");
                 SetDescription("An error occurred, check the log for information");
+                UpdateChangesDialog(result.Value, installWorker);
                 Util.Invoke(DialogProgressBar, () => DialogProgressBar.Style = ProgressBarStyle.Continuous);
                 Util.Invoke(DialogProgressBar, () => DialogProgressBar.Value = 0);
             }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -653,13 +653,13 @@ namespace CKAN
 
         public HashSet<ModChange> ComputeUserChangeSet()
         {
-            var changes = Modules.Where(mod => mod.IsInstallable()).Select(mod => mod.GetRequestedChange());
-            var changeset = new HashSet<ModChange>(
-                changes.Where(change => change.HasValue).
+            return new HashSet<ModChange>(Modules.
+                Where(mod => mod.IsInstallable()).
+                Select(mod => mod.GetRequestedChange()).
+                Where(change => change.HasValue).
                 Select(change => change.Value).
                 Select(change => new ModChange(change.Key, change.Value, null))
-                );
-            return changeset;
+            );
         }
     }
 }

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -68,8 +68,8 @@ namespace CKAN
         {
             try
             {
-                KSP current_instance1 = CurrentInstance;
-                Repo.UpdateAllRepositories(RegistryManager.Instance(CurrentInstance), current_instance1, GUI.user);
+                AddStatusMessage("Updating repositories...");
+                e.Result = Repo.UpdateAllRepositories(RegistryManager.Instance(CurrentInstance), CurrentInstance, GUI.user);
             }
             catch (UriFormatException ex)
             {
@@ -89,11 +89,17 @@ namespace CKAN
 
         private void PostUpdateRepo(object sender, RunWorkerCompletedEventArgs e)
         {
-            UpdateModsList(repo_updated: true);
-
-            HideWaitDialog(true);
-            AddStatusMessage("Repository successfully updated");
-            ShowRefreshQuestion();
+            if ((e.Result as int? ?? 0) > 0)
+            {
+                UpdateModsList(repo_updated: true);
+                AddStatusMessage("Repositories successfully updated.");
+                ShowRefreshQuestion();
+                HideWaitDialog(true);
+            }
+            else
+            {
+                AddStatusMessage("Repository update failed!");
+            }
 
             Util.Invoke(this, SwitchEnabledState);
             Util.Invoke(this, RecreateDialogs);

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -90,6 +90,11 @@ namespace CKAN
             Util.Invoke(LogTextBox, () => LogTextBox.AppendText(message + "\r\n"));
         }
 
+        private void RetryCurrentActionButton_Click(object sender, EventArgs e)
+        {
+            tabController.ShowTab("ChangesetTabPage", 1);
+        }
+
         private void CancelCurrentActionButton_Click(object sender, EventArgs e)
         {
             if (cancelCallback != null)

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -100,9 +100,9 @@ namespace CKAN
             if (cancelCallback != null)
             {
                 cancelCallback();
-                CancelCurrentActionButton.Enabled = false;
-                HideWaitDialog(true);
             }
+            CancelCurrentActionButton.Enabled = false;
+            HideWaitDialog(true);
         }
 
     }

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -78,9 +78,9 @@ namespace CKAN
 
             CKANCacheLabel.Text = String.Format
             (
-                "There are currently {0} cached files using {1} MB in total",
+                "There are currently {0} cached files using {1} in total",
                 m_cacheFileCount,
-                m_cacheSize / 1024 / 1024
+                CkanModule.FmtSize(m_cacheSize)
             );
         }
 
@@ -89,9 +89,9 @@ namespace CKAN
             YesNoDialog deleteConfirmationDialog = new YesNoDialog();
             string confirmationText = String.Format
             (
-                "Do you really want to delete {0} cached files, freeing {1} MB?",
+                "Do you really want to delete {0} cached files, freeing {1}?",
                 m_cacheFileCount,
-                m_cacheSize / 1024 / 1024
+                CkanModule.FmtSize(m_cacheSize)
             );
 
             if (deleteConfirmationDialog.ShowYesNoDialog(confirmationText) == System.Windows.Forms.DialogResult.Yes)


### PR DESCRIPTION
## Problem

If you try to install mods in GUI and one or more downloads errors out, it's not handled well.

| CKAN version | Outcome |
| --- | --- |
| 1.22.6 and earlier | `DownloadErrorsKraken` thrown and caught by the uncaught exceptions handler, effectively crashing the app |
| 1.24.0-PRE-1 (post-#2233) | Error raised, user can cancel and retry, but retrying doesn't attempt to download or install anything |

## Cause

Before #2233, GUI's downloads happened on this line:

https://github.com/KSP-CKAN/CKAN/blob/28c981e3bf71d3f596cd8f537bf33831e4e8ab36/GUI/MainInstall.cs#L123

That function can throw `DownloadErrorsKraken`s, and there's nothing there to catch them.

After #2233, that exception is handled, but the user's change set was still being lost in a few ways:

- The code to install was calling `UpdateChangesDialog` with a null parameter immediately after starting the install. This cleared the `Main.changeSet` variable and the grid for previewing changes.
- The post-install code was calling `UpdateModsList` regardless of success or failure, which rebuilds the GUIMod list from the registry. Unfortunately since each GUIMod tracks whether it is selected to install/remove/upgrade, and clicking Apply Changes rebuilds the change set from the GUIMod list, this also wiped the user's change set.

https://github.com/KSP-CKAN/CKAN/blob/bb028923969f731df7b2a66b592ad4c5e9f9baa0/GUI/MainChangeset.cs#L116-L122

## Changes

### Handling download exceptions

#2233 can be taken as a first step towards fixing this; it moved the download process into a `try{}` block that catches `DownloadErrorsKraken`, so the user isn't confronted with a scary Continue/Quit exception popup.

### Preserve change set on failure

Now we take the next step: we don't reset the change set until the end of the install attempt. If the install attempt is successful, we clear the change set and rebuild the list of GUIMods, since we are done with those changes. If the attempt fails, we keep the change set and also keep the current list of GUIMods, since they are used to regenerate the change set at the start of the next install attempt (see the code block above).

Fixes #2274.

### Retry button after failure

Building on these improvements, a Retry button now appears next to Cancel when an install fails, and clicking it restarts the previously attempted install process.

### Consolidated download error popup

Download error reporting is now more complete and user friendly. Rather than raising up to three popups in a row for download errors and ignoring remaining errors, GUI now shows all download errors in a single popup and adds them to the progress tab's log box as well for closer examination after the popup is closed. These errors are also now formatted better in Cmdline and ConsoleUI.

![image](https://user-images.githubusercontent.com/1559108/35894758-49e9c97a-0bac-11e8-9970-7be7f2634ab0.png)

![image](https://user-images.githubusercontent.com/1559108/35902672-038c3260-0bd4-11e8-880d-21ba2f0493eb.png)

### Host and size shown before downloading

We also now show the download host and size before each point where the user needs to decide whether to continue in GUI:

![image](https://user-images.githubusercontent.com/1559108/35942483-af207ff4-0c4d-11e8-9727-6df7d303c237.png)
![image](https://user-images.githubusercontent.com/1559108/35942488-b521e42e-0c4d-11e8-96c3-e5049aa14e19.png)
![image](https://user-images.githubusercontent.com/1559108/35942493-b719a87a-0c4d-11e8-860f-c34c3438a682.png)

### Jump to auth token screen if a download is throttled

If a user encounters the dreaded GitHub 403 response due to download throttling, we will notify them specifically that the download was throttled, and advise them that adding an authentication token might help. Cmdline says to try the authtoken command, and ConsoleUI and GUI both provide a yes/no popup to jump to their respective auth token editing screens. If the user selects yes, the GitHub auth token wiki is opened in the system browser as well.

Fixes #1025.
Part of addressing #2210.

### Don't report success after repo update fails

#1579 contains this gem:

![image](https://user-images.githubusercontent.com/1559108/36032821-1a7b341a-0da7-11e8-8cc8-16c80e753ab8.png)

A failure message followed by a success message. Now repo update failure will be reported as a failure and only a failure.

### Make Cancel button always work

Previously, the Cancel button on the progress screen in GUI only worked for module downloads, and not for repo updates. You could click it, but nothing happened. Now it always takes you back to the mod list.