### PR TITLE
Point to wiki page about certs on cert errors

### DIFF
--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -316,12 +316,16 @@ namespace CKAN
 
         public override string ToString()
         {
-            return
-                "\r\nOh no! Our download failed with a certificate error!\r\n\r\n" +
-                "If you're on Linux, try running:\r\n" +
-                "\tmozroots --import --ask-remove\r\n" +
-                "on the command-line to update your certificate store, and try again.\r\n\r\n"
-            ;
+            if (Platform.IsUnix)
+            {
+                return "Oh no! Our download failed with a certificate error!\r\n\r\n"
+                    + "Consult this page for help:\r\n"
+                    + "\thttps://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors";
+            }
+            else
+            {
+                return "Oh no! Our download failed with a certificate error!";
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

As #2278 points out, the error message for certificate errors is outdated:

```
Oh no! Our download failed with a certificate error!

If you're on Linux, try running:
	mozroots --import --ask-remove
on the command-line to update your certificate store, and try again.
```

According to our own wiki pages, `mozroots` has been superseded by `cert-sync` since Mono 3.12.0 in early 2015, but the error message still suggests `mozroots`.

## Changes

This pull request updates it to recommend the wiki page about certs instead:

- https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors

This page was created just now based on the information previously scattered across each Linux page about certs, which now link to the new page. This way instead of updating the code to keep up with changes in Mono, we can just update the wiki, and everyone has the latest info.

Since we can check the user's platform directly, "If you're on Linux" is removed.