### PR TITLE
Handle invalid installs (KSP.Version()==null) better

### DIFF
--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -168,24 +168,15 @@ namespace CKAN.CmdLine
 
         private int ListInstalls()
         {
-            string preferredGameDir = null;
-
-            var preferredInstance = Manager.GetPreferredInstance();
-
-            if (preferredInstance != null)
-            {
-                preferredGameDir = preferredInstance.GameDir();
-            }
-
             var output = Manager.Instances
-                .OrderByDescending(i => i.Value.GameDir() == preferredGameDir)
+                .OrderByDescending(i => i.Value.Name == Manager.AutoStartInstance)
                 .ThenByDescending(i => i.Value.Version() ?? KspVersion.Any)
                 .ThenBy(i => i.Key)
                 .Select(i => new
                 {
                     Name = i.Key,
                     Version = i.Value.Version()?.ToString() ?? "<NONE>",
-                    Default = i.Value.GameDir() == preferredGameDir ? "Yes" : "No",
+                    Default = i.Value.Name == Manager.AutoStartInstance ? "Yes" : "No",
                     Path = i.Value.GameDir()
                 })
                 .ToList();

--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -21,7 +21,7 @@ namespace CKAN.CmdLine
                 {
                     Console.Write(
                         manager.CurrentInstance != null
-                            ? $"CKAN {Meta.GetVersion()}: KSP {manager.CurrentInstance.Version().ToString()} ({manager.CurrentInstance.Name})> "
+                            ? $"CKAN {Meta.GetVersion()}: KSP {manager.CurrentInstance.Version()} ({manager.CurrentInstance.Name})> "
                             : $"CKAN {Meta.GetVersion()}> "
                     );
                 }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -277,7 +277,7 @@ namespace CKAN.ConsoleUI {
             mainMenu = new ConsolePopupMenu(opts);
 
             LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => $"KSP {manager.CurrentInstance.Version().ToString()} ({manager.CurrentInstance.Name})";
+            CenterHeader = () => $"KSP {manager.CurrentInstance.Version()} ({manager.CurrentInstance.Name})";
         }
 
         // Alt+H doesn't work on Mac, but F1 does, and we need

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -79,7 +79,7 @@ namespace CKAN
             }
 
             // If we only know of a single instance, return that.
-            if (instances.Count == 1)
+            if (instances.Count == 1 && instances.First().Value.Valid)
             {
                 return instances.First().Value;
             }

--- a/GUI/CompatibleKspVersionsDialog.cs
+++ b/GUI/CompatibleKspVersionsDialog.cs
@@ -19,15 +19,15 @@ namespace CKAN
 
             List<KspVersion> compatibleVersions = ksp.GetCompatibleVersions();
 
-            GameVersionLabel.Text = ksp.Version().ToString();
+            GameVersionLabel.Text  = ksp.Version()?.ToString() ?? "<NONE>";
             GameLocationLabel.Text = ksp.GameDir();
             List<KspVersion> knownVersions = new List<KspVersion>(ServiceLocator.Container.Resolve<IKspBuildMap>().KnownVersions);
             List<KspVersion> majorVersionsList = CreateMajorVersionsList(knownVersions);
             List<KspVersion> compatibleVersionsLeftOthers = new List<KspVersion>(compatibleVersions);
             compatibleVersionsLeftOthers.RemoveAll((el)=>knownVersions.Contains(el) || majorVersionsList.Contains(el));
 
-            SortAndAddVersionsToList(compatibleVersionsLeftOthers, compatibleVersions);            
-            SortAndAddVersionsToList(majorVersionsList, compatibleVersions);            
+            SortAndAddVersionsToList(compatibleVersionsLeftOthers, compatibleVersions);
+            SortAndAddVersionsToList(majorVersionsList, compatibleVersions);
             SortAndAddVersionsToList(knownVersions, compatibleVersions);
         }
 
@@ -37,7 +37,7 @@ namespace CKAN
             {
                 MessageBox.Show("KSP has been updated since you last reviewed your compatible KSP versions. Please make sure that settings are correct.");
                 CancelChooseCompatibleVersionsButton.Visible = false;
-                GameVersionLabel.Text = _ksp.Version().ToString() + " (previous game version: " + _ksp.VersionOfKspWhenCompatibleVersionsWereStored + ")";
+                GameVersionLabel.Text =  $"{_ksp.Version()} (previous game version: {_ksp.VersionOfKspWhenCompatibleVersionsWereStored})";
                 GameVersionLabel.ForeColor = System.Drawing.Color.Red;
             }
         }


### PR DESCRIPTION
## Problems

#2230 said:

> An invalid instance also has a null `Version` property, because you need a valid instance to get the version, so we have to handle that in the instance listing code now.

But there are still a few places where we assume `KSP.Version()` will never be null. This can cause a `System.NullReferenceException` when invalid instances are involved.

An invalid instance is never used as the current instance if you have any other instances, but if your _only_ instance is invalid, we'll still try to use it.

If your default instance is invalid, `ckan ksp list` will incorrectly report No in the Default column for that instance.

## Changes

Now every place where we use `KSP.Version()` either checks for null or handles null appropriately. In several cases this just amounted to removing `.ToString()` from a `$"{expression}"` string, since that syntax implicitly converts to string and also handles null (in my testing it's turned into an empty string).

`KSPManager` now checks `KSP.Valid` before returning the only instance as the current instance. If it's not valid, you'll get the instance selection popup and have to either add a valid instance or quit.

`ckan ksp list` now compares instance names to find the default, rather than going through `KSPManager.GetPreferredInstance()`, which **never** returns invalid instances.

Fixes #2282.