### PR TITLE
Fallback to archive.org URLs for failed downloads of FOSS packages

### DIFF
--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -152,8 +152,8 @@ namespace CKAN
             Net.DownloadWithProgress(
                 new[]
                 {
-                    new Net.DownloadTarget(fetchedUpdaterUrl.Item1, updaterFilename, fetchedUpdaterUrl.Item2),
-                    new Net.DownloadTarget(fetchedCkanUrl.Item1,    ckanFilename,    fetchedCkanUrl.Item2),
+                    new Net.DownloadTarget(fetchedUpdaterUrl.Item1, null, updaterFilename, fetchedUpdaterUrl.Item2),
+                    new Net.DownloadTarget(fetchedCkanUrl.Item1,    null, ckanFilename,    fetchedCkanUrl.Item2),
                 },
                 user
             );

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -121,19 +121,21 @@ namespace CKAN
 
         public class DownloadTarget
         {
-            public Uri    url      { get; private set; }
-            public string filename { get; private set; }
-            public long   size     { get; private set; }
-            public string mimeType { get; private set; }
+            public Uri    url         { get; private set; }
+            public Uri    fallbackUrl { get; private set; }
+            public string filename    { get; private set; }
+            public long   size        { get; private set; }
+            public string mimeType    { get; private set; }
 
-            public DownloadTarget(Uri url, string filename = null, long size = 0, string mimeType = "")
+            public DownloadTarget(Uri url, Uri fallback = null, string filename = null, long size = 0, string mimeType = "")
             {
-                this.url      = url;
-                this.filename = string.IsNullOrEmpty(filename)
+                this.url         = url;
+                this.fallbackUrl = fallback;
+                this.filename    = string.IsNullOrEmpty(filename)
                     ? FileTransaction.GetTempFileName()
                     : filename;
-                this.size     = size;
-                this.mimeType = mimeType;
+                this.size        = size;
+                this.mimeType    = mimeType;
             }
         }
 
@@ -144,7 +146,7 @@ namespace CKAN
 
         public static string DownloadWithProgress(Uri url, string filename = null, IUser user = null)
         {
-            var targets = new[] {new DownloadTarget(url, filename)};
+            var targets = new[] {new DownloadTarget(url, null, filename)};
             DownloadWithProgress(targets, user);
             return targets.First().filename;
         }

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -57,6 +57,7 @@ namespace CKAN
                 downloader.DownloadAndWait(
                     unique_downloads.Select(item => new Net.DownloadTarget(
                         item.Key,
+                        item.Value.InternetArchiveDownload,
                         // Use a temp file name
                         null,
                         item.Value.download_size,

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -624,6 +624,22 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Return an archive.org URL for this download, or null if it's not there.
+        /// The filenames look a lot like the filenames in Net.Cache, but don't be fooled!
+        /// Here it's the first 8 characters of the SHA1 of the DOWNLOADED FILE, not the URL!
+        /// </summary>
+        public Uri InternetArchiveDownload
+        {
+            get
+            {
+                return license.All(l => l.Redistributable)
+                    ? new Uri(
+                        $"https://archive.org/download/{identifier}-{version}/{download_hash.sha1.Substring(0, 8)}-{identifier}-{version}.zip")
+                    : null;
+            }
+        }
+
+        /// <summary>
         /// Format a byte count into readable file size
         /// </summary>
         /// <param name="bytes">Number of bytes in a file</param>

--- a/Core/Types/License.cs
+++ b/Core/Types/License.cs
@@ -13,7 +13,8 @@ namespace CKAN
         public static License UnknownLicense => _unknownLicense ?? (_unknownLicense = new License("unknown"));
 
         // TODO: It would be lovely for our build system to write these for us.
-        private static readonly HashSet<string> valid_licenses = new HashSet<string> {
+        private static readonly HashSet<string> valid_licenses = new HashSet<string>()
+        {
             "public-domain",
             "AFL-3.0",
             "AGPL-3.0",
@@ -49,6 +50,39 @@ namespace CKAN
             "open-source", "restricted", "unrestricted", "unknown"
         };
 
+        private static readonly HashSet<string> redistributable_licenses = new HashSet<string>()
+        {
+            "public-domain",
+            "Apache", "Apache-1.0", "Apache-2.0",
+            "Artistic", "Artistic-1.0", "Artistic-2.0",
+            "BSD-2-clause", "BSD-3-clause", "BSD-4-clause",
+            "ISC",
+            "CC-BY", "CC-BY-1.0", "CC-BY-2.0", "CC-BY-2.5", "CC-BY-3.0", "CC-BY-4.0",
+            "CC-BY-SA", "CC-BY-SA-1.0", "CC-BY-SA-2.0", "CC-BY-SA-2.5", "CC-BY-SA-3.0", "CC-BY-SA-4.0",
+            "CC-BY-NC", "CC-BY-NC-1.0", "CC-BY-NC-2.0", "CC-BY-NC-2.5", "CC-BY-NC-3.0", "CC-BY-NC-4.0",
+            "CC-BY-NC-SA", "CC-BY-NC-SA-1.0", "CC-BY-NC-SA-2.0", "CC-BY-NC-SA-2.5", "CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0",
+            "CC-BY-NC-ND", "CC-BY-NC-ND-1.0", "CC-BY-NC-ND-2.0", "CC-BY-NC-ND-2.5", "CC-BY-NC-ND-3.0", "CC-BY-NC-ND-4.0",
+            "CC0",
+            "CDDL", "CPL",
+            "EFL-1.0", "EFL-2.0",
+            "Expat", "MIT",
+            "GPL-1.0", "GPL-2.0", "GPL-3.0",
+            "LGPL-2.0", "LGPL-2.1", "LGPL-3.0",
+            "GFDL-1.0", "GFDL-1.1", "GFDL-1.2", "GFDL-1.3",
+            "GFDL-NIV-1.0", "GFDL-NIV-1.1", "GFDL-NIV-1.2", "GFDL-NIV-1.3",
+            "LPPL-1.0", "LPPL-1.1", "LPPL-1.2", "LPPL-1.3c",
+            "MPL-1.1",
+            "Perl",
+            "Python-2.0",
+            "QPL-1.0",
+            "W3C",
+            "Zlib",
+            "Zope",
+            "WTFPL",
+            "Unlicense",
+            "open-source", "unrestricted"
+        };
+
         private string license;
 
         /// <summary>
@@ -70,6 +104,21 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Return whether this license permits CKAN and others to redistribute the module.
+        /// We automatically upload such mods to https://archive.org/details/kspckanmods
+        /// </summary>
+        /// <returns>
+        /// True if redistributable, false otherwise.
+        /// </returns>
+        public bool Redistributable
+        {
+            get
+            {
+                return redistributable_licenses.Contains(license);
+            }
+        }
+
+        /// <summary>
         /// Returns the license as a string.
         /// </summary>
         public override string ToString()
@@ -78,4 +127,3 @@ namespace CKAN
         }
     }
 }
-


### PR DESCRIPTION
## Background

SpaceDock broke today, which is fun. VITAS reports that it looks like a denial of service attack.

The NetKAN bot has been uploading all permissively-licensed mods to https://archive.org/details/kspckanmods for quite a while now. Many or most of the SpaceDock downloads that are now failing, could in principle fall back to archive.org URLs. Such a feature could also help us deal with GitHub's download throttling or SpaceDock's certificate expirations.

## Changes

Now if the primary download fails for a permissively licensed mod, we try to find it on archive.org as a fallback.

Internally this involves defining a `fallbackUrl` property in `DownloadTarget` and `NetAsyncDownloaderDownloadPart`, both populated from a new `CkanModule.InternetArchiveDownload` property, which itself checks a new `License.Redistributable` property based on a new copy of the list from NetKAN-bot. Then if a download fails, we check whether it has a fallback URL, and if so and if we haven't already tried it, we try it. If the fallback fails as well, then we continue with the normal steps for a failed download.

Fixes #1682.