### PR TITLE
Show abstracts in available command

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -13,16 +13,26 @@ namespace CKAN.CmdLine
 
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
-            IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
-
+            AvailableOptions opts      = (AvailableOptions)raw_options;
+            IRegistryQuerier registry  = RegistryManager.Instance(ksp).registry;
             List<CkanModule> available = registry.Available(ksp.VersionCriteria());
 
             user.RaiseMessage("Mods available for KSP {0}", ksp.Version());
             user.RaiseMessage("");
 
-            foreach (CkanModule module in available)
+            if (opts.detail)
             {
-                user.RaiseMessage("* {0} ({1}) - {2} - {3}", module.identifier, module.version, module.name, module.@abstract);
+                foreach (CkanModule module in available)
+                {
+                    user.RaiseMessage("* {0} ({1}) - {2} - {3}", module.identifier, module.version, module.name, module.@abstract);
+                }
+            }
+            else
+            {
+                foreach (CkanModule module in available)
+                {
+                    user.RaiseMessage("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
+                }
             }
 
             return Exit.OK;

--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -22,7 +22,7 @@ namespace CKAN.CmdLine
 
             foreach (CkanModule module in available)
             {
-                user.RaiseMessage("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
+                user.RaiseMessage("* {0} ({1}) - {2} - {3}", module.identifier, module.version, module.name, module.@abstract);
             }
 
             return Exit.OK;

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -428,7 +428,12 @@ namespace CKAN.CmdLine
 
     internal class VersionOptions   : CommonOptions { }
     internal class CleanOptions     : InstanceSpecificOptions { }
-    internal class AvailableOptions : InstanceSpecificOptions { }
+
+    internal class AvailableOptions : InstanceSpecificOptions
+    {
+        [Option("detail", HelpText = "Show short description of each module")]
+        public bool detail { get; set; }
+    }
 
     internal class GuiOptions : InstanceSpecificOptions
     {


### PR DESCRIPTION
## Problem

Currently the `ckan available` command prints a module's identifier, latest compatible version, and full name:

```
$ ckan available | shuf -n 5
* CrewPortraits (1.3.1) - Crew Portraits
* SETI-CareerChallenge (1.3.0.0) - SETI-CareerChallenge
* JSIAdvancedTransparentPods (V0.1.15.0) - JSI Advanced Transparent Pods
* SigmaReplacements-Descriptions (D_v0.2.3) - Sigma Replacements: Descriptions
* NodeAlert (1.1.0) - NodeAlert
```

If you aren't already familiar with a given mod, this format isn't very helpful in deciding whether to install it. You would have to look up each individual mod to get more information.

## Change

Now a new `--detail` option is available to add the abstract (short description) to the end of each line:

```
$ ckan available --detail | shuf -n 5
* SearchAndRescue (1:11) - Search And Rescue - A pack of parts for KSP that can be used to build Coast Guard style ships and aircraft
* NEBULADecalsContinued (0.1.1.5) - NEBULA Decals Continued -  STDdM3y.jpg This mod allows to place decals on your crafts!
* KerbalNRAP (1.5.9) - Kerbal NRAP - Procedural Test Weights - Procedural test weights for launchers
* ContractsWindowPlus (8.1) - Contracts Window + - A new, more flexible contract monitoring window.
* ForScience (v1.5.0) - ForScience! - ForScience is autopilot for running, collecting and resetting experiments.
```

This way you can get a sense of what an unfamiliar mod does. The existing output is left as-is in case scripts are parsing it.

The @-symbol syntax is needed because `abstract` is a keyword in C#, and the @ allows it to be interpreted as a variable name instead.