### PR TITLE
Check zip validity in netkan

### DIFF
--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -41,6 +41,11 @@ namespace CKAN.NetKAN.Services
                         break;
                     case FileType.Zip:
                         extension = "zip";
+                        string invalidReason;
+                        if (!NetFileCache.ZipValid(downloadedFile, out invalidReason))
+                        {
+                            throw new Kraken($"{downloadedFile} is not a valid ZIP file: {invalidReason}");
+                        }
                         break;
                     default:
                         extension = "ckan-package";


### PR DESCRIPTION
## Problem

CKAN performs several integrity checks on the ZIP files it downloads, and refuses to install or even cache files that are invalid by its standards, which are mainly the standards of `SharpZipLib.ZipFile.TestArchive`. See #2285 and #2287 for details.

However, currently netkan doesn't perform these checks. Whatever file is at the download URL, goes into the index. Netkan happily indexes files that CKAN will refuse to install.

We're caught by surprise when a ZIP has a weird problem, and users are stuck with a version they can see but not install. We won't even find out about it unless someone files an issue on GitHub.

## Changes

Now netkan.exe calls the same ZIP validation check after it downloads a ZIP file that CKAN uses. If the file isn't valid, an exception is thrown:

```
$ netkan.exe NetKAN/CivilianPopulation.netkan 
63045 [1] FATAL CKAN.NetKAN.Program (null) - /tmp/CdFileMgr/81a93875-b11d-47.tmp is not a valid ZIP file: Error in step EntryHeader for CivilianPopulation/Experience/Traits.cfg: Exception during test - 'Extract version mismatch'
```

This will prevent (more) such files from being indexed, with an error added to http://status.ksp-ckan.org/ instead. If a new invalid ZIP is uploaded, we can report the problem to the author so they can fix it, and in the meantime the only thing users will notice is that that download is missing from CKAN.