### PR TITLE
Replace colons with hyphens in archive URLs

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -632,9 +632,10 @@ namespace CKAN
         {
             get
             {
+                string verStr = version.ToString().Replace(':', '-');
                 return license.All(l => l.Redistributable)
                     ? new Uri(
-                        $"https://archive.org/download/{identifier}-{version}/{download_hash.sha1.Substring(0, 8)}-{identifier}-{version}.zip")
+                        $"https://archive.org/download/{identifier}-{verStr}/{download_hash.sha1.Substring(0, 8)}-{identifier}-{verStr}.zip")
                     : null;
             }
         }


### PR DESCRIPTION
#2284 added the ability to fall back to archive.org URLs, but it didn't account for the special handling of epoch formatted version numbers, which need to have colons replaced by hyphens before building the URL:

https://github.com/KSP-CKAN/NetKAN-bot/blob/81751def110ea7ecf137d2630f8e3635b35117a3/lib/App/KSP_CKAN/Metadata/Ckan.pm#L180-L185

Now this is fixed.