### PR TITLE
Force-allow TLS 1.2 on .NET 4.5

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -4,6 +4,7 @@
 // License: CC-BY 4.0, LGPL, or MIT (your choice)
 
 using System;
+using System.Net;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -49,6 +50,10 @@ namespace CKAN.CmdLine
 
             Logging.Initialize();
             log.Info("CKAN started.");
+
+            // Force-allow TLS 1.2 for HTTPS URLs, because GitHub requires it.
+            // This is on by default in .NET 4.6, but not in 4.5.
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             // If we're starting with no options then invoke the GUI instead.
             if (args.Length == 0)

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -30,6 +31,10 @@ namespace CKAN.NetKAN
             try
             {
                 ProcessArgs(args);
+
+                // Force-allow TLS 1.2 for HTTPS URLs, because GitHub requires it.
+                // This is on by default in .NET 4.6, but not in 4.5.
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
                 // If we see the --version flag, then display our build info
                 // and exit.

--- a/quotes.txt
+++ b/quotes.txt
@@ -70,3 +70,8 @@ It is truly amazing how many extensions to BDArmory are only compatible with a
 KSP version that BDArmory is not compatible with.
 
     -- politas, NetKAN#4169
+%
+<HebaruSan> It's crazy that an app has to specify which version of TLS to use to get an HTTPS URL
+<HebaruSan> I mean, how the heck do we know? You're WebClient, you figure it out!!
+
+    -- regarding CKAN#2297


### PR DESCRIPTION
## Background

- GitHub has sunsetted TLS 1/1.1 as of today. [They gave us one year's warning](https://githubengineering.com/crypto-deprecation-notice/), but apparently we missed it or didn't realize it applied to us (or assumed that .NET would handle it properly for us). This means the only way to access an HTTPS URL on GitHub is now via TLS 1.2.
- .NET 4.5 can support TLS 1.2, but it is not enabled by default. .NET 4.6 enables it by default.
- CKAN targets .NET 4.5. Even if you have a later version installed, the behavior of the .NET components will mimic .NET 4.5.

## Problem

Released versions of CKAN can't access GitHub HTTPS URLs anymore. They cause TLS errors.

CKAN uses GitHub HTTPS URLs not just for mod downloads, but also for registry updates and application self-auto-updates. So you can't even refresh the registry or update CKAN itself.

## Workaround

You can force .NET 4.5 to allow _only_ TLS 1.2 by setting a registry key. This allows current versions of CKAN to work:

- https://github.com/KSP-CKAN/CKAN/issues/2293#issuecomment-367868078

However, this affects all applications rather than just CKAN, which might cause problems if any of them need TLS 1/1.1 to operate. Caution is advised.

Until we release a new version, this is the only option for getting CKAN to work.

## Considered but not done

One way to fix this would be to change `TargetFrameworkVersion` in our `csproj` files from v4.5 to v4.6. We probably don't want to do this because some fraction of people might still be running the old framework and would see errors. If you think this is the better solution, please say so below.

## Changes

Now we add `SecurityProtocolTypes.Tls12` to `System.Net.ServicePointManager.SecurityProtocol` at startup via an OR-equals `|=` operator. This enables TLS 1.2 while ensuring that no other supported protocols are disabled.

Credit to @TruePikachu for proposing this solution.

Fixes #2293.