### PR TITLE
Fix crash when trying to view empty auth token list

### DIFF
--- a/Core/Win32Registry.cs
+++ b/Core/Win32Registry.cs
@@ -103,7 +103,7 @@ namespace CKAN
         public static IEnumerable<string> GetAuthTokenHosts()
         {
             RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(authTokenKeyNoPrefix);
-            return key?.GetValueNames();
+            return key?.GetValueNames() ?? new string[0];
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

If you have never added any auth tokens (and therefore don't have the registry key `HKEY_CURRENT_USER\Software\CKAN\AuthTokens`), you may receive a null reference exception if you:

- Open the GUI settings window
- Edit the auth tokens in consoleui
- Run `ckan authtoken list`

This can be worked around by adding a fake auth token, which you may have to do from the command line with `ckan authtoken add host token`.

## Cause

`Win32Registry.GetAuthTokenHosts()` returns null because `Microsoft.Win32.Registry.CurrentUser.OpenSubKey` returns null.

## Changes

Now `Win32Registry.GetAuthTokenHosts()` returns a zero-element string array if `Microsoft.Win32.Registry.CurrentUser.OpenSubKey` returns null.

Fixes #2300.