### PR TITLE
Fix GUI sort by size

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -24,10 +24,9 @@ namespace CKAN
             {
                 return Sort(rows, CheckboxSorter);
             }
-            // XXX: Same for Integer columns
             else if (this.configuration.SortByColumnIndex == 7)
             {
-                return Sort(rows, IntegerSorter);
+                return Sort(rows, DownloadSizeSorter);
             }
             return Sort(rows, DefaultSorter);
         }
@@ -78,22 +77,12 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Transforms a DataGridViewRow into an integer suitable for sorting.
-        /// Uses this.m_Configuration.SortByColumnIndex to determine which
-        /// field to sort on.
+        /// Transforms a DataGridViewRow into a long representing the download size,
+        /// suitable for sorting.
         /// </summary>
-        private int IntegerSorter(DataGridViewRow row)
+        private long DownloadSizeSorter(DataGridViewRow row)
         {
-            var cell = row.Cells[this.configuration.SortByColumnIndex];
-
-            if (cell.Value.ToString() == "N/A")
-                return -1;
-            else if (cell.Value.ToString() == "1<KB")
-                return 0;
-
-            int result = -2;
-            int.TryParse(cell.Value as string, out result);
-            return result;
+            return (row.Tag as GUIMod)?.ToCkanModule()?.download_size ?? 0;
         }
 
         private void _UpdateFilters()


### PR DESCRIPTION
## Background

#2277 updated the Download column in GUI to use "B", "KB", "MB", and "GB" units depending on the magnitude of the size. Previously this column was always in KB.

## Problem

This broke the sorting of this column. There doesn't seem to be a pattern to it anymore.

![image](https://user-images.githubusercontent.com/1559108/36627348-079b1c50-1907-11e8-82d3-b5f72fdf996d.png)

## Cause

The size sort code depended on parsing the text of the cells, which is no longer useful when the units aren't the same or when the strings contain more than just numeric digits.

## Changes

Now the Download column sorts directly by the raw size data. The largest mods are:

![image](https://user-images.githubusercontent.com/1559108/36627371-3d88bed0-1907-11e8-9dac-db7974df14db.png)

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1240-bruce/&do=findComment&comment=3303380 .