### PR TITLE
Don't crash if download_hash isn't set

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -633,7 +633,8 @@ namespace CKAN
             get
             {
                 string verStr = version.ToString().Replace(':', '-');
-                return license.All(l => l.Redistributable)
+                // Some alternate registry repositories don't set download_hash
+                return (download_hash?.sha1 != null && license.All(l => l.Redistributable))
                     ? new Uri(
                         $"https://archive.org/download/{identifier}-{verStr}/{download_hash.sha1.Substring(0, 8)}-{identifier}-{verStr}.zip")
                     : null;


### PR DESCRIPTION
## Problem

If you try to install a mod that doesn't have a `download_hash` defined in its metadata, you might encounter this exception:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.CkanModule.get_InternetArchiveDownload()
   at CKAN.NetAsyncModulesDownloader.<>c.<DownloadModules>b__8_4(KeyValuePair`2 item)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at CKAN.NetAsyncModulesDownloader.DownloadModules(NetModuleCache cache, IEnumerable`1 modules)
   at CKAN.ModuleInstaller.DownloadModules(IEnumerable`1 mods, IDownloader downloader)
   at CKAN.ModuleInstaller.Upgrade(IEnumerable`1 modules, IDownloader netAsyncDownloader, Boolean enforceConsistency)
   at CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

## Cause

We currently assume `download_hash` won't be null when checking for fallback URLs:

https://github.com/KSP-CKAN/CKAN/blob/9712f94116e8651ad96e75ae5b6ba8d262b965b6/Core/Types/CkanModule.cs#L631-L641

https://ksp.sarbian.com/ckan/MechJeb2-ci.tar.gz contains bleeding metadata for edge versions of MechJeb2, and it does not include the download_hash properties. This makes these modules uninstallable until this bug is fixed.

## Changes

Now we check that `download_hash?.sha1` is not null before using it to provide a fallback URL.

This allows such modules to download and install normally.

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1240-bruce/&do=findComment&comment=3303984