### PR TITLE
Fix GUI instance name checking

### DIFF
--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -73,8 +73,8 @@ namespace CKAN
             try
             {
                 var instanceName = Path.GetFileName(path);
-                KSP instance = new KSP(path, instanceName, GUI.user);
                 instanceName = _manager.GetNextValidInstanceName(instanceName);
+                KSP instance = new KSP(path, instanceName, GUI.user);
                 _manager.AddInstance(instance);
                 UpdateInstancesList();
             }


### PR DESCRIPTION
## Problem

If you try to add a new game instance in GUI that has the same folder name as an existing instance, you get this exception:

![image](https://user-images.githubusercontent.com/10106634/36642099-25778a3e-1a32-11e8-9be1-fc484b514447.png)

This worked fine on previous versions.

## Cause

In #2239, this function:

https://github.com/KSP-CKAN/CKAN/blob/2cc20b505476d7114a235a9313aaa67817406a00/GUI/ChooseKSPInstance.cs#L73-L80

was changed to pass the name of the instance to the constructor of `KSP` instead of `AddInstance`, because instances now know their own names. However, the `GetNextValidInstanceName` call ended up in the wrong place; it should be before we use the name, but it's after:

https://github.com/KSP-CKAN/CKAN/blob/c1d33f89758376005044426312a6b503071d44ab/GUI/ChooseKSPInstance.cs#L73-L80

## Changes

Now `GetNextValidInstanceName` is called before the instance is created.

Fixes #2315.