### PR TITLE
Improve CKAN.app launch script

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -1,23 +1,33 @@
-#!/bin/sh
+#!/bin/bash
 
-# Check El Capitan's mono install location
-PATH="$PATH":/usr/local/bin
+# Check El Capitan's Mono install location
+# And Mono 5's install location
+# And the configured location in /etc/paths.d
+MONO_FRAMEWORK_PATH=/Library/Frameworks/Mono.framework/Versions/Current
+PATH="${PATH}:/usr/local/bin:${MONO_FRAMEWORK_PATH}/Commands"
+if [ -r /etc/paths.d/mono-commands ]
+then
+    PATH="${PATH}:$(cat /etc/paths.d/mono-commands)"
+fi
 export PATH
 
+# Look for mono now that we've assembled our PATH
 MONO=$(which mono)
 
 if [ -z "$MONO" -o ! -x "$MONO" ]
 then
-	# We could not find mono. The wiki explains how to install.
-	open 'https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-OSX'
+    # We could not find mono. The wiki explains how to install.
+    open 'https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-OSX'
 else
-	# Mono found, so we can run CKAN.
-	# Fetch the path relative to the launch point where this shell script exists. (taken from Tasque & macpack)
-	APP_PATH=$(echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+3] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }')
-	ASSEMBLY=ckan.exe
-	MONO_FRAMEWORK_PATH=/Library/Frameworks/Mono.framework/Versions/Current
-	export DYLD_FALLBACK_LIBRARY_PATH=$APP_PATH/Contents/MacOS:$MONO_FRAMEWORK_PATH/lib:/lib:/usr/lib
-
-	cd "$APP_PATH/Contents/MacOS"
-	exec -a "CKAN" "$MONO" --arch=32 $ASSEMBLY $@
+    # Mono found, so we can run CKAN
+    # The exe is called ckan.exe
+    ASSEMBLY=ckan.exe
+    # The script and ckan.exe are in the same folder, go there now
+    MACOS_PATH="$(cd "$(dirname "$0")" && pwd)"
+    cd "$MACOS_PATH"
+    # Set up and run mono
+    export MONO_MWF_USE_CARBON_BACKEND=1
+    export GDIPLUS_NOX=1
+    export DYLD_FALLBACK_LIBRARY_PATH="$MACOS_PATH:$MONO_FRAMEWORK_PATH/lib:/lib:/usr/lib"
+    "$MONO" --arch=32 "$ASSEMBLY" "$@"
 fi

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -31,11 +31,11 @@ $(EXESRC):
 
 $(SCRIPTDEST): $(SCRIPTSRC)
 	mkdir -p $(shell dirname $@)
-	cp -l $< $@
+	cp -l -f $< $@
 
 $(ICNSDEST): $(ICNSSRC)
 	mkdir -p $(shell dirname $@)
-	cp -l $< $@
+	cp -l -f $< $@
 
 $(PLISTDEST): $(PLISTSRC)
 	mkdir -p $(shell dirname $@)


### PR DESCRIPTION
## Problem

The currently released CKAN.app opens the wiki page about installing on Mac when it can't find Mono. Currently that is every time, even if Mono is installed.

## Cause

Non-ObjC app bundles on MacOSX are not provided:

1. The proper system PATH variable for running other programs (even though there is a `/etc/paths.d/` architecture for configuring it)
2. The path to their own folder

We need both to run `mono ckan.exe`, so we have to write code to figure them out at run time.

The mono executable has lived in several different places on MacOSX, there's no way to just ask where it is, and our script previously only checked a path that was used in an older version of Mono.

The script's logic for finding its own folder was an overly complicated `awk` script that may or may not have worked.

## Changes

Now we check more places for the mono executable, by way of the `/etc/paths.d/mono-commands` file.

Now our logic for finding our folder is simplified; we use `dirname $0` to find where the script lives, then we `cd` to that directory and run `pwd` to get its absolute path.

Fixes #2307.