### PR TITLE
Fix ArgumentOutOfRangeException when removing files from game root

### DIFF
--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -144,7 +144,7 @@ namespace CKAN
                     // Found Steam library
                     if (line.Contains("BaseInstallFolder"))
                     {
-                        
+
                         // This assumes config file is valid, we just skip it if it looks funny.
                         string[] split_line = line.Split('"');
 
@@ -189,7 +189,7 @@ namespace CKAN
 
         /// <summary>
         /// Gets the leading path elements. Ex: /a/b/c returns /a/b
-        /// 
+        ///
         /// Returns empty string if there is no leading path. (Eg: "Example.dll" -> "");
         /// </summary>
         /// <returns>The leading path elements.</returns>
@@ -242,10 +242,13 @@ namespace CKAN
                     )
                 );
             }
-        
+
             // The +1 here is because root will never have
-            // a trailing slash.
-            return path.Remove(0, root.Length + 1);
+            // a trailing slash. However, if the strings are
+            // the same, it causes an exception.
+            return path.Length > root.Length
+                ? path.Remove(0, root.Length + 1)
+                : "";
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

If you install a module that has `"install_to": "GameRoot"`, you'll get an exception when you try to upgrade or remove it:

```
$ ckan remove KSPLogiRGB-battlemoose
About to remove:

 * KSP Logitech RGB Control v1.0.3

Continue? [Y/n] 
Removing KSPLogiRGB-battlemoose...

Unhandled Exception:
System.ArgumentOutOfRangeException: Index and count must refer to a location within the string.
Parameter name: count
  at System.String.Remove (System.Int32 startIndex, System.Int32 count) [0x0004c] in <9689214c1e4645be91df75196bac3cbb>:0 
  at CKAN.KSPPathUtils.ToRelative (System.String path, System.String root) [0x00064] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.ModuleInstaller+<>c__DisplayClass34_0.<AddParentDirectories>b__1 (System.String dir) [0x0004f] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at System.Linq.Enumerable+SelectManySingleSelectorIterator`2[TSource,TResult].MoveNext () [0x00051] in <8107f84c62ea4c799b6ff1411a22ee10>:0 
  at System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].MoveNext () [0x0004e] in <8107f84c62ea4c799b6ff1411a22ee10>:0 
  at System.Collections.Generic.HashSet`1[T].UnionWith (System.Collections.Generic.IEnumerable`1[T] other) [0x00026] in <8107f84c62ea4c799b6ff1411a22ee10>:0 
  at System.Collections.Generic.HashSet`1[T]..ctor (System.Collections.Generic.IEnumerable`1[T] collection, System.Collections.Generic.IEqualityComparer`1[T] comparer) [0x0004b] in <8107f84c62ea4c799b6ff1411a22ee10>:0 
  at System.Collections.Generic.HashSet`1[T]..ctor (System.Collections.Generic.IEnumerable`1[T] collection) [0x00007] in <8107f84c62ea4c799b6ff1411a22ee10>:0 
  at CKAN.Extensions.ToHashSet[T] (System.Collections.Generic.IEnumerable`1[T] source) [0x00000] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.ModuleInstaller.AddParentDirectories (System.Collections.Generic.HashSet`1[T] directories) [0x00091] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.ModuleInstaller.Uninstall (System.String modName) [0x00105] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.ModuleInstaller.UninstallList (System.Collections.Generic.IEnumerable`1[T] mods) [0x00131] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.CmdLine.Remove.RunCommand (CKAN.KSP ksp, System.Object raw_options) [0x0016d] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.CmdLine.MainClass.RunSimpleAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user, CKAN.KSPManager manager) [0x003d8] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.CmdLine.MainClass.Execute (CKAN.KSPManager manager, CKAN.CmdLine.CommonOptions opts, System.String[] args) [0x0015b] in <cf1172f4644841da8b9b83c88c51f181>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x000a8] in <cf1172f4644841da8b9b83c88c51f181>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentOutOfRangeException: Index and count must refer to a location within the string.
```

## Cause

When a file is in GameRoot, `path` and `root` are the same on this line:

https://github.com/KSP-CKAN/CKAN/blob/86bf144ec7ce7fa36b1aaddaadfff2519481fc52/Core/KSPPathUtils.cs#L246-L249

So the second parameter of the `Remove` call ends up being longer than `path`, which causes the exception.

## Changes

Now we compare the lengths of the strings before calling `Remove`. If they're the same, we just return the empty string.

```
$ ckan remove KSPLogiRGB-battlemoose
About to remove:

 * KSP Logitech RGB Control v1.0.3

Continue? [Y/n] 
Removing KSPLogiRGB-battlemoose...
Done!
```

Fixes #2330.