### PR TITLE
Check NetKAN for support issues, don't close if last reply is by OP

### DIFF
--- a/bin/close-old-support-tickets.pl
+++ b/bin/close-old-support-tickets.pl
@@ -18,48 +18,60 @@ use Date::Parse qw(str2time);
 my $token = $ARGV[0] or die "Usage: $0 [token]\n";
 
 my $github = Net::GitHub->new(
-    RaiseError => 1,
+    RaiseError   => 1,
     access_token => $token,
 );
 
-my $date_cutoff = time() - 7 * 86400;   # 7 days ago
+# 7 days ago
+my $date_cutoff = time() - 7 * 86400;
 
-$github->set_default_user_repo("KSP-CKAN","CKAN");
+foreach my $repo (("CKAN", "NetKAN")) {
+    $github->set_default_user_repo("KSP-CKAN", $repo);
 
-my $issues = $github->issue;
+    my $issues = $github->issue;
 
-# Get all our candidate issues
+    # Get all our candidate issues
 
-my @candidates = $issues->repos_issues({
-    state => 'open',
-    labels => 'support',
-    assignee => "none",
-});
+    my @candidates = $issues->repos_issues({
+        state    => 'open',
+        labels   => 'support',
+        assignee => "none",
+    });
 
-# Walk through each one, and see if we can close it
+    # Walk through each one, and see if we can close it
 
-foreach my $candidate (@candidates) {
-    my $id    = $candidate->{number};
-    my $title = "$candidate->{title} (#$id)";
+    foreach my $candidate (@candidates) {
+        my $id     = $candidate->{number};
+        my $title  = "$candidate->{title} (#$id)";
+        my $author = $candidate->{user}{login};
 
-    if ($candidate->{comments} == 0) {
-        say "Skipped (no comments)    : $title";
-        next;
+        my $num_comments = +$candidate->{comments};
+        if ($num_comments == 0) {
+            say "Skipped (no comments)    : $title";
+            next;
+        }
+
+        # Skip if last comment is by OP
+        my @comments     = $issues->comments($id);
+        my $last_comment = $comments[$num_comments - 1];
+        if ($last_comment->{user}{login} eq $author) {
+            say "Skipped (author comment) : $title";
+        }
+
+        my $last_update = str2time($candidate->{updated_at});
+
+        if ($last_update > $date_cutoff) {
+            say "Skipped (recent update)  : $title";
+            next;
+        }
+
+        # Yay! Something we can close!
+        say "Closing $title";
+
+        close_ticket($issues, $id);
     }
 
-    my $last_update = str2time($candidate->{updated_at});
-
-    if ($last_update > $date_cutoff) {
-        say "Skipped (recent update ) : $title";
-        next;
-    }
-
-    # Yay! Something we can close!
-    say "Closing $title";
-
-    close_ticket($issues,$id);
 }
-
 say "Done!";
 
 sub close_ticket {


### PR DESCRIPTION
## Motivation

There's a robot that crawls CKAN issues and closes idle support tickets. This is nice for keeping the issues list tidy.

However, users are just as likely to submit support tickets for NetKAN, and those just accumulate.

Also the definition of "idle support ticket" isn't quite fair to issue authors, since it goes purely by time elapsed since last activity, as long as there's at least one comment. Consider this sequence:

1. You submit an issue
2. We mark it as Support and say "What about workaround X?"
3. You say "No, that didn't work"
4. 7 days elapse
5. The bot closes the issue

In this case, the ball is in the dev team's court, and the user has been responsive and hasn't been helped. The ticket should remain open until the _issue author_ is idle for 7 days.

## Changes

- Now the bot looks at the issues in NetKAN as well
- Issues where the latest comment is by the issue creator will no longer be closed

Tagging @techman83 as an FYI in case the server that runs this bot doesn't auto-update the script from GitHub.