### PR TITLE
Actually skip when last comment is by OP

### DIFF
--- a/bin/close-old-support-tickets.pl
+++ b/bin/close-old-support-tickets.pl
@@ -56,6 +56,7 @@ foreach my $repo (("CKAN", "NetKAN")) {
         my $last_comment = $comments[$num_comments - 1];
         if ($last_comment->{user}{login} eq $author) {
             say "Skipped (author comment) : $title";
+            next;
         }
 
         my $last_update = str2time($candidate->{updated_at});


### PR DESCRIPTION
@techman83 , KSP-CKAN/Netkan#5172 shouldn't have been closed; I forgot to make it actually skip to the next issue when the last comment is by the OP. It prints the message _saying_ it's going to skip, but continues processing the same issue as before.