### PR TITLE
Invalidate stale cached files from GitHub in Netkan

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -135,7 +135,9 @@ namespace CKAN
         /// <summary>>
         /// Returns the filename of an already cached url or null otherwise
         /// </summary>
-        public string GetCachedFilename(Uri url)
+        /// <param name="url">The URL to check for in the cache</param>
+        /// <param name="remoteTimestamp">Timestamp of the remote file, if known; cached files older than this will be considered invalid</param>
+        public string GetCachedFilename(Uri url, DateTime? remoteTimestamp = null)
         {
             log.DebugFormat("Checking cache for {0}", url);
 
@@ -169,7 +171,19 @@ namespace CKAN
                 string filename = Path.GetFileName(file);
                 if (filename.StartsWith(hash))
                 {
-                    return file;
+                    // Check local vs remote timestamps; if local is older, then it's invalid.
+                    // null means we don't know the remote timestamp (so file is OK)
+                    if (remoteTimestamp == null
+                        || remoteTimestamp < File.GetLastWriteTime(file).ToUniversalTime())
+                    {
+                        // File not too old, use it
+                        return file;
+                    }
+                    else
+                    {
+                        // Local file too old, delete it
+                        File.Delete(file);
+                    }
                 }
             }
 

--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -5,20 +5,22 @@ namespace CKAN.NetKAN.Model
 {
     internal sealed class Metadata
     {
-        private const string KrefPropertyName = "$kref";
-        private const string VrefPropertyName = "$vref";
+        private const string KrefPropertyName        = "$kref";
+        private const string VrefPropertyName        = "$vref";
         private const string SpecVersionPropertyName = "spec_version";
-        private const string VersionPropertyName = "version";
-        private const string DownloadPropertyName = "download";
+        private const string VersionPropertyName     = "version";
+        private const string DownloadPropertyName    = "download";
+        public  const string UpdatedPropertyName     = "x_netkan_asset_updated";
 
         private readonly JObject _json;
 
-        public string Identifier { get { return (string)_json["identifier"]; } }
-        public RemoteRef Kref { get; private set; }
-        public RemoteRef Vref { get; private set; }
-        public Version SpecVersion { get; private set; }
-        public Version Version { get; private set; }
-        public Uri Download { get; private set; }
+        public string    Identifier      { get { return (string)_json["identifier"]; } }
+        public RemoteRef Kref            { get; private set; }
+        public RemoteRef Vref            { get; private set; }
+        public Version   SpecVersion     { get; private set; }
+        public Version   Version         { get; private set; }
+        public Uri       Download        { get; private set; }
+        public DateTime? RemoteTimestamp { get; private set; }
 
         public Metadata(JObject json)
         {
@@ -87,6 +89,14 @@ namespace CKAN.NetKAN.Model
             if (json.TryGetValue(DownloadPropertyName, out downloadToken))
             {
                 Download = new Uri((string)downloadToken);
+            }
+
+            JToken   updatedToken;
+            DateTime t;
+            if (json.TryGetValue(UpdatedPropertyName, out updatedToken)
+                && DateTime.TryParse(updatedToken.ToString(), out t))
+            {
+                RemoteTimestamp = t;
             }
         }
 

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -11,9 +11,9 @@ namespace CKAN.NetKAN.Services
             _cache = cache;
         }
 
-        public string DownloadPackage(Uri url, string identifier)
+        public string DownloadPackage(Uri url, string identifier, DateTime? updated)
         {
-            var cachedFile = _cache.GetCachedFilename(url);
+            var cachedFile = _cache.GetCachedFilename(url, updated);
 
             if (!string.IsNullOrWhiteSpace(cachedFile))
             {

--- a/Netkan/Services/IHttpService.cs
+++ b/Netkan/Services/IHttpService.cs
@@ -4,7 +4,7 @@ namespace CKAN.NetKAN.Services
 {
     internal interface IHttpService
     {
-        string DownloadPackage(Uri url, string identifier);
+        string DownloadPackage(Uri url, string identifier, DateTime? updated);
         string DownloadText(Uri url);
     }
 }

--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -44,12 +44,18 @@ namespace CKAN.NetKAN.Sources.Github
                     var version = new Version((string)release["tag_name"]);
                     var author = (string)release["author"]["login"];
 
-                    Uri download = null;
+                    Uri       download = null;
+                    DateTime? updated  = null;
+                    DateTime  parsed;
 
                     if (reference.UseSourceArchive)
                     {
                         Log.Debug("Using GitHub source archive");
                         download = new Uri((string)release["zipball_url"]);
+                        if (DateTime.TryParse(release["published_at"].ToString(), out parsed))
+                        {
+                            updated = parsed;
+                        }
                     }
                     else
                     {
@@ -59,13 +65,17 @@ namespace CKAN.NetKAN.Sources.Github
                         {
                             Log.DebugFormat("Using GitHub asset: {0}", asset["name"]);
                             download = new Uri((string)asset["browser_download_url"]);
+                            if (DateTime.TryParse(asset["updated_at"].ToString(), out parsed))
+                            {
+                                updated = parsed;
+                            }
                             break;
                         }
                     }
 
                     if (download != null)
                     {
-                        return new GithubRelease(author, version, download);
+                        return new GithubRelease(author, version, download, updated);
                     }
                 }
             }

--- a/Netkan/Sources/Github/GithubRelease.cs
+++ b/Netkan/Sources/Github/GithubRelease.cs
@@ -4,15 +4,17 @@ namespace CKAN.NetKAN.Sources.Github
 {
     public sealed class GithubRelease
     {
-        public string Author { get; private set; }
-        public Version Version { get; private set; }
-        public Uri Download { get; private set; }
+        public string    Author       { get; private set; }
+        public Version   Version      { get; private set; }
+        public Uri       Download     { get; private set; }
+        public DateTime? AssetUpdated { get; private set; }
 
-        public GithubRelease(string author, Version version, Uri download)
+        public GithubRelease(string author, Version version, Uri download, DateTime? updated)
         {
-            Author = author;
-            Version = version;
-            Download = download;
+            Author       = author;
+            Version      = version;
+            Download     = download;
+            AssetUpdated = updated;
         }
     }
 }

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -53,7 +53,7 @@ namespace CKAN.NetKAN.Transformers
                     json.Remove("version");
                 }
 
-                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier);
+                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
                 var avc = _moduleService.GetInternalAvc(mod, file, metadata.Vref.Id);
 
                 if (avc != null)

--- a/Netkan/Transformers/DownloadAttributeTransformer.cs
+++ b/Netkan/Transformers/DownloadAttributeTransformer.cs
@@ -34,7 +34,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.InfoFormat("Executing Download attribute transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
-                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier);
+                string file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
 
                 if (file != null)
                 {

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -73,9 +73,10 @@ namespace CKAN.NetKAN.Transformers
 
                 if (ghRelease != null)
                 {
-                    json.SafeAdd("version", ghRelease.Version.ToString());
-                    json.SafeAdd("author", ghRelease.Author);
+                    json.SafeAdd("version",  ghRelease.Version.ToString());
+                    json.SafeAdd("author",   ghRelease.Author);
                     json.SafeAdd("download", Uri.EscapeUriString(ghRelease.Download.ToString()));
+                    json.SafeAdd(Model.Metadata.UpdatedPropertyName, ghRelease.AssetUpdated);
 
                     if (ghRef.Project.Contains("_"))
                     {

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -30,7 +30,7 @@ namespace CKAN.NetKAN.Transformers
             {
                 var json = metadata.Json();
 
-                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier);
+                string file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
 
                 var internalJson = _moduleService.GetInternalCkan(file);
 

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -17,7 +17,7 @@ namespace CKAN.NetKAN.Validators
         public void Validate(Metadata metadata)
         {
             var mod = CkanModule.FromJson(metadata.Json().ToString());
-            var file = _http.DownloadPackage(metadata.Download, metadata.Identifier);
+            var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
 
             // Make sure this would actually generate an install.
 

--- a/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
@@ -25,7 +25,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mFileService = new Mock<IFileService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>()))
+            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
                 .Returns(downloadFilePath);
 
             mFileService.Setup(i => i.GetFileHashSha1(downloadFilePath))
@@ -33,7 +33,7 @@ namespace Tests.NetKAN.Transformers
 
             mFileService.Setup(i => i.GetFileHashSha256(downloadFilePath))
                 .Returns(downloadHashSha256);
-            
+
             mFileService.Setup(i => i.GetSizeBytes(downloadFilePath))
                 .Returns(downloadSize);
 
@@ -72,7 +72,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mFileService = new Mock<IFileService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>()))
+            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
                 .Returns((string)null);
 
             var sut = new DownloadAttributeTransformer(mHttp.Object, mFileService.Object);

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -31,7 +31,8 @@ namespace Tests.NetKAN.Transformers
                 .Returns(new GithubRelease(
                     "ExampleProject",
                     new Version("1.0"),
-                    new Uri("http://github.example/download")
+                    new Uri("http://github.example/download"),
+                    null
                 ));
 
             var sut = new GithubTransformer(mApi.Object, matchPreleases: false);

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -24,7 +24,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>()))
+            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
                 .Returns(filePath);
 
             mModuleService.Setup(i => i.GetInternalCkan(filePath))
@@ -59,7 +59,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>()))
+            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
                 .Returns(filePath);
 
             mModuleService.Setup(i => i.GetInternalCkan(filePath))
@@ -97,7 +97,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>()))
+            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
                 .Returns(filePath);
 
             mModuleService.Setup(i => i.GetInternalCkan(filePath))


### PR DESCRIPTION
## Background

Both CKAN and Netkan cache module downloads to save network bandwidth and time. Downloaded files are placed in a cache folder with names like `A1B2C3D4-Modname-v1.0.zip`, with the first eight characters being the beginning of the download URL's SHA1 in hexadecimal.

In #2243, we added validation to make sure that invalid or corrupted files do not end up in the CKAN cache. This uses the `download_hash` property to check that the file we downloaded matches the file that Netkan indexed. Thanks to this change, `download_hash` properties must be correct and up to date for CKAN to work properly.

## Problem

1. GPP released a new version
2. The netkan bot indexed it
3. GPP replaced the previous download in-place with an updated version (fix to the KSP-AVC file)
4. Users started getting mismatched hash errors that blocked installation of the new GPP
5. The bot did not update `download_hash` property of the registry for the new version of GPP (it still matched the original upload)
6. We manually set the new correct hash values (KSP-CKAN/CKAN-meta#1326)
7. The bot reverted the hashes, and we had to fix them again
8. GPP graciously released a _new_ new version to help us escape this cycle

## Cause

The module cache currently assumes that a given URL will always correspond to the exact same download file. Netkan will download each URL once, and then every time it tries to access the same URL after that, it will re-use the same downloaded file. If the upstream file has changed, then the older version is _still_ used, and the `download_hash` values in CKAN's registry do not match the current download, so users can't install it.

After thirty days, the file is removed from the cache, so it would be redownloaded at that time if needed.

## Changes

Now for GitHub downloads specifically, we check when the download file was last updated via the API. This feeds into new properties `GithubRelease.AssetUpdated` and `Model.Metadata.RemoteTimestamp`, which are passed to a new parameter of `Core.Net.NetFileCache.GetCachedFileName`, which is responsible for looking up cached files. If this function finds a file that looks like a match, it checks the local timestamp, and if it's older than the timestamp from GitHub, it deletes the file instead of using it, forcing a re-download. This will ensure that stale files do not remain in the cache if they are replaced on GitHub.

We could probably do this for other download hosts as well, but that is not included in this pull request. You can consider GitHub downloads to be a sort of pilot program for this functionality.