### PR TITLE
Obey version properties of conflicts and depends relationships in sanity checks

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -128,6 +128,11 @@ namespace CKAN.CmdLine
                 User.RaiseMessage("Module {0} not found", kraken.module);
                 return Exit.ERROR;
             }
+            catch (InconsistentKraken kraken)
+            {
+                User.RaiseMessage(kraken.ToString());
+                return Exit.ERROR;
+            }
             User.RaiseMessage("\r\nDone!\r\n");
 
             return Exit.OK;

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1001,9 +1001,8 @@ namespace CKAN
                 log.DebugFormat("Started with {0}, removing {1}, and keeping {2}; our dlls are {3}", string.Join(", ", orig_installed), string.Join(", ", modules_to_remove), string.Join(", ", hypothetical), string.Join(", ", dlls));
 
                 // Find what would break with this configuration.
-                // The Values.SelectMany() flattens our list of broken mods.
-                var broken = new HashSet<string>(SanityChecker.FindUnmetDependencies(hypothetical, dlls)
-                    .Values.SelectMany(x => x).Select(x => x.identifier));
+                var broken = SanityChecker.FindUnsatisfiedDepends(hypothetical, dlls.ToHashSet())
+                    .Select(x => x.Key.identifier).ToHashSet();
 
                 // If nothing else would break, it's just the list of modules we're removing.
                 HashSet<string> to_remove = new HashSet<string>(modules_to_remove);

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Collections.Generic;
@@ -154,7 +155,7 @@ namespace CKAN
         internal static string FormatMessage(string requested, List<CkanModule> modules)
         {
             string oops = string.Format("Too many mods provide {0}:\r\n", requested);
-            return oops + String.Join("\r\n* ", modules);
+            return oops + String.Join("\r\n", modules.Select(m => $"* {m}"));
         }
     }
 
@@ -170,8 +171,7 @@ namespace CKAN
         {
             get
             {
-                const string message = "The following inconsistencies were found:\r\n";
-                return message + String.Join("\r\n * ", inconsistencies);
+                return header + String.Join("\r\n", inconsistencies.Select(msg => $"* {msg}"));
             }
         }
 
@@ -189,8 +189,10 @@ namespace CKAN
 
         public override string ToString()
         {
-            return InconsistenciesPretty + StackTrace;
+            return InconsistenciesPretty + "\r\n\r\n" + StackTrace;
         }
+
+        private const string header = "The following inconsistencies were found:\r\n";
     }
 
     /// <summary>

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -74,17 +74,17 @@ namespace Tests.Core.Relationships
 
             // This would actually be a terrible thing for users to have, but it tests the
             // relationship we want.
-            mods.Add(registry.LatestAvailable("CustomBiomesKerbal",null));
+            mods.Add(registry.LatestAvailable("CustomBiomesKerbal", null));
             Assert.IsTrue(CKAN.SanityChecker.IsConsistent(mods, dlls), "CustomBiomes DLL, with config added");
 
-            mods.Add(registry.LatestAvailable("CustomBiomesRSS",null));
+            mods.Add(registry.LatestAvailable("CustomBiomesRSS", null));
             Assert.IsFalse(CKAN.SanityChecker.IsConsistent(mods, dlls), "CustomBiomes with conflicting data");
         }
 
         [Test]
         public void ConflictWithDll()
         {
-            var mods = new List<CkanModule> { registry.LatestAvailable("SRL",null) };
+            var mods = new List<CkanModule> { registry.LatestAvailable("SRL", null) };
             var dlls = new List<string> { "QuickRevert" };
 
             Assert.IsTrue(CKAN.SanityChecker.IsConsistent(mods), "SRL can be installed by itself");
@@ -92,43 +92,33 @@ namespace Tests.Core.Relationships
         }
 
         [Test]
-        public void ModulesToProvides()
-        {
-            var mods = new List<CkanModule>
-            {
-                registry.LatestAvailable("CustomBiomes",null),
-                registry.LatestAvailable("CustomBiomesKerbal",null),
-                registry.LatestAvailable("DogeCoinFlag",null)
-            };
-
-            var provides = CKAN.SanityChecker.ModulesToProvides(mods);
-            Assert.Contains("CustomBiomes", provides.Keys);
-            Assert.Contains("CustomBiomesData", provides.Keys);
-            Assert.Contains("CustomBiomesKerbal", provides.Keys);
-            Assert.Contains("DogeCoinFlag", provides.Keys);
-            Assert.AreEqual(4, provides.Keys.Count);
-        }
-
-        [Test]
-        public void FindUnmetDependencies()
+        public void FindUnsatisfiedDepends()
         {
             var mods = new List<CkanModule>();
-            var dlls = Enumerable.Empty<string>();
-            Assert.IsEmpty(CKAN.SanityChecker.FindUnmetDependencies(mods, dlls), "Empty list");
+            var dlls = Enumerable.Empty<string>().ToHashSet();
+            Assert.IsEmpty(CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls), "Empty list");
 
-            mods.Add(registry.LatestAvailable("DogeCoinFlag",null));
-            Assert.IsEmpty(CKAN.SanityChecker.FindUnmetDependencies(mods, dlls), "DogeCoinFlag");
+            mods.Add(registry.LatestAvailable("DogeCoinFlag", null));
+            Assert.IsEmpty(CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls), "DogeCoinFlag");
 
-            mods.Add(registry.LatestAvailable("CustomBiomes",null));
-            Assert.Contains("CustomBiomesData", CKAN.SanityChecker.FindUnmetDependencies(mods, dlls).Keys, "Missing CustomBiomesData");
+            mods.Add(registry.LatestAvailable("CustomBiomes", null));
+            Assert.Contains(
+                "CustomBiomesData",
+                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls).Select(kvp => kvp.Value.name).ToList(),
+                "Missing CustomBiomesData"
+            );
 
-            mods.Add(registry.LatestAvailable("CustomBiomesKerbal",null));
-            Assert.IsEmpty(CKAN.SanityChecker.FindUnmetDependencies(mods, dlls), "CBD+CBK");
+            mods.Add(registry.LatestAvailable("CustomBiomesKerbal", null));
+            Assert.IsEmpty(CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls), "CBD+CBK");
 
             mods.RemoveAll(x => x.identifier == "CustomBiomes");
             Assert.AreEqual(2, mods.Count, "Checking removed CustomBiomes");
 
-            Assert.Contains("CustomBiomes", CKAN.SanityChecker.FindUnmetDependencies(mods, dlls).Keys, "Missing CustomBiomes");
+            Assert.Contains(
+                "CustomBiomes",
+                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls).Select(kvp => kvp.Value.name).ToList(),
+                "Missing CustomBiomes"
+            );
         }
 
         [Test]


### PR DESCRIPTION
## Background

Kopernicus has gotten into a habit of making frequent compatibility breaks with previous versions, with the expectation that planet pack makers will release updates to handle the new version. CKAN users would usually be burned by this, as we upgrade their Kopernicus before the planet packs are ready.

A conscientious planet pack maker may try to version-lock his mod to a specific version of Kopernicus to ensure that an upgrade does not take place until the dependent mod is ready for it.

## Problems

If a mod depends on a specific version of another mod, such as this from @Sigma88's [StockalikeSolarSystem](https://github.com/KSP-CKAN/CKAN-meta/blob/master/StockalikeSolarSystem/StockalikeSolarSystem-v0.5.5.ckan#L14-L25):

```json
    "depends": [
        {
            "name": "Kopernicus",
            "version": "2:release-1.3.1-3"
        },
        {
            "name": "SigmaDimensions",
            "version": "0.9.6"
        },
```

... then the correct dependency version will be pulled in at the initial install, but an upgrade command will happily replace it with a later version, breaking the dependency. And CKAN would never notice. This means that even if a planet pack maker goes to the trouble of setting up version-specific metadata, their CKAN users will get burned anyway.

Similarly, a version-specific _conflict_ such as:

```json
    "conflicts": [ { "name": "SigmaBinary-core", "version": "1:v1.6.11" } ],
```

... is currently applied to **all** versions of the conflicting mod, so not only can you not install the conflicting version of that mod, you can't install _any_ version of it. This problem rules out the use of this kind of metadata as a way of limiting the allowed versions for recommendations and suggestions.

## Cause

In `SanityChecker.cs`, both conflict checking and dependency checking completely ignore module versions. Conflicts and dependencies are handled solely in terms of their plain identifiers.

https://github.com/KSP-CKAN/CKAN/blob/b75a4502c1e59edb0fdc063a1326967beccb102c/Core/Relationships/SanityChecker.cs#L48-L54

https://github.com/KSP-CKAN/CKAN/blob/b75a4502c1e59edb0fdc063a1326967beccb102c/Core/Relationships/SanityChecker.cs#L167-L175

## Changes

Now all three of those `TODO`s are resolved:

- Conflict checking is split into a standalone function
- Conflict checking obeys version specifications
- Dependency checking obeys version specifications

This means that if you try to upgrade a module past the version where another module's `depends` clause wants it to be, you now get errors:

```
$ ckan upgrade --all

Upgrading modules...

The following inconsistencies were found:
* StockalikeSolarSystem v0.5.5 has an unsatisfied dependency: Kopernicus 2:release-1.3.1-3 is not installed
* StockalikeSolarSystem v0.5.5 has an unsatisfied dependency: SigmaDimensions 0.9.6 is not installed
* StockalikeSolarSystem v0.5.5 conflicts with SigmaBinary-core 1:v1.6.11

  at CKAN.SanityChecker.EnforceConsistency (System.Collections.Generic.IEnumerable`1[T] modules, System.Collections.Generic.IEnumerable`1[T] dlls) [0x0001e] in <e2a7ca14012c4404a5ab8dd1504e35ee>:0 
  at CKAN.Registry.CheckSanity () [0x00038] in <e2a7ca14012c4404a5ab8dd1504e35ee>:0 
  at CKAN.RegistryManager.Save (System.Boolean enforce_consistency) [0x0001d] in <e2a7ca14012c4404a5ab8dd1504e35ee>:0 
  at CKAN.ModuleInstaller.AddRemove (System.Collections.Generic.IEnumerable`1[T] add, System.Collections.Generic.IEnumerable`1[T] remove, System.Boolean enforceConsistency) [0x0006b] in <e2a7ca14012c4404a5ab8dd1504e35ee>:0 
  at CKAN.ModuleInstaller.Upgrade (System.Collections.Generic.IEnumerable`1[T] modules, CKAN.IDownloader netAsyncDownloader, System.Boolean enforceConsistency) [0x00159] in <e2a7ca14012c4404a5ab8dd1504e35ee>:0 
  at CKAN.CmdLine.Upgrade.RunCommand (CKAN.KSP ksp, System.Object raw_options) [0x00337] in <e2a7ca14012c4404a5ab8dd1504e35ee>:0 
```

To make this happen, `RelationshipDescriptor` now has a public `MatchesAny` function that can be used to see whether the given relationship is satisfied by any of a list of modules. This logic can be used the same way for both dependencies and conflicts.

The `TooManyModsProvideKraken` and `InconsistentKraken` messages are now cleaned up to print the previously missing bullet point for the first item in the list, caused by putting the bullet point in the delimiter for `String.Join`. And where the stack trace previously started on the same line as the last line of the main error message, now there's a blank line between those two sections.

Fixes #2324.
Fixes #2325.