### PR TITLE
Fix building on macOS

### DIFF
--- a/build
+++ b/build
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+set -x
 
 arg0=""
 remainingArgs=""
@@ -28,7 +29,7 @@ toolsDir="$buildDir/tools"
 packagesDir="$buildDir/lib/nuget"
 nugetExe="$toolsDir/NuGet/$nugetVersion/nuget.exe"
 packagesConfigFile="$rootDir/packages.config"
-cakeVersion="$(sed -nE "s|\s*<package\s+id=\"Cake\"\s+version=\"(.+)\"\s*/>\s*|\1|p" $packagesConfigFile)"
+cakeVersion="$(sed -nE "/id=\"Cake\"/s/.*version=\"(.+)\".*/\1/p" $packagesConfigFile)"
 cakeExe="$packagesDir/Cake.$cakeVersion/Cake.exe"
 
 nugetDir="$(dirname $nugetExe)"

--- a/build
+++ b/build
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
-set -x
 
 arg0=""
 remainingArgs=""


### PR DESCRIPTION
This PR tweaks the build script to make it easier to build on macOS.

`/usr/bin/sed` on macOS is a BSD sed, which was returning successfully with an empty string trying to parse the Cake version out of packages.config, thereby breaking the build. Rather than expect the user to install GNU sed, I've changed the expression to something that should work on both and (at least to me) reads more easily.

This branch now builds as-is for me on macOS. I've done minor testing that it's still OK with GNU sed on macOS and changing the build script to use `gsed`. I'm hoping CI will catch any other major problems. :)