### PR TITLE
Fix autoupdater tests on TLS-fragile platforms

### DIFF
--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -99,7 +99,6 @@ namespace CKAN
                     else if (url.EndsWith("AutoUpdater.exe"))
                     {
                         fetchedUpdaterUrl = new Tuple<Uri, long>(new Uri(url), (long)asset.size);
-                        break;
                     }
                 }
                 if (fetchedUpdaterUrl == null)

--- a/Tests/Core/Net/AutoUpdate.cs
+++ b/Tests/Core/Net/AutoUpdate.cs
@@ -29,14 +29,18 @@ namespace Tests.Core.AutoUpdate
         [Category("FlakyNetwork")]
         public void FetchLatestReleaseInfo()
         {
+            // Force-allow TLS 1.2 for HTTPS URLs, because GitHub requires it.
+            // This is on by default in .NET 4.6, but not in 4.5.
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
             var updater = CKAN.AutoUpdate.Instance;
 
             // Is is a *really* basic test to just make sure we get release info
             // if we ask for it.
             updater.FetchLatestReleaseInfo();
-            Assert.IsTrue(updater.IsFetched());
             Assert.IsNotNull(updater.ReleaseNotes);
             Assert.IsNotNull(updater.LatestVersion);
+            Assert.IsTrue(updater.IsFetched());
         }
 
         [Test]
@@ -54,6 +58,10 @@ namespace Tests.Core.AutoUpdate
 
         private void Fetch(Uri url, int whichOne)
         {
+            // Force-allow TLS 1.2 for HTTPS URLs, because GitHub requires it.
+            // This is on by default in .NET 4.6, but not in 4.5.
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
             CKAN.AutoUpdate.Instance.RetrieveUrl(CKAN.AutoUpdate.Instance.MakeRequest(url), whichOne);
         }
     }


### PR DESCRIPTION
## Problems

We have three failing tests currently. (Travis skips them by excluding anything tagged with FlakyNetwork, which these are.)

```
1) Failed : Tests.Core.AutoUpdate.AutoUpdate.FetchCkanUrl
  Expected: <CKAN.Kraken>
  But was:  <System.Net.WebException: The request was aborted: Could not create SSL/TLS secure channel.
   at System.Net.WebClient.DownloadDataInternal(Uri address, WebRequest& request)
   at System.Net.WebClient.DownloadString(Uri address)
   at CKAN.AutoUpdate.MakeRequest(Uri url) in C:\Users\user\github\CKAN\Core\Net\AutoUpdate.cs:line 215
   at Tests.Core.AutoUpdate.AutoUpdate.Fetch(Uri url, Int32 whichOne) in C:\Users\user\github\CKAN\Tests\Core\Net\AutoUpdate.cs:line 57
   at Tests.Core.AutoUpdate.AutoUpdate.<FetchCkanUrl>b__1_0() in C:\Users\user\github\CKAN\Tests\Core\Net\AutoUpdate.cs:line 22
   at NUnit.Framework.Assert.Throws(IResolveConstraint expression, TestDelegate code, String message, Object[] args)>
   at Tests.Core.AutoUpdate.AutoUpdate.FetchCkanUrl() in C:\Users\user\github\CKAN\Tests\Core\Net\AutoUpdate.cs:line 20

2) Error : Tests.Core.AutoUpdate.AutoUpdate.FetchLatestReleaseInfo
System.Net.WebException : The request was aborted: Could not create SSL/TLS secure channel.
   at System.Net.WebClient.DownloadDataInternal(Uri address, WebRequest& request)
   at System.Net.WebClient.DownloadString(Uri address)
   at CKAN.AutoUpdate.MakeRequest(Uri url) in C:\Users\user\github\CKAN\Core\Net\AutoUpdate.cs:line 215
   at CKAN.AutoUpdate.FetchLatestReleaseInfo() in C:\Users\user\github\CKAN\Core\Net\AutoUpdate.cs:line 87
   at Tests.Core.AutoUpdate.AutoUpdate.FetchLatestReleaseInfo() in C:\Users\user\github\CKAN\Tests\Core\Net\AutoUpdate.cs:line 36

3) Error : Tests.NetKAN.Sources.Github.GithubApiTests.GetsLatestReleaseCorrectly
System.Net.WebException : The request was aborted: Could not create SSL/TLS secure channel.
   at System.Net.WebClient.DownloadDataInternal(Uri address, WebRequest& request)
   at System.Net.WebClient.DownloadString(Uri address)
   at CKAN.NetKAN.Sources.Github.GithubApi.Call(String path) in C:\Users\user\github\CKAN\Netkan\Sources\Github\GithubApi.cs:line 96
   at CKAN.NetKAN.Sources.Github.GithubApi.GetLatestRelease(GithubRef reference) in C:\Users\user\github\CKAN\Netkan\Sources\Github\GithubApi.cs:line 32
   at Tests.NetKAN.Sources.Github.GithubApiTests.GetsLatestReleaseCorrectly() in C:\Users\user\github\CKAN\Tests\NetKAN\Sources\Github\GithubApiTests.cs:line
 22
```

## Causes

We need to set `ServicePointManager.SecurityProtocol` before accessing GitHub to enable TLS1.2, see #2297. Running tests bypasses that.

After you fix these three, another test failure happens:

```
1) Failed : Tests.Core.AutoUpdate.AutoUpdate.FetchLatestReleaseInfo
  Expected: True
  But was:  False
   at Tests.Core.AutoUpdate.AutoUpdate.FetchLatestReleaseInfo() in C:\Users\user\github\CKAN\Tests\Core\Net\AutoUpdate.cs:line 43
```

This happens because we stop searching a release for `ckan.exe` after we find `AutoUpdater.exe` due to an errant `break` statement. I think this means the auto-updater in 1.24.0 won't work.

## Changes

`ServicePointManager.SecurityProtocol` is set before network accesses in the affected tests.

The `break` statement is removed to make `FetchLatestReleaseInfo` continue through all the needed assets.

After these changes, all tests now pass.