### PR TITLE
Always switch to progress tab when starting a [re/un]install

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -974,7 +974,6 @@ namespace CKAN
                                 install_ops
                             )
                         );
-                        ShowWaitDialog();
                     }
                 }
                 catch

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -128,7 +128,6 @@ namespace CKAN
                     install_ops
                 )
             );
-            ShowWaitDialog();
         }
 
     }

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -24,6 +24,7 @@ namespace CKAN
 
         private void InstallMods(object sender, DoWorkEventArgs e) // this probably needs to be refactored
         {
+            ShowWaitDialog();
             installCanceled = false;
 
             ClearLog();


### PR DESCRIPTION
## Problem

If you:

1. Already have some mods installed via CKAN
2. Launch the CKAN GUI
3. Right click an installed mod
4. Choose "Reinstall"
5. Click Yes

... then the progress tab does not display. Instead only the status bar reports progress. Additional odd behaviors and glitches may be observed after this as well.

If you install a mod normally first (before step 3), then it works as expected.

## Cause

The sequence of calls needed to use the install flow correctly was:

https://github.com/KSP-CKAN/CKAN/blob/624839ffaa51de25c607531b23f9efb46d4ee612/GUI/Main.cs#L971-L977

Previously, the `ShowWaitDialog` call was missing from `reinstallToolStripMenuItem_Click`. This call creates or activates the progress tab, depending on whether it already exists, and also does some initialization of the progress bar.

## Changes

Now the `ShowWaitDialog` call is moved to `InstallMods`, which is the function that `RunWorkerAsync` calls to do its work. This simplifies the code for installing/uninstalling/reinstalling and fixes the reinstall flow.

Fixes #2343.