### PR TITLE
Allow building CKAN.app on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
             - make
             - sed
             - libplist-utils
-            - genisoimage
+            - xorriso
             # Stuff for building .deb files
             - gzip
             - fakeroot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - [Core] Fix ArgumentOutOfRangeException when removing files from game root (#2332 by: HebaruSan; reviewed: politas)
 - [Core] Obey version properties of conflicts and depends relationships in sanity checks (#2339 by: HebaruSan; reviewed: politas)
 - [Netkan] Invalidate stale cached files from GitHub in Netkan (#2337 by: HebaruSan; reviewed: politas)
+- [Build] Allow building CKAN.app on macOS (#2356 by: phardy; reviewed: HebaruSan)
 
 ### Internal
 

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -20,22 +20,22 @@ VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/
 
 $(DMG): $(EXEDEST) $(SCRIPTDEST) $(ICNSDEST) $(PLISTDEST)
 	mkdir -p $(OUTDIR)
-	genisoimage -V $(NAME) -D -R -apple -no-pad -o $@ $(DMGROOT)
+	xorrisofs -V $(NAME) -D -R -no-pad -o $@ $(DMGROOT)
 
 $(EXEDEST): $(EXESRC)
 	mkdir -p $(shell dirname $@)
-	cp -l $< $@
+	ln $< $@
 
 $(EXESRC):
 	cd .. && ./build --configuration=Release
 
 $(SCRIPTDEST): $(SCRIPTSRC)
 	mkdir -p $(shell dirname $@)
-	cp -l -f $< $@
+	ln -f $< $@
 
 $(ICNSDEST): $(ICNSSRC)
 	mkdir -p $(shell dirname $@)
-	cp -l -f $< $@
+	ln -f $< $@
 
 $(PLISTDEST): $(PLISTSRC)
 	mkdir -p $(shell dirname $@)


### PR DESCRIPTION
Implements the changes I suggested in #2355 for building the app bundle and disk image on macOS.