### PR TITLE
Install old versions of mods on double click from version list

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -941,51 +941,7 @@ namespace CKAN
 
                 menuStrip1.Enabled = false;
 
-                RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
-                install_ops.with_recommends = false;
-
-                try
-                {
-                    // Resolve the provides relationships in the dependencies
-                    List<ModChange> fullChangeSet = new List<ModChange>(
-                        await mainModList.ComputeChangeSetFromModList(
-                            registry_manager.registry,
-                            new HashSet<ModChange>()
-                            {
-                                new ModChange(
-                                    new GUIMod(
-                                        module,
-                                        registry_manager.registry,
-                                        CurrentInstance.VersionCriteria()
-                                    ),
-                                    GUIModChangeType.Install,
-                                    null
-                                )
-                            },
-                            ModuleInstaller.GetInstance(CurrentInstance, GUI.user),
-                            CurrentInstance.VersionCriteria()
-                        )
-                    );
-                    if (fullChangeSet != null && fullChangeSet.Count > 0)
-                    {
-                        installWorker.RunWorkerAsync(
-                            new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                                fullChangeSet,
-                                install_ops
-                            )
-                        );
-                    }
-                }
-                catch
-                {
-                    // If we failed, do the clean-up normally done by PostInstallMods.
-                    HideWaitDialog(false);
-                    menuStrip1.Enabled = true;
-                }
-                finally
-                {
-                    changeSet = null;
-                }
+                InstallModuleDriver(registry_manager.registry, module);
             }
         }
 

--- a/GUI/MainAllModVersions.Designer.cs
+++ b/GUI/MainAllModVersions.Designer.cs
@@ -80,9 +80,10 @@
             this.VersionsListView.TabIndex = 1;
             this.VersionsListView.UseCompatibleStateImageBehavior = false;
             this.VersionsListView.View = System.Windows.Forms.View.Details;
-            // 
+            this.VersionsListView.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.VersionsListView_DoubleClick);
+            //
             // label2
-            // 
+            //
             this.label2.AutoSize = true;
             this.label2.BackColor = System.Drawing.Color.Green;
             this.label2.ForeColor = System.Drawing.Color.White;

--- a/GUI/MainAllModVersions.cs
+++ b/GUI/MainAllModVersions.cs
@@ -14,6 +14,27 @@ namespace CKAN
             InitializeComponent();
         }
 
+        /// <summary>
+        /// React to double click of a version by prompting to install
+        /// </summary>
+        /// <param name="sender">The version list view</param>
+        /// <param name="e">The mouse click event</param>
+        public void VersionsListView_DoubleClick(object sender, MouseEventArgs e)
+        {
+            ListViewHitTestInfo info   = ((ListView)sender).HitTest(e.X, e.Y);
+            ListViewItem        item   = info.Item;
+            CkanModule          module = item.Tag as CkanModule;
+
+            if (module.IsCompatibleKSP(Main.Instance.Manager.CurrentInstance.VersionCriteria())
+                && Main.Instance.YesNoDialog($"Install {module}?"))
+            {
+                Main.Instance.InstallModuleDriver(
+                    RegistryManager.Instance(Main.Instance.Manager.CurrentInstance).registry,
+                    module
+                );
+            }
+        }
+
         public GUIMod SelectedModule
         {
             set
@@ -42,7 +63,15 @@ namespace CKAN
                 bool latestCompatibleVersionAlreadyFound = false;
                 VersionsListView.Items.AddRange(allAvailableVersions.Select(module =>
                 {
-                    ListViewItem toRet = new ListViewItem();
+                    ListViewItem toRet = new ListViewItem(new string[]
+                        {
+                            module.version.ToString(),
+                            module.HighestCompatibleKSP()
+                        })
+                    {
+                        Tag  = module
+                    };
+
                     if (module.IsCompatibleKSP(kspVersionCriteria))
                     {
                         if (!latestCompatibleVersionAlreadyFound)
@@ -61,11 +90,7 @@ namespace CKAN
                     {
                         toRet.Font = new Font(toRet.Font, FontStyle.Bold);
                     }
-
-                    toRet.Text = module.version.ToString();
-                    toRet.SubItems.Add(module.HighestCompatibleKSP());
                     return toRet;
-
                 }).ToArray());
             }
         }


### PR DESCRIPTION
## Background

Currently GUI can only install the latest compatible version of a given mod. So while there may be versions 1.0, 1.1, 1.2, and 1.3 of a mod in the registry, you can only install 1.3.

It may be desirable to install older versions of a mod in some cases. For example, I need to do this to investigate a bug report involving upgrades; if I can only install the latest versions, then I would have to install a bunch of mods and then wait for one of them to upgrade, and repeating such a test would involve more waiting. (Yes, there's a way to do it in Cmdline, but it's nice to have in GUI as well.)

There's a Versions tab that lists all versions of the mod and indicates which are compatible with the current game version. It's not interactive at the moment.

![image](https://user-images.githubusercontent.com/1559108/37540859-7b3c2380-2950-11e8-9914-13447e6148fd.png)

## Changes

Now if you double click one of the green versions, CKAN prompts you to confirm that you want to install it:

![image](https://user-images.githubusercontent.com/1559108/37540884-8ca0d544-2950-11e8-8520-3fb7c6b78ff5.png)

If you click yes, then off to the install flow you go:

![image](https://user-images.githubusercontent.com/1559108/37541218-a4b2b0c0-2951-11e8-9392-5d3510047708.png)

And when it finishes, the mod appears as installed and upgradeable in the mod list, as expected:

![image](https://user-images.githubusercontent.com/1559108/37540957-cd9d9c8a-2950-11e8-9f9f-092ef07dc530.png)

From a code perspective, the "import from .ckan file" code is refactored to a standalone function in MainInstall.cs, which is now shared with the newly added double click handler for the versions list view. To get the `CkanModule` from the list view, we now set them into the `.Tag` properties of the list view items.

Fixes #2077.