### PR TITLE
Allow downloader to be used multiple times

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -98,6 +98,7 @@ namespace CKAN
         /// </summary>
         private void Download(ICollection<Net.DownloadTarget> targets)
         {
+            downloads.Clear();
             foreach (Net.DownloadTarget target in targets)
             {
                 downloads.Add(new NetAsyncDownloaderDownloadPart(target));
@@ -261,6 +262,10 @@ namespace CKAN
 
         public void DownloadAndWait(ICollection<Net.DownloadTarget> urls)
         {
+            completed_downloads = 0;
+            // Make sure we are ready to start a fresh batch
+            complete_or_canceled.Reset();
+
             // Start the download!
             Download(urls);
 
@@ -453,7 +458,7 @@ namespace CKAN
                 log.InfoFormat("Finished downloading {0}", downloads[index].url);
             }
 
-            if (++completed_downloads == downloads.Count)
+            if (++completed_downloads >= downloads.Count)
             {
                 FinalizeDownloads();
             }


### PR DESCRIPTION
## Problem

If you try to upgrade a mod and install another mod in one pass in GUI, you'll get errors about one of the downloads not having enough bytes:

```
CKAN.InvalidModuleFileKraken: C:\Users\Jasper\AppData\Local\Temp\tmpD329.tmp has length 0, should be 15924
   bij CKAN.NetModuleCache.Store(CkanModule module, String path, String description, Boolean move)
   bij CKAN.NetAsyncModulesDownloader.ModuleDownloadsComplete(NetModuleCache cache, Uri[] urls, String[] filenames, Exception[] errors)
   bij CKAN.NetAsyncModulesDownloader.<>c__DisplayClass8_0.<DownloadModules>b__3(Uri[] _uris, String[] paths, Exception[] errors)
   bij CKAN.NetAsyncDownloader.triggerCompleted(Uri[] file_urls, String[] file_paths, Exception[] errors)
   bij CKAN.NetAsyncDownloader.FileDownloadComplete(Int32 index, Exception error)
   bij System.ComponentModel.AsyncCompletedEventHandler.Invoke(Object sender, AsyncCompletedEventArgs e)
   bij System.Net.WebClient.OnDownloadFileCompleted(AsyncCompletedEventArgs e)
   bij System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   bij System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   bij System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   bij System.Threading.ThreadPoolWorkQueue.Dispatch()
```

## Cause

As of #2233, we re-use the same `downloader` object for the upgrade and install operations:

https://github.com/KSP-CKAN/CKAN/blob/9ee358455b338c1164d8605dfd19559ee661919d/GUI/MainInstall.cs#L111-L118

However, `NetAsyncDownloader` doesn't support this. After the first set of downloads finishes, it retains state in its download list, completed downloads count, and a `ManualResetEvent` object that syncs up the threads. As a result, when you use it for a second pass of downloads, it immediately calls its completion code, which in turn tries to add the downloaded files to the cache, which fails because they're not downloaded yet.

## Changes

Now when you call `DownloadAndWait`, the downloader resets itself to handle a new batch of downloads. This allows it to handle multiple non-simultaneous download requests.

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1240-bruce/&do=findComment&comment=3321073