### PR TITLE
Deal with threading and download errors

### DIFF
--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -94,6 +94,10 @@ namespace CKAN
                         {
                             cache.Store(modules[i], filenames[i], modules[i].StandardName());
                         }
+                        catch (InvalidModuleFileKraken kraken)
+                        {
+                            User.RaiseError(kraken.ToString());
+                        }
                         catch (FileNotFoundException e)
                         {
                             log.WarnFormat("cache.Store(): FileNotFoundException: {0}", e.Message);

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -117,13 +117,13 @@ namespace CKAN
             // Check file size
             if (fi.Length != module.download_size)
                 throw new InvalidModuleFileKraken(module, path,
-                    $"{path} has length {fi.Length}, should be {module.download_size}");
+                    $"{module}: {path} has length {fi.Length}, should be {module.download_size}");
 
             // Check valid CRC
             string invalidReason;
             if (!NetFileCache.ZipValid(path, out invalidReason))
                 throw new InvalidModuleFileKraken(module, path,
-                    $"{path} is not a valid ZIP file: {invalidReason}");
+                    $"{module}: {path} is not a valid ZIP file: {invalidReason}");
 
             // Some older metadata doesn't have hashes
             if (module.download_hash != null)
@@ -132,13 +132,13 @@ namespace CKAN
                 string sha1 = GetFileHashSha1(path);
                 if (sha1 != module.download_hash.sha1)
                     throw new InvalidModuleFileKraken(module, path,
-                        $"{path} has SHA1 {sha1}, should be {module.download_hash.sha1}");
+                        $"{module}: {path} has SHA1 {sha1}, should be {module.download_hash.sha1}");
 
                 // Check SHA256 match
                 string sha256 = GetFileHashSha256(path);
                 if (sha256 != module.download_hash.sha256)
                     throw new InvalidModuleFileKraken(module, path,
-                        $"{path} has SHA256 {sha256}, should be {module.download_hash.sha256}");
+                        $"{module}: {path} has SHA256 {sha256}, should be {module.download_hash.sha256}");
             }
 
             // If no exceptions, then everything is fine

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -13,37 +13,52 @@ namespace CKAN
 
         public void ShowWaitDialog(bool cancelable = true)
         {
-            tabController.ShowTab("WaitTabPage", 2);
+            Util.Invoke(DialogProgressBar, () =>
+            {
+                tabController.ShowTab("WaitTabPage", 2);
 
-            CancelCurrentActionButton.Enabled = cancelable;
+                CancelCurrentActionButton.Enabled = cancelable;
 
-            DialogProgressBar.Value = 0;
-            DialogProgressBar.Minimum = 0;
-            DialogProgressBar.Maximum = 100;
-            DialogProgressBar.Style = ProgressBarStyle.Marquee;
-            MessageTextBox.Text = "Please wait";
-            StatusProgress.Value = 0;
-            StatusProgress.Style = ProgressBarStyle.Marquee;
-            StatusProgress.Visible = true;
+                DialogProgressBar.Value = 0;
+                DialogProgressBar.Minimum = 0;
+                DialogProgressBar.Maximum = 100;
+                DialogProgressBar.Style = ProgressBarStyle.Marquee;
+                MessageTextBox.Text = "Please wait";
+            });
+            Util.Invoke(statusStrip1, () =>
+            {
+                StatusProgress.Value = 0;
+                StatusProgress.Style = ProgressBarStyle.Marquee;
+                StatusProgress.Visible = true;
+            });
         }
 
         public void HideWaitDialog(bool success)
         {
-            MessageTextBox.Text = "All done!";
-            DialogProgressBar.Value = 100;
-            DialogProgressBar.Style = ProgressBarStyle.Continuous;
-            StatusProgress.Value = 100;
-            StatusProgress.Style = ProgressBarStyle.Continuous;
-            RecreateDialogs();
+            Util.Invoke(statusStrip1, () =>
+            {
+                StatusProgress.Value = 100;
+                StatusProgress.Style = ProgressBarStyle.Continuous;
+            });
+            Util.Invoke(DialogProgressBar, () =>
+            {
+                MessageTextBox.Text = "All done!";
+                DialogProgressBar.Value = 100;
+                DialogProgressBar.Style = ProgressBarStyle.Continuous;
+                RecreateDialogs();
 
-            tabController.SetActiveTab("ManageModsTabPage");
+                tabController.SetActiveTab("ManageModsTabPage");
 
-            CancelCurrentActionButton.Enabled = false;
-            DialogProgressBar.Value = 0;
-            DialogProgressBar.Style = ProgressBarStyle.Continuous;
-            StatusProgress.Value = 0;
-            StatusProgress.Style = ProgressBarStyle.Continuous;
-            StatusProgress.Visible = false;
+                CancelCurrentActionButton.Enabled = false;
+                DialogProgressBar.Value = 0;
+                DialogProgressBar.Style = ProgressBarStyle.Continuous;
+            });
+            Util.Invoke(statusStrip1, () =>
+            {
+                StatusProgress.Value = 0;
+                StatusProgress.Style = ProgressBarStyle.Continuous;
+                StatusProgress.Visible = false;
+            });
         }
 
         public void SetProgress(int progress)
@@ -61,6 +76,9 @@ namespace CKAN
             {
                 DialogProgressBar.Value = progress;
                 DialogProgressBar.Style = ProgressBarStyle.Continuous;
+            });
+            Util.Invoke(statusStrip1, () =>
+            {
                 StatusProgress.Value = progress;
                 StatusProgress.Style = ProgressBarStyle.Continuous;
             });
@@ -71,6 +89,9 @@ namespace CKAN
             Util.Invoke(DialogProgressBar, () =>
             {
                 DialogProgressBar.Style = ProgressBarStyle.Marquee;
+            });
+            Util.Invoke(statusStrip1, () =>
+            {
                 StatusProgress.Style    = ProgressBarStyle.Marquee;
             });
         }
@@ -92,7 +113,10 @@ namespace CKAN
 
         private void RetryCurrentActionButton_Click(object sender, EventArgs e)
         {
-            tabController.ShowTab("ChangesetTabPage", 1);
+            Util.Invoke(DialogProgressBar, () =>
+            {
+                tabController.ShowTab("ChangesetTabPage", 1);
+            });
         }
 
         private void CancelCurrentActionButton_Click(object sender, EventArgs e)
@@ -101,7 +125,10 @@ namespace CKAN
             {
                 cancelCallback();
             }
-            CancelCurrentActionButton.Enabled = false;
+            Util.Invoke(DialogProgressBar, () =>
+            {
+                CancelCurrentActionButton.Enabled = false;
+            });
             HideWaitDialog(true);
         }
 


### PR DESCRIPTION
## Problems

As of #2351, I'm getting these errors when trying to install a mod on Windows:

```
System.ArgumentException: Controls created on one thread cannot be parented to a control on a different thread.
   at System.Windows.Forms.Control.ControlCollection.Add(Control value)
   at System.Windows.Forms.ToolStripControlHost.SyncControlParent()
   at System.Windows.Forms.ToolStripControlHost.OnParentChanged(ToolStrip oldParent, ToolStrip newParent)
   at System.Windows.Forms.ToolStripItem.set_ParentInternal(ToolStrip value)
   at System.Windows.Forms.ToolStrip.SetDisplayedItems()
   at System.Windows.Forms.StatusStrip.SetDisplayedItems()
   at System.Windows.Forms.ToolStrip.OnLayout(LayoutEventArgs e)
   at System.Windows.Forms.StatusStrip.OnLayout(LayoutEventArgs levent)
   at System.Windows.Forms.Control.PerformLayout(LayoutEventArgs args)
   at System.Windows.Forms.ToolStrip.DoLayoutIfHandleCreated(ToolStripItemEventArgs e)
   at System.Windows.Forms.ToolStrip.OnItemVisibleChanged(ToolStripItemEventArgs e, Boolean performLayout)
   at System.Windows.Forms.ToolStripItem.OnVisibleChanged(EventArgs e)
   at System.Windows.Forms.ToolStripItem.SetVisibleCore(Boolean visible)
   at System.Windows.Forms.ToolStripControlHost.SetVisibleCore(Boolean visible)
   at CKAN.Main.ShowWaitDialog(MainCancelCallback cancelAction)
   at CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

Of course this works fine on Linux. Three cheers for "write once run anywhere."

If a downloaded file doesn't pass validation (invalid ZIP, wrong file size or hashes), a few problems happen:

- The error message doesn't name the mod with the problem, which makes it harder for the user to deal with it
- The error message is displayed by the uncaught exceptions handler, so the GUI ends up in an inconsistent state or crashes outright
- Other mods in the same download batch may be discarded instead of being added to the cache, even if they are valid

## Causes

WinForms on Windows only allows its GUI controls to be accessed from certain threads; other threads have to call `Control.Invoke` to pass code to be run on the appropriate thread. I assume this has to do with it being a wrapper around code from the 1990s, because if you were designing a GUI framework from scratch, you'd probably design it to not care about this sort of thing.

That's why `Util.Invoke` is sprinkled throughout the GUI code. The above exception happened on this line:

https://github.com/KSP-CKAN/CKAN/blob/a6619fef5cd12ed771606dd0ee8a841514c6b1dd/GUI/MainWait.cs#L27

... which was being called from a background thread without `Invoke`.

## Changes

Now `Util.Invoke` calls are added to all affected functions in `MainWait.cs`. The status bar progress bar is in a separate block because I found instances during investigation where putting it in the same `Invoke` as the regular progress bar wasn't good enough.

`InvalidModuleFileKraken` is now caught and displayed to the user in `NetAsyncModulesDownloader.ModuleDownloadsComplete`, which allows the loop to finish caching all the downloaded mods.

The mod name and version are added to the text for `InvalidModuleFileKraken`.

![image](https://user-images.githubusercontent.com/1559108/37569960-a379c4fa-2ae1-11e8-8c3b-beb7348c6fa3.png)
