### PR TITLE
More verbose and accurate version displays

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -115,7 +115,7 @@ namespace CKAN
             // KSP.
             if (latest_available_for_any_ksp != null)
             {
-                KSPCompatibility = KSPCompatibilityLong = latest_available_for_any_ksp.HighestCompatibleKSP();
+                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "";
 
                 // If the mod we have installed is *not* the mod we have installed, or we don't know
                 // what we have installed, indicate that an upgrade would be needed.

--- a/GUI/MainAllModVersions.Designer.cs
+++ b/GUI/MainAllModVersions.Designer.cs
@@ -60,7 +60,7 @@
             // 
             // CompatibleKSPVersion
             // 
-            this.CompatibleKSPVersion.Text = "Compatible KSP Version";
+            this.CompatibleKSPVersion.Text = "Compatible KSP Versions";
             this.CompatibleKSPVersion.Width = 248;
             // 
             // VersionsListView

--- a/GUI/MainAllModVersions.cs
+++ b/GUI/MainAllModVersions.cs
@@ -63,10 +63,13 @@ namespace CKAN
                 bool latestCompatibleVersionAlreadyFound = false;
                 VersionsListView.Items.AddRange(allAvailableVersions.Select(module =>
                 {
+                    ModuleVersion minMod = null, maxMod = null;
+                    KspVersion    minKsp = null, maxKsp = null;
+                    Registry.GetMinMaxVersions(new List<CkanModule>() {module}, out minMod, out maxMod, out minKsp, out maxKsp);
                     ListViewItem toRet = new ListViewItem(new string[]
                         {
                             module.version.ToString(),
-                            module.HighestCompatibleKSP()
+                            KspVersionRange.VersionSpan(minKsp, maxKsp).ToString()
                         })
                     {
                         Tag  = module

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -421,11 +421,18 @@ namespace CKAN
 
             foreach (CkanModule module in tooManyProvides.modules)
             {
-                ListViewItem item = new ListViewItem {Tag = module, Checked = false, Text = module.name};
-
-
-                ListViewItem.ListViewSubItem description =
-                    new ListViewItem.ListViewSubItem {Text = module.@abstract};
+                ListViewItem item = new ListViewItem()
+                {
+                    Tag = module,
+                    Checked = false,
+                    Text = CurrentInstance.Cache.IsMaybeCachedZip(module)
+                        ? $"{module.name} {module.version} (cached)"
+                        : $"{module.name} {module.version} ({module.download.Host ?? ""}, {CkanModule.FmtSize(module.download_size)})"
+                };
+                ListViewItem.ListViewSubItem description = new ListViewItem.ListViewSubItem()
+                {
+                    Text = module.@abstract
+                };
 
                 item.SubItems.Add(description);
                 ChooseProvidedModsListView.Items.Add(item);


### PR DESCRIPTION
## Problems

GUI's "Max KSP Version" column isn't always accurate; it assumes that the module version that CKAN considers "latest" always has the max KSP version, which sometimes is not the case. This was originally fixed in #2131, but the fix was reverted in #2150 as part of the rollback of #1929, as reported in KSP-CKAN/NetKAN#6368.

The Versions tab only shows the highest compatible game version, even though it's very common for mods to be compatible with a range of many game versions.

The prompt to choose a mod to satisfy a virtual dependency ("provides"-based) doesn't show the download host or file size, even though other places do.

## Changes

Now #2131's change is back.

Now the Versions tab will show the full range of each module version's game versions:

![image](https://user-images.githubusercontent.com/1559108/37716646-e47438c8-2d16-11e8-8b3e-67927bad4916.png)

Now when you are prompted to select a mod to satisfy a virtual dependency, the download host and file size will be shown to help inform your choice (already previously done for the change set confirmation list and the recommendation/suggestion list):

![image](https://user-images.githubusercontent.com/1559108/37716675-f9812686-2d16-11e8-8254-35e1b0774828.png)