### PR TITLE
Encode spaces in URL output

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -123,7 +123,9 @@ namespace CKAN
         {
             for (int i = 0; i < downloads.Count; i++)
             {
-                User.RaiseMessage("Downloading \"{0}\"", downloads[i].url);
+                // Encode spaces to avoid confusing URL parsers
+                User.RaiseMessage("Downloading \"{0}\"",
+                    downloads[i].url.ToString().Replace(" ", "%20"));
 
                 // We need a new variable for our closure/lambda, hence index = i.
                 int index = i;
@@ -160,7 +162,9 @@ namespace CKAN
             for (int i = 0; i < downloads.Count; i++)
             {
                 log.DebugFormat("Downloading {0}", downloads[i].url);
-                User.RaiseMessage("Downloading \"{0}\" (libcurl)", downloads[i].url);
+                // Encode spaces to avoid confusing URL parsers
+                User.RaiseMessage("Downloading \"{0}\" (libcurl)",
+                    downloads[i].url.ToString().Replace(" ", "%20"));
 
                 // Open our file, and make an easy object...
                 FileStream stream = File.OpenWrite(downloads[i].path);


### PR DESCRIPTION
## Problem

Currently in [the output for NetKAN pull request validation](https://ci.ksp-ckan.org/job/NetKAN/7091/console), the download URLs are printed with spaces unescaped:

![image](https://user-images.githubusercontent.com/1559108/37868726-24a675f8-2fa3-11e8-8efc-b1987f318b5b.png)

This trips up the Jenkins site's attempt to make the URLs clickable, which could be handy if someone investigating an issue wants to inspect the downloaded files locally. Only the part leading up to the first space is detected, which isn't the full URL that's being downloaded.

## Changes

Now we replace spaces in this output with `%20` as per standard URL encoding.

I looked into the proper functions for encoding URLs in C#, and none of them seemed appropriate for this. The problem is that `Uri.ToString()` outputs a _partially_ valid URL (correctly formatted but may contain spaces), which none of the various encoding functions expect. Some of them would encode the `://` part as `%3A%2F%2F`, which we definitely don't want, and the rest would miss the spaces. So I just went with `.Replace`.

This change affects **only** these specific output statements; no changes are made to the internals of URL handling for downloads, metadata, etc.

## Trivia

You may be familiar with the practice of encoding spaces in URLs as `+`. TIL that this is only valid in the keys and values of form fields, but _not_ in the base URL to which those keys and values are sent (or anywhere in non-form URLs)! This is why I went with `%20` in this case.