### PR TITLE
Sort by "update"-column on clicking "add available updates"

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -477,16 +477,20 @@ namespace CKAN
                 }
             }
 
-            
+            // set new sort column
             var new_sort_column = ModList.Columns[1];
             var current_sort_column = ModList.Columns[configuration.SortByColumnIndex];
-
+            
             // Reset the glyph.
             current_sort_column.HeaderCell.SortGlyphDirection = SortOrder.None;
             configuration.SortByColumnIndex = new_sort_column.Index;
             UpdateFilters(this);
 
             ModList.Refresh();
+
+            // Selects the top/bottom row and scrolls the list to it.
+            DataGridViewCell cell = ModList.Rows[0].Cells[2];
+            ModList.CurrentCell = cell;
         }
 
         public void UpdateModContentsTree(CkanModule module, bool force = false)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -477,6 +477,15 @@ namespace CKAN
                 }
             }
 
+            
+            var new_sort_column = ModList.Columns[1];
+            var current_sort_column = ModList.Columns[configuration.SortByColumnIndex];
+
+            // Reset the glyph.
+            current_sort_column.HeaderCell.SortGlyphDirection = SortOrder.None;
+            configuration.SortByColumnIndex = new_sort_column.Index;
+            UpdateFilters(this);
+
             ModList.Refresh();
         }
 


### PR DESCRIPTION
Hey, I just thought of a little enhancement, and decided to create the PR myself.

So now, after clicking the "Add all available updates" button, the modlist automatically sorts by "update" column and focuses/selects and scrolls to first row.

I'm not that experienced at programming and furthermore this is my first commit on CKAN and just copy-pasted together code which seemed to do the right things, after trying to get an overview of the code for some hours :D

Well, it worked after building, so yeah.