### PR TITLE
Clean-up and debuggability

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -23,9 +23,6 @@ namespace CKAN
         private static readonly ILog log = LogManager.GetLogger(typeof (Repo));
         private static TxFileManager file_transaction = new TxFileManager();
 
-        // Forward to keep existing code compiling, will be removed soon.
-        public static readonly Uri default_ckan_repo = CKAN.Repository.default_ckan_repo_uri;
-
         /// <summary>
         /// Download and update the local CKAN meta-info.
         /// Optionally takes a URL to the zipfile repo to download.
@@ -92,9 +89,9 @@ namespace CKAN
             {
                 repo_file = Net.Download(repo);
             }
-            catch (System.Net.WebException)
+            catch (System.Net.WebException ex)
             {
-                user.RaiseMessage("Connection to {0} could not be established.", repo);
+                user.RaiseMessage("Failed to download {0}: {1}", repo, ex.ToString());
                 return null;
             }
 
@@ -386,7 +383,7 @@ Do you wish to reinstall now?", sb)))
             // Use our default repo, unless we've been told otherwise.
             if (repo == null)
             {
-                repo = default_ckan_repo;
+                repo = CKAN.Repository.default_ckan_repo_uri;
             }
 
             List<CkanModule> newAvail = UpdateRegistry(repo, ksp, user);

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -198,7 +198,7 @@ namespace CKAN
             configuration = Configuration.LoadOrCreateConfiguration
                 (
                     Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml"),
-                    Repo.default_ckan_repo.ToString()
+                    CKAN.Repository.default_ckan_repo_uri.ToString()
                 );
 
             // Check if there is any other instances already running.
@@ -428,7 +428,7 @@ namespace CKAN
             configuration = Configuration.LoadOrCreateConfiguration
             (
                 Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml"),
-                Repo.default_ckan_repo.ToString()
+                CKAN.Repository.default_ckan_repo_uri.ToString()
             );
 
             if (CurrentInstance.CompatibleVersionsAreFromDifferentKsp)
@@ -722,7 +722,7 @@ namespace CKAN
             Enabled = true;
         }
 
-        private async void installFromckanToolStripMenuItem_Click(object sender, EventArgs e)
+        private void installFromckanToolStripMenuItem_Click(object sender, EventArgs e)
         {
             OpenFileDialog open_file_dialog = new OpenFileDialog { Filter = Resources.CKANFileFilter };
 

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -428,16 +428,24 @@ namespace CKAN
     {
         protected override void OnPaint(PaintEventArgs e)
         {
-            //Hacky workaround for https://bugzilla.xamarin.com/show_bug.cgi?id=24372
-            if (Platform.IsMono && !Platform.IsMonoFour)
+            try
             {
-                var first_row_index = typeof (MainModListGUI).BaseType
-                    .GetField("first_row_index", BindingFlags.NonPublic | BindingFlags.Instance);
-                var value = (int) first_row_index.GetValue(this);
-                if (value < 0 || value >= Rows.Count)
+                // Hacky workaround for https://bugzilla.xamarin.com/show_bug.cgi?id=24372
+                if (Platform.IsMono && !Platform.IsMonoFourOrLater)
                 {
-                    first_row_index.SetValue(this, 0);
+                    var first_row_index = typeof (MainModListGUI).BaseType
+                        .GetField("first_row_index", BindingFlags.NonPublic | BindingFlags.Instance);
+                    var value = (int) first_row_index.GetValue(this);
+                    if (value < 0 || value >= Rows.Count)
+                    {
+                        first_row_index.SetValue(this, 0);
+                    }
                 }
+            }
+            catch
+            {
+                // Never throw exceptions in OnPaint, or WinForms might decide to replace our control with a big red X
+                // https://blogs.msdn.microsoft.com/shawnhar/2010/11/22/winforms-and-the-big-red-x-of-doom/
             }
             base.OnPaint(e);
         }

--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Version: @VERSION@
 Architecture: all
 Section: utils
 Priority: optional
-Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, liblog4net1.2-cil, libnewtonsoft-json5.0-cil
+Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, liblog4net1.2-cil, libnewtonsoft-json5.0-cil, libmono-system-net-http-webrequest4.0-cil
 Maintainer: The CKAN authors <debian@ksp-ckan.org>
 Description: KSP-CKAN official client.
  Official client for the Comprehensive Kerbal Archive Network (CKAN).


### PR DESCRIPTION
The past few weeks have seen a steady trickle of obscure, difficult to investigate issues. This pull request attempts to extend CKAN's debugging capabilities in specific areas to make it possible to make progress on those issues. It also addresses a few very small or simple problems that came up.

## Debian dependency on webrequest

A user reported in a random comment on unrelated issue #1817 that the .deb package should depend on the `webrequest` package. This is now added to `debian/control.in`.

## Remove unnecessary `async` keyword

`installFromckanToolStripMenuItem_Click` is marked as `async`, but it doesn't need to be, which causes a warning to be raised at compile time. This is now removed.

Fixes #2376.

## Include webexception info in failure message for repo updates

#2391 contains multiple attestations that refreshing the registry sometimes fails, possibly related to how long CKAN has been running. A`WebException` is thrown when this happens, but its details are discarded.

Since the cause of this is unclear, we now add the exception to the error output. This is not a fix but may allow us to discover how to create a fix.

## Suppress exceptions in OnPaint and skip Mono 3 workaround in Mono 5

A user reports in #2396 that the CKAN window turns into a big red X sometimes on MacOSX. This is apparently something WinForms does when you throw an exception in a control's `OnPaint` method, which we have here:

https://github.com/KSP-CKAN/CKAN/blob/a495f435fff9a8e2c55ca5fdca0cb92d9a03c0e8/GUI/MainModList.cs#L427-L444

That was originally done to work around a bug in Mono 3 that was fixed in Mono 4. The idea was that the code would use the `IsMonoFour` check to avoid running on versions where the bug was fixed. However, now that we are mostly on Mono 5, `IsMonoFour` is no longer an adequate check; since Mono 5 is not Mono 4, this Mono 3 workaround has come back to life and is running on Mono 5.

Now all of that code is wrapped in a `try`/`catch` block that discards all the exceptions, and `IsMonoFour` is replaced with `IsMonoFourOrLater` to reflect the real intent of this code, preventing the Mono 3 workaround from running on Mono 5.

May or may not fix #2396.

## More debug messages around lock acquisition and registry creation

KSP-CKAN/NetKAN#6459 describes an issue in which CKAN "has stopped working" immediately on launch, even if you just run `ckan scan` from the command line. When we tried capturing the `--debug` output, the last message was

https://github.com/KSP-CKAN/CKAN/blob/a495f435fff9a8e2c55ca5fdca0cb92d9a03c0e8/Core/Registry/RegistryManager.cs#L241

In a working install, the next message would be one of these:

https://github.com/KSP-CKAN/CKAN/blob/a495f435fff9a8e2c55ca5fdca0cb92d9a03c0e8/Core/Registry/RegistryManager.cs#L291

https://github.com/KSP-CKAN/CKAN/blob/a495f435fff9a8e2c55ca5fdca0cb92d9a03c0e8/Core/Registry/RegistryManager.cs#L317

So something between those statements is somehow causing a crash. There's a lot of code in that gap. This pull request adds more `DebugFormat` statements to log all those various steps so we can narrow down what's happening.

Not a fix for KSP-CKAN/NetKAN#6459, but should help us to figure out what's going on with that issue.