### PR TITLE
Don't double encode GitHub download URLs

### DIFF
--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -75,7 +75,7 @@ namespace CKAN.NetKAN.Transformers
                 {
                     json.SafeAdd("version",  ghRelease.Version.ToString());
                     json.SafeAdd("author",   ghRelease.Author);
-                    json.SafeAdd("download", Uri.EscapeUriString(ghRelease.Download.ToString()));
+                    json.SafeAdd("download", ghRelease.Download.ToString());
                     json.SafeAdd(Model.Metadata.UpdatedPropertyName, ghRelease.AssetUpdated);
 
                     if (ghRef.Project.Contains("_"))


### PR DESCRIPTION
## Problem

Netkan currently is double-encoding GitHub download URLs, which causes any URL that has an encoded character to fail. See #2401 for details.

## Cause

The GitHub API returns the URL already encoded:

- https://api.github.com/repos/jrodrigv/DestructionEffects/releases

```json
        "browser_download_url": "https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip"
```

We then encode it again, which changes any `%` characters to `%25`, which makes the URL fail with a 404 status:

https://github.com/KSP-CKAN/CKAN/blob/a495f435fff9a8e2c55ca5fdca0cb92d9a03c0e8/Netkan/Transformers/GithubTransformer.cs#L78

## Changes

The `Uri.EscapeUriString` call is removed. The DestructionEffects netkan succeeds with this change.

Fixes #2401.