### PR TITLE
Option to override SpaceDock version with AVC version

### DIFF
--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -155,7 +155,12 @@ namespace CKAN.NetKAN.Transformers
                     {
                         // In practice, the version specified in .version files tends to be unreliable, with authors
                         // forgetting to update it when new versions are released. Therefore if we have a version
-                        // specified from another source such as SpaceDock, curse or a GitHub tag, don't overwrite it.
+                        // specified from another source such as SpaceDock, curse or a GitHub tag, don't overwrite it
+                        // unless x_netkan_trust_version_file is true.
+                        if ((bool?)json["x_netkan_trust_version_file"] ?? false)
+                        {
+                            json.Remove("version");
+                        }
                         json.SafeAdd("version", avc.version.ToString());
                     }
 


### PR DESCRIPTION
## Problem

A mod that exists only as a bundled folder in another mod on SpaceDock can't have its own version number in CKAN; it must use the bundling mod's version (see #2405). This misrepresents to the user what's being installed, and makes for an awkward transition if we have to switch the source mod, often requiring an epoch bump.

## Cause

A decision was made to never trust version files if we have another source of version info:

https://github.com/KSP-CKAN/CKAN/blob/a495f435fff9a8e2c55ca5fdca0cb92d9a03c0e8/Netkan/Transformers/AvcTransformer.cs#L154-L160

## Changes

Now there is a way to override the above behavior. If `"x_netkan_trust_version_file"` is set to `true` in a given netkan file, then the `"version"` property will be sourced preferentially from the version file, if any.

Fixes #2405; my test version generated `DynamicBatteryStorage-2-1.3.0.0.ckan` from the current netkan with that property added, which is the correct version from that bundled mod's version file.