### PR TITLE
Add more tests

### DIFF
--- a/Tests/Core/KSPPathUtils.cs
+++ b/Tests/Core/KSPPathUtils.cs
@@ -102,6 +102,20 @@ namespace Tests.Core
         }
 
         [Test]
+        public void ToRelative_PathEqualsRoot_DontCrash()
+        {
+            // Arrange
+            string path = "/home/fionna/KSP";
+            string root = "/home/fionna/KSP";
+            // Act & Assert
+            Assert.DoesNotThrow(() =>
+            {
+                string s = CKAN.KSPPathUtils.ToRelative(path, root);
+                Assert.IsEmpty(s);
+            });
+        }
+
+        [Test]
         public void ToAbsolute()
         {
             Assert.AreEqual(

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -20,7 +20,7 @@ namespace Tests.Core
         private DisposableKSP        _instance;
         private CKAN.Registry        _registry;
         private CKAN.ModuleInstaller _installer;
-        private CKAN.CkanModule      _testModule;
+        private CkanModule           _testModule;
         private string               _gameDataDir;
 
         /// <summary>

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -456,9 +456,7 @@ namespace Tests.Core.Relationships
                 mod_b,
                 depender
             });
-
         }
-
 
         [Test]
         public void Constructor_WithMissingDependants_Throws()
@@ -477,14 +475,13 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
-
         }
 
         [Test]
         [Category("Version")]
         [TestCase("1.0", "2.0")]
         [TestCase("1.0", "0.2")]
-        [TestCase("0", "0.2")]
+        [TestCase("0",   "0.2")]
         [TestCase("1.0", "0")]
         public void Constructor_WithMissingDependantsVersion_Throws(string ver, string dep)
         {
@@ -502,7 +499,6 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
-
         }
 
         [Test]
@@ -530,7 +526,6 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
-
         }
 
         [Test]
@@ -553,7 +548,6 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
-
         }
 
         [Test]
@@ -566,10 +560,12 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {
+                new RelationshipDescriptor
+                {
                     name = dependant.identifier,
                     min_version = new ModuleVersion(dep_min),
-                    max_version = new ModuleVersion(dep_max)}
+                    max_version = new ModuleVersion(dep_max)
+                }
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);
@@ -580,7 +576,6 @@ namespace Tests.Core.Relationships
                 options,
                 registry,
                 null));
-
         }
 
         [Test]
@@ -607,7 +602,6 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
-
         }
 
         [Test]
@@ -634,7 +628,6 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
-
         }
 
         [Test]
@@ -661,7 +654,6 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
-
         }
 
         [Test]
@@ -688,7 +680,6 @@ namespace Tests.Core.Relationships
                 dependant,
                 depender
             });
-
         }
 
         [Test]
@@ -708,7 +699,6 @@ namespace Tests.Core.Relationships
                 null));
         }
 
-
         [Test]
         public void ReasonFor_WithModsNotInList_ThrowsArgumentException()
         {
@@ -722,7 +712,6 @@ namespace Tests.Core.Relationships
             var mod_not_in_resolver_list = generator.GeneratorRandomModule();
             CollectionAssert.DoesNotContain(relationship_resolver.ModList(),mod_not_in_resolver_list);
             Assert.Throws<ArgumentException>(() => relationship_resolver.ReasonFor(mod_not_in_resolver_list));
-
         }
 
         [Test]
@@ -802,7 +791,7 @@ namespace Tests.Core.Relationships
                 CkanModule mod = generator.GeneratorRandomModule(depends: depends);
 
                 new RelationshipResolver(
-                    new CKAN.CkanModule[] { mod },
+                    new CkanModule[] { mod },
                     RelationshipResolver.DefaultOpts(),
                     registry,
                     new KspVersionCriteria (KspVersion.Parse("1.0.0"))

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -128,11 +128,11 @@ namespace Tests.Core.Relationships
         [Test]
         public void ReverseDepends()
         {
-            var mods = new List<CkanModule>
+            var mods = new List<CkanModule>()
             {
-                registry.LatestAvailable("CustomBiomes",null),
-                registry.LatestAvailable("CustomBiomesKerbal",null),
-                registry.LatestAvailable("DogeCoinFlag",null)
+                registry.LatestAvailable("CustomBiomes",       null),
+                registry.LatestAvailable("CustomBiomesKerbal", null),
+                registry.LatestAvailable("DogeCoinFlag",       null)
             };
 
             // Make sure some of our expectations regarding dependencies are correct.
@@ -162,7 +162,110 @@ namespace Tests.Core.Relationships
             expected.Clear();
             to_remove.Clear();
             TestDepends(to_remove, mods, null, null, expected, "Removing nothing");
+        }
 
+        [Test]
+        public void IsConsistent_MismatchedDependencyVersion_Inconsistent()
+        {
+            // Arrange
+            List<CkanModule> modules = new List<CkanModule>()
+            {
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""depender"",
+                    ""version"":    ""1.0.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""depends"": [ {
+                            ""name"":    ""dependency"",
+                            ""version"": ""1.2.3""
+                    } ]
+                }"),
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""dependency"",
+                    ""version"":    ""1.1.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01""
+                }")
+            };
+
+            // Act & Assert
+            Assert.IsFalse(CKAN.SanityChecker.IsConsistent(modules));
+        }
+
+        [Test]
+        public void IsConsistent_MatchedDependencyVersion_Consistent()
+        {
+            // Arrange
+            List<CkanModule> modules = new List<CkanModule>()
+            {
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""depender"",
+                    ""version"":    ""1.0.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""depends"": [ {
+                            ""name"":    ""dependency"",
+                            ""version"": ""1.2.3""
+                    } ]
+                }"),
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""dependency"",
+                    ""version"":    ""1.2.3"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01""
+                }")
+            };
+
+            // Act & Assert
+            Assert.IsTrue(CKAN.SanityChecker.IsConsistent(modules));
+        }
+
+        [Test]
+        public void IsConsistent_MismatchedConflictVersion_Consistent()
+        {
+            // Arrange
+            List<CkanModule> modules = new List<CkanModule>()
+            {
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""depender"",
+                    ""version"":    ""1.0.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""conflicts"": [ {
+                            ""name"":    ""dependency"",
+                            ""version"": ""1.2.3""
+                    } ]
+                }"),
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""dependency"",
+                    ""version"":    ""1.1.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01""
+                }")
+            };
+
+            // Act & Assert
+            Assert.IsTrue(CKAN.SanityChecker.IsConsistent(modules));
+        }
+
+        [Test]
+        public void IsConsistent_MatchedConflictVersion_Inconsistent()
+        {
+            // Arrange
+            List<CkanModule> modules = new List<CkanModule>()
+            {
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""depender"",
+                    ""version"":    ""1.0.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""conflicts"": [ {
+                            ""name"":    ""dependency"",
+                            ""version"": ""1.2.3""
+                    } ]
+                }"),
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""dependency"",
+                    ""version"":    ""1.2.3"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01""
+                }")
+            };
+
+            // Act & Assert
+            Assert.IsFalse(CKAN.SanityChecker.IsConsistent(modules));
         }
 
         private static void TestDepends(
@@ -189,5 +292,6 @@ namespace Tests.Core.Relationships
             // Check our actual results.
             CollectionAssert.AreEquivalent(expected, results, message);
         }
+
     }
 }

--- a/Tests/Core/Types/CkanModuleTests.cs
+++ b/Tests/Core/Types/CkanModuleTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using CKAN;
 using CKAN.Versioning;
@@ -9,14 +10,14 @@ using Newtonsoft.Json.Linq;
 namespace Tests.Core.Types
 {
     [TestFixture]
-    public class Module
+    public class CkanModuleTests
     {
         [Test]
         public void CompatibleWith()
         {
             CkanModule module = CkanModule.FromJson(TestData.kOS_014());
 
-            Assert.IsTrue(module.IsCompatibleKSP(new KspVersionCriteria (KspVersion.Parse("0.24.2"))));
+            Assert.IsTrue(module.IsCompatibleKSP(new KspVersionCriteria(KspVersion.Parse("0.24.2"))));
         }
 
         [Test]
@@ -32,7 +33,7 @@ namespace Tests.Core.Types
         [Test]
         public void MetaData()
         {
-            CkanModule module = CkanModule.FromJson (TestData.kOS_014 ());
+            CkanModule module = CkanModule.FromJson(TestData.kOS_014());
 
             Assert.AreEqual("kOS - Kerbal OS", module.name);
             Assert.AreEqual("kOS", module.identifier);
@@ -49,7 +50,7 @@ namespace Tests.Core.Types
             Assert.AreEqual("http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS-Scriptable-Autopilot-System-v0-11-2-13", module.resources.homepage.ToString());
             Assert.AreEqual("https://github.com/KSP-KOS/KOS/issues", module.resources.bugtracker.ToString());
             Assert.AreEqual("https://github.com/KSP-KOS/KOS", module.resources.repository.ToString());
-            
+
             Assert.AreEqual("C5A224AC4397770C0B19B4A6417F6C5052191608", module.download_hash.sha1.ToString());
             Assert.AreEqual("E0FB79C81D8FCDA8DB6E38B104106C3B7D078FDC06ACA2BC7834973B43D789CB", module.download_hash.sha256.ToString());
         }
@@ -122,7 +123,6 @@ namespace Tests.Core.Types
         {
             // We should support both two and three number dotted specs, on both
             // tagged and dev releases.
-
             Assert.IsTrue(CkanModule.IsSpecSupported(new ModuleVersion("v1.1")));
             Assert.IsTrue(CkanModule.IsSpecSupported(new ModuleVersion("v1.0.2")));
         }
@@ -130,13 +130,11 @@ namespace Tests.Core.Types
         [Test]
         public void FutureModule()
         {
-            // Modules form the future are unsupported.
-
+            // Modules from the future are unsupported.
             Assert.Throws<UnsupportedKraken>(delegate
             {
                 CkanModule.FromJson(TestData.FutureMetaData());
             });
-
         }
 
         [Test]
@@ -182,5 +180,52 @@ namespace Tests.Core.Types
                 mod.resources.homepage.ToString()
             );
         }
+
+        [Test]
+        public void InternetArchiveDownload_RedistributableLicense_CorrectURL()
+        {
+            // Arrange
+            CkanModule module = TestData.kOS_014_module();
+            // Act
+            Uri uri = module.InternetArchiveDownload;
+            // Assert
+            Assert.IsNotNull(uri);
+            Assert.AreEqual("https://archive.org/download/kOS-0.14/C5A224AC-kOS-0.14.zip", uri.ToString());
+        }
+
+        [Test]
+        public void InternetArchiveDownload_RestrictedLicense_NullURL()
+        {
+            // Arrange
+            CkanModule module = TestData.FireSpitterModule();
+            // Act
+            Uri uri = module.InternetArchiveDownload;
+            // Assert
+            Assert.IsNull(uri);
+        }
+
+        [Test]
+        public void InternetArchiveDownload_EpochVersion_CorrectURL()
+        {
+            // Arrange
+            CkanModule module = TestData.kOS_014_epoch_module();
+            // Act
+            Uri uri = module.InternetArchiveDownload;
+            // Assert
+            Assert.IsNotNull(uri);
+            Assert.AreEqual("https://archive.org/download/kOS-3-0.14/C5A224AC-kOS-3-0.14.zip", uri.ToString());
+        }
+
+        [Test]
+        public void InternetArchiveDownload_NoHash_NullURL()
+        {
+            // Arrange
+            CkanModule module = TestData.RandSCapsuleDyneModule();
+            // Act
+            Uri uri = module.InternetArchiveDownload;
+            // Assert
+            Assert.IsNull(uri);
+        }
+
     }
 }

--- a/Tests/Core/Types/GameComparator.cs
+++ b/Tests/Core/Types/GameComparator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CKAN;
 using CKAN.Versioning;
 using NUnit.Framework;
 using Tests.Data;
@@ -10,7 +11,7 @@ namespace Tests.Core.Types
     public class GameComparator
     {
         static readonly KspVersion gameVersion = KspVersion.Parse("1.0.4");
-        CKAN.CkanModule gameMod;
+        CkanModule gameMod;
 
         [SetUp]
         public void Setup()
@@ -67,7 +68,7 @@ namespace Tests.Core.Types
 
             // Now test!
             Assert.AreEqual(expected, comparator.Compatible(new KspVersionCriteria (gameVersion), gameMod));
-        }        
+        }
 
         [Test]
         [TestCase(typeof(CKAN.StrictGameComparator), false)]
@@ -177,4 +178,3 @@ namespace Tests.Core.Types
         }
     }
 }
-

--- a/Tests/Core/Versioning/KspVersionRangeTests.cs
+++ b/Tests/Core/Versioning/KspVersionRangeTests.cs
@@ -598,5 +598,66 @@ namespace Tests.Core.Versioning
             // Assert
             Assert.That(act, Throws.Nothing);
         }
+
+        [Test]
+        public void VersionSpan_AllVersions_CorrectString()
+        {
+            // Arrange
+            KspVersion min = KspVersion.Any;
+            KspVersion max = KspVersion.Any;
+            // Act
+            string s = KspVersionRange.VersionSpan(min, max);
+            // Assert
+            Assert.AreEqual("KSP all versions", s);
+        }
+
+        [Test]
+        public void VersionSpan_MinOnly_CorrectString()
+        {
+            // Arrange
+            KspVersion min = new KspVersion(1, 0, 0);
+            KspVersion max = KspVersion.Any;
+            // Act
+            string s = KspVersionRange.VersionSpan(min, max);
+            // Assert
+            Assert.AreEqual("KSP 1.0.0 and later", s);
+        }
+
+        [Test]
+        public void VersionSpan_MaxOnly_CorrectString()
+        {
+            // Arrange
+            KspVersion min = KspVersion.Any;
+            KspVersion max = new KspVersion(1, 0, 0);
+            // Act
+            string s = KspVersionRange.VersionSpan(min, max);
+            // Assert
+            Assert.AreEqual("KSP 1.0.0 and earlier", s);
+        }
+
+        [Test]
+        public void VersionSpan_OneOnly_CorrectString()
+        {
+            // Arrange
+            KspVersion min = new KspVersion(1, 0, 0);
+            KspVersion max = new KspVersion(1, 0, 0);
+            // Act
+            string s = KspVersionRange.VersionSpan(min, max);
+            // Assert
+            Assert.AreEqual("KSP 1.0.0", s);
+        }
+
+        [Test]
+        public void VersionSpan_FiniteRange_CorrectString()
+        {
+            // Arrange
+            KspVersion min = new KspVersion(1, 0, 0);
+            KspVersion max = new KspVersion(1, 1, 1);
+            // Act
+            string s = KspVersionRange.VersionSpan(min, max);
+            // Assert
+            Assert.AreEqual("KSP 1.0.0 - 1.1.1", s);
+        }
+
     }
 }

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -509,9 +509,47 @@ namespace Tests.Data
             ;
         }
 
+        public static string kOS_014_epoch()
+        {
+            return @"
+                {
+                    ""spec_version"": 1,
+                    ""name""     : ""kOS - Kerbal OS"",
+                    ""identifier"" : ""kOS"",
+                    ""abstract"" : ""A programming and automation environment for KSP craft."",
+                    ""download"" : ""https://github.com/KSP-KOS/KOS/releases/download/v0.14/kOS.v14.zip"",
+                    ""license""  : ""GPL-3.0"",
+                    ""version""  : ""3:0.14"",
+                    ""release_status"" : ""stable"",
+                    ""ksp_version"" : ""0.24.2"",
+                    ""resources"" : {
+                        ""homepage"" : ""http://forum.kerbalspaceprogram.com/threads/68089-0-23-kOS-Scriptable-Autopilot-System-v0-11-2-13"",
+                        ""manual""   : ""http://ksp-kos.github.io/KOS_DOC/"",
+                        ""bugtracker"": ""https://github.com/KSP-KOS/KOS/issues"",
+                        ""repository""   : ""https://github.com/KSP-KOS/KOS""
+                    },
+                    ""install"" : [
+                        {
+                            ""file""       : ""GameData/kOS"",
+                            ""install_to"" : ""GameData""
+                        }
+                    ],
+                    ""download_hash"": {
+                        ""sha1"": ""C5A224AC4397770C0B19B4A6417F6C5052191608"",
+                        ""sha256"": ""E0FB79C81D8FCDA8DB6E38B104106C3B7D078FDC06ACA2BC7834973B43D789CB""
+                    }
+                }"
+            ;
+        }
+
         public static CkanModule kOS_014_module()
         {
             return CkanModule.FromJson(kOS_014());
+        }
+
+        public static CkanModule kOS_014_epoch_module()
+        {
+            return CkanModule.FromJson(kOS_014_epoch());
         }
 
         public static string KS_CustomAsteroids_string()

--- a/Tests/GUI/GUIMod.cs
+++ b/Tests/GUI/GUIMod.cs
@@ -11,7 +11,8 @@ namespace Tests.GUI
     [TestFixture]
     public class GUIModTests
     {
-        //TODO Work out what mocking framework the project uses and write some more tests.
+
+        // TODO: Work out what mocking framework the project uses and write some more tests.
         [Test]
         public void NewGuiModsAreNotSelectedForUpgrade()
         {
@@ -25,6 +26,7 @@ namespace Tests.GUI
                 Assert.False(mod.IsUpgradeChecked);
             }
         }
+
         [Test]
         public void HasUpdateReturnsTrueWhenUpdateAvailible()
         {
@@ -42,5 +44,37 @@ namespace Tests.GUI
                 Assert.True(mod.HasUpdate);
             }
         }
+
+        [Test]
+        public void KSPCompatibility_OutOfOrderGameVersions_TrueMaxVersion()
+        {
+            using (var tidy = new DisposableKSP())
+            {
+                // Arrange
+                CkanModule mainVersion = CkanModule.FromJson(@"{
+                    ""identifier"":  ""OutOfOrderMod"",
+                    ""version"":     ""1.2.0"",
+                    ""ksp_version"": ""0.90"",
+                    ""download"":    ""http://www.ksp-ckan.org""
+                }");
+                CkanModule prevVersion = CkanModule.FromJson(@"{
+                    ""identifier"":  ""OutOfOrderMod"",
+                    ""version"":     ""1.1.0"",
+                    ""ksp_version"": ""1.4.2"",
+                    ""download"":    ""http://www.ksp-ckan.org""
+                }");
+
+                Registry registry = Registry.Empty();
+                registry.AddAvailable(mainVersion);
+                registry.AddAvailable(prevVersion);
+
+                // Act
+                GUIMod m = new GUIMod(mainVersion, registry, tidy.KSP.VersionCriteria(), false);
+
+                // Assert
+                Assert.AreEqual("1.4.2", m.KSPCompatibility);
+            }
+        }
+
     }
 }

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -48,5 +48,42 @@ namespace Tests.NetKAN.Transformers
                 (string)transformedJson["resources"]["repository"]
             );
         }
+
+        [Test]
+        public void Transform_DownloadURLWithEncodedCharacter_DontDoubleEncode()
+        {
+            // Arrange
+            JObject json = new JObject();
+            json["spec_version"] = 1;
+            json["$kref"] = "#/ckan/github/jrodrigv/DestructionEffects";
+
+            var mApi = new Mock<IGithubApi>();
+            mApi.Setup(i => i.GetRepo(It.IsAny<GithubRef>()))
+                .Returns(new GithubRepo()
+                {
+                    HtmlUrl = "https://github.com/jrodrigv/DestructionEffects"
+                });
+
+            mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>()))
+                .Returns(new GithubRelease(
+                    "DestructionEffects",
+                    new ModuleVersion("v1.8,0"),
+                    new Uri("https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip"),
+                    null
+                ));
+
+            ITransformer sut = new GithubTransformer(mApi.Object, matchPreleases: false);
+
+            // Act
+            Metadata result = sut.Transform(new Metadata(json));
+            JObject transformedJson = result.Json();
+
+            // Assert
+            Assert.AreEqual(
+                "https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip",
+                (string)transformedJson["download"]
+            );
+        }
+
     }
 }

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -20,43 +20,38 @@ namespace Tests.NetKAN.Transformers
             // Arrange
             var mApi = new Mock<ISpacedockApi>();
             mApi.Setup(i => i.GetMod(It.IsAny<int>()))
-                .Returns(MakeTestMod());
+                .Returns(new SpacedockMod()
+                {
+                    name              = "Dogecoin Flag",
+                    short_description = "Such test. Very unit. Wow.",
+                    author            = "pjf",
+                    license           = "CC-BY",
+                    versions          = new SDVersion[1]
+                    {
+                        new SDVersion()
+                        {
+                            friendly_version = new ModuleVersion("0.25"),
+                            download_path    = new Uri("http://example.com/")
+                        }
+                    }
+                });
 
-            var sut = new SpacedockTransformer(mApi.Object);
+            ITransformer sut = new SpacedockTransformer(mApi.Object);
 
-            var json = new JObject();
-            json["spec_version"] = 1;
-            json["$kref"] = "#/ckan/spacedock/1";
+            JObject json            = new JObject();
+            json["spec_version"]    = 1;
+            json["$kref"]           = "#/ckan/spacedock/1";
             json["ksp_version_min"] = "0.23.5";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
-            var transformedJson = result.Json();
+            Metadata result          = sut.Transform(new Metadata(json));
+            JObject  transformedJson = result.Json();
 
             // Assert
-            Assert.AreEqual(null, (string)transformedJson["ksp_version"]);
-            Assert.AreEqual(null, (string)transformedJson["ksp_version_max"]);
+            Assert.AreEqual(null,     (string)transformedJson["ksp_version"]);
+            Assert.AreEqual(null,     (string)transformedJson["ksp_version_max"]);
             Assert.AreEqual("0.23.5", (string)transformedJson["ksp_version_min"]);
         }
 
-        private static SpacedockMod MakeTestMod()
-        {
-            var sdmod = new SpacedockMod
-            {
-                license = "CC-BY",
-                name = "Dogecoin Flag",
-                short_description = "Such test. Very unit. Wow.",
-                author = "pjf",
-                versions = new SDVersion[1]
-            };
-
-            sdmod.versions[0] = new SDVersion
-            {
-                friendly_version = new ModuleVersion("0.25"),
-                download_path = new Uri("http://example.com/")
-            };
-
-            return sdmod;
-        }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -83,7 +83,7 @@
     <Compile Include="Core\Relationships\SanityChecker.cs" />
     <Compile Include="Core\Types\GameComparator.cs" />
     <Compile Include="Core\Types\License.cs" />
-    <Compile Include="Core\Types\Module.cs" />
+    <Compile Include="Core\Types\CkanModuleTests.cs" />
     <Compile Include="Core\Types\ModuleInstallDescriptorTests.cs" />
     <Compile Include="Core\Types\RelationshipDescriptor.cs" />
     <Compile Include="Core\Types\ReleaseStatus.cs" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\_build\lib\nuget\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\_build\lib\nuget\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -202,5 +203,11 @@
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
     <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+  </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\_build\lib\nuget\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\_build\lib\nuget\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
 </Project>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -6,4 +6,5 @@
   <package id="Moq" version="4.7.145" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="NUnit" version="3.9.0" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Tests are added (catching regressions unless otherwise noted):

- #2284 (archive.org URL formats)
- #2290
- #2313
- #2332
- #2339
- #2382 / #2131
- #2402
- #2406
- Game version range formats

The tests' names are of the form `MethodBeingTested_Scenario_DesiredOutcome`.
The code follows the Arrange / Act / Assert structure.

The tests for `CKAN.CkanModule` are moved from `Module` to `CkanModuleTests` so programmers familiar with `CkanModule` will have an easier time finding them.

Also courtesy of @DasSkelett (HebaruSan/CKAN#4), references are added to `Tests.csproj` to allow running the tests directly in Visual Studio.