### PR TITLE
Splitter and tabstrip visual improvements

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -453,12 +453,14 @@
             // 
             this.splitContainer1.Panel1.Controls.Add(this.ModList);
             // 
+            this.splitContainer1.Panel1MinSize = 200;
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.ModInfoTabControl);
+            this.splitContainer1.Panel2MinSize = 300;
             this.splitContainer1.Size = new System.Drawing.Size(1522, 836);
             this.splitContainer1.SplitterDistance = 1156;
-            this.splitContainer1.SplitterWidth = 6;
+            this.splitContainer1.SplitterWidth = 10;
             this.splitContainer1.TabIndex = 7;
             // 
             // ModList

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -74,7 +74,8 @@
             //
             // ModInfoTabControl
             //
-            this.ModInfoTabControl.Appearance = System.Windows.Forms.TabAppearance.FlatButtons;
+            this.ModInfoTabControl.Appearance = System.Windows.Forms.TabAppearance.Normal;
+            this.ModInfoTabControl.Multiline = true;
             this.ModInfoTabControl.Controls.Add(this.MetadataTabPage);
             this.ModInfoTabControl.Controls.Add(this.RelationshipTabPage);
             this.ModInfoTabControl.Controls.Add(this.ContentTabPage);
@@ -108,11 +109,14 @@
             // splitContainer2.Panel1
             //
             this.splitContainer2.Panel1.Controls.Add(this.MetaDataUpperLayoutPanel);
+            this.splitContainer2.Panel1MinSize = 100;
             //
             // splitContainer2.Panel2
             //
             this.splitContainer2.Panel2.Controls.Add(this.MetaDataLowerLayoutPanel);
+            this.splitContainer2.Panel2MinSize = 300;
             this.splitContainer2.Size = new System.Drawing.Size(348, 496);
+            this.splitContainer2.SplitterWidth = 10;
             this.splitContainer2.SplitterDistance = 235;
             this.splitContainer2.TabIndex = 0;
             //
@@ -146,6 +150,7 @@
             //
             // MetadataModuleAbstractLabel
             //
+            this.MetadataModuleAbstractLabel.BackColor = System.Drawing.SystemColors.Window;
             this.MetadataModuleAbstractLabel.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.MetadataModuleAbstractLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetadataModuleAbstractLabel.Location = new System.Drawing.Point(3, 49);
@@ -161,25 +166,26 @@
             this.MetaDataLowerLayoutPanel.ColumnCount = 2;
             this.MetaDataLowerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 26.16279F));
             this.MetaDataLowerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 73.83721F));
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.IdentifierLabel, 0, 7);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataIdentifierLabel, 0, 7);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.KSPCompatibilityLabel, 0, 6);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReleaseLabel, 0, 5);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.GitHubLabel, 0, 4);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.HomePageLabel, 0, 3);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.AuthorLabel, 0, 2);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.VersionLabel, 0, 0);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.LicenseLabel, 0, 1);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.AuthorLabel, 0, 2);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.HomePageLabel, 0, 3);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.GitHubLabel, 0, 4);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReleaseLabel, 0, 5);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.KSPCompatibilityLabel, 0, 6);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.IdentifierLabel, 0, 7);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleVersionLabel, 1, 0);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleLicenseLabel, 1, 1);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleAuthorLabel, 1, 2);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.VersionLabel, 0, 0);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleReleaseStatusLabel, 1, 5);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleHomePageLinkLabel, 1, 3);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleKSPCompatibilityLabel, 1, 6);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleGitHubLinkLabel, 1, 4);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleReleaseStatusLabel, 1, 5);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleKSPCompatibilityLabel, 1, 6);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataIdentifierLabel, 1, 7);
             this.MetaDataLowerLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataLowerLayoutPanel.Location = new System.Drawing.Point(0, 0);
             this.MetaDataLowerLayoutPanel.Name = "MetaDataLowerLayoutPanel";
+            this.MetaDataLowerLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 8, 0, 0);
             this.MetaDataLowerLayoutPanel.RowCount = 9;
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -33,7 +33,7 @@
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.MetaDataUpperLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.MetadataModuleNameLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleAbstractLabel = new System.Windows.Forms.RichTextBox();
+            this.MetadataModuleAbstractLabel = new System.Windows.Forms.Label();
             this.MetaDataLowerLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.IdentifierLabel = new System.Windows.Forms.Label();
             this.MetadataIdentifierLabel = new System.Windows.Forms.Label();
@@ -150,12 +150,10 @@
             //
             // MetadataModuleAbstractLabel
             //
-            this.MetadataModuleAbstractLabel.BackColor = System.Drawing.SystemColors.Window;
-            this.MetadataModuleAbstractLabel.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.MetadataModuleAbstractLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleAbstractLabel.ForeColor = System.Drawing.SystemColors.ControlText;
             this.MetadataModuleAbstractLabel.Location = new System.Drawing.Point(3, 49);
             this.MetadataModuleAbstractLabel.Name = "MetadataModuleAbstractLabel";
-            this.MetadataModuleAbstractLabel.ReadOnly = true;
             this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(340, 181);
             this.MetadataModuleAbstractLabel.TabIndex = 27;
             this.MetadataModuleAbstractLabel.Text = "";
@@ -501,7 +499,7 @@
         private System.Windows.Forms.SplitContainer splitContainer2;
         private System.Windows.Forms.TableLayoutPanel MetaDataUpperLayoutPanel;
         private System.Windows.Forms.Label MetadataModuleNameLabel;
-        private System.Windows.Forms.RichTextBox MetadataModuleAbstractLabel;
+        private System.Windows.Forms.Label MetadataModuleAbstractLabel;
         private System.Windows.Forms.TableLayoutPanel MetaDataLowerLayoutPanel;
         private System.Windows.Forms.Label IdentifierLabel;
         private System.Windows.Forms.Label MetadataIdentifierLabel;


### PR DESCRIPTION
## Problem

GUI has a vertical splitter between the mod list and the mod info pane and a horizontal splitter within one of the tabs of the mod info pane, but some users have found this to be non-obvious and ask whether information has been removed from the display (see #2412 and KSP-CKAN/NetKAN#6288).

The tab style chosen for the mod info pane is also a bit ugly and gray.

![screenshot](https://i.imgur.com/vS4dpEO.png)

![splitter low](https://i.imgur.com/DY5sKsE.png) ![splitter high](https://i.imgur.com/7KdZsgy.png)

## Changes

Now each pane of these splitters has a minimum size:

- The mod info pane always has enough width for all of its tabs
- The top part of the metadata tab always has enough height for both of its fields
- The bottom part of the metadata tab always has enough height for its fields
- The vertical splitter itself is widened slightly to try to make it more obvious
  (I tried to enlarge the horizontal splitter as well, but setting the property had no effect.)

And the tabs are changed to a more conventional style, which also gives the tab pages a white background.

Minimum sizes of the panes illustrated:

![image](https://user-images.githubusercontent.com/1559108/38960860-93a0b00c-4355-11e8-861d-d8a6d4280903.png)