### PR TITLE
Hide StatusProgress-bar if user cancels installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bugfixes
 - [GUI] Splitter and tabstrip visual improvements (#2413 by: HebaruSan; reviewed: politas)
+- [GUI] Fix "Collection was modified" exception for redundant optional dependencies (#2423 by: HebaruSan; reviewed: politas)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bugfixes
 - [GUI] Splitter and tabstrip visual improvements (#2413 by: HebaruSan; reviewed: politas)
 - [GUI] Fix "Collection was modified" exception for redundant optional dependencies (#2423 by: HebaruSan; reviewed: politas)
+- [core] Treat installed DLC as compatible dependency (#2424 by: HebaruSan; reviewed: politas)
 
 ### Internal
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -498,7 +498,8 @@ namespace CKAN
                 {
                     try
                     {
-                        if (!LatestAvailableWithProvides(dependency.name, ksp_version).Any())
+                        if (!dependency.MatchesAny(null, InstalledDlls.ToHashSet(), InstalledDlc)
+                            && !LatestAvailableWithProvides(dependency.name, ksp_version).Any())
                         {
                             return false;
                         }

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -251,6 +251,10 @@ namespace CKAN
                 if ((bool)install_cell.Value != IsInstallChecked)
                 {
                     install_cell.Value = IsInstallChecked;
+                    // These calls are needed to force the UI to update,
+                    // otherwise the checkbox will look checked when it's unchecked or vice versa
+                    row.DataGridView.RefreshEdit();
+                    row.DataGridView.Refresh();
                 }
             }
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -606,6 +606,17 @@ namespace CKAN
                 // We can just rerun it as the ModInfoTabControl has been removed.
                 too_many_provides_thrown = true;
             }
+            catch (DependencyNotSatisfiedKraken k)
+            {
+                GUI.user.RaiseError(
+                    "{0} depends on {1}, which is not compatible with the currently installed version of KSP",
+                    k.parent,
+                    k.module
+                );
+
+                // Uncheck the box
+                MarkModForInstall(k.parent.identifier, true);
+            }
 
             if (too_many_provides_thrown)
             {

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -392,18 +392,11 @@ namespace CKAN
                 RetryCurrentActionButton.Visible = false;
                 UpdateChangesDialog(null, installWorker);
             }
-            else if(!result.Key && installCanceled){
+            else if(installCanceled)
+            {
                 // User cancelled the installation
-                AddStatusMessage("Manually cancelled installation process!");
-                SetDescription("The user cancelled the installation manually!");
+                FailWaitDialog("Installation cancelled by user!", "User cancelled the installation manually!", "Install failed!");
                 UpdateChangesDialog(result.Value, installWorker);
-                RetryCurrentActionButton.Visible = true;
-                Util.Invoke(statusStrip1, () =>
-                {
-                    StatusProgress.Value = 0;
-                    StatusProgress.Style = ProgressBarStyle.Continuous;
-                    StatusProgress.Visible = false;
-                });
             }
             else
             {

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -392,6 +392,19 @@ namespace CKAN
                 RetryCurrentActionButton.Visible = false;
                 UpdateChangesDialog(null, installWorker);
             }
+            else if(!result.Key && installCanceled){
+                // User cancelled the installation
+                AddStatusMessage("Manually cancelled installation process!");
+                SetDescription("The user cancelled the installation manually!");
+                UpdateChangesDialog(result.Value, installWorker);
+                RetryCurrentActionButton.Visible = true;
+                Util.Invoke(statusStrip1, () =>
+                {
+                    StatusProgress.Value = 0;
+                    StatusProgress.Style = ProgressBarStyle.Continuous;
+                    StatusProgress.Visible = false;
+                });
+            }
             else
             {
                 // There was an error

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -330,11 +330,13 @@ namespace CKAN
 
             // If we're going to install something anyway, then don't list it in the
             // recommended list, since they can't de-select it anyway.
-            foreach (var kvp in selectable)
+            // The ToList dance is because we need to modify the dictionary while iterating over it,
+            // and C# doesn't like that.
+            foreach (CkanModule module in selectable.Keys.ToList())
             {
-                if (toInstall.Any(m => m.identifier == kvp.Key.identifier))
+                if (toInstall.Any(m => m.identifier == module.identifier))
                 {
-                    selectable.Remove(kvp.Key);
+                    selectable.Remove(module);
                 }
             }
 

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -395,19 +395,20 @@ namespace CKAN
             else if(installCanceled)
             {
                 // User cancelled the installation
-                FailWaitDialog("Installation cancelled by user!", "User cancelled the installation manually!", "Install failed!");
+                // check if the mod installation/upgrade/uninstall still concluded successful
+
+                // TODO: how to do this check?
+
+                // FailWaitDialog("Installation successful!", "Too late! Mods already installed!\r \nPlease undo your changes manually!", "All mods installed!");
+                FailWaitDialog("Installation cancelled by user!", "User cancelled the installation manually!", "Installation failed!");
+
                 UpdateChangesDialog(result.Value, installWorker);
             }
             else
             {
                 // There was an error
-                // Stay on the log dialog and re-apply the user's change set to allow retry
-                AddStatusMessage("Error!");
-                SetDescription("An error occurred, check the log for information");
+                FailWaitDialog("Error during installation!", "An unknown error occurred, please try again!", "Installation failed!");
                 UpdateChangesDialog(result.Value, installWorker);
-                RetryCurrentActionButton.Visible = true;
-                Util.Invoke(DialogProgressBar, () => DialogProgressBar.Style = ProgressBarStyle.Continuous);
-                Util.Invoke(DialogProgressBar, () => DialogProgressBar.Value = 0);
             }
 
             Util.Invoke(this, () => Enabled = true);

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -302,6 +302,13 @@ namespace CKAN
             }
             catch (ModuleNotFoundKraken)
             {
+                // Maybe it's a DLC?
+                ModuleVersion installedVersion = registry.InstalledVersion(identifier, false);
+                if (installedVersion != null)
+                {
+                    return nonModuleNode(identifier, installedVersion, relationship);
+                }
+
                 // If we don't find a module by this name, look for other modules that provide it.
                 List<CkanModule> dependencyModules = registry.LatestAvailableWithProvides(identifier, crit);
                 if (dependencyModules != null && dependencyModules.Count > 0)
@@ -339,6 +346,16 @@ namespace CKAN
                 ToolTipText = relationship.ToString(),
                 Tag         = module,
                 ForeColor   = compatible ? Color.Empty : Color.Red
+            };
+        }
+
+        private TreeNode nonModuleNode(string identifier, ModuleVersion version, RelationshipType relationship)
+        {
+            int icon = (int)relationship + 1;
+            return new TreeNode($"{identifier} {version}", icon, icon)
+            {
+                Name        = identifier,
+                ToolTipText = relationship.ToString()
             };
         }
 

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -591,13 +591,6 @@ namespace CKAN
                 {
                     kraken = k;
                 }
-                catch (ModuleNotFoundKraken k)
-                {
-                    //We shouldn't need this. However the relationship provider will throw TMPs with incompatible mods.
-                    user.RaiseError("Module {0} has not been found. This may be because it is not compatible " +
-                                    "with the currently installed version of KSP", k.module);
-                    return null;
-                }
                 //Shouldn't get here unless there is a kraken.
                 var mod = await too_many_provides(kraken);
                 if (mod != null)

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -67,23 +67,31 @@ namespace CKAN
         /// <param name="statusMsg">Message for the lower status bar</param>
         /// <param name="logMsg">Message to display on WaitDialog-Log (not the real log!)</param>
         /// <param name="description">Message displayed above the DialogProgress bar</param>
-        public void FailWaitDialog(string statusMsg, string logMsg, string description)
+        public void FailWaitDialog(string statusMsg, string logMsg, string description, bool successful)
         {
             Util.Invoke(statusStrip1, () =>
             {
                 StatusProgress.Value = 0;
                 StatusProgress.Style = ProgressBarStyle.Continuous;
                 StatusProgress.Visible = false;
+                StatusLabel.Visible = true;
 
                 AddStatusMessage(statusMsg);
             });
             Util.Invoke(WaitTabPage, () =>
             {
+                DialogProgressBar.Value =  successful ? 100 :  0;
+                DialogProgressBar.Style = ProgressBarStyle.Continuous;
+
                 RecreateDialogs();
-                RetryCurrentActionButton.Visible = true;
+                // Hide if mods installed correctly, so user can't retry
+                RetryCurrentActionButton.Visible = !successful;
                 CancelCurrentActionButton.Enabled = false;
             });
-
+            Util.Invoke(menuStrip1, () =>
+            {
+                ApplyToolButton.Enabled = !successful;
+            });
             AddLogMessage(logMsg);
             SetDescription(description);
         }

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -61,6 +61,12 @@ namespace CKAN
             });
         }
 
+        /// <summary>
+        /// Stay on log page and reset StatusProgress
+        /// </summary>
+        /// <param name="statusMsg">Message for the lower status bar</param>
+        /// <param name="logMsg">Message to display on WaitDialog-Log (not the real log!)</param>
+        /// <param name="description">Message displayed above the DialogProgress bar</param>
         public void FailWaitDialog(string statusMsg, string logMsg, string description)
         {
             Util.Invoke(statusStrip1, () =>

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -61,6 +61,27 @@ namespace CKAN
             });
         }
 
+        public void FailWaitDialog(string statusMsg, string logMsg, string description)
+        {
+            Util.Invoke(statusStrip1, () =>
+            {
+                StatusProgress.Value = 0;
+                StatusProgress.Style = ProgressBarStyle.Continuous;
+                StatusProgress.Visible = false;
+
+                AddStatusMessage(statusMsg);
+            });
+            Util.Invoke(WaitTabPage, () =>
+            {
+                RecreateDialogs();
+                RetryCurrentActionButton.Visible = true;
+                CancelCurrentActionButton.Enabled = false;
+            });
+
+            AddLogMessage(logMsg);
+            SetDescription(description);
+        }
+
         public void SetProgress(int progress)
         {
             if (progress < 0)
@@ -129,7 +150,6 @@ namespace CKAN
             {
                 CancelCurrentActionButton.Enabled = false;
             });
-            HideWaitDialog(true);
         }
 
     }


### PR DESCRIPTION
**Problem:**
If you manually cancel the Installation process, the lower right Progress bar keeps moving.

**Solution:**
Reset and hides `StatusProgress` bar if user cancels installation.
Give a better `StatusMessage` too (as "Error!" is not only verry vague, it's incorrect too in this case.)

Fixes #2417 