### PR TITLE
Replace max KSP version empty string with "any" in GUI

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -115,7 +115,7 @@ namespace CKAN
             // KSP.
             if (latest_available_for_any_ksp != null)
             {
-                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "N/D";
+                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "any";
 
                 // If the mod we have installed is *not* the mod we have installed, or we don't know
                 // what we have installed, indicate that an upgrade would be needed.

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -115,7 +115,7 @@ namespace CKAN
             // KSP.
             if (latest_available_for_any_ksp != null)
             {
-                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "";
+                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "N/D";
 
                 // If the mod we have installed is *not* the mod we have installed, or we don't know
                 // what we have installed, indicate that an upgrade would be needed.


### PR DESCRIPTION
If there's no max KSP version defined in a mod's metadata, CKAN GUI displays it as an empty string.
See ![maxV1](https://user-images.githubusercontent.com/28812678/39099958-28e14e26-4683-11e8-89fc-4d388e51f8fe.JPG)

It would be prettier and more informative if there is some text, so I changed the empty string to ~~"N/D"~~ "any".
This applies to the lower right metadata box and also the column in the modlist, as you can see here:
![maxV2](https://user-images.githubusercontent.com/28812678/39100011-afb8ccee-4683-11e8-92fd-8a2527d464a4.JPG)