### PR TITLE
Fix "Collection was modified" exception for redundant optional dependencies

### DIFF
--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -330,11 +330,13 @@ namespace CKAN
 
             // If we're going to install something anyway, then don't list it in the
             // recommended list, since they can't de-select it anyway.
-            foreach (var kvp in selectable)
+            // The ToList dance is because we need to modify the dictionary while iterating over it,
+            // and C# doesn't like that.
+            foreach (CkanModule module in selectable.Keys.ToList())
             {
-                if (toInstall.Any(m => m.identifier == kvp.Key.identifier))
+                if (toInstall.Any(m => m.identifier == module.identifier))
                 {
-                    selectable.Remove(kvp.Key);
+                    selectable.Remove(module);
                 }
             }
 


### PR DESCRIPTION
## Problem

If you choose multiple mods to install such that one of them recommends or suggests another mod being installed, an exception is thrown.

For example, (in KSP 1.2.2) B9AerospaceHX recommends KJR, and B9 suggests KJR. If you install both B9AerospaceHX and B9 together, then KJR is shown first as a recommendation, and if you accept the recommendation, an exception happens when the suggestions are being calculated.

## Cause

To avoid showing optional dependencies multiple times, we're looping over the dictionary containing optional dependencies and modifying it here:

https://github.com/KSP-CKAN/CKAN/blob/9e71f867240d9143e53035881e59bb4fc7d34377/GUI/MainInstall.cs#L333-L339

C# doesn't like that. It considers it dangerous to continue looping over a collection that may have more or fewer elements than when the loop first started (even though in this case it ought to be perfectly safe).

## Changes

Now we use `ToList` to copy the keys of the dictionary into a temporary object that won't throw exceptions when we modify the dictionary.

Fixes #2422.