### PR TITLE
Treat installed DLC as compatible dependency

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -498,7 +498,8 @@ namespace CKAN
                 {
                     try
                     {
-                        if (!LatestAvailableWithProvides(dependency.name, ksp_version).Any())
+                        if (!dependency.MatchesAny(null, InstalledDlls.ToHashSet(), InstalledDlc)
+                            && !LatestAvailableWithProvides(dependency.name, ksp_version).Any())
                         {
                             return false;
                         }

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -302,6 +302,13 @@ namespace CKAN
             }
             catch (ModuleNotFoundKraken)
             {
+                // Maybe it's a DLC?
+                ModuleVersion installedVersion = registry.InstalledVersion(identifier, false);
+                if (installedVersion != null)
+                {
+                    return nonModuleNode(identifier, installedVersion, relationship);
+                }
+
                 // If we don't find a module by this name, look for other modules that provide it.
                 List<CkanModule> dependencyModules = registry.LatestAvailableWithProvides(identifier, crit);
                 if (dependencyModules != null && dependencyModules.Count > 0)
@@ -339,6 +346,16 @@ namespace CKAN
                 ToolTipText = relationship.ToString(),
                 Tag         = module,
                 ForeColor   = compatible ? Color.Empty : Color.Red
+            };
+        }
+
+        private TreeNode nonModuleNode(string identifier, ModuleVersion version, RelationshipType relationship)
+        {
+            int icon = (int)relationship + 1;
+            return new TreeNode($"{identifier} {version}", icon, icon)
+            {
+                Name        = identifier,
+                ToolTipText = relationship.ToString()
             };
         }
 


### PR DESCRIPTION
## Problem

Modules that depend on `MakingHistory-DLC` are treated as incompatible in mod listings, even if you have the DLC.

You are still able to _install_ such modules via CmdLine, even though they are displayed as incompatible.

Relatedly, the MakingHistory-DLC entry in the relationships tab always shows up as red and "(not indexed").

![image](https://user-images.githubusercontent.com/1559108/39207257-0e3a4204-47ef-11e8-9290-1a4a026d913c.png)

## Cause

DLC checks were only added to functions that check whether an identifier is _installed_. To determine whether a module is _compatible_, we look up all of its dependencies via `LatestAvailableWithProvides` regardless of whether they're already installed, which returns a module, and there are no modules for Dlc objects, so this function doesn't find anything for `MakingHistory-DLC`.

The relationships tab in GUI also checks dependencies itself, and also wasn't updated.

## Changes

Now the helper function that checks dependencies treats installed DLC identifiers as compatible.

The relationships tab also now checks for installed DLC and shows it as compatible if it's installed.

![image](https://user-images.githubusercontent.com/1559108/39207081-97dcc046-47ee-11e8-99cd-a57354144159.png)

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1250-wallops/&do=findComment&comment=3362539

Tests are added:

- When no DLC is installed, make sure we consider a mod depending on MakingHistory-DLC as incompatible
- When MakingHistory-DLC is installed, make sure we consider a mod depending on MakingHistory-DLC as compatible
- When MakingHistory-DLC 1.1.0 is installed, make sure we consider a mod depending on MakingHistory-DLC 1.1.0 as compatible
- When MakingHistory-DLC 1.0.0 is installed, make sure we consider a mod depending on MakingHistory-DLC 1.1.0 as incompatible
