### PR TITLE
Uncheck checkbox after missing dependency error

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -251,6 +251,10 @@ namespace CKAN
                 if ((bool)install_cell.Value != IsInstallChecked)
                 {
                     install_cell.Value = IsInstallChecked;
+                    // These calls are needed to force the UI to update,
+                    // otherwise the checkbox will look checked when it's unchecked or vice versa
+                    row.DataGridView.RefreshEdit();
+                    row.DataGridView.Refresh();
                 }
             }
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -606,6 +606,17 @@ namespace CKAN
                 // We can just rerun it as the ModInfoTabControl has been removed.
                 too_many_provides_thrown = true;
             }
+            catch (DependencyNotSatisfiedKraken k)
+            {
+                GUI.user.RaiseError(
+                    "{0} depends on {1}, which is not compatible with the currently installed version of KSP",
+                    k.parent,
+                    k.module
+                );
+
+                // Uncheck the box
+                MarkModForInstall(k.parent.identifier, true);
+            }
 
             if (too_many_provides_thrown)
             {

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -591,13 +591,6 @@ namespace CKAN
                 {
                     kraken = k;
                 }
-                catch (ModuleNotFoundKraken k)
-                {
-                    //We shouldn't need this. However the relationship provider will throw TMPs with incompatible mods.
-                    user.RaiseError("Module {0} has not been found. This may be because it is not compatible " +
-                                    "with the currently installed version of KSP", k.module);
-                    return null;
-                }
                 //Shouldn't get here unless there is a kraken.
                 var mod = await too_many_provides(kraken);
                 if (mod != null)


### PR DESCRIPTION
## Background

It's possible for a mod with an incompatible dependency to be presented as compatible in GUI, as long as this dependency is more than one step away (i.e., a dependency of a dependency). For example, in KSP 1.4.2 currently, AJE Extended depends on AJE, which depends on FAR, which isn't compatible. So FAR and AJE are properly marked as incompatible, but AJE Extended is treated as compatible. This is covered by #2231 and not fixed here.

## Problem

After you check such an incompatible checkbox, you'll get the error popup about it _every time_ you click any other checkbox, until you uncheck the incompatible one.

## Cause

The only action we took in response to this condition was to raise an error message. This may partly be because we were catching `ModuleNotFoundKraken`, which doesn't indicate the depending module.

## Changes

Now we catch `DependencyNotSatisfiedKraken` (which inherits from `ModuleNotFoundKraken` and is the actual type of the exception already being thrown) and use its `parent` property to find the mod with the incompatible dependency, and uncheck it with `MarkModForInstall`. This unchecks the problematic module, so further selections may be made without seeing the same error message over and over.

Note that this only covers _missing dependencies_, and not any other sort of conflict. Unlike a mod-to-mod conflict, a mod with a missing dependency can never be installed, so there is no value in keeping it selected because there is no other way to solve the problem other than deselecting it.

Simply setting the `Value` property of the right cell resulted in a glitchy UI; the checkbox still appeared to be checked until the user took _another_ action on the grid, such as clicking anywhere within it, at which time the checkbox's true unchecked state was drawn. We now call `RefreshEdit` and `Refresh` on the grid after setting a cell value to work around this.

Fixes #2419.