### PR TITLE
Ignore splitter exceptions

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -280,7 +280,15 @@ namespace CKAN
             Location = configuration.WindowLoc;
             Size = configuration.WindowSize;
             WindowState = configuration.IsWindowMaximised ? FormWindowState.Maximized : FormWindowState.Normal;
-            splitContainer1.SplitterDistance = configuration.PanelPosition;
+            try
+            {
+                splitContainer1.SplitterDistance = configuration.PanelPosition;
+            }
+            catch
+            {
+                // SplitContainer is mis-designed to throw exceptions
+                // if the min/max limits are exceeded rather than simply obeying them.
+            }
             ModInfoTabControl.ModMetaSplitPosition = configuration.ModInfoPosition;
 
             if (!configuration.CheckForUpdatesOnLaunchNoNag && AutoUpdate.CanUpdate)

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -109,12 +109,12 @@
             // splitContainer2.Panel1
             //
             this.splitContainer2.Panel1.Controls.Add(this.MetaDataUpperLayoutPanel);
-            this.splitContainer2.Panel1MinSize = 100;
+            this.splitContainer2.Panel1MinSize = 75;
             //
             // splitContainer2.Panel2
             //
             this.splitContainer2.Panel2.Controls.Add(this.MetaDataLowerLayoutPanel);
-            this.splitContainer2.Panel2MinSize = 300;
+            this.splitContainer2.Panel2MinSize = 225;
             this.splitContainer2.Size = new System.Drawing.Size(348, 496);
             this.splitContainer2.SplitterWidth = 10;
             this.splitContainer2.SplitterDistance = 235;

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -69,7 +69,15 @@ namespace CKAN
             }
             set
             {
-                this.splitContainer2.SplitterDistance = value;
+                try
+                {
+                    this.splitContainer2.SplitterDistance = value;
+                }
+                catch
+                {
+                    // SplitContainer is mis-designed to throw exceptions
+                    // if the min/max limits are exceeded rather than simply obeying them.
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

In #2413, I set the `Panel1MinSize` and `Panel2MinSize` properties on our splitters, because they look like a simple way to ensure that important content is visible. Of course with .NET, even something this simple has to be arduous:

![image](https://user-images.githubusercontent.com/1559108/39262726-beb10166-48af-11e8-862f-35dd1e9c1b8d.png)

This happens at start-up if our saved splitter size is no longer allowed in the current window size. You can get to such a state easily by resizing the window with no problems, but then if you close and restart this exception is thrown.

## Changes

We may not be able to convince Microsoft how dumb it is to throw this exception, but now we do the next best thing and ignore it. The min sizes of the mod info pane are also reduced to about 75% of their previous values to allow them to fit a bit better into small windows.