### PR TITLE
Don't Force Apply button active when no update selected

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -466,16 +466,7 @@ namespace CKAN
 
         private void MarkAllUpdatesToolButton_Click(object sender, EventArgs e)
         {
-            foreach (DataGridViewRow row in ModList.Rows)
-            {
-                var mod = (GUIMod)row.Tag;
-                if (mod.HasUpdate && row.Cells[1] is DataGridViewCheckBoxCell)
-                {
-                    MarkModForUpdate(mod.Identifier);
-                    mod.SetUpgradeChecked(row, true);
-                    ApplyToolButton.Enabled = true;
-                }
-            }
+            MarkModsForUpdate();
 
             // only sort by Update column if checkbox in settings checked
             if (Main.Instance.configuration.AutoSortByUpdate)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -466,7 +466,14 @@ namespace CKAN
 
         private void MarkAllUpdatesToolButton_Click(object sender, EventArgs e)
         {
-            MarkModsForUpdate();
+            foreach (DataGridViewRow row in ModList.Rows)
+            {
+                var mod = (GUIMod)row.Tag;
+                if (mod.HasUpdate)
+                {
+                    MarkModForUpdate(mod.Identifier);
+                }
+            }
 
             // only sort by Update column if checkbox in settings checked
             if (Main.Instance.configuration.AutoSortByUpdate)
@@ -487,8 +494,6 @@ namespace CKAN
             }
 
             ModList.Refresh();
-
-
         }
 
         public void UpdateModContentsTree(CkanModule module, bool force = false)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -219,21 +219,16 @@ namespace CKAN
             }
         }
 
-        public void MarkModsForUpdate()
+        public void MarkModForUpdate(string identifier)
         {
-            Util.Invoke(this, () => _MarkModsForUpdate());
+            Util.Invoke(this, () => _MarkModForUpdate(identifier));
         }
         
-        public void _MarkModsForUpdate()
+        public void _MarkModForUpdate(string identifier)
         {
-            foreach (DataGridViewRow row in ModList.Rows)
-            {
-                var mod = (GUIMod) row.Tag;
-                if (mod.HasUpdate)
-                {
-                    mod.SetUpgradeChecked(row, true);
-                }
-            }
+            DataGridViewRow row = mainModList.full_list_of_mod_rows[identifier];
+            var mod = (GUIMod)row.Tag;
+            mod.SetUpgradeChecked(row, true);
         }
 
         private void ModList_SelectedIndexChanged(object sender, EventArgs e)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -219,21 +219,19 @@ namespace CKAN
             }
         }
 
-        public void MarkModForUpdate(string identifier)
+        public void MarkModsForUpdate()
         {
-            Util.Invoke(this, () => _MarkModForUpdate(identifier));
+            Util.Invoke(this, () => _MarkModsForUpdate());
         }
-
-
-        public void _MarkModForUpdate(string identifier)
+        
+        public void _MarkModsForUpdate()
         {
             foreach (DataGridViewRow row in ModList.Rows)
             {
                 var mod = (GUIMod) row.Tag;
-                if (mod.Identifier == identifier)
+                if (mod.HasUpdate)
                 {
-                    (row.Cells[1] as DataGridViewCheckBoxCell).Value = true;
-                    break;
+                    mod.SetUpgradeChecked(row, true);
                 }
             }
         }


### PR DESCRIPTION
Problem:
----------
#2428 showed, that `MarkAllUpdatesToolButton_Click()` always sets `ApplyToolButton.Enabled` to true, even without changeset. This is a very edge case of a bug which should get fixed soon (the changeset shouldn't be empty at all), but nevertheless, it would be better if the button doesn't get activated manually.


Solution:
---------
So I removed this `ApplyToolButton.Enabled` call, as it is unnecessary in addition, because `ApplyToolButton` gets always updated in `ChangeSetUpdated()` which again is called by `UpdateChangeSetAndConflicts()`, which then again is called by `ModList_CellValueChanged()`, in turn automatically called on any checkbox-changes...
_Ouf_
In short, `ApplyToolButton.Enabled` is called everywhere, anytime.

Furthermore I rearranged (and hopefully) improved the code for marking mods for updates.
Feedback welcome!