### PR TITLE
Ignore conflicts between versions of same mod

### DIFF
--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -132,18 +132,15 @@ namespace CKAN
             IDictionary<string, UnmanagedModuleVersion> dlc
         )
         {
-            modules = modules?.AsCollection();
-
             var confl = new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();
-
             if (modules != null)
             {
-                foreach (var m in modules.Where(m => m.conflicts != null))
+                foreach (CkanModule m in modules.Where(m => m.conflicts != null))
                 {
-                    // Remove self from the list, so we're only comparing to OTHER modules
-                    var others = modules.Where(other => !ReferenceEquals(other, m)).AsCollection();
-
-                    foreach (var dep in m.conflicts)
+                    // Remove self from the list, so we're only comparing to OTHER modules.
+                    // Also remove other versions of self, to avoid conflicts during upgrades.
+                    var others = modules.Where(other => other.identifier != m.identifier);
+                    foreach (RelationshipDescriptor dep in m.conflicts)
                     {
                         if (dep.MatchesAny(others, dlls, dlc))
                         {
@@ -152,7 +149,6 @@ namespace CKAN
                     }
                 }
             }
-
             return confl;
         }
 

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -175,8 +175,8 @@ namespace Tests.Core.Relationships
                     ""version"":    ""1.0.0"",
                     ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
                     ""depends"": [ {
-                            ""name"":    ""dependency"",
-                            ""version"": ""1.2.3""
+                        ""name"":    ""dependency"",
+                        ""version"": ""1.2.3""
                     } ]
                 }"),
                 CkanModule.FromJson(@"{
@@ -201,8 +201,8 @@ namespace Tests.Core.Relationships
                     ""version"":    ""1.0.0"",
                     ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
                     ""depends"": [ {
-                            ""name"":    ""dependency"",
-                            ""version"": ""1.2.3""
+                        ""name"":    ""dependency"",
+                        ""version"": ""1.2.3""
                     } ]
                 }"),
                 CkanModule.FromJson(@"{
@@ -227,8 +227,8 @@ namespace Tests.Core.Relationships
                     ""version"":    ""1.0.0"",
                     ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
                     ""conflicts"": [ {
-                            ""name"":    ""dependency"",
-                            ""version"": ""1.2.3""
+                        ""name"":    ""dependency"",
+                        ""version"": ""1.2.3""
                     } ]
                 }"),
                 CkanModule.FromJson(@"{
@@ -253,8 +253,8 @@ namespace Tests.Core.Relationships
                     ""version"":    ""1.0.0"",
                     ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
                     ""conflicts"": [ {
-                            ""name"":    ""dependency"",
-                            ""version"": ""1.2.3""
+                        ""name"":    ""dependency"",
+                        ""version"": ""1.2.3""
                     } ]
                 }"),
                 CkanModule.FromJson(@"{
@@ -266,6 +266,34 @@ namespace Tests.Core.Relationships
 
             // Act & Assert
             Assert.IsFalse(CKAN.SanityChecker.IsConsistent(modules));
+        }
+
+        [Test]
+        public void IsConsistent_MultipleVersionsOfSelfConflictingModule_Consistent()
+        {
+            // Arrange
+            List<CkanModule> modules = new List<CkanModule>()
+            {
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""self-conflictor"",
+                    ""version"":    ""1.0.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""conflicts"": [ {
+                        ""name"":    ""self-conflictor""
+                    } ]
+                }"),
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""self-conflictor"",
+                    ""version"":    ""1.2.3"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""conflicts"": [ {
+                        ""name"":    ""self-conflictor""
+                    } ]
+                }")
+            };
+
+            // Act & Assert
+            Assert.IsTrue(CKAN.SanityChecker.IsConsistent(modules));
         }
 
         private static void TestDepends(


### PR DESCRIPTION
## Problem

If a mod conflicts with itself, it can no longer be upgraded as of #2339; see #2428 for details of a specific example involving Scatterer.

## Cause

When we upgrade, we ask the `SanityChecker` to look for missing dependencies and conflicts in a scenario in which the new versions are installed without removing the old versions. Since the old and new modules are both there, we check whether they conflict with one another, and a self-conflict is treated as a real conflict.

Prior to #2339, this was avoided by ignoring conflicts if the identifiers were the same, but when we made conflicts version-specific, we only ignored that conflict if the identifier _and version_ are the same.

## Changes

Now `SanityChecker` will ignore any conflict between two mods with the same identifier, as it did historically. Other conflicts will still care about versions, so #2339 is not voided.

A test is added to catch regressions.

Fixes #2428.