### PR TITLE
Test upgrading mod with conflict on its own provides

### DIFF
--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -296,6 +296,36 @@ namespace Tests.Core.Relationships
             Assert.IsTrue(CKAN.SanityChecker.IsConsistent(modules));
         }
 
+        [Test]
+        public void IsConsistent_MultipleVersionsOfSelfProvidesConflictingModule_Consistent()
+        {
+            // Arrange
+            List<CkanModule> modules = new List<CkanModule>()
+            {
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""provides-conflictor"",
+                    ""version"":    ""1.0.0"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""provides"":   [ ""providee"" ],
+                    ""conflicts"": [ {
+                        ""name"":    ""providee""
+                    } ]
+                }"),
+                CkanModule.FromJson(@"{
+                    ""identifier"": ""provides-conflictor"",
+                    ""version"":    ""1.2.3"",
+                    ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                    ""provides"":   [ ""providee"" ],
+                    ""conflicts"": [ {
+                        ""name"":    ""providee""
+                    } ]
+                }")
+            };
+
+            // Act & Assert
+            Assert.IsTrue(CKAN.SanityChecker.IsConsistent(modules));
+        }
+
         private static void TestDepends(
             List<string> to_remove,
             List<CkanModule> mods,


### PR DESCRIPTION
#2430 added a test of the sanity checker to make sure that multiple versions of a mod that conflicts with its own identifier don't conflict with one another. This is a requirement for the way upgrades work.

However, users also reported the same problem for a slightly different scenario. A mod can also self-conflict if it both `"provides"` an identifier and `"conflicts"` with that same identifier. `VesselMoverContinued` and `MechJeb2-RO` suffer from this variant of the problem (they provide and conflict with `VesselMover` and `MechJeb2`, respectively). The actual fix covers both scenarios, but the test only checks conflicts with the identifier, so it's not inconceivable that some future change might break them separately and not be caught.

This pull request adds a test to catch this case.