### PR TITLE
Replace max KSP "9.9.9" with "any"

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -115,23 +115,18 @@ namespace CKAN
             // KSP.
             if (latest_available_for_any_ksp != null)
             {
-                string str = registry.LatestCompatibleKSP(mod.identifier)?.ToString();
-                int major = registry.LatestCompatibleKSP(mod.identifier).Major;
-                int minor = registry.LatestCompatibleKSP(mod.identifier).Minor;
-                int patch = registry.LatestCompatibleKSP(mod.identifier).Patch;
+                KspVersion ver = registry.LatestCompatibleKSP(mod.identifier);
+                string str = ver?.ToString();
+                int major = ver.Major;
+                int minor = ver.Minor;
+                int patch = ver.Patch;
 
 
                 if (str == null
-                    || (major + 1) % 10 == 0 
-                    || (major == 1 && (minor + 1) % 10 == 0)
+                    || (major + 1) % 10 == 0                                  
+                    || (major == 1 && minor > 90 && (minor + 1) % 10 == 0)    // 1.99.x, not 1.9.x
                     )
                     KSPCompatibility = "any";
-
-                else if (major == 1
-                    && minor != -1 
-                    && (patch > 8 || patch == -1)
-                    )
-                    KSPCompatibility = major + "." + minor + ".9";
 
                 else
                     KSPCompatibility = str;

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -115,7 +115,27 @@ namespace CKAN
             // KSP.
             if (latest_available_for_any_ksp != null)
             {
-                KSPCompatibility = KSPCompatibilityLong = registry.LatestCompatibleKSP(mod.identifier)?.ToString() ?? "any";
+                string str = registry.LatestCompatibleKSP(mod.identifier)?.ToString();
+                int major = registry.LatestCompatibleKSP(mod.identifier).Major;
+                int minor = registry.LatestCompatibleKSP(mod.identifier).Minor;
+                int patch = registry.LatestCompatibleKSP(mod.identifier).Patch;
+
+
+                if (str == null
+                    || (major + 1) % 10 == 0 
+                    || (major == 1 && (minor + 1) % 10 == 0)
+                    )
+                    KSPCompatibility = "any";
+
+                else if (major == 1
+                    && minor != -1 
+                    && (patch > 8 || patch == -1)
+                    )
+                    KSPCompatibility = major + "." + minor + ".9";
+
+                else
+                    KSPCompatibility = str;
+
 
                 // If the mod we have installed is *not* the mod we have installed, or we don't know
                 // what we have installed, indicate that an upgrade would be needed.
@@ -123,6 +143,10 @@ namespace CKAN
                 {
                     KSPCompatibilityLong = string.Format("{0} (using mod version {1})",
                         KSPCompatibility, latest_available_for_any_ksp.version);
+                }
+                else
+                {
+                    KSPCompatibilityLong = KSPCompatibility;
                 }
             }
             else


### PR DESCRIPTION
https://github.com/KSP-CKAN/CKAN/pull/2420
https://github.com/KSP-CKAN/NetKAN/issues/5356

CKAN GUI replace:

```
0.90    // unchanged
1.4     → 1.4.9
1.4.10  → 1.4.9
1.4.90  → 1.4.9
1.4.99  → 1.4.9
1.9.9   → any
9.99.99 → any
```




