### PR TITLE
Handle zero byte registry.json file

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -299,7 +299,9 @@ namespace CKAN
             log.DebugFormat("Trying to load registry from {0}", path);
             string json = File.ReadAllText(path);
             log.Debug("Registry JSON loaded; parsing...");
-            registry = JsonConvert.DeserializeObject<Registry>(json, settings);
+            // A 0-byte registry.json file loads as null without exceptions
+            registry = JsonConvert.DeserializeObject<Registry>(json, settings)
+                ?? Registry.Empty();
             log.Debug("Registry loaded and parsed");
             ScanDlc();
             log.InfoFormat("Loaded CKAN registry at {0}", path);

--- a/Tests/Core/Registry/RegistryManager.cs
+++ b/Tests/Core/Registry/RegistryManager.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Tests.Data;
 using System.IO;
@@ -62,5 +64,30 @@ namespace Tests.Core.RegistryManager
                 }
             }
         }
+
+        [Test]
+        public void Registry_ZeroByteRegistryJson_EmptyRegistryWithoutCrash()
+        {
+            // Arrange
+            string registryPath = TestData.DataDir("zero-byte-registry.json");
+            DisposableKSP dispksp;
+            CKAN.KSP      ksp;
+
+            // Act
+            dispksp = new DisposableKSP(null, registryPath);
+            ksp     = dispksp.KSP;
+
+            // Assert
+            CKAN.Registry reg = CKAN.RegistryManager.Instance(ksp).registry;
+            Assert.IsNotNull(reg);
+            // These lists should all be empty, copied from CKAN.Registry.Empty()
+            Assert.IsFalse(reg.InstalledModules.Any());
+            Assert.IsFalse(reg.InstalledDlls.Any());
+            Assert.IsFalse(reg.HasAnyAvailable());
+            // installed_files isn't exposed for testing
+            // A default repo is set during load
+            Assert.IsTrue(reg.Repositories.Any());
+        }
+
     }
 }


### PR DESCRIPTION
## Problem

If your `registry.json` file is zero bytes long, CKAN crashes on load:

![image](https://user-images.githubusercontent.com/18198370/39391768-b89953d2-4a76-11e8-90dd-30e22c1a5913.png)

## Cause

`RegistryManager` approaches registry creation by trying to load `registry.json` and then creating a new file if an exception is thrown during the load attempt. If the file contains a valid registry, it is simply loaded. If it doesn't exist, then a missing file exception is caught and the file is created.

If the file exists but is empty, then no exceptions are thrown, but the registry reference is set to null. Later, we attempt to use this reference, which causes an exception that isn't caught.

I was not able to figure out a way that a zero-byte file could be created. It might have something to do with the `ChinhDo.Transactions` library that CKAN uses for some filesystem access; I looked into this library at one point, and it essentially creates a temp folder and then copies files in/out of it, so maybe weird things can happen with files if something goes wrong with that.

## Changes

Now if the attempt to load returns a null reference, we fall back to `Registry.Empty()`. This allows the load attempt to complete without errors, and the application will work as normal.

A test is added to check that loading an empty registry file generates an empty registry without exceptions.

Fixes #2433.