### PR TITLE
Show conflict messages in status bar

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -8,7 +8,7 @@ namespace CKAN.Extensions
     {
         public static ICollection<T> AsCollection<T>(this IEnumerable<T> source)
         {
-            if (source is null)
+            if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
             return source is ICollection<T> collection ? collection : source.ToArray();
@@ -16,7 +16,7 @@ namespace CKAN.Extensions
 
         public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
         {
-            if (source is null)
+            if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
             return new HashSet<T>(source);

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -201,13 +201,13 @@ namespace CKAN
             // adding them to the list. This *must* be pre-populated with all
             // user-specified modules, as they may be supplying things that provide
             // virtual packages.
-            foreach (var module in ckan_modules)
+            foreach (CkanModule module in ckan_modules)
             {
                 log.DebugFormat("Preparing to resolve relationships for {0} {1}", module.identifier, module.version);
 
                 //Need to check against installed mods and those to install.
                 var mods = modlist.Values.Concat(installed_modules).Where(listed_mod => listed_mod.ConflictsWith(module));
-                foreach (var listed_mod in mods)
+                foreach (CkanModule listed_mod in mods)
                 {
                     if (options.procede_with_inconsistencies)
                     {
@@ -216,8 +216,8 @@ namespace CKAN
                     }
                     else
                     {
-                        throw new InconsistentKraken(string.Format("{0} conflicts with {1}, can't install both.", module,
-                            listed_mod));
+                        throw new InconsistentKraken(
+                            $"{module} conflicts with {listed_mod}");
                     }
                 }
 
@@ -234,16 +234,29 @@ namespace CKAN
                 Resolve(module, options);
             }
 
-            if (!options.without_enforce_consistency)
+            try
             {
-                var final_modules = new List<CkanModule>(modlist.Values);
-                final_modules.AddRange(installed_modules);
                 // Finally, let's do a sanity check that our solution is actually sane.
                 SanityChecker.EnforceConsistency(
-                    final_modules,
+                    modlist.Values.Concat(installed_modules),
                     registry.InstalledDlls,
                     registry.InstalledDlc
-                    );
+                );
+            }
+            catch (BadRelationshipsKraken k)
+            {
+                // Add to this.conflicts (catches conflicting DLLs and DLCs that the above loops miss)
+                foreach (var kvp in k.Conflicts)
+                {
+                    conflicts.Add(new KeyValuePair<CkanModule, CkanModule>(
+                        kvp.Key, null
+                    ));
+                }
+                if (!options.without_enforce_consistency)
+                {
+                    // Only re-throw if caller asked for consistency enforcement
+                    throw;
+                }
             }
         }
 
@@ -301,9 +314,7 @@ namespace CKAN
         /// options.without_toomanyprovides_kraken is not set.
         ///
         /// See RelationshipResolverOptions for further adjustments that can be made.
-        ///
         /// </summary>
-
         private void ResolveStanza(IEnumerable<RelationshipDescriptor> stanza, SelectionReason reason,
             RelationshipResolverOptions options, bool soft_resolve = false, IEnumerable<RelationshipDescriptor> old_stanza = null)
         {
@@ -312,7 +323,7 @@ namespace CKAN
                 return;
             }
 
-            foreach (var descriptor in stanza)
+            foreach (RelationshipDescriptor descriptor in stanza)
             {
                 string dep_name = descriptor.name;
                 log.DebugFormat("Considering {0}", dep_name);
@@ -419,7 +430,7 @@ namespace CKAN
                 var fixed_mods = new HashSet<CkanModule>(modlist.Values);
                 fixed_mods.UnionWith(installed_modules);
 
-                var conflicting_mod = fixed_mods.FirstOrDefault(mod => mod.ConflictsWith(candidate));
+                CkanModule conflicting_mod = fixed_mods.FirstOrDefault(mod => mod.ConflictsWith(candidate));
                 if (conflicting_mod == null)
                 {
                     // Okay, looks like we want this one. Adding.
@@ -440,8 +451,8 @@ namespace CKAN
                     }
                     else
                     {
-                        throw new InconsistentKraken(string.Format("{0} conflicts with {1}, can't install both.", conflicting_mod,
-                            candidate));
+                        throw new InconsistentKraken(
+                            $"{conflicting_mod} conflicts with {candidate}");
                     }
                 }
             }
@@ -535,11 +546,11 @@ namespace CKAN
                 var dict = new Dictionary<CkanModule, String>();
                 foreach (var conflict in conflicts)
                 {
-                    var module = conflict.Key;
+                    CkanModule module = conflict.Key;
+                    CkanModule other  = conflict.Value;
                     dict[module] = string.Format("{0} conflicts with {1}\r\n\r\n{0}:\r\n{2}\r\n{1}:\r\n{3}",
-                        module.identifier, conflict.Value.identifier,
-                        ReasonStringFor(module), ReasonStringFor(conflict.Value));
-                    ;
+                        module.identifier, other?.identifier ?? "an unmanaged DLL or DLC",
+                        ReasonStringFor(module), ReasonStringFor(other));
                 }
                 return dict;
             }
@@ -557,6 +568,11 @@ namespace CKAN
         /// <returns></returns>
         public string ReasonStringFor(CkanModule mod)
         {
+            if (mod == null)
+            {
+                // If we don't have a CkanModule, it must be a DLL or DLC
+                return "Unmanaged";
+            }
             var reason = ReasonFor(mod);
             var is_root_type = reason.GetType() == typeof(SelectionReason.UserRequested)
                 || reason.GetType() == typeof(SelectionReason.Installed);

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -539,14 +539,9 @@ namespace CKAN
         /// </summary>
         internal static bool UniConflicts(CkanModule mod1, CkanModule mod2)
         {
-            if (mod1.conflicts == null)
-            {
-                return false;
-            }
-            return
-                mod1.conflicts.Any(
-                    conflict =>
-                        mod2.ProvidesList.Contains(conflict.name) && conflict.WithinBounds(mod2.version));
+            return mod1?.conflicts?.Any(
+                conflict => conflict.MatchesAny(new CkanModule[] {mod2}, null, null)
+            ) ?? false;
         }
 
         /// <summary>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -175,6 +175,14 @@ namespace CKAN
             }
         }
 
+        public string ShortDescription
+        {
+            get
+            {
+                return String.Join("; ", inconsistencies);
+            }
+        }
+
         public InconsistentKraken(ICollection<string> inconsistencies, Exception innerException = null)
             : base(null, innerException)
         {
@@ -193,6 +201,33 @@ namespace CKAN
         }
 
         private const string header = "The following inconsistencies were found:\r\n";
+    }
+
+    /// <summary>
+    /// A mutation of InconsistentKraken that allows catching code to extract the causes of the errors.
+    /// </summary>
+    public class BadRelationshipsKraken : InconsistentKraken
+    {
+        public BadRelationshipsKraken(
+            ICollection<KeyValuePair<CkanModule, RelationshipDescriptor>> depends,
+            ICollection<KeyValuePair<CkanModule, RelationshipDescriptor>> conflicts
+        ) : base(
+            (depends?.Select(dep => $"{dep.Key} missing dependency {dep.Value}")
+                ?? new string[] {}
+            ).Concat(
+                conflicts?.Select(conf => $"{conf.Key} conflicts with {conf.Value}")
+                ?? new string[] {}
+            ).ToArray()
+        )
+        {
+            Depends   = depends?.ToList()
+                ?? new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();
+            Conflicts = conflicts?.ToList()
+                ?? new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();
+        }
+
+        public List<KeyValuePair<CkanModule, RelationshipDescriptor>> Depends   { get; private set; }
+        public List<KeyValuePair<CkanModule, RelationshipDescriptor>> Conflicts { get; private set; }
     }
 
     /// <summary>

--- a/Core/Versioning/ModuleVersion.cs
+++ b/Core/Versioning/ModuleVersion.cs
@@ -31,7 +31,7 @@ namespace CKAN.Versioning
         private static readonly ConcurrentDictionary<Tuple<string, string>, int> ComparisonCache =
             new ConcurrentDictionary<Tuple<string, string>, int>();
     }
-    
+
     public partial class ModuleVersion
     {
         private readonly int _epoch;
@@ -298,7 +298,7 @@ namespace CKAN.Versioning
                 return comparison;
             }
 
-            if (other is null)
+            if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
             if (other._epoch == _epoch && other._version.Equals(_version))

--- a/Core/Versioning/UnmanagedModuleVersion.cs
+++ b/Core/Versioning/UnmanagedModuleVersion.cs
@@ -12,8 +12,8 @@ namespace CKAN.Versioning
         // HACK: Hardcoding a value of "0" for autodetected DLLs preserves previous behavior.
         public UnmanagedModuleVersion(string version) : base(version ?? "0")
         {
-            IsUnknownVersion = version is null;
-            _string = version is null ? "(unmanaged)" : $"{version} (unmanaged)";
+            IsUnknownVersion = version == null;
+            _string = version == null ? "(unmanaged)" : $"{version} (unmanaged)";
         }
 
         public override string ToString()

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -617,6 +617,7 @@
             this.StatusProgress.Maximum = 100;
             this.StatusProgress.Size = new System.Drawing.Size(300, 20);
             this.StatusProgress.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            //
             // MainTabControl
             // 
             this.MainTabControl.Controls.Add(this.ManageModsTabPage);

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -108,14 +108,18 @@ namespace CKAN
 
         private void ConflictsUpdated()
         {
+            if (Conflicts == null) {
+                // Clear status bar if no conflicts
+                AddStatusMessage("");
+            }
             foreach (DataGridViewRow row in ModList.Rows)
             {
-                var module = (GUIMod)row.Tag;
+                GUIMod module = (GUIMod)row.Tag;
                 string value;
 
                 if (Conflicts != null && Conflicts.TryGetValue(module, out value))
                 {
-                    var conflict_text = value;
+                    string conflict_text = value;
                     foreach (DataGridViewCell cell in row.Cells)
                     {
                         cell.ToolTipText = conflict_text;
@@ -127,18 +131,15 @@ namespace CKAN
                         ModList.InvalidateRow(row.Index);
                     }
                 }
-                else
+                else if (row.DefaultCellStyle.BackColor != Color.Empty)
                 {
-                    if (row.DefaultCellStyle.BackColor != Color.Empty)
+                    foreach (DataGridViewCell cell in row.Cells)
                     {
-                        foreach (DataGridViewCell cell in row.Cells)
-                        {
-                            cell.ToolTipText = null;
-                        }
-
-                        row.DefaultCellStyle.BackColor = Color.Empty;
-                        ModList.InvalidateRow(row.Index);
+                        cell.ToolTipText = null;
                     }
+
+                    row.DefaultCellStyle.BackColor = Color.Empty;
+                    ModList.InvalidateRow(row.Index);
                 }
             }
         }
@@ -597,9 +598,10 @@ namespace CKAN
                 var module_installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
                 full_change_set = await mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer, CurrentInstance.VersionCriteria());
             }
-            catch (InconsistentKraken)
+            catch (InconsistentKraken k)
             {
                 // Need to be recomputed due to ComputeChangeSetFromModList possibly changing it with too many provides handling.
+                AddStatusMessage(k.ShortDescription);
                 user_change_set = mainModList.ComputeUserChangeSet();
                 new_conflicts = MainModList.ComputeConflictsFromModList(registry, user_change_set, CurrentInstance.VersionCriteria());
                 full_change_set = null;

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -25,7 +25,7 @@ namespace CKAN
             string msg = String.Format(text, args);
             // No newlines in status bar
             Util.Invoke(statusStrip1, () =>
-                StatusLabel.Text = msg.Replace("\r\n", " ").Replace("\n", " ")
+                StatusLabel.ToolTipText = StatusLabel.Text = msg.Replace("\r\n", " ").Replace("\n", " ")
             );
             AddLogMessage(msg);
         }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -223,7 +223,7 @@ namespace CKAN
         {
             Util.Invoke(this, () => _MarkModForUpdate(identifier));
         }
-        
+
         public void _MarkModForUpdate(string identifier)
         {
             DataGridViewRow row = mainModList.full_list_of_mod_rows[identifier];
@@ -234,8 +234,6 @@ namespace CKAN
         private void ModList_SelectedIndexChanged(object sender, EventArgs e)
         {
             var module = GetSelectedModule();
-
-            AddStatusMessage(string.Empty);
 
             ModInfoTabControl.SelectedModule = module;
             if (module == null)


### PR DESCRIPTION
## Problems

If you try to install two mods that conflict with one another, they'll be highlighted red, but there are no hints as to the cause if they're not on-screen.

If you manually install a mod, and then attempt to install or upgrade a mod in CKAN that conflicts with it, the mod is not highlighted red and there are no other clues as to what's going on, see KSP-CKAN/NetKAN#6533.

Some effort was made toward creating a popup for this in #2237, but it was not completed. Part of the challenge is that a popup can be disruptive and is not something we would want to happen every time the user clicks a checkbox.

## Causes

Conflicts previously were used to mark rows red, abort the creation of a change set, and leave the Apply button disabled, but specific descriptive messages weren't shown.

The code that highlights conflicts relies on `RelationshipResolver.ConflictList`, which only checks conflicts between `CkanModule`s and ignores DLLs and DLCs.

## Changes

The changes in this pull request are somewhat high risk and should be subjected to close scrutiny. It's possible that I missed an important test case, so please try any obscure things you can think of and report problems!

### Status bar shows conflict messages

Now if you select two conflicting mods for install, a short description of the conflict is shown in the status bar to explain why the rows are highlighted:

![image](https://user-images.githubusercontent.com/1559108/39786266-733d86b0-52e5-11e8-98e8-a64814af6108.png)

If more than one conflict is present, only one will be shown, because we stop looking once we find the first. If the displayed problem is fixed, then the other conflict will be shown. Hopefully this will be enough to help users figure out what to do.

Previously, clicking any row would clear the previous status bar message. This doesn't make sense anymore now that the status bar contains useful information about the current conflict. This is now removed, and instead the message is cleared if we are able to successfully calculate a change set without problems.

### Conflicts with DLLs included in `RelationshipResolver.ConflictList`

`SanityChecker` is rewritten to throw a new `BadRelationshipsKraken` exception instead of `InconsistentKraken`. This new exception inherits from the old one for backwards compatibility. Where `InconsistentKraken` provided only a list of opaque error strings, the new exception provides machine-readable descriptions of the problems to allow calling code to react to them.

`RelationshipResolver` now always runs `SanityChecker`. (`SanityChecker`'s exception is only passed along if not turned off in the resolver options, as before.) If any conflicts with DLLs and DLCs are found, these are added to the data structure that provides `RelationshipResolver.ConflictList` (by way of the new exception described above). This allows the conflicting row to be highlighted. A description of the conflict will be shown in the status bar as described above:

![image](https://user-images.githubusercontent.com/1559108/39786503-81dc4c0a-52e6-11e8-9bea-4e2d5a13d927.png)

### Small things

The ", cannot install both" suffix is removed from the messages for conflicts, for consistency with other places that already don't have this.

In the course of investigation, I found several places where we check `variable is null`. The `is` operator in C# dynamically checks _types_, not values, and from what I can tell it's better to check `variable == null`. This pull request makes that change.

The `var` keyword obscures code because it's harder to tell what type an object is and what we're allowed to call on it. This is replaced with types in several places.

The status bar tooltip is now set to the text it contains, in case some message is very long and some runtime displays such tooltips (I was not able to get these to display on Mono).

Some conflict-checking code in `CkanModule` was duplicative of logic in `RelationshipDescriptor`. Now the duplication is removed by having one function call the other.

A blank comment line was missing from the auto generated code in `Main.Designer.cs`. This is now restored, which hopefully will help prevent parsing problems in Visual Studio.