### PR TITLE
Improve handling of missing game version

### DIFF
--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -69,7 +69,7 @@ namespace CKAN
             }
         }
 
-        public bool Valid { get { return IsKspDir(gameDir); } }
+        public bool Valid { get { return IsKspDir(gameDir) && Version() != null; } }
 
         /// <summary>
         /// Create the CKAN directory and any supporting files.
@@ -124,7 +124,7 @@ namespace CKAN
         {
             CompatibleKspVersionsDto compatibleKspVersionsDto = new CompatibleKspVersionsDto();
 
-            compatibleKspVersionsDto.VersionOfKspWhenWritten = Version().ToString();
+            compatibleKspVersionsDto.VersionOfKspWhenWritten = Version()?.ToString();
             compatibleKspVersionsDto.CompatibleKspVersions = _compatibleVersions.Select(v => v.ToString()).ToList();
 
             String json = JsonConvert.SerializeObject(compatibleKspVersionsDto);
@@ -142,7 +142,11 @@ namespace CKAN
                 CompatibleKspVersionsDto compatibleKspVersionsDto = JsonConvert.DeserializeObject<CompatibleKspVersionsDto>(json);
 
                 _compatibleVersions = compatibleKspVersionsDto.CompatibleKspVersions.Select(v => KspVersion.Parse(v)).ToList();
-                this.VersionOfKspWhenCompatibleVersionsWereStored = KspVersion.Parse(compatibleKspVersionsDto.VersionOfKspWhenWritten);
+
+                // Get version without throwing exceptions for null
+                KspVersion mainVer = null;
+                KspVersion.TryParse(compatibleKspVersionsDto.VersionOfKspWhenWritten, out mainVer);
+                this.VersionOfKspWhenCompatibleVersionsWereStored = mainVer;
             }
         }
 

--- a/Tests/Core/KSP.cs
+++ b/Tests/Core/KSP.cs
@@ -115,5 +115,65 @@ namespace Tests.Core
             );
         }
 
+        [Test]
+        public void Valid_MissingVersionData_False()
+        {
+            // Arrange
+            string gamedir  = TestData.NewTempDir();
+            string ckandir  = Path.Combine(gamedir, "CKAN");
+            string buildid  = Path.Combine(gamedir, "buildID.txt");
+            string readme   = Path.Combine(gamedir, "readme.txt");
+            string jsonpath = Path.Combine(ckandir, "compatible_ksp_versions.json");
+            const string compatible_ksp_versions_json = @"{
+                ""VersionOfKspWhenWritten"": ""1.4.3"",
+                ""CompatibleKspVersions"":   [""1.4""]
+            }";
+
+            // Generate a valid game dir except for missing buildID.txt and readme.txt
+            TestData.CopyDirectory(TestData.good_ksp_dir(), gamedir);
+            File.Delete(buildid);
+            File.Delete(readme);
+
+            // Save GameDir/CKAN/compatible_ksp_versions.json
+            Directory.CreateDirectory(ckandir);
+            File.WriteAllText(jsonpath, compatible_ksp_versions_json);
+
+            // Act
+            CKAN.KSP my_ksp = new CKAN.KSP(gamedir, "missing-ver-test", NullUser.User);
+
+            // Assert
+            Assert.IsFalse(my_ksp.Valid);
+        }
+
+        [Test]
+        public void Constructor_NullMainCompatVer_NoCrash()
+        {
+            // Arrange
+            string gamedir  = TestData.NewTempDir();
+            string ckandir  = Path.Combine(gamedir, "CKAN");
+            string buildid  = Path.Combine(gamedir, "buildID.txt");
+            string readme   = Path.Combine(gamedir, "readme.txt");
+            string jsonpath = Path.Combine(ckandir, "compatible_ksp_versions.json");
+            const string compatible_ksp_versions_json = @"{
+                ""VersionOfKspWhenWritten"": null,
+                ""CompatibleKspVersions"":   [""1.4""]
+            }";
+
+            // Generate a valid game dir except for missing buildID.txt and readme.txt
+            TestData.CopyDirectory(TestData.good_ksp_dir(), gamedir);
+            File.Delete(buildid);
+            File.Delete(readme);
+
+            // Save GameDir/CKAN/compatible_ksp_versions.json
+            Directory.CreateDirectory(ckandir);
+            File.WriteAllText(jsonpath, compatible_ksp_versions_json);
+
+            // Act & Assert
+            Assert.DoesNotThrow(() =>
+            {
+                CKAN.KSP my_ksp = new CKAN.KSP(gamedir, "null-compat-ver-test", NullUser.User);
+            });
+        }
+
     }
 }


### PR DESCRIPTION
## Problem

If you:

1. Have exactly one game instance
2. Set at least one additional compatible version in the compatible versions dialog
3. Remove `buildID.txt` and `readme.txt`, _without_ removing the KSP folder or the CKAN folder
4. Launch CKAN

... then on load, you get the compatible versions popup warning you about a version change (if in GUI), and clicking Save causes an exception:

```
************** Exception Text **************
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.KSP.SaveCompatibleVersions()
   at CKAN.CompatibleKspVersionsDialog.SaveButton_Click(Object sender, EventArgs e)
   at System.Windows.Forms.Control.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ButtonBase.WndProc(Message& m)
   at System.Windows.Forms.Button.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

(One way to make this happen is apparently to uninstall in Steam, then re-install to a different Steam library folder. See #2443.)

The problem is in Core, so the other UIs are also affected, but the details vary.

## Causes

`KSP.Version()` is allowed to be null in most places (and it happens when the buildID.txt and readme.txt files are missing), but the code to load and save compatible versions doesn't like it. (This is somewhat ironic as that code would be one of the better ways of handling this situation, since you could use it to set the correct game version manually.)

For saving, `ToString()` is called on the null reference.

For loading, if `compatible_ksp_versions.json` has a null value for the `VersionOfKspWhenWritten` property, it is passed to `KspVersion.Parse`, which throws exceptions on null. (That property can't be null currently, but it will be possible once we allow the save to proceed with a null.)

To be considered invalid, a game instance must lack a GameData folder. If it merely lacks the files that provide the game version, this is treated as fine; you can attempt to open and use such an instance even though we know it's missing at least some data that should be there.

## Changes

Now the null conditional operator ("`?.`") is used to avoid a null reference exception at save. This allows a null value to be written to the file.

Now we use `KspVersion.TryParse` instead of `Parse` to allow `VersionOfKspWhenCompatibleVersionsWereStored` to be set to null at load.

Finally, a game instance without a version is now treated as invalid. This means you can't open them from the Select KSP Install window, and they won't be auto-opened at launch. If your only known instance loses its version info (say, by uninstalling in Steam), then it'll automatically open the Select KSP Install window instead.

Fixes #2443.