### PR TITLE
Pass game instance from cmdline to GUI/ConsoleUI

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -58,7 +58,7 @@ namespace CKAN.CmdLine
             // If we're starting with no options then invoke the GUI instead.
             if (args.Length == 0)
             {
-                return Gui(new GuiOptions(), args);
+                return Gui(null, new GuiOptions(), args);
             }
 
             try
@@ -174,10 +174,10 @@ namespace CKAN.CmdLine
                 switch (cmdline.action)
                 {
                     case "gui":
-                        return Gui((GuiOptions)options, args);
+                        return Gui(manager, (GuiOptions)options, args);
 
                     case "consoleui":
-                        return ConsoleUi(options, args);
+                        return ConsoleUi(manager, options, args);
 
                     case "prompt":
                         return new Prompt().RunCommand(manager, cmdline.options);
@@ -243,21 +243,21 @@ namespace CKAN.CmdLine
             return Exit.ERROR;
         }
 
-        private static int Gui(GuiOptions options, string[] args)
+        private static int Gui(KSPManager manager, GuiOptions options, string[] args)
         {
             // TODO: Sometimes when the GUI exits, we get a System.ArgumentException,
             // but trying to catch it here doesn't seem to help. Dunno why.
 
-            GUI.Main_(args, options.ShowConsole);
+            GUI.Main_(args, manager, options.ShowConsole);
 
             return Exit.OK;
         }
 
-        private static int ConsoleUi(CommonOptions opts, string[] args)
+        private static int ConsoleUi(KSPManager manager, CommonOptions opts, string[] args)
         {
             // Debug/verbose output just messes up the screen
             LogManager.GetRepository().Threshold = Level.Warn;
-            return CKAN.ConsoleUI.ConsoleUI.Main_(args, opts.Debug);
+            return CKAN.ConsoleUI.ConsoleUI.Main_(args, manager, opts.Debug);
         }
 
         private static int Version(IUser user)

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -441,7 +441,7 @@ namespace CKAN.CmdLine
         public bool ShowConsole { get; set; }
     }
 
-    internal class ConsoleUIOptions : CommonOptions { }
+    internal class ConsoleUIOptions : InstanceSpecificOptions { }
 
     internal class UpdateOptions : InstanceSpecificOptions
     {

--- a/ConsoleUI/ConsoleCKAN.cs
+++ b/ConsoleUI/ConsoleCKAN.cs
@@ -13,13 +13,13 @@ namespace CKAN.ConsoleUI {
         /// Starts with a splash screen, then instance selection if no default,
         /// then list of mods.
         /// </summary>
-        public ConsoleCKAN(bool debug)
+        public ConsoleCKAN(KSPManager mgr, bool debug)
         {
             // KSPManager only uses its IUser object to construct KSP objects,
             // which only use it to inform the user about the creation of the CKAN/ folder.
             // These aren't really intended to be displayed, so the manager
             // can keep a NullUser reference forever.
-            KSPManager manager = new KSPManager(new NullUser());
+            KSPManager manager = mgr ?? new KSPManager(new NullUser());
 
             // The splash screen returns true when it's safe to run the rest of the app.
             // This can be blocked by a lock file, for example.

--- a/ConsoleUI/Program.cs
+++ b/ConsoleUI/Program.cs
@@ -17,7 +17,7 @@ namespace CKAN.ConsoleUI
         [STAThread]
         public static void Main(string[] args)
         {
-            Main_(args);
+            Main_(args, null);
         }
 
         /// <summary>
@@ -25,15 +25,16 @@ namespace CKAN.ConsoleUI
         /// and by other parts of CKAN that want to launch the console UI.
         /// </summary>
         /// <param name="args">Command line arguments</param>
+        /// <param name="manager">Game instance manager object potentially initialized by command line flags</param>
         /// <param name="debug">True if debug options should be available, false otherwise</param>
         /// <returns>
         /// Process exit status
         /// </returns>
-        public static int Main_(string[] args, bool debug = false)
+        public static int Main_(string[] args, KSPManager manager, bool debug = false)
         {
             Logging.Initialize();
 
-            new ConsoleCKAN(debug);
+            new ConsoleCKAN(manager, debug);
 
             // Tell RegistryManager not to throw Dispose-related exceptions at exit
             RegistryManager.DisposeAll();

--- a/ConsoleUI/SplashScreen.cs
+++ b/ConsoleUI/SplashScreen.cs
@@ -24,9 +24,8 @@ namespace CKAN.ConsoleUI {
         public bool Run()
         {
             // If there's a default instance, try to get the lock for it.
-            if (manager.GetPreferredInstance() != null
-                    && !KSPListScreen.TryGetInstance(manager.CurrentInstance, () => Draw(false))) {
-
+            KSP ksp = manager.CurrentInstance ?? manager.GetPreferredInstance();
+            if (ksp != null && !KSPListScreen.TryGetInstance(ksp, () => Draw(false))) {
                 Console.ResetColor();
                 Console.Clear();
                 Console.CursorVisible = true;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -158,10 +158,11 @@ namespace CKAN
             }
         }
 
-        public Main(string[] cmdlineArgs, GUIUser user, bool showConsole)
+        public Main(string[] cmdlineArgs, KSPManager mgr, GUIUser user, bool showConsole)
         {
             log.Info("Starting the GUI");
             commandLineArgs = cmdlineArgs;
+            manager = mgr ?? new KSPManager(user);
             currentUser = user;
 
             user.displayMessage = AddStatusMessage;
@@ -182,7 +183,6 @@ namespace CKAN
 
             // We want to check if our current instance is null first,
             // as it may have already been set by a command-line option.
-            Manager = new KSPManager(user);
             if (CurrentInstance == null && manager.GetPreferredInstance() == null)
             {
                 Hide();

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -16,7 +16,7 @@ namespace CKAN
             Main_(args);
         }
 
-        public static void Main_(string[] args, bool showConsole = false)
+        public static void Main_(string[] args, KSPManager manager = null, bool showConsole = false)
         {
             Logging.Initialize();
 
@@ -33,7 +33,7 @@ namespace CKAN
             }
             else
             {
-                new Main(args, user, showConsole);
+                new Main(args, manager, user, showConsole);
             }
         }
 


### PR DESCRIPTION
## Problem

If you have multiple game instances, you can choose between them with these command line options:

```
  --ksp                   KSP install to use

  --kspdir                KSP dir to use
```

However, these currently don't work for GUI or ConsoleUI. Instead, they will use the default instance if one is defined, or ask the user to choose an instance.

For GUI, these options are allowed and parsed (to the extent of raising an error if an invalid instance is specified), but not used to drive the UI.

For ConsoleUI, these options are not considered valid.

## Changes

Now the `--ksp` and `--kspdir` flags work for both GUI and ConsoleUI.

The knowledge of which instance to use is stored into `CmdLine`'s  `KSPManager` object by `InstanceSpecificOptions.Handle`. To make GUI and ConsoleUI obey this, we pass this same manager object to them via new parameters.

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1251-broglio/&do=findComment&comment=3380669