### PR TITLE
Remove "v" in "installed version" and "latest version" columns

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1162,6 +1162,21 @@ namespace CKAN
             }
         }
 
+
+
+        /// <summary>
+        /// Remove prepending v V. Version_ etc
+        /// </summary>
+        public static string StripV(string version)
+        {
+            Match match = Regex.Match(version, @"^(?<num>\d\:)?[vV]+(ersion)?[_.]*(?<ver>\d.*)$");
+
+            if (match.Success)
+                return match.Groups["num"].Value + match.Groups["ver"].Value;
+            else
+                return version;
+        }
+
         /// <summary>
         /// Returns a version string shorn of any leading epoch as delimited by a single colon
         /// </summary>

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -15,6 +15,7 @@ namespace CKAN
         public bool CheckForUpdatesOnLaunchNoNag = false;
 
         public bool HideEpochs = true;
+        public bool HideV = false;
 
         public bool RefreshOnStartup = true; // Defaults to true, so everyone is forced to refresh on first start
         public bool RefreshOnStartupNoNag = false;

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using System.Linq;
 using CKAN.Versioning;
 using CKAN.GameVersionProviders;
+using System.Text.RegularExpressions;
 
 namespace CKAN
 {
@@ -81,6 +82,20 @@ namespace CKAN
                 return (int)Math.Pow(10, Math.Floor(Math.Log10(num + 1)) + 1) - 1;
         }
 
+        /// <summary>
+        /// Remove prepending v V. Version_ etc
+        /// Leave 2 in 2:v5.4.3, whatever 2 is.
+        /// </summary>
+        private string RemoveV(string version)
+        {
+            Match match = Regex.Match(version, @"^(?<num>\d\:)?[vV]+(ersion)?[_.]*(?<ver>\d.*)$");
+
+            if (match.Success)
+                return match.Groups["num"].Value + match.Groups["ver"].Value;
+            else
+                return version;
+        }
+
         public GUIMod(CkanModule mod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool incompatible = false)
         {
             IsCKAN = mod is CkanModule;
@@ -110,6 +125,8 @@ namespace CKAN
             }
 
             InstalledVersion = installed_version != null ? installed_version.ToString() : "-";
+
+            InstalledVersion = RemoveV(InstalledVersion);
 
             // Let's try to find the compatibility for this mod. If it's not in the registry at
             // all (because it's a DarkKAN mod) then this might fail.
@@ -205,6 +222,8 @@ namespace CKAN
             {
                 LatestVersion = "-";
             }
+
+            LatestVersion = RemoveV(LatestVersion); 
 
             KSPversion = ksp_version != null ? ksp_version.ToString() : "-";
 

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -4,7 +4,6 @@ using System.Windows.Forms;
 using System.Linq;
 using CKAN.Versioning;
 using CKAN.GameVersionProviders;
-using System.Text.RegularExpressions;
 
 namespace CKAN
 {

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -82,20 +82,6 @@ namespace CKAN
                 return (int)Math.Pow(10, Math.Floor(Math.Log10(num + 1)) + 1) - 1;
         }
 
-        /// <summary>
-        /// Remove prepending v V. Version_ etc
-        /// Leave 2 in 2:v5.4.3, whatever 2 is.
-        /// </summary>
-        private string RemoveV(string version)
-        {
-            Match match = Regex.Match(version, @"^(?<num>\d\:)?[vV]+(ersion)?[_.]*(?<ver>\d.*)$");
-
-            if (match.Success)
-                return match.Groups["num"].Value + match.Groups["ver"].Value;
-            else
-                return version;
-        }
-
         public GUIMod(CkanModule mod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool incompatible = false)
         {
             IsCKAN = mod is CkanModule;
@@ -125,8 +111,6 @@ namespace CKAN
             }
 
             InstalledVersion = installed_version != null ? installed_version.ToString() : "-";
-
-            InstalledVersion = RemoveV(InstalledVersion);
 
             // Let's try to find the compatibility for this mod. If it's not in the registry at
             // all (because it's a DarkKAN mod) then this might fail.
@@ -222,8 +206,6 @@ namespace CKAN
             {
                 LatestVersion = "-";
             }
-
-            LatestVersion = RemoveV(LatestVersion); 
 
             KSPversion = ksp_version != null ? ksp_version.ToString() : "-";
 

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -173,7 +173,7 @@ namespace CKAN
 
             // Update our mod listing. If we're doing a repo update, then we don't refresh
             // all (in case the user has selected changes they wish to apply).
-            mainModList.ConstructModList(gui_mods.ToList(), mc, !repo_updated, configuration.HideEpochs);
+            mainModList.ConstructModList(gui_mods.ToList(), mc, !repo_updated, configuration.HideEpochs, configuration.HideV);
             mainModList.Modules = new ReadOnlyCollection<GUIMod>(
                 mainModList.full_list_of_mod_rows.Values.Select(row => row.Tag as GUIMod).ToList());
 
@@ -662,7 +662,7 @@ namespace CKAN
         /// <param name="modules">A list of modules that may require updating</param>
         /// <param name="refreshAll">If set to <c>true</c> then always rebuild the list from scratch</param>
         /// <param name="hideEpochs">If true, remove epochs from the displayed versions</param>
-        public IEnumerable<DataGridViewRow> ConstructModList(IEnumerable<GUIMod> modules, List<ModChange> mc = null, bool refreshAll = false, bool hideEpochs = false)
+        public IEnumerable<DataGridViewRow> ConstructModList(IEnumerable<GUIMod> modules, List<ModChange> mc = null, bool refreshAll = false, bool hideEpochs = false, bool hideV = false)
         {
 
             if (refreshAll || full_list_of_mod_rows == null)
@@ -710,8 +710,26 @@ namespace CKAN
 
                 var name = new DataGridViewTextBoxCell {Value = mod.Name};
                 var author = new DataGridViewTextBoxCell {Value = mod.Authors};
-                var installVersion = new DataGridViewTextBoxCell {Value = hideEpochs ? ModuleInstaller.StripEpoch(mod.InstalledVersion) : mod.InstalledVersion };
-                var latestVersion = new DataGridViewTextBoxCell {Value = hideEpochs ? ModuleInstaller.StripEpoch(mod.LatestVersion) : mod.LatestVersion };
+
+                var installVersion = new DataGridViewTextBoxCell {
+                Value =
+                        hideEpochs ? 
+                            (hideV ? ModuleInstaller.StripEpoch(ModuleInstaller.StripV(mod.InstalledVersion))
+                            : ModuleInstaller.StripEpoch(mod.InstalledVersion))
+                        :   (hideV ? ModuleInstaller.StripV(mod.InstalledVersion)
+                            : mod.InstalledVersion)
+                };
+
+                var latestVersion = new DataGridViewTextBoxCell
+                {
+                    Value =
+                        hideEpochs ?
+                            (hideV ? ModuleInstaller.StripEpoch(ModuleInstaller.StripV(mod.LatestVersion))
+                            : ModuleInstaller.StripEpoch(mod.LatestVersion))
+                        : (hideV ? ModuleInstaller.StripV(mod.LatestVersion)
+                            : mod.LatestVersion)
+                };
+
                 var desc = new DataGridViewTextBoxCell {Value = mod.Abstract};
                 var compat = new DataGridViewTextBoxCell {Value = mod.KSPCompatibility};
                 var size = new DataGridViewTextBoxCell {Value = mod.DownloadSize};

--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -54,6 +54,7 @@
             this.HideEpochsCheckbox = new System.Windows.Forms.CheckBox();
             this.MoreSettingsGroupBox = new System.Windows.Forms.GroupBox();
             this.AutoSortUpdateCheckBox = new System.Windows.Forms.CheckBox();
+            this.HideVCheckbox = new System.Windows.Forms.CheckBox();
             this.RepositoryGroupBox.SuspendLayout();
             this.AuthTokensGroupBox.SuspendLayout();
             this.CacheGroupBox.SuspendLayout();
@@ -64,9 +65,10 @@
             // NewRepoButton
             // 
             this.NewRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.NewRepoButton.Location = new System.Drawing.Point(6, 94);
+            this.NewRepoButton.Location = new System.Drawing.Point(8, 116);
+            this.NewRepoButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NewRepoButton.Name = "NewRepoButton";
-            this.NewRepoButton.Size = new System.Drawing.Size(56, 23);
+            this.NewRepoButton.Size = new System.Drawing.Size(75, 28);
             this.NewRepoButton.TabIndex = 6;
             this.NewRepoButton.Text = "New";
             this.NewRepoButton.UseVisualStyleBackColor = true;
@@ -80,9 +82,11 @@
             this.RepositoryGroupBox.Controls.Add(this.ReposListBox);
             this.RepositoryGroupBox.Controls.Add(this.NewRepoButton);
             this.RepositoryGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RepositoryGroupBox.Location = new System.Drawing.Point(12, 12);
+            this.RepositoryGroupBox.Location = new System.Drawing.Point(16, 15);
+            this.RepositoryGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.RepositoryGroupBox.Name = "RepositoryGroupBox";
-            this.RepositoryGroupBox.Size = new System.Drawing.Size(476, 127);
+            this.RepositoryGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.RepositoryGroupBox.Size = new System.Drawing.Size(635, 156);
             this.RepositoryGroupBox.TabIndex = 12;
             this.RepositoryGroupBox.TabStop = false;
             this.RepositoryGroupBox.Text = "Metadata Repositories";
@@ -91,9 +95,10 @@
             // 
             this.DownRepoButton.Enabled = false;
             this.DownRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.DownRepoButton.Location = new System.Drawing.Point(130, 94);
+            this.DownRepoButton.Location = new System.Drawing.Point(173, 116);
+            this.DownRepoButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.DownRepoButton.Name = "DownRepoButton";
-            this.DownRepoButton.Size = new System.Drawing.Size(56, 23);
+            this.DownRepoButton.Size = new System.Drawing.Size(75, 28);
             this.DownRepoButton.TabIndex = 11;
             this.DownRepoButton.Text = "Down";
             this.DownRepoButton.UseVisualStyleBackColor = true;
@@ -103,9 +108,10 @@
             // 
             this.UpRepoButton.Enabled = false;
             this.UpRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.UpRepoButton.Location = new System.Drawing.Point(68, 94);
+            this.UpRepoButton.Location = new System.Drawing.Point(91, 116);
+            this.UpRepoButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.UpRepoButton.Name = "UpRepoButton";
-            this.UpRepoButton.Size = new System.Drawing.Size(56, 23);
+            this.UpRepoButton.Size = new System.Drawing.Size(75, 28);
             this.UpRepoButton.TabIndex = 10;
             this.UpRepoButton.Text = "Up";
             this.UpRepoButton.UseVisualStyleBackColor = true;
@@ -115,9 +121,10 @@
             // 
             this.DeleteRepoButton.Enabled = false;
             this.DeleteRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.DeleteRepoButton.Location = new System.Drawing.Point(414, 94);
+            this.DeleteRepoButton.Location = new System.Drawing.Point(552, 116);
+            this.DeleteRepoButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.DeleteRepoButton.Name = "DeleteRepoButton";
-            this.DeleteRepoButton.Size = new System.Drawing.Size(56, 23);
+            this.DeleteRepoButton.Size = new System.Drawing.Size(75, 28);
             this.DeleteRepoButton.TabIndex = 9;
             this.DeleteRepoButton.Text = "Delete";
             this.DeleteRepoButton.UseVisualStyleBackColor = true;
@@ -126,9 +133,11 @@
             // ReposListBox
             // 
             this.ReposListBox.FormattingEnabled = true;
-            this.ReposListBox.Location = new System.Drawing.Point(6, 19);
+            this.ReposListBox.ItemHeight = 16;
+            this.ReposListBox.Location = new System.Drawing.Point(8, 23);
+            this.ReposListBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ReposListBox.Name = "ReposListBox";
-            this.ReposListBox.Size = new System.Drawing.Size(464, 69);
+            this.ReposListBox.Size = new System.Drawing.Size(617, 84);
             this.ReposListBox.TabIndex = 9;
             this.ReposListBox.SelectedIndexChanged += new System.EventHandler(this.ReposListBox_SelectedIndexChanged);
             // 
@@ -138,9 +147,11 @@
             this.AuthTokensGroupBox.Controls.Add(this.NewAuthTokenButton);
             this.AuthTokensGroupBox.Controls.Add(this.DeleteAuthTokenButton);
             this.AuthTokensGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.AuthTokensGroupBox.Location = new System.Drawing.Point(12, 145);
+            this.AuthTokensGroupBox.Location = new System.Drawing.Point(16, 178);
+            this.AuthTokensGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AuthTokensGroupBox.Name = "AuthTokensGroupBox";
-            this.AuthTokensGroupBox.Size = new System.Drawing.Size(476, 127);
+            this.AuthTokensGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AuthTokensGroupBox.Size = new System.Drawing.Size(635, 156);
             this.AuthTokensGroupBox.TabIndex = 13;
             this.AuthTokensGroupBox.TabStop = false;
             this.AuthTokensGroupBox.Text = "Authentication Tokens";
@@ -148,18 +159,21 @@
             // AuthTokensListBox
             // 
             this.AuthTokensListBox.FormattingEnabled = true;
-            this.AuthTokensListBox.Location = new System.Drawing.Point(6, 19);
+            this.AuthTokensListBox.ItemHeight = 16;
+            this.AuthTokensListBox.Location = new System.Drawing.Point(8, 23);
+            this.AuthTokensListBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AuthTokensListBox.Name = "AuthTokensListBox";
-            this.AuthTokensListBox.Size = new System.Drawing.Size(464, 69);
+            this.AuthTokensListBox.Size = new System.Drawing.Size(617, 84);
             this.AuthTokensListBox.TabIndex = 14;
             this.AuthTokensListBox.SelectedIndexChanged += new System.EventHandler(this.AuthTokensListBox_SelectedIndexChanged);
             // 
             // NewAuthTokenButton
             // 
             this.NewAuthTokenButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.NewAuthTokenButton.Location = new System.Drawing.Point(6, 94);
+            this.NewAuthTokenButton.Location = new System.Drawing.Point(8, 116);
+            this.NewAuthTokenButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NewAuthTokenButton.Name = "NewAuthTokenButton";
-            this.NewAuthTokenButton.Size = new System.Drawing.Size(56, 23);
+            this.NewAuthTokenButton.Size = new System.Drawing.Size(75, 28);
             this.NewAuthTokenButton.TabIndex = 15;
             this.NewAuthTokenButton.Text = "New";
             this.NewAuthTokenButton.UseVisualStyleBackColor = true;
@@ -169,9 +183,10 @@
             // 
             this.DeleteAuthTokenButton.Enabled = false;
             this.DeleteAuthTokenButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.DeleteAuthTokenButton.Location = new System.Drawing.Point(414, 94);
+            this.DeleteAuthTokenButton.Location = new System.Drawing.Point(552, 116);
+            this.DeleteAuthTokenButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.DeleteAuthTokenButton.Name = "DeleteAuthTokenButton";
-            this.DeleteAuthTokenButton.Size = new System.Drawing.Size(56, 23);
+            this.DeleteAuthTokenButton.Size = new System.Drawing.Size(75, 28);
             this.DeleteAuthTokenButton.TabIndex = 16;
             this.DeleteAuthTokenButton.Text = "Delete";
             this.DeleteAuthTokenButton.UseVisualStyleBackColor = true;
@@ -182,9 +197,11 @@
             this.CacheGroupBox.Controls.Add(this.ClearCKANCacheButton);
             this.CacheGroupBox.Controls.Add(this.CKANCacheLabel);
             this.CacheGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CacheGroupBox.Location = new System.Drawing.Point(12, 279);
+            this.CacheGroupBox.Location = new System.Drawing.Point(16, 343);
+            this.CacheGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CacheGroupBox.Name = "CacheGroupBox";
-            this.CacheGroupBox.Size = new System.Drawing.Size(476, 49);
+            this.CacheGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.CacheGroupBox.Size = new System.Drawing.Size(635, 60);
             this.CacheGroupBox.TabIndex = 10;
             this.CacheGroupBox.TabStop = false;
             this.CacheGroupBox.Text = "Cache";
@@ -192,9 +209,10 @@
             // ClearCKANCacheButton
             // 
             this.ClearCKANCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ClearCKANCacheButton.Location = new System.Drawing.Point(341, 16);
+            this.ClearCKANCacheButton.Location = new System.Drawing.Point(455, 20);
+            this.ClearCKANCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ClearCKANCacheButton.Name = "ClearCKANCacheButton";
-            this.ClearCKANCacheButton.Size = new System.Drawing.Size(129, 23);
+            this.ClearCKANCacheButton.Size = new System.Drawing.Size(172, 28);
             this.ClearCKANCacheButton.TabIndex = 1;
             this.ClearCKANCacheButton.Text = "Clear cache";
             this.ClearCKANCacheButton.UseVisualStyleBackColor = true;
@@ -203,9 +221,10 @@
             // CKANCacheLabel
             // 
             this.CKANCacheLabel.AutoSize = true;
-            this.CKANCacheLabel.Location = new System.Drawing.Point(3, 21);
+            this.CKANCacheLabel.Location = new System.Drawing.Point(4, 26);
+            this.CKANCacheLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.CKANCacheLabel.Name = "CKANCacheLabel";
-            this.CKANCacheLabel.Size = new System.Drawing.Size(271, 13);
+            this.CKANCacheLabel.Size = new System.Drawing.Size(359, 17);
             this.CKANCacheLabel.TabIndex = 0;
             this.CKANCacheLabel.Text = "There are currently N files in the cache, taking up M MB";
             // 
@@ -220,9 +239,11 @@
             this.AutoUpdateGroupBox.Controls.Add(this.LocalVersionLabelLabel);
             this.AutoUpdateGroupBox.Controls.Add(this.CheckForUpdatesButton);
             this.AutoUpdateGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.AutoUpdateGroupBox.Location = new System.Drawing.Point(12, 334);
+            this.AutoUpdateGroupBox.Location = new System.Drawing.Point(16, 411);
+            this.AutoUpdateGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AutoUpdateGroupBox.Name = "AutoUpdateGroupBox";
-            this.AutoUpdateGroupBox.Size = new System.Drawing.Size(476, 105);
+            this.AutoUpdateGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AutoUpdateGroupBox.Size = new System.Drawing.Size(635, 129);
             this.AutoUpdateGroupBox.TabIndex = 11;
             this.AutoUpdateGroupBox.TabStop = false;
             this.AutoUpdateGroupBox.Text = "Auto-Updates";
@@ -230,9 +251,10 @@
             // RefreshOnStartupCheckbox
             // 
             this.RefreshOnStartupCheckbox.AutoSize = true;
-            this.RefreshOnStartupCheckbox.Location = new System.Drawing.Point(275, 43);
+            this.RefreshOnStartupCheckbox.Location = new System.Drawing.Point(367, 53);
+            this.RefreshOnStartupCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.RefreshOnStartupCheckbox.Name = "RefreshOnStartupCheckbox";
-            this.RefreshOnStartupCheckbox.Size = new System.Drawing.Size(167, 17);
+            this.RefreshOnStartupCheckbox.Size = new System.Drawing.Size(220, 21);
             this.RefreshOnStartupCheckbox.TabIndex = 7;
             this.RefreshOnStartupCheckbox.Text = "Update repositories on launch";
             this.RefreshOnStartupCheckbox.UseVisualStyleBackColor = true;
@@ -241,9 +263,10 @@
             // CheckUpdateOnLaunchCheckbox
             // 
             this.CheckUpdateOnLaunchCheckbox.AutoSize = true;
-            this.CheckUpdateOnLaunchCheckbox.Location = new System.Drawing.Point(275, 16);
+            this.CheckUpdateOnLaunchCheckbox.Location = new System.Drawing.Point(367, 20);
+            this.CheckUpdateOnLaunchCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CheckUpdateOnLaunchCheckbox.Name = "CheckUpdateOnLaunchCheckbox";
-            this.CheckUpdateOnLaunchCheckbox.Size = new System.Drawing.Size(195, 17);
+            this.CheckUpdateOnLaunchCheckbox.Size = new System.Drawing.Size(252, 21);
             this.CheckUpdateOnLaunchCheckbox.TabIndex = 6;
             this.CheckUpdateOnLaunchCheckbox.Text = "Check for CKAN updates on launch";
             this.CheckUpdateOnLaunchCheckbox.UseVisualStyleBackColor = true;
@@ -253,9 +276,10 @@
             // 
             this.InstallUpdateButton.Enabled = false;
             this.InstallUpdateButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.InstallUpdateButton.Location = new System.Drawing.Point(116, 76);
+            this.InstallUpdateButton.Location = new System.Drawing.Point(155, 94);
+            this.InstallUpdateButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.InstallUpdateButton.Name = "InstallUpdateButton";
-            this.InstallUpdateButton.Size = new System.Drawing.Size(104, 23);
+            this.InstallUpdateButton.Size = new System.Drawing.Size(139, 28);
             this.InstallUpdateButton.TabIndex = 5;
             this.InstallUpdateButton.Text = "Install update";
             this.InstallUpdateButton.UseVisualStyleBackColor = true;
@@ -264,45 +288,50 @@
             // LatestVersionLabel
             // 
             this.LatestVersionLabel.AutoSize = true;
-            this.LatestVersionLabel.Location = new System.Drawing.Point(86, 43);
+            this.LatestVersionLabel.Location = new System.Drawing.Point(115, 53);
+            this.LatestVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LatestVersionLabel.Name = "LatestVersionLabel";
-            this.LatestVersionLabel.Size = new System.Drawing.Size(25, 13);
+            this.LatestVersionLabel.Size = new System.Drawing.Size(32, 17);
             this.LatestVersionLabel.TabIndex = 4;
             this.LatestVersionLabel.Text = "???";
             // 
             // LatestVersionLabelLabel
             // 
             this.LatestVersionLabelLabel.AutoSize = true;
-            this.LatestVersionLabelLabel.Location = new System.Drawing.Point(7, 43);
+            this.LatestVersionLabelLabel.Location = new System.Drawing.Point(9, 53);
+            this.LatestVersionLabelLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LatestVersionLabelLabel.Name = "LatestVersionLabelLabel";
-            this.LatestVersionLabelLabel.Size = new System.Drawing.Size(76, 13);
+            this.LatestVersionLabelLabel.Size = new System.Drawing.Size(101, 17);
             this.LatestVersionLabelLabel.TabIndex = 3;
             this.LatestVersionLabelLabel.Text = "Latest version:";
             // 
             // LocalVersionLabel
             // 
             this.LocalVersionLabel.AutoSize = true;
-            this.LocalVersionLabel.Location = new System.Drawing.Point(86, 20);
+            this.LocalVersionLabel.Location = new System.Drawing.Point(115, 25);
+            this.LocalVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LocalVersionLabel.Name = "LocalVersionLabel";
-            this.LocalVersionLabel.Size = new System.Drawing.Size(37, 13);
+            this.LocalVersionLabel.Size = new System.Drawing.Size(47, 17);
             this.LocalVersionLabel.TabIndex = 2;
             this.LocalVersionLabel.Text = "v0.0.0";
             // 
             // LocalVersionLabelLabel
             // 
             this.LocalVersionLabelLabel.AutoSize = true;
-            this.LocalVersionLabelLabel.Location = new System.Drawing.Point(7, 20);
+            this.LocalVersionLabelLabel.Location = new System.Drawing.Point(9, 25);
+            this.LocalVersionLabelLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LocalVersionLabelLabel.Name = "LocalVersionLabelLabel";
-            this.LocalVersionLabelLabel.Size = new System.Drawing.Size(73, 13);
+            this.LocalVersionLabelLabel.Size = new System.Drawing.Size(96, 17);
             this.LocalVersionLabelLabel.TabIndex = 1;
             this.LocalVersionLabelLabel.Text = "Local version:";
             // 
             // CheckForUpdatesButton
             // 
             this.CheckForUpdatesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CheckForUpdatesButton.Location = new System.Drawing.Point(6, 76);
+            this.CheckForUpdatesButton.Location = new System.Drawing.Point(8, 94);
+            this.CheckForUpdatesButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CheckForUpdatesButton.Name = "CheckForUpdatesButton";
-            this.CheckForUpdatesButton.Size = new System.Drawing.Size(104, 23);
+            this.CheckForUpdatesButton.Size = new System.Drawing.Size(139, 28);
             this.CheckForUpdatesButton.TabIndex = 0;
             this.CheckForUpdatesButton.Text = "Check for updates";
             this.CheckForUpdatesButton.UseVisualStyleBackColor = true;
@@ -311,9 +340,10 @@
             // HideEpochsCheckbox
             // 
             this.HideEpochsCheckbox.AutoSize = true;
-            this.HideEpochsCheckbox.Location = new System.Drawing.Point(6, 42);
+            this.HideEpochsCheckbox.Location = new System.Drawing.Point(8, 52);
+            this.HideEpochsCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.HideEpochsCheckbox.Name = "HideEpochsCheckbox";
-            this.HideEpochsCheckbox.Size = new System.Drawing.Size(261, 17);
+            this.HideEpochsCheckbox.Size = new System.Drawing.Size(349, 21);
             this.HideEpochsCheckbox.TabIndex = 8;
             this.HideEpochsCheckbox.Text = "Hide epoch numbers in mod list (Requires Restart)";
             this.HideEpochsCheckbox.UseVisualStyleBackColor = true;
@@ -321,11 +351,14 @@
             // 
             // MoreSettingsGroupBox
             // 
+            this.MoreSettingsGroupBox.Controls.Add(this.HideVCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.HideEpochsCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.AutoSortUpdateCheckBox);
-            this.MoreSettingsGroupBox.Location = new System.Drawing.Point(12, 446);
+            this.MoreSettingsGroupBox.Location = new System.Drawing.Point(16, 549);
+            this.MoreSettingsGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MoreSettingsGroupBox.Name = "MoreSettingsGroupBox";
-            this.MoreSettingsGroupBox.Size = new System.Drawing.Size(476, 65);
+            this.MoreSettingsGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.MoreSettingsGroupBox.Size = new System.Drawing.Size(635, 113);
             this.MoreSettingsGroupBox.TabIndex = 14;
             this.MoreSettingsGroupBox.TabStop = false;
             this.MoreSettingsGroupBox.Text = "More Settings";
@@ -333,19 +366,32 @@
             // AutoSortUpdateCheckBox
             // 
             this.AutoSortUpdateCheckBox.AutoSize = true;
-            this.AutoSortUpdateCheckBox.Location = new System.Drawing.Point(6, 19);
+            this.AutoSortUpdateCheckBox.Location = new System.Drawing.Point(8, 23);
+            this.AutoSortUpdateCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AutoSortUpdateCheckBox.Name = "AutoSortUpdateCheckBox";
-            this.AutoSortUpdateCheckBox.Size = new System.Drawing.Size(393, 17);
+            this.AutoSortUpdateCheckBox.Size = new System.Drawing.Size(511, 21);
             this.AutoSortUpdateCheckBox.TabIndex = 0;
             this.AutoSortUpdateCheckBox.Text = "Automatically sort by \"Update\"-column when clicking \"Add available updates\"";
             this.AutoSortUpdateCheckBox.UseVisualStyleBackColor = true;
             this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
             // 
+            // HideVCheckbox
+            // 
+            this.HideVCheckbox.AutoSize = true;
+            this.HideVCheckbox.Location = new System.Drawing.Point(8, 80);
+            this.HideVCheckbox.Margin = new System.Windows.Forms.Padding(4);
+            this.HideVCheckbox.Name = "HideVCheckbox";
+            this.HideVCheckbox.Size = new System.Drawing.Size(268, 21);
+            this.HideVCheckbox.TabIndex = 9;
+            this.HideVCheckbox.Text = "Hide \"v\" in mod list (Requires Restart)";
+            this.HideVCheckbox.UseVisualStyleBackColor = true;
+            this.HideVCheckbox.CheckedChanged += new System.EventHandler(this.HideVCheckbox_CheckedChanged);
+            // 
             // SettingsDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(495, 519);
+            this.ClientSize = new System.Drawing.Size(660, 675);
             this.Controls.Add(this.MoreSettingsGroupBox);
             this.Controls.Add(this.AutoUpdateGroupBox);
             this.Controls.Add(this.CacheGroupBox);
@@ -353,6 +399,7 @@
             this.Controls.Add(this.AuthTokensGroupBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "SettingsDialog";
             this.Text = "Settings";
             this.Load += new System.EventHandler(this.SettingsDialog_Load);
@@ -395,5 +442,6 @@
         private System.Windows.Forms.CheckBox HideEpochsCheckbox;
         private System.Windows.Forms.GroupBox MoreSettingsGroupBox;
         private System.Windows.Forms.CheckBox AutoSortUpdateCheckBox;
+        private System.Windows.Forms.CheckBox HideVCheckbox;
     }
 }

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -38,6 +38,7 @@ namespace CKAN
             CheckUpdateOnLaunchCheckbox.Checked = Main.Instance.configuration.CheckForUpdatesOnLaunch;
             RefreshOnStartupCheckbox.Checked = Main.Instance.configuration.RefreshOnStartup;
             HideEpochsCheckbox.Checked = Main.Instance.configuration.HideEpochs;
+            HideVCheckbox.Checked = Main.Instance.configuration.HideV;
             AutoSortUpdateCheckBox.Checked = Main.Instance.configuration.AutoSortByUpdate;
 
 
@@ -429,10 +430,18 @@ namespace CKAN
             Main.Instance.configuration.Save();
         }
 
+        private void HideVCheckbox_CheckedChanged(object sender, EventArgs e)
+        {
+            Main.Instance.configuration.HideV = HideVCheckbox.Checked;
+            Main.Instance.configuration.Save();
+        }
+
         private void AutoSortUpdateCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.AutoSortByUpdate = AutoSortUpdateCheckBox.Checked;
             Main.Instance.configuration.Save();
         }
+
+
     }
 }

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -639,6 +639,7 @@ namespace Tests.Data
               <CheckForUpdatesOnLaunch>true</CheckForUpdatesOnLaunch>
               <CheckForUpdatesOnLaunchNoNag>true</CheckForUpdatesOnLaunchNoNag>
               <HideEpochs>true</HideEpochs>
+              <HideV>false</HideV>
               <SortByColumnIndex>2</SortByColumnIndex>
               <SortDescending>false</SortDescending>
               <WindowSize>


### PR DESCRIPTION
```
v3.4.5-whatever → 3.4.5-whatever
V.3.4.5         → 3.4.5
Version_3.4.5   → 3.4.5
V21             → 21
vessel_5.1      → vessel_5.1
```

cons:	
```
V1deo → 1deo
```

Not sure what is `2` in `2:v3.4.5`, and why it in `LatestVersion` and not in the GUI column, I mean where `2:` is removed from `LatestVersion`, but `2:` is leaved there.
```
2:v3.4.5 → 2:3.4.5
```
