### PR TITLE
Support new Curse URLs with non-numeric IDs

### DIFF
--- a/Netkan/Sources/Curse/ICurseApi.cs
+++ b/Netkan/Sources/Curse/ICurseApi.cs
@@ -3,8 +3,8 @@ namespace CKAN.NetKAN.Sources.Curse
     internal interface ICurseApi
     {
         /// <summary>
-        /// Given a mod Id, returns a CurseMod with its metadata from the network.
+        /// Given a mod name or id, returns a CurseMod with its metadata from the network
         /// </summary>
-        CurseMod GetMod(int modId);
+        CurseMod GetMod(string nameOrId);
     }
 }

--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -34,7 +34,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
                 // Look up our mod on Curse by its Id.
-                var curseMod = _api.GetMod(Convert.ToInt32(metadata.Kref.Id));
+                var curseMod = _api.GetMod(metadata.Kref.Id);
                 var latestVersion = curseMod.Latest();
 
                 Log.InfoFormat("Found Curse mod: {0} {1}", curseMod.GetName(), latestVersion.GetFileVersion());

--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -32,18 +32,43 @@ namespace Tests.NetKAN.Sources.Curse
 
         [Test]
         [Category("FlakyNetwork"), Category("Online")]
+        public void GetsOldModCorrectly()
+        {
+            // Arrange
+            var sut = new CurseApi(new CachingHttpService(_cache));
+
+            // Act
+            var result = sut.GetMod("220221"); // MechJeb
+
+            // Assert
+            var latestVersion = result.Latest();
+
+            Assert.That(result.id, Is.EqualTo(220221));
+            Assert.That(result.members, Is.Not.Null);
+            Assert.That(result.thumbnail, Is.Not.Null);
+            Assert.That(result.license, Is.Not.Null);
+            Assert.That(result.title, Is.Not.Null);
+            Assert.That(result.description, Is.Not.Null);
+            Assert.That(result.files.Count, Is.GreaterThan(0));
+            Assert.That(latestVersion.GetDownloadUrl(), Is.Not.Null);
+            Assert.That(latestVersion.GetFileVersion(), Is.Not.Null);
+            Assert.That(latestVersion.version, Is.Not.Null); // KSP Version
+        }
+
+        [Test]
+        [Category("FlakyNetwork"), Category("Online")]
         public void GetsModCorrectly()
         {
             // Arrange
             var sut = new CurseApi(new CachingHttpService(_cache));
 
             // Act
-            var result = sut.GetMod(220221); // MechJeb
+            var result = sut.GetMod("photonsail");
 
             // Assert
             var latestVersion = result.Latest();
 
-            Assert.That(result.id, Is.EqualTo(220221));
+            Assert.That(result.id, Is.EqualTo(296653));
             Assert.That(result.members, Is.Not.Null);
             Assert.That(result.thumbnail, Is.Not.Null);
             Assert.That(result.license, Is.Not.Null);
@@ -63,7 +88,7 @@ namespace Tests.NetKAN.Sources.Curse
             var sut = new CurseApi(new CachingHttpService(_cache));
 
             // Act
-            TestDelegate act = () => sut.GetMod(-1);
+            TestDelegate act = () => sut.GetMod("-1");
 
             // Assert
             Assert.That(act, Throws.Exception.InstanceOf<Kraken>());

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -17,7 +17,7 @@ namespace Tests.NetKAN.Transformers
         {
             // Arrange
             var mApi = new Mock<ICurseApi>();
-            mApi.Setup(i => i.GetMod(It.IsAny<int>()))
+            mApi.Setup(i => i.GetMod(It.IsAny<string>()))
                 .Returns(MakeTestMod());
 
             var sut = new CurseTransformer(mApi.Object);


### PR DESCRIPTION
## Background

The format of Curse API URLs changed recently, but some old URLs are still supported; see the discussion in KSP-CKAN/NetKAN#6608 for details.

Old format:

- https://api.cfwidget.com/project/220602

New format:

- https://api.cfwidget.com/kerbal/ksp-mods/photonsail

Any old URL that had been accessed before March 2017 still works thanks to caching internal to the API, but any newly added mod must use the new format.

## Problem

Netkan fails on mods added to curse after March 2017. See KSP-CKAN/NetKAN#6608 for an example; PhotonSailor can't be indexed without updating our Curse API logic.

(UPDATE: We switched that mod to SpaceDock instead, so the urgency is lower, but the problem would still affect future new mods hosted only on Curse.)

## Changes

Now the `id` part of the `#/ckan/curse/id` kref string may contain either a number or a non-number. If it's a number, the old format URL is used for backwards compatibility with existing metadata. If it's not a number, then the new format is used.

In addition, the Netkan log message that prints the API URL being accessed is promoted from debug to info, so it can be seen when `--verbose` is enabled.

A test is added to exercise the new format.