### PR TITLE
Fix Netkan error message when both ksp_version and ksp_version_min/_max are present

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -748,6 +748,7 @@ namespace CKAN
         private readonly string why;
 
         public InvalidModuleAttributesException(string why, CkanModule module = null)
+            : base(why)
         {
             this.why = why;
             this.module = module;

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -85,6 +85,8 @@ namespace CKAN.NetKAN
             }
             catch (Exception e)
             {
+                e = e.GetBaseException() ?? e;
+
                 Log.Fatal(e.Message);
 
                 if (Options == null || Options.Debug)


### PR DESCRIPTION
## Problem

KSP-CKAN/NetKAN#6654 got tripped up by this very confusing error message:

```
9493 [1] FATAL CKAN.NetKAN.Program (null) - Exception has been thrown by the target of an invocation.
```

The root cause was that the generated metadata had this:

```json
  "ksp_version": "1.4.0",
  "ksp_version_min": "1.4.0",
  "ksp_version_max": "1.4.99",
```

These properties aren't supposed to be combined; either you have `ksp_version`, or you have `_min` and/or `_max`. We have a check for that with its own special exception here:

https://github.com/KSP-CKAN/CKAN/blob/4120e9b1cb60f0937a8c9fb71e6279a4d72012a2/Core/Types/CkanModule.cs#L444-L449

However, that info wasn't making it all the way to the output.

## Changes

Netkan now uses `Exception.GetBaseException()` to strip away useless wrapper exceptions.

`InvalidModuleAttributesException` now passes its `why` parameter to its base class's constructor, which populates `Exception.Message` for Netkan to print out.

Now the error looks like this instead:

```
1344 [1] FATAL CKAN.NetKAN.Program (null) - ksp_version mixed with ksp_version_(min|max)
```