### PR TITLE
Fix crash when initializing CKAN dirs at argumentless GUI startup

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -40,9 +40,9 @@ namespace CKAN.CmdLine
                 Debugger.Launch();
             }
 
-            if (args.Length == 1 && args.Any(i => i == "--verbose" || i == "--debug"))
+            // Default to GUI if there are no command line args or if the only args are flags rather than commands.
+            if (args.All(a => a == "--verbose" || a == "--debug" || a == "--asroot" || a == "--show-console"))
             {
-                // Start the gui with logging enabled #437
                 var guiCommand = args.ToList();
                 guiCommand.Insert(0, "gui");
                 args = guiCommand.ToArray();
@@ -54,12 +54,6 @@ namespace CKAN.CmdLine
             // Force-allow TLS 1.2 for HTTPS URLs, because GitHub requires it.
             // This is on by default in .NET 4.6, but not in 4.5.
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
-
-            // If we're starting with no options then invoke the GUI instead.
-            if (args.Length == 0)
-            {
-                return Gui(null, new GuiOptions(), args);
-            }
 
             try
             {

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -21,12 +21,18 @@ namespace CKAN
 
         protected override void DisplayMessage(string message, params object[] args)
         {
-            displayMessage(message, args);
+            if (displayMessage != null)
+            {
+                displayMessage(message, args);
+            }
         }
 
         protected override void DisplayError(string message, params object[] args)
         {
-            displayError(message, args);
+            if (displayError != null)
+            {
+                displayError(message, args);
+            }
         }
 
         protected override void ReportProgress(string format, int percent)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -163,11 +163,13 @@ namespace CKAN
         {
             log.Info("Starting the GUI");
             commandLineArgs = cmdlineArgs;
+
+            // These are used by KSPManager's constructor to show messages about directory creation
+            user.displayMessage = AddStatusMessage;
+            user.displayError   = ErrorDialog;
+
             manager = mgr ?? new KSPManager(user);
             currentUser = user;
-
-            user.displayMessage = AddStatusMessage;
-            user.displayError = ErrorDialog;
 
             controlFactory = new ControlFactory();
             Instance = this;


### PR DESCRIPTION
## Problem

Starting in CKAN 1.25.2, If you run the GUI without arguments, and it needs to initialize your CKAN folder, you'll see this:

```
$ mono ckan.exe 
exception inside UnhandledException handler: Object reference not set to an instance of an object

[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
  at CKAN.GUIUser.DisplayMessage (System.String message, System.Object[] args) [0x00000] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.NullUser.RaiseMessage (System.String message, System.Object[] args) [0x00000] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.KSP.SetupCkanDirectories () [0x000dd] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.KSP..ctor (System.String gameDir, System.String name, CKAN.IUser user) [0x00038] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x00060] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x00028] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.Main..ctor (System.String[] cmdlineArgs, CKAN.KSPManager mgr, CKAN.GUIUser user, System.Boolean showConsole) [0x00039] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at (wrapper remoting-invoke-with-check) CKAN.Main..ctor(string[],CKAN.KSPManager,CKAN.GUIUser,bool)
  at CKAN.GUI.Main_ (System.String[] args, CKAN.KSPManager manager, System.Boolean showConsole) [0x0003b] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.CmdLine.MainClass.Gui (CKAN.KSPManager manager, CKAN.CmdLine.GuiOptions options, System.String[] args) [0x00008] in <352d74f237564d2e9ff313cc9ac1989e>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x000a1] in <352d74f237564d2e9ff313cc9ac1989e>:0 
```

This doesn't happen if you run `ckan gui`, which the .deb package does.

## Causes

Many different things had to go subtly wrong for this to happen.

When CKAN creates the child folders of the CKAN folder, it (somewhat pointlessly) uses its `IUser` reference to announce the folders it's creating:

https://github.com/KSP-CKAN/CKAN/blob/7e0552316a1bdd72577e86537d0cf34c96eeb59c/Core/KSP.cs#L77-L115

These are never seen because only `NullUser` objects were passed as `User` here previously, and that class discards the messages. (They may be displayed when using CmdLine, I'm not sure.) This code is called from `KSPManager`'s constructor.

As of #2449, it's possible for a `GUIUser` to be passed instead. `GUIUser` is not a well encapsulated class; it relies on external code to set its properties so it can work properly. Specifically, if its `displayMessage` property isn't set, then calling `GUIUser.DisplayMessage` will throw an exception:

https://github.com/KSP-CKAN/CKAN/blob/7e0552316a1bdd72577e86537d0cf34c96eeb59c/GUI/GUIUser.cs#L10
https://github.com/KSP-CKAN/CKAN/blob/7e0552316a1bdd72577e86537d0cf34c96eeb59c/GUI/GUIUser.cs#L22-L25

In the `NullUser` family of which `GUIUser` is a part, `DisplayMessage` is a synonym for `RaiseMessage`, so that exception could happen when we try to announce that we created a directory:

https://github.com/KSP-CKAN/CKAN/blob/7e0552316a1bdd72577e86537d0cf34c96eeb59c/Core/User.cs#L74-L77

And sure enough, as of #2449, we can end up calling `SetupCkanDirectories` (via `KSPManager`'s constructor) before that property is set:

https://github.com/KSP-CKAN/CKAN/blob/7e0552316a1bdd72577e86537d0cf34c96eeb59c/GUI/Main.cs#L166-L170

This vulnerability is only hit if you run "ckan" or "mono ckan" without any other parameters, because a special block of code detects that case and `null` is passed here to let GUI make its own `KSPManager` object:

https://github.com/KSP-CKAN/CKAN/blob/7e0552316a1bdd72577e86537d0cf34c96eeb59c/Cmdline/Main.cs#L58-L62

In all other cases, the command line parsing code creates the `KSPManager` object here so it can find the default game instance, which avoids the issue since it doesn't use `GUIUser`:

https://github.com/KSP-CKAN/CKAN/blob/7e0552316a1bdd72577e86537d0cf34c96eeb59c/Cmdline/Main.cs#L125-L128

## Changes

The two different sets of logic for defaulting to "gui" when no other command is present are now merged into one for consistency. Instead of checking the number of arguments twice, we use the Linq function `All` to check the arguments, which returns true if the list is empty, and instead of prepending "gui" to the arg list in one case and directly calling `Gui` in the other, we now always prepend "gui" to allow full processing of the arguments consistent with other cases. Technically this would have been enough to fix the crash by itself (since now the argumentless case works the same as "ckan gui", which doesn't crash), but the other problem areas warrant some attention as well to increase general robustness.

Now `GUIUser` checks if its properties are null before calling them, so this situation won't cause null reference exceptions again. This also would have fixed the crash by itself.

Now if GUI needs to instantiate its own `KSPManager`, it will set the required `GUIUser` properties before it does that. This also would have fixed the crash by itself.

Fixes #2483.