### PR TITLE
Fix GUIMod crash when module doesn't have a compatible game version

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -268,7 +268,7 @@ namespace CKAN
 
         private bool Equals(GUIMod other)
         {
-            return Equals(Name, other.Name);
+            return Equals(Identifier, other.Identifier);
         }
 
         public override bool Equals(object obj)
@@ -281,7 +281,7 @@ namespace CKAN
 
         public override int GetHashCode()
         {
-            return (Name != null ? Name.GetHashCode() : 0);
+            return Identifier?.GetHashCode() ?? 0;
         }
 
     }

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -42,9 +42,6 @@ namespace CKAN
         public bool IsCKAN { get; private set; }
         public string Abbrevation { get; private set; }
 
-        private bool VersionMaxWasGenerated = false;
-        private Dictionary<string, KspVersion> VersionsMax;
-
         /// <summary>
         /// Return whether this mod is installable.
         /// Used for determining whether to show a checkbox in the leftmost column.
@@ -66,19 +63,6 @@ namespace CKAN
         public string Version
         {
             get { return IsInstalled ? InstalledVersion : LatestVersion; }
-        }
-
-        /// <returns>
-        ///   0 - 9   //  9  - 99    //  99 - 999    
-        ///   1 - 9   //  10 - 99    // 100 - 999
-        ///   8 - 9   //  98 - 99    // 
-        /// </returns>
-        private int UptoNines(int num)
-        {
-            //if (num == 0)
-            //    return 0;
-            //else
-                return (int)Math.Pow(10, Math.Floor(Math.Log10(num + 1)) + 1) - 1;
         }
 
         public GUIMod(CkanModule mod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool incompatible = false)
@@ -132,45 +116,8 @@ namespace CKAN
             // KSP.
             if (latest_available_for_any_ksp != null)
             {
-                if (!VersionMaxWasGenerated)
-                {
-                    VersionMaxWasGenerated = true;
-                    List<KspVersion> versions = new KspBuildMap(new Win32Registry()).KnownVersions;  // should be sorted
-
-                    VersionsMax = new Dictionary<string, KspVersion>();
-                    VersionsMax[""] = versions.Last();
-
-                    foreach (var v in versions)
-                    {
-                        VersionsMax[v.Major.ToString()] = v;        // add or replace
-                        VersionsMax[v.Major + "." + v.Minor] = v;   
-                    }
-                }
-
-                const int Undefined = -1;
-
-                KspVersion ksp_ver = registry.LatestCompatibleKSP(mod.identifier);
-                string ver = ksp_ver?.ToString();
-                int major = ksp_ver.Major, minor = ksp_ver.Minor, patch = ksp_ver.Patch;
-                KspVersion value;
-
-                if ( major == Undefined
-                    //|| (major >= UptoNines(VersionsMax[""].Major))       // 9.99.99
-                    || (major > VersionsMax[""].Major)                     // 2.0.0 
-                    || (major == VersionsMax[""].Major && VersionsMax.TryGetValue(major.ToString(), out value) && minor >= UptoNines(value.Minor))  // 1.99.99 ?
-                    )
-                    KSPCompatibility = "any";
-
-                else if (minor != Undefined
-                    && VersionsMax.TryGetValue(major + "." + minor, out value)
-                    && (patch == Undefined || patch >= UptoNines(value.Patch))
-                    )
-                    KSPCompatibility = major + "." + minor + "." + UptoNines(value.Patch);
-
-                else
-                    KSPCompatibility = ver;
-
-                // KSPCompatibility += " | " + major + "." + minor + "." + patch;   // for testing
+                KSPCompatibility = registry.LatestCompatibleKSP(mod.identifier)?.ToYalovString()
+                    ?? "Unknown";
 
                 // If the mod we have installed is *not* the mod we have installed, or we don't know
                 // what we have installed, indicate that an upgrade would be needed.
@@ -178,13 +125,11 @@ namespace CKAN
                 {
                     KSPCompatibilityLong = string.Format("{0} (using mod version {1})",
                         KSPCompatibility, latest_available_for_any_ksp.version);
-                    //    ver, latest_available_for_any_ksp.version);   //  true values in the right tab
 
                 }
                 else
                 {
                     KSPCompatibilityLong = KSPCompatibility;
-                    // KSPCompatibilityLong = ver;   //  true values in the right tab
                 }
             }
             else


### PR DESCRIPTION
## Problems

As of #2437, if you have an installed module that has since been completely de-indexed (e.g., MiniAVC: KSP-CKAN/CKAN-meta#561, https://github.com/KSP-CKAN/CKAN-meta/commit/6cd629492ab5c35e02137b93ecb20b9d8f3dcb1a), this exception happens at GUI startup:

```
System.NullReferenceException: Object reference not set to an instance of an object
  at CKAN.GUIMod..ctor (CKAN.CkanModule mod, CKAN.IRegistryQuerier registry, CKAN.Versioning.KspVersionCriteria current_ksp_version, System.Boolean incompatible) [0x003d6] in <60e037f139274e47b1d6c0206eefe140>:0 
  at CKAN.Main+<>c__DisplayClass229_0.<_UpdateModsList>b__2 (CKAN.InstalledModule m) [0x00006] in <60e037f139274e47b1d6c0206eefe140>:0 
  at System.Linq.Enumerable+SelectEnumerableIterator`2[TSource,TResult].MoveNext () [0x00048] in <cc3b329d40bd4675ae0e985e302972af>:0 
  at System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].MoveNext () [0x0004e] in <cc3b329d40bd4675ae0e985e302972af>:0 
  at CKAN.Main._UpdateModsList (System.Boolean repo_updated, System.Collections.Generic.List`1[T] mc) [0x000fe] in <60e037f139274e47b1d6c0206eefe140>:0 
  at CKAN.Main+<>c__DisplayClass228_0.<UpdateModsList>b__0 () [0x0001b] in <60e037f139274e47b1d6c0206eefe140>:0 
  at CKAN.Util.Invoke[T] (T obj, System.Action action) [0x0002d] in <60e037f139274e47b1d6c0206eefe140>:0 
  at CKAN.Main.UpdateModsList (System.Boolean repo_updated, System.Collections.Generic.List`1[T] mc) [0x0001c] in <60e037f139274e47b1d6c0206eefe140>:0 
  at CKAN.Main.CurrentInstanceUpdated () [0x00062] in <60e037f139274e47b1d6c0206eefe140>:0 
  at CKAN.Main.OnLoad (System.EventArgs e) [0x002c2] in <60e037f139274e47b1d6c0206eefe140>:0 
  at System.Windows.Forms.Form.OnLoadInternal (System.EventArgs e) [0x00023] in <beba0b11547e4333a33d4d8cdf7b7c51>:0 
Waiting on threads to park on joinable thread list timed out.
```

Unrelatedly, if you had the old standalone MiniAVC module installed, it was not shown in the mod list.

## Causes

This happens when one of your installed modules is totally de-indexed. I only understood this after @cculianu shared his `registry.json`, so this PR's description previously said the cause was unknown:

> <details>
> <summary>Old obsolete investigation notes</summary>
> The exact cause is a bit mysterious. Only @cculianu has reported seeing this so far. A testing component revealed that the exception happens while the GUI is attempting to generate a mod list row for MiniAVC 1.0.3.0:
> 
> ```
> System.Exception: Failed to construct a GUIMod for MiniAVC 1.0.3.0 (Object reference not set to an instance of an object)
> ```
> 
> The same testing component established that the exception is thrown inside this block from #2437:
> 
> https://github.com/KSP-CKAN/CKAN/blob/ab714c224b9b446ac4a6d9c9b209b73f14bfa752/GUI/GUIMod.cs#L135-L173
> 
> However...
> 
> - MiniAVC isn't indexed in CKAN! It's only distributed as a bundled DLL inside other mods.
> - If CKAN installed MiniAVC.dll as part of another mod, then it would not be added to the mods list but rather counted as an installed file and ignored, so it must have gotten there some other way; yet the issue report says no manual changes were made to GameData.
> - 1.0.3.0 is a valid MiniAVC release version (from 2014), but there is no known pathway by which CKAN could have gotten that version string without metadata for it in the registry!
> 
> Hitting a dead end in trying to make this crash happen on my PC, I turned to auditing the code.
> </details>
> 

The crash happens here; since MiniAVC isn't in the registry, the `LatestCompatibleKSP` call returns null, and shortly after that the code attempts to access properties of that null reference:

https://github.com/KSP-CKAN/CKAN/blob/ab714c224b9b446ac4a6d9c9b209b73f14bfa752/GUI/GUIMod.cs#L152-L154

## Changes

- #2437's version formatting logic is moved from being embedded in `GUIMod`'s constructor to `KspVersion.ToYalovString`. This eliminates the possibility of the version object being null inside the function. Instead, null is now checked before the function is called, and we fall back to a version string of "Unknown" in that case. It also allows us to use this logic in other places as well as test it (not included in this PR).
- The `VersionsMax` dictionary is now static and only generated once rather than being redundantly re-generated for every module.
- A bunch of commented code is removed.
- `VersionMaxWasGenerated` is removed and the generation code it governed is moved to a static constructor which accomplishes the same thing more reliably with less overhead.
- `GUIMod`'s comparison operations now check the `Identifier` rather than the `Name`. This allows the old MiniAVC module to appear in the mod list, where it previously was hidden because its `Name` was the same as KSP-AVC's.

Fixes #2481.