### PR TITLE
Fix missing CdFileMgr folder errors

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -31,7 +31,6 @@ namespace CKAN
         private static SortedList<string, ModuleInstaller> instances = new SortedList<string, ModuleInstaller>();
 
         private static readonly ILog log = LogManager.GetLogger(typeof(ModuleInstaller));
-        private static readonly TxFileManager file_transaction = new TxFileManager();
 
         private RegistryManager registry_manager;
         private KSP ksp;
@@ -686,6 +685,8 @@ namespace CKAN
         /// </summary>
         internal static void CopyZipEntry(ZipFile zipfile, ZipEntry entry, string fullPath, bool makeDirs)
         {
+            TxFileManager file_transaction = new TxFileManager();
+
             if (entry.IsDirectory)
             {
                 // Skip if we're not making directories for this install.
@@ -809,6 +810,8 @@ namespace CKAN
 
         private void Uninstall(string modName)
         {
+            TxFileManager file_transaction = new TxFileManager();
+
             using (var transaction = CkanTransaction.CreateTransactionScope())
             {
                 InstalledModule mod = registry_manager.registry.InstalledModule(modName);

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -21,7 +21,6 @@ namespace CKAN
         public static string UserAgentString = "Mozilla/4.0 (compatible; CKAN)";
 
         private static readonly ILog          log             = LogManager.GetLogger(typeof(Net));
-        private static readonly TxFileManager FileTransaction = new TxFileManager();
 
         public static readonly Dictionary<string, Uri> ThrottledHosts = new Dictionary<string, Uri>()
         {
@@ -46,6 +45,8 @@ namespace CKAN
 
         public static string Download(string url, string filename = null, IUser user = null)
         {
+            TxFileManager FileTransaction = new TxFileManager();
+
             user = user ?? new NullUser();
             user.RaiseMessage("Downloading {0}", url);
 
@@ -128,6 +129,8 @@ namespace CKAN
 
             public DownloadTarget(Uri url, Uri fallback = null, string filename = null, long size = 0, string mimeType = "")
             {
+                TxFileManager FileTransaction = new TxFileManager();
+
                 this.url         = url;
                 this.fallbackUrl = fallback;
                 this.filename    = string.IsNullOrEmpty(filename)

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -24,7 +24,6 @@ namespace CKAN
         private FileSystemWatcher watcher;
         private string[] cachedFiles;
         private string cachePath;
-        private static readonly TxFileManager tx_file = new TxFileManager();
         private static readonly ILog log = LogManager.GetLogger(typeof (NetFileCache));
 
         public NetFileCache(string _cachePath)
@@ -291,6 +290,8 @@ namespace CKAN
         {
             log.DebugFormat("Storing {0}", url);
 
+            TxFileManager tx_file = new TxFileManager();
+
             // Make sure we clear our cache entry first.
             Remove(url);
 
@@ -330,6 +331,8 @@ namespace CKAN
         /// </summary>
         public bool Remove(Uri url)
         {
+            TxFileManager tx_file = new TxFileManager();
+
             string file = GetCachedFilename(url);
 
             if (file != null)

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -21,7 +21,6 @@ namespace CKAN
     public static class Repo
     {
         private static readonly ILog log = LogManager.GetLogger(typeof (Repo));
-        private static TxFileManager file_transaction = new TxFileManager();
 
         /// <summary>
         /// Download and update the local CKAN meta-info.
@@ -79,6 +78,8 @@ namespace CKAN
         /// </summary>
         private static List<CkanModule> UpdateRegistry(Uri repo, KSP ksp, IUser user)
         {
+            TxFileManager file_transaction = new TxFileManager();
+
             // Use this opportunity to also update the build mappings... kind of hacky
             ServiceLocator.Container.Resolve<IKspBuildMap>().Refresh();
 

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -24,7 +24,6 @@ namespace CKAN
         private FileStream lockfileStream = null;
         private StreamWriter lockfileWriter = null;
 
-        private readonly TxFileManager file_transaction = new TxFileManager();
 
         // The only reason we have a KSP field is so we can pass it to the registry
         // when deserialising, and *it* only needs it to do registry upgrades.
@@ -414,6 +413,8 @@ namespace CKAN
 
         public void Save(bool enforce_consistency = true)
         {
+            TxFileManager file_transaction = new TxFileManager();
+
             log.InfoFormat("Saving CKAN registry at {0}", path);
 
             if (enforce_consistency)
@@ -463,6 +464,8 @@ namespace CKAN
         /// <param name="with_versions">True to include the mod versions in the file, false to omit them</param>
         public void ExportInstalled(string path, bool recommends, bool with_versions)
         {
+            TxFileManager file_transaction = new TxFileManager();
+
             string serialized = SerializeCurrentInstall(recommends, with_versions);
             file_transaction.WriteAllText(path, serialized);
         }


### PR DESCRIPTION
## Background

CKAN uses a transaction library to make its filesystem operations atomic / rollbackable. This library uses a temp folder at `%TEMP%\CdFileMgr` or `/tmp/CdFileMgr` to store in-progress changes so they can be un-done if there's a problem.

## Problem

If CKAN is left open for a long time (~24 hours?) on Windows, this exception may be seen when attempting to update the registry or install a module:

```
System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\Users\name\AppData\Local\Temp\CdFileMgr\02a3e0a6-bc35-40.json'.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.File.InternalCopy(String sourceFileName, String destFileName, Boolean overwrite, Boolean checkHost)
   at ChinhDo.Transactions.WriteAllTextOperation.Execute()
   at ChinhDo.Transactions.TxFileManager.EnlistOperation(IRollbackableOperation operation)
   at CKAN.RegistryManager.Save(Boolean enforce_consistency)
   at CKAN.ModuleInstaller.InstallList(ICollection`1 modules, RelationshipResolverOptions options, IDownloader downloader)
   at CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

## Cause

So far no one has been able to pin down exactly how or when this happens, but it seems the operating system must be deleting the empty `CdFileMgr` folder while CKAN is running. We have looked at a few of the possible utilities or scheduled tasks that might be set up to do this, but none of them admit to it. 

After the folder is deleted, any call to the transaction library will cause a filesystem exception, so it's important for the folder to exist.

The transaction library creates `CdFileMgr` when you instantiate `TxFileManager`:

- https://github.com/rsevil/Transactions/blob/8125415d5a74eb129d2d0311762362dfa2679193/src/ChinhDo.Transactions.FileManager/TxFileManager.cs#L16-L22
- https://github.com/rsevil/Transactions/blob/8125415d5a74eb129d2d0311762362dfa2679193/src/ChinhDo.Transactions.FileManager/Utils/FileUtils.cs#L8-L20

However, CKAN only does this in a handful of `private static readonly` objects. Once they're all instantiated, there are no more `Directory.Create` calls available to restore `CdFileMgr` if the OS deletes it out from under us.

## Changes

Now our `TxFileManager` objects are created on the fly as needed; all the `private static readonly` instances are replaced. This will allow the transaction library to ensure that the directory exists right before we need to use it.

Fixes #2342. Fixes #2391.

@linuxgurugamer, you seem to have had the most "luck" reproducing this issue. Would you be willing to stress test this build?

- [ckan.zip](https://github.com/KSP-CKAN/CKAN/files/2268177/ckan.zip)