### PR TITLE
Set default Exception.Message string for ModuleNotFoundKraken

### DIFF
--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -59,12 +59,17 @@ namespace CKAN
         public string version;
 
         // TODO: Is there a way to set the stringify version of this?
-        public ModuleNotFoundKraken(string module, string version = null, string reason = null, Exception innerException = null)
+        public ModuleNotFoundKraken(string module, string version, string reason, Exception innerException = null)
             : base(reason, innerException)
         {
-            this.module = module;
+            this.module  = module;
             this.version = version;
         }
+
+        public ModuleNotFoundKraken(string module, string version = null)
+            : this(module, version, $"Module not found: {module} {version ?? ""}")
+        { }
+
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

When a `ModuleNotFoundKraken` exception is thrown without a description, the `Exception.Message` property is empty. This makes it harder to figure out what caused it.

## Changes

Now `ModuleNotFoundKraken` will auto-generate a simple description if you don't pass one in:

> Module not found: ModuleName v1.2.3.4

Fixes #1992.