### PR TITLE
Replace New in repository filter with Newly compatible filter

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -397,7 +397,7 @@
             // 
             this.FilterNewButton.Name = "FilterNewButton";
             this.FilterNewButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterNewButton.Text = "New in repository";
+            this.FilterNewButton.Text = "Newly compatible";
             this.FilterNewButton.Click += new System.EventHandler(this.FilterNewButton_Click);
             // 
             // FilterNotInstalledButton


### PR DESCRIPTION
## Motivation

GUI's "New in repository" filter shows mods that had no versions at all in the index before the last refresh. It's pretty rare for a mod to be newly indexed, so the usefulness of this is limited. Users would prefer a filter that shows newly indexed mods plus previously-incompatible mods that just had a compatible version indexed.

## Changes

"New in repository" is replaced with "Newly compatible". It now shows mods that were incompatible before the last refresh and compatible after. This is accomplished by limiting the old and new module lists that we compare to only those that are compatible.

| Compatible before? | Compatible after? | New? |
| --- | --- | --- |
| No | No | No |
| Yes | No | No |
| Yes | Yes | No |
| No | Yes | Yes |

Newly-indexed *incompatible* mods will also appear in this filter, in case anyone is interested in them.

Fixes #1923.