### PR TITLE
Fix red X on HideTab

### DIFF
--- a/GUI/TabController.cs
+++ b/GUI/TabController.cs
@@ -111,6 +111,11 @@ namespace CKAN
 
         private void _HideTab(string name)
         {
+            // Unsafe to hide the active tab as of Mono 5.14
+            if (m_TabControl.SelectedTab.Name == name)
+            {
+                m_TabControl.DeselectTab(name);
+            }
             m_TabControl.TabPages.Remove(m_TabPages[name]);
         }
 


### PR DESCRIPTION
## Problem

If you install a mod with recommendations, suggestions, or a `provides` dependency in GUI on Linux with a recent-ish version of Mono, you get a big red X when you accept the recommendations or `provides` selection prompt:

![ckan](https://user-images.githubusercontent.com/29617038/44100833-e801da8a-9fb3-11e8-9e14-9bc1981bbbe0.png)

This was observed on Mono 5.14.0.177, but it works fine on Mono 5.10.1.20. Intermediate versions have not yet been tested.

## Cause

As of some recent version of Mono, it's apparently no longer safe to hide the active tab of a `TabControl`. The control keeps the active tab index as it was, pointing to the removed tab, and then when the runtime attempts to draw the control, it tries to use that index to get the active tab, which doesn't work because it's gone:

```
System.ArgumentOutOfRangeException: ControlCollection does not have that many controls
Parameter name: index
Actual value was 3.
  at System.Windows.Forms.Control+ControlCollection.get_Item (System.Int32 index) [0x00027] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.TabControl.GetTab (System.Int32 index) [0x00006] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.TabControl.GetTabRect (System.Int32 index) [0x00000] in <185f5064526646d192550947861d97b1>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.TabControl.GetTabRect(int)
  at System.Windows.Forms.Theming.Default.TabControlPainter.Draw (System.Drawing.Graphics dc, System.Drawing.Rectangle area, System.Windows.Forms.TabControl tab) [0x000df] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.ThemeWin32Classic.DrawTabControl (System.Drawing.Graphics dc, System.Drawing.Rectangle area, System.Windows.Forms.TabControl tab) [0x0000a] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.TabControl.Draw (System.Drawing.Graphics dc, System.Drawing.Rectangle clip) [0x00005] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.TabControl.OnPaintInternal (System.Windows.Forms.PaintEventArgs pe) [0x00017] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.Control.WmPaint (System.Windows.Forms.Message& m) [0x0006d] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.Control.WndProc (System.Windows.Forms.Message& m) [0x001a4] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.TabControl.WndProc (System.Windows.Forms.Message& m) [0x00057] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.Control+ControlWindowTarget.OnMessage (System.Windows.Forms.Message& m) [0x00000] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.Control+ControlNativeWindow.WndProc (System.Windows.Forms.Message& m) [0x0000b] in <185f5064526646d192550947861d97b1>:0 
  at System.Windows.Forms.NativeWindow.WndProc (System.IntPtr hWnd, System.Windows.Forms.Msg msg, System.IntPtr wParam, System.IntPtr lParam) [0x00085] in <185f5064526646d192550947861d97b1>:0 
```

(However, the actual code for `TabControl` hasn't changed in many years. Maybe it's a new race condition due to threading changes in the draw logic? Who knows.)

This happens in two places currently:

https://github.com/KSP-CKAN/CKAN/blob/37c8477acccd8cebe204da4905cd67760e6bdb31/GUI/MainInstall.cs#L133

https://github.com/KSP-CKAN/CKAN/blob/37c8477acccd8cebe204da4905cd67760e6bdb31/GUI/MainDialogs.cs#L69

It can also be made to happen in a third place if we move  a `HideTab` call before a `ShowTab` call:

https://github.com/KSP-CKAN/CKAN/blob/37c8477acccd8cebe204da4905cd67760e6bdb31/GUI/MainChangeset.cs#L108-L109

## Changes

Luckily we already have a `TabController` wrapper, so we can work around this cleanly.

Now `TabController.HideTab` calls `DeselectTab` if the tab it's hiding is selected (which Mono should be doing itself anyway). This makes it safe to hide tabs again.

Fixes #2499.