### PR TITLE
Fix crash on invalid portable or Steam folder

### DIFF
--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -75,7 +75,11 @@ namespace CKAN
 
             if (path != null)
             {
-                return new KSP(path, "portable", User);
+                KSP portableInst = new KSP(path, "portable", User);
+                if (portableInst.Valid)
+                {
+                    return portableInst;
+                }
             }
 
             // If we only know of a single instance, return that.

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -114,7 +114,8 @@ namespace CKAN
             try
             {
                 string gamedir = KSP.FindGameDir();
-                return AddInstance(new KSP(gamedir, "auto", User));
+                KSP foundInst = new KSP(gamedir, "auto", User);
+                return foundInst.Valid ? AddInstance(foundInst) : null;
             }
             catch (DirectoryNotFoundException)
             {


### PR DESCRIPTION
## Background

A game folder needs a few things to be considered valid by CKAN:

- GameData folder
- Version info, from readme.txt, buildID64.txt, or buildid.txt

Without these, CKAN can't do its job, so it looks for other game folders or gives up and asks the user to specify one. (Or at least that's how it's supposed to work.)

## Problem

If you have KSP installed in your Steam library, and you delete the readme.txt, buildID64.txt, and buildid.txt files, GUI should show the Select KSP Install window to let you specify a valid game folder, but instead it throws this exception:

```
CKAN.NotKSPDirKraken: Could not find KSP version in buildID.txt or readme.txt
at CKAN.KSP.CkanDir()
at CKAN.Main..ctor(String[] cmdlineArgs, KSPManager mgr, GUIUser user, Boolean showConsole)
at CKAN.GUI.Main_(String[] args, KSPManager manager, Boolean showConsole)
at CKAN.CmdLine.MainClass.Main(String[] args)
```

Similarly, the same problem can happen if you run `ckan.exe` from a folder that also has a `GameData` subfolder but not a full copy of KSP.

## Cause

That exception means we've loaded and tried to use an invalid game folder; we should be skipping it instead. We check whether a game folder is valid earlier if it's loaded from the registry, but not if it's being auto-added because `KSP.FindGameDir` found it in a Steam library. In effect the Steam library logic skips some of the folder validation.

Similarly, the "portable" instance logic also skips the same validation.

## Changes

Now `FindAndRegisterDefaultInstance` won't add or return invalid instances, and an invalid "portable" instance will be skipped.
This should mean that GUI will pop up the Select KSP Install window, as intended.

Fixes #2504.