### PR TITLE
Add Install Date column to GUI mod list

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -74,6 +74,7 @@
             this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SizeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.InstallDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -481,6 +482,7 @@
             this.LatestVersion,
             this.KSPCompatibility,
             this.SizeCol,
+            this.InstallDate,
             this.Description});
             this.ModList.ContextMenuStrip = this.ModListContextMenuStrip;
             this.ModList.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -561,6 +563,14 @@
             this.SizeCol.ReadOnly = true;
             this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             // 
+            // InstallDate
+            //
+            this.InstallDate.HeaderText = "Install Date";
+            this.InstallDate.Name = "InstallDate";
+            this.InstallDate.ReadOnly = true;
+            this.InstallDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.InstallDate.Width = 140;
+            //
             // Description
             // 
             this.Description.HeaderText = "Description";
@@ -1147,6 +1157,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn LatestVersion;
         private System.Windows.Forms.DataGridViewTextBoxColumn KSPCompatibility;
         private System.Windows.Forms.DataGridViewTextBoxColumn SizeCol;
+        private System.Windows.Forms.DataGridViewTextBoxColumn InstallDate;
         private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.ContextMenuStrip ModListContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;


### PR DESCRIPTION
## Motivation

CKAN tracks the date and time when a mod was installed, but this information is not shown in GUI. It could be useful to be able to sort installed mods so you can see the order in which they were installed.

## Changes

Now a new sortable Install Date column shows when mods were installed:

![image](https://user-images.githubusercontent.com/1559108/44476327-11476280-a5fd-11e8-95b1-af2ec8991069.png)

To achieve this, you can now construct a `GUIMod` object from an `InstalledModule`, or a `CkanModule`, or a `string` identifier. The constructors are layered by `: this()` calls so the simplest initialization is done first, then supplemented by whatever additional info is at hand. The `InstalledModule`-based constructor populates a new `InstallDate` property.

`MainModList._UpdateModsList` is updated to generate `GUIMod` objects based on `InstalledModule` objects when they are available.

The logic for making one row of the mod list is now split out from `MainModList.ConstructModList` into a new private `MakeRow` function.

Fixes #954. Fixes #1046. Fixes #1933.