### PR TITLE
Catch illegal characters in ZIP exceptions

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -274,6 +274,11 @@ namespace CKAN
                 invalidReason = ze.Message;
                 return false;
             }
+            catch (ArgumentException ex)
+            {
+                invalidReason = ex.Message;
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

If you try to install a ZIP file that contains files with names that are illegal on your OS, an exception is thrown to the unhandled exception handler:

```
Unhandled exception:
System.ArgumentException: Illegal characters in path.
   at System.IO.Path.CheckInvalidPathChars(String path, Boolean checkAdditional)
   at System.IO.Path.IsPathRooted(String path)
   at ICSharpCode.SharpZipLib.Zip.ZipEntry.CleanName(String name)
   at ICSharpCode.SharpZipLib.Zip.ZipEntry..ctor(String name, Int32 versionRequiredToExtract, Int32 madeByInfo, CompressionMethod method)
   at ICSharpCode.SharpZipLib.Zip.ZipFile.ReadEntries()
   at ICSharpCode.SharpZipLib.Zip.ZipFile..ctor(String name)
   at CKAN.NetFileCache.ZipValid(String filename, String& invalidReason)
   at CKAN.NetModuleCache.Store(CkanModule module, String path, String description, Boolean move)
   at CKAN.NetAsyncModulesDownloader.ModuleDownloadsComplete(NetModuleCache cache, Uri[] urls, String[] filenames, Exception[] errors)
   at CKAN.NetAsyncModulesDownloader.<>c__DisplayClass8_0.<DownloadModules>b__3(Uri[] _uris, String[] paths, Exception[] errors)
   at CKAN.NetAsyncDownloader.triggerCompleted(Uri[] file_urls, String[] file_paths, Exception[] errors)
   at CKAN.NetAsyncDownloader.FileDownloadComplete(Int32 index, Exception error)
   at System.Net.WebClient.OnDownloadFileCompleted(AsyncCompletedEventArgs e)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch() 
```

Windows is the big offender here:

![invalid characters](https://user-images.githubusercontent.com/1559108/42302367-0a5c6eac-800a-11e8-8f8e-5c88a15e860f.png)

See #2467 for the latest example.

## Changes

Now we catch `System.ArgumentException` in `NetFileCache.ZipValid` and incorporate its error message into the normal flow of handling an invalid ZIP.

Fixes #1364.