### PR TITLE
Catch invalid $kref in Netkan

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Validators\InstallsFilesValidator.cs" />
     <Compile Include="Validators\IsCkanModuleValidator.cs" />
     <Compile Include="Validators\IValidator.cs" />
+    <Compile Include="Validators\KrefValidator.cs" />
     <Compile Include="Validators\MatchingIdentifiersValidator.cs" />
     <Compile Include="Validators\NetkanValidator.cs" />
   </ItemGroup>

--- a/Netkan/Model/RemoteRef.cs
+++ b/Netkan/Model/RemoteRef.cs
@@ -25,7 +25,9 @@ namespace CKAN.NetKAN.Model
             Source = arguments.Source;
             Id = arguments.Id;
 
-            _string = Id == null ? string.Format("#/{0}", Source) : string.Format("#/{0}/{1}", Source, Id);
+            _string = Id == null
+                ? $"#/ckan/{Source}"
+                : $"#/ckan/{Source}/{Id}";
         }
 
         public override string ToString()

--- a/Netkan/Validators/KrefValidator.cs
+++ b/Netkan/Validators/KrefValidator.cs
@@ -1,0 +1,36 @@
+using log4net;
+﻿using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Services;
+
+namespace CKAN.NetKAN.Validators
+{
+    internal sealed class KrefValidator : IValidator
+    {
+        public KrefValidator() { }
+
+        public void Validate(Metadata metadata)
+        {
+            Log.Info("Validating that metadata contains valid or null $kref");
+
+            switch (metadata.Kref?.Source)
+            {
+                case null:
+                case "curse":
+                case "github":
+                case "http":
+                case "jenkins":
+                case "netkan":
+                case "spacedock":
+                    // We know this $kref, looks good
+                    break;
+
+                default:
+                    // Anything not in the above list won't trigger a Transformer
+                    throw new Kraken($"Invalid $kref: {metadata.Kref}");
+            }
+
+        }
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(KrefValidator));
+    }
+}

--- a/Netkan/Validators/NetkanValidator.cs
+++ b/Netkan/Validators/NetkanValidator.cs
@@ -11,7 +11,8 @@ namespace CKAN.NetKAN.Validators
         {
             _validators = new List<IValidator>
             {
-                new HasIdentifierValidator()
+                new HasIdentifierValidator(),
+                new KrefValidator()
             };
         }
 


### PR DESCRIPTION
## Problem

Currently if you have an invalid `$kref`:

```json
    "$kref"        : "#/ckan/techman/iscool",
```

The error message isn't super clear:

```
$ ../CKAN/_build/netkan.exe NetKAN/KSP-AVC.netkan 
343 [1] ERROR CKAN.CkanModule (null) - KSP-AVC missing required field download
354 [1] FATAL CKAN.NetKAN.Program (null) - KSP-AVC missing required field download
```

Here it's telling us that it doesn't have a `download` property, which is indeed caused by the `$kref` being invalid, but it's rather indirect and not necessarily clear to a new user.

## Changes

Now the `NetkanValidator` has a new validation step that checks whether `metadata.Kref.Source` is a known valid value (null is also OK). If not, it prints a new error message:

```
$ ../CKAN/_build/netkan.exe NetKAN/KSP-AVC.netkan 
288 [1] FATAL CKAN.NetKAN.Program (null) - Invalid $kref: #/ckan/techman/iscool
```

`RemoteRef.ToString` previously dropped the `/ckan/` portion of the original string; `#/ckan/techman/iscool` became `#/techman/iscool`. To reduce confusion, this function now preserves the original string.

Fixes #374.