### PR TITLE
Handle KSP-AVC krefs

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Sources\Spacedock\SpacedockMod.cs" />
     <Compile Include="Sources\Spacedock\SpacedockUser.cs" />
     <Compile Include="Transformers\AvcTransformer.cs" />
+    <Compile Include="Transformers\AvcKrefTransformer.cs" />
     <Compile Include="Transformers\CurseTransformer.cs" />
     <Compile Include="Transformers\DownloadAttributeTransformer.cs" />
     <Compile Include="Transformers\EpochTransformer.cs" />

--- a/Netkan/Sources/Avc/AvcVersion.cs
+++ b/Netkan/Sources/Avc/AvcVersion.cs
@@ -5,7 +5,14 @@ namespace CKAN.NetKAN.Sources.Avc
 {
     public class AvcVersion
     {
-        // Right now we only support KSP versioning info.
+        [JsonProperty("NAME")]
+        public string Name;
+
+        [JsonProperty("DOWNLOAD")]
+        public string Download;
+
+        [JsonProperty("GITHUB")]
+        public AvcVersionGithubRef Github;
 
         [JsonProperty("URL")]
         public string Url;
@@ -21,5 +28,15 @@ namespace CKAN.NetKAN.Sources.Avc
 
         [JsonConverter(typeof(JsonAvcToKspVersion))]
         public KspVersion ksp_version_max;
+
+    }
+
+    public class AvcVersionGithubRef
+    {
+        [JsonProperty("USERNAME")]
+        public string Username;
+
+        [JsonProperty("REPOSITORY")]
+        public string Repository;
     }
 }

--- a/Netkan/Transformers/AvcKrefTransformer.cs
+++ b/Netkan/Transformers/AvcKrefTransformer.cs
@@ -1,0 +1,59 @@
+using System;
+using CKAN.NetKAN.Extensions;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Sources.Avc;
+using log4net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CKAN.NetKAN.Transformers
+{
+    /// <summary>
+    /// An <see cref="ITransformer"/> that looks up data from a KSP-AVC URL.
+    /// </summary>
+    internal sealed class AvcKrefTransformer : ITransformer
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(AvcKrefTransformer));
+
+        public string Name { get { return "avc-kref"; } }
+
+        public AvcKrefTransformer() { }
+
+        public Metadata Transform(Metadata metadata)
+        {
+            if (metadata.Kref?.Source == "ksp-avc")
+            {
+                var json = metadata.Json();
+
+                Log.InfoFormat("Executing KSP-AVC $kref transformation with {0}", metadata.Kref);
+                Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
+
+                AvcVersion remoteAvc = JsonConvert.DeserializeObject<AvcVersion>(
+                    Net.DownloadText(new Uri(metadata.Kref.Id))
+                );
+
+                json.SafeAdd("name",     remoteAvc.Name);
+                json.SafeAdd("download", remoteAvc.Download);
+
+                // Set .resources.repository based on GITHUB properties
+                if (remoteAvc.Github?.Username != null && remoteAvc.Github?.Repository != null)
+                {
+                    // Make sure resources exist.
+                    if (json["resources"] == null)
+                        json["resources"] = new JObject();
+                    var resourcesJson = (JObject)json["resources"];
+                    resourcesJson.SafeAdd("repository", $"https://github.com/{remoteAvc.Github.Username}/{remoteAvc.Github.Repository}");
+                }
+
+                // Use standard KSP-AVC logic to set version and the ksp_version_* properties
+                AvcTransformer.ApplyVersions(json, remoteAvc);
+
+                Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
+
+                return new Metadata(json);
+            }
+
+            return metadata;
+        }
+    }
+}

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -33,6 +33,7 @@ namespace CKAN.NetKAN.Transformers
                 new GithubTransformer(new GithubApi(githubToken), prerelease),
                 new HttpTransformer(),
                 new JenkinsTransformer(http),
+                new AvcKrefTransformer(),
                 new InternalCkanTransformer(http, moduleService),
                 new AvcTransformer(http, moduleService),
                 new VersionEditTransformer(),

--- a/Netkan/Validators/KrefValidator.cs
+++ b/Netkan/Validators/KrefValidator.cs
@@ -18,6 +18,7 @@ namespace CKAN.NetKAN.Validators
                 case "curse":
                 case "github":
                 case "http":
+                case "ksp-avc":
                 case "jenkins":
                 case "netkan":
                 case "spacedock":

--- a/Spec.md
+++ b/Spec.md
@@ -625,7 +625,7 @@ When used, the following fields will be auto-filled if not already present:
 
 ###### `#/ckan/curse/:cid`
 
-Indicates that data should be fetched from Curse, using the `:cid` provided. For example: `#/ckan/curse/220221`.
+Indicates that data should be fetched from Curse, using the `:cid` provided. The `:cid` may be a number for modules indexed prior to March 2018, or the name from the Curse URL otherwise. For example: `#/ckan/curse/220221` or `#/ckan/curse/photonsail`.
 
 When used, the following fields will be auto-filled if not already present:
 
@@ -710,8 +710,8 @@ An example `.netkan` excerpt:
     }
 }
 ```
-###### `#/ckan/http/:url`
 
+###### `#/ckan/http/:url`
 
 Indicates data should be fetched from a HTTP server, using the `:url` provided. For example: `#/ckan/http/https://ksp.marce.at/Home/DownloadMod?modId=2`.
 
@@ -726,6 +726,23 @@ This method depends on the existence of an AVC `.version` file in the download f
 to determine:
 
 - `version`
+
+###### `#/ckan/ksp-avc/:url`
+
+Indicates that data should be fetched from a KSP-AVC .version file at the `:url` provided. The file should be in the KSP-AVC JSON file format, see [the KSP-AVC spec](http://ksp.cybutek.net/kspavc/Documents/README.htm). The `DOWNLOAD` property of the file is used to find the download. For example: `#/ckan/ksp-avc/http://taniwha.org/~bill/EL.version`
+
+When used, the following fields will be auto-filled if not already present:
+
+- `name`
+- `download`
+- `download_size`
+- `download_hash`
+- `download_content_type`
+- `resources.repository`
+- `version`
+- `ksp_version`
+- `ksp_version_min`
+- `ksp_version_max`
 
 ###### `#/ckan/netkan/:url`
 


### PR DESCRIPTION
## Motivation

[ExtraPlanetaryLaunchpads's netkan](https://github.com/KSP-CKAN/NetKAN/blob/master/NetKAN/ExtraPlanetaryLaunchpads.netkan) currently uses a `$kref` property with a hard coded URL. This means that we have to update the netkan manually every time there's a new release.

This mod has a publicly hosted remote .version file at http://taniwha.org/~bill/EL.version

The [KSP-AVC spec](http://ksp.cybutek.net/kspavc/Documents/README.htm) says:

> * DOWNLOAD - Optional
> Web address where the latest version can be downloaded.
> This is only used from the remote version file.

In principle this should let us pick up new versions automatically, but currently that functionality doesn't exist.

## Changes

Now Netkan will support this format:

```json
    "$kref": "#/ckan/ksp-avc/http://taniwha.org/~bill/EL.version",
```

The `Id` part of the `$kref` gives a URL to check for a .version file, which contains a `DOWNLOAD` property that points to the latest version of the mod.

To accomplish this, a new `AvcKrefTransformer` class is added (the awkward name is because there's already an `AvcTransformer` which handles `$vref`, which needs to remain separate and is called too late to handle a `$kref` properly). The remaining AVC properties are added to `AvcVersion`, and used by the new transformer to set metadata properties. Setting the `download` property allows the remaining transformers to download the file and index it.

To set `version` and `ksp_version` / `_min` / `_max`, `AvcTransformer`'s logic for this is split out into a public static function for sharing.

In testing, the above `$kref` generated a .ckan file for ExtraPlanetaryLaunchpads 6.0.0 that exactly matches the one already in the index.

Fixes #286. Fixes #1765.