### PR TITLE
Add download count column to GUI

### DIFF
--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -12,6 +12,8 @@ namespace CKAN
         IEnumerable<string> InstalledDlls { get; }
         IDictionary<string, UnmanagedModuleVersion> InstalledDlc { get; }
 
+        int? DownloadCount(string identifier);
+
         /// <summary>
         /// Returns a simple array of all latest available modules for
         /// the specified version of KSP.

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -38,6 +38,29 @@ namespace CKAN
         [JsonProperty] private Dictionary<string, InstalledModule> installed_modules;
         [JsonProperty] private Dictionary<string, string> installed_files; // filename => module
 
+        [JsonProperty] public readonly SortedDictionary<string, int> download_counts = new SortedDictionary<string, int>();
+
+        public int? DownloadCount(string identifier)
+        {
+            int count;
+            if (download_counts.TryGetValue(identifier, out count))
+            {
+                return count;
+            }
+            return null;
+        }
+
+        public void SetDownloadCounts(SortedDictionary<string, int> counts)
+        {
+            if (counts != null)
+            {
+                foreach (var kvp in counts)
+                {
+                    download_counts[kvp.Key] = kvp.Value;
+                }
+            }
+        }
+
         // Index of which mods provide what, format:
         //   providers[provided] = { provider1, provider2, ... }
         // Built by BuildProvidesIndex, makes LatestAvailableWithProvides much faster.

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -21,6 +21,7 @@ namespace CKAN
         public DateTime? InstallDate { get; private set; }
         public string LatestVersion { get; private set; }
         public string DownloadSize { get; private set; }
+        public int? DownloadCount { get; private set; }
         public bool IsCached { get; private set; }
 
         // These indicate the maximum KSP version that the maximum available
@@ -127,6 +128,7 @@ namespace CKAN
             Identifier     = identifier;
             IsIncompatible = incompatible;
             IsAutodetected = registry.IsAutodetected(identifier);
+            DownloadCount  = registry.DownloadCount(identifier);
 
             ModuleVersion latest_version = null;
             try

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -75,6 +75,7 @@
             this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SizeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.InstallDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DownloadCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -483,6 +484,7 @@
             this.KSPCompatibility,
             this.SizeCol,
             this.InstallDate,
+            this.DownloadCount,
             this.Description});
             this.ModList.ContextMenuStrip = this.ModListContextMenuStrip;
             this.ModList.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -570,6 +572,14 @@
             this.InstallDate.ReadOnly = true;
             this.InstallDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.InstallDate.Width = 140;
+            //
+            // DownloadCount
+            //
+            this.DownloadCount.HeaderText = "Downloads";
+            this.DownloadCount.Name = "DownloadCount";
+            this.DownloadCount.ReadOnly = true;
+            this.DownloadCount.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.DownloadCount.Width = 70;
             //
             // Description
             // 
@@ -1158,6 +1168,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn KSPCompatibility;
         private System.Windows.Forms.DataGridViewTextBoxColumn SizeCol;
         private System.Windows.Forms.DataGridViewTextBoxColumn InstallDate;
+        private System.Windows.Forms.DataGridViewTextBoxColumn DownloadCount;
         private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.ContextMenuStrip ModListContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -27,6 +27,7 @@ namespace CKAN
                 case 0: case 1: return Sort(rows, CheckboxSorter);
                 case 7:         return Sort(rows, DownloadSizeSorter);
                 case 8:         return Sort(rows, InstallDateSorter);
+                case 9:         return Sort(rows, r => (r.Tag as GUIMod)?.DownloadCount ?? 0);
             }
             return Sort(rows, DefaultSorter);
         }
@@ -766,12 +767,13 @@ namespace CKAN
                         : mod.LatestVersion)
             };
 
-            var compat      = new DataGridViewTextBoxCell() { Value = mod.KSPCompatibility };
-            var size        = new DataGridViewTextBoxCell() { Value = mod.DownloadSize     };
-            var installDate = new DataGridViewTextBoxCell() { Value = mod.InstallDate      };
-            var desc        = new DataGridViewTextBoxCell() { Value = mod.Abstract         };
+            var compat        = new DataGridViewTextBoxCell() { Value = mod.KSPCompatibility };
+            var size          = new DataGridViewTextBoxCell() { Value = mod.DownloadSize     };
+            var installDate   = new DataGridViewTextBoxCell() { Value = mod.InstallDate      };
+            var downloadCount = new DataGridViewTextBoxCell() { Value = mod.DownloadCount    };
+            var desc          = new DataGridViewTextBoxCell() { Value = mod.Abstract         };
 
-            item.Cells.AddRange(selecting, updating, name, author, installVersion, latestVersion, compat, size, installDate, desc);
+            item.Cells.AddRange(selecting, updating, name, author, installVersion, latestVersion, compat, size, installDate, downloadCount, desc);
 
             selecting.ReadOnly = selecting is DataGridViewTextBoxCell;
             updating.ReadOnly  = updating  is DataGridViewTextBoxCell;


### PR DESCRIPTION
## Motivation

KSP-CKAN/NetKAN-bot#67 created a script that updates a [download_counts.json file in CKAN-meta](https://github.com/KSP-CKAN/CKAN-meta/blob/master/download_counts.json) containing the download counts of mods. This data is available now (and already being downloaded whenever anyone clicks Refresh!), but it's not being used yet.

## Changes

Now when you refresh the registry, we extract the `download_counts.json` file and parse it, then store the values it contains in a dictionary at `Registry.download_counts`.

A new Downloads column is added to GUI displaying this value for each mod. The user can sort this column to identify major mods that they haven't tried before.

~~Congrats to KIS for winning the popularity contest:~~

Correction: Congrats to EVE for winning the popularity contest (now that KSP-CKAN/NetKAN-bot#73 is counting older branches):

![image](https://user-images.githubusercontent.com/1559108/44939568-e7ecac00-ad4b-11e8-8a40-20c1f0c1a150.png)

Fixes #2415.