### PR TITLE
Show innermost download exceptions

### DIFF
--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -294,7 +294,7 @@ namespace CKAN
             foreach (var kvp in kraken.exceptions)
             {
                 exceptions.Add(new KeyValuePair<CkanModule, Exception>(
-                    modules[kvp.Key], kvp.Value
+                    modules[kvp.Key], kvp.Value.GetBaseException() ?? kvp.Value
                 ));
             }
         }


### PR DESCRIPTION
## Problem

#2527 shows a bunch of errors along these lines:

```
Error downloading KerbalEngineerRedux 1.1.5.3: An exception occurred during a WebClient request.
```

This says "An exception" instead of specifying what the problem is because it's one of .NET's annoying wrapper exceptions. The useful info is hidden in `exception.InnerException`, or `exception.InnerException.InnerException`, or even `exception.InnerException.InnerException.InnerException`.

## Changes

Now we use `GetBaseException` as we did #2480 to strip off all the wrapper exceptions and display the actual problem. This is not a fix for #2527, but it makes such problems more debuggable. We can share a test build with that issue's author if the issue happens consistently for them.