### PR TITLE
Fix grid colors for dark themes

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -470,6 +470,8 @@
             this.ModList.AllowUserToDeleteRows = false;
             this.ModList.AllowUserToResizeRows = false;
             this.ModList.BackgroundColor = System.Drawing.SystemColors.Window;
+            this.ModList.ColumnHeadersDefaultCellStyle.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.ModList.DefaultCellStyle.ForeColor = System.Drawing.SystemColors.WindowText;
             this.ModList.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             this.ModList.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
             this.ModList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;


### PR DESCRIPTION
## Background

Windows (and by extension .NET, and by further extension Mono) has a color theming system with two main pairs of foreground/background colors:

| Background | Foreground | Description |
| --- | --- | --- |
| `SystemColors.Control` | `SystemColors.ControlText` | For "3D" controls like buttons or tabstrips |
| `SystemColors.Window` | `SystemColors.WindowText` | For editable controls like text boxes or grids |

## Problem

The mod list looks bad in Linux with a dark theme:

![image](https://user-images.githubusercontent.com/1559108/46364902-b6ae1700-c63c-11e8-9350-4a289f678b0b.png)

- The grid header has black text on a dark gray background
- The mod rows have light gray text on a white background

## Cause

Mono's `DataGridView` has some bad defaults for its colors; the `WindowText` and `ControlText` colors are switched:

| Cell | Background | Foreground |
| --- | --- | --- |
| Header | `SystemColors.Control` | `SystemColors.WindowText` |
| Regular row | `SystemColors.Window` | `SystemColors.ControlText` |

https://github.com/mono/mono/blob/f0921fd850b0c8e61d5954fa71471189d2a55447/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs#L176-L177

https://github.com/mono/mono/blob/f0921fd850b0c8e61d5954fa71471189d2a55447/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs#L191-L192

On a standard theme, both foreground colors are black, so this is not noticeable. On a dark theme, `ControlText` is light and `Control` is dark, so the mismatch is very apparent.

Submitted mono/mono#10944 to hopefully get this fixed upstream.

## Changes

Luckily the defaults can be controlled by applications; now we:

- Set the default cell style foreground color of the header to `ControlText` since it is a 3D control.
- Set the default cell style foreground color of the normal rows to `WindowText` to make them match their background

This fixes part of #2525 (we can't fix the menu or toolbar unless mono/mono#10942 is merged).

![image](https://user-images.githubusercontent.com/1559108/46365200-9a5eaa00-c63d-11e8-8b49-330baf68c07e.png)

## Alternate approaches considered and not done

We could try to make the grid background dark instead of white. This would be done by setting it to `SystemColors.Control`. However, this would mess up non-dark themes, making the control the color of a button.