### PR TITLE
Fix YesNoDialog layout

### DIFF
--- a/GUI/AskUserForAutoUpdatesDialog.Designer.cs
+++ b/GUI/AskUserForAutoUpdatesDialog.Designer.cs
@@ -47,7 +47,6 @@
             // YesButton
             // 
             this.YesButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.YesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.YesButton.Location = new System.Drawing.Point(401, 44);
             this.YesButton.Name = "YesButton";
             this.YesButton.Size = new System.Drawing.Size(149, 23);
@@ -58,7 +57,6 @@
             // button1
             // 
             this.button1.DialogResult = System.Windows.Forms.DialogResult.No;
-            this.button1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button1.Location = new System.Drawing.Point(323, 44);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(72, 23);

--- a/GUI/YesNoDialog.Designer.cs
+++ b/GUI/YesNoDialog.Designer.cs
@@ -78,16 +78,16 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(418, 127);
-            this.ControlBox = false;
             this.Controls.Add(this.NoButton);
             this.Controls.Add(this.YesButton);
             this.Controls.Add(this.panel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Name = "YesNoDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "CKAN";
             this.panel1.ResumeLayout(false);
             this.ResumeLayout(false);
-
+            this.PerformLayout();
         }
 
         #endregion

--- a/GUI/YesNoDialog.cs
+++ b/GUI/YesNoDialog.cs
@@ -7,8 +7,6 @@ namespace CKAN
         public YesNoDialog()
         {
             InitializeComponent();
-            ApplyFormCompatibilityFixes();
-            StartPosition = FormStartPosition.CenterScreen;
         }
 
         public DialogResult ShowYesNoDialog(string text)


### PR DESCRIPTION
## Background

When you launch CKAN for the very first time (or after clearing the relevant settings from CKAN/GUIConfig.xml), two popups appear to "nag" the user about making certain decisions:

![image](https://user-images.githubusercontent.com/1559108/46373220-f137a400-c67c-11e8-979d-ea527668958b.png)

![image](https://user-images.githubusercontent.com/1559108/46373223-f399fe00-c67c-11e8-808d-caf685bac22c.png)

## Problem

As shown above, the second popup's buttons are cut off and unreadable if you have this setting turned on in Windows:

![image](https://user-images.githubusercontent.com/1559108/46373267-14625380-c67d-11e8-888e-1bb38bacc2eb.png)

## Cause

Since AskUserForAutoUpdatesDialog works fine regardless of the above setting, I focused on what was different between the two. There are several differences that seem to affect whether the layout is shown correctly (see next section).

## Changes

Now YesNoDialog works more like AskUserForAutoUpdatesDialog:

- It's a FixedToolWindow instead of a FixedDialog
- It has a close X button
- Its StartPosition is set in its .Designer.cs file instead of the ... other? file (whatever it's called in C#)
- It calls PerformLayout at the end of its .Designer.cs file
- It doesn't use the ApplyFormCompatibilityFixes hack anymore, since it doesn't seem to do anything

This seems to fix the problem:

![image](https://user-images.githubusercontent.com/1559108/46373327-41af0180-c67d-11e8-994e-b29c51ab1cb4.png)

And AskUserForAutoUpdatesDialog works a little bit more like YesNoDialog, for consistency:

- The button style is now non-flat

![image](https://user-images.githubusercontent.com/1559108/46373322-3c51b700-c67d-11e8-9d66-623bacf4fa87.png)

Fixes #908.