### PR TITLE
Handle exception for missing libcurl

### DIFF
--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -283,6 +283,18 @@ namespace CKAN
                     GUI.user.RaiseMessage("\r\n{0}", kraken.Message);
                     return;
                 }
+                catch (DllNotFoundException exc)
+                {
+                    if (GUI.user.RaiseYesNoDialog("libcurl installation not found. Open wiki page for help?"))
+                    {
+                        Process.Start(new ProcessStartInfo()
+                        {
+                            UseShellExecute = true,
+                            FileName        = "https://github.com/KSP-CKAN/CKAN/wiki/libcurl"
+                        });
+                    }
+                    throw;
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

If CKAN tries to use `libcurl` and doesn't find it, we get an uncaught `DllNotFoundException`:

```
Unhandled Exception:
System.DllNotFoundException: libcurl
  at (wrapper managed-to-native) CurlSharp.NativeMethods:curl_global_init (int)
  at CurlSharp.Curl.GlobalInit (CurlInitFlag flags) [0x00000] in <filename unknown>:0 
  at CKAN.Curl.Init () [0x00000] in <filename unknown>:0 
  at CKAN.NetAsyncDownloader.DownloadCurl () [0x00000] in <filename unknown>:0 
  at CKAN.NetAsyncDownloader.Download (ICollection`1 urls) [0x00000] in <filename unknown>:0 
  at CKAN.NetAsyncDownloader.DownloadModules (CKAN.NetFileCache cache, IEnumerable`1 modules) [0x00000] in <filename unknown>:0 
  at CKAN.ModuleInstaller.InstallList (ICollection`1 modules, CKAN.RelationshipResolverOptions options, IDownloader downloader) [0x00000] in <filename unknown>:0 
  at CKAN.ModuleInstaller.InstallList (System.Collections.Generic.List`1 modules, CKAN.RelationshipResolverOptions options, IDownloader downloader) [0x00000] in <filename unknown>:0 
  at CKAN.CmdLine.Install.RunCommand (CKAN.KSP ksp, System.Object raw_options) [0x00000] in <filename unknown>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x00000] in <filename unknown>:0 
```

## Changes

Now GUI catches this exception and offers to open a [wiki page](https://github.com/KSP-CKAN/CKAN/wiki/libcurl) explaining what to do.

Fixes #1293.
Fixes #2436.