### PR TITLE
Handle two-part KSP-AVC versions

### DIFF
--- a/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
+++ b/Netkan/Sources/Avc/JsonAvcToKspVersion.cs
@@ -24,9 +24,9 @@ namespace CKAN.NetKAN.Sources.Avc
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
             JsonSerializer serializer)
         {
-            var major = "0";
-            var minor = "0";
-            var patch = "0";
+            string major = null;
+            string minor = null;
+            string patch = null;
 
             var token = JToken.Load(reader);
             Log.DebugFormat("Read Token: {0}, {1}", new object[] {token.Type, token.ToString()});
@@ -62,15 +62,15 @@ namespace CKAN.NetKAN.Sources.Avc
             //AVC uses -1 to indicate a wildcard.
             int integer;
             string version;
-            if (int.TryParse(major, out integer) && integer == AvcWildcard)
+            if (major == null || int.TryParse(major, out integer) && integer == AvcWildcard)
             {
                 return KspVersion.Any;
             }
-            else if (int.TryParse(minor, out integer) && integer == AvcWildcard)
+            else if (minor == null || int.TryParse(minor, out integer) && integer == AvcWildcard)
             {
                 version = major;
             }
-            else if (int.TryParse(patch, out integer) && integer == AvcWildcard)
+            else if (patch == null || int.TryParse(patch, out integer) && integer == AvcWildcard)
             {
                 version = string.Join(".", major, minor);
             }


### PR DESCRIPTION
## Problem

CKAN has pretty excellent handling for two-part game versions (e.g., "1.3" or "1.4") thanks to #1645, but to use it with a .version file you need to use a "-1" wildcard, as in:

```json
	"KSP_VERSION_MIN": {
		"MAJOR": 1,
		"MINOR": 3,
		"PATCH": -1
	},
```

Which is kind of awkward and not terribly well known. Simply leaving out PATCH will raise an error:

```
1382 [1] FATAL CKAN.NetKAN.Program (null) - One of the identified items was in an invalid format.
```

I tested that format with KSP-AVC itself, and it worked fine, so Netkan should handle it as well.

## Changes

Now you can leave out PATCH, MINOR, or even MAJOR, and the wildcard will be assumed.

Fixes #1687.