### PR TITLE
One Cache to Rule Them All

### DIFF
--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Linq;
+using CommandLine;
+using CommandLine.Text;
+using log4net;
+using CKAN.Versioning;
+
+namespace CKAN.CmdLine
+{
+    public class Cache : ISubCommand
+    {
+        public Cache() { }
+
+        private class CacheSubOptions : VerbCommandOptions
+        {
+            [VerbOption("list", HelpText = "List the download cache path")]
+            public CommonOptions ListOptions { get; set; }
+
+            [VerbOption("set", HelpText = "Set the download cache path")]
+            public SetOptions SetOptions { get; set; }
+
+            [VerbOption("clear", HelpText = "Clear the download cache directory")]
+            public CommonOptions ClearOptions { get; set; }
+
+            [VerbOption("reset", HelpText = "Set the download cache path to the default")]
+            public CommonOptions ResetOptions { get; set; }
+
+            [HelpVerbOption]
+            public string GetUsage(string verb)
+            {
+                HelpText ht = HelpText.AutoBuild(this, verb);
+                // Add a usage prefix line
+                ht.AddPreOptionsLine(" ");
+                if (string.IsNullOrEmpty(verb))
+                {
+                    ht.AddPreOptionsLine("ckan cache - Manage the download cache path of CKAN");
+                    ht.AddPreOptionsLine($"Usage: ckan cache <command> [options]");
+                }
+                else
+                {
+                    ht.AddPreOptionsLine("cache " + verb + " - " + GetDescription(verb));
+                    switch (verb)
+                    {
+                        // First the commands with one string argument
+                        case "set":
+                            ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options] path");
+                            break;
+
+                        // Now the commands with only --flag type options
+                        case "list":
+                        case "clear":
+                        case "reset":
+                        default:
+                            ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options]");
+                            break;
+                    }
+                }
+                return ht;
+            }
+        }
+
+        private class SetOptions : CommonOptions
+        {
+            [ValueOption(0)]
+            public string Path { get; set; }
+        }
+
+        /// <summary>
+        /// Execute a cache subcommand
+        /// </summary>
+        /// <param name="mgr">KSPManager object containing our instances and cache</param>
+        /// <param name="opts">Command line options object</param>
+        /// <param name="unparsed">Raw command line options</param>
+        /// <returns>
+        /// Exit code for shell environment
+        /// </returns>
+        public int RunSubCommand(KSPManager mgr, CommonOptions opts, SubCommandOptions unparsed)
+        {
+            string[] args = unparsed.options.ToArray();
+
+            int exitCode = Exit.OK;
+            // Parse and process our sub-verbs
+            Parser.Default.ParseArgumentsStrict(args, new CacheSubOptions(), (string option, object suboptions) =>
+            {
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions options = (CommonOptions)suboptions;
+                    options.Merge(opts);
+                    user     = new ConsoleUser(options.Headless);
+                    manager  = mgr ?? new KSPManager(user);
+                    exitCode = options.Handle(manager, user);
+                    if (exitCode != Exit.OK)
+                        return;
+
+                    switch (option)
+                    {
+                        case "list":
+                            exitCode = ListCacheDirectory((CommonOptions)suboptions);
+                            break;
+
+                        case "set":
+                            exitCode = SetCacheDirectory((SetOptions)suboptions);
+                            break;
+
+                        case "clear":
+                            exitCode = ClearCacheDirectory((CommonOptions)suboptions);
+                            break;
+
+                        case "reset":
+                            exitCode = ResetCacheDirectory((CommonOptions)suboptions);
+                            break;
+
+                        default:
+                            user.RaiseMessage("Unknown command: cache {0}", option);
+                            exitCode = Exit.BADOPT;
+                            break;
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+            return exitCode;
+        }
+
+        private int ListCacheDirectory(CommonOptions options)
+        {
+            IWin32Registry winReg = new Win32Registry();
+            user.RaiseMessage(winReg.DownloadCacheDir);
+            printCacheInfo();
+            return Exit.OK;
+        }
+
+        private int SetCacheDirectory(SetOptions options)
+        {
+            if (string.IsNullOrEmpty(options.Path))
+            {
+                user.RaiseError("set <path> - argument missing, perhaps you forgot it?");
+                return Exit.BADOPT;
+            }
+
+            string failReason;
+            if (manager.TrySetupCache(options.Path, out failReason))
+            {
+                IWin32Registry winReg = new Win32Registry();
+                user.RaiseMessage($"Download cache set to {winReg.DownloadCacheDir}");
+                printCacheInfo();
+                return Exit.OK;
+            }
+            else
+            {
+                user.RaiseError($"Invalid path: {failReason}");
+                return Exit.BADOPT;
+            }
+        }
+
+        private int ClearCacheDirectory(CommonOptions options)
+        {
+            manager.Cache.RemoveAll();
+            user.RaiseMessage("Download cache cleared.");
+            printCacheInfo();
+            return Exit.OK;
+        }
+
+        private int ResetCacheDirectory(CommonOptions options)
+        {
+            string failReason;
+            if (manager.TrySetupCache("", out failReason))
+            {
+                IWin32Registry winReg = new Win32Registry();
+                user.RaiseMessage($"Download cache reset to {winReg.DownloadCacheDir}");
+                printCacheInfo();
+            }
+            else
+            {
+                user.RaiseError($"Can't reset cache path: {failReason}");
+            }
+            return Exit.OK;
+        }
+
+        private void printCacheInfo()
+        {
+            int fileCount;
+            long bytes;
+            manager.Cache.GetSizeInfo(out fileCount, out bytes);
+            user.RaiseMessage($"{fileCount} files, {CkanModule.FmtSize(bytes)}");
+        }
+
+        private KSPManager manager;
+        private IUser      user;
+
+        private static readonly ILog       log = LogManager.GetLogger(typeof(Cache));
+    }
+
+}

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -17,8 +17,9 @@ namespace CKAN.CmdLine
         /// Initialize the command
         /// </summary>
         /// <param name="user">IUser object for user interaction</param>
-        public Import(IUser user)
+        public Import(KSPManager mgr, IUser user)
         {
+            manager   = mgr;
             this.user = user;
         }
 
@@ -45,7 +46,7 @@ namespace CKAN.CmdLine
                 {
                     log.InfoFormat("Importing {0} files", toImport.Count);
                     List<string>    toInstall = new List<string>();
-                    ModuleInstaller inst      = ModuleInstaller.GetInstance(ksp, user);
+                    ModuleInstaller inst      = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                     inst.ImportFiles(toImport, user, mod => toInstall.Add(mod.identifier), !opts.Headless);
                     if (toInstall.Count > 0)
                     {
@@ -99,8 +100,9 @@ namespace CKAN.CmdLine
             }
         }
 
-        private        readonly IUser user;
-        private static readonly ILog  log = LogManager.GetLogger(typeof(Import));
+        private        readonly KSPManager manager;
+        private        readonly IUser      user;
+        private static readonly ILog       log = LogManager.GetLogger(typeof(Import));
     }
 
 }

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -9,12 +9,27 @@ namespace CKAN.CmdLine
         private static readonly ILog log = LogManager.GetLogger(typeof(Install));
 
         public IUser user { get; set; }
+        private KSPManager manager;
 
-        public Install(IUser user)
+        /// <summary>
+        /// Initialize the install command object
+        /// </summary>
+        /// <param name="mgr">KSPManager containing our instances</param>
+        /// <param name="user">IUser object for interaction</param>
+        public Install(KSPManager mgr, IUser user)
         {
+            manager   = mgr;
             this.user = user;
         }
 
+        /// <summary>
+        /// Installs a module, if available
+        /// </summary>
+        /// <param name="ksp">Game instance into which to install</param>
+        /// <param name="raw_options">Command line options object</param>
+        /// <returns>
+        /// Exit code for shell environment
+        /// </returns>
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
             InstallOptions options = (InstallOptions) raw_options;
@@ -113,7 +128,7 @@ namespace CKAN.CmdLine
             // Install everything requested. :)
             try
             {
-                var installer = ModuleInstaller.GetInstance(ksp, user);
+                var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                 installer.InstallList(options.modules, install_ops);
             }
             catch (DependencyNotSatisfiedKraken ex)
@@ -187,7 +202,7 @@ namespace CKAN.CmdLine
                 // Add the module to the list.
                 options.modules.Add(ex.modules[result].identifier);
 
-                return (new Install(user).RunCommand(ksp, options));
+                return (new Install(manager, user).RunCommand(ksp, options));
             }
             catch (FileExistsKraken ex)
             {

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -10,13 +10,27 @@ namespace CKAN.CmdLine
         private static readonly ILog log = LogManager.GetLogger(typeof(Remove));
 
         public IUser user { get; set; }
+        private KSPManager manager;
 
-        public Remove(IUser user)
+        /// <summary>
+        /// Initialize the remove command object
+        /// </summary>
+        /// <param name="mgr">KSPManager containing our instances</param>
+        /// <param name="user">IUser object for interaction</param>
+        public Remove(KSPManager mgr, IUser user)
         {
+            manager   = mgr;
             this.user = user;
         }
 
-        // Uninstalls a module, if it exists.
+        /// <summary>
+        /// Uninstalls a module, if it exists.
+        /// </summary>
+        /// <param name="ksp">Game instance from which to remove</param>
+        /// <param name="raw_options">Command line options object</param>
+        /// <returns>
+        /// Exit code for shell environment
+        /// </returns>
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
 
@@ -62,7 +76,7 @@ namespace CKAN.CmdLine
             {
                 try
                 {
-                    var installer = ModuleInstaller.GetInstance(ksp, user);
+                    var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                     Search.AdjustModulesCase(ksp, options.modules);
                     installer.UninstallList(options.modules);
                 }

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -6,12 +6,27 @@ namespace CKAN.CmdLine
     public class Update : ICommand
     {
         public IUser user { get; set; }
+        private KSPManager manager;
 
-        public Update(IUser user)
+        /// <summary>
+        /// Initialize the update command object
+        /// </summary>
+        /// <param name="mgr">KSPManager containing our instances</param>
+        /// <param name="user">IUser object for interaction</param>
+        public Update(KSPManager mgr, IUser user)
         {
+            manager   = mgr;
             this.user = user;
         }
 
+        /// <summary>
+        /// Update the registry
+        /// </summary>
+        /// <param name="ksp">Game instance to update</param>
+        /// <param name="raw_options">Command line options object</param>
+        /// <returns>
+        /// Exit code for shell environment
+        /// </returns>
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
             UpdateOptions options = (UpdateOptions) raw_options;
@@ -135,7 +150,7 @@ namespace CKAN.CmdLine
             RegistryManager registry_manager = RegistryManager.Instance(ksp);
 
             var updated = repository == null
-                ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, user)
+                ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, manager.Cache, user)
                 : CKAN.Repo.Update(registry_manager, ksp, user, repository);
 
             user.RaiseMessage("Updated information on {0} available modules", updated);

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -9,13 +9,27 @@ namespace CKAN.CmdLine
         private static readonly ILog log = LogManager.GetLogger(typeof(Upgrade));
 
         public IUser User { get; set; }
+        private KSPManager manager;
 
-        public Upgrade(IUser user)
+        /// <summary>
+        /// Initialize the upgrade command object
+        /// </summary>
+        /// <param name="mgr">KSPManager containing our instances</param>
+        /// <param name="user">IUser object for interaction</param>
+        public Upgrade(KSPManager mgr, IUser user)
         {
+            manager   = mgr;
             User = user;
         }
 
-
+        /// <summary>
+        /// Upgrade an installed module
+        /// </summary>
+        /// <param name="ksp">Game instance from which to remove</param>
+        /// <param name="raw_options">Command line options object</param>
+        /// <returns>
+        /// Exit code for shell environment
+        /// </returns>
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
             UpgradeOptions options = (UpgradeOptions) raw_options;
@@ -115,13 +129,13 @@ namespace CKAN.CmdLine
 
                     }
 
-                    ModuleInstaller.GetInstance(ksp, User).Upgrade(to_upgrade, new NetAsyncModulesDownloader(User));
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(to_upgrade, new NetAsyncModulesDownloader(User));
                 }
                 else
                 {
                     // TODO: These instances all need to go.
                     Search.AdjustModulesCase(ksp, options.modules);
-                    ModuleInstaller.GetInstance(ksp, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User));
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User));
                 }
             }
             catch (ModuleNotFoundKraken kraken)

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -57,6 +57,7 @@
     </Compile>
     <Compile Include="Action\AuthToken.cs" />
     <Compile Include="Action\Available.cs" />
+    <Compile Include="Action\Cache.cs" />
     <Compile Include="Action\Compare.cs" />
     <Compile Include="Action\Compat.cs" />
     <Compile Include="Action\ICommand.cs" />

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -87,6 +87,10 @@ namespace CKAN.CmdLine
 
                     case "authtoken":
                         return (new AuthToken()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+
+                    case "cache":
+                        return (new Cache()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+
                 }
             }
             catch (NoGameInstanceKraken)
@@ -180,7 +184,7 @@ namespace CKAN.CmdLine
                         return Version(user);
 
                     case "update":
-                        return (new Update(user)).RunCommand(GetGameInstance(manager), cmdline.options);
+                        return (new Update(manager, user)).RunCommand(GetGameInstance(manager), cmdline.options);
 
                     case "available":
                         return (new Available(user)).RunCommand(GetGameInstance(manager), cmdline.options);
@@ -188,7 +192,7 @@ namespace CKAN.CmdLine
                     case "add":
                     case "install":
                         Scan(GetGameInstance(manager), user, cmdline.action);
-                        return (new Install(user)).RunCommand(GetGameInstance(manager), cmdline.options);
+                        return (new Install(manager, user)).RunCommand(GetGameInstance(manager), cmdline.options);
 
                     case "scan":
                         return Scan(GetGameInstance(manager), user);
@@ -204,17 +208,17 @@ namespace CKAN.CmdLine
 
                     case "uninstall":
                     case "remove":
-                        return (new Remove(user)).RunCommand(GetGameInstance(manager), cmdline.options);
+                        return (new Remove(manager, user)).RunCommand(GetGameInstance(manager), cmdline.options);
 
                     case "upgrade":
                         Scan(GetGameInstance(manager), user, cmdline.action);
-                        return (new Upgrade(user)).RunCommand(GetGameInstance(manager), cmdline.options);
+                        return (new Upgrade(manager, user)).RunCommand(GetGameInstance(manager), cmdline.options);
 
                     case "import":
-                        return (new Import(user)).RunCommand(GetGameInstance(manager), options);
+                        return (new Import(manager, user)).RunCommand(GetGameInstance(manager), options);
 
                     case "clean":
-                        return Clean(GetGameInstance(manager));
+                        return Clean(manager.Cache);
 
                     case "compare":
                         return (new Compare(user)).RunCommand(cmdline.options);
@@ -294,9 +298,9 @@ namespace CKAN.CmdLine
             }
         }
 
-        private static int Clean(CKAN.KSP current_instance)
+        private static int Clean(NetModuleCache cache)
         {
-            current_instance.CleanCache();
+            cache.RemoveAll();
             return Exit.OK;
         }
     }

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -97,6 +97,9 @@ namespace CKAN.CmdLine
         [VerbOption("authtoken", HelpText = "Manage authentication tokens")]
         public AuthTokenSubOptions AuthToken { get; set; }
 
+        [VerbOption("cache", HelpText = "Manage download cache path")]
+        public SubCommandOptions Cache { get; set; }
+
         [VerbOption("compat", HelpText = "Manage KSP version compatibility")]
         public SubCommandOptions Compat { get; set; }
 

--- a/ConsoleUI/DownloadImportDialog.cs
+++ b/ConsoleUI/DownloadImportDialog.cs
@@ -15,8 +15,9 @@ namespace CKAN.ConsoleUI {
         /// Let the user choose some zip files, then import them to the mod cache.
         /// </summary>
         /// <param name="gameInst">Game instance to import into</param>
+        /// <param name="cache">Cache object to import into</param>
         /// <param name="cp">Change plan object for marking things to be installed</param>
-        public static void ImportDownloads(KSP gameInst, ChangePlan cp)
+        public static void ImportDownloads(KSP gameInst, NetModuleCache cache, ChangePlan cp)
         {
             ConsoleFileMultiSelectDialog cfmsd = new ConsoleFileMultiSelectDialog(
                 "Import Downloads",
@@ -28,7 +29,7 @@ namespace CKAN.ConsoleUI {
 
             if (files.Count > 0) {
                 ProgressScreen  ps   = new ProgressScreen("Importing Downloads", "Calculating...");
-                ModuleInstaller inst = ModuleInstaller.GetInstance(gameInst, ps);
+                ModuleInstaller inst = ModuleInstaller.GetInstance(gameInst, cache, ps);
                 ps.Run(() => inst.ImportFiles(files, ps,
                     (CkanModule mod) => cp.Install.Add(mod)));
                 // Don't let the installer re-use old screen references

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -55,7 +55,7 @@ namespace CKAN.ConsoleUI {
 
                         // FUTURE: BackgroundWorker
 
-                        ModuleInstaller inst = ModuleInstaller.GetInstance(manager.CurrentInstance, this);
+                        ModuleInstaller inst = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, this);
                         inst.onReportModInstalled = OnModInstalled;
                         if (plan.Remove.Count > 0) {
                             inst.UninstallList(plan.Remove);

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -103,7 +103,7 @@ namespace CKAN.ConsoleUI {
             AddBinding(Keys.Escape, (object sender) => false);
 
             AddTip("Ctrl+D", "Download",
-                () => !manager.CurrentInstance.Cache.IsMaybeCachedZip(mod)
+                () => !manager.Cache.IsMaybeCachedZip(mod)
             );
             AddBinding(Keys.CtrlD, (object sender) => {
                 Download();
@@ -460,13 +460,13 @@ namespace CKAN.ConsoleUI {
         {
             ProgressScreen            ps   = new ProgressScreen($"Downloading {mod.identifier}");
             NetAsyncModulesDownloader dl   = new NetAsyncModulesDownloader(ps);
-            ModuleInstaller           inst = ModuleInstaller.GetInstance(manager.CurrentInstance, ps);
+            ModuleInstaller           inst = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, ps);
             LaunchSubScreen(
                 ps,
                 () => {
                     try {
-                        dl.DownloadModules(inst.Cache, new List<CkanModule> {mod});
-                        if (!inst.Cache.IsMaybeCachedZip(mod)) {
+                        dl.DownloadModules(manager.Cache, new List<CkanModule> {mod});
+                        if (!manager.Cache.IsMaybeCachedZip(mod)) {
                             ps.RaiseError("Download failed, file is corrupted");
                         }
                     } catch (Exception ex) {

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -288,7 +288,7 @@ namespace CKAN.ConsoleUI {
 
         private bool ImportDownloads()
         {
-            DownloadImportDialog.ImportDownloads(manager.CurrentInstance, plan);
+            DownloadImportDialog.ImportDownloads(manager.CurrentInstance, manager.Cache, plan);
             RefreshList();
             return true;
         }
@@ -385,6 +385,7 @@ namespace CKAN.ConsoleUI {
                     Repo.UpdateAllRepositories(
                         RegistryManager.Instance(manager.CurrentInstance),
                         manager.CurrentInstance,
+                        manager.Cache,
                         this
                     );
                 } catch (Exception ex) {

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -20,7 +20,7 @@ namespace CKAN
     /// <summary>
     /// Everything for dealing with KSP itself.
     /// </summary>
-    public class KSP : IDisposable
+    public class KSP
     {
         /// <summary>
         /// List of DLLs that should never be added to the autodetect list.
@@ -45,8 +45,6 @@ namespace CKAN
         public KspVersion VersionOfKspWhenCompatibleVersionsWereStored { get; private set; }
         public bool CompatibleVersionsAreFromDifferentKsp { get { return _compatibleVersions.Count > 0 && VersionOfKspWhenCompatibleVersionsWereStored != Version(); } }
 
-        public NetModuleCache Cache { get; private set; }
-
         #endregion
         #region Construction and Initialisation
 
@@ -65,7 +63,6 @@ namespace CKAN
             {
                 SetupCkanDirectories();
                 LoadCompatibleVersions();
-                Cache = new NetModuleCache(DownloadCacheDir());
             }
         }
 
@@ -88,11 +85,6 @@ namespace CKAN
                 ScanGameData();
             }
 
-            if (!Directory.Exists(DownloadCacheDir()))
-            {
-                User.RaiseMessage("Creating {0}", DownloadCacheDir());
-                Directory.CreateDirectory(DownloadCacheDir());
-            }
             if (!Directory.Exists(InstallHistoryDir()))
             {
                 User.RaiseMessage("Creating {0}", InstallHistoryDir());
@@ -163,24 +155,6 @@ namespace CKAN
         #endregion
 
         #region Destructors and Disposal
-
-        /// <summary>
-        /// Releases all resource used by the <see cref="CKAN.KSP"/> object.
-        /// </summary>
-        /// <remarks>Call <see cref="Dispose"/> when you are finished using the <see cref="CKAN.KSP"/>. The <see cref="Dispose"/>
-        /// method leaves the <see cref="CKAN.KSP"/> in an unusable state. After calling <see cref="Dispose"/>, you must
-        /// release all references to the <see cref="CKAN.KSP"/> so the garbage collector can reclaim the memory that
-        /// the <see cref="CKAN.KSP"/> was occupying.</remarks>
-        public void Dispose()
-        {
-            if (Cache != null)
-            {
-                Cache.Dispose();
-                Cache = null;
-            }
-
-            // Attempting to dispose of the related RegistryManager object here is a bad idea, it cause loads of failures
-        }
 
         #endregion
 
@@ -425,31 +399,6 @@ namespace CKAN
         #endregion
 
         #region CKAN/GameData Directory Maintenance
-
-        /// <summary>
-        /// Removes all files from the download (cache) directory.
-        /// </summary>
-        public void CleanCache()
-        {
-            // TODO: We really should be asking our Cache object to do the
-            // cleaning, rather than doing it ourselves.
-
-            log.Info("Cleaning cache directory");
-
-            string[] files = Directory.GetFiles(DownloadCacheDir(), "*", SearchOption.AllDirectories);
-
-            foreach (string file in files)
-            {
-                if (Directory.Exists(file))
-                {
-                    log.DebugFormat("Skipping directory: {0}", file);
-                    continue;
-                }
-
-                log.DebugFormat("Deleting {0}", file);
-                File.Delete(file);
-            }
-        }
 
         /// <summary>
         /// Clears the registry of DLL data, and refreshes it by scanning GameData.

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -18,6 +18,15 @@ namespace CKAN
         /// <summary>
         /// Initialize the cache
         /// </summary>
+        /// <param name="mgr">KSPManager containing instances that might have legacy caches</param>
+        public NetModuleCache(KSPManager mgr, string path)
+        {
+            cache = new NetFileCache(mgr, path);
+        }
+
+        /// <summary>
+        /// Initialize the cache
+        /// </summary>
         /// <param name="path">Path to directory to use as the cache</param>
         public NetModuleCache(string path)
         {
@@ -29,13 +38,13 @@ namespace CKAN
         {
             cache.Dispose();
         }
-        public void Clear()
+        public void RemoveAll()
         {
-            cache.OnCacheChanged();
+            cache.RemoveAll();
         }
-        public string GetCachePath()
+        public void MoveFrom(string fromDir)
         {
-            return cache.GetCachePath();
+            cache.MoveFrom(fromDir);
         }
         public bool IsCached(CkanModule m)
         {
@@ -60,6 +69,10 @@ namespace CKAN
         public string GetCachedZip(CkanModule m)
         {
             return cache.GetCachedZip(m.download);
+        }
+        public void GetSizeInfo(out int numFiles, out long numBytes)
+        {
+            cache.GetSizeInfo(out numFiles, out numBytes);
         }
 
         /// <summary>

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -28,7 +28,7 @@ namespace CKAN
         /// Optionally takes a URL to the zipfile repo to download.
         /// Returns the number of unique modules updated.
         /// </summary>
-        public static int UpdateAllRepositories(RegistryManager registry_manager, KSP ksp, IUser user)
+        public static int UpdateAllRepositories(RegistryManager registry_manager, KSP ksp, NetModuleCache cache, IUser user)
         {
             SortedDictionary<string, Repository> sortedRepositories = registry_manager.registry.Repositories;
             List<CkanModule> allAvail = new List<CkanModule>();
@@ -63,7 +63,7 @@ namespace CKAN
                 List<CkanModule> metadataChanges = GetChangedInstalledModules(registry_manager.registry);
                 if (metadataChanges.Count > 0)
                 {
-                    HandleModuleChanges(metadataChanges, user, ksp);
+                    HandleModuleChanges(metadataChanges, user, ksp, cache);
                 }
 
                 // Return how many we got!
@@ -166,7 +166,7 @@ namespace CKAN
         /// <param name="metadataChanges">List of modules that changed</param>
         /// <param name="user">Object for user interaction callbacks</param>
         /// <param name="ksp">Game instance</param>
-        private static void HandleModuleChanges(List<CkanModule> metadataChanges, IUser user, KSP ksp)
+        private static void HandleModuleChanges(List<CkanModule> metadataChanges, IUser user, KSP ksp, NetModuleCache cache)
         {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < metadataChanges.Count; i++)
@@ -182,7 +182,7 @@ You should reinstall them in order to preserve consistency with the repository.
 
 Do you wish to reinstall now?", sb)))
             {
-                ModuleInstaller installer = ModuleInstaller.GetInstance(ksp, new NullUser());
+                ModuleInstaller installer = ModuleInstaller.GetInstance(ksp, cache, new NullUser());
                 // New upstream metadata may break the consistency of already installed modules
                 // e.g. if user installs modules A and B and then later up A is made to conflict with B
                 // This is perfectly normal and shouldn't produce an error, therefore we skip enforcing

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -183,14 +183,17 @@ namespace CKAN
             Homepage = "N/A";
         }
 
+        /// <summary>
+        /// Refresh the IsCached property based on current contents of the cache
+        /// </summary>
         public void UpdateIsCached()
         {
-            if (Main.Instance?.CurrentInstance?.Cache == null || Mod?.download == null)
+            if (Main.Instance?.Manager?.Cache == null || Mod?.download == null)
             {
                 return;
             }
 
-            IsCached = Main.Instance.CurrentInstance.Cache.IsMaybeCachedZip(Mod);
+            IsCached = Main.Instance.Manager.Cache.IsMaybeCachedZip(Mod);
         }
 
         public CkanModule ToCkanModule()

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -597,7 +597,7 @@ namespace CKAN
             var user_change_set = mainModList.ComputeUserChangeSet();
             try
             {
-                var module_installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
+                var module_installer = ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, GUI.user);
                 full_change_set = await mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer, CurrentInstance.VersionCriteria());
             }
             catch (InconsistentKraken k)

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -49,7 +49,7 @@ namespace CKAN
                 CkanModule m = change.Mod.ToModule();
                 ListViewItem item = new ListViewItem()
                 {
-                    Text = CurrentInstance.Cache.IsMaybeCachedZip(m)
+                    Text = Manager.Cache.IsMaybeCachedZip(m)
                         ? $"{m.name} {m.version} (cached)"
                         : $"{m.name} {m.version} ({m.download.Host ?? ""}, {CkanModule.FmtSize(m.download_size)})"
                 };

--- a/GUI/MainImport.cs
+++ b/GUI/MainImport.cs
@@ -41,7 +41,7 @@ namespace CKAN
 
                 try
                 {
-                    ModuleInstaller.GetInstance(CurrentInstance, currentUser).ImportFiles(
+                    ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, currentUser).ImportFiles(
                         GetFiles(dlg.FileNames),
                         currentUser,
                         (CkanModule mod) => MarkModForInstall(mod.identifier, false)

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -50,7 +50,7 @@ namespace CKAN
                                 null
                             )
                         },
-                        ModuleInstaller.GetInstance(CurrentInstance, GUI.user),
+                        ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, GUI.user),
                         CurrentInstance.VersionCriteria()
                     )
                 );
@@ -86,7 +86,7 @@ namespace CKAN
             var opts = (KeyValuePair<ModChanges, RelationshipResolverOptions>) e.Argument;
 
             IRegistryQuerier registry  = RegistryManager.Instance(manager.CurrentInstance).registry;
-            ModuleInstaller  installer = ModuleInstaller.GetInstance(CurrentInstance, GUI.user);
+            ModuleInstaller  installer = ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, GUI.user);
             // Avoid accumulating multiple event handlers
             installer.onReportModInstalled -= OnModInstalled;
             installer.onReportModInstalled += OnModInstalled;
@@ -283,7 +283,7 @@ namespace CKAN
                     GUI.user.RaiseMessage("\r\n{0}", kraken.Message);
                     return;
                 }
-                catch (DllNotFoundException exc)
+                catch (DllNotFoundException)
                 {
                     if (GUI.user.RaiseYesNoDialog("libcurl installation not found. Open wiki page for help?"))
                     {
@@ -439,7 +439,7 @@ namespace CKAN
                 {
                     Tag = module,
                     Checked = false,
-                    Text = CurrentInstance.Cache.IsMaybeCachedZip(module)
+                    Text = Manager.Cache.IsMaybeCachedZip(module)
                         ? $"{module.name} {module.version} (cached)"
                         : $"{module.name} {module.version} ({module.download.Host ?? ""}, {CkanModule.FmtSize(module.download_size)})"
                 };
@@ -559,7 +559,7 @@ namespace CKAN
                 {
                     Tag = module,
                     Checked = !suggested,
-                    Text = CurrentInstance.Cache.IsMaybeCachedZip(pair.Key)
+                    Text = Manager.Cache.IsMaybeCachedZip(pair.Key)
                         ? $"{pair.Key.name} {pair.Key.version} (cached)"
                         : $"{pair.Key.name} {pair.Key.version} ({pair.Key.download.Host ?? ""}, {CkanModule.FmtSize(pair.Key.download_size)})"
                 };

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -434,7 +434,7 @@ namespace CKAN
             ContentsPreviewTree.Nodes.Clear();
             ContentsPreviewTree.Nodes.Add(module.name);
 
-            IEnumerable<string> contents = ModuleInstaller.GetInstance(manager.CurrentInstance, GUI.user).GetModuleContentsList(module);
+            IEnumerable<string> contents = ModuleInstaller.GetInstance(manager.CurrentInstance, Main.Instance.Manager.Cache, GUI.user).GetModuleContentsList(module);
             if (contents == null)
             {
                 return;
@@ -455,7 +455,7 @@ namespace CKAN
 
             NetAsyncModulesDownloader downloader = new NetAsyncModulesDownloader(Main.Instance.currentUser);
 
-            downloader.DownloadModules(Main.Instance.CurrentInstance.Cache, new List<CkanModule> { (CkanModule)e.Argument });
+            downloader.DownloadModules(Main.Instance.Manager.Cache, new List<CkanModule> { (CkanModule)e.Argument });
             e.Result = e.Argument;
         }
 

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -69,7 +69,7 @@ namespace CKAN
             try
             {
                 AddStatusMessage("Updating repositories...");
-                e.Result = Repo.UpdateAllRepositories(RegistryManager.Instance(CurrentInstance), CurrentInstance, GUI.user);
+                e.Result = Repo.UpdateAllRepositories(RegistryManager.Instance(CurrentInstance), CurrentInstance, Manager.Cache, GUI.user);
             }
             catch (UriFormatException ex)
             {

--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -40,8 +40,12 @@
             this.NewAuthTokenButton = new System.Windows.Forms.Button();
             this.DeleteAuthTokenButton = new System.Windows.Forms.Button();
             this.CacheGroupBox = new System.Windows.Forms.GroupBox();
-            this.ClearCKANCacheButton = new System.Windows.Forms.Button();
-            this.CKANCacheLabel = new System.Windows.Forms.Label();
+            this.ClearCacheButton = new System.Windows.Forms.Button();
+            this.ChangeCacheButton = new System.Windows.Forms.Button();
+            this.ResetCacheButton = new System.Windows.Forms.Button();
+            this.OpenCacheButton = new System.Windows.Forms.Button();
+            this.CachePath = new System.Windows.Forms.TextBox();
+            this.CacheSummary = new System.Windows.Forms.Label();
             this.AutoUpdateGroupBox = new System.Windows.Forms.GroupBox();
             this.RefreshOnStartupCheckbox = new System.Windows.Forms.CheckBox();
             this.CheckUpdateOnLaunchCheckbox = new System.Windows.Forms.CheckBox();
@@ -61,9 +65,9 @@
             this.AutoUpdateGroupBox.SuspendLayout();
             this.MoreSettingsGroupBox.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // NewRepoButton
-            // 
+            //
             this.NewRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.NewRepoButton.Location = new System.Drawing.Point(8, 116);
             this.NewRepoButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -73,9 +77,9 @@
             this.NewRepoButton.Text = "New";
             this.NewRepoButton.UseVisualStyleBackColor = true;
             this.NewRepoButton.Click += new System.EventHandler(this.NewRepoButton_Click);
-            // 
+            //
             // RepositoryGroupBox
-            // 
+            //
             this.RepositoryGroupBox.Controls.Add(this.DownRepoButton);
             this.RepositoryGroupBox.Controls.Add(this.UpRepoButton);
             this.RepositoryGroupBox.Controls.Add(this.DeleteRepoButton);
@@ -90,9 +94,9 @@
             this.RepositoryGroupBox.TabIndex = 12;
             this.RepositoryGroupBox.TabStop = false;
             this.RepositoryGroupBox.Text = "Metadata Repositories";
-            // 
+            //
             // DownRepoButton
-            // 
+            //
             this.DownRepoButton.Enabled = false;
             this.DownRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.DownRepoButton.Location = new System.Drawing.Point(173, 116);
@@ -103,9 +107,9 @@
             this.DownRepoButton.Text = "Down";
             this.DownRepoButton.UseVisualStyleBackColor = true;
             this.DownRepoButton.Click += new System.EventHandler(this.DownRepoButton_Click);
-            // 
+            //
             // UpRepoButton
-            // 
+            //
             this.UpRepoButton.Enabled = false;
             this.UpRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.UpRepoButton.Location = new System.Drawing.Point(91, 116);
@@ -116,9 +120,9 @@
             this.UpRepoButton.Text = "Up";
             this.UpRepoButton.UseVisualStyleBackColor = true;
             this.UpRepoButton.Click += new System.EventHandler(this.UpRepoButton_Click);
-            // 
+            //
             // DeleteRepoButton
-            // 
+            //
             this.DeleteRepoButton.Enabled = false;
             this.DeleteRepoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.DeleteRepoButton.Location = new System.Drawing.Point(552, 116);
@@ -129,9 +133,9 @@
             this.DeleteRepoButton.Text = "Delete";
             this.DeleteRepoButton.UseVisualStyleBackColor = true;
             this.DeleteRepoButton.Click += new System.EventHandler(this.DeleteRepoButton_Click);
-            // 
+            //
             // ReposListBox
-            // 
+            //
             this.ReposListBox.FormattingEnabled = true;
             this.ReposListBox.ItemHeight = 16;
             this.ReposListBox.Location = new System.Drawing.Point(8, 23);
@@ -140,9 +144,9 @@
             this.ReposListBox.Size = new System.Drawing.Size(617, 84);
             this.ReposListBox.TabIndex = 9;
             this.ReposListBox.SelectedIndexChanged += new System.EventHandler(this.ReposListBox_SelectedIndexChanged);
-            // 
+            //
             // AuthTokensGroupBox
-            // 
+            //
             this.AuthTokensGroupBox.Controls.Add(this.AuthTokensListBox);
             this.AuthTokensGroupBox.Controls.Add(this.NewAuthTokenButton);
             this.AuthTokensGroupBox.Controls.Add(this.DeleteAuthTokenButton);
@@ -155,9 +159,9 @@
             this.AuthTokensGroupBox.TabIndex = 13;
             this.AuthTokensGroupBox.TabStop = false;
             this.AuthTokensGroupBox.Text = "Authentication Tokens";
-            // 
+            //
             // AuthTokensListBox
-            // 
+            //
             this.AuthTokensListBox.FormattingEnabled = true;
             this.AuthTokensListBox.ItemHeight = 16;
             this.AuthTokensListBox.Location = new System.Drawing.Point(8, 23);
@@ -166,9 +170,9 @@
             this.AuthTokensListBox.Size = new System.Drawing.Size(617, 84);
             this.AuthTokensListBox.TabIndex = 14;
             this.AuthTokensListBox.SelectedIndexChanged += new System.EventHandler(this.AuthTokensListBox_SelectedIndexChanged);
-            // 
+            //
             // NewAuthTokenButton
-            // 
+            //
             this.NewAuthTokenButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.NewAuthTokenButton.Location = new System.Drawing.Point(8, 116);
             this.NewAuthTokenButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -178,9 +182,9 @@
             this.NewAuthTokenButton.Text = "New";
             this.NewAuthTokenButton.UseVisualStyleBackColor = true;
             this.NewAuthTokenButton.Click += new System.EventHandler(this.NewAuthTokenButton_Click);
-            // 
+            //
             // DeleteAuthTokenButton
-            // 
+            //
             this.DeleteAuthTokenButton.Enabled = false;
             this.DeleteAuthTokenButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.DeleteAuthTokenButton.Location = new System.Drawing.Point(552, 116);
@@ -191,45 +195,96 @@
             this.DeleteAuthTokenButton.Text = "Delete";
             this.DeleteAuthTokenButton.UseVisualStyleBackColor = true;
             this.DeleteAuthTokenButton.Click += new System.EventHandler(this.DeleteAuthTokenButton_Click);
-            // 
+            //
             // CacheGroupBox
-            // 
-            this.CacheGroupBox.Controls.Add(this.ClearCKANCacheButton);
-            this.CacheGroupBox.Controls.Add(this.CKANCacheLabel);
+            //
+            this.CacheGroupBox.Controls.Add(this.ClearCacheButton);
+            this.CacheGroupBox.Controls.Add(this.ChangeCacheButton);
+            this.CacheGroupBox.Controls.Add(this.ResetCacheButton);
+            this.CacheGroupBox.Controls.Add(this.OpenCacheButton);
+            this.CacheGroupBox.Controls.Add(this.CachePath);
+            this.CacheGroupBox.Controls.Add(this.CacheSummary);
             this.CacheGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CacheGroupBox.Location = new System.Drawing.Point(16, 343);
             this.CacheGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CacheGroupBox.Name = "CacheGroupBox";
             this.CacheGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.CacheGroupBox.Size = new System.Drawing.Size(635, 60);
+            this.CacheGroupBox.Size = new System.Drawing.Size(635, 120);
             this.CacheGroupBox.TabIndex = 10;
             this.CacheGroupBox.TabStop = false;
-            this.CacheGroupBox.Text = "Cache";
-            // 
-            // ClearCKANCacheButton
-            // 
-            this.ClearCKANCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ClearCKANCacheButton.Location = new System.Drawing.Point(455, 20);
-            this.ClearCKANCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.ClearCKANCacheButton.Name = "ClearCKANCacheButton";
-            this.ClearCKANCacheButton.Size = new System.Drawing.Size(172, 28);
-            this.ClearCKANCacheButton.TabIndex = 1;
-            this.ClearCKANCacheButton.Text = "Clear cache";
-            this.ClearCKANCacheButton.UseVisualStyleBackColor = true;
-            this.ClearCKANCacheButton.Click += new System.EventHandler(this.ClearCKANCacheButton_Click);
-            // 
-            // CKANCacheLabel
-            // 
-            this.CKANCacheLabel.AutoSize = true;
-            this.CKANCacheLabel.Location = new System.Drawing.Point(4, 26);
-            this.CKANCacheLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.CKANCacheLabel.Name = "CKANCacheLabel";
-            this.CKANCacheLabel.Size = new System.Drawing.Size(359, 17);
-            this.CKANCacheLabel.TabIndex = 0;
-            this.CKANCacheLabel.Text = "There are currently N files in the cache, taking up M MB";
-            // 
+            this.CacheGroupBox.Text = "Download Cache";
+            //
+            // ClearCacheButton
+            //
+            this.ClearCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ClearCacheButton.Location = new System.Drawing.Point(116, 80);
+            this.ClearCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.ClearCacheButton.Name = "ClearCacheButton";
+            this.ClearCacheButton.Size = new System.Drawing.Size(100, 28);
+            this.ClearCacheButton.TabIndex = 1;
+            this.ClearCacheButton.Text = "Clear";
+            this.ClearCacheButton.UseVisualStyleBackColor = true;
+            this.ClearCacheButton.Click += new System.EventHandler(this.ClearCacheButton_Click);
+            //
+            // ChangeCacheButton
+            //
+            this.ChangeCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ChangeCacheButton.Location = new System.Drawing.Point(8, 80);
+            this.ChangeCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.ChangeCacheButton.Name = "ChangeCacheButton";
+            this.ChangeCacheButton.Size = new System.Drawing.Size(100, 28);
+            this.ChangeCacheButton.TabIndex = 1;
+            this.ChangeCacheButton.Text = "Change...";
+            this.ChangeCacheButton.UseVisualStyleBackColor = true;
+            this.ChangeCacheButton.Click += new System.EventHandler(this.ChangeCacheButton_Click);
+            //
+            // ResetCacheButton
+            //
+            this.ResetCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ResetCacheButton.Location = new System.Drawing.Point(224, 80);
+            this.ResetCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.ResetCacheButton.Name = "ResetCacheButton";
+            this.ResetCacheButton.Size = new System.Drawing.Size(100, 28);
+            this.ResetCacheButton.TabIndex = 1;
+            this.ResetCacheButton.Text = "Reset";
+            this.ResetCacheButton.UseVisualStyleBackColor = true;
+            this.ResetCacheButton.Click += new System.EventHandler(this.ResetCacheButton_Click);
+            //
+            // OpenCacheButton
+            //
+            this.OpenCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.OpenCacheButton.Location = new System.Drawing.Point(332, 80);
+            this.OpenCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.OpenCacheButton.Name = "OpenCacheButton";
+            this.OpenCacheButton.Size = new System.Drawing.Size(100, 28);
+            this.OpenCacheButton.TabIndex = 1;
+            this.OpenCacheButton.Text = "Open";
+            this.OpenCacheButton.UseVisualStyleBackColor = true;
+            this.OpenCacheButton.Click += new System.EventHandler(this.OpenCacheButton_Click);
+            //
+            // CachePath
+            //
+            this.CachePath.AutoSize = false;
+            this.CachePath.BackColor = System.Drawing.SystemColors.Control;
+            this.CachePath.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.CachePath.Location = new System.Drawing.Point(8, 24);
+            this.CachePath.Name = "CachePath";
+            this.CachePath.Size = new System.Drawing.Size(620, 17);
+            this.CachePath.TabIndex = 11;
+            this.CachePath.TextChanged += new System.EventHandler(this.CachePath_TextChanged);
+            //
+            // CacheSummary
+            //
+            this.CacheSummary.AutoSize = true;
+            this.CacheSummary.Location = new System.Drawing.Point(8, 52);
+            this.CacheSummary.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.CacheSummary.Name = "CacheSummary";
+            this.CacheSummary.Size = new System.Drawing.Size(359, 17);
+            this.CacheSummary.TabIndex = 12;
+            this.CacheSummary.Text = "N files, M MB";
+            //
             // AutoUpdateGroupBox
-            // 
+            //
             this.AutoUpdateGroupBox.Controls.Add(this.RefreshOnStartupCheckbox);
             this.AutoUpdateGroupBox.Controls.Add(this.CheckUpdateOnLaunchCheckbox);
             this.AutoUpdateGroupBox.Controls.Add(this.InstallUpdateButton);
@@ -239,7 +294,7 @@
             this.AutoUpdateGroupBox.Controls.Add(this.LocalVersionLabelLabel);
             this.AutoUpdateGroupBox.Controls.Add(this.CheckForUpdatesButton);
             this.AutoUpdateGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.AutoUpdateGroupBox.Location = new System.Drawing.Point(16, 411);
+            this.AutoUpdateGroupBox.Location = new System.Drawing.Point(16, 471);
             this.AutoUpdateGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AutoUpdateGroupBox.Name = "AutoUpdateGroupBox";
             this.AutoUpdateGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -247,9 +302,9 @@
             this.AutoUpdateGroupBox.TabIndex = 11;
             this.AutoUpdateGroupBox.TabStop = false;
             this.AutoUpdateGroupBox.Text = "Auto-Updates";
-            // 
+            //
             // RefreshOnStartupCheckbox
-            // 
+            //
             this.RefreshOnStartupCheckbox.AutoSize = true;
             this.RefreshOnStartupCheckbox.Location = new System.Drawing.Point(367, 53);
             this.RefreshOnStartupCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -259,9 +314,9 @@
             this.RefreshOnStartupCheckbox.Text = "Update repositories on launch";
             this.RefreshOnStartupCheckbox.UseVisualStyleBackColor = true;
             this.RefreshOnStartupCheckbox.CheckedChanged += new System.EventHandler(this.RefreshOnStartupCheckbox_CheckedChanged);
-            // 
+            //
             // CheckUpdateOnLaunchCheckbox
-            // 
+            //
             this.CheckUpdateOnLaunchCheckbox.AutoSize = true;
             this.CheckUpdateOnLaunchCheckbox.Location = new System.Drawing.Point(367, 20);
             this.CheckUpdateOnLaunchCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -271,9 +326,9 @@
             this.CheckUpdateOnLaunchCheckbox.Text = "Check for CKAN updates on launch";
             this.CheckUpdateOnLaunchCheckbox.UseVisualStyleBackColor = true;
             this.CheckUpdateOnLaunchCheckbox.CheckedChanged += new System.EventHandler(this.CheckUpdateOnLaunchCheckbox_CheckedChanged);
-            // 
+            //
             // InstallUpdateButton
-            // 
+            //
             this.InstallUpdateButton.Enabled = false;
             this.InstallUpdateButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.InstallUpdateButton.Location = new System.Drawing.Point(155, 94);
@@ -284,9 +339,9 @@
             this.InstallUpdateButton.Text = "Install update";
             this.InstallUpdateButton.UseVisualStyleBackColor = true;
             this.InstallUpdateButton.Click += new System.EventHandler(this.InstallUpdateButton_Click);
-            // 
+            //
             // LatestVersionLabel
-            // 
+            //
             this.LatestVersionLabel.AutoSize = true;
             this.LatestVersionLabel.Location = new System.Drawing.Point(115, 53);
             this.LatestVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
@@ -294,9 +349,9 @@
             this.LatestVersionLabel.Size = new System.Drawing.Size(32, 17);
             this.LatestVersionLabel.TabIndex = 4;
             this.LatestVersionLabel.Text = "???";
-            // 
+            //
             // LatestVersionLabelLabel
-            // 
+            //
             this.LatestVersionLabelLabel.AutoSize = true;
             this.LatestVersionLabelLabel.Location = new System.Drawing.Point(9, 53);
             this.LatestVersionLabelLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
@@ -304,9 +359,9 @@
             this.LatestVersionLabelLabel.Size = new System.Drawing.Size(101, 17);
             this.LatestVersionLabelLabel.TabIndex = 3;
             this.LatestVersionLabelLabel.Text = "Latest version:";
-            // 
+            //
             // LocalVersionLabel
-            // 
+            //
             this.LocalVersionLabel.AutoSize = true;
             this.LocalVersionLabel.Location = new System.Drawing.Point(115, 25);
             this.LocalVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
@@ -314,9 +369,9 @@
             this.LocalVersionLabel.Size = new System.Drawing.Size(47, 17);
             this.LocalVersionLabel.TabIndex = 2;
             this.LocalVersionLabel.Text = "v0.0.0";
-            // 
+            //
             // LocalVersionLabelLabel
-            // 
+            //
             this.LocalVersionLabelLabel.AutoSize = true;
             this.LocalVersionLabelLabel.Location = new System.Drawing.Point(9, 25);
             this.LocalVersionLabelLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
@@ -324,9 +379,9 @@
             this.LocalVersionLabelLabel.Size = new System.Drawing.Size(96, 17);
             this.LocalVersionLabelLabel.TabIndex = 1;
             this.LocalVersionLabelLabel.Text = "Local version:";
-            // 
+            //
             // CheckForUpdatesButton
-            // 
+            //
             this.CheckForUpdatesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CheckForUpdatesButton.Location = new System.Drawing.Point(8, 94);
             this.CheckForUpdatesButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -336,9 +391,9 @@
             this.CheckForUpdatesButton.Text = "Check for updates";
             this.CheckForUpdatesButton.UseVisualStyleBackColor = true;
             this.CheckForUpdatesButton.Click += new System.EventHandler(this.CheckForUpdatesButton_Click);
-            // 
+            //
             // HideEpochsCheckbox
-            // 
+            //
             this.HideEpochsCheckbox.AutoSize = true;
             this.HideEpochsCheckbox.Location = new System.Drawing.Point(8, 52);
             this.HideEpochsCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -348,13 +403,13 @@
             this.HideEpochsCheckbox.Text = "Hide epoch numbers in mod list (Requires Restart)";
             this.HideEpochsCheckbox.UseVisualStyleBackColor = true;
             this.HideEpochsCheckbox.CheckedChanged += new System.EventHandler(this.HideEpochsCheckbox_CheckedChanged);
-            // 
+            //
             // MoreSettingsGroupBox
-            // 
+            //
             this.MoreSettingsGroupBox.Controls.Add(this.HideVCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.HideEpochsCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.AutoSortUpdateCheckBox);
-            this.MoreSettingsGroupBox.Location = new System.Drawing.Point(16, 549);
+            this.MoreSettingsGroupBox.Location = new System.Drawing.Point(16, 609);
             this.MoreSettingsGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MoreSettingsGroupBox.Name = "MoreSettingsGroupBox";
             this.MoreSettingsGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -362,9 +417,9 @@
             this.MoreSettingsGroupBox.TabIndex = 14;
             this.MoreSettingsGroupBox.TabStop = false;
             this.MoreSettingsGroupBox.Text = "More Settings";
-            // 
+            //
             // AutoSortUpdateCheckBox
-            // 
+            //
             this.AutoSortUpdateCheckBox.AutoSize = true;
             this.AutoSortUpdateCheckBox.Location = new System.Drawing.Point(8, 23);
             this.AutoSortUpdateCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -374,9 +429,9 @@
             this.AutoSortUpdateCheckBox.Text = "Automatically sort by \"Update\"-column when clicking \"Add available updates\"";
             this.AutoSortUpdateCheckBox.UseVisualStyleBackColor = true;
             this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
-            // 
+            //
             // HideVCheckbox
-            // 
+            //
             this.HideVCheckbox.AutoSize = true;
             this.HideVCheckbox.Location = new System.Drawing.Point(8, 80);
             this.HideVCheckbox.Margin = new System.Windows.Forms.Padding(4);
@@ -386,12 +441,12 @@
             this.HideVCheckbox.Text = "Hide \"v\" in mod list (Requires Restart)";
             this.HideVCheckbox.UseVisualStyleBackColor = true;
             this.HideVCheckbox.CheckedChanged += new System.EventHandler(this.HideVCheckbox_CheckedChanged);
-            // 
+            //
             // SettingsDialog
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(660, 675);
+            this.ClientSize = new System.Drawing.Size(660, 735);
             this.Controls.Add(this.MoreSettingsGroupBox);
             this.Controls.Add(this.AutoUpdateGroupBox);
             this.Controls.Add(this.CacheGroupBox);
@@ -420,8 +475,12 @@
         private System.Windows.Forms.Button NewRepoButton;
         private System.Windows.Forms.GroupBox RepositoryGroupBox;
         private System.Windows.Forms.GroupBox CacheGroupBox;
-        private System.Windows.Forms.Label CKANCacheLabel;
-        private System.Windows.Forms.Button ClearCKANCacheButton;
+        private System.Windows.Forms.TextBox CachePath;
+        private System.Windows.Forms.Label CacheSummary;
+        private System.Windows.Forms.Button ClearCacheButton;
+        private System.Windows.Forms.Button ChangeCacheButton;
+        private System.Windows.Forms.Button ResetCacheButton;
+        private System.Windows.Forms.Button OpenCacheButton;
         private System.Windows.Forms.Button DeleteRepoButton;
         private System.Windows.Forms.ListBox ReposListBox;
         private System.Windows.Forms.Button UpRepoButton;

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -54,8 +54,11 @@ namespace CKAN.NetKAN
 
                     var moduleService = new ModuleService();
                     var fileService = new FileService();
-                    cache = FindCache(new KSPManager(new ConsoleUser(false)));
-                    http  = new CachingHttpService(cache);
+                    cache = FindCache(
+                        new KSPManager(new ConsoleUser(false)),
+                        new Win32Registry()
+                    );
+                    http = new CachingHttpService(cache);
 
                     var netkan = ReadNetkan();
                     Log.Info("Finished reading input");
@@ -136,7 +139,7 @@ namespace CKAN.NetKAN
             }
         }
 
-        private static NetFileCache FindCache(KSPManager kspManager)
+        private static NetFileCache FindCache(KSPManager kspManager, IWin32Registry reg)
         {
             if (Options.CacheDir != null)
             {
@@ -146,10 +149,9 @@ namespace CKAN.NetKAN
 
             try
             {
-                var ksp = kspManager.GetPreferredInstance();
-                Log.InfoFormat("Using CKAN cache at {0}", ksp.Cache.GetCachePath());
+                Log.InfoFormat("Using main CKAN meta-cache at {0}", reg.DownloadCacheDir);
                 /// Create a new file cache in the same location so NetKAN can download pure URLs not sourced from CkanModules
-                return new NetFileCache(ksp.Cache.GetCachePath());
+                return new NetFileCache(kspManager, reg.DownloadCacheDir);
             }
             catch
             {

--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -33,7 +33,7 @@ namespace Tests.Core
         public void Sanity()
         {
             Assert.IsInstanceOf<NetFileCache>(cache);
-            Assert.IsTrue(Directory.Exists(cache.GetCachePath()));
+            Assert.IsInstanceOf<NetModuleCache>(module_cache);
         }
 
         [Test]
@@ -41,9 +41,6 @@ namespace Tests.Core
         {
             Uri url = new Uri("http://example.com/");
             string file = TestData.DogeCoinFlagZip();
-
-            // Sanity check, our cache dir is there, right?
-            Assert.IsTrue(Directory.Exists(cache.GetCachePath()));
 
             // Our URL shouldn't be cached to begin with.
             Assert.IsFalse(cache.IsCached(url));

--- a/Tests/Core/FakeWin32Registry.cs
+++ b/Tests/Core/FakeWin32Registry.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CKAN;
+using NUnit.Framework;
+using Tests.Data;
+
+namespace Tests.Core
+{
+    public class FakeWin32Registry : IWin32Registry
+    {
+        public FakeWin32Registry(CKAN.KSP instance, string autostart)
+            : this(
+                new List<Tuple<string, string>>
+                {
+                    new Tuple<string, string>("test", instance.GameDir())
+                },
+                autostart
+            )
+        {
+        }
+
+        /// <summary>
+        /// Initialize the fake registry
+        /// </summary>
+        /// <param name="instances">List of name/path pairs for the instances</param>
+        /// <param name="auto_start_instance">The auto start instance to use</param>
+        public FakeWin32Registry(List<Tuple<string, string>> instances, string auto_start_instance)
+        {
+            Instances         = instances;
+            AutoStartInstance = auto_start_instance;
+            DownloadCacheDir  = TestData.NewTempDir();
+        }
+
+        /// <summary>
+        /// The instances in the fake registry
+        /// </summary>
+        public List<Tuple<string, string>> Instances        { get; set; }
+        /// <summary>
+        /// Build map for the fake registry
+        /// </summary>
+        public string                      BuildMap         { get; set; }
+        /// <summary>
+        /// Path to download cache folder for the fake registry
+        /// </summary>
+        public string                      DownloadCacheDir { get; set; }
+
+        /// <summary>
+        /// Number of instances in the fake registry
+        /// </summary>
+        public int InstanceCount
+        {
+            get { return Instances.Count; }
+        }
+
+        // In the Win32Registry it is not possible to get null in autostart.
+        private string _AutoStartInstance;
+        /// <summary>
+        /// The auto start instance for the fake registry
+        /// </summary>
+        public string AutoStartInstance
+        {
+            get { return _AutoStartInstance ?? string.Empty; }
+            set
+            {
+                _AutoStartInstance = value;
+            }
+        }
+
+        /// <summary>
+        /// Retrieve and instance from the fake registry
+        /// </summary>
+        /// <param name="i">Index of the instance to retrieve</param>
+        /// <returns>
+        /// Name/path pair for the requested instance
+        /// </returns>
+        public Tuple<string, string> GetInstance(int i)
+        {
+            return Instances[i];
+        }
+
+        /// <summary>
+        /// Set the instance data for the fake registry
+        /// </summary>
+        /// <param name="instances">New list of instances to use</param>
+        /// <param name="autoStartInstance">Which instance to use for auto start</param>
+        /// <returns>
+        /// Returns
+        /// </returns>
+        public void SetRegistryToInstances(SortedList<string, CKAN.KSP> instances, string autoStartInstance)
+        {
+            Instances =
+                instances.Select(kvpair => new Tuple<string, string>(kvpair.Key, kvpair.Value.GameDir())).ToList();
+            AutoStartInstance = autoStartInstance;
+        }
+
+        /// <summary>
+        /// The instances in the fake registry
+        /// </summary>
+        public IEnumerable<Tuple<string, string>> GetInstances()
+        {
+            return Instances;
+        }
+
+        /// <summary>
+        /// The build map of the fake registry
+        /// </summary>
+        public string GetKSPBuilds()
+        {
+            return BuildMap;
+        }
+
+        /// <summary>
+        /// Set the build map for the fake registry
+        /// </summary>
+        /// <param name="buildMap">New build map to use</param>
+        public void SetKSPBuilds(string buildMap)
+        {
+            BuildMap = buildMap;
+        }
+    }
+}

--- a/Tests/Core/KSP.cs
+++ b/Tests/Core/KSP.cs
@@ -30,7 +30,6 @@ namespace Tests.Core
                 // For some reason the KSP instance doesn't do this itself causing test failures because the registry
                 // lock file is still in use. So just dispose of it ourselves.
                 CKAN.RegistryManager.Instance(ksp).Dispose();
-                ksp.Dispose();
             }
 
             Directory.Delete(ksp_dir, true);

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -71,6 +71,7 @@ namespace Tests.Core
             manager.RenameInstance(nameInReg,"newname");
             Assert.False(manager.HasInstance(nameInReg));
         }
+
         [Test]
         public void RenameInstance_HasInstanceNewName()
         {
@@ -96,15 +97,15 @@ namespace Tests.Core
         }
 
         [Test]
-        public void AddInstance_ManagarHasInstance()
+        public void AddInstance_ManagerHasInstance()
         {
             using (var tidy2 = new DisposableKSP())
             {
                 const string newInstance = "tidy2";
                 tidy2.KSP.Name = newInstance;
-                Assert.That(manager.HasInstance(newInstance), Is.False);
+                Assert.IsFalse(manager.HasInstance(newInstance));
                 manager.AddInstance(tidy2.KSP);
-                Assert.That(manager.HasInstance(newInstance),Is.True);
+                Assert.IsTrue(manager.HasInstance(newInstance));
             }
         }
 
@@ -152,74 +153,13 @@ namespace Tests.Core
 
         private FakeWin32Registry GetTestWin32Reg(string name)
         {
-            return new FakeWin32Registry(new List<Tuple<string, string>>
-            {
-                new Tuple<string, string>(name, tidy.KSP.GameDir())
-            });
-        }
-    }
-
-    public class FakeWin32Registry : IWin32Registry
-    {
-        public FakeWin32Registry(CKAN.KSP instance,string autostart = "test")
-        {
-            Instances = new List<Tuple<string, string>>
-            {
-                new Tuple<string, string>("test", instance.GameDir())
-            };
-            AutoStartInstance = autostart;
-        }
-
-        public FakeWin32Registry(List<Tuple<string, string>> instances, string auto_start_instance = null)
-        {
-            Instances = instances;
-            AutoStartInstance = auto_start_instance;
-        }
-
-        public List<Tuple<string, string>> Instances { get; set; }
-        public string BuildMap { get; set; }
-
-        public int InstanceCount
-        {
-            get { return Instances.Count; }
-            }
-
-        // In the Win32Registry it is not possible to get null in autostart.
-        private string _AutoStartInstance;
-        public string AutoStartInstance
-        {
-            get { return _AutoStartInstance ?? string.Empty; }
-            set
-            {
-                _AutoStartInstance = value;
-            }
-        }
-
-        public Tuple<string, string> GetInstance(int i)
-        {
-            return Instances[i];
-        }
-
-        public void SetRegistryToInstances(SortedList<string, CKAN.KSP> instances, string autoStartInstance)
-        {
-            Instances =
-                instances.Select(kvpair => new Tuple<string, string>(kvpair.Key, kvpair.Value.GameDir())).ToList();
-            AutoStartInstance = autoStartInstance;
-        }
-
-        public IEnumerable<Tuple<string, string>> GetInstances()
-        {
-            return Instances;
-        }
-
-        public string GetKSPBuilds()
-        {
-            return BuildMap;
-        }
-
-        public void SetKSPBuilds(string buildMap)
-        {
-            BuildMap = buildMap;
+            return new FakeWin32Registry(
+                new List<Tuple<string, string>>
+                {
+                    new Tuple<string, string>(name, tidy.KSP.GameDir())
+                },
+                null
+            );
         }
     }
 }

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -17,6 +17,7 @@ namespace Tests.Core
     [TestFixture]
     public class ModuleInstallerDirTest
     {
+        private KSPManager           _manager;
         private DisposableKSP        _instance;
         private CKAN.Registry        _registry;
         private CKAN.ModuleInstaller _installer;
@@ -32,14 +33,15 @@ namespace Tests.Core
         {
             _testModule = TestData.DogeCoinFlag_101_module();
 
+            _manager   = new KSPManager(NullUser.User);
             _instance  = new DisposableKSP();
             _registry  = CKAN.RegistryManager.Instance(_instance.KSP).registry;
-            _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, NullUser.User);
+            _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, NullUser.User);
 
             _gameDataDir = _instance.KSP.GameData();
             _registry.AddAvailable(_testModule);
             var testModFile = TestData.DogeCoinFlagZip();
-            _instance.KSP.Cache.Store(_testModule, testModFile);
+            _manager.Cache.Store(_testModule, testModFile);
             _installer.InstallList(
                 new List<string>() { _testModule.identifier },
                 new RelationshipResolverOptions()

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -13,12 +13,12 @@ namespace Tests.Core.Net
     [TestFixture]
     public class NetAsyncModulesDownloader
     {
-
-        private CKAN.RegistryManager manager;
-        private CKAN.Registry registry;
-        private DisposableKSP ksp;
-        private CKAN.IDownloader async;
-        private NetModuleCache cache;
+        private CKAN.KSPManager      manager;
+        private CKAN.RegistryManager registry_manager;
+        private CKAN.Registry        registry;
+        private DisposableKSP        ksp;
+        private CKAN.IDownloader     async;
+        private NetModuleCache       cache;
 
         private static readonly ILog log = LogManager.GetLogger(typeof (NetAsyncModulesDownloader));
 
@@ -28,20 +28,21 @@ namespace Tests.Core.Net
             // Make sure curl is all set up.
             Curl.Init();
 
+            manager = new KSPManager(new NullUser());
             // Give us a registry to play with.
             ksp = new DisposableKSP();
-            manager = CKAN.RegistryManager.Instance(ksp.KSP);
-            registry = manager.registry;
+            registry_manager = CKAN.RegistryManager.Instance(ksp.KSP);
+            registry = registry_manager.registry;
             registry.ClearDlls();
             registry.Installed().Clear();
             // Make sure we have a registry we can use.
-            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
+            CKAN.Repo.Update(registry_manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
 
             // Ready our downloader.
             async = new CKAN.NetAsyncModulesDownloader(new NullUser());
 
             // General shortcuts
-            cache = ksp.KSP.Cache;
+            cache = manager.Cache;
         }
 
         [TearDown]
@@ -72,10 +73,10 @@ namespace Tests.Core.Net
             Assert.IsFalse(cache.IsCached(kOS));
 
             //
-            log.InfoFormat("Downloading kOS from {0}",kOS.download);
+            log.InfoFormat("Downloading kOS from {0}", kOS.download);
 
             // Download our module.
-            async.DownloadModules(ksp.KSP.Cache, modules);
+            async.DownloadModules(manager.Cache, modules);
 
             // Assert that we have it, and it passes zip validation.
             Assert.IsTrue(cache.IsCachedZip(kOS));

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -68,8 +68,6 @@ namespace Tests.Data
                 }
             }
 
-            //proceed to dispose our wrapped KSP object
-            KSP.Dispose();
             KSP = null;
         }
     }

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -54,17 +54,20 @@ namespace Tests.GUI
         {
             _instance = new DisposableKSP();
             _registry = Registry.Empty();
-            _manager = new KSPManager(new NullUser(), new FakeWin32Registry(_instance.KSP));
+            _manager = new KSPManager(
+                new NullUser(),
+                new FakeWin32Registry(_instance.KSP, _instance.KSP.Name)
+            );
 
             // this module contains a ksp_version of "any" which repros our issue
             _anyVersionModule = TestData.DogeCoinFlag_101_module();
 
             // install it and set it as pre-installed
-            _instance.KSP.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
+            _manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
             _registry.RegisterModule(_anyVersionModule, new string[] { }, _instance.KSP);
             _registry.AddAvailable(_anyVersionModule);
 
-            ModuleInstaller.GetInstance(_instance.KSP, _manager.User).InstallList(
+            ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                 new List<CkanModule> { { _anyVersionModule } },
                 new RelationshipResolverOptions(),
                 new NetAsyncModulesDownloader(_manager.User)
@@ -130,7 +133,7 @@ namespace Tests.GUI
             Assert.DoesNotThrow(() =>
             {
                 // perform the install of the "other" module - now we need to sort
-                ModuleInstaller.GetInstance(_instance.KSP, _manager.User).InstallList(
+                ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                     _modList.ComputeUserChangeSet().Select(change => change.Mod.ToCkanModule()).ToList(),
                     new RelationshipResolverOptions(),
                     new NetAsyncModulesDownloader(_manager.User)

--- a/Tests/GUI/GUIMod.cs
+++ b/Tests/GUI/GUIMod.cs
@@ -18,7 +18,12 @@ namespace Tests.GUI
         {
             using (var tidy = new DisposableKSP())
             {
-                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(tidy.KSP)) {CurrentInstance = tidy.KSP};
+                KSPManager manager = new KSPManager(
+                    new NullUser(),
+                    new FakeWin32Registry(tidy.KSP, tidy.KSP.Name)
+                ) {
+                    CurrentInstance = tidy.KSP
+                };
                 var registry = Registry.Empty();
                 var ckan_mod = TestData.kOS_014_module();
                 registry.AddAvailable(ckan_mod);

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -85,7 +85,12 @@ namespace Tests.GUI
         {
             using (var tidy = new DisposableKSP())
             {
-                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(tidy.KSP)) { CurrentInstance = tidy.KSP };
+                KSPManager manager = new KSPManager(
+                    new NullUser(),
+                    new FakeWin32Registry(tidy.KSP, tidy.KSP.Name)
+                ) {
+                    CurrentInstance = tidy.KSP
+                };
 
                 var ckan_mod = TestData.FireSpitterModule();
                 var registry = Registry.Empty();
@@ -112,7 +117,12 @@ namespace Tests.GUI
         {
             using (var tidy = new DisposableKSP())
             {
-                KSPManager manager = new KSPManager(new NullUser(), new FakeWin32Registry(tidy.KSP)) { CurrentInstance = tidy.KSP };
+                KSPManager manager = new KSPManager(
+                    new NullUser(),
+                    new FakeWin32Registry(tidy.KSP, tidy.KSP.Name)
+                ) {
+                    CurrentInstance = tidy.KSP
+                };
                 var registry = Registry.Empty();
                 registry.AddAvailable(TestData.FireSpitterModule());
                 registry.AddAvailable(TestData.kOS_014_module());
@@ -132,6 +142,7 @@ namespace Tests.GUI
         {
             using (var tidy = new DisposableKSP())
             {
+                var manager = new KSPManager(new NullUser());
                 var registry = Registry.Empty();
                 var generator = new RandomModuleGenerator(new Random(0451));
                 var provide_ident = "provide";
@@ -148,7 +159,7 @@ namespace Tests.GUI
                 registry.AddAvailable(mod);
                 registry.AddAvailable(moda);
                 registry.AddAvailable(modb);
-                var installer = ModuleInstaller.GetInstance(tidy.KSP, null);
+                var installer = ModuleInstaller.GetInstance(tidy.KSP, manager.Cache, null);
                 var main_mod_list = new MainModList(null, async kraken => await Task.FromResult(choice_of_provide));
                 var a = new HashSet<ModChange>
                 {

--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -12,22 +12,23 @@ namespace Tests.NetKAN.Sources.Curse
     [Category("Online")]
     public sealed class CurseApiTests
     {
+        private string       _cachePath;
         private NetFileCache _cache;
 
         [OneTimeSetUp]
         public void TestFixtureSetup()
         {
-            var tempDirectory = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
+            _cachePath = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
 
-            Directory.CreateDirectory(tempDirectory);
+            Directory.CreateDirectory(_cachePath);
 
-            _cache = new NetFileCache(tempDirectory);
+            _cache = new NetFileCache(_cachePath);
         }
 
         [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
-            Directory.Delete(_cache.GetCachePath(), recursive: true);
+            Directory.Delete(_cachePath, recursive: true);
         }
 
         [Test]

--- a/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
+++ b/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
@@ -12,22 +12,23 @@ namespace Tests.NetKAN.Sources.Spacedock
     [Category("Online")]
     public sealed class SpacedockApiTests
     {
+        private string       _cachePath;
         private NetFileCache _cache;
 
         [OneTimeSetUp]
         public void TestFixtureSetup()
         {
-            var tempDirectory = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
+            _cachePath = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
 
-            Directory.CreateDirectory(tempDirectory);
+            Directory.CreateDirectory(_cachePath);
 
-            _cache = new NetFileCache(tempDirectory);
+            _cache = new NetFileCache(_cachePath);
         }
 
         [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
-            Directory.Delete(_cache.GetCachePath(), recursive: true);
+            Directory.Delete(_cachePath, recursive: true);
         }
 
         [Test]

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Core\FileIdentifier.cs" />
     <Compile Include="Core\KSP.cs" />
     <Compile Include="Core\KSPManager.cs" />
+    <Compile Include="Core\FakeWin32Registry.cs" />
     <Compile Include="Core\KSPPathUtils.cs" />
     <Compile Include="Core\ModuleInstaller.cs" />
     <Compile Include="Core\ModuleInstallerDirTest.cs" />


### PR DESCRIPTION
## Background

CKAN stores downloads in a cache, so if you install a module twice, it won't be downloaded twice. Currently this cache lives at the game-instance level. Let's say for the sake of argument that a user had several game instances:

![image](https://user-images.githubusercontent.com/1559108/46644249-1fb5f300-cb45-11e8-82d9-8db336fc1d03.png)

Then each of these would have its own independent download cache, at `<GameRoot>/CKAN/downloads`.

## Problems

- If you install a module in your 1.2.2 instance, and then install the same module in your 1.2.2_Dakar instance, it would be downloaded twice and stored on disk twice.
- The cache can grow quite big and takes up space on the same disk/partition where KSP is installed with no option for configuration (other than manually arranged symlinks on Linux)

Three Caches for the Elven-kings under the sky,
Seven for the Dwarf-lords in halls of stone,
Nine for Mortal Men, doomed to die,

... is a bit much for CKAN.

## Previous approaches

#2185 started addressing this, but it had some problems and @Olympic1 has been too busy to develop it further. This pull request tries to learn from and avoid the issues that came up in that effort.

- `ckan help` didn't show the `cache` command
- All instances' `registry.json` files were loaded at startup, causing a big performance hit
- Some of the tests didn't work because `0000400` isn't an octal literal in C#
- The cache folder configuration was stored in several places (Windows registry, CKAN instance registry, `GUIConfig.xml` file), which is kind of awkward to coordinate and opens the door to things getting out of sync

## Changes

### Core

The cache object is removed from the game-instance level altogether; the `KSP` class no longer has a `Cache` property (though it retains its cache *folder* property). Instead the cache now lives in `KSPManager`, the object that sits above all the instances. This makes it a truly global cache.

Various places have been updated to pass a cache or manager object where an instance would have worked previously.

Cache size measurement and clearing are migrated into the cache object itself.

The cache writes new downloads into one configurable location.The default cache location is:

```csharp
Path.Combine(
    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
    "CKAN",
    "downloads"
);
```

- On Linux this is `~/.local/share/CKAN/downloads`
- On Windows it is `C:\Users\<user>\AppData\Local\CKAN\downloads`

This can be overridden by using the various UIs to set a Windows/Mono registry key:

```
KEY_CURRENT_USER\Software\CKAN\DownloadCacheDir
```

This allows the user to select a location on their system with the appropriate combination of capacity and responsiveness, according to their preferences. When you change the setting, files are migrated from the old folder to the new.

If the user has old cache folders in his existing game instances, these will be checked after the main cache folder but not written to. This ensures that previously downloaded files will not be re-downloaded regardless of the instances in which they were originally downloaded or newly needed. The user is free to migrate or purge these folders or leave them alone as he pleases. By not auto-migrating the contents of such folders, we avoid the risk of filling a disk when moving lots of big files from one folder to another.

Newly configured game instances will not have a `CKAN/downloads` folder created.

### Netkan

Netkan is updated to use the configurable global cache. The `--cachedir` parameter still overrides the default path, so the bot should not be affected.

### CmdLine

CmdLine now has several new subcommands (which show up in `ckan help`):

- `ckan cache list` - show the current cache location and size
- `ckan cache set <path>` - change the cache location
- `ckan cache clear` - delete all the files in the cache
- `ckan cache reset` - set the cache location back to the default

### GUI

The GUI settings window's cache section is re-done:

![image](https://user-images.githubusercontent.com/1559108/46644084-81299200-cb44-11e8-96ed-8f7dc6ac4860.png)

- The cache path field is editable (this is necessary because the folder select window hides dot-folders, see mono/mono#10320)
- The Change... button opens a folder select window to choose a new path folder
- The Reset button sets the path back to the default, in case the user messes up the field and wants a do-over
- The Open button opens the cache in the operating system's file manager

If you type an invalid folder, the text description between the field and the buttons turns red and explains the problem (and the most recent valid selection will be used if the window is closed):

![image](https://user-images.githubusercontent.com/1559108/46644164-c77ef100-cb44-11e8-9f73-971e68d8cbb4.png)

There is no "nag" feature on startup. Rather, the new cache structure will "just work" without the user having to worry about the details, but if they want to change it, it's there in the settings.

Fixes #584.
Fixes #960.
Closes #2185.