### PR TITLE
Configurable cache size limit

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -219,6 +219,8 @@ namespace CKAN
 
             }
 
+            EnforceCacheSizeLimit();
+
             // We can scan GameData as a separate transaction. Installing the mods
             // leaves everything consistent, and this is just gravy. (And ScanGameData
             // acts as a Tx, anyway, so we don't need to provide our own.)
@@ -253,6 +255,8 @@ namespace CKAN
                 User.RaiseProgress("Committing filesystem changes", 80);
 
                 transaction.Complete();
+
+                EnforceCacheSizeLimit();
             }
         }
 
@@ -996,6 +1000,8 @@ namespace CKAN
                 registry_manager.Save(enforceConsistency);
 
                 tx.Complete();
+
+                EnforceCacheSizeLimit();
             }
         }
 
@@ -1156,6 +1162,18 @@ namespace CKAN
                 {
                     f.Delete();
                 }
+            }
+
+            EnforceCacheSizeLimit();
+        }
+
+        private void EnforceCacheSizeLimit()
+        {
+            // Purge old downloads if we're over the limit
+            Win32Registry winReg = new Win32Registry();
+            if (winReg.CacheSizeLimit.HasValue)
+            {
+                Cache.EnforceSizeLimit(winReg.CacheSizeLimit.Value, registry_manager.registry);
             }
         }
 

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -74,6 +74,10 @@ namespace CKAN
         {
             cache.GetSizeInfo(out numFiles, out numBytes);
         }
+        public void EnforceSizeLimit(long bytes, Registry registry)
+        {
+            cache.EnforceSizeLimit(bytes, registry);
+        }
 
         /// <summary>
         /// Calculate the SHA1 hash of a file

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1097,15 +1097,54 @@ namespace CKAN
         public Dictionary<string, List<CkanModule>> GetSha1Index()
         {
             var index = new Dictionary<string, List<CkanModule>>();
-            foreach (var kvp in available_modules) {
+            foreach (var kvp in available_modules)
+            {
                 AvailableModule am = kvp.Value;
-                foreach (var kvp2 in am.module_version) {
+                foreach (var kvp2 in am.module_version)
+                {
                     CkanModule mod = kvp2.Value;
-                    if (mod.download_hash != null) {
-                        if (index.ContainsKey(mod.download_hash.sha1)) {
+                    if (mod.download_hash != null)
+                    {
+                        if (index.ContainsKey(mod.download_hash.sha1))
+                        {
                             index[mod.download_hash.sha1].Add(mod);
-                        } else {
+                        }
+                        else
+                        {
                             index.Add(mod.download_hash.sha1, new List<CkanModule>() {mod});
+                        }
+                    }
+                }
+            }
+            return index;
+        }
+
+        /// <summary>
+        /// Get a dictionary of all mod versions indexed by their download URLs' hash.
+        /// Useful for finding the mods for a group of URLs without repeatedly searching the entire registry.
+        /// </summary>
+        /// <returns>
+        /// dictionary[urlHash] = {mod1, mod2, mod3};
+        /// </returns>
+        public Dictionary<string, List<CkanModule>> GetDownloadHashIndex()
+        {
+            var index = new Dictionary<string, List<CkanModule>>();
+            foreach (var kvp in available_modules)
+            {
+                AvailableModule am = kvp.Value;
+                foreach (var kvp2 in am.module_version)
+                {
+                    CkanModule mod = kvp2.Value;
+                    if (mod.download != null)
+                    {
+                        string hash = NetFileCache.CreateURLHash(mod.download);
+                        if (index.ContainsKey(hash))
+                        {
+                            index[hash].Add(mod);
+                        }
+                        else
+                        {
+                            index.Add(hash, new List<CkanModule>() {mod});
                         }
                     }
                 }

--- a/Core/Versioning/KspVersionCriteria.cs
+++ b/Core/Versioning/KspVersionCriteria.cs
@@ -6,7 +6,7 @@ namespace CKAN.Versioning
 {
     public class KspVersionCriteria
     {
-        private List<KspVersion> _versions = new List<KspVersion> ();
+        private List<KspVersion> _versions = new List<KspVersion>();
 
         public KspVersionCriteria (KspVersion v)
         {
@@ -32,6 +32,14 @@ namespace CKAN.Versioning
             {
                 return _versions.AsReadOnly();
             }
+        }
+
+        public KspVersionCriteria Union(KspVersionCriteria other)
+        {
+            return new KspVersionCriteria(
+                null,
+                _versions.Union(other.Versions).ToList()
+            );
         }
 
         public override String ToString()

--- a/Core/Win32Registry.cs
+++ b/Core/Win32Registry.cs
@@ -14,6 +14,7 @@ namespace CKAN
         string GetKSPBuilds();
         void SetKSPBuilds(string buildMap);
         string DownloadCacheDir { get; set; }
+        long? CacheSizeLimit { get; set; }
     }
 
     public class Win32Registry : IWin32Registry
@@ -54,6 +55,30 @@ namespace CKAN
                         value = Path.GetFullPath(value);
                     }
                     SetRegistryValue(@"DownloadCacheDir", value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get and set the maximum number of bytes allowed in the cache.
+        /// Unlimited if null.
+        /// </summary>
+        public long? CacheSizeLimit
+        {
+            get
+            {
+                string val = GetRegistryValue<string>(@"CacheSizeLimit", null);
+                return string.IsNullOrEmpty(val) ? null : (long?)Convert.ToInt64(val);
+            }
+            set
+            {
+                if (!value.HasValue)
+                {
+                    DeleteRegistryValue(@"CacheSizeLimit");
+                }
+                else
+                {
+                    SetRegistryValue(@"CacheSizeLimit", value.Value);
                 }
             }
         }

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -104,6 +104,7 @@
     </Compile>
     <Compile Include="Configuration.cs" />
     <Compile Include="ControlFactory.cs" />
+    <Compile Include="DropdownMenuButton.cs" />
     <Compile Include="ErrorDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/DropdownMenuButton.cs
+++ b/GUI/DropdownMenuButton.cs
@@ -1,0 +1,65 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    /// <summary>
+    /// Button with a Menu property that displays when you click
+    /// Also shows a down-pointing triangle on the button
+    ///
+    /// Based on https://stackoverflow.com/a/24087828/2422988
+    /// </summary>
+    public class DropdownMenuButton : Button
+    {
+        /// <summary>
+        /// The menu to use for the dropdown
+        /// </summary>
+        [
+            DefaultValue(null),
+            Browsable(true),
+            DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)
+        ]
+        public ContextMenuStrip Menu { get; set; }
+
+        /// <summary>
+        /// Draw the triangle on the button
+        /// </summary>
+        /// <param name="pevent">The paint event details</param>
+        protected override void OnPaint(PaintEventArgs pevent)
+        {
+            base.OnPaint(pevent);
+
+            if (Menu != null)
+            {
+                int arrowX = ClientRectangle.Width - 14,
+                    arrowY = ClientRectangle.Height / 2 - 1;
+
+                pevent.Graphics.FillPolygon(
+                    Enabled ? SystemBrushes.ControlText : SystemBrushes.ButtonShadow,
+                    new Point[]
+                    {
+                        new Point(arrowX,     arrowY),
+                        new Point(arrowX + 7, arrowY),
+                        new Point(arrowX + 3, arrowY + 4)
+                    }
+                );
+            }
+        }
+
+        /// <summary>
+        /// Show the Menu on click
+        /// </summary>
+        /// <param name="mevent">The mouse event details</param>
+        protected override void OnMouseDown(MouseEventArgs mevent)
+        {
+            base.OnMouseDown(mevent);
+
+            if (Menu != null && mevent.Button == MouseButtons.Left)
+            {
+                Menu.Show(this, new Point(0, Height));
+            }
+        }
+    }
+}

--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -40,12 +40,18 @@
             this.NewAuthTokenButton = new System.Windows.Forms.Button();
             this.DeleteAuthTokenButton = new System.Windows.Forms.Button();
             this.CacheGroupBox = new System.Windows.Forms.GroupBox();
-            this.ClearCacheButton = new System.Windows.Forms.Button();
+            this.ClearCacheButton = new CKAN.DropdownMenuButton();
+            this.ClearCacheMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.PurgeToLimitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.PurgeAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ChangeCacheButton = new System.Windows.Forms.Button();
             this.ResetCacheButton = new System.Windows.Forms.Button();
             this.OpenCacheButton = new System.Windows.Forms.Button();
             this.CachePath = new System.Windows.Forms.TextBox();
+            this.CacheLimit = new System.Windows.Forms.TextBox();
             this.CacheSummary = new System.Windows.Forms.Label();
+            this.CacheLimitPreLabel = new System.Windows.Forms.Label();
+            this.CacheLimitPostLabel = new System.Windows.Forms.Label();
             this.AutoUpdateGroupBox = new System.Windows.Forms.GroupBox();
             this.RefreshOnStartupCheckbox = new System.Windows.Forms.CheckBox();
             this.CheckUpdateOnLaunchCheckbox = new System.Windows.Forms.CheckBox();
@@ -203,33 +209,59 @@
             this.CacheGroupBox.Controls.Add(this.ResetCacheButton);
             this.CacheGroupBox.Controls.Add(this.OpenCacheButton);
             this.CacheGroupBox.Controls.Add(this.CachePath);
+            this.CacheGroupBox.Controls.Add(this.CacheLimit);
             this.CacheGroupBox.Controls.Add(this.CacheSummary);
+            this.CacheGroupBox.Controls.Add(this.CacheLimitPreLabel);
+            this.CacheGroupBox.Controls.Add(this.CacheLimitPostLabel);
             this.CacheGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CacheGroupBox.Location = new System.Drawing.Point(16, 343);
             this.CacheGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CacheGroupBox.Name = "CacheGroupBox";
             this.CacheGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.CacheGroupBox.Size = new System.Drawing.Size(635, 120);
+            this.CacheGroupBox.Size = new System.Drawing.Size(635, 140);
             this.CacheGroupBox.TabIndex = 10;
             this.CacheGroupBox.TabStop = false;
             this.CacheGroupBox.Text = "Download Cache";
             //
             // ClearCacheButton
             //
+            this.ClearCacheButton.Menu = this.ClearCacheMenu;
             this.ClearCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ClearCacheButton.Location = new System.Drawing.Point(116, 80);
+            this.ClearCacheButton.Location = new System.Drawing.Point(116, 100);
             this.ClearCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ClearCacheButton.Name = "ClearCacheButton";
             this.ClearCacheButton.Size = new System.Drawing.Size(100, 28);
             this.ClearCacheButton.TabIndex = 1;
-            this.ClearCacheButton.Text = "Clear";
+            this.ClearCacheButton.Text = "Purge";
             this.ClearCacheButton.UseVisualStyleBackColor = true;
-            this.ClearCacheButton.Click += new System.EventHandler(this.ClearCacheButton_Click);
+            //
+            // ClearCacheMenu
+            //
+            this.ClearCacheMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+                this.PurgeToLimitMenuItem,
+                this.PurgeAllMenuItem
+            });
+            this.ClearCacheMenu.Name = "ClearCacheMenu";
+            this.ClearCacheMenu.Size = new System.Drawing.Size(180, 70);
+            //
+            // PurgeToLimitMenuItem
+            //
+            this.PurgeToLimitMenuItem.Name = "PurgeToLimitMenuItem";
+            this.PurgeToLimitMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.PurgeToLimitMenuItem.Text = "Purge to limit";
+            this.PurgeToLimitMenuItem.Click += new System.EventHandler(this.PurgeToLimitMenuItem_Click);
+            //
+            // PurgeAllMenuItem
+            //
+            this.PurgeAllMenuItem.Name = "PurgeAllMenuItem";
+            this.PurgeAllMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.PurgeAllMenuItem.Text = "Purge all";
+            this.PurgeAllMenuItem.Click += new System.EventHandler(this.PurgeAllMenuItem_Click);
             //
             // ChangeCacheButton
             //
             this.ChangeCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChangeCacheButton.Location = new System.Drawing.Point(8, 80);
+            this.ChangeCacheButton.Location = new System.Drawing.Point(8, 100);
             this.ChangeCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ChangeCacheButton.Name = "ChangeCacheButton";
             this.ChangeCacheButton.Size = new System.Drawing.Size(100, 28);
@@ -241,7 +273,7 @@
             // ResetCacheButton
             //
             this.ResetCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ResetCacheButton.Location = new System.Drawing.Point(224, 80);
+            this.ResetCacheButton.Location = new System.Drawing.Point(224, 100);
             this.ResetCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ResetCacheButton.Name = "ResetCacheButton";
             this.ResetCacheButton.Size = new System.Drawing.Size(100, 28);
@@ -253,7 +285,7 @@
             // OpenCacheButton
             //
             this.OpenCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.OpenCacheButton.Location = new System.Drawing.Point(332, 80);
+            this.OpenCacheButton.Location = new System.Drawing.Point(332, 100);
             this.OpenCacheButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.OpenCacheButton.Name = "OpenCacheButton";
             this.OpenCacheButton.Size = new System.Drawing.Size(100, 28);
@@ -283,6 +315,38 @@
             this.CacheSummary.TabIndex = 12;
             this.CacheSummary.Text = "N files, M MB";
             //
+            // CacheLimitPreLabel
+            //
+            this.CacheLimitPreLabel.AutoSize = true;
+            this.CacheLimitPreLabel.Location = new System.Drawing.Point(8, 76);
+            this.CacheLimitPreLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.CacheLimitPreLabel.Name = "CacheLimitPreLabel";
+            this.CacheLimitPreLabel.Size = new System.Drawing.Size(148, 17);
+            this.CacheLimitPreLabel.TabIndex = 12;
+            this.CacheLimitPreLabel.Text = "Maximum cache size:";
+            //
+            // CacheLimit
+            //
+            this.CacheLimit.AutoSize = false;
+            this.CacheLimit.BackColor = System.Drawing.SystemColors.Control;
+            this.CacheLimit.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.CacheLimit.Location = new System.Drawing.Point(156, 72);
+            this.CacheLimit.Name = "CacheLimit";
+            this.CacheLimit.Size = new System.Drawing.Size(75, 17);
+            this.CacheLimit.TabIndex = 11;
+            this.CacheLimit.TextChanged += new System.EventHandler(this.CacheLimit_TextChanged);
+            this.CacheLimit.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.CacheLimit_KeyPress);
+            //
+            // CacheLimitPostLabel
+            //
+            this.CacheLimitPostLabel.AutoSize = true;
+            this.CacheLimitPostLabel.Location = new System.Drawing.Point(236, 76);
+            this.CacheLimitPostLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.CacheLimitPostLabel.Name = "CacheLimitPostLabel";
+            this.CacheLimitPostLabel.Size = new System.Drawing.Size(60, 17);
+            this.CacheLimitPostLabel.TabIndex = 12;
+            this.CacheLimitPostLabel.Text = "MB (empty for unlimited)";
+            //
             // AutoUpdateGroupBox
             //
             this.AutoUpdateGroupBox.Controls.Add(this.RefreshOnStartupCheckbox);
@@ -294,7 +358,7 @@
             this.AutoUpdateGroupBox.Controls.Add(this.LocalVersionLabelLabel);
             this.AutoUpdateGroupBox.Controls.Add(this.CheckForUpdatesButton);
             this.AutoUpdateGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.AutoUpdateGroupBox.Location = new System.Drawing.Point(16, 471);
+            this.AutoUpdateGroupBox.Location = new System.Drawing.Point(16, 491);
             this.AutoUpdateGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AutoUpdateGroupBox.Name = "AutoUpdateGroupBox";
             this.AutoUpdateGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -409,7 +473,7 @@
             this.MoreSettingsGroupBox.Controls.Add(this.HideVCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.HideEpochsCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.AutoSortUpdateCheckBox);
-            this.MoreSettingsGroupBox.Location = new System.Drawing.Point(16, 609);
+            this.MoreSettingsGroupBox.Location = new System.Drawing.Point(16, 629);
             this.MoreSettingsGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MoreSettingsGroupBox.Name = "MoreSettingsGroupBox";
             this.MoreSettingsGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -446,7 +510,7 @@
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(660, 735);
+            this.ClientSize = new System.Drawing.Size(660, 755);
             this.Controls.Add(this.MoreSettingsGroupBox);
             this.Controls.Add(this.AutoUpdateGroupBox);
             this.Controls.Add(this.CacheGroupBox);
@@ -476,8 +540,14 @@
         private System.Windows.Forms.GroupBox RepositoryGroupBox;
         private System.Windows.Forms.GroupBox CacheGroupBox;
         private System.Windows.Forms.TextBox CachePath;
+        private System.Windows.Forms.TextBox CacheLimit;
         private System.Windows.Forms.Label CacheSummary;
-        private System.Windows.Forms.Button ClearCacheButton;
+        private System.Windows.Forms.Label CacheLimitPreLabel;
+        private System.Windows.Forms.Label CacheLimitPostLabel;
+        private CKAN.DropdownMenuButton ClearCacheButton;
+        private System.Windows.Forms.ContextMenuStrip ClearCacheMenu;
+        private System.Windows.Forms.ToolStripMenuItem PurgeToLimitMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem PurgeAllMenuItem;
         private System.Windows.Forms.Button ChangeCacheButton;
         private System.Windows.Forms.Button ResetCacheButton;
         private System.Windows.Forms.Button OpenCacheButton;

--- a/Tests/Core/FakeWin32Registry.cs
+++ b/Tests/Core/FakeWin32Registry.cs
@@ -44,6 +44,10 @@ namespace Tests.Core
         /// Path to download cache folder for the fake registry
         /// </summary>
         public string                      DownloadCacheDir { get; set; }
+        /// <summary>
+        /// Maximum number of bytes of downloads to retain on disk
+        /// </summary>
+        public long?                       CacheSizeLimit   { get; set; }
 
         /// <summary>
         /// Number of instances in the fake registry


### PR DESCRIPTION
## Motivation

CKAN's download cache currently grows without limit. We write to it, but we don't remove files unless the user runs `ckan clean` or clicks the Clear button in the cache section of the GUI settings. This means that in order to avoid filling up a disk, the user might have to manually monitor the cache size and clear it periodically, or delete individual files. It would be nice to have something more automated.

## Changes

This pull request builds upon #2535 to create a configurable cache size limit. The default is to allow unlimited cache size, as it is today. (This pull request has been rebased to show only its own changes, where formerly #2535's commit was included.)

### Core

`Win32Registry.CacheSizeLimit` now stores the maximum number of bytes allowed in the cache, or `null` if unlimited.

`ModuleInstaller` enforces this limit after it finishes installing mods. Note that this means that we may temporarily exceed the limit during installation if required to fit the mods being installed. This also means that a user can set a limit of 0 bytes if they wish all downloads to be downloaded every time and never cached, and that will work.

The algorithm to purge cache files will delete, in order:

1. Files that do not correspond to any download in the registry (mods that you downloaded before their URLs changed, such as old KerbalStuff files)
2. Files that are in the registry but are not compatible with any of your game instances (mods that you downloaded when you were using old game versions)
3. Files that are compatible with at least one of your game instances

Within each subgroup, files are deleted in age order, oldest first. Deletion stops once the total cache size falls under the limit. Both the main configurable cache folder and the legacy per-instance caches are checked and purged together according to the above rules, and we compare the sum of their sizes to the limit to determine compliance.

### CmdLine

The `ckan cache` command has two new subcommands:

- `ckan cache showlimit` - Print the cache size limit in MB, or "Unlimited" if unlimited
- `ckan cache setlimit <new limit>` - Set the cache size limit to the argument in MB, or clear it to allow unlimited caching if no argument is given

These commands do not enforce the limit. That will happen after mods are installed.

### GUI

The cache section in the settings is expanded, the buttons are pushed down, and a limit field is added in the middle:

![image](https://user-images.githubusercontent.com/1559108/46925892-06ed8780-cff4-11e8-8e76-ed9d01592109.png)

Changing this value does **not** immediately enforce the new limit (hence the size being over the limit in the above screenshot). That only happens after you install some mods. I don't want to auto-delete files while the user is still editing the value in the field, which may be smaller than their intended value.

The Clear button is replaced with a Purge dropdown button. When clicked, two options appear, one of which enforces the configured limit, the other of which deletes all files in the cache. If the cache is empty, the dropdown is disabled. If the cache is under the current limit, then the dropdown option to enforce the limit is disabled.

Fixes #2438.