### PR TITLE
Stop auto-moving cached files

### DIFF
--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -337,12 +337,10 @@ namespace CKAN
                 {
                     Win32Registry.DownloadCacheDir = "";
                     Cache = new NetModuleCache(this, Win32Registry.DownloadCacheDir);
-                    Cache.MoveFrom(origPath);
                 }
                 else
                 {
                     Cache = new NetModuleCache(this, path);
-                    Cache.MoveFrom(origPath);
                     Win32Registry.DownloadCacheDir = path;
                 }
                 failureReason = null;

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -464,8 +464,18 @@ namespace CKAN
                     string toFile = Path.Combine(cachePath, Path.GetFileName(fromFile));
                     if (File.Exists(toFile))
                     {
-                        // Don't need multiple copies of the same file
-                        File.Delete(fromFile);
+                        if (File.GetCreationTime(fromFile) == File.GetCreationTime(toFile))
+                        {
+                            // Same filename with same timestamp, almost certainly the same
+                            // actual file on disk via different paths thanks to symlinks.
+                            // Skip this whole folder!
+                            break;
+                        }
+                        else
+                        {
+                            // Don't need multiple copies of the same file
+                            File.Delete(fromFile);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## Problem

#2535 created a setting to allow the user to choose a folder to use as a download cache. For convenience, it also attempted to copy cached files from the old folder to the new when the setting changed.

This just wasn't safe. First @politas had a mishap where it tried to copy the same folder to the same folder and deleted all the cached files. Then I partly scrambled my home directory just by holding backspace to clear the field in GUI. If the two developers working on some code aren't able to use it correctly, it's too error-prone and needs to be fixed.

## Changes

`MoveFrom` now will only delete a duplicate file if the creation timestamps are different. If the same timestamp is found, then we conclude that the parent folder is the same as the destination folder, and stop copying the folder completely. This ensures that we never consider the same file a duplicate of itself and delete it.

`MoveFrom` also is no longer called when you change the cache folder setting. Migrating cached files is now the user's responsibility. This will prevent us from moving files to or from incorrect paths while the user is editing the field in GUI.

Maybe we'll be able to find a good way to auto-move cached files, but this pull request is just about limiting the damage.

Fixes #2537.