### PR TITLE
Fix text colors for dark themes

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -865,6 +865,7 @@
             this.LogTextBox.Multiline = true;
             this.LogTextBox.Name = "LogTextBox";
             this.LogTextBox.ReadOnly = true;
+            this.LogTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.LogTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.LogTextBox.Size = new System.Drawing.Size(1505, 851);
             this.LogTextBox.TabIndex = 8;
@@ -1109,9 +1110,11 @@
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.MainTabControl.ResumeLayout(false);
+            this.MainTabControl.PerformLayout();
             this.ManageModsTabPage.ResumeLayout(false);
             this.ManageModsTabPage.PerformLayout();
             this.ChangesetTabPage.ResumeLayout(false);
+            this.ChangesetTabPage.PerformLayout();
             this.WaitTabPage.ResumeLayout(false);
             this.WaitTabPage.PerformLayout();
             this.ChooseRecommendedModsTabPage.ResumeLayout(false);

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -143,7 +143,7 @@
             //
             this.MetadataModuleNameLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetadataModuleNameLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MetadataModuleNameLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.MetadataModuleNameLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.MetadataModuleNameLabel.Location = new System.Drawing.Point(3, 0);
             this.MetadataModuleNameLabel.Name = "MetadataModuleNameLabel";
             this.MetadataModuleNameLabel.Size = new System.Drawing.Size(340, 46);
@@ -215,7 +215,7 @@
             //
             this.IdentifierLabel.AutoSize = true;
             this.IdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.IdentifierLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.IdentifierLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.IdentifierLabel.Location = new System.Drawing.Point(3, 210);
             this.IdentifierLabel.Name = "IdentifierLabel";
             this.IdentifierLabel.Size = new System.Drawing.Size(84, 20);
@@ -237,7 +237,7 @@
             //
             this.KSPCompatibilityLabel.AutoSize = true;
             this.KSPCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.KSPCompatibilityLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.KSPCompatibilityLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.KSPCompatibilityLabel.Location = new System.Drawing.Point(3, 180);
             this.KSPCompatibilityLabel.Name = "KSPCompatibilityLabel";
             this.KSPCompatibilityLabel.Size = new System.Drawing.Size(84, 30);
@@ -248,7 +248,7 @@
             //
             this.ReleaseLabel.AutoSize = true;
             this.ReleaseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReleaseLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.ReleaseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.ReleaseLabel.Location = new System.Drawing.Point(3, 150);
             this.ReleaseLabel.Name = "ReleaseLabel";
             this.ReleaseLabel.Size = new System.Drawing.Size(84, 30);
@@ -259,7 +259,7 @@
             //
             this.GitHubLabel.AutoSize = true;
             this.GitHubLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GitHubLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.GitHubLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.GitHubLabel.Location = new System.Drawing.Point(3, 120);
             this.GitHubLabel.Name = "GitHubLabel";
             this.GitHubLabel.Size = new System.Drawing.Size(84, 30);
@@ -270,7 +270,7 @@
             //
             this.HomePageLabel.AutoSize = true;
             this.HomePageLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HomePageLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.HomePageLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.HomePageLabel.Location = new System.Drawing.Point(3, 90);
             this.HomePageLabel.Name = "HomePageLabel";
             this.HomePageLabel.Size = new System.Drawing.Size(84, 30);
@@ -281,7 +281,7 @@
             //
             this.AuthorLabel.AutoSize = true;
             this.AuthorLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AuthorLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.AuthorLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.AuthorLabel.Location = new System.Drawing.Point(3, 60);
             this.AuthorLabel.Name = "AuthorLabel";
             this.AuthorLabel.Size = new System.Drawing.Size(84, 30);
@@ -292,7 +292,7 @@
             //
             this.LicenseLabel.AutoSize = true;
             this.LicenseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.LicenseLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.LicenseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.LicenseLabel.Location = new System.Drawing.Point(3, 30);
             this.LicenseLabel.Name = "LicenseLabel";
             this.LicenseLabel.Size = new System.Drawing.Size(84, 30);
@@ -333,7 +333,7 @@
             //
             this.VersionLabel.AutoSize = true;
             this.VersionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.VersionLabel.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.VersionLabel.ForeColor = System.Drawing.SystemColors.GrayText;
             this.VersionLabel.Location = new System.Drawing.Point(3, 0);
             this.VersionLabel.Name = "VersionLabel";
             this.VersionLabel.Size = new System.Drawing.Size(84, 30);


### PR DESCRIPTION
## Problems

In a dark theme, the status log and parts of the mod info pane feature dark text on a dark background:

![image](https://user-images.githubusercontent.com/1559108/46973584-4b763300-d087-11e8-98b8-85c4e17303c4.png)

![image](https://user-images.githubusercontent.com/1559108/46973624-6779d480-d087-11e8-9609-3cf978aceef1.png)

Looks fine in a normal theme:

![image](https://user-images.githubusercontent.com/1559108/46973626-6a74c500-d087-11e8-80e9-4a738bd51135.png)

## Causes

1. A text box in .NET defaults to `WindowText` (black) on `Window` (white), but if you set its `ReadOnly=true`, as we do in this case, the background is changed to `Control` (dark gray) without changing the foreground, to give it a disabled appearance
2. We set the `ForeColor` of the mod info pane labels to `ControlDarkDark`; the meaning of this value is:
   [Gets a Color structure that is the dark shadow color of a 3-D element.](https://docs.microsoft.com/en-us/dotnet/api/system.drawing.systemcolors)
   This color is not meant to be used for text foreground colors, and using it assumes a light background color.

## Changes

Now these places look better.

1. The log text box's `ForeColor` is now `ControlText`, to match its background.
   ![image](https://user-images.githubusercontent.com/1559108/46973651-811b1c00-d087-11e8-9753-b67c97b0383c.png)
2. The labels in the mod info pane now have a `ForeColor` of `GrayText`, which the spec defines as "Gets a Color structure that is the color of dimmed text." This is meant to be used as a text color, and it will provide visual distinction from the normal text color:
![image](https://user-images.githubusercontent.com/1559108/46973678-9132fb80-d087-11e8-88db-234de40332d8.png)
   Standard themes still look OK:
   ![image](https://user-images.githubusercontent.com/1559108/46973666-8d06de00-d087-11e8-8c8e-38c6ef1cc78b.png)

Somewhat related to #2525 but not a fix for the specific things in that issue.