### PR TITLE
Fix toolbar background colors for dark themes

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -114,6 +114,7 @@
     <Compile Include="FormCompatibility.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="FlatToolStripRenderer.cs" />
     <Compile Include="GUIMod.cs" />
     <Compile Include="GUIUser.cs" />
     <Compile Include="HintTextBox.cs">

--- a/GUI/FlatToolStripRenderer.cs
+++ b/GUI/FlatToolStripRenderer.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    /// <summary>
+    /// Custom toolstrip renderer that just fills the background with the BackColor.
+    ///
+    /// The default Mono one uses a gradient between a hardcoded light color and a system color that Mono doesn't load correctly.
+    /// </summary>
+    public class FlatToolStripRenderer : ToolStripProfessionalRenderer
+    {
+
+        protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
+        {
+            // Brushes need to be disposed
+            using (SolidBrush bgBrush = new SolidBrush(e.BackColor))
+            {
+                e.Graphics.FillRectangle(bgBrush, e.AffectedBounds);
+            }
+        }
+
+    }
+}

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -296,7 +296,6 @@
             this.menuStrip2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.menuStrip2.AutoSize = false;
-            this.menuStrip2.BackColor = System.Drawing.SystemColors.Control;
             this.menuStrip2.Dock = System.Windows.Forms.DockStyle.None;
             this.menuStrip2.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.menuStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -181,6 +181,14 @@ namespace CKAN
 
             InitializeComponent();
 
+            // Replace mono's broken, ugly toolstrip renderer
+            menuStrip1.Renderer = new FlatToolStripRenderer();
+            menuStrip2.Renderer = new FlatToolStripRenderer();
+            fileToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
+            settingsToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
+            helpToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
+            FilterToolButton.DropDown.Renderer = new FlatToolStripRenderer();
+
             // We need to initialize the error dialog first to display errors.
             errorDialog = controlFactory.CreateControl<ErrorDialog>();
 


### PR DESCRIPTION
## Problem

CKAN's toolbars are hideous with a dark theme:

![screenshot](https://user-images.githubusercontent.com/1559108/46361551-8e6dea80-c633-11e8-97d1-242612b4b5cf.png)

## Cause

See mono/mono#11287; Mono is trying to use `SystemColors.ButtonFace` for the left edge of a toolstrip, fading to a hard coded light color with a linear gradient. But Mono doesn't load `ButtonFace` from the system settings, instead leaving it with a compile time default.

## Upstream fix

mono/mono#11287 is trying to fix this in Mono by switching from `ButtonFace` to `SystemColors.Control`, which is set by Mono's theme loader. However, there are some downsides:

- Even with the fix, the default toolstrip renderer still uses an ugly gradient to a hard coded light color at the right edge
- That fix won't reach users until Mono puts out a new release and users upgrade to it (assuming it gets merged)

![upstream](https://user-images.githubusercontent.com/1559108/47245076-79c47d00-d3bd-11e8-93ea-a23418eefdf4.png)

## Changes

Luckily this part of Mono is 90% customization / overrides / defaults / etc., so there are plenty of hooks here for us to make it work however we want. When Mono wants to draw a control, it first checks whether that control has a `.Renderer` property, and if it does, it delegates the drawing to that object. Now we populate that property with our own renderer that just draws the background color normally. This looks better than the renderer built into Mono, even after the other fix, and will work for all users regardless of their version of Mono.

![image](https://user-images.githubusercontent.com/1559108/47247423-2b1ce000-d3c9-11e8-8b98-ab27b2c1e172.png)

Fixes #2525.