### PR TITLE
Clean up popup positioning in GUI

### DIFF
--- a/GUI/ChooseKSPInstance.Designer.cs
+++ b/GUI/ChooseKSPInstance.Designer.cs
@@ -158,6 +158,7 @@
             this.Controls.Add(this.KSPInstancesListView);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "ChooseKSPInstance";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Select KSP install";
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -21,12 +21,19 @@ namespace CKAN
 
         public bool HasSelections => KSPInstancesListView.SelectedItems.Count > 0;
 
-        public ChooseKSPInstance()
+        /// <summary>
+        /// Initialize the game instance selection window
+        /// </summary>
+        /// <param name="centerScreen">true to center the window on the screen, false to center it on the parent</param>
+        public ChooseKSPInstance(bool centerScreen)
         {
             _manager = Main.Instance.Manager;
             InitializeComponent();
 
-            StartPosition = FormStartPosition.CenterScreen;
+            if (centerScreen)
+            {
+                StartPosition = FormStartPosition.CenterScreen;
+            }
 
             if (!_manager.Instances.Any())
             {

--- a/GUI/CompatibleKspVersionsDialog.Designer.cs
+++ b/GUI/CompatibleKspVersionsDialog.Designer.cs
@@ -163,7 +163,7 @@
             this.SaveButton.Name = "saveButton";
             this.SaveButton.Size = new System.Drawing.Size(75, 23);
             this.SaveButton.TabIndex = 11;
-            this.SaveButton.Text = "Save";
+            this.SaveButton.Text = "Accept";
             this.SaveButton.UseVisualStyleBackColor = true;
             this.SaveButton.Click += new System.EventHandler(this.SaveButton_Click);
             // 
@@ -204,7 +204,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.CancelChooseCompatibleVersionsButton;
             this.ClientSize = new System.Drawing.Size(443, 364);
-            this.ControlBox = false;
             this.Controls.Add(this.CancelChooseCompatibleVersionsButton);
             this.Controls.Add(this.GameLocationLabel);
             this.Controls.Add(this.label8);
@@ -221,13 +220,13 @@
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "CompatibleKspVersionsDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Compatible Ksp Versions";
+            this.Text = "Compatible KSP Versions";
             this.Shown += new System.EventHandler(this.CompatibleKspVersionsDialog_Shown);
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/GUI/CompatibleKspVersionsDialog.cs
+++ b/GUI/CompatibleKspVersionsDialog.cs
@@ -1,9 +1,10 @@
-﻿using CKAN.GameVersionProviders;
+using System;
+using System.Linq;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using Autofac;
 using CKAN.Versioning;
-using System;
+using CKAN.GameVersionProviders;
 
 namespace CKAN
 {
@@ -11,11 +12,20 @@ namespace CKAN
     {
         private KSP _ksp;
 
-        public CompatibleKspVersionsDialog(KSP ksp)
+        /// <summary>
+        /// Initialize the compatible game versions dialog
+        /// </summary>
+        /// <param name="ksp">Game instance</param>
+        /// <param name="centerScreen">true to center the dialog on the screen, false to center on the parent</param>
+        public CompatibleKspVersionsDialog(KSP ksp, bool centerScreen)
         {
-
             this._ksp = ksp;
             InitializeComponent();
+
+            if (centerScreen)
+            {
+                StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            }
 
             List<KspVersion> compatibleVersions = ksp.GetCompatibleVersions();
 
@@ -61,7 +71,7 @@ namespace CKAN
         {
             versions.Sort();
             versions.Reverse();
-            foreach (var version in versions)
+            foreach (KspVersion version in versions)
             {
                 if (!version.Equals(_ksp.Version()))
                 {
@@ -70,7 +80,7 @@ namespace CKAN
             }
         }
 
-        private void AddVersionToListButton_Click(object sender, System.EventArgs e)
+        private void AddVersionToListButton_Click(object sender, EventArgs e)
         {
             if (AddVersionToListTextBox.Text.Length == 0)
             {
@@ -97,18 +107,17 @@ namespace CKAN
 
         private void CancelButton_Click(object sender, EventArgs e)
         {
+            DialogResult = DialogResult.Cancel;
             this.Close();
         }
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            List<KspVersion> selectedVersion = new List<KspVersion>();
-            foreach (KspVersion item in SelectedVersionsCheckedListBox.CheckedItems)
-            {
-                selectedVersion.Add(item);
-            }
-            _ksp.SetCompatibleVersions(selectedVersion);
+            _ksp.SetCompatibleVersions(
+                SelectedVersionsCheckedListBox.CheckedItems.Cast<KspVersion>().ToList()
+            );
 
+            DialogResult = DialogResult.OK;
             this.Close();
         }
     }

--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -459,6 +459,7 @@
             this.Text = "Settings";
             this.Load += new System.EventHandler(this.SettingsDialog_Load);
             this.RepositoryGroupBox.ResumeLayout(false);
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.AuthTokensGroupBox.ResumeLayout(false);
             this.CacheGroupBox.ResumeLayout(false);
             this.CacheGroupBox.PerformLayout();

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -19,10 +19,12 @@ namespace CKAN
 
         private List<Repository> _sortedRepos = new List<Repository>();
 
+        /// <summary>
+        /// Initialize a settings window
+        /// </summary>
         public SettingsDialog()
         {
             InitializeComponent();
-            StartPosition = FormStartPosition.CenterScreen;
             winReg = new Win32Registry();
         }
 


### PR DESCRIPTION
## Background

If a KSP update happens, CKAN will alert you at launch:

![image](https://user-images.githubusercontent.com/1559108/47272734-8e387f00-d54f-11e8-9f48-2f0be9b2dda2.png)

This window can also be accessed via the menus, Settings &rArr; Compatible KSP Versions.

## Problems

- If it auto-opens at launch, this window will be positioned at the upper left corner of your leftmost monitor, which makes it difficult to notice
- A Save button normally saves something without closing, but this one closes the window
- Capitalization of "Ksp" in the title is wrong because it's an acronym standing for Kerbal Space Program
- If the user opens this window manually and then cancels out, the mod list is regenerated needlessly

## Changes

- The window will be centered on the screen at startup
- The window will be centered on its parent if the user opens it manually
- The Save button now says Accept instead, to make it clearer that it closes the window
- "KSP" is now all caps
- There's a Close X button in the toolbar
- The mod list is only regenerated if the user clicks Accept

![image](https://user-images.githubusercontent.com/1559108/47272766-e079a000-d54f-11e8-8e91-1aa5858ccef2.png)

Other changes:

- The Select KSP Install window will now be centered on screen at startup
- The Select KSP Install window will now be centered on its parent if the user opens it manually