### PR TITLE
Don't throw exceptions when resetting cache dir

### DIFF
--- a/Core/Win32Registry.cs
+++ b/Core/Win32Registry.cs
@@ -206,7 +206,7 @@ namespace CKAN
         private static void DeleteRegistryValue(string name)
         {
             RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(CKAN_KEY_NO_PREFIX, true);
-            key.DeleteValue(name);
+            key.DeleteValue(name, false);
         }
 
     }


### PR DESCRIPTION
## Problem

In the settings, if you click the Reset in the cache section twice, an exception occurs:

```
************** Tekst van uitzondering **************
System.ArgumentException: Er bestaat geen waarde met deze naam.
   bij System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   bij Microsoft.Win32.RegistryKey.DeleteValue(String name)
   bij CKAN.Win32Registry.DeleteRegistryValue(String name)
   bij CKAN.Win32Registry.set_DownloadCacheDir(String value)
   bij CKAN.KSPManager.TrySetupCache(String path, String& failureReason)
   bij CKAN.SettingsDialog.UpdateCacheInfo(String newPath)
   bij CKAN.SettingsDialog.ResetCacheButton_Click(Object sender, EventArgs e)
   bij System.Windows.Forms.Control.OnClick(EventArgs e)
   bij System.Windows.Forms.Button.OnClick(EventArgs e)
   bij System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   bij System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   bij System.Windows.Forms.Control.WndProc(Message& m)
   bij System.Windows.Forms.ButtonBase.WndProc(Message& m)
   bij System.Windows.Forms.Button.WndProc(Message& m)
   bij System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

This probably also happens if you run `ckan cache reset` twice.

## Cause

`RegistryKey.DeleteValue` doesn't like it when you try to delete a value that doesn't exist.

## Change

There's another version of that function that has a second parameter:

> [throwOnMissingValue](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey.deletevalue)
> Boolean
> Indicates whether an exception should be raised if the specified value cannot be found. If this argument is true and the specified value does not exist, an exception is raised. If this argument is false and the specified value does not exist, no action is taken.

Now we pass that as `false`.

Fixes #2545.