### PR TITLE
Sign releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,17 @@ jobs:
         run: ./build --configuration=Release
       - name: Run tests
         run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
+      - name: Sign release
+        run: |
+          signcode \
+            -spc codesigning.spc \
+            -v   codesigning.pvk \
+            -a   sha1 \
+            -$   individual \
+            -t   http://timestamp.verisign.com/scripts/timstamp.dll \
+            -n   'Comprehensive Kerbal Archive Network client' \
+            -i   https://github.com/KSP-CKAN/CKAN \
+            _build/repack/$BUILD_CONFIGURATION/ckan.exe
 
       - name: Build dmg
         run: ./build osx --configuration=Release --exclusive


### PR DESCRIPTION
## Warning

These changes are NOT complete and require further steps to be completed. This will most likely cause the build to fail initially.

Please do not merge until all of the below steps have been performed.

## Motivation

Currently CKAN users may be warned that `ckan.exe` isn't trusted because it was downloaded from the internet and isn't signed.

## Changes

Now when Travis builds a release, it will sign `ckan.exe` with a certificate. This will suppress the warning about running an unsigned application.

(This will provide Windows users with a comforting false sense of security, because the author of a dangerous download could easily do exactly what we're doing here; simply purchasing a certificate is no guarantee of competence or benevolence.)

## Steps still remaining

@politas, you said in #1354 that you would be willing to pay 14 euros to acquire a certificate from Certum; the following steps assume you've done that.

The next step is to add the certificate to the repo. Travis provides a way to do that securely, but the person doing it has to have the private key. Either you could send it to me, or you could complete the process yourself by following the below instructions. I have used [a page about signing Android apps in Travis](https://android.jlelse.eu/using-travisci-to-securely-build-and-deploy-a-signed-version-of-your-android-app-94afdf5cf5b4) as a reference, in combination with the documentation for Mono's `signcode` and [an example of another project's signcode command that I found](http://package-import.ubuntu.com/diffs/gammu). I expect this to work, but it's possible some adjustments may be needed along the way (e.g., different file names).

1. Open a command prompt and `cd` to the CKAN source dir
2. Check out this PR's branch (`HebaruSan/feature/signed-releases`)
3. Save the Software Publisher File (.spc) to `codesigning.spc` in the root source folder of the CKAN repo
4. `git add codesigning.spc`
5. Save the Private Key File (.pvk) to `codesigning.pvk` in the same folder
   Do **NOT** add this to git! It's a private key, so we need to make sure nobody but Travis can read it.
6. If you don't have a `travis` command:
   ```
   sudo apt install ruby ruby-dev
   sudo gem install travis
   ```
7. `travis login` with your GitHub credentials
8. `travis encrypt-file codesigning.pvk --add`
   This will create a new encryption key and initialization vector, save them in Travis, use them to encrypt the private key, and add a command to `.travis.yml` to decrypt the private key on Travis during builds.
9. `git add codesigning.pvk.enc .travis.yml`
   This adds the Travis changes and the encrypted private key to the repo, which is safe because only Travis has the key to decrypt it.
10. Commit and push these changes to the branch

Fixes #1354.