### PR TITLE
Fix null ref exception when repo has empty ckan file

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -548,7 +548,11 @@ Do you wish to reinstall now?", sb)))
             try
             {
                 CkanModule module = CkanModule.FromJson(metadata);
-                log.DebugFormat("Found {0} version {1}", module.identifier, module.version);
+                // FromJson can return null for the empty string
+                if (module != null)
+                {
+                    log.DebugFormat("Found {0} version {1}", module.identifier, module.version);
+                }
                 return module;
             }
             catch (Exception exception)


### PR DESCRIPTION
## Problem

If you refresh the registry and the remote repo contains an empty .ckan file, you may see exceptions with stack traces like these:

```
   bei CKAN.Repo.ProcessRegistryMetadataFromJSON(String metadata, Registry registry, String filename) in C:\Users\Martin\Documents\Visual Studio 2015\Projects\CKAN\Core\Net\Repo.cs:Zeile 69.
   bei CKAN.Repo.UpdateRegistryFromZip(String path, Registry registry) in C:\Users\Martin\Documents\Visual Studio 2015\Projects\CKAN\Core\Net\Repo.cs:Zeile 383.
   bei CKAN.Repo.UpdateRegistry(Uri repo, Registry registry, KSP ksp, IUser user, Boolean clear) in C:\Users\Martin\Documents\Visual Studio 2015\Projects\CKAN\Core\Net\Repo.cs:Zeile 161.
   bei CKAN.Repo.UpdateAllRepositories(RegistryManager registry_manager, KSP ksp, IUser user) in C:\Users\Martin\Documents\Visual Studio 2015\Projects\CKAN\Core\Net\Repo.cs:Zeile 89.
   bei CKAN.Main.UpdateRepo(Object sender, DoWorkEventArgs e) in C:\Users\Martin\Documents\Visual Studio 2015\Projects\CKAN\GUI\MainRepo.cs:Zeile 62.
```

```
************** Exception Text **************
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.Main.UpdateRepo()
   at System.Windows.Forms.ToolStripMenuItem.OnClick(EventArgs e)
   at System.Windows.Forms.ToolStripItem.HandleClick(EventArgs e)
   at System.Windows.Forms.ToolStripItem.HandleMouseUp(MouseEventArgs e)
   at System.Windows.Forms.ToolStrip.OnMouseUp(MouseEventArgs mea)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ToolStrip.WndProc(Message& m)
   at System.Windows.Forms.MenuStrip.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Causes

An empty file would cause the first line here to return null:

https://github.com/KSP-CKAN/CKAN/blob/b9a91fa2a3b8780a4f8310127f13cfc6400a816c/Core/Net/Repo.cs#L550-L551

If that happens, then the second line still tries to access a property on the null reference.

## Changes

Now we skip that debug output if the reference is null.

Fixes #1381.