### PR TITLE
Show latest updates after refresh

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -222,6 +222,31 @@ namespace CKAN
             return null;
         }
 
+        /// <summary>
+        /// Set the properties to match a change set element.
+        /// Doesn't update grid, use SetInstallChecked or SetUpgradeChecked
+        /// if you need to update the grid.
+        /// </summary>
+        /// <param name="change">Type of change</param>
+        public void SetRequestedChange(GUIModChangeType change)
+        {
+            switch (change)
+            {
+                case GUIModChangeType.Install:
+                    IsInstallChecked = true;
+                    IsUpgradeChecked = false;
+                    break;
+                case GUIModChangeType.Remove:
+                    IsInstallChecked = false;
+                    IsUpgradeChecked = false;
+                    break;
+                case GUIModChangeType.Update:
+                    IsInstallChecked = true;
+                    IsUpgradeChecked = true;
+                    break;
+            }
+        }
+
         public static implicit operator CkanModule(GUIMod mod)
         {
             return mod.ToModule();

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -91,7 +91,7 @@ namespace CKAN
         {
             if ((e.Result as int? ?? 0) > 0)
             {
-                UpdateModsList(repo_updated: true);
+                UpdateModsList(true, ChangeSet);
                 AddStatusMessage("Repositories successfully updated.");
                 ShowRefreshQuestion();
                 HideWaitDialog(true);


### PR DESCRIPTION
## Problem

After you click Refresh in GUI, the latest updates are downloaded from the repo, but only certain changes are reflected in the mod list:

- Newly added mods
- New versions
- Installation status

But if other things change, this isn't shown in the mod list until you restart CKAN:

- Game version compatibility
- Display name or abstract
- Author
- Download size or count
- Etc.

## Cause

`ConstructModList` goes out of its way to cause this problem in order to avoid losing user changes. A `refreshAll` parameter is passed based on whether we're doing a repo update, in which case the previous `GUIMod` objects are mostly kept. This is kind of odd because a repo update is the only way that most of those properties can be changed.

https://github.com/KSP-CKAN/CKAN/blob/b9a91fa2a3b8780a4f8310127f13cfc6400a816c/GUI/MainModList.cs#L198-L199

https://github.com/KSP-CKAN/CKAN/blob/b9a91fa2a3b8780a4f8310127f13cfc6400a816c/GUI/MainModList.cs#L682

https://github.com/KSP-CKAN/CKAN/blob/b9a91fa2a3b8780a4f8310127f13cfc6400a816c/GUI/MainModList.cs#L692-L697

(The answer to that final question is, "No.")

## Changes

Now the `GUIMod` objects built by `UpdateModsList` will have `.IsInstallChecked` and `.IsUpgradeChecked` set to match the change set parameter, and the Refresh button passes the current change set in that parameter. This ensures that the new `GUIMod` objects will not lose the change set when refreshing.

Then `ConstructModList` just unconditionally generates new rows for everything, since it can trust that their checkbox values are reflected in the `GUIMod` objects. The `refreshAll` parameter is removed as it is no longer needed.

Together, these changes mean that if you select several mods to install and click Refresh, then those same mods will still be checked afterwards, and all rows will show the latest info, even the ones you checked.

Fixes #1738.