### PR TITLE
Allow game version of "any" with a vref

### DIFF
--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -379,6 +379,12 @@ namespace CKAN.Versioning
             if (ReferenceEquals(input, null))
                 return false;
 
+            if (input == "any")
+            {
+                result = KspVersion.Any;
+                return true;
+            }
+
             var major = Undefined;
             var minor = Undefined;
             var patch = Undefined;
@@ -784,8 +790,6 @@ namespace CKAN.Versioning
             {
                 case null:
                     return null;
-                case "any":
-                    return KspVersion.Any;
                 default:
                     KspVersion result;
 


### PR DESCRIPTION
## Problem

[The spec](https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md) allows `ksp_version` to be `"any"`:

> ksp_version
> The version of KSP this mod is targeting. This may be the string "any", a number (eg: 0.23.5) or may only contain the first two parts of the version string (eg: 0.25). In the latter case, any release starting with the ksp_version is considered acceptable.
> 
> If no KSP target version is included, a default of "any" is assumed.

58 mods currently use a value of '"any"` for this field.

KSP-CKAN/NetKAN#6791 is trying to join them, but it also features a `$vref` property. This causes an exception:

```
7796 [1] FATAL CKAN.NetKAN.Program (null) - One of the identified items was in an invalid format.
7797 [1] FATAL CKAN.NetKAN.Program (null) -   at CKAN.Versioning.KspVersion.Parse (System.String input) [0x00024] in <7ed2106435a041acb5b4d9ca840a60c4>:0 
  at CKAN.NetKAN.Transformers.AvcTransformer.ApplyVersions (Newtonsoft.Json.Linq.JObject json, CKAN.NetKAN.Sources.Avc.AvcVersion avc) [0x0004e] in <7ed2106435a041acb5b4d9ca840a60c4>:0 
  at CKAN.NetKAN.Transformers.AvcTransformer.Transform (CKAN.NetKAN.Model.Metadata metadata) [0x0018d] in <7ed2106435a041acb5b4d9ca840a60c4>:0 
  at CKAN.NetKAN.Transformers.NetkanTransformer+<>c.<Transform>b__4_0 (CKAN.NetKAN.Model.Metadata transformedMetadata, CKAN.NetKAN.Transformers.ITransformer transformer) [0x00000] in <7ed2106435a041acb5b4d9ca840a60c4>:0 
  at System.Linq.Enumerable.Aggregate[TSource,TAccumulate] (System.Collections.Generic.IEnumerable`1[T] source, TAccumulate seed, System.Func`3[T1,T2,TResult] func) [0x0002e] in <9a2f23a52d30476eafb596a55ecb4b63>:0 
  at CKAN.NetKAN.Transformers.NetkanTransformer.Transform (CKAN.NetKAN.Model.Metadata metadata) [0x00001] in <7ed2106435a041acb5b4d9ca840a60c4>:0 
  at CKAN.NetKAN.Program.Main (System.String[] args) [0x000f1] in <7ed2106435a041acb5b4d9ca840a60c4>:0 
```

## Cause

Support for `"any"` is implemented in `KspVersionJsonConverter.ReadJson`, which is used by `JsonConvert.DeserializeObject<KspVersion>` to convert a JSON string to a `KspVersion` object when parsing a .ckan file.

But in the case of the `$vref` handling code, we need to parse the value of `ksp_version` by itself in order to compare version numbers and select the right minimum/maximum versions. `KspVersion.Parse` is used for this, but it doesn't support `"any"`.

## Changes

Now `"any"` is handled in `KspVersion.TryParse` instead of `KspVersionJsonConverter.ReadJson`. (The latter calls `TryParse`, so it will still work the same way.) This will allow `"any"` to be used alongside `$vref`.

## Rejected alternatives

We could also update the `$vref` handler to use `KspVersionJsonConverter.ReadJson` instead of `Parse`. However, this function would require its input string to contain a JSON *string*, not just a string *value*; it would have to start and end with quote characters, which it currently doesn't, and trying to add them would make that code more complex and error-prone (consider things like null handling).