### PR TITLE
Bump spec version

### DIFF
--- a/Spec.md
+++ b/Spec.md
@@ -126,8 +126,8 @@ reference CKAN client that will read this file.
 For compatibility with pre-release clients, and the v1.0 client, the special
 *integer* `1` should be used.
 
-This document describes the CKAN specification 'v1.20'. Changes since spec `1`
-are marked with **v1.2** through to **v1.20** respectively. For maximum
+This document describes the CKAN specification 'v1.25'. Changes since spec `1`
+are marked with **v1.2** through to **v1.25** respectively. For maximum
 compatibility, using older spec versions is preferred when newer features are
 not required.
 


### PR DESCRIPTION
This value hasn't been updated, though the following updates are shown elsewhere in the file:
24 - include_only, include_only_regexp
25 - install_to / missions