### PR TITLE
Show mod info for change set, recs/sugs, and providers

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -446,26 +446,29 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 111);
+            this.splitContainer1.Location = new System.Drawing.Point(0, 35);
             this.splitContainer1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.splitContainer1.Name = "splitContainer1";
-            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            //
             // splitContainer1.Panel1
-            // 
-            this.splitContainer1.Panel1.Controls.Add(this.ModList);
-            // 
+            //
+            this.splitContainer1.Panel1.Controls.Add(this.MainTabControl);
             this.splitContainer1.Panel1MinSize = 200;
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.ModInfoTabControl);
             this.splitContainer1.Panel2MinSize = 300;
-            this.splitContainer1.Size = new System.Drawing.Size(1522, 836);
+            this.splitContainer1.Size = new System.Drawing.Size(1544, 981);
             this.splitContainer1.SplitterDistance = 1156;
             this.splitContainer1.SplitterWidth = 10;
             this.splitContainer1.TabIndex = 7;
             // 
             // ModList
             // 
+            this.ModList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.ModList.AllowUserToAddRows = false;
             this.ModList.AllowUserToDeleteRows = false;
             this.ModList.AllowUserToResizeRows = false;
@@ -488,14 +491,13 @@
             this.DownloadCount,
             this.Description});
             this.ModList.ContextMenuStrip = this.ModListContextMenuStrip;
-            this.ModList.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ModList.Location = new System.Drawing.Point(0, 0);
+            this.ModList.Location = new System.Drawing.Point(0, 111);
             this.ModList.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ModList.MultiSelect = false;
             this.ModList.Name = "ModList";
             this.ModList.RowHeadersVisible = false;
             this.ModList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.ModList.Size = new System.Drawing.Size(1156, 836);
+            this.ModList.Size = new System.Drawing.Size(1536, 837);
             this.ModList.TabIndex = 3;
             this.ModList.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModList_CellContentClick);
             this.ModList.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModList_CellMouseDoubleClick);
@@ -653,7 +655,8 @@
             this.MainTabControl.SelectedIndex = 0;
             this.MainTabControl.Size = new System.Drawing.Size(1544, 981);
             this.MainTabControl.TabIndex = 9;
-            // 
+            this.MainTabControl.SelectedIndexChanged += new System.EventHandler(this.MainTabControl_OnSelectedIndexChanged);
+            //
             // ManageModsTabPage
             // 
             this.ManageModsTabPage.BackColor = System.Drawing.SystemColors.Control;
@@ -664,7 +667,7 @@
             this.ManageModsTabPage.Controls.Add(this.FilterByDescriptionLabel);
             this.ManageModsTabPage.Controls.Add(this.FilterByDescriptionTextBox);
             this.ManageModsTabPage.Controls.Add(this.menuStrip2);
-            this.ManageModsTabPage.Controls.Add(this.splitContainer1);
+            this.ManageModsTabPage.Controls.Add(this.ModList);
             this.ManageModsTabPage.Location = new System.Drawing.Point(4, 29);
             this.ManageModsTabPage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ManageModsTabPage.Name = "ManageModsTabPage";
@@ -745,7 +748,7 @@
             this.ChangesetTabPage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChangesetTabPage.Name = "ChangesetTabPage";
             this.ChangesetTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ChangesetTabPage.Size = new System.Drawing.Size(1536, 1001);
+            this.ChangesetTabPage.Size = new System.Drawing.Size(1536, 948);
             this.ChangesetTabPage.TabIndex = 2;
             this.ChangesetTabPage.Text = "Changeset";
             this.ChangesetTabPage.UseVisualStyleBackColor = true;
@@ -754,7 +757,7 @@
             // 
             this.CancelChangesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelChangesButton.Location = new System.Drawing.Point(1288, 949);
+            this.CancelChangesButton.Location = new System.Drawing.Point(1288, 896);
             this.CancelChangesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.CancelChangesButton.Name = "CancelChangesButton";
             this.CancelChangesButton.Size = new System.Drawing.Size(112, 35);
@@ -767,7 +770,7 @@
             // 
             this.ConfirmChangesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ConfirmChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ConfirmChangesButton.Location = new System.Drawing.Point(1410, 949);
+            this.ConfirmChangesButton.Location = new System.Drawing.Point(1410, 896);
             this.ConfirmChangesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ConfirmChangesButton.Name = "ConfirmChangesButton";
             this.ConfirmChangesButton.Size = new System.Drawing.Size(112, 35);
@@ -790,10 +793,11 @@
             this.ChangesListView.Location = new System.Drawing.Point(-2, 0);
             this.ChangesListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChangesListView.Name = "ChangesListView";
-            this.ChangesListView.Size = new System.Drawing.Size(1532, 939);
+            this.ChangesListView.Size = new System.Drawing.Size(1532, 886);
             this.ChangesListView.TabIndex = 4;
             this.ChangesListView.UseCompatibleStateImageBehavior = false;
             this.ChangesListView.View = System.Windows.Forms.View.Details;
+            this.ChangesListView.SelectedIndexChanged += new System.EventHandler(ChangesListView_SelectedIndexChanged);
             //
             // Mod
             //
@@ -822,7 +826,7 @@
             this.WaitTabPage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.WaitTabPage.Name = "WaitTabPage";
             this.WaitTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.WaitTabPage.Size = new System.Drawing.Size(1536, 1001);
+            this.WaitTabPage.Size = new System.Drawing.Size(1536, 948);
             this.WaitTabPage.TabIndex = 1;
             this.WaitTabPage.Text = "Status log";
             // 
@@ -830,7 +834,7 @@
             // 
             this.CancelCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelCurrentActionButton.Location = new System.Drawing.Point(1410, 951);
+            this.CancelCurrentActionButton.Location = new System.Drawing.Point(1410, 898);
             this.CancelCurrentActionButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.CancelCurrentActionButton.Name = "CancelCurrentActionButton";
             this.CancelCurrentActionButton.Size = new System.Drawing.Size(112, 35);
@@ -843,7 +847,7 @@
             //
             this.RetryCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RetryCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RetryCurrentActionButton.Location = new System.Drawing.Point(1290, 951);
+            this.RetryCurrentActionButton.Location = new System.Drawing.Point(1290, 898);
             this.RetryCurrentActionButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RetryCurrentActionButton.Name = "RetryCurrentActionButton";
             this.RetryCurrentActionButton.Size = new System.Drawing.Size(112, 35);
@@ -866,7 +870,7 @@
             this.LogTextBox.ReadOnly = true;
             this.LogTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.LogTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.LogTextBox.Size = new System.Drawing.Size(1505, 851);
+            this.LogTextBox.Size = new System.Drawing.Size(1505, 799);
             this.LogTextBox.TabIndex = 8;
             // 
             // DialogProgressBar
@@ -908,7 +912,7 @@
             this.ChooseRecommendedModsTabPage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseRecommendedModsTabPage.Name = "ChooseRecommendedModsTabPage";
             this.ChooseRecommendedModsTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ChooseRecommendedModsTabPage.Size = new System.Drawing.Size(1536, 1001);
+            this.ChooseRecommendedModsTabPage.Size = new System.Drawing.Size(1536, 948);
             this.ChooseRecommendedModsTabPage.TabIndex = 3;
             this.ChooseRecommendedModsTabPage.Text = "Choose recommended mods";
             this.ChooseRecommendedModsTabPage.UseVisualStyleBackColor = true;
@@ -917,7 +921,7 @@
             // 
             this.RecommendedModsCancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RecommendedModsCancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsCancelButton.Location = new System.Drawing.Point(1288, 949);
+            this.RecommendedModsCancelButton.Location = new System.Drawing.Point(1288, 896);
             this.RecommendedModsCancelButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RecommendedModsCancelButton.Name = "RecommendedModsCancelButton";
             this.RecommendedModsCancelButton.Size = new System.Drawing.Size(112, 35);
@@ -930,7 +934,7 @@
             // 
             this.RecommendedModsContinueButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RecommendedModsContinueButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsContinueButton.Location = new System.Drawing.Point(1410, 949);
+            this.RecommendedModsContinueButton.Location = new System.Drawing.Point(1410, 896);
             this.RecommendedModsContinueButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RecommendedModsContinueButton.Name = "RecommendedModsContinueButton";
             this.RecommendedModsContinueButton.Size = new System.Drawing.Size(112, 35);
@@ -944,7 +948,7 @@
             this.RecommendedModsToggleCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.RecommendedModsToggleCheckbox.AutoSize = true;
             this.RecommendedModsToggleCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsToggleCheckbox.Location = new System.Drawing.Point(12, 956);
+            this.RecommendedModsToggleCheckbox.Location = new System.Drawing.Point(12, 903);
             this.RecommendedModsToggleCheckbox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RecommendedModsToggleCheckbox.Name = "RecommendedModsToggleCheckbox";
             this.RecommendedModsToggleCheckbox.Size = new System.Drawing.Size(131, 24);
@@ -979,11 +983,12 @@
             this.RecommendedModsListView.Location = new System.Drawing.Point(9, 45);
             this.RecommendedModsListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RecommendedModsListView.Name = "RecommendedModsListView";
-            this.RecommendedModsListView.Size = new System.Drawing.Size(1510, 894);
+            this.RecommendedModsListView.Size = new System.Drawing.Size(1510, 841);
             this.RecommendedModsListView.TabIndex = 5;
             this.RecommendedModsListView.UseCompatibleStateImageBehavior = false;
             this.RecommendedModsListView.View = System.Windows.Forms.View.Details;
-            // 
+            this.RecommendedModsListView.SelectedIndexChanged += new System.EventHandler(RecommendedModsListView_SelectedIndexChanged);
+            //
             // columnHeader3
             // 
             this.columnHeader3.Text = "Mod";
@@ -1009,7 +1014,7 @@
             this.ChooseProvidedModsTabPage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseProvidedModsTabPage.Name = "ChooseProvidedModsTabPage";
             this.ChooseProvidedModsTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ChooseProvidedModsTabPage.Size = new System.Drawing.Size(1536, 1001);
+            this.ChooseProvidedModsTabPage.Size = new System.Drawing.Size(1536, 948);
             this.ChooseProvidedModsTabPage.TabIndex = 4;
             this.ChooseProvidedModsTabPage.Text = "Choose mods";
             this.ChooseProvidedModsTabPage.UseVisualStyleBackColor = true;
@@ -1018,7 +1023,7 @@
             // 
             this.ChooseProvidedModsCancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ChooseProvidedModsCancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChooseProvidedModsCancelButton.Location = new System.Drawing.Point(1286, 948);
+            this.ChooseProvidedModsCancelButton.Location = new System.Drawing.Point(1286, 895);
             this.ChooseProvidedModsCancelButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseProvidedModsCancelButton.Name = "ChooseProvidedModsCancelButton";
             this.ChooseProvidedModsCancelButton.Size = new System.Drawing.Size(112, 35);
@@ -1031,7 +1036,7 @@
             // 
             this.ChooseProvidedModsContinueButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ChooseProvidedModsContinueButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChooseProvidedModsContinueButton.Location = new System.Drawing.Point(1407, 948);
+            this.ChooseProvidedModsContinueButton.Location = new System.Drawing.Point(1407, 895);
             this.ChooseProvidedModsContinueButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseProvidedModsContinueButton.Name = "ChooseProvidedModsContinueButton";
             this.ChooseProvidedModsContinueButton.Size = new System.Drawing.Size(112, 35);
@@ -1056,11 +1061,12 @@
             this.ChooseProvidedModsListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseProvidedModsListView.MultiSelect = false;
             this.ChooseProvidedModsListView.Name = "ChooseProvidedModsListView";
-            this.ChooseProvidedModsListView.Size = new System.Drawing.Size(1510, 894);
+            this.ChooseProvidedModsListView.Size = new System.Drawing.Size(1510, 841);
             this.ChooseProvidedModsListView.TabIndex = 8;
             this.ChooseProvidedModsListView.UseCompatibleStateImageBehavior = false;
             this.ChooseProvidedModsListView.View = System.Windows.Forms.View.Details;
-            // 
+            this.ChooseProvidedModsListView.SelectedIndexChanged += new System.EventHandler(ChooseProvidedModsListView_SelectedIndexChanged);
+            //
             // columnHeader6
             // 
             this.columnHeader6.Text = "Mod";
@@ -1086,7 +1092,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1544, 1038);
-            this.Controls.Add(this.MainTabControl);
+            this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -242,7 +242,7 @@ namespace CKAN
                 Util.HideConsoleWindow();
 
             // Disable the modinfo controls until a mod has been choosen.
-            ModInfoTabControl.SelectedModule = null;
+            ActiveModInfo = null;
 
             // WinForms on Mac OS X has a nasty bug where the UI thread hogs the CPU,
             // making our download speeds really slow unless you move the mouse while
@@ -974,6 +974,76 @@ namespace CKAN
             else
             {
                 AddStatusMessage("Not found.");
+            }
+        }
+
+        private GUIMod ActiveModInfo
+        {
+            set {
+                if (value == null)
+                {
+                    splitContainer1.Panel2Collapsed = true;
+                }
+                else
+                {
+                    if (splitContainer1.Panel2Collapsed)
+                    {
+                        splitContainer1.Panel2Collapsed = false;
+                    }
+                    ModInfoTabControl.SelectedModule = value;
+                }
+            }
+        }
+
+        private void ShowSelectionModInfo(ListView.SelectedListViewItemCollection selection)
+        {
+            CkanModule module = (CkanModule)selection?.Cast<ListViewItem>().FirstOrDefault()?.Tag;
+
+            ActiveModInfo = module == null ? null : new GUIMod(
+                module,
+                RegistryManager.Instance(CurrentInstance).registry,
+                CurrentInstance.VersionCriteria()
+            );
+        }
+
+        private void ChangesListView_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ShowSelectionModInfo(ChangesListView.SelectedItems);
+        }
+
+        private void RecommendedModsListView_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ShowSelectionModInfo(RecommendedModsListView.SelectedItems);
+        }
+
+        private void ChooseProvidedModsListView_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ShowSelectionModInfo(ChooseProvidedModsListView.SelectedItems);
+        }
+
+        private void MainTabControl_OnSelectedIndexChanged(object sender, EventArgs e)
+        {
+            switch (MainTabControl.SelectedTab?.Name)
+            {
+                case "ManageModsTabPage":
+                    ModList_SelectedIndexChanged(sender, e);
+                    break;
+
+                case "WaitTabPage":
+                    ShowSelectionModInfo(null);
+                    break;
+
+                case "ChangesetTabPage":
+                    ShowSelectionModInfo(ChangesListView.SelectedItems);
+                    break;
+
+                case "ChooseRecommendedModsTabPage":
+                    ShowSelectionModInfo(RecommendedModsListView.SelectedItems);
+                    break;
+
+                case "ChooseProvidedModsTabPage":
+                    ShowSelectionModInfo(ChooseProvidedModsListView.SelectedItems);
+                    break;
             }
         }
 

--- a/GUI/MainAllModVersions.Designer.cs
+++ b/GUI/MainAllModVersions.Designer.cs
@@ -76,7 +76,7 @@
             listViewItem4});
             this.VersionsListView.Location = new System.Drawing.Point(3, 76);
             this.VersionsListView.Name = "VersionsListView";
-            this.VersionsListView.Size = new System.Drawing.Size(421, 174);
+            this.VersionsListView.Size = new System.Drawing.Size(348, 423);
             this.VersionsListView.TabIndex = 1;
             this.VersionsListView.UseCompatibleStateImageBehavior = false;
             this.VersionsListView.View = System.Windows.Forms.View.Details;
@@ -142,8 +142,6 @@
             // 
             // MainAllModVersions
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.label7);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.label5);
@@ -153,10 +151,9 @@
             this.Controls.Add(this.VersionsListView);
             this.Controls.Add(this.label1);
             this.Name = "MainAllModVersions";
-            this.Size = new System.Drawing.Size(427, 253);
+            this.Size = new System.Drawing.Size(354, 502);
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -51,7 +51,8 @@ namespace CKAN
                 {
                     Text = Manager.Cache.IsMaybeCachedZip(m)
                         ? $"{m.name} {m.version} (cached)"
-                        : $"{m.name} {m.version} ({m.download.Host ?? ""}, {CkanModule.FmtSize(m.download_size)})"
+                        : $"{m.name} {m.version} ({m.download.Host ?? ""}, {CkanModule.FmtSize(m.download_size)})",
+                    Tag  = change.Mod.ToModule()
                 };
 
                 var sub_change_type = new ListViewItem.ListViewSubItem {Text = change.ChangeType.ToString()};

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -70,6 +70,7 @@
             this.MetaDataLowerLayoutPanel.SuspendLayout();
             this.RelationshipTabPage.SuspendLayout();
             this.ContentTabPage.SuspendLayout();
+            this.AllModVersions.SuspendLayout();
             this.AllModVersionsTabPage.SuspendLayout();
             this.SuspendLayout();
             //
@@ -90,7 +91,7 @@
             //
             // MetadataTabPage
             //
-            this.MetadataTabPage.Controls.Add(this.splitContainer2);
+            this.MetadataTabPage.Controls.Add(this.MetaDataLowerLayoutPanel);
             this.MetadataTabPage.Location = new System.Drawing.Point(4, 25);
             this.MetadataTabPage.Name = "MetadataTabPage";
             this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(3);
@@ -101,7 +102,6 @@
             //
             // splitContainer2
             //
-            this.splitContainer2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer2.Location = new System.Drawing.Point(3, 3);
             this.splitContainer2.Name = "splitContainer2";
@@ -114,7 +114,7 @@
             //
             // splitContainer2.Panel2
             //
-            this.splitContainer2.Panel2.Controls.Add(this.MetaDataLowerLayoutPanel);
+            this.splitContainer2.Panel2.Controls.Add(this.ModInfoTabControl);
             this.splitContainer2.Panel2MinSize = 225;
             this.splitContainer2.Size = new System.Drawing.Size(348, 496);
             this.splitContainer2.SplitterWidth = 10;
@@ -487,7 +487,7 @@
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.ModInfoTabControl);
+            this.Controls.Add(this.splitContainer2);
             this.Name = "MainModInfoTab";
             this.Size = new System.Drawing.Size(362, 531);
             this.ModInfoTabControl.ResumeLayout(false);
@@ -501,9 +501,10 @@
             this.MetaDataLowerLayoutPanel.PerformLayout();
             this.RelationshipTabPage.ResumeLayout(false);
             this.ContentTabPage.ResumeLayout(false);
+            this.AllModVersions.ResumeLayout(false);
             this.AllModVersionsTabPage.ResumeLayout(false);
             this.ResumeLayout(false);
-
+            this.PerformLayout();
         }
 
         #endregion

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -270,7 +270,7 @@ namespace CKAN
         {
             var module = GetSelectedModule();
 
-            ModInfoTabControl.SelectedModule = module;
+            ActiveModInfo = module;
             if (module == null)
                 return;
 

--- a/GUI/MainTabControl.cs
+++ b/GUI/MainTabControl.cs
@@ -5,16 +5,18 @@ namespace CKAN
 {
     public class MainTabControl : TabControl
     {
-        public MainTabControl() : base()
-        {
-        }
+        public MainTabControl() : base() { }
 
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
             base.OnSelectedIndexChanged(e);
-            if (this.SelectedTab != null && this.SelectedTab.Name.Equals("ManageModsTabPage"))
-                ((Main)this.Parent).ModList.Focus();
+            switch (this.SelectedTab?.Name)
+            {
+                case "ManageModsTabPage":
+                    // Focus the grid
+                    Main.Instance.ModList.Focus();
+                    break;
+            }
         }
     }
 }
-


### PR DESCRIPTION
## Motivation

GUI has several places where mods are listed but all the user can access is their name and abstract.

- Change set
- Recommendations / suggestions
- Providing modules

If you want to see the long description, license, home page, relationships, etc., you have to cancel whatever you're doing and then look up the mods separately on the main mod list.

## Changes

Now the mod info pane is available in these lists if you click a row. This allows the user to get complete info about any mod about which they're being asked to make decisions. The mod info pane will disappear if you clear the list's selection.

Main mod list:

![image](https://user-images.githubusercontent.com/1559108/47597411-15249780-d954-11e8-8172-dbca56619204.png)

Provides:

![image](https://user-images.githubusercontent.com/1559108/47597413-18b81e80-d954-11e8-969a-cef5aa077aa3.png)

Change set:

![image](https://user-images.githubusercontent.com/1559108/47597417-253c7700-d954-11e8-8e68-42dc92dcaf02.png)

Recommendations:

![image](https://user-images.githubusercontent.com/1559108/47597420-29689480-d954-11e8-8775-0370ff601dd8.png)

To accomplish this, the structure of the main form is rearranged so the vertical splitter now contains the main tab control and the mod info:

Pre:

- MainTabControl
  - ManageModsTabPage
    - splitContainer1
      - ModList
      - MainModInfo

Post:

- splitContainer1
  - MainTabControl
    - ManageModsTabPage
      - Modlist
  - MainModInfo

Then when the selection changes in any of those lists, we get the `CkanModule` for it, create a `GUIMod`, and pass it to the mod info pane.

Fixes #1868.