### PR TITLE
Fix crash at startup on Windows

### DIFF
--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsDialog));
             this.NewRepoButton = new System.Windows.Forms.Button();
             this.RepositoryGroupBox = new System.Windows.Forms.GroupBox();
@@ -301,7 +302,7 @@
             this.CachePath.ForeColor = System.Drawing.SystemColors.ControlText;
             this.CachePath.Location = new System.Drawing.Point(8, 24);
             this.CachePath.Name = "CachePath";
-            this.CachePath.Size = new System.Drawing.Size(620, 17);
+            this.CachePath.Size = new System.Drawing.Size(620, 22);
             this.CachePath.TabIndex = 11;
             this.CachePath.TextChanged += new System.EventHandler(this.CachePath_TextChanged);
             //
@@ -332,7 +333,7 @@
             this.CacheLimit.ForeColor = System.Drawing.SystemColors.ControlText;
             this.CacheLimit.Location = new System.Drawing.Point(156, 72);
             this.CacheLimit.Name = "CacheLimit";
-            this.CacheLimit.Size = new System.Drawing.Size(75, 17);
+            this.CacheLimit.Size = new System.Drawing.Size(75, 22);
             this.CacheLimit.TabIndex = 11;
             this.CacheLimit.TextChanged += new System.EventHandler(this.CacheLimit_TextChanged);
             this.CacheLimit.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.CacheLimit_KeyPress);


### PR DESCRIPTION
## Problem

If you run the master HEAD version in Windows, you get this exception at startup:

```
Unhandled exception:
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.ArgumentNullException: Value cannot be null.
Parameter name: container
   at System.Windows.Forms.ContextMenuStrip..ctor(IContainer container)
   at CKAN.SettingsDialog.InitializeComponent()
   at CKAN.SettingsDialog..ctor()
   --- End of inner exception stack trace ---
   at System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean noCheck, Boolean& canBeCached, RuntimeMethodHandleInternal& ctor, Boolean& bNeedSecurityCheck)
   at System.RuntimeType.CreateInstanceSlow(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache, StackCrawlMark& stackMark)
   at System.Activator.CreateInstance[T]()
   at CKAN.ControlFactory.CreateControl[T]()
   at CKAN.Main.RecreateDialogs()
   at CKAN.Main..ctor(String[] cmdlineArgs, KSPManager mgr, GUIUser user, Boolean showConsole)
   at CKAN.GUI.Main_(String[] args, KSPManager manager, Boolean showConsole)
   at CKAN.CmdLine.MainClass.Gui(KSPManager manager, GuiOptions options, String[] args)
   at CKAN.CmdLine.MainClass.RunSimpleAction(Options cmdline, CommonOptions options, String[] args, IUser user, KSPManager manager)
   at CKAN.CmdLine.MainClass.Execute(KSPManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args) 
```

## Cause

This line initializes the purge button dropdown menu from #2536 in the settings window:

https://github.com/KSP-CKAN/CKAN/blob/681dd7e9ece6dada49d437aa16d8e669d2afb809/GUI/SettingsDialog.Designer.cs#L44

However, `this.components` isn't currently being set. In the main form from which the above line was borrowed, there's a line to set it, but this isn't present in the settings form:

https://github.com/KSP-CKAN/CKAN/blob/681dd7e9ece6dada49d437aa16d8e669d2afb809/GUI/Main.Designer.cs#L31

We should have copied and pasted this when we made the dropdown, but it's not apparent that it's required or might be missing.

## Changes

Now `this.components` is initialized in the settings window and the exception is gone.

The cache settings text boxes are also made 5 pixels taller, since they were a bit squished on Windows previously.