### PR TITLE
Avoid null ksp_version in Netkan

### DIFF
--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -95,6 +95,19 @@ namespace CKAN.Versioning
         }
 
         /// <summary>
+        /// Check whether a version is null or Any.
+        /// We group them here because they mean the same thing.
+        /// </summary>
+        /// <param name="v">The version to check</param>
+        /// <returns>
+        /// True if null or Any, false otherwise
+        /// </returns>
+        public static bool IsNullOrAny(KspVersion v)
+        {
+            return v == null || v.IsAny;
+        }
+
+        /// <summary>
         /// Initialize a new instance of the <see cref="KspVersion"/> class with all components unspecified.
         /// </summary>
         public KspVersion()

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -119,16 +119,16 @@ namespace CKAN.NetKAN.Transformers
             var kspMins  = new List<KspVersion>();
             var kspMaxes = new List<KspVersion>();
 
-            if (existingKspMin != null)
+            if (!KspVersion.IsNullOrAny(existingKspMin))
                 kspMins.Add(existingKspMin);
 
-            if (avcKspMin != null)
+            if (!KspVersion.IsNullOrAny(avcKspMin))
                 kspMins.Add(avcKspMin);
 
-            if (existingKspMax != null)
+            if (!KspVersion.IsNullOrAny(existingKspMax))
                 kspMaxes.Add(existingKspMax);
 
-            if (avcKspMax != null)
+            if (!KspVersion.IsNullOrAny(avcKspMax))
                 kspMaxes.Add(avcKspMax);
 
             var kspMin = kspMins.Any()  ? kspMins.Min()  : null;


### PR DESCRIPTION
## Problem

#2553 tried to fix a problem with setting `"ksp_version": "any"` in a netkan that also has a `$vref`. The change worked insofar as netkan was able to generate a .ckan file instead of erroring out, but the script that checks the .ckan file against the schema found a problem: `ksp_version` was null, and that's not allowed.

```
    "ksp_version": null,
```

```
Validating built/CommunityTerrainTexturePack-1-1.0.4.ckan.. Failed! See below for error description.
None is not of type u'string'

Failed validating u'type' in schema[u'properties'][u'ksp_version']:
    {u'description': u'A version of KSP',
     u'pattern': u'^(any|[0-9]+\\.[0-9]+(\\.[0-9]+)?)$',
     u'type': u'string'}

On instance[u'ksp_version']:
    None
```

This is blocking KSP-CKAN/NetKAN#6791.

## Cause

`KspVersion.Any.ToString()` returns null because of this:

https://github.com/KSP-CKAN/CKAN/blob/5b548502a0ae449d32929b9cbce4299aab76fbca/Core/Versioning/KspVersion.cs#L774

(This is kind of gross, since the string "any" is specifically allowed in the spec and could be used here, but I'm reluctant to mess with such a core assumption.)

Then when we parse "any" and return `KspVersion.Any`, these lines then set `ksp_version` to null:

https://github.com/KSP-CKAN/CKAN/blob/5b548502a0ae449d32929b9cbce4299aab76fbca/Netkan/Transformers/AvcTransformer.cs#L145-L152

## Changes

The `if` checks in these lines are in charge of keeping `null` out of the lists of possible min and max versions:

https://github.com/KSP-CKAN/CKAN/blob/5b548502a0ae449d32929b9cbce4299aab76fbca/Netkan/Transformers/AvcTransformer.cs#L122-L132

Now they're updated to also prevent `KspVersion.Any` from being added to those lists. This is done with a new static helper function `KspVersion.IsNullOrAny` in the style of `string.IsNullOrEmpty`. This will cause the AVC transformer to not make any changes, and the "any" value from the original netkan will flow through to the .ckan file, which is valid according to the spec.