### PR TITLE
Don't show status progress bar till actually installing

### DIFF
--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -78,9 +78,7 @@ namespace CKAN
 
         private void InstallMods(object sender, DoWorkEventArgs e) // this probably needs to be refactored
         {
-            ShowWaitDialog();
             installCanceled = false;
-
             ClearLog();
 
             var opts = (KeyValuePair<ModChanges, RelationshipResolverOptions>) e.Argument;
@@ -134,16 +132,14 @@ namespace CKAN
 
             if (installCanceled)
             {
-                tabController.HideTab("WaitTabPage");
                 tabController.ShowTab("ManageModsTabPage");
                 e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
                 return;
             }
 
             // Now let's make all our changes.
-
             tabController.RenameTab("WaitTabPage", "Status log");
-            tabController.ShowTab("WaitTabPage");
+            ShowWaitDialog();
             tabController.SetTabLock(true);
 
             IDownloader downloader = new NetAsyncModulesDownloader(GUI.user);


### PR DESCRIPTION
## Problem

If you choose to install a mod that has recommendations or suggestions, the status-bar progress bar will appear while the recommendation and suggestion lists are visible.

![image](https://user-images.githubusercontent.com/1559108/47868187-86a09200-ddfb-11e8-9c34-9a03ea538f7b.png)

If you then cancel out of these screens, that progress bar will remain visible on the main mod list, effectively stuck there until you start and complete another installation.

![image](https://user-images.githubusercontent.com/1559108/47868201-9324ea80-ddfb-11e8-836b-56cc854fa094.png)

## Cause

This progress bar is shown and hidden in the `ShowWaitDialog` and `HideWaitDialog` functions that initialize and reset the log tab and its progress bar, respectively.

`ShowWaitDialog` is called too early in the install process, before recommendations and suggestions are handled. We don't need it yet at that point, so the tab sits uselessly in the background while the user deals with recommendations and suggestions, and the status bar shows a progress bar when it shouldn't.

## Changes

Now we don't call `ShowWaitDialog` until after recommendations and suggestions are handled, when we're ready to do the actual installation. This will leave the progress bar hidden until it's needed. It also simplifies the clean-up a bit when the user cancels.

Fixes #2417.
Closes #2418. (Addressing the same issue, somewhat more complexly, but now has conflicts with master and hard to tell what the changes were.)