### PR TITLE
Allow uninstallation of conflicting mods

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -135,7 +135,7 @@ namespace CKAN
 
         public void InstallList(List<string> modules, RelationshipResolverOptions options, IDownloader downloader = null)
         {
-            var resolver = new RelationshipResolver(modules, options, registry_manager.registry, ksp.VersionCriteria());
+            var resolver = new RelationshipResolver(modules, null, options, registry_manager.registry, ksp.VersionCriteria());
             InstallList(resolver.ModList().ToList(), options, downloader);
         }
 
@@ -150,7 +150,7 @@ namespace CKAN
         public void InstallList(ICollection<CkanModule> modules, RelationshipResolverOptions options, IDownloader downloader = null)
         {
             // TODO: Break this up into smaller pieces! It's huge!
-            var resolver = new RelationshipResolver(modules, options, registry_manager.registry, ksp.VersionCriteria());
+            var resolver = new RelationshipResolver(modules, null, options, registry_manager.registry, ksp.VersionCriteria());
             var modsToInstall = resolver.ModList().ToList();
             List<CkanModule> downloads = new List<CkanModule>();
 
@@ -1018,7 +1018,7 @@ namespace CKAN
             options.with_recommends = false;
             options.with_suggests = false;
 
-            var resolver = new RelationshipResolver(identifiers.ToList(), options, registry_manager.registry, ksp.VersionCriteria());
+            var resolver = new RelationshipResolver(identifiers.ToList(), null, options, registry_manager.registry, ksp.VersionCriteria());
             Upgrade(resolver.ModList(), netAsyncDownloader, enforceConsistency);
         }
 

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -514,6 +514,7 @@ namespace CKAN
                 {
                     RelationshipResolver resolver = new RelationshipResolver(
                         new List<CkanModule> { pair.Key },
+                        null,
                         opts,
                         RegistryManager.Instance(manager.CurrentInstance).registry,
                         CurrentInstance.VersionCriteria()

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -606,7 +606,10 @@ namespace CKAN
                 TooManyModsProvideKraken kraken;
                 try
                 {
-                    new RelationshipResolver(modules_to_install.ToList(), options, registry, version);
+                    new RelationshipResolver(
+                        modules_to_install,
+                        modules_to_remove,
+                        options, registry, version);
                     handled_all_too_many_provides = true;
                     continue;
                 }
@@ -635,10 +638,10 @@ namespace CKAN
                 changeSet.Add(new ModChange(new GUIMod(module_by_version, registry, version), GUIModChangeType.Remove, null));
             }
 
-            var resolver = new RelationshipResolver(options, registry, version);
-            resolver.RemoveModsFromInstalledList(
-                changeSet.Where(change => change.ChangeType.Equals(GUIModChangeType.Remove)).Select(m => m.Mod.ToModule()));
-            resolver.AddModulesToInstall(modules_to_install.ToList());
+            var resolver = new RelationshipResolver(
+                modules_to_install,
+                changeSet.Where(change => change.ChangeType.Equals(GUIModChangeType.Remove)).Select(m => m.Mod.ToModule()),
+                options, registry, version);
             changeSet.UnionWith(
                 resolver.ModList()
                     .Select(m => new ModChange(new GUIMod(m, registry, version), GUIModChangeType.Install, resolver.ReasonFor(m))));
@@ -859,7 +862,12 @@ namespace CKAN
                     name => CkanModule.FromIDandVersion(registry, name, ksp_version)
                 )
             );
-            var resolver = new RelationshipResolver(mods_to_check, options, registry, ksp_version);
+            var resolver = new RelationshipResolver(
+                mods_to_check,
+                change_set.Where(ch => ch.ChangeType == GUIModChangeType.Remove)
+                    .Select(ch => ch.Mod.ToModule()),
+                options, registry, ksp_version
+            );
             return resolver.ConflictList.ToDictionary(item => new GUIMod(item.Key, registry, ksp_version),
                 item => item.Value);
         }

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -34,6 +34,7 @@ namespace Tests.Core.Relationships
             registry = CKAN.Registry.Empty();
             options = RelationshipResolver.DefaultOpts();
             Assert.DoesNotThrow(() => new RelationshipResolver(new List<string>(),
+                null,
                 options,
                 registry,
                 null));
@@ -55,13 +56,14 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
 
 
             options.proceed_with_inconsistencies = true;
-            var resolver = new RelationshipResolver(list, options, registry, null);
+            var resolver = new RelationshipResolver(list, null, options, registry, null);
 
             Assert.That(resolver.ConflictList.Any(s => Equals(s.Key, mod_a)));
             Assert.That(resolver.ConflictList.Any(s => Equals(s.Key, mod_b)));
@@ -86,6 +88,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -110,6 +113,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -134,6 +138,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -159,6 +164,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -183,6 +189,7 @@ namespace Tests.Core.Relationships
 
             Assert.DoesNotThrow(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -206,6 +213,7 @@ namespace Tests.Core.Relationships
 
             Assert.DoesNotThrow(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -229,6 +237,7 @@ namespace Tests.Core.Relationships
 
             Assert.DoesNotThrow(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -253,6 +262,7 @@ namespace Tests.Core.Relationships
 
             Assert.DoesNotThrow(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -282,6 +292,7 @@ namespace Tests.Core.Relationships
             AddToRegistry(mod_b, mod_c, mod_d);
             Assert.Throws<TooManyModsProvideKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -297,6 +308,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -317,7 +329,7 @@ namespace Tests.Core.Relationships
             AddToRegistry(mod_a);
             registry.Installed().Add(mod_a.identifier, mod_a.version);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.IsEmpty(relationship_resolver.ModList());
         }
 
@@ -336,7 +348,7 @@ namespace Tests.Core.Relationships
             AddToRegistry(suggester, suggested);
             registry.Installed().Add(suggested.identifier, suggested.version);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
         }
 
@@ -359,7 +371,7 @@ namespace Tests.Core.Relationships
             list.Add(mod.identifier);
             AddToRegistry(suggester, suggested, mod);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.DoesNotContain(relationship_resolver.ModList(), suggested);
         }
 
@@ -384,6 +396,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -403,7 +416,7 @@ namespace Tests.Core.Relationships
             list.Add(suggester.identifier);
             AddToRegistry(suggester, suggested);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
         }
 
@@ -429,12 +442,12 @@ namespace Tests.Core.Relationships
             list.Add(suggester.identifier);
             AddToRegistry(suggester, suggested, suggested2);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.Contains(relationship_resolver.ModList(), suggested2);
 
             options.with_all_suggests = false;
 
-            relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.DoesNotContain(relationship_resolver.ModList(), suggested2);
         }
 
@@ -453,7 +466,7 @@ namespace Tests.Core.Relationships
             });
             list.Add(depender.identifier);
             AddToRegistry(mod_b, depender);
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
 
             CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
             {
@@ -476,6 +489,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -500,6 +514,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -521,12 +536,14 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
             list.Add(dependant.identifier);
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -549,6 +566,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -577,6 +595,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -600,7 +619,7 @@ namespace Tests.Core.Relationships
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
             {
                 dependant,
@@ -626,7 +645,7 @@ namespace Tests.Core.Relationships
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
             {
                 dependant,
@@ -652,7 +671,7 @@ namespace Tests.Core.Relationships
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
             {
                 dependant,
@@ -678,7 +697,7 @@ namespace Tests.Core.Relationships
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
             {
                 dependant,
@@ -698,6 +717,7 @@ namespace Tests.Core.Relationships
 
             Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
                 list,
+                null,
                 options,
                 registry,
                 null));
@@ -711,7 +731,7 @@ namespace Tests.Core.Relationships
             list.Add(mod.identifier);
             registry.AddAvailable(mod);
             AddToRegistry(mod);
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
 
             var mod_not_in_resolver_list = generator.GeneratorRandomModule();
             CollectionAssert.DoesNotContain(relationship_resolver.ModList(),mod_not_in_resolver_list);
@@ -727,7 +747,7 @@ namespace Tests.Core.Relationships
             registry.AddAvailable(mod);
             AddToRegistry(mod);
 
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             var reason = relationship_resolver.ReasonFor(mod);
             Assert.That(reason, Is.AssignableTo<SelectionReason.UserRequested>());
         }
@@ -744,7 +764,7 @@ namespace Tests.Core.Relationships
             AddToRegistry(mod, suggested);
 
             options.with_all_suggests = true;
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             var reason = relationship_resolver.ReasonFor(suggested);
 
             Assert.That(reason, Is.AssignableTo<SelectionReason.Suggested>());
@@ -775,7 +795,7 @@ namespace Tests.Core.Relationships
 
             options.with_all_suggests = true;
             options.with_recommends = true;
-            var relationship_resolver = new RelationshipResolver(list, options, registry, null);
+            var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
             var reason = relationship_resolver.ReasonFor(recommendedA);
             Assert.That(reason, Is.AssignableTo<SelectionReason.Recommended>());
             Assert.That(reason.Parent, Is.EqualTo(suggested));
@@ -802,6 +822,7 @@ namespace Tests.Core.Relationships
 
                 new RelationshipResolver(
                     new CkanModule[] { mod },
+                    null,
                     RelationshipResolver.DefaultOpts(),
                     registry,
                     new KspVersionCriteria (KspVersion.Parse("1.0.0"))


### PR DESCRIPTION
## Problem

If you manually install a mod that conflicts with a CKAN-managed mod that you've installed, you won't be able to remove the CKAN-managed mod:

![screenshot](https://user-images.githubusercontent.com/1559108/47838096-2f240700-dda6-11e8-9a53-ff9865f8fbb3.png)

You ought to be able to, though, because the conflict won't be present after the mod is removed.

## Cause

`RelationshipResolver` is in charge of detecting conflicts in a change set. It has a `RemoveModsFromInstalledList` function to handle removal, but this is inconsistently used at the moment. In the above scenario, it's not used at all, so `RelationshipResolver` thinks you will still have the conflicting mod installed after you remove it.

At a deeper level, `RelationshipResolver`'s public interface is awkward and confusing for typical tasks. There's a constructor that accepts no modules, and there's one that accepts modules to install but not modules to remove. This gives the impression that `RelationshipResolver` can't handle removing modules, unless the programmer notices the `RemoveModsFromInstalledList` function. Even then, that function can't be used together with the constructor accepting modules to install because the constructor will check for conflicts and throw exceptions before `RemoveModsFromInstalledList` can be called. Instead you have to use the constructor that accepts no modules, and then call `RemoveModsFromInstalledList` followed by `AddModulesToInstall`.

## Changes

`RelationshipResolver`'s constructor accepting a list of mods to install now also accepts a list of mods to uninstall, which are removed from the candidate mod list before the mods to install are added. This new parameter is non-optional as a cue to make the programmer think about whether modules could be removed in a given use case. All calling code is updated to pass the new parameter appropriately.

`RelationshipResolver.AddModulesToInstall` and `RelationshipResolver.RemoveModsFromInstalledList` are now private because the constructor should be used instead.

Fixes #2559.