### PR TITLE
Purge more bloat from `registry.json`

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -359,8 +359,7 @@ namespace CKAN
             using (JsonTextWriter writer = new JsonTextWriter(sw))
             {
                 writer.Formatting = Formatting.Indented;
-                writer.Indentation = 1;
-                writer.IndentChar = '\t';
+                writer.Indentation = 0;
 
                 JsonSerializer serializer = new JsonSerializer();
                 serializer.Serialize(writer, registry);

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -259,7 +260,8 @@ namespace CKAN
         [JsonProperty("download_hash", NullValueHandling = NullValueHandling.Ignore)]
         public DownloadHashesDescriptor download_hash;
 
-        [JsonProperty("download_content_type", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("download_content_type", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue("application/zip")]
         public string download_content_type;
 
         [JsonProperty("identifier", Required = Required.Always)]
@@ -274,7 +276,8 @@ namespace CKAN
         [JsonProperty("ksp_version_min", NullValueHandling = NullValueHandling.Ignore)]
         public KspVersion ksp_version_min;
 
-        [JsonProperty("ksp_version_strict")]
+        [JsonProperty("ksp_version_strict", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
         public bool ksp_version_strict = false;
 
         [JsonProperty("license")]

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -26,10 +27,12 @@ namespace CKAN
         [JsonProperty("find_regexp", NullValueHandling = NullValueHandling.Ignore)]
         public string find_regexp;
 
-        [JsonProperty("find_matches_files")]
+        [JsonProperty("find_matches_files", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
         public bool find_matches_files;
 
-        [JsonProperty("install_to", Required = Required.Always)]
+        [JsonProperty("install_to", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue("GameData")]
         public string install_to;
 
         [JsonProperty("as", NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
## Motivation

The `registry.json` file nowadays is about 20 MB, 10% of which is repetitions of the following lines:

| Line | Occurrences |
| --- | ---:|
| `"ksp_version_strict": false,` | 14817 |
| `"download_content_type": "application/zip",` | 14764 |
| `"find_matches_files": false,` | 13504 |
| `"install_to": "GameData"` (without a comma) | 8378 |
| `"install_to": "GameData",` (with a comma) | 1725 |

A further 3.5 MB is tab characters indenting the JSON. While it can be useful to inspect this file from time to time, its primary function is to be read by code, so this formatting is not necessary.

This takes up disk space and increases the time to save and load the registry.

## Changes

Now the above values of the above properties are treated as the default; when the property has that value, it will be left out of the serialization, and if the property is missing when de-serializing, it will be set to the default. There will be no change in runtime behavior because the de-serializer will still set the properties as needed.

Similarly, the indenting is removed (but the line breaks remain).

This reduces the size of `registry.json` by about 5.5 MB, similar to #2179.

```
-rw-r--r-- 1 20846338 Nov  2 18:42  OLD-registry.json
-rw-r--r-- 1 15320905 Nov  2 19:02  NEW-registry.json

$ echo $((20846338-15320905))
5525433
```
