### PR TITLE
Treat AVC min without max as open range

### DIFF
--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -110,9 +110,23 @@ namespace CKAN.NetKAN.Transformers
             var existingKspMax = existingKspMaxStr == null ? null : KspVersion.Parse(existingKspMaxStr);
 
             // Get the minimum and maximum KSP versions that are in the AVC file.
-            // Use specific KSP version if min/max don't exist.
-            var avcKspMin = avc.ksp_version_min ?? avc.ksp_version;
-            var avcKspMax = avc.ksp_version_max ?? avc.ksp_version;
+            // http://ksp.cybutek.net/kspavc/Documents/README.htm
+            // KSP-AVC allows (requires?) KSP_VERSION to be set
+            // when KSP_VERSION_MIN/_MAX are set, but CKAN treats
+            // its equivalent properties as mutually exclusive.
+            // Only fallback if neither min nor max are defined,
+            // for open ranges.
+            KspVersion avcKspMin, avcKspMax;
+            if (avc.ksp_version_min == null && avc.ksp_version_max == null)
+            {
+                // Use specific KSP version if min/max don't exist
+                avcKspMin = avcKspMax = avc.ksp_version;
+            }
+            else
+            {
+                avcKspMin = avc.ksp_version_min;
+                avcKspMax = avc.ksp_version_max;
+            }
 
             // Now calculate the minimum and maximum KSP versions between both the existing metadata and the
             // AVC file.


### PR DESCRIPTION
## Problem

A .version file containing this:

```json
    "KSP_VERSION":
    {
        "MAJOR":1,
        "MINOR":5,
        "PATCH":0
    },
     "KSP_VERSION_MIN":{
         "MAJOR":1,
         "MINOR":5,
         "PATCH":0
     },
```

Is resulting in this metadata:

```json
    "ksp_version": "1.5.0",
```

The minimum value is essentially ignored.

## Cause

The [KSP-AVC spec](http://ksp.cybutek.net/kspavc/Documents/README.htm) says:

- **KSP_VERSION** - Optional, Required for MIN/MAX
  Version of KSP that the add-on was made to support.
- **KSP_VERSION_MIN** - Optional
  Minimum version of KSP that the add-on supports.
  _Requires KSP_VERSION field to work._
- **KSP_VERSION_MAX** - Optional
  Maximum version of KSP that the add-on supports.
  _Requires KSP_VERSION field to work._

This implies that if you want to specify `KSP_VERSION_MIN`, you *must* specify `KSP_VERSION`. This does not make sense, but it's in the spec, and some modders may feel compelled to follow it strictly as written.

Under that interpretation, if you wanted to specify "all versions after 1.5.0", you would create a file as shown above, but it would not translate into equivalent CKAN metadata.

## Changes

Now if a .version file has `KSP_VERSION_MIN` and `KSP_VERSION` but not `KSP_VERSION_MAX`, we don't set `ksp_version_max`. (And vice versa for `MAX` and `MIN`.)