### PR TITLE
Fix schema install_to Missions syntax

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -359,7 +359,7 @@
                 {
                     "description" : "Spec v1.25 Missions path",
                     "type"        : "string",
-                    "pattern"     : "^Missions/"
+                    "pattern"     : "^Missions"
                 }
             ]
         },


### PR DESCRIPTION
## Background

As of #2371, `"Missions"` is allowed in the `install_to` property:

https://github.com/KSP-CKAN/CKAN/blob/f641e203ade6c789881522ad0e95a9dc326c505f/Core/ModuleInstaller.cs#L493-L496

## Problem

The schema requires `"Missions/"` with a slash at the end, so `"Missions"` without the slash will be flagged as invalid:

https://github.com/KSP-CKAN/CKAN/blob/f641e203ade6c789881522ad0e95a9dc326c505f/CKAN.schema#L359-L363

This is blocking KSP-CKAN/NetKAN#6827.

## Changes

Now the schema is fixed to allow `"Missions"` as per the code.

**QUESTION**: Do we need to bump the spec version for this? Effectively it's a bug in the schema itself, and this syntax hasn't been used yet. The code already supports the version without the slash.