### PR TITLE
Show recommendations of installed modules in GUI

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -168,6 +168,8 @@
     <Compile Include="MainModList.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="MainRecommendations.cs">
+    </Compile>
     <Compile Include="MainRepo.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -40,6 +40,7 @@
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.importDownloadsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.auditRecommendationsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ExitToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cKANSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -177,6 +178,8 @@
             this.toolStripSeparator2,
             this.exportModListToolStripMenuItem,
             this.toolStripSeparator3,
+            this.auditRecommendationsMenuItem,
+            this.toolStripSeparator3,
             this.ExitToolButton});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(50, 29);
@@ -233,6 +236,14 @@
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(278, 6);
             // 
+            //
+            // importDownloadsToolStripMenuItem
+            //
+            this.auditRecommendationsMenuItem.Name = "auditRecommendationsMenuItem";
+            this.auditRecommendationsMenuItem.Size = new System.Drawing.Size(281, 30);
+            this.auditRecommendationsMenuItem.Text = "Audit recommendations";
+            this.auditRecommendationsMenuItem.Click += new System.EventHandler(this.auditRecommendationsMenuItem_Click);
+            //
             // ExitToolButton
             // 
             this.ExitToolButton.Name = "ExitToolButton";
@@ -1258,6 +1269,7 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem importDownloadsToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        private System.Windows.Forms.ToolStripMenuItem auditRecommendationsMenuItem;
         private System.Windows.Forms.ToolStripMenuItem ExitToolButton;
         public System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem cKANSettingsToolStripMenuItem;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1018,11 +1018,6 @@ namespace CKAN
             ShowSelectionModInfo(ChangesListView.SelectedItems);
         }
 
-        private void RecommendedModsListView_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            ShowSelectionModInfo(RecommendedModsListView.SelectedItems);
-        }
-
         private void ChooseProvidedModsListView_SelectedIndexChanged(object sender, EventArgs e)
         {
             ShowSelectionModInfo(ChooseProvidedModsListView.SelectedItems);
@@ -1052,18 +1047,6 @@ namespace CKAN
                     ShowSelectionModInfo(ChooseProvidedModsListView.SelectedItems);
                     break;
             }
-        }
-
-        private void RecommendedModsToggleCheckbox_CheckedChanged(object sender, EventArgs e)
-        {
-            var state = ((CheckBox)sender).Checked;
-            foreach (ListViewItem item in RecommendedModsListView.Items)
-            {
-                if (item.Checked != state)
-                    item.Checked = state;
-            }
-
-            RecommendedModsListView.Refresh();
         }
 
         private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -40,15 +40,12 @@ namespace CKAN
             return yesNoDialog.ShowYesNoDialog(text) == DialogResult.Yes;
         }
 
-        //Ugly Hack. Possible fix is to alter the relationship provider so we can use a loop
-        //over reason for to find a user requested mod. Or, you know, pass in a handler to it.
+        // Ugly Hack. Possible fix is to alter the relationship provider so we can use a loop
+        // over reason for to find a user requested mod. Or, you know, pass in a handler to it.
         private readonly ConcurrentStack<GUIMod> last_mod_to_have_install_toggled = new ConcurrentStack<GUIMod>();
-        public async Task<CkanModule> TooManyModsProvide(TooManyModsProvideKraken kraken)
-        {
-            //We want LMtHIT to be the last user selection. If we alter this handling a too many provides
-            // it needs to be reset so a potential second too many provides doesn't use the wrong mod.
-            GUIMod mod;
 
+        private async Task<CkanModule> TooManyModsProvideCore(TooManyModsProvideKraken kraken)
+        {
             TaskCompletionSource<CkanModule> task = new TaskCompletionSource<CkanModule>();
             Util.Invoke(this, () =>
             {
@@ -56,7 +53,16 @@ namespace CKAN
                 tabController.ShowTab("ChooseProvidedModsTabPage", 3);
                 tabController.SetTabLock(true);
             });
-            var module = await task.Task;
+            return await task.Task;
+        }
+
+        public async Task<CkanModule> TooManyModsProvide(TooManyModsProvideKraken kraken)
+        {
+            // We want LMtHIT to be the last user selection. If we alter this handling a too many provides
+            // it needs to be reset so a potential second too many provides doesn't use the wrong mod.
+            GUIMod mod;
+
+            var module = await TooManyModsProvideCore(kraken);
 
             if (module == null
                     && last_mod_to_have_install_toggled.TryPeek(out mod))

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -172,6 +172,30 @@ namespace CKAN
                     }
                     resolvedAllProvidedMods = true;
                 }
+                catch (TooManyModsProvideKraken k)
+                {
+                    // Prompt user to choose which mod to use
+                    CkanModule chosen = TooManyModsProvideCore(k).Result;
+                    // Close the selection prompt
+                    Util.Invoke(this, () =>
+                    {
+                        tabController.ShowTab("WaitTabPage");
+                        tabController.HideTab("ChooseProvidedModsTabPage");
+                    });
+                    if (chosen != null)
+                    {
+                        // User picked a mod, queue it up for installation
+                        toInstall.Add(chosen);
+                        // DON'T return so we can loop around and try the above InstallList call again
+                    }
+                    else
+                    {
+                        // User cancelled, get out
+                        tabController.ShowTab("ManageModsTabPage");
+                        e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
+                        return;
+                    }
+                }
                 catch (DependencyNotSatisfiedKraken ex)
                 {
                     GUI.user.RaiseMessage(

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -19,9 +19,6 @@ namespace CKAN
         // this may happen on the recommended/suggested mods dialogs
         private volatile bool installCanceled;
 
-        // this will be the final list of mods we want to install
-        private HashSet<CkanModule> toInstall = new HashSet<CkanModule>();
-
         /// <summary>
         /// Initiate the GUI installer flow for one specific module
         /// </summary>
@@ -90,7 +87,8 @@ namespace CKAN
             installer.onReportModInstalled += OnModInstalled;
             // setup progress callback
 
-            toInstall       = new HashSet<CkanModule>();
+            // this will be the final list of mods we want to install
+            HashSet<CkanModule> toInstall = new HashSet<CkanModule>();
             var toUninstall = new HashSet<string>();
             var toUpgrade   = new HashSet<string>();
 
@@ -120,13 +118,13 @@ namespace CKAN
             {
                 if (change.ChangeType == GUIModChangeType.Install)
                 {
-                    AddMod(change.Mod.ToModule().recommends, recommended, change.Mod.Identifier, registry);
-                    AddMod(change.Mod.ToModule().suggests,   suggested,   change.Mod.Identifier, registry);
+                    AddMod(change.Mod.ToModule().recommends, recommended, change.Mod.Identifier, registry, toInstall);
+                    AddMod(change.Mod.ToModule().suggests,   suggested,   change.Mod.Identifier, registry, toInstall);
                 }
             }
 
-            ShowSelection(recommended);
-            ShowSelection(suggested, true);
+            ShowSelection(recommended, toInstall);
+            ShowSelection(suggested,   toInstall, true);
 
             tabController.HideTab("ChooseRecommendedModsTabPage");
 
@@ -294,80 +292,6 @@ namespace CKAN
             }
         }
 
-        private void AddMod(
-            IEnumerable<RelationshipDescriptor>  relations,
-            Dictionary<CkanModule, List<string>> chooseAble,
-            string                               identifier,
-            IRegistryQuerier                     registry)
-        {
-            if (relations == null)
-                return;
-            foreach (RelationshipDescriptor rel in relations)
-            {
-                List<CkanModule> providers = registry.LatestAvailableWithProvides(
-                    rel.name,
-                    CurrentInstance.VersionCriteria(),
-                    rel
-                );
-                foreach (CkanModule provider in providers)
-                {
-                    if (!registry.IsInstalled(provider.identifier)
-                        && !toInstall.Any(m => m.identifier == provider.identifier))
-                    {
-                        // We want to show this mod to the user. Add it.
-                        List<string> dependers;
-                        if (chooseAble.TryGetValue(provider, out dependers))
-                        {
-                            // Add the dependent mod to the list of reasons this dependency is shown.
-                            dependers.Add(identifier);
-                        }
-                        else
-                        {
-                            // Add a new entry if this provider isn't listed yet.
-                            chooseAble.Add(provider, new List<string>() { identifier });
-                        }
-                    }
-                }
-            }
-        }
-
-        private void ShowSelection(Dictionary<CkanModule, List<string>> selectable, bool suggest = false)
-        {
-            if (installCanceled)
-                return;
-
-            // If we're going to install something anyway, then don't list it in the
-            // recommended list, since they can't de-select it anyway.
-            // The ToList dance is because we need to modify the dictionary while iterating over it,
-            // and C# doesn't like that.
-            foreach (CkanModule module in selectable.Keys.ToList())
-            {
-                if (toInstall.Any(m => m.identifier == module.identifier))
-                {
-                    selectable.Remove(module);
-                }
-            }
-
-            Dictionary<CkanModule, string> mods = GetShowableMods(selectable);
-
-            // If there are any mods that would be recommended, prompt the user to make
-            // selections.
-            if (mods.Any())
-            {
-                Util.Invoke(this, () => UpdateRecommendedDialog(mods, suggest));
-
-                tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
-                tabController.SetTabLock(true);
-
-                lock (this)
-                {
-                    Monitor.Wait(this);
-                }
-
-                tabController.SetTabLock(false);
-            }
-        }
-
         private void OnModInstalled(CkanModule mod)
         {
             AddStatusMessage("Module \"{0}\" successfully installed", mod.name);
@@ -485,118 +409,5 @@ namespace CKAN
             }
         }
 
-        /// <summary>
-        /// Tries to get every mod in the Dictionary, which can be installed
-        /// It also transforms the Recommender list to a string
-        /// </summary>
-        /// <param name="mods"></param>
-        /// <returns></returns>
-        private Dictionary<CkanModule, string> GetShowableMods(Dictionary<CkanModule, List<string>> mods)
-        {
-            Dictionary<CkanModule, string> modules = new Dictionary<CkanModule, string>();
-
-            var opts = new RelationshipResolverOptions
-            {
-                with_all_suggests              = false,
-                with_recommends                = false,
-                with_suggests                  = false,
-                without_enforce_consistency    = false,
-                without_toomanyprovides_kraken = true
-            };
-
-            foreach (var pair in mods)
-            {
-                try
-                {
-                    RelationshipResolver resolver = new RelationshipResolver(
-                        new List<CkanModule> { pair.Key },
-                        null,
-                        opts,
-                        RegistryManager.Instance(manager.CurrentInstance).registry,
-                        CurrentInstance.VersionCriteria()
-                    );
-
-                    if (resolver.ModList().Any())
-                    {
-                        // Resolver was able to find a way to install, so show it to the user
-                        modules.Add(pair.Key, String.Join(",", pair.Value.ToArray()));
-                    }
-                }
-                catch { }
-            }
-            return modules;
-        }
-
-        private void UpdateRecommendedDialog(Dictionary<CkanModule, string> mods, bool suggested = false)
-        {
-            if (!suggested)
-            {
-                RecommendedDialogLabel.Text =
-                    "The following modules have been recommended by one or more of the chosen modules:";
-                RecommendedModsListView.Columns[1].Text = "Recommended by:";
-                RecommendedModsToggleCheckbox.Text = "(De-)select all recommended mods.";
-                RecommendedModsToggleCheckbox.Checked=true;
-                tabController.RenameTab("ChooseRecommendedModsTabPage", "Choose recommended mods");
-            }
-            else
-            {
-                RecommendedDialogLabel.Text =
-                    "The following modules have been suggested by one or more of the chosen modules:";
-                RecommendedModsListView.Columns[1].Text = "Suggested by:";
-                RecommendedModsToggleCheckbox.Text = "(De-)select all suggested mods.";
-                RecommendedModsToggleCheckbox.Checked=false;
-                tabController.RenameTab("ChooseRecommendedModsTabPage", "Choose suggested mods");
-            }
-
-            RecommendedModsListView.Items.Clear();
-            foreach (var pair in mods)
-            {
-                CkanModule module = pair.Key;
-                ListViewItem item = new ListViewItem()
-                {
-                    Tag = module,
-                    Checked = !suggested,
-                    Text = Manager.Cache.IsMaybeCachedZip(pair.Key)
-                        ? $"{pair.Key.name} {pair.Key.version} (cached)"
-                        : $"{pair.Key.name} {pair.Key.version} ({pair.Key.download.Host ?? ""}, {CkanModule.FmtSize(pair.Key.download_size)})"
-                };
-
-                ListViewItem.ListViewSubItem recommendedBy = new ListViewItem.ListViewSubItem() { Text = pair.Value };
-
-                item.SubItems.Add(recommendedBy);
-
-                ListViewItem.ListViewSubItem description = new ListViewItem.ListViewSubItem {Text = module.@abstract};
-
-                item.SubItems.Add(description);
-
-                RecommendedModsListView.Items.Add(item);
-            }
-        }
-
-        private void RecommendedModsContinueButton_Click(object sender, EventArgs e)
-        {
-            foreach (ListViewItem item in RecommendedModsListView.Items)
-            {
-                if (item.Checked)
-                {
-                    toInstall.Add((CkanModule) item.Tag);
-                }
-            }
-
-            lock (this)
-            {
-                Monitor.Pulse(this);
-            }
-        }
-
-        private void RecommendedModsCancelButton_Click(object sender, EventArgs e)
-        {
-            installCanceled = true;
-
-            lock (this)
-            {
-                Monitor.Pulse(this);
-            }
-        }
     }
 }

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using CKAN.Versioning;
+
+namespace CKAN
+{
+    using ModChanges = List<ModChange>;
+    public partial class Main
+    {
+
+        private void ShowSelection(Dictionary<CkanModule, List<string>> selectable, HashSet<CkanModule> toInstall, bool suggest = false)
+        {
+            if (installCanceled)
+                return;
+
+            // If we're going to install something anyway, then don't list it in the
+            // recommended list, since they can't de-select it anyway.
+            // The ToList dance is because we need to modify the dictionary while iterating over it,
+            // and C# doesn't like that.
+            foreach (CkanModule module in selectable.Keys.ToList())
+            {
+                if (toInstall.Any(m => m.identifier == module.identifier))
+                {
+                    selectable.Remove(module);
+                }
+            }
+
+            Dictionary<CkanModule, string> mods = GetShowableMods(selectable);
+
+            // If there are any mods that would be recommended, prompt the user to make
+            // selections.
+            if (mods.Any())
+            {
+                Util.Invoke(this, () => UpdateRecommendedDialog(mods, suggest));
+
+                tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
+                tabController.SetTabLock(true);
+
+                lock (this)
+                {
+                    Monitor.Wait(this);
+                }
+
+                if (!installCanceled)
+                {
+                    toInstall.UnionWith(GetSelected());
+                }
+                tabController.SetTabLock(false);
+            }
+        }
+
+        private void AddMod(
+            IEnumerable<RelationshipDescriptor>  relations,
+            Dictionary<CkanModule, List<string>> chooseAble,
+            string                               identifier,
+            IRegistryQuerier                     registry,
+            HashSet<CkanModule>                  toInstall)
+        {
+            if (relations == null)
+                return;
+            foreach (RelationshipDescriptor rel in relations)
+            {
+                List<CkanModule> providers = registry.LatestAvailableWithProvides(
+                    rel.name,
+                    CurrentInstance.VersionCriteria(),
+                    rel
+                );
+                foreach (CkanModule provider in providers)
+                {
+                    if (!registry.IsInstalled(provider.identifier)
+                        && !toInstall.Any(m => m.identifier == provider.identifier))
+                    {
+                        // We want to show this mod to the user. Add it.
+                        List<string> dependers;
+                        if (chooseAble.TryGetValue(provider, out dependers))
+                        {
+                            // Add the dependent mod to the list of reasons this dependency is shown.
+                            dependers.Add(identifier);
+                        }
+                        else
+                        {
+                            // Add a new entry if this provider isn't listed yet.
+                            chooseAble.Add(provider, new List<string>() { identifier });
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tries to get every mod in the Dictionary, which can be installed
+        /// It also transforms the Recommender list to a string
+        /// </summary>
+        /// <param name="mods"></param>
+        /// <returns></returns>
+        private Dictionary<CkanModule, string> GetShowableMods(Dictionary<CkanModule, List<string>> mods)
+        {
+            Dictionary<CkanModule, string> modules = new Dictionary<CkanModule, string>();
+
+            var opts = new RelationshipResolverOptions
+            {
+                with_all_suggests              = false,
+                with_recommends                = false,
+                with_suggests                  = false,
+                without_enforce_consistency    = false,
+                without_toomanyprovides_kraken = true
+            };
+
+            foreach (var pair in mods)
+            {
+                try
+                {
+                    RelationshipResolver resolver = new RelationshipResolver(
+                        new List<CkanModule> { pair.Key },
+                        null,
+                        opts,
+                        RegistryManager.Instance(manager.CurrentInstance).registry,
+                        CurrentInstance.VersionCriteria()
+                    );
+
+                    if (resolver.ModList().Any())
+                    {
+                        // Resolver was able to find a way to install, so show it to the user
+                        modules.Add(pair.Key, String.Join(",", pair.Value.ToArray()));
+                    }
+                }
+                catch { }
+            }
+            return modules;
+        }
+
+        private void UpdateRecommendedDialog(Dictionary<CkanModule, string> mods, bool suggested = false)
+        {
+            if (!suggested)
+            {
+                RecommendedDialogLabel.Text =
+                    "The following modules have been recommended by one or more of the chosen modules:";
+                RecommendedModsListView.Columns[1].Text = "Recommended by:";
+                RecommendedModsToggleCheckbox.Text = "(De-)select all recommended mods.";
+                RecommendedModsToggleCheckbox.Checked=true;
+                tabController.RenameTab("ChooseRecommendedModsTabPage", "Choose recommended mods");
+            }
+            else
+            {
+                RecommendedDialogLabel.Text =
+                    "The following modules have been suggested by one or more of the chosen modules:";
+                RecommendedModsListView.Columns[1].Text = "Suggested by:";
+                RecommendedModsToggleCheckbox.Text = "(De-)select all suggested mods.";
+                RecommendedModsToggleCheckbox.Checked=false;
+                tabController.RenameTab("ChooseRecommendedModsTabPage", "Choose suggested mods");
+            }
+
+            RecommendedModsListView.Items.Clear();
+            foreach (var pair in mods)
+            {
+                CkanModule module = pair.Key;
+                ListViewItem item = new ListViewItem()
+                {
+                    Tag = module,
+                    Checked = !suggested,
+                    Text = Manager.Cache.IsMaybeCachedZip(pair.Key)
+                        ? $"{pair.Key.name} {pair.Key.version} (cached)"
+                        : $"{pair.Key.name} {pair.Key.version} ({pair.Key.download.Host ?? ""}, {CkanModule.FmtSize(pair.Key.download_size)})"
+                };
+
+                ListViewItem.ListViewSubItem recommendedBy = new ListViewItem.ListViewSubItem() { Text = pair.Value };
+
+                item.SubItems.Add(recommendedBy);
+
+                ListViewItem.ListViewSubItem description = new ListViewItem.ListViewSubItem {Text = module.@abstract};
+
+                item.SubItems.Add(description);
+
+                RecommendedModsListView.Items.Add(item);
+            }
+        }
+
+        private void RecommendedModsListView_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ShowSelectionModInfo(RecommendedModsListView.SelectedItems);
+        }
+
+        private void RecommendedModsToggleCheckbox_CheckedChanged(object sender, EventArgs e)
+        {
+            var state = ((CheckBox)sender).Checked;
+            foreach (ListViewItem item in RecommendedModsListView.Items)
+            {
+                if (item.Checked != state)
+                    item.Checked = state;
+            }
+
+            RecommendedModsListView.Refresh();
+        }
+
+        private void RecommendedModsContinueButton_Click(object sender, EventArgs e)
+        {
+            lock (this)
+            {
+                Monitor.Pulse(this);
+            }
+        }
+
+        private HashSet<CkanModule> GetSelected()
+        {
+            var toInstall = new HashSet<CkanModule>();
+            foreach (ListViewItem item in RecommendedModsListView.Items)
+            {
+                if (item.Checked)
+                {
+                    toInstall.Add((CkanModule) item.Tag);
+                }
+            }
+            return toInstall;
+        }
+
+        private void RecommendedModsCancelButton_Click(object sender, EventArgs e)
+        {
+            installCanceled = true;
+
+            lock (this)
+            {
+                Monitor.Pulse(this);
+            }
+        }
+
+        private void auditRecommendationsMenuItem_Click(object sender, EventArgs e)
+        {
+            // Run in a background task so GUI thread can react to user
+            Task.Factory.StartNew(() => AuditRecommendations(
+                RegistryManager.Instance(CurrentInstance).registry,
+                CurrentInstance.VersionCriteria()
+            ));
+        }
+
+        private void AuditRecommendations(IRegistryQuerier registry, KspVersionCriteria versionCriteria)
+        {
+            var recommended = new Dictionary<CkanModule, List<string>>();
+            var suggested   = new Dictionary<CkanModule, List<string>>();
+            var toInstall   = new HashSet<CkanModule>();
+
+            // Find recommendations and suggestions
+            foreach (var mod in registry.InstalledModules.Select(im => im.Module))
+            {
+                AddMod(mod.recommends, recommended, mod.identifier, registry, toInstall);
+                AddMod(mod.suggests,   suggested,   mod.identifier, registry, toInstall);
+            }
+
+            if (!recommended.Any() && !suggested.Any())
+            {
+                GUI.user.RaiseError("No recommendations or suggestions found.");
+                return;
+            }
+
+            // Prompt user to choose
+            installCanceled = false;
+            ShowSelection(recommended, toInstall);
+            ShowSelection(suggested,   toInstall, true);
+            tabController.HideTab("ChooseRecommendedModsTabPage");
+
+            // Install
+            if (!installCanceled && toInstall.Any())
+            {
+                installWorker.RunWorkerAsync(
+                    new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
+                        toInstall.Select(mod => new ModChange(
+                            new GUIMod(mod, registry, versionCriteria),
+                            GUIModChangeType.Install,
+                            null
+                        )).ToList(),
+                        RelationshipResolver.DefaultOpts()
+                    )
+                );
+            }
+        }
+
+    }
+}

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -29,7 +29,12 @@ namespace CKAN
                 }
             }
 
-            Dictionary<CkanModule, string> mods = GetShowableMods(selectable);
+            Dictionary<CkanModule, string> mods = GetShowableMods(
+                selectable,
+                RegistryManager.Instance(CurrentInstance).registry,
+                CurrentInstance.VersionCriteria(),
+                toInstall
+            );
 
             // If there are any mods that would be recommended, prompt the user to make
             // selections.
@@ -95,9 +100,17 @@ namespace CKAN
         /// Tries to get every mod in the Dictionary, which can be installed
         /// It also transforms the Recommender list to a string
         /// </summary>
-        /// <param name="mods"></param>
-        /// <returns></returns>
-        private Dictionary<CkanModule, string> GetShowableMods(Dictionary<CkanModule, List<string>> mods)
+        /// <param name="mods">Map from recommendations to lists of recommenders</param>
+        /// <param name="registry">Registry of current game instance</param>
+        /// <param name="versionCriteria">Versions compatible with current instance</param>
+        /// <param name="toInstall">Modules planned to be installed</param>
+        /// <returns>Map from installable recommendations to string describing recommenders</returns>
+        private Dictionary<CkanModule, string> GetShowableMods(
+            Dictionary<CkanModule, List<string>> mods,
+            IRegistryQuerier                     registry,
+            KspVersionCriteria                   versionCriteria,
+            HashSet<CkanModule>                  toInstall
+        )
         {
             Dictionary<CkanModule, string> modules = new Dictionary<CkanModule, string>();
 
@@ -114,12 +127,12 @@ namespace CKAN
             {
                 try
                 {
+                    List<CkanModule> instPlusOne = toInstall.ToList();
+                    instPlusOne.Add(pair.Key);
                     RelationshipResolver resolver = new RelationshipResolver(
-                        new List<CkanModule> { pair.Key },
+                        instPlusOne,
                         null,
-                        opts,
-                        RegistryManager.Instance(manager.CurrentInstance).registry,
-                        CurrentInstance.VersionCriteria()
+                        opts, registry, versionCriteria
                     );
 
                     if (resolver.ModList().Any())


### PR DESCRIPTION
## Motivation

When installing a mod, CKAN shows the user other mods that are recommended or suggested by that mod, and the user can choose whether to install them as well.

If the user chooses not to install these mods, but then later has second thoughts, there's no easy way to try again. They would have to remember what the mods were and choose to install them, check the Relationships tab in mod info, or uninstall and re-install the dependent mods.

## Changes

Now there's a new File &rArr; Audit recommendations menu option:

![image](https://user-images.githubusercontent.com/1559108/48592067-97462180-e93e-11e8-90b3-c4a93044a4f1.png)

If you click this and none of your installed mods have recommendations or suggestions, it'll tell you that:

![image](https://user-images.githubusercontent.com/1559108/48592091-b04ed280-e93e-11e8-98b2-f2978c6c6cb2.png)

Otherwise, it takes you to the Choose recommended mods tab, listing the mods that are recommended by currently installed mods.

![image](https://user-images.githubusercontent.com/1559108/48592282-96fa5600-e93f-11e8-96a8-5533ab357970.png)

Clicking Continue jumps to Choose suggested mods:

![image](https://user-images.githubusercontent.com/1559108/48592296-a1b4eb00-e93f-11e8-8906-9606a83d8f42.png)

If you click Cancel at any point, or if you don't select anything to install, then it just stops. Otherwise it takes you to the installer flow. (One possibly confusing point here is that the recommendations / suggestion lists might appear again if any of the mods you chose to install have recommendations or suggestions.) The chosen mods are downloaded and installed:

![image](https://user-images.githubusercontent.com/1559108/48592345-e0e33c00-e93f-11e8-87d6-c73a99e34591.png)

### Code details

The private member variable `Main.toInstall` is removed and replaced with a local variable, to improve encapsulation and because that's how it's already used. To share this object effectively, it's now a parameter to the other functions that use it. Where `RecommendedModsContinueButton_Click` previously manipulated `toInstall` directly, now `ShowSelection` does that work instead.

A lot of the code in `MainInstall.cs` was specifically for handling recommendations and suggestions. This is now split out into `MainRecommendations.cs`, along with a function or two from another file, to make it easier to find and reduce the clutter of `MainInstall.cs`.

`MainRecommendations.cs` then has a bit of new code at the end to gather installed mods' recommendations and suggestions and feed them into the selection prompts, then launch the installer.

`ShowSelection` uses `Monitor.Wait` to wait for the cancel or continue buttons to be clicked and call `Monitor.Pulse`, which requires the foreground GUI thread to be unoccupied, so the menu item click handler has to start a new thread. I used `Task.Factory.StartNew` for this, but I'm not sure that's the best way, please advise.

Fixes #1764.

## Side fixes

### Recommendation conflicts with mods we're installing

If you select several mods to install and some have recommendations or suggestions, recommendations and suggestions that conflict with installed mods will be hidden, but ones that conflict with mods that are *planned to install in this change set* will be shown.

Now recommendations and suggestions will only be shown if they don't conflict with installed mods **or** mods planned to be installed in the current change set.

Fixes KSP-CKAN/NetKAN#6709.

### Recommendations with virtual dependencies

If you select a mod to install that has a recommendation with a virtual dependency, that recommendation won't appear in the list, even if it can be satisfied by installing some combination of allowable mods. For example, `ExtrasolarPlanetsBeyondKerbol-stock` recommends `Scatterer`, which depends on `Scatterer-sunflare` and `Scatterer-config`, each of which are provided by several possible mods (assuming you have KSP 1.3; some haven't been updated past that point yet). Installing `ExtrasolarPlanetsBeyondKerbol-stock` won't ask if you want to install `Scatterer`.

Now such recommendations show up as available in GUI.

This requires two main pieces:

1. Allowing the recommendation to appear. This requires us to handle `TooManyModsProvideKraken` in the recommendation logic, which we now do in a new `CanInstall` function.
2. Prompting the user to resolve the virtual dependency when installing. This requires handling `TooManyModsProvideKraken` in `Main.InstallMods`. This may have existed at some point, but if it did it went missing at some point. Now it's definitely present, so you can be asked to choose a mod to satisfy a virtual dependency after you choose a recommendation.

Fixes #2268.