### PR TITLE
Restore uninstallation of dependencies

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -609,7 +609,7 @@ namespace CKAN
                 {
                     new RelationshipResolver(
                         modules_to_install,
-                        modules_to_remove,
+                        null,
                         options, registry, version);
                     handled_all_too_many_provides = true;
                     continue;


### PR DESCRIPTION
## Problem

As of #2561, if you try to remove a module that other installed modules depend on, you can't; the Apply button stays disabled and the status bar reports missing dependencies:

![image](https://user-images.githubusercontent.com/1559108/48649861-f877fe80-e9eb-11e8-8e29-dc3aeeee682c.png)

Before that pull request, this was allowed and would allow you to remove the module and mods depending on it. This isn't something we should break.

## Background

`MainModList.ComputeChangeSetFromModList` creates multiple `RelationshipResolver`s for different purposes. First it creates one or more in a loop to resolve all `provides` relationships (even if there are no `provides` relationships involved):

https://github.com/KSP-CKAN/CKAN/blob/8b791df8109b245f22e3fa819c003bbdf0d4dc85/GUI/MainModList.cs#L604-L616

After that it find mods with unsatisfied dependencies and queues them up to be removed:

https://github.com/KSP-CKAN/CKAN/blob/8b791df8109b245f22e3fa819c003bbdf0d4dc85/GUI/MainModList.cs#L634-L640

Then at the end it creates another `RelationshipResolver` to determine the actual change set:

https://github.com/KSP-CKAN/CKAN/blob/8b791df8109b245f22e3fa819c003bbdf0d4dc85/GUI/MainModList.cs#L642-L651

## Cause

As of #2561, `RelationshipResolver` has a parameter for modules to uninstall. This allows us to specify a complete change set for evaluation, so that operations that depend on removal for their validity can succeed.

When that parameter was added, the `provides` loop of `MainModList.ComputeChangeSetFromModList` was updated to pass `modules_to_remove`, but this caused exceptions to be thrown if you were removing a dependency. This loop isn't designed to handle those exceptions, so they propagated out and messed everything up.

## Changes

Now the loop to resolve `provides` relationships passes `null` instead of `modules_to_remove`. This will avoid raising exceptions for missing dependencies, and so the rest of the logic can run as expected. Other usages of `RelationshipResolver` still use work as before.

Fixes #2578.