### PR TITLE
Remove newline from Done progress message

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -130,6 +130,7 @@ namespace CKAN.CmdLine
             {
                 var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                 installer.InstallList(options.modules, install_ops);
+                user.RaiseMessage("\r\n");
             }
             catch (DependencyNotSatisfiedKraken ex)
             {

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -232,7 +232,7 @@ namespace CKAN
                 ksp.ScanGameData();
             }
 
-            User.RaiseProgress("Done!\r\n", 100);
+            User.RaiseProgress("Done!", 100);
         }
 
         public void InstallList(ModuleResolution modules, RelationshipResolverOptions options)


### PR DESCRIPTION
## Problem

I may be the only person bothered by this, but if you install mods in GUI, at the end the label above the progress bar says "(Done!" without a close parenthesis:

![image](https://user-images.githubusercontent.com/1559108/48665590-4b63bb80-eaa9-11e8-9278-52ba870c2212.png)

(I think you may even be able to see some of the rest of the message wrapped onto the next line in Mono.)

## Cause

There's a `"\r\n"` in the `RaiseProgress` message at the end of the install flow:

https://github.com/KSP-CKAN/CKAN/blob/e5fc437da1a3814ee248b4c26bce671881830b3d/Core/ModuleInstaller.cs#L235

GUI inserts this string into the middle of a larger formatted string, which is then split in half at that point:

https://github.com/KSP-CKAN/CKAN/blob/e5fc437da1a3814ee248b4c26bce671881830b3d/GUI/GUIUser.cs#L40

https://github.com/KSP-CKAN/CKAN/blob/e5fc437da1a3814ee248b4c26bce671881830b3d/GUI/MainWait.cs#L99-L102

The newline was probably included to make installing via CmdLine look better.

## Changes

Now that newline sequence is removed and the close parenthesis appears:

![image](https://user-images.githubusercontent.com/1559108/48665614-b8775100-eaa9-11e8-81dd-338155d969d2.png)


A newline is added to the CmdLine install code to make it look the same as before.
