### PR TITLE
Add Netkan option to overwrite cached files

### DIFF
--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -31,6 +31,9 @@ namespace CKAN.NetKAN
         [Option("prerelease", HelpText = "Index GitHub prereleases")]
         public bool PreRelease { get; set; }
 
+        [Option("overwrite-cache", HelpText = "Overwrite cached files")]
+        public bool OverwriteCache { get; set; }
+
         [Option("version", HelpText = "Display the netkan version number and exit")]
         public bool Version { get; set; }
 

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -58,7 +58,7 @@ namespace CKAN.NetKAN
                         new KSPManager(new ConsoleUser(false)),
                         new Win32Registry()
                     );
-                    http = new CachingHttpService(cache);
+                    http = new CachingHttpService(cache, Options.OverwriteCache);
 
                     var netkan = ReadNetkan();
                     Log.Info("Finished reading input");

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -6,15 +6,24 @@ namespace CKAN.NetKAN.Services
     internal sealed class CachingHttpService : IHttpService
     {
         private readonly NetFileCache _cache;
-        private          HashSet<Uri> _requestedURLs = new HashSet<Uri>();
+        private          HashSet<Uri> _requestedURLs  = new HashSet<Uri>();
+        private          bool         _overwriteCache = false;
 
-        public CachingHttpService(NetFileCache cache)
+        public CachingHttpService(NetFileCache cache, bool overwrite = false)
         {
-            _cache = cache;
+            _cache          = cache;
+            _overwriteCache = overwrite;
         }
 
         public string DownloadPackage(Uri url, string identifier, DateTime? updated)
         {
+            if (_overwriteCache && !_requestedURLs.Contains(url))
+            {
+                // Discard cached file if command line says so,
+                // but only the first time in each run
+                _cache.Remove(url);
+            }
+
             _requestedURLs.Add(url);
 
             var cachedFile = _cache.GetCachedFilename(url, updated);


### PR DESCRIPTION
## Problem

If a mod author uploads a release to SpaceDock, then deletes it and re-uploads the same version with a changed file (usually because the first version had an error), the original version will remain in the Netkan bot's cache, and the metadata for that release will have an incorrect file size and hashes. Resolving this situation requires having @techman83 manually purge the files from the bot's cache.

## Purge cache pls

BoyVoyage and Mk3Expansion have this problem right now, according to the latest posts on the forum; these files need to go:

- `C121BF1D-netkan-BonVoyage.zip`
- `61E04792-netkan-Mk3Expansion.zip`
- `BBB54E05-netkan-StockalikeMiningExtension.zip`

## Changes

Now Netkan has a new `--overwrite-cache` command line flag. When this is present, Netkan will delete the cached file for a URL the first time that URL is requested per run, then re-download it normally.

When a release is uploaded to SpaceDock, it triggers a special web hook for the Netkan bot to re-index just that one module, which downloads the module's file into the bot's cache at that moment. If the file is already in the cache, then the cached version is used instead of re-downloading.

If/after this PR is merged, I am planning to update the bot's Perl scripts to pass the `--overwrite-cache` parameter only in that special web hook. The normal bot execution would continue to run the same as before, but a release notification on SpaceDock would always ensure that the latest file is downloaded rather than re-used from the cache.

I believe this should eliminate the need to manually purge the bot's cache.