### PR TITLE
Fix crash on selecting filtered-out provider module

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -279,10 +279,13 @@ namespace CKAN
                 if ((bool)install_cell.Value != IsInstallChecked)
                 {
                     install_cell.Value = IsInstallChecked;
-                    // These calls are needed to force the UI to update,
-                    // otherwise the checkbox will look checked when it's unchecked or vice versa
-                    row.DataGridView.RefreshEdit();
-                    row.DataGridView.Refresh();
+                    if (row.DataGridView != null)
+                    {
+                        // These calls are needed to force the UI to update,
+                        // otherwise the checkbox will look checked when it's unchecked or vice versa
+                        row.DataGridView.RefreshEdit();
+                        row.DataGridView.Refresh();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

If you:

1. Launch GUI
2. Search/filter for a mod that has a virtual dependency, for example Realistic Progression Zero
3. Check the box to install it
4. Receive the prompt to select a mod to provide a dependency
5. Select a mod that's not visible in the main mod list due to filtering

... then you'll get a crash:

![screenshot](https://user-images.githubusercontent.com/2370113/48960544-b90e5c80-ef6d-11e8-8088-6aec31dbf947.png)

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.GUIMod.SetInstallChecked(DataGridViewRow row, Nullable`1 set_value_to)
   at CKAN.Main._MarkModForInstall(String identifier, Boolean uninstall)
   at CKAN.Main.<>c__DisplayClass264_0.<MarkModForInstall>b__0()
   at CKAN.Util.Invoke[T](T obj, Action action)
   at CKAN.Main.MarkModForInstall(String identifier, Boolean uncheck)
   at CKAN.Main.<TooManyModsProvide>d__237.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at CKAN.MainModList.<ComputeChangeSetFromModList>d__29.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at CKAN.Main.<UpdateChangeSetAndConflicts>d__61.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at CKAN.Main.<ModList_CellValueChanged>d__274.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
```

## Cause

Apparently `row.DataGridView` is null here if the row isn't visible:

https://github.com/KSP-CKAN/CKAN/blob/c4f067beb328a1391f1fc5d4020c0a2d1fcaf60e/GUI/GUIMod.cs#L279-L286

WinForms loves surprises.

## Changes

Now the crash no longer occurs.

We will just skip those calls if the reference is null. This should be fine as they were just added to force the checkbox to refresh in visible rows, and it's not necessary for invisible ones, as they seem to be re-initialized upon becoming visible.

Fixes #2584.