### PR TITLE
Set window properties on X11

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -227,6 +227,7 @@
     <Compile Include="TabController.cs" />
     <Compile Include="URLHandlers.cs" />
     <Compile Include="Util.cs" />
+    <Compile Include="X11.cs" />
     <Compile Include="YesNoDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -259,6 +259,12 @@ namespace CKAN
                 timer.Start();
             }
 
+            // Set the window name and class for X11
+            if (Platform.IsUnix)
+            {
+                HandleCreated += (sender, e) => X11.SetWMClass("CKAN", "CKAN", Handle);
+            }
+
             Application.Run(this);
 
             var registry = RegistryManager.Instance(Manager.CurrentInstance);

--- a/GUI/X11.cs
+++ b/GUI/X11.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace CKAN
+{
+    public struct XClassHint
+    {
+        public IntPtr res_name;
+        public IntPtr res_class;
+    }
+
+    public static class X11
+    {
+        /// <summary>
+        /// Set the window identifying properties in X11
+        /// </summary>
+        /// <param name="name">The window name</param>
+        /// <param name="wmClass">The window class</param>
+        /// <param name="handle">Value of Form.Handle for the window</param>
+        public static void SetWMClass(string name, string wmClass, IntPtr handle)
+        {
+            var hint = new XClassHint()
+            {
+                res_name  = Marshal.StringToCoTaskMemAnsi(name),
+                res_class = Marshal.StringToCoTaskMemAnsi(wmClass)
+            };
+            IntPtr classHints = Marshal.AllocCoTaskMem(Marshal.SizeOf(hint));
+            Marshal.StructureToPtr(hint, classHints, true);
+
+            XSetClassHint(DisplayHandle, GetWindow(handle), classHints);
+
+            Marshal.FreeCoTaskMem(hint.res_name);
+            Marshal.FreeCoTaskMem(hint.res_class);
+            Marshal.FreeCoTaskMem(classHints);
+        }
+
+        private static readonly Assembly MonoWinformsAssembly = Assembly
+            .LoadWithPartialName("System.Windows.Forms");
+
+        private static readonly Type Hwnd = MonoWinformsAssembly
+            .GetType("System.Windows.Forms.Hwnd");
+
+        private static IntPtr DisplayHandle
+        {
+            get
+            {
+                return (IntPtr)MonoWinformsAssembly
+                    .GetType("System.Windows.Forms.XplatUIX11")
+                    .GetField(
+                        "DisplayHandle",
+                        BindingFlags.NonPublic | BindingFlags.Static
+                    ).GetValue(null);
+            }
+        }
+
+        private static IntPtr GetWindow(IntPtr handle)
+        {
+            return (IntPtr)Hwnd.GetField(
+                "whole_window",
+                BindingFlags.NonPublic | BindingFlags.Instance
+            ).GetValue(GetHwnd(handle));
+        }
+
+        private static object GetHwnd(IntPtr handle)
+        {
+            return Hwnd.GetMethod(
+                "ObjectFromHandle",
+                BindingFlags.Public | BindingFlags.Static
+            ).Invoke(null, new object[] { handle });
+        }
+
+        [DllImport("libX11", EntryPoint = "XSetClassHint", CharSet = CharSet.Ansi)]
+        private extern static int XSetClassHint(IntPtr display, IntPtr window, IntPtr classHint);
+    }
+}


### PR DESCRIPTION
## Problem

Currently a typical Linux desktop environment doesn't know CKAN's name; here is GNOME Shell labeling it as "Unknown" in the top bar and the dash:

![image](https://user-images.githubusercontent.com/1559108/48964010-fa4e3e80-ef64-11e8-8c36-ab857671fa59.png)

![image](https://user-images.githubusercontent.com/1559108/48964011-fd492f00-ef64-11e8-804c-58c4114f643d.png)

## Cause

X11 windows have properties, including name and class, which define the identity of a window. Mono doesn't set them.

## Changes

Now if we're running on Linux, we set the X11 window properties for name and class to "CKAN", which will allow desktop environments to identify it properly:

![image](https://user-images.githubusercontent.com/1559108/48964014-02a67980-ef65-11e8-9a91-1d2e5718ea3f.png)

![image](https://user-images.githubusercontent.com/1559108/48964015-05a16a00-ef65-11e8-888d-aa4c2558cffc.png)

Fixes #2567.