### PR TITLE
Fix tray icon menu position and color on Linux (Gnome)

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -176,6 +176,9 @@
     <Compile Include="MainTabControl.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="MainTrayIcon.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="MainWait.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -1146,7 +1146,8 @@
             this.quitToolStripMenuItem});
             this.minimizedContextMenuStrip.Name = "minimizedContextMenuStrip";
             this.minimizedContextMenuStrip.Size = new System.Drawing.Size(181, 148);
-            // 
+            this.minimizedContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.minimizedContextMenuStrip_Opening);
+            //
             // updatesToolStripMenuItem
             // 
             this.updatesToolStripMenuItem.Name = "updatesToolStripMenuItem";

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -192,6 +192,7 @@ namespace CKAN
             settingsToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
             helpToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
             FilterToolButton.DropDown.Renderer = new FlatToolStripRenderer();
+            this.minimizedContextMenuStrip.Renderer = new FlatToolStripRenderer();
 
             // We need to initialize the error dialog first to display errors.
             errorDialog = controlFactory.CreateControl<ErrorDialog>();
@@ -1130,113 +1131,6 @@ namespace CKAN
         {
             UpdateTrayState();
         }
-
-        private void minimizeNotifyIcon_MouseDoubleClick(object sender, MouseEventArgs e)
-        {
-            OpenWindow();
-        }
-
-        private void updatesToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            OpenWindow();
-            MarkAllUpdatesToolButton_Click(sender, e);
-        }
-
-        private void refreshToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            UpdateRepo();
-        }
-
-        private void pauseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            configuration.RefreshPaused = !configuration.RefreshPaused;
-            if (configuration.RefreshPaused)
-            {
-                refreshTimer.Stop();
-                pauseToolStripMenuItem.Text = "Resume";
-            }
-            else
-            {
-                refreshTimer.Start();
-                pauseToolStripMenuItem.Text = "Pause";
-            }
-        }
-
-        private void openCKANToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            OpenWindow();
-        }
-
-        private void cKANSettingsToolStripMenuItem1_Click(object sender, EventArgs e)
-        {
-            OpenWindow();
-            new SettingsDialog().ShowDialog();
-        }
-
-        #region Tray Behaviour
-
-        public void CheckTrayState()
-        {
-            enableTrayIcon = configuration.EnableTrayIcon;
-            minimizeToTray = configuration.MinimizeToTray;
-            pauseToolStripMenuItem.Enabled = winReg.RefreshRate != 0;
-            pauseToolStripMenuItem.Text = configuration.RefreshPaused ? "Resume" : "Pause";
-            UpdateTrayState();
-        }
-
-        private void UpdateTrayState()
-        {
-            if (enableTrayIcon)
-            {
-                minimizeNotifyIcon.Visible = true;
-
-                if (WindowState == FormWindowState.Minimized)
-                {
-                    if (minimizeToTray)
-                    {
-                        // Remove our taskbar entry
-                        Hide();
-                    }
-                }
-                else
-                {
-                    // Save the window state
-                    configuration.IsWindowMaximised = WindowState == FormWindowState.Maximized;
-                    configuration.Save();
-                }
-            }
-            else
-            {
-                minimizeNotifyIcon.Visible = false;
-            }
-        }
-
-        public void UpdateTrayInfo()
-        {
-            var count = mainModList.CountModsByFilter(GUIModFilter.InstalledUpdateAvailable);
-
-            if (count == 0)
-            {
-                updatesToolStripMenuItem.Enabled = false;
-                updatesToolStripMenuItem.Text = "No available updates";
-            }
-            else
-            {
-                updatesToolStripMenuItem.Enabled = true;
-                updatesToolStripMenuItem.Text = $"{count} available update" + (count == 1 ? "" : "s");
-            }
-        }
-
-        /// <summary>
-        /// Open the GUI and set it to the correct state.
-        /// </summary>
-        public void OpenWindow()
-        {
-            Show();
-            WindowState = configuration.IsWindowMaximised ? FormWindowState.Maximized : FormWindowState.Normal;
-        }
-
-        #endregion
 
         #region Navigation History
 

--- a/GUI/MainTrayIcon.cs
+++ b/GUI/MainTrayIcon.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Drawing;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    public partial class Main
+    {
+        #region Tray Behaviour
+
+        public void CheckTrayState()
+        {
+            enableTrayIcon = configuration.EnableTrayIcon;
+            minimizeToTray = configuration.MinimizeToTray;
+            pauseToolStripMenuItem.Enabled = winReg.RefreshRate != 0;
+            pauseToolStripMenuItem.Text = configuration.RefreshPaused ? "Resume" : "Pause";
+            UpdateTrayState();
+        }
+
+        private void UpdateTrayState()
+        {
+            if (enableTrayIcon)
+            {
+                minimizeNotifyIcon.Visible = true;
+
+                if (WindowState == FormWindowState.Minimized)
+                {
+                    if (minimizeToTray)
+                    {
+                        // Remove our taskbar entry
+                        Hide();
+                    }
+                }
+                else
+                {
+                    // Save the window state
+                    configuration.IsWindowMaximised = WindowState == FormWindowState.Maximized;
+                    configuration.Save();
+                }
+            }
+            else
+            {
+                //minimizeNotifyIcon.Visible = false;
+            }
+        }
+
+        public void UpdateTrayInfo()
+        {
+            var count = mainModList.CountModsByFilter(GUIModFilter.InstalledUpdateAvailable);
+
+            if (count == 0)
+            {
+                updatesToolStripMenuItem.Enabled = false;
+                updatesToolStripMenuItem.Text = "No available updates";
+            }
+            else
+            {
+                updatesToolStripMenuItem.Enabled = true;
+                updatesToolStripMenuItem.Text = $"{count} available update" + (count == 1 ? "" : "s");
+            }
+        }
+
+        /// <summary>
+        /// Open the GUI and set it to the correct state.
+        /// </summary>
+        public void OpenWindow()
+        {
+            Show();
+            WindowState = configuration.IsWindowMaximised ? FormWindowState.Maximized : FormWindowState.Normal;
+        }
+
+        private void minimizeNotifyIcon_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            OpenWindow();
+        }
+
+        private void updatesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            OpenWindow();
+            MarkAllUpdatesToolButton_Click(sender, e);
+        }
+
+        private void refreshToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UpdateRepo();
+        }
+
+        private void pauseToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            configuration.RefreshPaused = !configuration.RefreshPaused;
+            if (configuration.RefreshPaused)
+            {
+                refreshTimer.Stop();
+                pauseToolStripMenuItem.Text = "Resume";
+            }
+            else
+            {
+                refreshTimer.Start();
+                pauseToolStripMenuItem.Text = "Pause";
+            }
+        }
+
+        private void openCKANToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            OpenWindow();
+        }
+
+        private void cKANSettingsToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            OpenWindow();
+            new SettingsDialog().ShowDialog();
+        }
+
+        private void minimizedContextMenuStrip_Opening(object sender, CancelEventArgs e)
+        {
+            // The menu location can be partly off-screen by default.
+            // Fix it.
+            minimizedContextMenuStrip.Location = ClampedLocation(
+                minimizedContextMenuStrip.Location,
+                minimizedContextMenuStrip.Size
+            );
+        }
+
+        private Point ClampedLocation(Point location, Size size)
+        {
+            var rect = new Rectangle(location, size);
+            // Find a screen that the default position overlaps
+            foreach (Screen screen in Screen.AllScreens)
+            {
+                if (screen.WorkingArea.IntersectsWith(rect))
+                {
+                    // Slide the whole menu fully onto the screen
+                    if (location.X < screen.WorkingArea.Top)
+                        location.X = screen.WorkingArea.Top;
+                    if (location.Y < screen.WorkingArea.Left)
+                        location.Y = screen.WorkingArea.Left;
+                    if (location.X + size.Width > screen.WorkingArea.Right)
+                        location.X = screen.WorkingArea.Right - size.Width;
+                    if (location.Y + size.Height > screen.WorkingArea.Bottom)
+                        location.Y = screen.WorkingArea.Bottom - size.Height;
+                    // Stop checking screens
+                    break;
+                }
+            }
+            return location;
+        }
+
+        #endregion
+
+    }
+}


### PR DESCRIPTION
## Problem

#2565 added a tray icon with a context menu. On Linux, it has light text on a white background and it can be displayed mostly off-screen:

![screenshot](https://user-images.githubusercontent.com/1559108/48962606-75086100-ef47-11e8-8a91-f0ee4f01f45d.png)

(The icon is invisible as well. I don't know why that is, so this pull request doesn't attempt to fix it.)

## Cause

Mono?

## Changes

Now the background matches other menus, and the position is always on screen:

![image](https://user-images.githubusercontent.com/1559108/48964968-59b64980-ef79-11e8-84b7-3a398b56d052.png)

In addition, the tray icon related code is moved from `Main.cs` to `MainTrayIcon.cs`.