### PR TITLE
Add legend for relationships tab

### DIFF
--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -54,6 +54,16 @@
             this.MetadataModuleGitHubLinkLabel = new System.Windows.Forms.LinkLabel();
             this.RelationshipTabPage = new System.Windows.Forms.TabPage();
             this.DependsGraphTree = new System.Windows.Forms.TreeView();
+            this.LegendDependsImage = new System.Windows.Forms.PictureBox();
+            this.LegendRecommendsImage = new System.Windows.Forms.PictureBox();
+            this.LegendSuggestsImage = new System.Windows.Forms.PictureBox();
+            this.LegendSupportsImage = new System.Windows.Forms.PictureBox();
+            this.LegendConflictsImage = new System.Windows.Forms.PictureBox();
+            this.LegendDependsLabel = new System.Windows.Forms.Label();
+            this.LegendRecommendsLabel = new System.Windows.Forms.Label();
+            this.LegendSuggestsLabel = new System.Windows.Forms.Label();
+            this.LegendSupportsLabel = new System.Windows.Forms.Label();
+            this.LegendConflictsLabel = new System.Windows.Forms.Label();
             this.ContentTabPage = new System.Windows.Forms.TabPage();
             this.ContentsPreviewTree = new System.Windows.Forms.TreeView();
             this.ContentsDownloadButton = new System.Windows.Forms.Button();
@@ -387,6 +397,16 @@
             // RelationshipTabPage
             //
             this.RelationshipTabPage.Controls.Add(this.DependsGraphTree);
+            this.RelationshipTabPage.Controls.Add(this.LegendDependsImage);
+            this.RelationshipTabPage.Controls.Add(this.LegendRecommendsImage);
+            this.RelationshipTabPage.Controls.Add(this.LegendSuggestsImage);
+            this.RelationshipTabPage.Controls.Add(this.LegendSupportsImage);
+            this.RelationshipTabPage.Controls.Add(this.LegendConflictsImage);
+            this.RelationshipTabPage.Controls.Add(this.LegendDependsLabel);
+            this.RelationshipTabPage.Controls.Add(this.LegendRecommendsLabel);
+            this.RelationshipTabPage.Controls.Add(this.LegendSuggestsLabel);
+            this.RelationshipTabPage.Controls.Add(this.LegendSupportsLabel);
+            this.RelationshipTabPage.Controls.Add(this.LegendConflictsLabel);
             this.RelationshipTabPage.Location = new System.Drawing.Point(4, 25);
             this.RelationshipTabPage.Name = "RelationshipTabPage";
             this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(3);
@@ -401,7 +421,7 @@
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.DependsGraphTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.DependsGraphTree.Location = new System.Drawing.Point(3, 7);
+            this.DependsGraphTree.Location = new System.Drawing.Point(3, 96);
             this.DependsGraphTree.Name = "DependsGraphTree";
             this.DependsGraphTree.Size = new System.Drawing.Size(345, 489);
             this.DependsGraphTree.TabIndex = 0;
@@ -418,6 +438,76 @@
             this.DependsGraphTree.ImageList.Images.Add("Suggests", global::CKAN.Properties.Resources.info);
             this.DependsGraphTree.ImageList.Images.Add("Supports", global::CKAN.Properties.Resources.smile);
             this.DependsGraphTree.ImageList.Images.Add("Conflicts", global::CKAN.Properties.Resources.alert);
+            //
+            // LegendDependsImage
+            //
+            this.LegendDependsImage.BackColor = System.Drawing.SystemColors.Window;
+            this.LegendDependsImage.Image = global::CKAN.Properties.Resources.star;
+            this.LegendDependsImage.Location = new System.Drawing.Point(6, 3);
+            this.LegendDependsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.LegendDependsImage.ClientSize = new System.Drawing.Size(14, 14);
+            //
+            // LegendRecommendsImage
+            //
+            this.LegendRecommendsImage.BackColor = System.Drawing.SystemColors.Window;
+            this.LegendRecommendsImage.Image = global::CKAN.Properties.Resources.thumbup;
+            this.LegendRecommendsImage.Location = new System.Drawing.Point(6, 21);
+            this.LegendRecommendsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.LegendRecommendsImage.ClientSize = new System.Drawing.Size(14, 14);
+            //
+            // LegendSuggestsImage
+            //
+            this.LegendSuggestsImage.BackColor = System.Drawing.SystemColors.Window;
+            this.LegendSuggestsImage.Image = global::CKAN.Properties.Resources.info;
+            this.LegendSuggestsImage.Location = new System.Drawing.Point(6, 39);
+            this.LegendSuggestsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.LegendSuggestsImage.ClientSize = new System.Drawing.Size(14, 14);
+            //
+            // LegendSupportsImage
+            //
+            this.LegendSupportsImage.BackColor = System.Drawing.SystemColors.Window;
+            this.LegendSupportsImage.Image = global::CKAN.Properties.Resources.smile;
+            this.LegendSupportsImage.Location = new System.Drawing.Point(6, 57);
+            this.LegendSupportsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.LegendSupportsImage.ClientSize = new System.Drawing.Size(14, 14);
+            //
+            // LegendConflictsImage
+            //
+            this.LegendConflictsImage.BackColor = System.Drawing.SystemColors.Window;
+            this.LegendConflictsImage.Image = global::CKAN.Properties.Resources.alert;
+            this.LegendConflictsImage.Location = new System.Drawing.Point(6, 75);
+            this.LegendConflictsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.LegendConflictsImage.ClientSize = new System.Drawing.Size(14, 14);
+            //
+            // LegendDependsLabel
+            //
+            this.LegendDependsLabel.AutoSize = true;
+            this.LegendDependsLabel.Location = new System.Drawing.Point(24, 3);
+            this.LegendDependsLabel.Text = "Depends";
+            //
+            // LegendRecommendsLabel
+            //
+            this.LegendRecommendsLabel.AutoSize = true;
+            this.LegendRecommendsLabel.Location = new System.Drawing.Point(24, 21);
+            this.LegendRecommendsLabel.Text = "Recommends";
+            //
+            // LegendSuggestsLabel
+            //
+            this.LegendSuggestsLabel.AutoSize = true;
+            this.LegendSuggestsLabel.Location = new System.Drawing.Point(24, 39);
+            this.LegendSuggestsLabel.Text = "Suggests";
+            //
+            // LegendSupportsLabel
+            //
+            this.LegendSupportsLabel.AutoSize = true;
+            this.LegendSupportsLabel.Location = new System.Drawing.Point(24, 57);
+            this.LegendSupportsLabel.Text = "Supports";
+            //
+            // LegendConflictsLabel
+            //
+            this.LegendConflictsLabel.AutoSize = true;
+            this.LegendConflictsLabel.Location = new System.Drawing.Point(24, 75);
+            this.LegendConflictsLabel.Text = "Conflicts";
             //
             // ContentTabPage
             //
@@ -535,6 +625,16 @@
         private System.Windows.Forms.LinkLabel MetadataModuleGitHubLinkLabel;
         private System.Windows.Forms.TabPage RelationshipTabPage;
         private System.Windows.Forms.TreeView DependsGraphTree;
+        private System.Windows.Forms.PictureBox LegendDependsImage;
+        private System.Windows.Forms.PictureBox LegendRecommendsImage;
+        private System.Windows.Forms.PictureBox LegendSuggestsImage;
+        private System.Windows.Forms.PictureBox LegendSupportsImage;
+        private System.Windows.Forms.PictureBox LegendConflictsImage;
+        private System.Windows.Forms.Label LegendDependsLabel;
+        private System.Windows.Forms.Label LegendRecommendsLabel;
+        private System.Windows.Forms.Label LegendSuggestsLabel;
+        private System.Windows.Forms.Label LegendSupportsLabel;
+        private System.Windows.Forms.Label LegendConflictsLabel;
         private System.Windows.Forms.TabPage ContentTabPage;
         private System.Windows.Forms.TreeView ContentsPreviewTree;
         private System.Windows.Forms.Button ContentsDownloadButton;


### PR DESCRIPTION
## Motivation

Someone mentioned recently that it can be inconvenient to read the relationships tab because the meaning of the icons aren't apparent, you have to hover them to see what the relationship is. It's a fair point.

## Changes

Now a legend is added above the relationships tree, similar to the one above the list of versions:

![image](https://user-images.githubusercontent.com/1559108/49347431-f48ee200-f663-11e8-99c1-4eaea6cc7818.png)