### PR TITLE
Fix file menu separator

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -134,6 +134,7 @@
             this.openKSPDirectoryToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.cKANSettingsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.quitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.menuStrip2.SuspendLayout();
@@ -179,7 +180,7 @@
             this.exportModListToolStripMenuItem,
             this.toolStripSeparator3,
             this.auditRecommendationsMenuItem,
-            this.toolStripSeparator3,
+            this.toolStripSeparator7,
             this.ExitToolButton});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(50, 29);
@@ -236,6 +237,12 @@
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(278, 6);
             // 
+            //
+            // toolStripSeparator7
+            //
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            this.toolStripSeparator7.Size = new System.Drawing.Size(278, 6);
+            //
             //
             // importDownloadsToolStripMenuItem
             //
@@ -1364,6 +1371,7 @@
         private System.Windows.Forms.ToolStripMenuItem openKSPDirectoryToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem cKANSettingsToolStripMenuItem1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
         private System.Windows.Forms.ToolStripMenuItem quitToolStripMenuItem;
     }
 }


### PR DESCRIPTION
## Problem

There's supposed to be a separator line between Audit recommendations and Exit, but it doesn't appear:

![image](https://user-images.githubusercontent.com/1559108/49347652-fce81c80-f665-11e8-9d15-3b78c1f538ab.png)

## Cause

Wanting to be frugal, I re-used `toolStripSeparator3` rather than creating a new separator, since the actual separator object stores essentially no data.

That apparently doesn't work.

## Changes

Now we use a new `toolStripSeparator7` object instead. This makes the separator show up:

![image](https://user-images.githubusercontent.com/1559108/49347664-0a9da200-f666-11e8-8701-9c9736734dbb.png)
