### PR TITLE
Fix error popup text for dark themes

### DIFF
--- a/GUI/ErrorDialog.Designer.cs
+++ b/GUI/ErrorDialog.Designer.cs
@@ -44,6 +44,7 @@
             // 
             // ErrorMessage
             // 
+            this.ErrorMessage.ForeColor = System.Drawing.SystemColors.ControlText;
             this.ErrorMessage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ErrorMessage.Location = new System.Drawing.Point(0, 0);
             this.ErrorMessage.Name = "ErrorMessage";


### PR DESCRIPTION
## Problem

If you launch CKAN with a dark theme while another copy is already running, there's an error message with black text on a dark background:

![image](https://user-images.githubusercontent.com/1559108/49347999-4cc7e300-f668-11e8-9ba4-608a44dcd68d.png)

## Cause

Same as #2540, the error text box has `Readonly=true`, which changes the background without updating the foreground.

## Changes

Now the text color is readable on a dark theme:

![image](https://user-images.githubusercontent.com/1559108/49348003-52bdc400-f668-11e8-92e8-0c3c3011621c.png)
