### PR TITLE
Checkbox to uninstall all mods and reset changeset

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -69,6 +69,7 @@
             this.NavForwardToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.ModList = new CKAN.MainModListGUI();
+            this.InstallAllCheckbox = new System.Windows.Forms.CheckBox();
             this.Installed = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.UpdateCol = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ModName = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -544,8 +545,8 @@
             this.ModList.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ModList_MouseDown);
             // 
             // Installed
-            // 
-            this.Installed.HeaderText = "Installed";
+            //
+            this.Installed.HeaderText = "    Inst";
             this.Installed.Name = "Installed";
             this.Installed.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.Installed.Width = 50;
@@ -696,6 +697,7 @@
             // ManageModsTabPage
             // 
             this.ManageModsTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.ManageModsTabPage.Controls.Add(this.InstallAllCheckbox);
             this.ManageModsTabPage.Controls.Add(this.FilterByAuthorTextBox);
             this.ManageModsTabPage.Controls.Add(this.FilterByAuthorLabel);
             this.ManageModsTabPage.Controls.Add(this.FilterByNameLabel);
@@ -712,6 +714,14 @@
             this.ManageModsTabPage.TabIndex = 0;
             this.ManageModsTabPage.Text = "Manage mods";
             // 
+            //
+            // InstallAllCheckbox
+            //
+            this.InstallAllCheckbox.Location = new System.Drawing.Point(4, 118);
+            this.InstallAllCheckbox.Size = new System.Drawing.Size(18, 18);
+            this.InstallAllCheckbox.Checked = true;
+            this.InstallAllCheckbox.CheckedChanged += new System.EventHandler(this.InstallAllCheckbox_CheckChanged);
+            //
             // FilterByAuthorTextBox
             // 
             this.FilterByAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
@@ -1299,6 +1309,7 @@
         private System.Windows.Forms.ToolStripMenuItem NavForwardToolButton;
         private System.Windows.Forms.SplitContainer splitContainer1;
         public CKAN.MainModListGUI ModList;
+        private System.Windows.Forms.CheckBox InstallAllCheckbox;
         private System.Windows.Forms.DataGridViewCheckBoxColumn Installed;
         private System.Windows.Forms.DataGridViewCheckBoxColumn UpdateCol;
         private System.Windows.Forms.DataGridViewTextBoxColumn ModName;

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -76,6 +76,18 @@ namespace CKAN
             }
         }
 
+        private void ClearChangeSet()
+        {
+            foreach (DataGridViewRow row in mainModList.full_list_of_mod_rows.Values)
+            {
+                GUIMod mod = row.Tag as GUIMod;
+                if (mod.IsInstallChecked != mod.IsInstalled)
+                {
+                    mod.SetInstallChecked(row, mod.IsInstalled);
+                }
+            }
+        }
+
         /// <summary>
         /// This method creates the Install part of the changeset
         /// It arranges the changeset in a human-friendly order
@@ -104,11 +116,9 @@ namespace CKAN
 
         private void CancelChangesButton_Click(object sender, EventArgs e)
         {
-            UpdateModsList();
+            ClearChangeSet();
             UpdateChangesDialog(null, installWorker);
             tabController.ShowTab("ManageModsTabPage");
-            tabController.HideTab("ChangesetTabPage");
-            ApplyToolButton.Enabled = false;
         }
 
         private void ConfirmChangesButton_Click(object sender, EventArgs e)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -443,6 +443,33 @@ namespace CKAN
             }
         }
 
+        private void InstallAllCheckbox_CheckChanged(object sender, EventArgs e)
+        {
+            if (this.InstallAllCheckbox.Checked)
+            {
+                // Reset changeset
+                foreach (DataGridViewRow row in mainModList.full_list_of_mod_rows.Values)
+                {
+                    GUIMod mod = row.Tag as GUIMod;
+                    if (mod.IsInstallChecked != mod.IsInstalled)
+                    {
+                        mod.SetInstallChecked(row, mod.IsInstalled);
+                    }
+                }
+            }
+            else
+            {
+                // Uninstall all
+                foreach (DataGridViewRow row in mainModList.full_list_of_mod_rows.Values)
+                {
+                    GUIMod mod = row.Tag as GUIMod;
+                    if (mod.IsInstallChecked)
+                    {
+                        mod.SetInstallChecked(row, false);
+                    }
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -448,14 +448,7 @@ namespace CKAN
             if (this.InstallAllCheckbox.Checked)
             {
                 // Reset changeset
-                foreach (DataGridViewRow row in mainModList.full_list_of_mod_rows.Values)
-                {
-                    GUIMod mod = row.Tag as GUIMod;
-                    if (mod.IsInstallChecked != mod.IsInstalled)
-                    {
-                        mod.SetInstallChecked(row, mod.IsInstalled);
-                    }
-                }
+                ClearChangeSet();
             }
             else
             {


### PR DESCRIPTION
## Motivation

If you have a lot of mods installed, uninstalling all of them can require a lot of clicking.

## Changes

Now the Installed column's header shows "Inst" and a checkbox.

![image](https://user-images.githubusercontent.com/1559108/49351662-214df400-f67a-11e8-80c8-824edbeaffe2.png)

If you uncheck this checkbox, all of your installed mods are queued up for uninstallation:

![image](https://user-images.githubusercontent.com/1559108/49351606-ddf38580-f679-11e8-9167-46b69fc2a377.png)

If you check the checkbox, the change set is reset to empty (installed mods checked, others not):

![image](https://user-images.githubusercontent.com/1559108/49351648-0da28d80-f67a-11e8-882d-75f4fee80a58.png)

Fixes #1148.
Fixes #1945.
Fixes #1451.

## Side fix

Currently if you queue up a change set, click Apply, and then change your mind and click Clear, there's a noticeable delay to clear the change set because the whole grid is repopulated unnecessarily.

Now the change set is cleared much more quickly.