### PR TITLE
Stop splitters from migrating between sessions

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -306,6 +306,18 @@ namespace CKAN
         protected override void OnShown(EventArgs e)
         {
             actuallyVisible = true;
+
+            try
+            {
+                splitContainer1.SplitterDistance = configuration.PanelPosition;
+            }
+            catch
+            {
+                // SplitContainer is mis-designed to throw exceptions
+                // if the min/max limits are exceeded rather than simply obeying them.
+            }
+            ModInfoTabControl.ModMetaSplitPosition = configuration.ModInfoPosition;
+
             base.OnShown(e);
         }
 
@@ -320,16 +332,6 @@ namespace CKAN
             Location = configuration.WindowLoc;
             Size = configuration.WindowSize;
             WindowState = configuration.IsWindowMaximised ? FormWindowState.Maximized : FormWindowState.Normal;
-            try
-            {
-                splitContainer1.SplitterDistance = configuration.PanelPosition;
-            }
-            catch
-            {
-                // SplitContainer is mis-designed to throw exceptions
-                // if the min/max limits are exceeded rather than simply obeying them.
-            }
-            ModInfoTabControl.ModMetaSplitPosition = configuration.ModInfoPosition;
 
             if (!configuration.CheckForUpdatesOnLaunchNoNag && AutoUpdate.CanUpdate)
             {


### PR DESCRIPTION
## Problem

If you close and re-open GUI, the splitters between the mod list and the mod info and between the mod name/description and the mod info tabs are supposed to retain their positions. However, currently they tend to migrate rightwards and downwards rather than staying the same.

For example, across several open/close cycles where I did nothing but exit CKAN, the `ModInfoPosition` property in GUIConfig.xml took on this sequence of values:

292, 569, 891, 891, 891

Closing this window:

![image](https://user-images.githubusercontent.com/1559108/49401309-66226b00-f70c-11e8-85a3-13118a0def62.png)

... results in this window at the next launch:

![image](https://user-images.githubusercontent.com/1559108/49401313-69b5f200-f70c-11e8-964b-1252810b7ea9.png)

## Cause

Forms raise events in [the following order at launch](https://docs.microsoft.com/en-us/dotnet/framework/winforms/order-of-events-in-windows-forms?view=netframework-4.7.2):

1. Load
2. Activated
3. Shown

In a typical WinForms application, a form has a hard coded layout of a static size set at design time, which is then modified to fit other window sizes. To handle this, the various container controls have their layouts recalculated to fit the actual size of the window. This happens after Load and before Shown.

Currently CKAN restores the positions of its splitters in Load, before the container layouts are recalculated. This means that the saved positions are used as inputs into the recalculation process rather than absolute positions. When the layout is recalculated, different splitter positions are determined.

## Changes

Now the splitter positions are set in `OnShown` instead of `OnLoad`. This ensures that the window size is the same as when the position was saved, and the layout will not be rearranged afterwards. The position is now always the same after closing and re-opening CKAN.