### PR TITLE
Confirm quit with pending change set or conflicts

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -446,6 +446,45 @@ namespace CKAN
                 return;
             }
 
+            if (Conflicts != null)
+            {
+                if (Conflicts.Any())
+                {
+                    // Ask if they want to resolve conflicts
+                    string confDescrip = Conflicts
+                        .Select(kvp => kvp.Value)
+                        .Aggregate((a, b) => $"{a}, {b}");
+                    if (!YesNoDialog($"There are conflicts. Really quit?\r\n\r\n{confDescrip}"))
+                    {
+                        e.Cancel = true;
+                        return;
+                    }
+                }
+                else
+                {
+                    // The Conflicts dictionary is empty even when there are unmet dependencies.
+                    if (!YesNoDialog("There are unmet dependencies. Really quit?"))
+                    {
+                        e.Cancel = true;
+                        return;
+                    }
+                }
+            }
+            else if (ChangeSet?.Any() ?? false)
+            {
+                // Ask if they want to discard the change set
+                string changeDescrip = ChangeSet
+                    .GroupBy(ch => ch.ChangeType, ch => ch.Mod.Name)
+                    .Select(grp => $"{grp.Key}: "
+                        + grp.Aggregate((a, b) => $"{a}, {b}"))
+                    .Aggregate((a, b) => $"{a}\r\n{b}");
+                if (!YesNoDialog($"You have unapplied changes. Really quit?\r\n\r\n{changeDescrip}"))
+                {
+                    e.Cancel = true;
+                    return;
+                }
+            }
+
             // Copy window location to app settings
             configuration.WindowLoc = Location;
 

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -343,8 +343,7 @@ namespace CKAN
                 // install successful
                 AddStatusMessage("Success!");
                 HideWaitDialog(true);
-                tabController.HideTab("ChangesetTabPage");
-                ApplyToolButton.Enabled = false;
+                ChangeSet = null;
                 RetryCurrentActionButton.Visible = false;
                 UpdateChangesDialog(null, installWorker);
             }


### PR DESCRIPTION
## Motivation

If you open a typical application, make changes, and then quit without saving, you're prompted to confirm that you really want to quit. This is done to prevent the user from losing work and having to re-do it if they click the quit button accidentally.

![image](https://user-images.githubusercontent.com/1559108/49423375-e8d31680-f75c-11e8-951a-155afb8e0912.png)

If you open CKAN, select mods to install or uninstall, and then quit without applying changes, it just closes.

## Changes

Now if you select changes and try to quit, you get one of three prompts depending on whether there are conflicts or unmet dependencies. Clicking Yes closes CKAN, while clicking No closes the dialog and leaves CKAN running.

![image](https://user-images.githubusercontent.com/1559108/49414584-93d1d900-f739-11e8-8d78-9e621d07634d.png)
![image](https://user-images.githubusercontent.com/1559108/49414586-97656000-f739-11e8-8e84-43498f0fb747.png)
![image](https://user-images.githubusercontent.com/1559108/49414589-992f2380-f739-11e8-902c-41027aa50754.png)

To avoid prompting unnecessarily after a successful installation, we now clear the change set after a successful installation. Previously we were leaving the change set intact (in the `Main.ChangeSet` variable) but hiding the change set tab and disabling the apply changes button, which ordinarily are side effects of clearing the change set. This put the application into a bit of an inconsistent state which clearing the change set avoids.