### PR TITLE
Fix platform checks and crash on Mac OS X

### DIFF
--- a/Core/Platform.cs
+++ b/Core/Platform.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Reflection;
-
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-
 
 namespace CKAN
 {
@@ -18,11 +16,45 @@ namespace CKAN
     {
         static Platform()
         {
-            IsMac = IsRunningOnMac();
-            IsMono = IsOnMono();
-            // Depends on IsMono
+            // This call throws if we try to do it as a static initializer.
             IsMonoFourOrLater = IsOnMonoFourOrLater();
         }
+
+        /// <summary>
+        /// Are we on a Mac?
+        /// </summary>
+        /// <value><c>true</c> if is mac; otherwise, <c>false</c>.</value>
+        public static readonly bool IsMac = IsRunningOnMac();
+
+        /// <summary>
+        /// Are we on a Unix (including Linux, but *not* Mac) system.
+        /// Note that Mono thinks Mac is Unix! So we need to negate Mac explicitly.
+        /// </summary>
+        /// <value><c>true</c> if is unix; otherwise, <c>false</c>.</value>
+        public static readonly bool IsUnix = Environment.OSVersion.Platform == PlatformID.Unix && !IsMac;
+
+        /// <summary>
+        /// Are we on a flavour of Windows? This is implemented internally by checking
+        /// if we're not on Unix or Mac.
+        /// </summary>
+        /// <value><c>true</c> if is windows; otherwise, <c>false</c>.</value>
+        public static readonly bool IsWindows = !IsUnix && !IsMac;
+
+        /// <summary>
+        /// Are we on Mono?
+        /// </summary>
+        public static readonly bool IsMono = Type.GetType("Mono.Runtime") != null;
+
+        /// <summary>
+        /// Are we running on a Mono with major version 4 or later?
+        /// </summary>
+        public static readonly bool IsMonoFourOrLater;
+
+        /// <summary>
+        /// Are we running in an X11 environment?
+        /// </summary>
+        public static readonly bool IsX11 = IsUnix && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DISPLAY"));
+
 
         // From https://github.com/mono/monodevelop/blob/master/main/src/core/Mono.Texteditor/Mono.TextEditor/Platform.cs
         // Environment.OSVersion.Platform returns Unix for Mac OS X as of Mono v4.0.0:
@@ -55,48 +87,6 @@ namespace CKAN
 
         [DllImport("libc")]
         private static extern int uname(IntPtr buf);
-
-
-        /// <summary>
-        /// Are we on a Unix (including Linux, but *not* Mac) system.
-        /// </summary>
-        /// <value><c>true</c> if is unix; otherwise, <c>false</c>.</value>
-        public static bool IsUnix
-        {
-            get { return Environment.OSVersion.Platform == PlatformID.Unix; }
-        }
-
-        /// <summary>
-        /// Are we on a Mac?
-        /// </summary>
-        /// <value><c>true</c> if is mac; otherwise, <c>false</c>.</value>
-        public static bool IsMac { get; private set; }
-
-
-        /// <summary>
-        /// Are we on a flavour of Windows? This is implemented internally by checking
-        /// if we're not on Unix or Mac.
-        /// </summary>
-        /// <value><c>true</c> if is windows; otherwise, <c>false</c>.</value>
-        public static bool IsWindows
-        {
-            get { return !(IsUnix || IsMac); }
-        }
-
-        /// <summary>
-        /// Are we on Mono?
-        /// </summary>
-        public static bool IsMono { get; private set; }
-
-        private static bool IsOnMono()
-        {
-            return Type.GetType("Mono.Runtime") != null;
-        }
-
-        /// <summary>
-        /// Are we running on a Mono with major version 4 or later?
-        /// </summary>
-        public static bool IsMonoFourOrLater { get; private set; }
 
         private static bool IsOnMonoFourOrLater()
         {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -261,7 +261,7 @@ namespace CKAN
             }
 
             // Set the window name and class for X11
-            if (Platform.IsUnix)
+            if (Platform.IsX11)
             {
                 HandleCreated += (sender, e) => X11.SetWMClass("CKAN", "CKAN", Handle);
             }

--- a/GUI/X11.cs
+++ b/GUI/X11.cs
@@ -28,7 +28,14 @@ namespace CKAN
             IntPtr classHints = Marshal.AllocCoTaskMem(Marshal.SizeOf(hint));
             Marshal.StructureToPtr(hint, classHints, true);
 
-            XSetClassHint(DisplayHandle, GetWindow(handle), classHints);
+            try
+            {
+                XSetClassHint(DisplayHandle, GetWindow(handle), classHints);
+            }
+            catch (DllNotFoundException)
+            {
+                // If the DLL isn't there, don't worry about it
+            }
 
             Marshal.FreeCoTaskMem(hint.res_name);
             Marshal.FreeCoTaskMem(hint.res_class);


### PR DESCRIPTION
## Problem

Mac clients are failing currently:

```
System.DllNotFoundException: libX11.dylib
  at (wrapper managed-to-native) CKAN.X11.XSetClassHint(intptr,intptr,intptr)
  at CKAN.X11.SetWMClass (System.String name, System.String wmClass, System.IntPtr handle) [0x0004c] in <2c2371fb3f2949b2a6dfae930758e6ee>:0 
  at CKAN.Main.<.ctor>b__37_5 (System.Object sender, System.EventArgs e) [0x00010] in <2c2371fb3f2949b2a6dfae930758e6ee>:0 
  at (wrapper delegate-invoke) <Module>.invoke_void_object_EventArgs(object,System.EventArgs)
  at System.Windows.Forms.Control.OnHandleCreated (System.EventArgs e) [0x00019] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.Form.OnHandleCreated (System.EventArgs e) [0x00016] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.Control.WmCreate (System.Windows.Forms.Message& m) [0x00000] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.Control.WndProc (System.Windows.Forms.Message& m) [0x0021c] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.ScrollableControl.WndProc (System.Windows.Forms.Message& m) [0x00000] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.ContainerControl.WndProc (System.Windows.Forms.Message& m) [0x00029] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.Form.WndProc (System.Windows.Forms.Message& m) [0x00166] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.Control+ControlWindowTarget.OnMessage (System.Windows.Forms.Message& m) [0x00000] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.Control+ControlNativeWindow.WndProc (System.Windows.Forms.Message& m) [0x0000b] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
  at System.Windows.Forms.NativeWindow.WndProc (System.IntPtr hWnd, System.Windows.Forms.Msg msg, System.IntPtr wParam, System.IntPtr lParam) [0x00085] in <7cb6368c5ba549ff8a02965fd9de701e>:0 
1926 [1] ERROR CKAN.URLHandlers (null) - There was an error while registering the URL handler for ckan:// - Could not find a part of the path "/Users/teamgros/.local/share/applications/mimeapps.list".
1936 [1] ERROR CKAN.URLHandlers (null) -   at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x00164] in <14f1e720d53a4a6a8800252bec102319>:0 
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options, System.String msgPath, System.Boolean bFromProxy, System.Boolean useLongPath, System.Boolean checkHost) [0x00000] in <14f1e720d53a4a6a8800252bec102319>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions,string,bool,bool,bool)
  at System.IO.StreamWriter.CreateFile (System.String path, System.Boolean append, System.Boolean checkHost) [0x0001c] in <14f1e720d53a4a6a8800252bec102319>:0 
  at System.IO.StreamWriter..ctor (System.String path, System.Boolean append, System.Text.Encoding encoding, System.Int32 bufferSize, System.Boolean checkHost) [0x00055] in <14f1e720d53a4a6a8800252bec102319>:0 
  at System.IO.StreamWriter..ctor (System.String path, System.Boolean append, System.Text.Encoding encoding, System.Int32 bufferSize) [0x00000] in <14f1e720d53a4a6a8800252bec102319>:0 
  at System.IO.StreamWriter..ctor (System.String path) [0x00008] in <14f1e720d53a4a6a8800252bec102319>:0 
  at (wrapper remoting-invoke-with-check) System.IO.StreamWriter..ctor(string)
  at System.IO.File.WriteAllLines (System.String path, System.String[] contents) [0x00000] in <14f1e720d53a4a6a8800252bec102319>:0 
  at CKAN.URLHandlers.RegisterURLHandler_Linux () [0x00050] in <2c2371fb3f2949b2a6dfae930758e6ee>:0 
  at CKAN.URLHandlers.RegisterURLHandler (CKAN.Configuration config, CKAN.IUser user) [0x00007] in <2c2371fb3f2949b2a6dfae930758e6ee>:0 
Terminated: 15
```

## Cause

#2586 added some X11-specific code to set the window name. We use `Platform.IsUnix` to determine whether to run it:

https://github.com/KSP-CKAN/CKAN/blob/7413c232f2ff7f58692617ae7c3cfa12551a7f6f/GUI/Main.cs#L263-L267

`Platform.IsUnix`'s documentation says "but *not* Mac":

https://github.com/KSP-CKAN/CKAN/blob/7413c232f2ff7f58692617ae7c3cfa12551a7f6f/Core/Platform.cs#L60-L67

However, this is false; `IsUnix` is true on Mac, because `Environment.OSVersion.Platform` has the same value on both.
https://docs.microsoft.com/en-us/dotnet/api/system.platformid?view=netframework-4.7.2

Notably, this causes the wrong code to run on Macs in other places:

https://github.com/KSP-CKAN/CKAN/blob/7413c232f2ff7f58692617ae7c3cfa12551a7f6f/GUI/Configuration.cs#L88-L94

https://github.com/KSP-CKAN/CKAN/blob/7413c232f2ff7f58692617ae7c3cfa12551a7f6f/GUI/URLHandlers.cs#L36-L39

## Changes

Now `Platform.IsUnix` is false on Mac, as per the documentation. This will prevent that code from running on Mac, and might also prevent some problems with those `Configuration` and `URLHandler` snippets.

Now the X11-specific code from #2586 is governed by a new `Platform.IsX11` value, which is only true if you're on Unix and the `$DISPLAY` environment variable is defined. Maybe this will help if you have Wayland.

Now even if you somehow manage to execute the `XSetClassHint` statement on a system that doesn't support it, the `DllNotFoundException` exception is simply ignored, because its failure is of no importance.

Fixes #2595.