### PR TITLE
Warn before launching KSP with installed incompatible modules

### DIFF
--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -180,12 +180,32 @@ namespace CKAN
         {
             List<CkanModule> releases = querier.AllAvailable(identifier);
             if (releases != null && releases.Count > 0) {
-                ModuleVersion    minMod = null, maxMod = null;
-                KspVersion minKsp = null, maxKsp = null;
+                ModuleVersion minMod = null, maxMod = null;
+                KspVersion    minKsp = null, maxKsp = null;
                 Registry.GetMinMaxVersions(releases, out minMod, out maxMod, out minKsp, out maxKsp);
                 return KspVersionRange.VersionSpan(minKsp, maxKsp);
             }
             return "";
+        }
+
+        /// <summary>
+        /// Generate a string describing the range of game versions
+        /// compatible with the given module.
+        /// </summary>
+        /// <param name="identifier">Mod name to findDependencyShallow</param>
+        /// <returns>
+        /// String describing range of compatible game versions.
+        /// </returns>
+        public static string CompatibleGameVersions(this IRegistryQuerier querier, CkanModule module)
+        {
+            ModuleVersion minMod = null, maxMod = null;
+            KspVersion    minKsp = null, maxKsp = null;
+            Registry.GetMinMaxVersions(
+                new CkanModule[] { module },
+                out minMod, out maxMod,
+                out minKsp, out maxKsp
+            );
+            return KspVersionRange.VersionSpan(minKsp, maxKsp);
         }
     }
 }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -110,6 +110,19 @@ namespace CKAN
             get { return _installedDlcModules; }
         }
 
+        /// <summary>
+        /// Find installed modules that are not compatible with the given versions
+        /// </summary>
+        /// <param name="crit">Version criteria against which to check modules</param>
+        /// <returns>
+        /// Installed modules that are incompatible, if any
+        /// </returns>
+        public IEnumerable<InstalledModule> IncompatibleInstalled(KspVersionCriteria crit)
+        {
+            return installed_modules.Values
+                .Where(im => !im.Module.IsCompatibleKSP(crit));
+        }
+
         #region Registry Upgrades
 
         [OnDeserialized]

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -756,6 +756,20 @@ namespace CKAN
             if (split.Length == 0)
                 return;
 
+            var registry = RegistryManager.Instance(CurrentInstance).registry;
+            var incomp   = registry.IncompatibleInstalled(CurrentInstance.VersionCriteria());
+            if (incomp.Any())
+            {
+                // Warn that it might not be safe to run KSP with incompatible modules installed
+                string incompatDescrip = incomp
+                    .Select(m => $"{m.Module} ({registry.CompatibleGameVersions(m.Module)})")
+                    .Aggregate((a, b) => $"{a}, {b}");
+                if (!YesNoDialog($"Some installed modules are incompatible! It might not be safe to launch KSP. Really launch?\r\n\r\n{incompatDescrip}"))
+                {
+                    return;
+                }
+            }
+
             var binary = split[0];
             var args = string.Join(" ", split.Skip(1));
 


### PR DESCRIPTION
## Motivation

If you install a bunch of mods with CKAN and then Steam auto-updates your KSP version, you might end up with mods that are incompatible and would not be possible to install from scratch if you started over. The effect of this can range from nothing to crashing the game or corrupting saves.

Many users may not notice that this has happened until it is too late, and new users may not even be aware that the risk exists.

## Changes

Now if you click to launch KSP with incompatible modules installed, CKAN will show a warning that lists them along with their compatible game versions:

![image](https://user-images.githubusercontent.com/1559108/49485085-1ec8d700-f7ff-11e8-8c4f-710cd69ccc15.png)