### PR TITLE
Show correct error messages after canceling (un)installations/upgrades

### DIFF
--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -147,8 +147,9 @@ namespace CKAN
                 installCanceled = true;
             };
 
-             // checks if all actions were successfull
-             bool resolvedAllProvidedMods = false;
+            // checks if all actions were successfull
+            bool processSuccessful = false;
+            bool resolvedAllProvidedMods = false;
             // uninstall/installs/upgrades until every list is empty
             // if the queue is NOT empty, resolvedAllProvidedMods is set to false until the action is done
             while (!resolvedAllProvidedMods)
@@ -158,32 +159,37 @@ namespace CKAN
                     e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
                     if (toUninstall.Count > 0)
                     {
-                        resolvedAllProvidedMods = false;
-                        if (!installCanceled) {
+                        processSuccessful = false;
+                        if (!installCanceled)
+                        {
                             installer.UninstallList(toUninstall);
-                            resolvedAllProvidedMods = true;
+                            processSuccessful = true;
                         }
                     }
                     if (toUpgrade.Count > 0)
                     {
-                        resolvedAllProvidedMods = false;
-                        if (!installCanceled) {
+                        processSuccessful = false;
+                        if (!installCanceled)
+                        {
                             installer.Upgrade(toUpgrade, downloader);
-                            resolvedAllProvidedMods = true;
+                            processSuccessful = true;
                         }
                     }
                     if (toInstall.Count > 0)
                     {
-                        resolvedAllProvidedMods = false;
-                        if (!installCanceled) {
+                        processSuccessful = false;
+                        if (!installCanceled)
+                        {
                             installer.InstallList(toInstall, opts.Value, downloader);
-                            resolvedAllProvidedMods = true;
+                            processSuccessful = true;
                         }
                     }
-                    e.Result = new KeyValuePair<bool, ModChanges>(resolvedAllProvidedMods, opts.Key);
-                    if (installCanceled) {
-                        return; 
+                    e.Result = new KeyValuePair<bool, ModChanges>(processSuccessful, opts.Key);
+                    if (installCanceled)
+                    {
+                        return;
                     }
+                    resolvedAllProvidedMods = true;
                 }
                 catch (TooManyModsProvideKraken k)
                 {

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -147,30 +147,43 @@ namespace CKAN
                 installCanceled = true;
             };
 
-            bool resolvedAllProvidedMods = false;
+             // checks if all actions were successfull
+             bool resolvedAllProvidedMods = false;
+            // uninstall/installs/upgrades until every list is empty
+            // if the queue is NOT empty, resolvedAllProvidedMods is set to false until the action is done
             while (!resolvedAllProvidedMods)
             {
                 try
                 {
                     e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
-                    if (!installCanceled && toUninstall.Count > 0)
+                    if (toUninstall.Count > 0)
                     {
-                        installer.UninstallList(toUninstall);
+                        resolvedAllProvidedMods = false;
+                        if (!installCanceled) {
+                            installer.UninstallList(toUninstall);
+                            resolvedAllProvidedMods = true;
+                        }
                     }
-                    if (!installCanceled && toUpgrade.Count > 0)
+                    if (toUpgrade.Count > 0)
                     {
-                        installer.Upgrade(toUpgrade, downloader);
+                        resolvedAllProvidedMods = false;
+                        if (!installCanceled) {
+                            installer.Upgrade(toUpgrade, downloader);
+                            resolvedAllProvidedMods = true;
+                        }
                     }
-                    if (!installCanceled && toInstall.Count > 0)
+                    if (toInstall.Count > 0)
                     {
-                        installer.InstallList(toInstall, opts.Value, downloader);
+                        resolvedAllProvidedMods = false;
+                        if (!installCanceled) {
+                            installer.InstallList(toInstall, opts.Value, downloader);
+                            resolvedAllProvidedMods = true;
+                        }
                     }
-                    e.Result = new KeyValuePair<bool, ModChanges>(!installCanceled, opts.Key);
-                    if (installCanceled)
-                    {
-                        return;
+                    e.Result = new KeyValuePair<bool, ModChanges>(resolvedAllProvidedMods, opts.Key);
+                    if (installCanceled) {
+                        return; 
                     }
-                    resolvedAllProvidedMods = true;
                 }
                 catch (TooManyModsProvideKraken k)
                 {
@@ -327,7 +340,7 @@ namespace CKAN
 
             tabController.SetTabLock(false);
 
-            if (result.Key)
+            if (result.Key && !installCanceled)
             {
                 // Rebuilds the list of GUIMods
                 UpdateModsList(false, result.Value);
@@ -344,20 +357,26 @@ namespace CKAN
                 AddStatusMessage("Success!");
                 HideWaitDialog(true);
                 tabController.HideTab("ChangesetTabPage");
+                // move to UpdateChangesDialog()?
                 ApplyToolButton.Enabled = false;
                 RetryCurrentActionButton.Visible = false;
                 UpdateChangesDialog(null, installWorker);
             }
-            else
+            else if(installCanceled) {
+                // User cancelled the installation
+                // Rebuilds the list of GUIMods
+                UpdateModsList(false, result.Value);
+                UpdateChangesDialog(null, installWorker);
+                if (result.Key) {
+                    FailWaitDialog("Cancellation to late, process complete!", "User canceled the process manually, but all mods already (un)installed/upgraded.", "Process complete!", result.Key);
+                } else {
+                    FailWaitDialog("Process canceled by user!", "User canceled the process manually!", "(Un)Install/Upgrade canceled!", result.Key);
+                }
+            } else
             {
                 // There was an error
-                // Stay on the log dialog and re-apply the user's change set to allow retry
-                AddStatusMessage("Error!");
-                SetDescription("An error occurred, check the log for information");
+                FailWaitDialog("Error during installation!", "An unknown error occurred, please try again!", "Installation failed!", result.Key);
                 UpdateChangesDialog(result.Value, installWorker);
-                RetryCurrentActionButton.Visible = true;
-                Util.Invoke(DialogProgressBar, () => DialogProgressBar.Style = ProgressBarStyle.Continuous);
-                Util.Invoke(DialogProgressBar, () => DialogProgressBar.Value = 0);
             }
 
             Util.Invoke(this, () => Enabled = true);

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -61,6 +61,30 @@ namespace CKAN
             });
         }
 
+        /// <summary>
+        /// Stay on log page and reset StatusProgress
+        /// </summary>
+        /// <param name="statusMsg">Message for the lower status bar</param>
+        /// <param name="logMsg">Message to display on WaitDialog-Log (not the real log!)</param>
+        /// <param name="description">Message displayed above the DialogProgress bar</param>
+        public void FailWaitDialog(string statusMsg, string logMsg, string description, bool success)
+        {
+            Util.Invoke(statusStrip1, () => {
+                StatusProgress.Visible = false;
+                AddStatusMessage(statusMsg);
+            });
+            Util.Invoke(WaitTabPage, () => {
+                RecreateDialogs();
+                RetryCurrentActionButton.Visible = !success;
+                CancelCurrentActionButton.Enabled = false;
+                SetProgress(100);
+            });
+            tabController.HideTab("ChangesetTabPage");
+            AddLogMessage(logMsg);
+            SetDescription(description);
+            ApplyToolButton.Enabled = !success;
+        }
+
         public void SetProgress(int progress)
         {
             if (progress < 0)
@@ -129,7 +153,6 @@ namespace CKAN
             {
                 CancelCurrentActionButton.Enabled = false;
             });
-            HideWaitDialog(true);
         }
 
     }


### PR DESCRIPTION
## Problem
If you cancel the installation/uninstall/update process after it's already complete, but before the Cancel button is greyed out you still get the "Error!" message and the Apply changes button is still active.
![grafik](https://user-images.githubusercontent.com/28812678/49550315-75134400-f8eb-11e8-9195-640581a21711.png)
(Ignore the location of the Retry button atm, this seems to be another bug)

This is due to the entire GUI PostInstallMods() function only checking for e.Result.Key wich is set to false if the installation is canceled, despite the real result possibly being successful. This leads to those false error messages and  GUI behavior.

## Solution
e.Result.Key is now set to the value of processSuccesful (if you know a better name, let me know!). PostInstallMods now also distinguishes the "installCanceled but positive processSuccesful case.
The corresponding messages and GUI actions are now handled by a new FailWaitDialog() in MainWait.cs.

Furthermore the GUI ModList gets updated and UpdateChangesDialog is called. This solves the Apply changes button falsely being active as well as "installed" checkboxes having the false state.

Also the now empty changes tab is hidden (as after normal, not canceled installation).
![ckan_3](https://user-images.githubusercontent.com/28812678/49551130-5498b900-f8ee-11e8-84fd-63608500d511.png)
![grafik](https://user-images.githubusercontent.com/28812678/49551160-74c87800-f8ee-11e8-8c27-f27f122f6b11.png)

Redo of #2418