### PR TITLE
Fix spelling error of netkan-bot in close-old-support-tickets.pl

### DIFF
--- a/bin/close-old-support-tickets.pl
+++ b/bin/close-old-support-tickets.pl
@@ -79,7 +79,7 @@ sub close_ticket {
     my ($issues, $id) = @_;
 
     $issues->create_comment($id, {
-        body => "Hey there! I'm a fun-loving automated bot who's responsible for making sure old support tickets get closed out. As we haven't seen any activity on this ticket for a while, we're hoping the problem has been resolved and I'm closing out the ticket automaically. If I'm doing this in error, please add a comment to this ticket to let us know, and we'll re-open it!"
+        body => "Hey there! I'm a fun-loving automated bot who's responsible for making sure old support tickets get closed out. As we haven't seen any activity on this ticket for a while, we're hoping the problem has been resolved and I'm closing out the ticket automatically. If I'm doing this in error, please add a comment to this ticket to let us know, and we'll re-open it!"
     });
 
     $issues->update_issue( $id, { state => "closed" });


### PR DESCRIPTION
Our lovely netkan-bot has been doomed to spell "automatically" without a second t for longer than 3 and a half years (god bless git blame)! Time to relieve him of this disgrace!

![screen](https://user-images.githubusercontent.com/28812678/49678877-bdffff80-fa87-11e8-9e8a-8c6c4b9a402b.png)