### PR TITLE
Don't auto-install recommendations when auditing recommendations

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1012,13 +1012,7 @@ namespace CKAN
         /// </summary>
         public void Upgrade(IEnumerable<string> identifiers, IDownloader netAsyncDownloader, bool enforceConsistency = true)
         {
-            var options = new RelationshipResolverOptions();
-
-            // We do not wish to pull in any suggested or recommended mods.
-            options.with_recommends = false;
-            options.with_suggests = false;
-
-            var resolver = new RelationshipResolver(identifiers.ToList(), null, options, registry_manager.registry, ksp.VersionCriteria());
+            var resolver = new RelationshipResolver(identifiers.ToList(), null, RelationshipResolver.DependsOnlyOpts(), registry_manager.registry, ksp.VersionCriteria());
             Upgrade(resolver.ModList(), netAsyncDownloader, enforceConsistency);
         }
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -191,14 +191,25 @@ namespace CKAN
         // and the defaults in the class definition should do the right thing.
         public static RelationshipResolverOptions DefaultOpts()
         {
-            var opts = new RelationshipResolverOptions
+            return new RelationshipResolverOptions
             {
-                with_recommends = true,
-                with_suggests = false,
+                with_recommends   = true,
+                with_suggests     = false,
                 with_all_suggests = false
             };
+        }
 
-            return opts;
+        /// <summary>
+        /// Options to install without recommendations.
+        /// </summary>
+        public static RelationshipResolverOptions DependsOnlyOpts()
+        {
+            return new RelationshipResolverOptions
+            {
+                with_recommends   = false,
+                with_suggests     = false,
+                with_all_suggests = false
+            };
         }
 
         /// <summary>

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -155,11 +155,13 @@ namespace CKAN
                 UpdateChangesDialog(ChangeSet.ToList(), installWorker);
                 tabController.ShowTab("ChangesetTabPage", 1, false);
                 ApplyToolButton.Enabled = true;
+                auditRecommendationsMenuItem.Enabled = false;
             }
             else
             {
                 tabController.HideTab("ChangesetTabPage");
                 ApplyToolButton.Enabled = false;
+                auditRecommendationsMenuItem.Enabled = true;
             }
         }
 

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -119,15 +119,13 @@ namespace CKAN
             menuStrip1.Enabled = false;
             RetryCurrentActionButton.Visible = false;
 
-            RelationshipResolverOptions install_ops = RelationshipResolver.DefaultOpts();
-            install_ops.with_recommends = false;
             //Using the changeset passed in can cause issues with versions.
             // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.
             // TODO Work out why this is.
             installWorker.RunWorkerAsync(
                 new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                     mainModList.ComputeUserChangeSet().ToList(),
-                    install_ops
+                    RelationshipResolver.DependsOnlyOpts()
                 )
             );
         }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -572,11 +572,6 @@ namespace CKAN
         {
             var modules_to_install = new HashSet<CkanModule>();
             var modules_to_remove = new HashSet<CkanModule>();
-            var options = new RelationshipResolverOptions
-            {
-                without_toomanyprovides_kraken = false,
-                with_recommends = false
-            };
 
             foreach (var change in changeSet)
             {
@@ -610,7 +605,8 @@ namespace CKAN
                     new RelationshipResolver(
                         modules_to_install,
                         null,
-                        options, registry, version);
+                        RelationshipResolver.DependsOnlyOpts(),
+                        registry, version);
                     handled_all_too_many_provides = true;
                     continue;
                 }
@@ -642,7 +638,7 @@ namespace CKAN
             var resolver = new RelationshipResolver(
                 modules_to_install,
                 changeSet.Where(change => change.ChangeType.Equals(GUIModChangeType.Remove)).Select(m => m.Mod.ToModule()),
-                options, registry, version);
+                RelationshipResolver.DependsOnlyOpts(), registry, version);
             changeSet.UnionWith(
                 resolver.ModList()
                     .Select(m => new ModChange(new GUIMod(m, registry, version), GUIModChangeType.Install, resolver.ReasonFor(m))));

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -114,14 +114,7 @@ namespace CKAN
         {
             return mods.Where(kvp => CanInstall(
                 registry, versionCriteria,
-                new RelationshipResolverOptions()
-                {
-                    with_all_suggests              = false,
-                    with_recommends                = false,
-                    with_suggests                  = false,
-                    without_enforce_consistency    = false,
-                    without_toomanyprovides_kraken = false
-                },
+                RelationshipResolver.DependsOnlyOpts(),
                 toInstall.ToList().Concat(new List<CkanModule>() { kvp.Key }).ToList()
             )).ToDictionary(
                 kvp => kvp.Key,
@@ -336,7 +329,7 @@ namespace CKAN
                             GUIModChangeType.Install,
                             null
                         )).ToList(),
-                        RelationshipResolver.DefaultOpts()
+                        RelationshipResolver.DependsOnlyOpts()
                     )
                 );
             }


### PR DESCRIPTION
## Problem

If you use the File &rArr; Audit recommendations option from #2577 to select one or more mods to install, those mods' recommendations will also be installed regardless of whether you selected them.

## Cause

`RelationshipResolver` takes a `RelationshipResolverOptions` parameter that specifies what to do with recommendations and suggestions, among other things. Since it can be inconvenient to set 7 boolean member variables individually, a `RelationshipResolver.DefaultOpts()` function returns a default set of options.

This `DefaultOpts()` object was used for Audit recommendations. Unfortunately that object sets `with_recommends` to true, so this causes all recommendations of the specified mods to be treated as hard dependencies, which doesn't make sense to do in GUI. It's kind of awkward to have a "default" object that you never want to use as-is.

## Changes

Now `DefaultOpts` has a companion function called `DependsOnlyOpts`, which doesn't pull in recommendations. This is now used in five places which previously had this behavior, including normal installation and the Audit recommendations flow.

Also, the Audit recommendations menu item is now disabled if you have a change set. This is to prevent confusion about what should happen in such situations.

![image](https://user-images.githubusercontent.com/1559108/49690767-fe00ca00-fafb-11e8-9413-9a05f51513a4.png)

Fixes #2604.