### PR TITLE
Suppress wrapping of status bar in Mono

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -662,6 +662,7 @@
             // StatusLabel
             //
             this.StatusLabel.Name = "StatusLabel";
+            this.StatusLabel.Font = System.Drawing.SystemFonts.DefaultFont;
             this.StatusLabel.Size = new System.Drawing.Size(1050, 29);
             this.StatusLabel.Spring = true;
             this.StatusLabel.Text = "";


### PR DESCRIPTION
## Problem

If the status bar contains a string beyond a certain length in Mono, it'll be wrapped near the end, splitting off the last word and chopping off pieces of the letters, even if there's plenty of space in the status bar to fit:

![image](https://user-images.githubusercontent.com/1559108/49681959-2216c980-fa70-11e8-8e33-f316524f26aa.png)

![image](https://user-images.githubusercontent.com/1559108/49682208-1dedaa80-fa76-11e8-95c2-ef63395999f4.png)

## Cause

I poked around in the mono source for a while trying to figure out what's going on, but I wasn't able to identify a clear cause. There are many layers of rendering code involved here:

- ToolStripStatusLabel
- ToolStripLabel
- ToolStripItem
- TextRenderer
- ToolStripRenderer

At least two of these have their own special data structure for handling fonts, padding, etc., so I suspect there's a discrepancy somewhere in all of that translation between different assumptions and contexts. Specifically, I suspect they're calculating the exact size needed for the text and then passing it to a function that expects to receive a size that includes padding (and then subtracts it), but I wasn't able to confirm that. Or maybe there's simply a bug in the code that calculates the size of the text.

Interestingly, there's a one-line hack commented out (from 12 years ago!) that fixes the problem if you uncomment it:

https://github.com/mono/mono/blob/449e36638fc0b7188b2e9fbd9734a5b263ba9d22/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripItem.cs#L1521

I think this adds enough padding to make room for the text. However, I can't guarantee that this fix wouldn't break anything else because this code is shared with controls other than the status bar label, so I've decided not to do a mono pull request for that. But this does suggest that someone was aware of this problem at one point and never got around to formulating a proper fix.

## Changes

Now the font is slightly smaller and fits without wrapping:

![image](https://user-images.githubusercontent.com/1559108/49681969-5b4f3980-fa70-11e8-9ae8-a0dc0353d8d6.png)

I wish I could explain exactly why this fixes it, but so far all I have is, "It just does."