### PR TITLE
Remove unnecessary parameter in Configuration methods

### DIFF
--- a/CKAN.sln
+++ b/CKAN.sln
@@ -89,5 +89,6 @@ Global
 		$2.inheritsSet = Mono
 		$2.inheritsScope = text/x-csharp
 		$2.scope = text/x-csharp
+        $2.SpaceAfterMethodCallName = False
 	EndGlobalSection
 EndGlobal

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -81,7 +81,7 @@ namespace CKAN
             SaveConfiguration(this, path);
         }
 
-        public static Configuration LoadOrCreateConfiguration(string path, string defaultRepo)
+        public static Configuration LoadOrCreateConfiguration(string path)
         {
             if (!File.Exists(path))
             {

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -99,7 +99,7 @@ namespace CKAN
             return LoadConfiguration(path);
         }
 
-        public static Configuration LoadConfiguration(string path)
+        private static Configuration LoadConfiguration(string path)
         {
             var serializer = new XmlSerializer(typeof (Configuration));
 
@@ -137,7 +137,7 @@ namespace CKAN
             return configuration;
         }
 
-        public static void SaveConfiguration(Configuration configuration)
+        private static void SaveConfiguration(Configuration configuration)
         {
             var serializer = new XmlSerializer(typeof (Configuration));
 

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -78,7 +78,7 @@ namespace CKAN
 
         public void Save()
         {
-            SaveConfiguration(this, path);
+            SaveConfiguration(this);
         }
 
         public static Configuration LoadOrCreateConfiguration(string path)
@@ -88,12 +88,12 @@ namespace CKAN
                 var configuration = new Configuration
                 {
                     path = path,
-                        CommandLineArguments = Platform.IsUnix ? "./KSP.x86_64 -single-instance" :
+                    CommandLineArguments = Platform.IsUnix ? "./KSP.x86_64 -single-instance" :
                             Platform.IsMac  ? "./KSP.app/Contents/MacOS/KSP" :
                             "KSP_x64.exe -single-instance"
                 };
 
-                SaveConfiguration(configuration, path);
+                SaveConfiguration(configuration);
             }
 
             return LoadConfiguration(path);
@@ -137,11 +137,11 @@ namespace CKAN
             return configuration;
         }
 
-        public static void SaveConfiguration(Configuration configuration, string path)
+        public static void SaveConfiguration(Configuration configuration)
         {
             var serializer = new XmlSerializer(typeof (Configuration));
 
-            using (var writer = new StreamWriter(path))
+            using (var writer = new StreamWriter(configuration.path))
             {
                 serializer.Serialize(writer, configuration);
                 writer.Close();

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -213,8 +213,7 @@ namespace CKAN
 
             configuration = Configuration.LoadOrCreateConfiguration
                 (
-                    Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml"),
-                    CKAN.Repository.default_ckan_repo_uri.ToString()
+                    Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml")
                 );
 
             // Check if there is any other instances already running.
@@ -477,8 +476,7 @@ namespace CKAN
             });
 
             configuration = Configuration.LoadOrCreateConfiguration(
-                Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml"),
-                CKAN.Repository.default_ckan_repo_uri.ToString()
+                Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml")
             );
 
             if (CurrentInstance.CompatibleVersionsAreFromDifferentKsp)

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -476,7 +476,7 @@ namespace CKAN
             });
 
             configuration = Configuration.LoadOrCreateConfiguration(
-                Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml")
+                Path.Combine(CurrentInstance.CkanDir (), "GUIConfig.xml")
             );
 
             if (CurrentInstance.CompatibleVersionsAreFromDifferentKsp)

--- a/Tests/GUI/Configuration.cs
+++ b/Tests/GUI/Configuration.cs
@@ -23,7 +23,7 @@ namespace Tests.GUI
         }
 
         [Test]
-        public void LoadConfiguration_MalformedXMLFile_ThrowsKraken()
+        public void LoadOrCreateConfiguration_MalformedXMLFile_ThrowsKraken()
         {
             string tempFile = Path.Combine(tempDir, "invalid.xml");
 
@@ -32,11 +32,11 @@ namespace Tests.GUI
                 stream.Write("This is not a valid XML file.");
             }
 
-            Assert.Throws<Kraken>(() => Configuration.LoadConfiguration(tempFile));
+            Assert.Throws<Kraken>(() => Configuration.LoadOrCreateConfiguration(tempFile));
         }
 
         [Test]
-        public void LoadConfiguration_CorrectConfigurationFile_Loaded()
+        public void LoadOrCreateConfiguration_CorrectConfigurationFile_Loaded()
         {
             string tempFile = Path.Combine(tempDir, "valid.xml");
 
@@ -45,7 +45,7 @@ namespace Tests.GUI
                 stream.Write(TestData.ConfigurationFile());
             }
 
-            var result = Configuration.LoadConfiguration(tempFile);
+            var result = Configuration.LoadOrCreateConfiguration(tempFile);
 
             Assert.IsNotNull(result);
         }


### PR DESCRIPTION
## defaultRepo
`Configuration.LoadOrCreateConfiguration()` gets passed a `defaultRepo` parameter.
This is a relic of the early days of CKAN it seems, when the repositories were saved in the GUI configuration, but this got moved to the registry in 536637f7fe2fded1878bf66fb9b5aabee012770f.
Since then the parameter sits there unused.

## path
Also `SaveConfiguration()` gets passed a `path` parameter, which is redundant since there is a specific path variable in the `Configuration` class. It's a bit dangerous too, because it could lead to a difference between the real save path and the one set in the configuration.
Now SaveConfiguration() takes the value out of the according object of Configuration, which happened in `Save()` before.

## Add `SpaceAfterMethodCallName` to code formatting guideline
I added `$2.SpaceAfterMethodCallName = False` to the solution file, because MonoDevelop always inserted a space between method calls an round brackets.
Don't know if Visual Studio is okay with this, but I think in the worst case VS auto-removes the line again.
I encountered a strange Github display bug with the indentation in CKAN.sln, hence the 2 additional commits.