### PR TITLE
Revert unintentional tray icon change from #2587

### DIFF
--- a/GUI/MainTrayIcon.cs
+++ b/GUI/MainTrayIcon.cs
@@ -41,7 +41,7 @@ namespace CKAN
             }
             else
             {
-                //minimizeNotifyIcon.Visible = false;
+                minimizeNotifyIcon.Visible = false;
             }
         }
 


### PR DESCRIPTION
## Problem

There are probably situations now where the tray icon won't go away once you enable it.

## Cause

#2587 made an unintentional change to the tray icon code. The line that hides it when it's already visible was commented out. I think this was done for testing and then missed when committing because the code was moved to a new file.

## Changes

Now it's back as it was.