### PR TITLE
Allow selection of text in mod info panel

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -237,6 +237,7 @@
     <Compile Include="YesNoDialog.Designer.cs">
       <DependentUpon>YesNoDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="TransparentTextBox.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="AboutDialog.resx">

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -20,17 +20,6 @@
             base.Dispose(disposing);
         }
 
-        /// <summary>
-        /// Create a new TransparentTextBox control that allows the backcolor to be transparent
-        /// </summary>
-        private partial class TransparentTextBox : System.Windows.Forms.TextBox
-        {
-            public TransparentTextBox ()
-            {
-                SetStyle (System.Windows.Forms.ControlStyles.SupportsTransparentBackColor, true);
-            }
-        }
-
         #region Component Designer generated code
 
         /// <summary>
@@ -44,8 +33,8 @@
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.MetaDataUpperLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.MetadataModuleNameTextBox = new TransparentTextBox();
-            this.MetadataModuleAbstractLabel = new System.Windows.Forms.Label ();
-            this.MetadataModuleDescriptionLabel = new System.Windows.Forms.Label ();
+            this.MetadataModuleAbstractLabel = new System.Windows.Forms.Label();
+            this.MetadataModuleDescriptionTextBox = new TransparentTextBox();
             this.MetaDataLowerLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.IdentifierLabel = new System.Windows.Forms.Label();
             this.MetadataIdentifierTextBox = new TransparentTextBox();
@@ -55,13 +44,13 @@
             this.HomePageLabel = new System.Windows.Forms.Label();
             this.AuthorLabel = new System.Windows.Forms.Label();
             this.LicenseLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleVersionLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleLicenseLabel = new System.Windows.Forms.Label();
+            this.MetadataModuleVersionTextBox = new TransparentTextBox();
+            this.MetadataModuleLicenseTextBox = new TransparentTextBox();
             this.MetadataModuleAuthorTextBox = new TransparentTextBox();
             this.VersionLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleReleaseStatusLabel = new System.Windows.Forms.Label();
+            this.MetadataModuleReleaseStatusTextBox = new TransparentTextBox();
             this.MetadataModuleHomePageLinkLabel = new System.Windows.Forms.LinkLabel();
-            this.MetadataModuleKSPCompatibilityLabel = new System.Windows.Forms.Label();
+            this.MetadataModuleKSPCompatibilityTextBox = new TransparentTextBox();
             this.MetadataModuleGitHubLinkLabel = new System.Windows.Forms.LinkLabel();
             this.RelationshipTabPage = new System.Windows.Forms.TabPage();
             this.DependsGraphTree = new System.Windows.Forms.TreeView();
@@ -139,7 +128,7 @@
             this.MetaDataUpperLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleNameTextBox, 0, 0);
             this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleAbstractLabel, 0, 1);
-            this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleDescriptionLabel, 0, 2);
+            this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleDescriptionTextBox, 0, 2);
             this.MetaDataUpperLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataUpperLayoutPanel.Location = new System.Drawing.Point(0, 0);
             this.MetaDataUpperLayoutPanel.Name = "MetaDataUpperLayoutPanel";
@@ -159,8 +148,8 @@
             this.MetadataModuleNameTextBox.Size = new System.Drawing.Size(340, 46);
             this.MetadataModuleNameTextBox.TabIndex = 0;
             this.MetadataModuleNameTextBox.Text = "Mod Name";
-            this.MetadataModuleNameTextBox.ReadOnly = true;
             this.MetadataModuleNameTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.MetadataModuleNameTextBox.ReadOnly = true;
             this.MetadataModuleNameTextBox.BackColor = MetaDataUpperLayoutPanel.BackColor;
             this.MetadataModuleNameTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.MetadataModuleNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
@@ -172,19 +161,22 @@
             this.MetadataModuleAbstractLabel.Location = new System.Drawing.Point(3, 49);
             this.MetadataModuleAbstractLabel.Name = "MetadataModuleAbstractLabel";
             this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(340, 61);
+            this.MetadataModuleAbstractLabel.AutoSize = true;
             this.MetadataModuleAbstractLabel.TabIndex = 27;
             this.MetadataModuleAbstractLabel.Text = "";
             //
-            // MetadataModuleDescriptionLabel
+            // MetadataModuleDescriptionTextBox
             //
-            this.MetadataModuleDescriptionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-
-            this.MetadataModuleDescriptionLabel.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataModuleDescriptionLabel.Location = new System.Drawing.Point (3, 129);
-            this.MetadataModuleDescriptionLabel.Name = "MetadataModuleDescriptionLabel";
-            this.MetadataModuleDescriptionLabel.Size = new System.Drawing.Size (340, 121);
-            this.MetadataModuleDescriptionLabel.TabIndex = 28;
-            this.MetadataModuleDescriptionLabel.Text = "";
+            this.MetadataModuleDescriptionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleDescriptionTextBox.Location = new System.Drawing.Point (3, 129);
+            this.MetadataModuleDescriptionTextBox.Name = "MetadataModuleDescriptionLabel";
+            this.MetadataModuleDescriptionTextBox.Size = new System.Drawing.Size (340, 121);
+            this.MetadataModuleDescriptionTextBox.TabIndex = 28;
+            this.MetadataModuleDescriptionTextBox.Text = "";
+            this.MetadataModuleDescriptionTextBox.ReadOnly = true;
+            this.MetadataModuleDescriptionTextBox.BackColor = MetaDataUpperLayoutPanel.BackColor;
+            this.MetadataModuleDescriptionTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleDescriptionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             //
             // MetaDataLowerLayoutPanel
             //
@@ -200,13 +192,13 @@
             this.MetaDataLowerLayoutPanel.Controls.Add(this.ReleaseLabel, 0, 5);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.KSPCompatibilityLabel, 0, 6);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.IdentifierLabel, 0, 7);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleVersionLabel, 1, 0);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleLicenseLabel, 1, 1);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleVersionTextBox, 1, 0);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleLicenseTextBox, 1, 1);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleAuthorTextBox, 1, 2);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleHomePageLinkLabel, 1, 3);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleGitHubLinkLabel, 1, 4);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleReleaseStatusLabel, 1, 5);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleKSPCompatibilityLabel, 1, 6);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleReleaseStatusTextBox, 1, 5);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleKSPCompatibilityTextBox, 1, 6);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataIdentifierTextBox, 1, 7);
             this.MetaDataLowerLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataLowerLayoutPanel.Location = new System.Drawing.Point(0, 0);
@@ -316,25 +308,33 @@
             this.LicenseLabel.TabIndex = 3;
             this.LicenseLabel.Text = "License:";
             //
-            // MetadataModuleVersionLabel
+            // MetadataModuleVersionTextBox
             //
-            this.MetadataModuleVersionLabel.AutoSize = true;
-            this.MetadataModuleVersionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleVersionLabel.Location = new System.Drawing.Point(93, 0);
-            this.MetadataModuleVersionLabel.Name = "MetadataModuleVersionLabel";
-            this.MetadataModuleVersionLabel.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleVersionLabel.TabIndex = 2;
-            this.MetadataModuleVersionLabel.Text = "0.0.0";
+            this.MetadataModuleVersionTextBox.AutoSize = true;
+            this.MetadataModuleVersionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleVersionTextBox.Location = new System.Drawing.Point(93, 0);
+            this.MetadataModuleVersionTextBox.Name = "MetadataModuleVersionLabel";
+            this.MetadataModuleVersionTextBox.Size = new System.Drawing.Size(250, 30);
+            this.MetadataModuleVersionTextBox.TabIndex = 2;
+            this.MetadataModuleVersionTextBox.Text = "0.0.0";
+            this.MetadataModuleVersionTextBox.ReadOnly = true;
+            this.MetadataModuleVersionTextBox.BackColor = MetadataTabPage.BackColor;
+            this.MetadataModuleVersionTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleVersionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             //
-            // MetadataModuleLicenseLabel
+            // MetadataModuleLicenseTextBox
             //
-            this.MetadataModuleLicenseLabel.AutoSize = true;
-            this.MetadataModuleLicenseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleLicenseLabel.Location = new System.Drawing.Point(93, 30);
-            this.MetadataModuleLicenseLabel.Name = "MetadataModuleLicenseLabel";
-            this.MetadataModuleLicenseLabel.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleLicenseLabel.TabIndex = 4;
-            this.MetadataModuleLicenseLabel.Text = "None";
+            this.MetadataModuleLicenseTextBox.AutoSize = true;
+            this.MetadataModuleLicenseTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleLicenseTextBox.Location = new System.Drawing.Point(93, 30);
+            this.MetadataModuleLicenseTextBox.Name = "MetadataModuleLicenseLabel";
+            this.MetadataModuleLicenseTextBox.Size = new System.Drawing.Size(250, 30);
+            this.MetadataModuleLicenseTextBox.TabIndex = 4;
+            this.MetadataModuleLicenseTextBox.Text = "None";
+            this.MetadataModuleLicenseTextBox.ReadOnly = true;
+            this.MetadataModuleLicenseTextBox.BackColor = MetadataTabPage.BackColor;
+            this.MetadataModuleLicenseTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleLicenseTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             //
             // MetadataModuleAuthorTextBox
             //
@@ -361,15 +361,19 @@
             this.VersionLabel.TabIndex = 1;
             this.VersionLabel.Text = "Version:";
             //
-            // MetadataModuleReleaseStatusLabel
+            // MetadataModuleReleaseStatusTextBox
             //
-            this.MetadataModuleReleaseStatusLabel.AutoSize = true;
-            this.MetadataModuleReleaseStatusLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleReleaseStatusLabel.Location = new System.Drawing.Point(93, 150);
-            this.MetadataModuleReleaseStatusLabel.Name = "MetadataModuleReleaseStatusLabel";
-            this.MetadataModuleReleaseStatusLabel.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleReleaseStatusLabel.TabIndex = 11;
-            this.MetadataModuleReleaseStatusLabel.Text = "Stable";
+            this.MetadataModuleReleaseStatusTextBox.AutoSize = true;
+            this.MetadataModuleReleaseStatusTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleReleaseStatusTextBox.Location = new System.Drawing.Point(93, 150);
+            this.MetadataModuleReleaseStatusTextBox.Name = "MetadataModuleReleaseStatusLabel";
+            this.MetadataModuleReleaseStatusTextBox.Size = new System.Drawing.Size(250, 30);
+            this.MetadataModuleReleaseStatusTextBox.TabIndex = 11;
+            this.MetadataModuleReleaseStatusTextBox.Text = "Stable";
+            this.MetadataModuleReleaseStatusTextBox.ReadOnly = true;
+            this.MetadataModuleReleaseStatusTextBox.BackColor = MetadataTabPage.BackColor;
+            this.MetadataModuleReleaseStatusTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleReleaseStatusTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             //
             // MetadataModuleHomePageLinkLabel
             //
@@ -383,15 +387,19 @@
             this.MetadataModuleHomePageLinkLabel.Text = "linkLabel1";
             this.MetadataModuleHomePageLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             //
-            // MetadataModuleKSPCompatibilityLabel
+            // MetadataModuleKSPCompatibilityTextBox
             //
-            this.MetadataModuleKSPCompatibilityLabel.AutoSize = true;
-            this.MetadataModuleKSPCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleKSPCompatibilityLabel.Location = new System.Drawing.Point(93, 180);
-            this.MetadataModuleKSPCompatibilityLabel.Name = "MetadataModuleKSPCompatibilityLabel";
-            this.MetadataModuleKSPCompatibilityLabel.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleKSPCompatibilityLabel.TabIndex = 14;
-            this.MetadataModuleKSPCompatibilityLabel.Text = "0.0.0";
+            this.MetadataModuleKSPCompatibilityTextBox.AutoSize = true;
+            this.MetadataModuleKSPCompatibilityTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleKSPCompatibilityTextBox.Location = new System.Drawing.Point(93, 180);
+            this.MetadataModuleKSPCompatibilityTextBox.Name = "MetadataModuleKSPCompatibilityLabel";
+            this.MetadataModuleKSPCompatibilityTextBox.Size = new System.Drawing.Size(250, 30);
+            this.MetadataModuleKSPCompatibilityTextBox.TabIndex = 14;
+            this.MetadataModuleKSPCompatibilityTextBox.Text = "0.0.0";
+            this.MetadataModuleKSPCompatibilityTextBox.ReadOnly = true;
+            this.MetadataModuleKSPCompatibilityTextBox.BackColor = MetadataTabPage.BackColor;
+            this.MetadataModuleKSPCompatibilityTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleKSPCompatibilityTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             //
             // MetadataModuleGitHubLinkLabel
             //
@@ -536,7 +544,7 @@
         private System.Windows.Forms.TableLayoutPanel MetaDataUpperLayoutPanel;
         private TransparentTextBox MetadataModuleNameTextBox;
         private System.Windows.Forms.Label MetadataModuleAbstractLabel;
-        private System.Windows.Forms.Label MetadataModuleDescriptionLabel;
+        private TransparentTextBox MetadataModuleDescriptionTextBox;
         private System.Windows.Forms.TableLayoutPanel MetaDataLowerLayoutPanel;
         private System.Windows.Forms.Label IdentifierLabel;
         private TransparentTextBox MetadataIdentifierTextBox;
@@ -546,13 +554,13 @@
         private System.Windows.Forms.Label HomePageLabel;
         private System.Windows.Forms.Label AuthorLabel;
         private System.Windows.Forms.Label LicenseLabel;
-        private System.Windows.Forms.Label MetadataModuleVersionLabel;
-        private System.Windows.Forms.Label MetadataModuleLicenseLabel;
+        private TransparentTextBox MetadataModuleVersionTextBox;
+        private TransparentTextBox MetadataModuleLicenseTextBox;
         private TransparentTextBox MetadataModuleAuthorTextBox;
         private System.Windows.Forms.Label VersionLabel;
-        private System.Windows.Forms.Label MetadataModuleReleaseStatusLabel;
+        private TransparentTextBox MetadataModuleReleaseStatusTextBox;
         private System.Windows.Forms.LinkLabel MetadataModuleHomePageLinkLabel;
-        private System.Windows.Forms.Label MetadataModuleKSPCompatibilityLabel;
+        private TransparentTextBox MetadataModuleKSPCompatibilityTextBox;
         private System.Windows.Forms.LinkLabel MetadataModuleGitHubLinkLabel;
         private System.Windows.Forms.TabPage RelationshipTabPage;
         private System.Windows.Forms.TreeView DependsGraphTree;

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -138,11 +138,11 @@ namespace CKAN
             CkanModule module = gui_module.ToModule();
 
             Util.Invoke(MetadataModuleNameTextBox, () => MetadataModuleNameTextBox.Text = gui_module.Name);
-            Util.Invoke(MetadataModuleVersionLabel, () => MetadataModuleVersionLabel.Text = gui_module.LatestVersion.ToString());
-            Util.Invoke(MetadataModuleLicenseLabel, () => MetadataModuleLicenseLabel.Text = string.Join(", ", module.license));
+            Util.Invoke(MetadataModuleVersionTextBox, () => MetadataModuleVersionTextBox.Text = gui_module.LatestVersion.ToString());
+            Util.Invoke(MetadataModuleLicenseTextBox, () => MetadataModuleLicenseTextBox.Text = string.Join(", ", module.license));
             Util.Invoke(MetadataModuleAuthorTextBox, () => MetadataModuleAuthorTextBox.Text = gui_module.Authors);
             Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = module.@abstract);
-            Util.Invoke(MetadataModuleDescriptionLabel, () => MetadataModuleDescriptionLabel.Text = module.description);
+            Util.Invoke(MetadataModuleDescriptionTextBox, () => MetadataModuleDescriptionTextBox.Text = module.description);
             Util.Invoke(MetadataIdentifierTextBox, () => MetadataIdentifierTextBox.Text = module.identifier);
 
             // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
@@ -162,10 +162,10 @@ namespace CKAN
 
             if (module.release_status != null)
             {
-                Util.Invoke(MetadataModuleReleaseStatusLabel, () => MetadataModuleReleaseStatusLabel.Text = module.release_status.ToString());
+                Util.Invoke(MetadataModuleReleaseStatusTextBox, () => MetadataModuleReleaseStatusTextBox.Text = module.release_status.ToString());
             }
 
-            Util.Invoke(MetadataModuleKSPCompatibilityLabel, () => MetadataModuleKSPCompatibilityLabel.Text = gui_module.KSPCompatibilityLong);
+            Util.Invoke(MetadataModuleKSPCompatibilityTextBox, () => MetadataModuleKSPCompatibilityTextBox.Text = gui_module.KSPCompatibilityLong);
         }
 
         private void BeforeExpand(object sender, TreeViewCancelEventArgs args)

--- a/GUI/TransparentTextBox.cs
+++ b/GUI/TransparentTextBox.cs
@@ -1,0 +1,23 @@
+﻿using System;
+namespace CKAN
+{
+    /// <summary>
+    /// Create a new TransparentTextBox control that allows the backcolor of textboxes to be transparent.
+    /// <para>
+    /// Either set the BackColor to Color.Transparent or the color of the parent container.
+    /// Multiline is set to true.
+    /// Used in <see cref="MainModInfo"/>.</para>
+    /// </summary>
+    public class TransparentTextBox : System.Windows.Forms.TextBox
+    {
+        public TransparentTextBox ()
+        {
+            SetStyle(
+                System.Windows.Forms.ControlStyles.SupportsTransparentBackColor |
+                System.Windows.Forms.ControlStyles.ResizeRedraw |
+                System.Windows.Forms.ControlStyles.OptimizedDoubleBuffer |
+                System.Windows.Forms.ControlStyles.AllPaintingInWmPaint, true);
+            Multiline = true;
+        }
+    }
+}


### PR DESCRIPTION
## Feature request
#2591 asked for the ability to select and copy the text out of some labels in the mod info panel.
This was not possible because you cant copy text out of labels.

## Changes
I changed the **mod name (at the top), the mod author and the mod identifier label** to not-editable textboxes with the same background and text color as the labels had before. Also I removed the per standard in textboxes activated border, so they are seamless.
They look like the labels before (in dark and in white themes, at least with mono on Kubuntu), but now you can copy text.
Some pics:
![bright](https://user-images.githubusercontent.com/28812678/49699931-e39c1e80-fbd7-11e8-80e7-3b728093a81f.jpeg) ![dark](https://user-images.githubusercontent.com/28812678/49699875-1691e280-fbd7-11e8-8970-a1274f91dc9e.jpeg)


## Important
**I directly manipulated the `MainModInfo.Designer.cs` in MonoDevelop, and as far as I know, Visual Studio doesn't really like this, so someone using VS should verify whether VS complains/changes something back by itself or not.**
I also renamed the comments inside the Designer.cs for this, but you never know.

Closes #2591 