### PR TITLE
Jenkins as a Netkan "source"

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -87,6 +87,12 @@
     <Compile Include="Sources\Github\GithubRelease.cs" />
     <Compile Include="Sources\Github\GithubRepo.cs" />
     <Compile Include="Sources\Github\IGithubApi.cs" />
+    <Compile Include="Sources\Jenkins\IJenkinsApi.cs" />
+    <Compile Include="Sources\Jenkins\JenkinsApi.cs" />
+    <Compile Include="Sources\Jenkins\JenkinsArtifact.cs" />
+    <Compile Include="Sources\Jenkins\JenkinsBuild.cs" />
+    <Compile Include="Sources\Jenkins\JenkinsOptions.cs" />
+    <Compile Include="Sources\Jenkins\JenkinsRef.cs" />
     <Compile Include="Sources\Spacedock\ISpaceDock.cs" />
     <Compile Include="Sources\Spacedock\SDVersion.cs" />
     <Compile Include="Sources\Spacedock\SpaceDockApi.cs" />

--- a/Netkan/Sources/Jenkins/IJenkinsApi.cs
+++ b/Netkan/Sources/Jenkins/IJenkinsApi.cs
@@ -1,0 +1,7 @@
+namespace CKAN.NetKAN.Sources.Jenkins
+{
+    internal interface IJenkinsApi
+    {
+        JenkinsBuild GetLatestBuild(JenkinsRef reference, JenkinsOptions options);
+    }
+}

--- a/Netkan/Sources/Jenkins/JenkinsApi.cs
+++ b/Netkan/Sources/Jenkins/JenkinsApi.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using log4net;
+using Newtonsoft.Json;
+using CKAN.NetKAN.Services;
+
+namespace CKAN.NetKAN.Sources.Jenkins
+{
+    internal class JenkinsApi : IJenkinsApi
+    {
+        public JenkinsApi(IHttpService http)
+        {
+            _http = http;
+        }
+
+        public JenkinsBuild GetLatestBuild(JenkinsRef reference, JenkinsOptions options)
+        {
+            if (options == null)
+            {
+                options = new JenkinsOptions();
+            }
+            string url = Regex.Replace(reference.BaseUri.ToString(), @"/$", "");
+            return Call<JenkinsBuild>(
+                $"{url}/{BuildTypeToProperty[options.BuildType]}/api/json"
+            );
+        }
+
+        private T Call<T>(string url)
+        {
+            return Call<T>(new Uri(url));
+        }
+
+        private T Call<T>(Uri url)
+        {
+            return JsonConvert.DeserializeObject<T>(Call(url));
+        }
+
+        private string Call(string url)
+        {
+            return Call(new Uri(url));
+        }
+
+        private string Call(Uri url)
+        {
+            return _http.DownloadText(url);
+        }
+
+        private static readonly Dictionary<string, string> BuildTypeToProperty = new Dictionary<string, string>()
+        {
+            { "any",          "lastBuild"             },
+            { "completed",    "lastCompletedBuild"    },
+            { "failed",       "lastFailedBuild"       },
+            { "stable",       "lastStableBuild"       },
+            { "successful",   "lastSuccessfulBuild"   },
+            { "unstable",     "lastUnstableBuild"     },
+            { "unsuccessful", "lastUnsuccessfulBuild" }
+        };
+
+        private IHttpService _http;
+        private static readonly ILog Log = LogManager.GetLogger(typeof(JenkinsApi));
+    }
+}

--- a/Netkan/Sources/Jenkins/JenkinsArtifact.cs
+++ b/Netkan/Sources/Jenkins/JenkinsArtifact.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Jenkins
+{
+    public class JenkinsArtifact
+    {
+        [JsonProperty("fileName")]
+        public string FileName;
+
+        [JsonProperty("relativePath")]
+        public string RelativePath;
+    }
+}

--- a/Netkan/Sources/Jenkins/JenkinsBuild.cs
+++ b/Netkan/Sources/Jenkins/JenkinsBuild.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Jenkins
+{
+    public class JenkinsBuild
+    {
+        [JsonProperty("url")]
+        public string Url;
+
+        [JsonProperty("artifacts")]
+        public JenkinsArtifact[] Artifacts;
+    }
+}

--- a/Netkan/Sources/Jenkins/JenkinsOptions.cs
+++ b/Netkan/Sources/Jenkins/JenkinsOptions.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Jenkins
+{
+    public class JenkinsOptions
+    {
+        [JsonProperty("build", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue("stable")]
+        public string BuildType = "stable";
+
+        [JsonProperty("use_filename_version")]
+        [DefaultValue(false)]
+        public bool UseFilenameVersion = false;
+
+        private Regex _assetMatch;
+        [JsonProperty("asset_match")]
+        public Regex AssetMatchPattern
+        {
+            get { return _assetMatch ?? Constants.DefaultAssetMatchPattern; }
+            set { _assetMatch = value; }
+        }
+    }
+}

--- a/Netkan/Sources/Jenkins/JenkinsRef.cs
+++ b/Netkan/Sources/Jenkins/JenkinsRef.cs
@@ -1,0 +1,19 @@
+using System;
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Sources.Jenkins
+{
+    internal class JenkinsRef : RemoteRef
+    {
+        public JenkinsRef(string remoteRefToken)
+            : this(new RemoteRef(remoteRefToken)) { }
+
+        public JenkinsRef(RemoteRef remoteRef)
+            : base(remoteRef)
+        {
+            BaseUri = new Uri(remoteRef.Id);
+        }
+
+        public readonly Uri BaseUri;
+    }
+}

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -5,6 +5,7 @@ using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Sources.Curse;
 using CKAN.NetKAN.Sources.Github;
 using CKAN.NetKAN.Sources.Spacedock;
+using CKAN.NetKAN.Sources.Jenkins;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -32,7 +33,7 @@ namespace CKAN.NetKAN.Transformers
                 new CurseTransformer(new CurseApi(http)),
                 new GithubTransformer(new GithubApi(githubToken), prerelease),
                 new HttpTransformer(),
-                new JenkinsTransformer(http),
+                new JenkinsTransformer(new JenkinsApi(http)),
                 new AvcKrefTransformer(http),
                 new InternalCkanTransformer(http, moduleService),
                 new AvcTransformer(http, moduleService),

--- a/Tests/NetKAN/Sources/Jenkins/JenkinsApiTests.cs
+++ b/Tests/NetKAN/Sources/Jenkins/JenkinsApiTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using CKAN;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Sources.Jenkins;
+
+namespace Tests.NetKAN.Sources.Jenkins
+{
+	[TestFixture]
+	public sealed class JenkinsApiTests
+	{
+		[OneTimeSetUp]
+        public void TestFixtureSetup()
+        {
+            _cachePath = Path.Combine(
+				Path.GetTempPath(),
+				"CKAN",
+				Guid.NewGuid().ToString("N")
+			);
+            Directory.CreateDirectory(_cachePath);
+            _cache = new NetFileCache(_cachePath);
+        }
+
+        [OneTimeTearDown]
+        public void TestFixtureTearDown()
+        {
+            Directory.Delete(_cachePath, recursive: true);
+        }
+
+
+		[Test]
+		[Category("FlakyNetwork")]
+		[Category("Online")]
+		public void GetLatestBuild_ModuleManager_Works()
+		{
+			// Arrange
+            IJenkinsApi sut = new JenkinsApi(new CachingHttpService(_cache));
+
+            // Act
+			JenkinsBuild build = sut.GetLatestBuild(
+				new JenkinsRef("#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ModuleManager/"),
+				new JenkinsOptions()
+			);
+
+            // Assert
+            Assert.IsNotNull(build.Url);
+            Assert.IsNotNull(build.Artifacts);
+		}
+
+        private string       _cachePath;
+        private NetFileCache _cache;
+	}
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="NetKAN\Sources\Curse\CurseApiTests.cs" />
     <Compile Include="NetKAN\Sources\Github\GithubApiTests.cs" />
     <Compile Include="NetKAN\Sources\Spacedock\SpacedockApiTests.cs" />
+    <Compile Include="NetKAN\Sources\Jenkins\JenkinsApiTests.cs" />
     <Compile Include="NetKAN\Transformers\AvcKrefTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\AvcTransformerTests.cs" />
     <Compile Include="NetKAN\Transformers\CurseTransformerTests.cs" />


### PR DESCRIPTION
## Background

The Netkan transformers for GitHub, SpaceDock, and Curse are implemented as "sources":

- an interface defining an API
- a class implementing that interface
- classes defining objects returned by the API

See https://github.com/KSP-CKAN/CKAN/tree/master/Netkan/Sources

This provides a common, test-friendly structure for these `$kref`s.

## Motivation

Currently Jenkins, the `$kref` method for all of (and only) @sarbian's mods, doesn't work this way.

- It's a single monolithic class with all of the logic in the `Transform` method
- It has no tests

It also makes twice as many calls to the server as strictly necessary: one to get overall info about the job, and one to get the latest build using its build number.

## Changes

Now Jenkins is implemented as a source like the others.

Now there are tests for Jenkins!

Now we get the latest build in one step using the URL for that:
- https://ksp.sarbian.com/jenkins/job/ModuleManager/lastStableBuild/api/json
- https://wiki.jenkins.io/display/JENKINS/Remote+access+API
