### PR TITLE
Encapsulate usages of WebClient

### DIFF
--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -160,14 +160,12 @@ namespace CKAN.CmdLine
 
         private static RepositoryList FetchMasterRepositoryList(Uri master_uri = null)
         {
-            WebClient client = new WebClient();
-
             if (master_uri == null)
             {
                 master_uri = Repository.default_repo_master_list;
             }
 
-            string json = client.DownloadString(master_uri);
+            string json = Net.DownloadText(master_uri);
             return JsonConvert.DeserializeObject<RepositoryList>(json);
         }
 

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -170,7 +170,7 @@ namespace CKAN
             }.DownloadAndWait(downloadTargets);
         }
 
-        public static string DownloadText(Uri url)
+        public static string DownloadText(Uri url, string authToken = "")
         {
             log.DebugFormat("About to download {0}", url.OriginalString);
 
@@ -179,13 +179,13 @@ namespace CKAN
                 WebClient agent = MakeDefaultHttpClient();
 
                 // Check whether to use an auth token for this host
-                string token;
-                if (Win32Registry.TryGetAuthToken(url.Host, out token)
-                        && !string.IsNullOrEmpty(token))
+                if (!string.IsNullOrEmpty(authToken)
+                    || (Win32Registry.TryGetAuthToken(url.Host, out authToken)
+                        && !string.IsNullOrEmpty(authToken)))
                 {
                     log.InfoFormat("Using auth token for {0}", url.Host);
                     // Send our auth token to the GitHub API (or whoever else needs one)
-                    agent.Headers.Add("Authorization", $"token {token}");
+                    agent.Headers.Add("Authorization", $"token {authToken}");
                 }
 
                 return agent.DownloadString(url.OriginalString);

--- a/Core/Types/Repository.cs
+++ b/Core/Types/Repository.cs
@@ -53,7 +53,7 @@ namespace CKAN
             try
             {
                 return JsonConvert.DeserializeObject<RepositoryList>(
-                    new WebClient().DownloadString(Repository.default_repo_master_list)
+                    Net.DownloadText(Repository.default_repo_master_list)
                 );
             }
             catch

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -15,14 +15,12 @@ namespace CKAN
 
         public static RepositoryList FetchMasterRepositoryList(Uri master_uri = null)
         {
-            WebClient client = new WebClient();
-
             if (master_uri == null)
             {
                 master_uri = Repository.default_repo_master_list;
             }
 
-            string json = client.DownloadString(master_uri);
+            string json = Net.DownloadText(master_uri);
             return JsonConvert.DeserializeObject<RepositoryList>(json);
         }
 

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -78,6 +78,10 @@ namespace CKAN.NetKAN.Services
         {
             return Net.DownloadText(url);
         }
+        public string DownloadText(Uri url, string authToken)
+        {
+            return Net.DownloadText(url, authToken);
+        }
 
         public IEnumerable<Uri> RequestedURLs { get { return _requestedURLs; } }
 

--- a/Netkan/Services/IHttpService.cs
+++ b/Netkan/Services/IHttpService.cs
@@ -7,6 +7,7 @@ namespace CKAN.NetKAN.Services
     {
         string DownloadPackage(Uri url, string identifier, DateTime? updated);
         string DownloadText(Uri url);
+        string DownloadText(Uri url, string authToken);
 
         IEnumerable<Uri> RequestedURLs { get; }
     }

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -30,7 +30,7 @@ namespace CKAN.NetKAN.Transformers
                 new MetaNetkanTransformer(http),
                 new SpacedockTransformer(new SpacedockApi(http)),
                 new CurseTransformer(new CurseApi(http)),
-                new GithubTransformer(new GithubApi(githubToken), prerelease),
+                new GithubTransformer(new GithubApi(http, githubToken), prerelease),
                 new HttpTransformer(),
                 new JenkinsTransformer(http),
                 new AvcKrefTransformer(http),

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -1,5 +1,9 @@
-using CKAN.NetKAN.Sources.Github;
+using System;
+using System.IO;
 using NUnit.Framework;
+using CKAN;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Sources.Github;
 
 namespace Tests.NetKAN.Sources.Github
 {
@@ -9,14 +13,33 @@ namespace Tests.NetKAN.Sources.Github
         // Ironically, despite the fact that these run on travis-ci, which is strongly integrated
         // to github, these sometimes cause test failures because github will throw random
         // 403s. (Hence we disable them in travis with --exclude=FlakyNetwork)
-        
+
+        private string       _cachePath;
+        private NetFileCache _cache;
+
+        [OneTimeSetUp]
+        public void TestFixtureSetup()
+        {
+            _cachePath = Path.Combine(Path.GetTempPath(), "CKAN", Guid.NewGuid().ToString("N"));
+
+            Directory.CreateDirectory(_cachePath);
+
+            _cache = new NetFileCache(_cachePath);
+        }
+
+        [OneTimeTearDown]
+        public void TestFixtureTearDown()
+        {
+            Directory.Delete(_cachePath, recursive: true);
+        }
+
         [Test]
         [Category("FlakyNetwork")]
         [Category("Online")]
         public void GetsLatestReleaseCorrectly()
         {
             // Arrange
-            var sut = new GithubApi();
+            var sut = new GithubApi(new CachingHttpService(_cache));
 
             // Act
             var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test", false, false));


### PR DESCRIPTION
## Motivation

We currently have some network problems that hypothetically might be helped by transitioning from `WebClient` to some other library for network access (e.g., #2546), but currently `WebClient` code is spread through several places in the code, making it difficult to refactor cleanly.

## Changes

The Netkan source `GitHubApi` now accepts an `IHttpService` parameter as the other Netkan sources do and uses it to access the GitHub API instead of making its own `WebClient`. This allows tests of this class to "mock" network accesses (though no test does this yet).

All other places that were previously using `WebClient` directly now call one of two central access points: `Net.DownloadText` or `NetAsyncDownloader`. This will make it easier to transition all of this code to some other underlying library in the future if needed.