### PR TITLE
Handle multiple game versions from Curse

### DIFF
--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
+﻿using System.Linq;
 using System.Text.RegularExpressions;
+using log4net;
+using Newtonsoft.Json.Linq;
+using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Sources.Curse;
-using log4net;
-using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -42,8 +44,20 @@ namespace CKAN.NetKAN.Transformers
                 // Only pre-fill version info if there's none already. GH #199
                 if (json["ksp_version_min"] == null && json["ksp_version_max"] == null && json["ksp_version"] == null)
                 {
-                    Log.DebugFormat("Writing ksp_version from Curse: {0}", latestVersion.version);
-                    json["ksp_version"] = latestVersion.version.ToString();
+
+                    KspVersion minVer = latestVersion.versions.Min();
+                    KspVersion maxVer = latestVersion.versions.Max();
+                    if (minVer == maxVer)
+                    {
+                        Log.DebugFormat("Writing ksp_version from Curse: {0}", latestVersion.version);
+                        json["ksp_version"] = latestVersion.version.ToString();
+                    }
+                    else
+                    {
+                        Log.DebugFormat("Writing ksp_version_min,_max from Curse: {0}, {1}", minVer, maxVer);
+                        json["ksp_version_min"] = minVer.ToString();
+                        json["ksp_version_max"] = maxVer.ToString();
+                    }
                 }
 
                 var useDownloadNameVersion = false;


### PR DESCRIPTION
## Background

Curse lets mod authors select multiple game versions (this list appears upon hovering the "+9" with the mouse):

![image](https://user-images.githubusercontent.com/1559108/50135458-d5927180-0259-11e9-9260-faa0721bb2be.png)

This data appears in a `versions` property in the API:

https://api.cfwidget.com/project/283006

```json
"versions":["1.2","1.2.1","1.2.2","1.3","1.3.1","1.4.0","1.4.1","1.4.2","1.4.3","1.4.4"]
```

## Problem

Currently Netkan ignores those values; instead, the single game version from the `version` property in the API is used, and any broader compatibility can only be set with a `$vref` or with overrides.

I think the quirks of the selection of the value of that property somehow caused KSP-CKAN/NetKAN#6622.

## Changes

Now we parse the full game version list. This is done with by adding a new `CurseFile.versions` property and extending `JsonConvertKSPVersion` to support arrays.

If there are multiple game versions, we set `ksp_version_min` to the earliest and `ksp_version_max` to the latest. Otherwise the single game version is set to `ksp_version`, as before.

Fixes KSP-CKAN/NetKAN#6622 better than KSP-CKAN/NetKAN#6674 did (the latter can now be reverted).