### PR TITLE
Show progress bar while loading registry

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -153,7 +153,8 @@ namespace CKAN.CmdLine
                 ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, manager.Cache, user)
                 : CKAN.Repo.Update(registry_manager, ksp, user, repository);
 
-            user.RaiseMessage("Updated information on {0} available modules", updated);
+            user.RaiseMessage("Updated information on {0} available modules",
+                registry_manager.registry.Available(ksp.VersionCriteria()).Count);
         }
     }
 }

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -28,7 +28,7 @@ namespace CKAN
         /// Optionally takes a URL to the zipfile repo to download.
         /// Returns the number of unique modules updated.
         /// </summary>
-        public static int UpdateAllRepositories(RegistryManager registry_manager, KSP ksp, NetModuleCache cache, IUser user)
+        public static bool UpdateAllRepositories(RegistryManager registry_manager, KSP ksp, NetModuleCache cache, IUser user)
         {
             SortedDictionary<string, Repository> sortedRepositories = registry_manager.registry.Repositories;
             List<CkanModule> allAvail = new List<CkanModule>();
@@ -42,7 +42,7 @@ namespace CKAN
                 {
                     // Report failure if any repo fails, rather than losing half the list.
                     // UpdateRegistry will have alerted the user to specific errors already.
-                    return 0;
+                    return false;
                 }
                 else
                 {
@@ -66,13 +66,14 @@ namespace CKAN
                     HandleModuleChanges(metadataChanges, user, ksp, cache);
                 }
 
-                // Return how many we got!
-                return registry_manager.registry.Available(ksp.VersionCriteria()).Count;
+                // Registry.Available is slow, just return success,
+                // caller can check it if it's really needed
+                return true;
             }
             else
             {
                 // Return failure
-                return 0;
+                return false;
             }
         }
 
@@ -372,7 +373,7 @@ Do you wish to reinstall now?", sb)))
         /// <returns>
         /// Number of modules found in repo
         /// </returns>
-        public static int Update(RegistryManager registry_manager, KSP ksp, IUser user, string repo = null)
+        public static bool Update(RegistryManager registry_manager, KSP ksp, IUser user, string repo = null)
         {
             if (repo == null)
             {
@@ -383,7 +384,7 @@ Do you wish to reinstall now?", sb)))
         }
 
         // Same as above, just with a Uri instead of string for the repo
-        public static int Update(RegistryManager registry_manager, KSP ksp, IUser user, Uri repo = null)
+        public static bool Update(RegistryManager registry_manager, KSP ksp, IUser user, Uri repo = null)
         {
             // Use our default repo, unless we've been told otherwise.
             if (repo == null)
@@ -405,8 +406,9 @@ Do you wish to reinstall now?", sb)))
 
             ShowUserInconsistencies(registry_manager.registry, user);
 
-            // Return how many we got!
-            return registry_manager.registry.Available(ksp.VersionCriteria()).Count;
+            // Registry.Available is slow, just return success,
+            // caller can check it if it's really needed
+            return true;
         }
 
         /// <summary>

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -92,7 +92,7 @@ namespace CKAN
 
         private void PostUpdateRepo(object sender, RunWorkerCompletedEventArgs e)
         {
-            if ((e.Result as int? ?? 0) > 0)
+            if (e.Result as bool? ?? true)
             {
                 UpdateModsList(true, ChangeSet);
                 AddStatusMessage("Repositories successfully updated.");


### PR DESCRIPTION
## Problem

Refreshing the mod list in GUI involves two steps:

1. Getting the new data from the server
2. Updating the lists and filters

Step 2 can take several seconds. While it's happening, the window freezes, because the intensive processing is done on the GUI thread (whereas step 1 has a progress bar). The freeze also happens when switching instances and changing version compatibility.

## Changes

Now while the mod list is loading, the processing takes place in a background thread, and the progress bar screen is shown with messages indicating which step we're on (helpful for identifying slow pieces!):

![image](https://user-images.githubusercontent.com/1559108/50202310-95181e00-0355-11e9-808a-98eeb18e069d.png)

This keeps the UI responsive and assures the user that it hasn't crashed. When finished, the tab is hidden.

## Side performance tweak

While implementing this, I found out that the slowest step is `Registry.Available`, with a typical run time of up to a few seconds (I thought it would be loading the data from the `registry.json` file).

Unrelated to the above changes, this function was always called at the end of a repo update, but that was just to generate an `int` return value that isn't even used most of the time. So now those functions return `bool` and just return `true` instead of calling `Registry.Available`, and calling code is updated to call `Registry.Available` when it's actually needed. This should slightly speed up refreshes in GUI.