### PR TITLE
Fix System.ObjectDisposedException for TransparentTextBox

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -247,7 +247,7 @@ namespace CKAN
             if (!showConsole)
                 Util.HideConsoleWindow();
 
-            // Disable the modinfo controls until a mod has been choosen.
+            // Disable the modinfo controls until a mod has been choosen. This has an effect if the modlist is empty.
             ActiveModInfo = null;
 
             // WinForms on Mac OS X has a nasty bug where the UI thread hogs the CPU,

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -269,6 +269,13 @@ namespace CKAN
 
         private void ModList_SelectedIndexChanged(object sender, EventArgs e)
         {
+            // Skip if already disposed (i.e. after the form has been closed).
+            // Needed for TransparentTextBoxes
+            if (ModInfoTabControl.IsDisposed)
+            {
+                return;
+            }
+
             var module = GetSelectedModule();
 
             ActiveModInfo = module;


### PR DESCRIPTION
With #2610 I created a new TransparentTextBox class derived from TextBox, which allows textboxes with transparent background.
For unknown reasons, they behave different to normal textboxes when you close the GUI.
The seem to get disposed too early, because `DataGridView` wants to clear the selection before getting disposed. This triggers multiple methods one after the other, including `Main.ModList_SelectedIndexChanged()`, which finally leads to hiding the mod info tab and its included controls.
But all transparent textboxes are already disposed, so it throws the
```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'CKAN.TransparentTextBox'.
```
error.

----

Workaround:

Now I break the chain in `Main.ModList_SelectedIndexChanged()` by testing if the `ModInfoTabControl` is already disposed, and if so, do nothing more, so don't try to hide every control in the end.

HebaruSan currently tries to find the cause of the bug.

Fixes #2618 , more or less.