### PR TITLE
Fix UpdateModsList crash on Mono

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -155,7 +155,7 @@ namespace CKAN
             tabController.RenameTab("WaitTabPage", "Loading modules");
             ShowWaitDialog(false);
             tabController.SetTabLock(true);
-            SwitchEnabledState();
+            Util.Invoke(this, SwitchEnabledState);
             ClearLog();
 
             AddLogMessage("Loading registry...");
@@ -257,7 +257,7 @@ namespace CKAN
             HideWaitDialog(true);
             tabController.HideTab("WaitTabPage");
             tabController.SetTabLock(false);
-            SwitchEnabledState();
+            Util.Invoke(this, SwitchEnabledState);
         }
 
         public void MarkModForInstall(string identifier, bool uncheck = false)


### PR DESCRIPTION
## Problem

I'm getting this crash at GUI startup on Mono:

```
[xcb] Too much data requested from _XRead
[xcb] This is most likely caused by a broken X extension library
[xcb] Aborting, sorry about that.
cli: ../../src/xcb_io.c:732: _XRead: Assertion `!xcb_xlib_too_much_data_requested' failed.
Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.Windows.Forms.X11Keyboard.XCreateFontSet (intptr,string,intptr&,int&,intptr) [0x0000b] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.X11Keyboard.CreateOverTheSpotXic (intptr,intptr) [0x00023] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.X11Keyboard.CreateXic (intptr,intptr) [0x00042] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.X11Keyboard.CreateXicForWindow (intptr) [0x00000] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.X11Keyboard.FocusIn (intptr) [0x00032] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.XplatUIX11.SetFocus (intptr) [0x00054] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.XplatUI.SetFocus (intptr) [0x00000] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.Control.Select (System.Windows.Forms.Control) [0x0005d] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.Control.FocusInternal (bool) [0x0002a] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.Form.FocusInternal (bool) [0x00016] in <a78030b9a9a543b381a52822d20656d0>:0
  at System.Windows.Forms.Control.Focus () [0x00000] in <a78030b9a9a543b381a52822d20656d0>:0
  at CKAN.Main.SwitchEnabledState () [0x0003e] in <d26c8e7f3da1413293cb83e9482c631b>:0
  at CKAN.Main._UpdateModsList (bool,System.Collections.Generic.IEnumerable`1<CKAN.ModChange>) [0x005aa] in <d26c8e7f3da1413293cb83e9482c631b>:0
  at CKAN.Main/<>c__DisplayClass256_0.<UpdateModsList>b__0 () [0x0001b] in <d26c8e7f3da1413293cb83e9482c631b>:0
  at System.Threading.Tasks.Task.InnerInvoke () <0x0004e>
  at System.Threading.Tasks.Task.Execute () <0x00024>
  at System.Threading.Tasks.Task.ExecutionContextCallback (object) <0x00028>
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) <0x00171>
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task&) <0x000b2>
  at System.Threading.Tasks.Task.ExecuteEntry (bool) <0x0010f>
  at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () <0x00007>
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00074] in <7b0d87324cab49bf96eac679025e77d1>:0
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () <0x00005>
  at (wrapper runtime-invoke) <Module>.runtime_invoke_bool (object,intptr,intptr,intptr) [0x0001e] in <7b0d87324cab49bf96eac679025e77d1>:0
```

## Cause

`SwitchEnabledState` is running on the wrong thread. It needs to run on the GUI thread, but instead it's running on the background thread handling the registry load.

## Changes

Now the usual `Util.Invoke` call is used to put `SwitchEnabledState` on the GUI thread.

Fixes #2624.