### PR TITLE
Add possibility to clone KSP installs and create dummy ones

### DIFF
--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -27,6 +27,9 @@ namespace CKAN.CmdLine
             [VerbOption("default", HelpText = "Set the default KSP install")]
             public DefaultOptions DefaultOptions { get; set; }
 
+            [VerbOption("fake", HelpText = "Fake a KSP install")]
+            public CommonOptions FakeOptions { get; set; }
+
             [HelpVerbOption]
             public string GetUsage(string verb)
             {
@@ -61,6 +64,7 @@ namespace CKAN.CmdLine
 
                         // Now the commands with only --flag type options
                         case "list":
+                        case "fake":
                         default:
                             ht.AddPreOptionsLine($"Usage: ckan ksp {verb} [options]");
                             break;
@@ -151,6 +155,10 @@ namespace CKAN.CmdLine
                         case "use":
                         case "default":
                             exitCode = SetDefaultInstall((DefaultOptions)suboptions);
+                            break;
+
+                        case "fake":
+                            exitCode = FakeNewKSPInstall();
                             break;
 
                         default:
@@ -359,6 +367,36 @@ namespace CKAN.CmdLine
 
             User.RaiseMessage("Successfully set \"{0}\" as the default KSP installation", name);
             return Exit.OK;
+        }
+
+        /// <summary>
+        /// Creates a new fake KSP install after the conditions CKAN tests for valid install directories.
+        /// Used for developing and testing purposes.
+        /// </summary>
+        private int FakeNewKSPInstall ()
+        {
+            // TODO
+            // Create new folder
+            // Currently inside directory in which ckan is started, later choosable
+            // Create fake file buildID.txt
+            // Create fake file readme.txt
+
+            try
+            {
+                string folder = "_fakeKSP/";
+                System.IO.Directory.CreateDirectory(folder);
+                System.IO.Directory.CreateDirectory(folder + "GameData");
+                System.IO.File.WriteAllText(folder + "buildID.txt", "build id = 023352018.10.17");
+                System.IO.File.WriteAllText(folder + "readme.txt", "Version 1.5.1");
+
+                return Exit.OK;
+            }
+            catch (Exception e)
+            {
+                User.RaiseError(e.ToString());
+                
+                return Exit.ERROR;
+            }
         }
     }
 }

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Versioning\KspVersionCriteria.cs" />
     <Compile Include="Versioning\KspVersionRange.cs" />
     <Compile Include="Win32Registry.cs" />
+    <Compile Include="Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -198,11 +198,10 @@ namespace CKAN
         /// <param name="new_name">The name for the new instance.</param>
         /// <param name="new_path">The loaction of the new instance.</param>
         /// <param name="version">The version of the new instance. Should have a build number.</param>
-        /// <param name="DLC">Whether to fake the DLC too.</param>
-        /// <param name="dlcVersion">The version of the DLC. Can be null if DLC == false.</param>
-        public void FakeInstance(string new_name, string new_path, KspVersion version, bool DLC, string dlcVersion)
+        /// <param name="dlcVersion">The version of the DLC. Null if DLC should be faked.</param>
+        public void FakeInstance(string new_name, string new_path, KspVersion version, string dlcVersion = null)
         {
-            if (!version.IsValid())
+            if (!version.InBuildMap())
             {
                 throw new ArgumentOutOfRangeException(nameof(version), "The specified KSP version is not a valid version.");
             }
@@ -226,10 +225,11 @@ namespace CKAN
                     File.WriteAllText(Path.Combine(new_path, "buildID64.txt"), String.Format("build id = {0}", version.Build));
                 }
 
-                File.WriteAllText(Path.Combine(new_path, "readme.txt"), String.Format("Version {0}", version.ToString()));
+                // Create the readme.txt WITHOUT build number.
+                File.WriteAllText(Path.Combine(new_path, "readme.txt"), String.Format("Version {0}", new KspVersion(version.Major, version.Minor, version.Patch).ToString()));
 
                 // If a installed DLC should be simulated, we create the needed folder structure and the readme.txt
-                if (DLC && version.CompareTo(new KspVersion(1, 4, 0)) >= 0)
+                if (dlcVersion != null && version.CompareTo(new KspVersion(1, 4, 0)) >= 0)
                 {
                     Directory.CreateDirectory(Path.Combine(new_path, "GameData", "SquadExpansion", "MakingHistory"));
                     File.WriteAllText(

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -1,17 +1,28 @@
 ﻿using System;
 using System.IO;
+using System.Transactions;
 
 namespace CKAN
 {
     public static class Utilities
     {
         /// <summary>
-        /// Copies a directory and optionally its subdirectories.
+        /// Copies a directory and optionally its subdirectories as a transaction.
         /// </summary>
         /// <param name="sourceDirPath">Source directory path.</param>
         /// <param name="destDirPath">Destination directory path.</param>
         /// <param name="copySubDirs">Copy sub dirs recursively if set to <c>true</c>.</param>
         public static void CopyDirectory(string sourceDirPath, string destDirPath, bool copySubDirs)
+        {
+            using (TransactionScope transaction = CkanTransaction.CreateTransactionScope())
+            {
+                _CopyDirectory(sourceDirPath, destDirPath, copySubDirs);
+                transaction.Complete();
+            }
+        }
+
+
+        private static void _CopyDirectory(string sourceDirPath, string destDirPath, bool copySubDirs)
         {
             DirectoryInfo sourceDir = new DirectoryInfo(sourceDirPath);
 
@@ -49,7 +60,7 @@ namespace CKAN
                 foreach (DirectoryInfo subdir in dirs)
                 {
                     string temppath = Path.Combine(destDirPath, subdir.Name);
-                    CopyDirectory(subdir.FullName, temppath, copySubDirs);
+                    _CopyDirectory(subdir.FullName, temppath, copySubDirs);
                 }
             }
         }

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -6,7 +6,7 @@ namespace CKAN
     public static class Utilities
     {
         /// <summary>
-        /// Copies a directory and optionally its supdirectories.
+        /// Copies a directory and optionally its subdirectories.
         /// </summary>
         /// <param name="sourceDirPath">Source directory path.</param>
         /// <param name="destDirPath">Destination directory path.</param>
@@ -17,9 +17,9 @@ namespace CKAN
 
             if (!sourceDir.Exists)
             {
-                throw new DirectoryNotFoundException(
-                    "Source directory does not exist or could not be found: "
-                    + sourceDirPath);
+                throw new DirectoryNotFoundKraken(
+                    sourceDirPath,
+                    "Source directory does not exist or could not be found.");
             }
 
             // If the destination directory doesn't exist, create it.
@@ -27,9 +27,9 @@ namespace CKAN
             {
                 Directory.CreateDirectory(destDirPath);
             }
-            else if (Directory.GetDirectories(sourceDirPath).Length != 0 || Directory.GetFiles(sourceDirPath).Length != 0)
+            else if (Directory.GetDirectories(destDirPath).Length != 0 || Directory.GetFiles(destDirPath).Length != 0)
             {
-                throw new IOException("Directory not empty: "+ sourceDirPath);
+                throw new IOException("Directory not empty: " + destDirPath);
             }
 
             // Get the files in the directory and copy them to the new location.

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+
+namespace CKAN
+{
+    public static class Utilities
+    {
+        /// <summary>
+        /// Copies a directory and optionally its supdirectories.
+        /// </summary>
+        /// <param name="sourceDirPath">Source directory path.</param>
+        /// <param name="destDirPath">Destination directory path.</param>
+        /// <param name="copySubDirs">Copy sub dirs recursively if set to <c>true</c>.</param>
+        public static void CopyDirectory(string sourceDirPath, string destDirPath, bool copySubDirs)
+        {
+            DirectoryInfo sourceDir = new DirectoryInfo(sourceDirPath);
+
+            if (!sourceDir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + sourceDirPath);
+            }
+
+            // If the destination directory doesn't exist, create it.
+            if (!Directory.Exists(destDirPath))
+            {
+                Directory.CreateDirectory(destDirPath);
+            }
+            else if (Directory.GetDirectories(sourceDirPath).Length != 0 || Directory.GetFiles(sourceDirPath).Length != 0)
+            {
+                throw new IOException("Directory not empty: "+ sourceDirPath);
+            }
+
+            // Get the files in the directory and copy them to the new location.
+            FileInfo[] files = sourceDir.GetFiles();
+            foreach (FileInfo file in files)
+            {
+                string temppath = Path.Combine(destDirPath, file.Name);
+                file.CopyTo(temppath, false);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+            if (copySubDirs)
+            {
+                // Get the subdirectories for the specified directory.
+                DirectoryInfo[] dirs = sourceDir.GetDirectories();
+
+                foreach (DirectoryInfo subdir in dirs)
+                {
+                    string temppath = Path.Combine(destDirPath, subdir.Name);
+                    CopyDirectory(subdir.FullName, temppath, copySubDirs);
+                }
+            }
+        }
+    }
+}

--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -446,7 +446,29 @@ namespace CKAN.Versioning
         }
 
         /// <summary>
+        /// Searches the build map if it knows the version.
+        /// </summary>
+        /// <returns><c>true</c>, if version is valid, <c>false</c> otherwise.</returns>
+        public bool IsValid()
+        {
+            List<KspVersion> knownVersions = new KspBuildMap(new Win32Registry()).KnownVersions;
+
+            foreach (KspVersion ver in knownVersions)
+            {
+                if (ver.Major == Major && ver.Minor == Minor && ver.Patch == Patch)
+                {
+                    if (ver.Build == Build || !IsBuildDefined)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Returns a complete KspVersion object, including the build number.
+        /// If a version number has multiple possible builds, it takes the earliest one.
         /// </summary>
         /// <returns>The build for the version. Null if version is not known in the build map.</returns>
         public KspVersion AddBuildToVersion ()

--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -467,8 +467,8 @@ namespace CKAN.Versioning
         }
 
         /// <summary>
-        /// Returns a complete KspVersion object, including the build number.
-        /// If a version number has multiple possible builds, it takes the earliest one.
+        /// Returns a "complete" KspVersion object, including the build number.
+        /// If a version number has multiple possible builds, it takes the latest one.
         /// </summary>
         /// <returns>The build for the version. Null if version is not known in the build map.</returns>
         public KspVersion AddBuildToVersion ()
@@ -479,6 +479,7 @@ namespace CKAN.Versioning
             }
 
             List<KspVersion> knownVersions = new KspBuildMap(new Win32Registry()).KnownVersions;
+            knownVersions.Reverse();
             KspVersion version = null;
 
             foreach (KspVersion ver in knownVersions)

--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -444,6 +444,31 @@ namespace CKAN.Versioning
                 return false;
             }
         }
+
+        /// <summary>
+        /// Returns a complete KspVersion object, including the build number.
+        /// </summary>
+        /// <returns>The build for the version. Null if version is not known in the build map.</returns>
+        public KspVersion AddBuildToVersion ()
+        {
+            if (!IsPatchDefined)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            List<KspVersion> knownVersions = new KspBuildMap(new Win32Registry()).KnownVersions;
+            KspVersion version = null;
+
+            foreach (KspVersion ver in knownVersions)
+            {
+                if (ver.Major == Major && ver.Minor == Minor && ver.Patch == Patch)
+                {
+                    version = new KspVersion(ver.Major, ver.Minor, ver.Patch, ver.Build);
+                    break;
+                }
+            }
+            return version;
+        }
     }
 
     public sealed partial class KspVersion : IEquatable<KspVersion>

--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -446,10 +446,10 @@ namespace CKAN.Versioning
         }
 
         /// <summary>
-        /// Searches the build map if it knows the version.
+        /// Searches the build map if the version is a valid, known KSP version.
         /// </summary>
-        /// <returns><c>true</c>, if version is valid, <c>false</c> otherwise.</returns>
-        public bool IsValid()
+        /// <returns><c>true</c>, if version is in the build map, <c>false</c> otherwise.</returns>
+        public bool InBuildMap()
         {
             List<KspVersion> knownVersions = new KspBuildMap(new Win32Registry()).KnownVersions;
 
@@ -457,6 +457,9 @@ namespace CKAN.Versioning
             {
                 if (ver.Major == Major && ver.Minor == Minor && ver.Patch == Patch)
                 {
+                    // If it found a matching maj, min and patch,
+                    // test if the build numbers are the same too, but ignore if the
+                    // version is NOT build defined.
                     if (ver.Build == Build || !IsBuildDefined)
                     {
                         return true;
@@ -471,7 +474,7 @@ namespace CKAN.Versioning
         /// If a version number has multiple possible builds, it takes the latest one.
         /// </summary>
         /// <returns>The build for the version. Null if version is not known in the build map.</returns>
-        public KspVersion AddBuildToVersion ()
+        public KspVersion FindKnownVersion ()
         {
             if (!IsPatchDefined)
             {

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -110,6 +110,37 @@ namespace Tests.Core
         }
 
         [Test]
+        public void CloneInstance_BadInstance_ThrowsNotKSPDirKraken()
+        {
+            using (var badKSP = new DisposableKSP(String.Concat(TestData.bad_ksp_dirs().First())))
+            {
+                string tempdir = TestData.NewTempDir();
+
+                Assert.Throws<NotKSPDirKraken>(() =>
+                    manager.CloneInstance(badKSP.KSP, "badInstance", tempdir));
+
+                // Tidy up                        
+                System.IO.Directory.Delete(tempdir, true);
+            }
+        }
+
+        [Test]
+        public void CloneInstance_GoodInstance_ManagerHasValidInstance()
+        {
+            using (var KSP = new DisposableKSP())
+            {
+                string instanceName = "goodInstance";
+                string tempdir = String.Concat(TestData.NewTempDir());
+
+                manager.CloneInstance(KSP.KSP, instanceName, tempdir);
+                Assert.IsTrue(manager.HasInstance(instanceName));
+
+                // Tidy up.
+                System.IO.Directory.Delete(tempdir, true);
+            }
+        }
+
+        [Test]
         public void GetPreferredInstance_WithAutoStart_ReturnsAutoStart()
         {
             Assert.That(manager.GetPreferredInstance(),Is.EqualTo(tidy.KSP));

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -109,17 +109,37 @@ namespace Tests.Core
             }
         }
 
+        // CloneInstance
+
         [Test]
         public void CloneInstance_BadInstance_ThrowsNotKSPDirKraken()
         {
-            using (var badKSP = new DisposableKSP(String.Concat(TestData.bad_ksp_dirs().First())))
+            string badName = "badInstance";
+            string tempdir = TestData.NewTempDir();
+            CKAN.KSP badKSP = new CKAN.KSP(TestData.bad_ksp_dirs().First(), "badDir", new NullUser());
+
+            Assert.Throws<NotKSPDirKraken>(() =>
+                manager.CloneInstance(badKSP, badName, tempdir));
+            Assert.IsFalse(manager.HasInstance(badName));
+
+            // Tidy up                        
+            System.IO.Directory.Delete(tempdir, true);
+        }
+
+        [Test]
+        public void CloneInstance_ToNotEmptyFolder_ThrowsIOException()
+        {
+            using (var KSP = new DisposableKSP())
             {
+                string instanceName = "newInstance";
                 string tempdir = TestData.NewTempDir();
+                System.IO.File.Create(System.IO.Path.Combine(tempdir, "shouldntbehere.txt"));
 
-                Assert.Throws<NotKSPDirKraken>(() =>
-                    manager.CloneInstance(badKSP.KSP, "badInstance", tempdir));
+                Assert.Throws<System.IO.IOException>(() =>
+                    manager.CloneInstance(KSP.KSP, instanceName, tempdir));
+                Assert.IsFalse(manager.HasInstance(instanceName));
 
-                // Tidy up                        
+                // Tidy up.
                 System.IO.Directory.Delete(tempdir, true);
             }
         }
@@ -129,8 +149,8 @@ namespace Tests.Core
         {
             using (var KSP = new DisposableKSP())
             {
-                string instanceName = "goodInstance";
-                string tempdir = String.Concat(TestData.NewTempDir());
+                string instanceName = "newInstance";
+                string tempdir = TestData.NewTempDir();
 
                 manager.CloneInstance(KSP.KSP, instanceName, tempdir);
                 Assert.IsTrue(manager.HasInstance(instanceName));
@@ -139,6 +159,61 @@ namespace Tests.Core
                 System.IO.Directory.Delete(tempdir, true);
             }
         }
+
+        // FakeInstance
+
+        [Test]
+        public void FakeInstance_InvalidVersion_ThrowsArgumentOutOfRangeException()
+        {
+            string name = "testname";
+            string tempdir = TestData.NewTempDir();
+            CKAN.Versioning.KspVersion version = CKAN.Versioning.KspVersion.Parse("1.1.99");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                manager.FakeInstance(name, tempdir, version));
+            Assert.IsFalse(manager.HasInstance(name));
+
+            // Tidy up.
+            System.IO.Directory.Delete(tempdir, true);
+        }
+
+        [Test]
+        public void FakeInstance_InNotEmptyFolder_ThrowsBadInstallLocationKraken()
+        {
+            string name = "testname";
+            string tempdir = TestData.NewTempDir();
+            CKAN.Versioning.KspVersion version = CKAN.Versioning.KspVersion.Parse("1.5.1");
+            System.IO.File.Create(System.IO.Path.Combine(tempdir, "shouldntbehere.txt"));
+
+            Assert.Throws<BadInstallLocationKraken>(() =>
+                manager.FakeInstance(name, tempdir, version));
+            Assert.IsFalse(manager.HasInstance(name));
+
+            // Tidy up.
+            System.IO.Directory.Delete(tempdir, true);
+        }
+
+        [Test]
+        public void FakeInstance_ValidArgumentsWithDLC_ManagerHasValidInstance()
+        {
+            string name = "testname";
+            string dlcVersion = "1.1.0";
+            string tempdir = TestData.NewTempDir();
+            CKAN.Versioning.KspVersion version = CKAN.Versioning.KspVersion.Parse("1.6.0");
+
+            manager.FakeInstance(name, tempdir, version, dlcVersion);
+            CKAN.KSP newKSP = new CKAN.KSP(tempdir, name, new NullUser());
+            CKAN.DLC.MakingHistoryDlcDetector detector = new CKAN.DLC.MakingHistoryDlcDetector();
+
+            Assert.IsTrue(manager.HasInstance(name));
+            Assert.IsTrue(detector.IsInstalled(newKSP, out string _dump, out CKAN.Versioning.UnmanagedModuleVersion dlcVersionObject));
+            Assert.IsTrue(dlcVersionObject.ToString().Contains(dlcVersion));
+
+            // Tidy up.
+            System.IO.Directory.Delete(tempdir, true);
+        }
+
+        // GetPreferredInstance
 
         [Test]
         public void GetPreferredInstance_WithAutoStart_ReturnsAutoStart()

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -401,7 +401,7 @@ namespace Tests.Data
         {
             var dirs = new List<string>
             {
-                Path.Combine(DataDir(), "KSP/bad-ksp"),
+                Path.Combine(DataDir(), "KSP/bad-KSP"),
                 Path.Combine(DataDir(), "KSP/missing-gamedata")
             };
 


### PR DESCRIPTION
~As I am a responsible developer and always test my changes on multiple systems before release...~
Because I am currently out of reach of my PC (christmas, family and useless stuff like this), I tried to work on CKAN a bit from a device with no KSP install.
But CKAN is rather bitchy about having a correct KSP install, and doesn't even let you in the GUI (which is the correct behavior in my opinion).

So to solve this issue, I added the `ckan ksp fake` command to create a dummy KSP directory, containing a GamaData folder, a `buildID.txt`, a `buildID64.txt` and a `readme.txt`.

This should also be useful for quick tests of mod related issues.

---
Following options are implemented:
- [x] choose the KSP version
- [x] get the build number for the version 
- [x] and the path (currently a folder `_fakeKSP` is created inside the folder from which the command is executed)
- [x] support DLC with different versions (no validation yet)
- [x] automatically add the ksp instance to the known instances? Would make sense, I think.
- [x] add validation
- [x] more logging
- [x] add a clone method to clone an existing KSP instance
- [x] implement the clone method in the cmdline
- [x] add a buildID64
- [x] add tests

Side effects:
* New `CopyDirectory()` function to properly copy a folder with all subfolders. Implemented as a transaction.
* New `FindKnownVersion()` function to find a build number for a ksp version
* New `InBuildMap()` bool to check if a version is in the build map.

Right now the command structure is as follows:
`ckan ksp fake [commonOptions] name path version dlcVersion`
* where name is the name with which the new instance is added to the known instances
* and     path can be absolute or relative
* and     version is in the form that it can be parsed by `KspVersion.Parse()` (i.e. e.g. `1.5.1`)
* and     dlcVersion is the version for the dlc. Not being evaluated right now. To exclude the DLC, type "none".

And:
`ckan ksp clone [commonOptions] instanceNameOrPath newname newpath`
*  where instanceNameOrPath is the name of an existing instance (-> see `ckan ksp list`) or the path to it
* and name is the name for the new instance
* and path is the path for the new instance (relative or absolute)
* This command copies the FULL KSP directory, including all exes, logs, game files and whatsoever.