### PR TITLE
Dispose caches in tests

### DIFF
--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -26,6 +26,10 @@ namespace Tests.Core
         [TearDown]
         public void RemoveCache()
         {
+            cache.Dispose();
+            cache = null;
+            module_cache.Dispose();
+            module_cache = null;            
             Directory.Delete(cache_dir, true);
         }
 

--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -28,6 +28,8 @@ namespace Tests.NetKAN.Sources.Curse
         [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
+            _cache.Dispose();
+            _cache = null;
             Directory.Delete(_cachePath, recursive: true);
         }
 

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -30,6 +30,8 @@ namespace Tests.NetKAN.Sources.Github
         [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
+            _cache.Dispose();
+            _cache = null;
             Directory.Delete(_cachePath, recursive: true);
         }
 

--- a/Tests/NetKAN/Sources/Jenkins/JenkinsApiTests.cs
+++ b/Tests/NetKAN/Sources/Jenkins/JenkinsApiTests.cs
@@ -7,17 +7,17 @@ using CKAN.NetKAN.Sources.Jenkins;
 
 namespace Tests.NetKAN.Sources.Jenkins
 {
-	[TestFixture]
-	public sealed class JenkinsApiTests
-	{
-		[OneTimeSetUp]
+    [TestFixture]
+    public sealed class JenkinsApiTests
+    {
+        [OneTimeSetUp]
         public void TestFixtureSetup()
         {
             _cachePath = Path.Combine(
-				Path.GetTempPath(),
-				"CKAN",
-				Guid.NewGuid().ToString("N")
-			);
+                Path.GetTempPath(),
+                "CKAN",
+                Guid.NewGuid().ToString("N")
+            );
             Directory.CreateDirectory(_cachePath);
             _cache = new NetFileCache(_cachePath);
         }
@@ -25,30 +25,32 @@ namespace Tests.NetKAN.Sources.Jenkins
         [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
+            _cache.Dispose();
+            _cache = null;
             Directory.Delete(_cachePath, recursive: true);
         }
 
 
-		[Test]
-		[Category("FlakyNetwork")]
-		[Category("Online")]
-		public void GetLatestBuild_ModuleManager_Works()
-		{
-			// Arrange
+        [Test]
+        [Category("FlakyNetwork")]
+        [Category("Online")]
+        public void GetLatestBuild_ModuleManager_Works()
+        {
+            // Arrange
             IJenkinsApi sut = new JenkinsApi(new CachingHttpService(_cache));
 
             // Act
-			JenkinsBuild build = sut.GetLatestBuild(
-				new JenkinsRef("#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ModuleManager/"),
-				new JenkinsOptions()
-			);
+            JenkinsBuild build = sut.GetLatestBuild(
+                new JenkinsRef("#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ModuleManager/"),
+                new JenkinsOptions()
+            );
 
             // Assert
             Assert.IsNotNull(build.Url);
             Assert.IsNotNull(build.Artifacts);
-		}
+        }
 
         private string       _cachePath;
         private NetFileCache _cache;
-	}
+    }
 }

--- a/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
+++ b/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
@@ -28,6 +28,8 @@ namespace Tests.NetKAN.Sources.Spacedock
         [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
+            _cache.Dispose();
+            _cache = null;
             Directory.Delete(_cachePath, recursive: true);
         }
 


### PR DESCRIPTION
## Problem

As of recently (probably #2613), `./build test` is failing on Mono for me with this:

```
1) Failed : Tests.Core.ModuleInstaller.ModuleManagerInstancesAreDecoupled
  Expected: No Exception to be thrown
  But was:  <System.InvalidOperationException: object_op ---> System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
   --- End of inner exception stack trace ---
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.Core.ModuleInstaller+<>c__DisplayClass33_0.<ModuleManagerInstancesAreDecoupled>b__0 () [0x0002d] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at NUnit.Framework.Constraints.ThrowsConstraint+VoidInvocationDescriptor.Invoke () [0x00000] in <64cd73ddfc8a470aa513c8243b429bdb>:0 
  at NUnit.Framework.Constraints.ThrowsConstraint+ExceptionInterceptor.Intercept (System.Object invocation) [0x00047] in <64cd73ddfc8a470aa513c8243b429bdb>:0 >
  at Tests.Core.ModuleInstaller.ModuleManagerInstancesAreDecoupled () [0x00012] in <97f91e4bcf864d088cb8bdba82567a3c>:0 

2) Error : Tests.Core.ModuleInstaller.UninstallEmptyDirs
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.Core.ModuleInstaller.UninstallEmptyDirs () [0x0002b] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

3) Error : Tests.Core.ModuleInstaller.UninstallModNotFound
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.Core.ModuleInstaller.UninstallModNotFound () [0x0002c] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

4) SetUp Error : Tests.Core.ModuleInstallerDirTest
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.Core.ModuleInstallerDirTest.SetUp () [0x0000c] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

5) SetUp Error : Tests.GUI.GH1866
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.GUI.GH1866.Up () [0x0003f] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

6) Error : Tests.GUI.GUIModTests.NewGuiModsAreNotSelectedForUpgrade
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.GUI.GUIModTests.NewGuiModsAreNotSelectedForUpgrade () [0x00025] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

7) Error : Tests.GUI.MainModListTests.ConstructModList_NumberOfRows_IsEqualToNumberOfMods
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.GUI.MainModListTests.ConstructModList_NumberOfRows_IsEqualToNumberOfMods () [0x00025] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

8) Error : Tests.GUI.MainModListTests.IsVisible_WithAllAndNoNameFilter_ReturnsTrueForCompatible
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.GUI.MainModListTests.IsVisible_WithAllAndNoNameFilter_ReturnsTrueForCompatible () [0x00025] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

9) Error : Tests.GUI.MainModListTests.TooManyProvidesCallsHandlers
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetFileCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00000] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.NetModuleCache..ctor (CKAN.KSPManager mgr, System.String path) [0x00008] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.TrySetupCache (System.String path, System.String& failureReason) [0x00046] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager.LoadInstancesFromRegistry () [0x000c4] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at CKAN.KSPManager..ctor (CKAN.IUser user, CKAN.IWin32Registry win32_registry) [0x0002c] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.GUI.MainModListTests.TooManyProvidesCallsHandlers () [0x00039] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at NUnit.Framework.Internal.ExceptionHelper.Rethrow (System.Exception exception) [0x00006] in <64cd73ddfc8a470aa513c8243b429bdb>:0 
  at NUnit.Framework.Internal.AsyncInvocationRegion+AsyncTaskInvocationRegion.WaitForPendingOperationsToComplete (System.Object invocationResult) [0x00030] in <64cd73ddfc8a470aa513c8243b429bdb>:0 
  at NUnit.Framework.Internal.Commands.TestMethodCommand.RunAsyncTestMethod (NUnit.Framework.Internal.TestExecutionContext context) [0x00038] in <64cd73ddfc8a470aa513c8243b429bdb>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

10) SetUp Error : Tests.NetKAN.Sources.Curse.CurseApiTests
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.NetKAN.Sources.Curse.CurseApiTests.TestFixtureSetup () [0x00034] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

11) SetUp Error : Tests.NetKAN.Sources.Github.GithubApiTests
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.NetKAN.Sources.Github.GithubApiTests.TestFixtureSetup () [0x00034] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

12) SetUp Error : Tests.NetKAN.Sources.Jenkins.JenkinsApiTests
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.NetKAN.Sources.Jenkins.JenkinsApiTests.TestFixtureSetup () [0x00034] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 

13) SetUp Error : Tests.NetKAN.Sources.Spacedock.SpacedockApiTests
System.InvalidOperationException : object_op
  ----> System.IO.IOException : The configured user limit (128) on the number of inotify instances has been reached.
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x001a6] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.StartDispatching (System.Object handle) [0x00004] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.Start () [0x0001b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0003d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at CKAN.NetFileCache..ctor (System.String path) [0x000c3] in <cf423684ab1b4d4094879f5e6256e5e3>:0 
  at Tests.NetKAN.Sources.Spacedock.SpacedockApiTests.TestFixtureSetup () [0x00034] in <97f91e4bcf864d088cb8bdba82567a3c>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <7b0d87324cab49bf96eac679025e77d1>:0 
--IOException
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEvents () [0x0007b] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.StartRaisingEventsIfNotDisposed () [0x00019] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents (System.Boolean value) [0x0001d] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at (wrapper remoting-invoke-with-check) System.IO.CoreFX.FileSystemWatcher.set_EnableRaisingEvents(bool)
  at System.IO.CoreFXFileSystemWatcherProxy+<>c.<StartDispatching>b__9_0 (System.IO.CoreFX.FileSystemWatcher internal_fsw, System.IO.FileSystemWatcher fsw) [0x00048] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
  at System.IO.CoreFXFileSystemWatcherProxy.Operation (System.Action`4[T1,T2,T3,T4] map_op, System.Action`2[T1,T2] object_op, System.Object handle, System.Action`2[T1,T2] cancel_op) [0x00184] in <eeec8e88b1fc462e84ade7bf334d0c97>:0 
```

## Cause

All of these tests instantiate a `NetFileCache` or `NetModuleCache` member variable in a setup step, and in the teardown step they just delete the cache directory. For example:

https://github.com/KSP-CKAN/CKAN/blob/f98b9f0e89d018fd9703d6681d7b96d2d97dc8e3/Tests/NetKAN/Sources/Curse/CurseApiTests.cs#L18-L32

However, this is not enough to clean up after a cache object. `NetFileCache` inherits from `IDisposable` and uses its `Dispose` method to dispose the `FileSystemWatcher` object that is mentioned so many times in the above errors:

https://github.com/KSP-CKAN/CKAN/blob/f98b9f0e89d018fd9703d6681d7b96d2d97dc8e3/Core/Net/NetFileCache.cs#L79-L92

Apparently we finally have enough cache objects being created to run into problems with not disposing them.

## Changes

Now we dispose the cache objects we create for tests in the teardown functions. This fixes the above errors for me.