### PR TITLE
Don't override menu renderers on Windows

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -188,13 +188,16 @@ namespace CKAN
             InitializeComponent();
 
             // Replace mono's broken, ugly toolstrip renderer
-            menuStrip1.Renderer = new FlatToolStripRenderer();
-            menuStrip2.Renderer = new FlatToolStripRenderer();
-            fileToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
-            settingsToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
-            helpToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
-            FilterToolButton.DropDown.Renderer = new FlatToolStripRenderer();
-            this.minimizedContextMenuStrip.Renderer = new FlatToolStripRenderer();
+            if (Platform.IsMono)
+            {
+                menuStrip1.Renderer = new FlatToolStripRenderer();
+                menuStrip2.Renderer = new FlatToolStripRenderer();
+                fileToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
+                settingsToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
+                helpToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
+                FilterToolButton.DropDown.Renderer = new FlatToolStripRenderer();
+                this.minimizedContextMenuStrip.Renderer = new FlatToolStripRenderer();
+            }
 
             // We need to initialize the error dialog first to display errors.
             errorDialog = controlFactory.CreateControl<ErrorDialog>();

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -25,7 +25,10 @@ namespace CKAN
         public SettingsDialog()
         {
             InitializeComponent();
-            this.ClearCacheMenu.Renderer = new FlatToolStripRenderer();
+            if (Platform.IsMono)
+            {
+                this.ClearCacheMenu.Renderer = new FlatToolStripRenderer();
+            }
             winReg = new Win32Registry();
         }
 


### PR DESCRIPTION
## Problem

Since #2541, our menus have looked ugly on Windows:

![image](https://user-images.githubusercontent.com/1559108/50728146-54722000-111d-11e9-9ac4-2b755d9ed5bc.png)

## Cause

We made a custom toolbar/menu renderer to work around Mono's mishandling of dark themes, but this looks bad on Windows.

## Changes

Now we only apply that workaround on Mono, and Windows looks nicer:

![image](https://user-images.githubusercontent.com/1559108/50728159-913e1700-111d-11e9-9b4e-9ddcf3b26676.png)