### PR TITLE
Handle plus without shift in ConsoleUI

### DIFF
--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -111,12 +111,19 @@ namespace CKAN.ConsoleUI.Toolkit {
 
         /// <summary>
         /// Representation of plus key for key bindings
+        /// Both with and without Shift for those pesky Germans
         /// </summary>
-        public static readonly ConsoleKeyInfo Plus = new ConsoleKeyInfo(
-            (System.Char)'+',
-            Platform.IsWindows ? ConsoleKey.OemPlus : ConsoleKey.Add,
-            Platform.IsWindows ? true : false, false, false
-        );
+        public static readonly ConsoleKeyInfo[] Plus = new ConsoleKeyInfo[] {
+            new ConsoleKeyInfo(
+                (System.Char)'+',
+                Platform.IsWindows ? ConsoleKey.OemPlus : ConsoleKey.Add,
+                false, false, false
+            ), new ConsoleKeyInfo(
+                (System.Char)'+',
+                Platform.IsWindows ? ConsoleKey.OemPlus : ConsoleKey.Add,
+                true, false, false
+            )
+        };
 
         /// <summary>
         /// Representation of minus key for key bindings

--- a/ConsoleUI/Toolkit/ScreenObject.cs
+++ b/ConsoleUI/Toolkit/ScreenObject.cs
@@ -63,13 +63,25 @@ namespace CKAN.ConsoleUI.Toolkit {
             new Dictionary<ConsoleKeyInfo, ConsoleScreen.KeyAction>();
 
         /// <summary>
-        /// Add a custom key bindings
+        /// Add a custom key binding
         /// </summary>
         /// <param name="k">Key to bind</param>
         /// <param name="a">Action to bind to key</param>
         public void AddBinding(ConsoleKeyInfo k, ConsoleScreen.KeyAction a)
         {
             Bindings.Add(k, a);
+        }
+
+        /// <summary>
+        /// Add custom key bindings
+        /// </summary>
+        /// <param name="keys">Keys to bind</param>
+        /// <param name="a">Action to bind to key</param>
+        public void AddBinding(IEnumerable<ConsoleKeyInfo> keys, ConsoleScreen.KeyAction a)
+        {
+            foreach (ConsoleKeyInfo k in keys) {
+                AddBinding(k, a);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

Germans can't install mods in ConsoleUI, because their '+' key doesn't work.

## Cause

ConsoleUI was developed under the QWERTY keyboard layout, where '+' is typed by pressing Shift-equals, and Windows reports this with the Shift modifier (Mono reports it without the modifier, so there was already a workaround for that).

However in a QWERTZ layout, '+' is an unshifted key, so it doesn't match the `ConsoleKeyInfo` object we used for key bindings.

![qwertz](https://camo.githubusercontent.com/7acd47da8677ca24757c60e068f408452d4c068e/68747470733a2f2f75706c6f61642e77696b696d656469612e6f72672f77696b6970656469612f636f6d6d6f6e732f332f33362f4b425f4765726d616e792e737667)

## Changes

Now we represent Plus as an array of two `ConsoleKeyInfo` objects, one with Shift and one without, to cover both cases. The framework is updated to allow `IEnumerable<ConsoleKeyInfo>` to be passed to `AddBinding`, so existing usages of `Keys.Plus` will work as-is.

Fixes #2633 (the part that can be fixed).