### PR TITLE
Allow overriding menu tip in ConsoleUI

### DIFF
--- a/ConsoleUI/AuthTokenListScreen.cs
+++ b/ConsoleUI/AuthTokenListScreen.cs
@@ -15,9 +15,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         public AuthTokenScreen() : base()
         {
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => "Authentication Tokens";
-            mainMenu     = new ConsolePopupMenu(new List<ConsoleMenuOption>() {
+            mainMenu = new ConsolePopupMenu(new List<ConsoleMenuOption>() {
                 new ConsoleMenuOption("Make a GitHub API token", "",
                     "Open the web page for creating GitHub API authentication tokens",
                     true, openGitHubURL)
@@ -79,6 +77,22 @@ namespace CKAN.ConsoleUI {
                 }
                 return true;
             });
+        }
+
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Authentication Tokens";
         }
 
         private bool openGitHubURL()

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -112,9 +112,22 @@ namespace CKAN.ConsoleUI {
                 }
                 return false;
             });
+        }
 
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => "Recommendations & Suggestions";
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Recommendations & Suggestions";
         }
 
         /// <summary>

--- a/ConsoleUI/KSPListScreen.cs
+++ b/ConsoleUI/KSPListScreen.cs
@@ -130,10 +130,31 @@ namespace CKAN.ConsoleUI {
             });
 
             AddObject(kspList);
+            mainMenu = kspList.SortMenu();
+        }
 
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => "KSP Instances";
-            mainMenu     = kspList.SortMenu();
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "KSP Instances";
+        }
+
+        /// <summary>
+        /// Label the menu as Sort
+        /// </summary>
+        protected override string MenuTip()
+        {
+            return "Sort";
         }
 
         /// <summary>

--- a/ConsoleUI/KSPScreen.cs
+++ b/ConsoleUI/KSPScreen.cs
@@ -43,9 +43,22 @@ namespace CKAN.ConsoleUI {
             AddObject(name);
             AddObject(new ConsoleLabel(1, pathRow, labelWidth, () => "Path to KSP:"));
             AddObject(path);
+        }
 
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => "Edit KSP Instance";
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Edit KSP Instance";
         }
 
         /// <summary>

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -161,9 +161,30 @@ namespace CKAN.ConsoleUI {
                     mainMenu = new ConsolePopupMenu(opts);
                 }
             }
+        }
 
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => "Mod Details";
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+             return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Mod Details";
+        }
+
+        /// <summary>
+        /// Label menu as Links
+        /// </summary>
+        protected override string MenuTip()
+        {
+            return "Links";
         }
 
         private bool ViewMetadata()

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -275,9 +275,22 @@ namespace CKAN.ConsoleUI {
                     true, CaptureKey));
             }
             mainMenu = new ConsolePopupMenu(opts);
+        }
 
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => $"KSP {manager.CurrentInstance.Version()} ({manager.CurrentInstance.Name})";
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return $"KSP {manager.CurrentInstance.Version()} ({manager.CurrentInstance.Name})";
         }
 
         // Alt+H doesn't work on Mac, but F1 does, and we need

--- a/ConsoleUI/ProgressScreen.cs
+++ b/ConsoleUI/ProgressScreen.cs
@@ -14,9 +14,9 @@ namespace CKAN.ConsoleUI {
         /// <summary>
         /// Initialize the Screen
         /// </summary>
-        /// <param name="taskDescription">Description of the task being done for the header</param>
+        /// <param name="descrip">Description of the task being done for the header</param>
         /// <param name="initMsg">Starting string to put in the progress bar</param>
-        public ProgressScreen(string taskDescription, string initMsg = "")
+        public ProgressScreen(string descrip, string initMsg = "")
         {
             // A nice frame to take up some of the blank space at the top
             AddObject(new ConsoleDoubleFrame(
@@ -37,9 +37,24 @@ namespace CKAN.ConsoleUI {
             AddObject(progress);
             AddObject(messages);
 
-            topMessage   = initMsg;
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => taskDescription;
+            topMessage      = initMsg;
+            taskDescription = descrip;
+        }
+
+        /// <summary>
+        /// Put CKAN 1.25.5 in upper left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description of what we're doing in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return taskDescription;
         }
 
         // IUser stuff for managing the progress bar and message box
@@ -106,8 +121,9 @@ namespace CKAN.ConsoleUI {
         private ConsoleProgressBar progress;
         private ConsoleTextBox     messages;
 
-        private string topMessage = "";
-        private double percent    = 0;
+        private string topMessage      = "";
+        private string taskDescription = "";
+        private double percent         = 0;
     }
 
 }

--- a/ConsoleUI/RepoScreen.cs
+++ b/ConsoleUI/RepoScreen.cs
@@ -61,9 +61,22 @@ namespace CKAN.ConsoleUI {
                 }
                 mainMenu = new ConsolePopupMenu(opts);
             }
+        }
 
-            LeftHeader   = () => $"CKAN {Meta.GetVersion()}";
-            CenterHeader = () => "Edit Mod List Source";
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Edit Mod List Source";
         }
 
         /// <summary>

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -15,7 +15,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         protected ConsoleScreen()
         {
             AddTip(
-                "F10", "Menu",
+                "F10", MenuTip(),
                 () => mainMenu != null
             );
             AddBinding(Keys.F10, (object sender) => {
@@ -46,11 +46,27 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <summary>
         /// Function returning text to be shown at the left edge of the top header bar
         /// </summary>
-        protected Func<string> LeftHeader   = () => "";
+        protected virtual string LeftHeader()
+        {
+            return "";
+        }
+
         /// <summary>
         /// Function returning text to be shown in the center of the top header bar
         /// </summary>
-        protected Func<string> CenterHeader = () => "";
+        protected virtual string CenterHeader()
+        {
+            return "";
+        }
+
+        /// <summary>
+        /// Function returning text to be shown to explain the F10 menu hotkey
+        /// </summary>
+        protected virtual string MenuTip()
+        {
+            return "Menu";
+        }
+
         /// <summary>
         /// Menu to open for F10 from the hamburger icon of this screen
         /// </summary>


### PR DESCRIPTION
## Motivation

The screen tip for the main menu is always "F10 - Menu" in ConsoleUI, but sometimes a more specific string might be helpful.

## Changes

Now the "F10 - Menu" tip is changed on two screens:

- "F10 - Links" on the mod info screen
- "F10 - Sort" on the game instance list screen

As a bit of side cleanup, `ConsoleScreen.LeftHeader` and `ConsoleScreen.CenterHeader` are now changed from `Func<string>` variables to virtual string functions (to be consistent with the newly added `MenuTip`). This is a cleaner way of providing a function that can be overridden in a child class.