### PR TITLE
`ckan ksp fake/clone` fixes

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -125,6 +125,9 @@ namespace CKAN.CmdLine
                 }
             }
 
+            // Write passed message
+            RaiseMessage(message);
+
             // List options.
             for (int i = 0; i < args.Length; i++)
             {

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -203,7 +203,7 @@ namespace CKAN
         {
             if (!version.InBuildMap())
             {
-                throw new ArgumentOutOfRangeException(nameof(version), "The specified KSP version is not a known version.");
+                throw new IncorrectKSPVersionKraken(String.Format("The specified KSP version is not a known version: {0}", version.ToString()));
             }
             if (Directory.Exists(new_path) && (Directory.GetFiles(new_path).Length != 0 || Directory.GetDirectories(new_path).Length != 0))
             {

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -203,7 +203,7 @@ namespace CKAN
         {
             if (!version.InBuildMap())
             {
-                throw new ArgumentOutOfRangeException(nameof(version), "The specified KSP version is not a valid version.");
+                throw new ArgumentOutOfRangeException(nameof(version), "The specified KSP version is not a known version.");
             }
             if (Directory.Exists(new_path) && (Directory.GetFiles(new_path).Length != 0 || Directory.GetDirectories(new_path).Length != 0))
             {
@@ -217,6 +217,12 @@ namespace CKAN
                 // Create a KSP root directory, containing a GameData folder, a buildID.txt/buildID64.txt and a readme.txt
                 Directory.CreateDirectory(new_path);
                 Directory.CreateDirectory(Path.Combine(new_path, "GameData"));
+                Directory.CreateDirectory(Path.Combine(new_path, "Ships"));
+                Directory.CreateDirectory(Path.Combine(new_path, "Ships", "VAB"));
+                Directory.CreateDirectory(Path.Combine(new_path, "Ships", "SPH"));
+                Directory.CreateDirectory(Path.Combine(new_path, "Ships", "@thumbs"));
+                Directory.CreateDirectory(Path.Combine(new_path, "Ships", "@thumbs", "VAB"));
+                Directory.CreateDirectory(Path.Combine(new_path, "Ships", "@thumbs", "SPH"));
 
                 // Don't write the buildID.txts if we have no build, otherwise it would be -1.
                 if (version.IsBuildDefined)

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -494,4 +494,15 @@ namespace CKAN
         }
     }
 
+    /// <summary>
+    /// The version is either not in the build map, or incomplete or something like this.
+    /// </summary>
+    public class IncorrectKSPVersionKraken : Kraken
+    {
+        public IncorrectKSPVersionKraken(string reason = null, Exception inner_exception = null)
+            : base(reason, inner_exception)
+        {
+        }
+    }
+
 }

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -169,7 +169,7 @@ namespace Tests.Core
             string tempdir = TestData.NewTempDir();
             CKAN.Versioning.KspVersion version = CKAN.Versioning.KspVersion.Parse("1.1.99");
 
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Assert.Throws<IncorrectKSPVersionKraken>(() =>
                 manager.FakeInstance(name, tempdir, version));
             Assert.IsFalse(manager.HasInstance(name));
 


### PR DESCRIPTION
@HebaruSan discovered some issues with my new two functions. This is how they behave now: 

Both functions:
Write human-readable messages if there are too few arguments provided, no error messages due to crashes.

`ckan ksp fake`:
* Creates now all subdirs requested (see https://github.com/KSP-CKAN/CKAN/pull/2627#discussion_r244621435).
* Added `--set-default` flag to make the new instance the default afterwards.
* Also, if a user inputs a version number at least with major and minor, a selection dialog is raised to select a specific version (including build) known in the build map (else a message is raised to inform him to input a version with major and Minor at least).

This logic is now added as a new method of `Versioning.KspVersion` -> `KspVersion RaiseVersionSelectionDialog(IUser)`.
Note that, despite the IUser being passed, only the cmdline User and the consoleUI User implement a `RaiseSelectionDialog`, so it won't work in the GUI without implementing a `RaiseSelectionDialog`.
Thanks @HebaruSan for the idea. 

Fixes #2641
Fixes #2640
Fixes #2639
Fixes #2638
Fixes #2637