### PR TITLE
Derive User classes directly from IUser interface instead of the NullUser class.

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -31,6 +31,15 @@ namespace CKAN.CmdLine
         public bool Headless { get; }
 
         /// <summary>
+        /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/>
+        /// should show confirmation prompts. Depends on <see cref="T:CKAN.CmdLine.ConsoleUser.Headless"/>.
+        /// </summary>
+        public bool ConfirmPrompt
+        {
+            get { return !Headless; }
+        }
+
+        /// <summary>
         /// Ask the user for a yes or no input.
         /// </summary>
         /// <param name="question">Question.</param>

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -72,7 +72,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         protected ConsolePopupMenu mainMenu = null;
 
-        // IUser
+        #region IUser
 
         /// <summary>
         /// Tell IUser clients that we have the ability to interact with the user
@@ -207,7 +207,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="percent">Value from 0 to 100 representing task completion</param>
         protected virtual void Progress(string message, int percent) { }
 
-        // End IUser
+        #endregion IUser
 
         private void DrawSelectedHamburger()
         {

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -79,6 +79,12 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         public bool Headless { get { return false; } }
 
+        /// <summary>
+        /// Show confirmation prompts.
+        /// Atm used to ask for confirmation prior to installing mods.
+        /// </summary>
+        public bool ConfirmPrompt { get { return true; } }
+
         // These functions can be implemented the same on all screens,
         // so they are not virtual.
 

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -177,7 +177,15 @@ namespace CKAN
                 }
             }
 
-            bool ok = User.RaiseYesNoDialog("\r\nContinue?");
+            bool ok;
+            if (User.GetType().ToString() == "CKAN.GUIUser")
+            {
+                ok = true;
+            }
+            else
+            {
+                ok = User.RaiseYesNoDialog("\r\nContinue?");
+            }
 
             if (!ok)
             {
@@ -770,7 +778,15 @@ namespace CKAN
                 User.RaiseMessage(" * {0} {1}", module.Module.name, module.Module.version);
             }
 
-            bool ok = User.RaiseYesNoDialog("\r\nContinue?");
+            bool ok;
+            if (User.GetType().ToString() == "CKAN.GUIUser")
+            {
+                ok = true;
+            }
+            else
+            {
+                ok = User.RaiseYesNoDialog("\r\nContinue?");
+            }
 
             if (!ok)
             {

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -779,13 +779,13 @@ namespace CKAN
             }
 
             bool ok;
-            if (User.GetType().ToString() == "CKAN.GUIUser")
+            if (User.ConfirmPrompt)
             {
-                ok = true;
+                ok = User.RaiseYesNoDialog("\r\nContinue?");
             }
             else
             {
-                ok = User.RaiseYesNoDialog("\r\nContinue?");
+                ok = true;
             }
 
             if (!ok)

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -178,13 +178,13 @@ namespace CKAN
             }
 
             bool ok;
-            if (User.GetType().ToString() == "CKAN.GUIUser")
+            if (User.ConfirmPrompt)
             {
-                ok = true;
+                ok = User.RaiseYesNoDialog("\r\nContinue?");
             }
             else
             {
-                ok = User.RaiseYesNoDialog("\r\nContinue?");
+                ok = true;
             }
 
             if (!ok)

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -8,6 +8,7 @@ namespace CKAN
     public interface IUser
     {
         bool Headless { get; }
+        bool ConfirmPrompt { get; }
 
         bool RaiseYesNoDialog(string question);
         int  RaiseSelectionDialog(string message, params object[] args);
@@ -23,22 +24,35 @@ namespace CKAN
     /// </summary>
     public class NullUser : IUser
     {
-        public static readonly IUser User = new NullUser();
+        /// <summary>
+        /// NullUser is headless. Variable not used for NullUser.
+        /// </summary>
+        public bool Headless
+        {
+            get { return true; }
+        }
 
-        public virtual bool Headless
+        /// <summary>
+        /// Indicates if a confirmation prompt should be shown for this type of User.
+        /// NullUser returns false.
+        /// </summary>
+        /// <value><c>true</c> if confirm prompt should be shown; <c>false</c> if not.</value>
+        public bool ConfirmPrompt
         {
             get { return false; }
         }
 
-        protected virtual void DisplayMessage(string message, params object[] args)
-        {
-        }
-
+        /// <summary>
+        /// NullUser returns true.
+        /// </summary>
         public bool RaiseYesNoDialog(string question)
         {
             return true;
         }
 
+        /// <summary>
+        /// NullUser returns 0.
+        /// </summary>
         public int RaiseSelectionDialog(string message, params object[] args)
         {
             return 0;

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -1,9 +1,10 @@
-// Communicate with the user (status messages, yes/no questions, etc)
-// This class will proxy to either the GUI or cmdline functionality.
-
 namespace CKAN
 {
-
+    /// <summary>
+    /// This interface holds all methods which communicate with the user in some way.
+    /// Every CKAN interface (GUI, cmdline, consoleUI) has an implementation of the IUser interface.
+    /// The implementations define HOW we interact with the user.
+    /// </summary>
     public interface IUser
     {
         bool Headless { get; }
@@ -13,38 +14,20 @@ namespace CKAN
         void RaiseError(string message, params object[] args);
 
         void RaiseProgress(string message, int percent);
-        void RaiseMessage(string message, params object[] url);
+        void RaiseMessage(string message, params object[] args);
     }
 
-    //Can be used in tests to supress output or as a base class for other types of user.
-    //It supplies no op event handlers so that subclasses can avoid null checks.
+    /// <summary>
+    /// To be used in tests.
+    /// Supresses all output.
+    /// </summary>
     public class NullUser : IUser
     {
         public static readonly IUser User = new NullUser();
 
-        public NullUser() { }
-
         public virtual bool Headless
         {
             get { return false; }
-        }
-
-        protected virtual bool DisplayYesNoDialog(string message)
-        {
-            return true;
-        }
-
-        protected virtual int DisplaySelectionDialog(string message, params object[] args)
-        {
-            return 0;
-        }
-
-        protected virtual void DisplayError(string message, params object[] args)
-        {
-        }
-
-        protected virtual void ReportProgress(string format, int percent)
-        {
         }
 
         protected virtual void DisplayMessage(string message, params object[] args)
@@ -53,28 +36,24 @@ namespace CKAN
 
         public bool RaiseYesNoDialog(string question)
         {
-            return DisplayYesNoDialog(question);
+            return true;
         }
 
         public int RaiseSelectionDialog(string message, params object[] args)
         {
-            return DisplaySelectionDialog(message, args);
+            return 0;
         }
 
         public void RaiseError(string message, params object[] args)
         {
-            DisplayError(message, args);
         }
 
         public void RaiseProgress(string message, int percent)
         {
-            ReportProgress(message, percent);
         }
 
         public void RaiseMessage(string message, params object[] args)
         {
-            DisplayMessage(message, args);
         }
-
     }
 }

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -238,8 +238,12 @@
       <DependentUpon>YesNoDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="TransparentTextBox.cs" />
-    <Compile Include="SelectionDialog.cs" />
-    <Compile Include="SelectionDialog.Designer.cs" />
+    <Compile Include="SelectionDialog.cs">
+        <Subtype>Form</Subtype>
+    </Compile>
+    <Compile Include="SelectionDialog.Designer.cs">
+        <DependentUpon>SelectionDialog.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="AboutDialog.resx">
@@ -296,6 +300,9 @@
     <EmbeddedResource Include="YesNoDialog.resx">
       <DependentUpon>YesNoDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="SelectionDialog.resx">
+      <DependentUpon>SelectionDialog.cs</DependentUpon>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -304,7 +311,6 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-    <None Include="SelectionDialog.resx" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -238,6 +238,8 @@
       <DependentUpon>YesNoDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="TransparentTextBox.cs" />
+    <Compile Include="SelectionDialog.cs" />
+    <Compile Include="SelectionDialog.Designer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="AboutDialog.resx">
@@ -302,6 +304,7 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
+    <None Include="SelectionDialog.resx" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">

--- a/GUI/ChooseKSPInstance.cs
+++ b/GUI/ChooseKSPInstance.cs
@@ -87,7 +87,7 @@ namespace CKAN
             }
             catch (NotKSPDirKraken k)
             {
-                GUI.user.displayError("Directory {0} is not valid KSP directory.",
+                GUI.user.RaiseError("Directory {0} is not valid KSP directory.",
                     new object[] { k.path });
                 return;
             }
@@ -125,7 +125,7 @@ namespace CKAN
             }
             catch (NotKSPDirKraken k)
             {
-                GUI.user.displayError("Directory {0} is not valid KSP directory.",
+                GUI.user.RaiseError("Directory {0} is not valid KSP directory.",
                     new object[] { k.path });
             }
         }

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -16,6 +16,17 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Indicates if a confirmation prompt should be shown for this type of User.
+        /// E.g. don't ask for confirmation prior to installing mods in the GUI,
+        /// because it's already done in a different way.
+        /// </summary>
+        /// <value><c>true</c> if confirm prompt should be shown; <c>false</c> if not.</value>
+        public bool ConfirmPrompt
+        {
+            get { return false; }
+        }
+
+        /// <summary>
         /// Shows a small form with the question.
         /// User can select yes or no (ya dont say).
         /// </summary>

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -34,8 +34,7 @@ namespace CKAN
         /// <param name="args">Array of offered options.</param>
         public int RaiseSelectionDialog(string message, params object[] args)
         {
-            // TODO Implement a selection dialog for the GUI
-            throw new NotImplementedException();
+            return Main.Instance.SelectionDialog(message, args);
         }
 
         /// <summary>

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -2,43 +2,72 @@ using System;
 
 namespace CKAN
 {
-
-    public class GUIUser : NullUser
+    /// <summary>
+    /// The GUI implementation of the IUser interface.
+    /// </summary>
+    public class GUIUser : IUser
     {
-        public delegate bool DisplayYesNo(string message);
-
-        public Action<string, object[]> displayMessage;
-        public Action<string, object[]> displayError;
-        public DisplayYesNo displayYesNo;
-
-        protected override bool DisplayYesNoDialog(string message)
+        /// <summary>
+        /// A GUIUser is obviously not headless. Returns false.
+        /// </summary>
+        public bool Headless
         {
-            if (displayYesNo == null)
-                return true;
-
-            return displayYesNo(message);
+            get { return false; }
         }
 
-        protected override void DisplayMessage(string message, params object[] args)
+        /// <summary>
+        /// Shows a small form with the question.
+        /// User can select yes or no (ya dont say).
+        /// </summary>
+        /// <returns><c>true</c> if user pressed yes, <c>false</c> if no.</returns>
+        /// <param name="question">Question.</param>
+        public bool RaiseYesNoDialog (string question)
         {
-            if (displayMessage != null)
-            {
-                displayMessage(message, args);
-            }
+            return Main.Instance.YesNoDialog(question);
         }
 
-        protected override void DisplayError(string message, params object[] args)
+        /// <summary>
+        /// Will show a small form with the message and a list to choose from.
+        /// </summary>
+        /// <returns>The index of the selection in the args array. 0-based!</returns>
+        /// <param name="message">Message.</param>
+        /// <param name="args">Array of offered options.</param>
+        public int RaiseSelectionDialog(string message, params object[] args)
         {
-            if (displayError != null)
-            {
-                displayError(message, args);
-            }
+            // TODO Implement a selection dialog for the GUI
+            throw new NotImplementedException();
         }
 
-        protected override void ReportProgress(string format, int percent)
+        /// <summary>
+        /// Shows a message box containing the formatted error message.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="args">Arguments to format the message.</param>
+        public void RaiseError (string message, params object[] args)
         {
-            Main.Instance.SetDescription($"{format} - {percent}%");
+            Main.Instance.ErrorDialog(message, args);
+        }
+
+        /// <summary>
+        /// Sets the progress bars and the message box of the current WaitTabPage.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="percent">Progress in percent.</param>
+        public void RaiseProgress( string message, int percent)
+        {
+            Main.Instance.SetDescription($"{message} - {percent}%");
             Main.Instance.SetProgress(percent);
+        }
+
+        /// <summary>
+        /// Displays the formatted message in the lower StatusStrip.
+        /// Removes any newline strings.
+        /// </summary>
+        /// <param name="message">Message.</param>
+        /// <param name="args">Arguments to fromat the message.</param>
+        public void RaiseMessage (string message, params object[] args)
+        {
+            Main.Instance.AddStatusMessage(message, args);
         }
     }
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -170,10 +170,6 @@ namespace CKAN
             log.Info("Starting the GUI");
             commandLineArgs = cmdlineArgs;
 
-            // These are used by KSPManager's constructor to show messages about directory creation
-            user.displayMessage = AddStatusMessage;
-            user.displayError   = ErrorDialog;
-
             manager = mgr ?? new KSPManager(user);
             currentUser = user;
 
@@ -389,10 +385,7 @@ namespace CKAN
             installWorker.RunWorkerCompleted += PostInstallMods;
             installWorker.DoWork += InstallMods;
 
-            var old_YesNoDialog = currentUser.displayYesNo;
-            currentUser.displayYesNo = YesNoDialog;
             URLHandlers.RegisterURLHandler(configuration, currentUser);
-            currentUser.displayYesNo = old_YesNoDialog;
 
             ApplyToolButton.Enabled = false;
 

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -11,6 +11,7 @@ namespace CKAN
         private SettingsDialog settingsDialog;
         private PluginsDialog pluginsDialog;
         private YesNoDialog yesNoDialog;
+        private SelectionDialog selectionDialog;
 
         public void RecreateDialogs()
         {
@@ -18,6 +19,7 @@ namespace CKAN
             settingsDialog = controlFactory.CreateControl<SettingsDialog>();
             pluginsDialog = controlFactory.CreateControl<PluginsDialog>();
             yesNoDialog = controlFactory.CreateControl<YesNoDialog>();
+            selectionDialog = controlFactory.CreateControl<SelectionDialog>();
         }
 
         public void AddStatusMessage(string text, params object[] args)
@@ -38,6 +40,11 @@ namespace CKAN
         public bool YesNoDialog(string text)
         {
             return yesNoDialog.ShowYesNoDialog(text) == DialogResult.Yes;
+        }
+
+        public int SelectionDialog(string message, params object[] args)
+        {
+            return selectionDialog.ShowSelectionDialog(message, args);
         }
 
         // Ugly Hack. Possible fix is to alter the relationship provider so we can use a loop

--- a/GUI/MainImport.cs
+++ b/GUI/MainImport.cs
@@ -31,10 +31,7 @@ namespace CKAN
             if (dlg.ShowDialog() == DialogResult.OK
                     && dlg.FileNames.Length > 0)
             {
-
-                // Set up GUI to respond to IUser calls...
-                GUIUser.DisplayYesNo old_YesNoDialog = currentUser.displayYesNo;
-                currentUser.displayYesNo = YesNoDialog;
+                // Show WaitTabPage (status page) and lock it.
                 tabController.RenameTab("WaitTabPage", "Status log");
                 tabController.ShowTab("WaitTabPage");
                 tabController.SetTabLock(true);
@@ -50,7 +47,6 @@ namespace CKAN
                 finally
                 {
                     // Put GUI back the way we found it
-                    currentUser.displayYesNo = old_YesNoDialog;
                     tabController.SetTabLock(false);
                     tabController.HideTab("WaitTabPage");
                 }

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -26,9 +26,6 @@ namespace CKAN
 
         public void UpdateRepo()
         {
-            var old_dialog = currentUser.displayYesNo;
-            currentUser.displayYesNo = YesNoDialog;
-
             tabController.RenameTab("WaitTabPage", "Updating repositories");
 
             CurrentInstance.ScanGameData();
@@ -37,10 +34,7 @@ namespace CKAN
             {
                 m_UpdateRepoWorker.RunWorkerAsync();
             }
-            finally
-            {
-                currentUser.displayYesNo = old_dialog;
-            }
+            catch { }
 
             Util.Invoke(this, SwitchEnabledState);
 
@@ -84,8 +78,6 @@ namespace CKAN
             {
                 errorDialog.ShowErrorDialog("Failed to connect to repository. Exception: " + ex.Message);
             }
-
-            currentUser.displayYesNo = null;
         }
 
         private void PostUpdateRepo(object sender, RunWorkerCompletedEventArgs e)
@@ -112,14 +104,12 @@ namespace CKAN
         {
             if (!configuration.RefreshOnStartupNoNag)
             {
-                currentUser.displayYesNo = YesNoDialog;
                 configuration.RefreshOnStartupNoNag = true;
-                if (!currentUser.displayYesNo("Would you like CKAN to refresh the modlist every time it is loaded? (You can always manually refresh using the button up top.)"))
+                if (!currentUser.RaiseYesNoDialog("Would you like CKAN to refresh the modlist every time it is loaded? (You can always manually refresh using the button up top.)"))
                 {
                     configuration.RefreshOnStartup = false;
                 }
                 configuration.Save();
-                currentUser.displayYesNo = null;
             }
         }
 

--- a/GUI/SelectionDialog.Designer.cs
+++ b/GUI/SelectionDialog.Designer.cs
@@ -1,0 +1,129 @@
+﻿using System;
+
+namespace CKAN
+{
+    partial class SelectionDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose (bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent ()
+        {
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.MessageLabel = new System.Windows.Forms.Label();
+            this.SelectButton = new System.Windows.Forms.Button();
+            this.DefaultButton = new System.Windows.Forms.Button();
+            this.CancelButton = new System.Windows.Forms.Button();
+            this.OptionsList = new System.Windows.Forms.ListBox();
+            this.panel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.MessageLabel);
+            this.panel1.Controls.Add(this.OptionsList);
+            this.panel1.Controls.Add(this.CancelButton);
+            this.panel1.Controls.Add(this.DefaultButton);
+            this.panel1.Controls.Add(this.SelectButton);
+            this.panel1.Location = new System.Drawing.Point(10, 10);
+            this.panel1.Size = new System.Drawing.Size(400, 400);
+            this.panel1.Name = "panel1";
+            this.OptionsList.TabStop = false;
+            this.DefaultButton.UseVisualStyleBackColor = true;
+            // 
+            // MessageLabel
+            // 
+            this.MessageLabel.Location = new System.Drawing.Point(5, 5);
+            this.MessageLabel.Size = new System.Drawing.Size(390, 40);
+            this.MessageLabel.Name = "MessageLabel";
+            this.OptionsList.TabStop = false;
+            this.MessageLabel.Text = "Please select:";
+            this.MessageLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.DefaultButton.UseVisualStyleBackColor = true;
+            //
+            // OptionsList
+            //
+            this.OptionsList.Location = new System.Drawing.Point(5, 55);
+            this.OptionsList.Size = new System.Drawing.Size(390, 315);
+            this.OptionsList.SelectionMode = System.Windows.Forms.SelectionMode.One;
+            this.OptionsList.MultiColumn = false;
+            this.OptionsList.SelectedIndexChanged += new System.EventHandler(OptionsList_SelectedIndexChanged);
+            this.OptionsList.Name = "OptionsList";
+            this.DefaultButton.UseVisualStyleBackColor = true;
+            // 
+            // SelectButton
+            //
+            this.SelectButton.Location = new System.Drawing.Point(325, 375);
+            this.SelectButton.Size = new System.Drawing.Size(60, 20);
+            this.SelectButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.SelectButton.Name = "SelectButton";
+            this.SelectButton.TabIndex = 1;
+            this.SelectButton.Text = "Select";
+            this.SelectButton.UseVisualStyleBackColor = true;
+            // 
+            // DefaultButton
+            // 
+            this.DefaultButton.Location = new System.Drawing.Point(160, 375);
+            this.DefaultButton.Size = new System.Drawing.Size(60, 20);
+            this.DefaultButton.DialogResult = System.Windows.Forms.DialogResult.Yes;
+            this.DefaultButton.Name = "SelectButton";
+            this.DefaultButton.TabIndex = 0;
+            this.DefaultButton.Text = "Default";
+            this.DefaultButton.UseVisualStyleBackColor = true;
+            // 
+            // CancelButton
+            // 
+            this.CancelButton.Location = new System.Drawing.Point(5, 375);
+            this.CancelButton.Size = new System.Drawing.Size(60, 20);
+            this.CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CancelButton.Name = "CancelButton";
+            this.CancelButton.TabIndex = 2;
+            this.CancelButton.Text = "Cancel";
+            this.CancelButton.UseVisualStyleBackColor = true;
+            // 
+            // SelectionDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(420, 420);
+            this.Controls.Add(this.panel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "SelectionDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "CKAN Selection Dialog";
+            this.panel1.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Label MessageLabel;
+        private System.Windows.Forms.Button SelectButton;
+        private System.Windows.Forms.Button DefaultButton;
+        private new System.Windows.Forms.Button CancelButton;
+        private System.Windows.Forms.ListBox OptionsList;
+    }
+}

--- a/GUI/SelectionDialog.cs
+++ b/GUI/SelectionDialog.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    public partial class SelectionDialog : FormCompatibility
+    {
+        int currentSelected;
+
+        public SelectionDialog ()
+        {
+            InitializeComponent();
+            currentSelected = 0;
+        }
+
+        /// <summary>
+        /// Shows the selection dialog.
+        /// </summary>
+        /// <returns>The selected index, -1 if canceled.</returns>
+        /// <param name="message">Message.</param>
+        /// <param name="args">Array of items to select from.</param>
+        public int ShowSelectionDialog (string message, params object[] args)
+        {
+            int defaultSelection = -1;
+            int return_cancel = -1;
+
+            // Validate input.
+            if (String.IsNullOrWhiteSpace(message))
+            {
+                throw new Kraken("Passed message string must be non-empty.");
+            }
+
+            if (args.Length == 0)
+            {
+                throw new Kraken("Passed list of selection candidates must be non-empty.");
+            }
+
+            // Hide the default button unless we have a default option
+            Util.Invoke(DefaultButton, DefaultButton.Hide);
+            // Clear the item list.
+            Util.Invoke(OptionsList, OptionsList.Items.Clear);
+
+            // Check if we have a default option.
+            if (args[0] is int)
+            {
+                // Check that the default selection makes sense.
+                defaultSelection = (int)args[0];
+
+                if (defaultSelection < 0 || defaultSelection > args.Length - 1)
+                {
+                    throw new Kraken("Passed default arguments is out of range of the selection candidates.");
+                }
+
+                // Extract the relevant arguments.
+                object[] newArgs = new object[args.Length - 1];
+
+                for (int i = 1; i < args.Length; i++)
+                {
+                    newArgs[i - 1] = args[i];
+                }
+
+                args = newArgs;
+
+                // Show the defaultButton.
+                Util.Invoke(DefaultButton, DefaultButton.Show);
+            }
+
+            // Further data validation.
+            foreach (object argument in args)
+            {
+                if (String.IsNullOrWhiteSpace(argument.ToString()))
+                {
+                    throw new Kraken("Candidate may not be empty.");
+                }
+            }
+
+            // Add all items to the OptionsList.
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (defaultSelection == i)
+                {
+                    Util.Invoke(OptionsList, () => OptionsList.Items.Add(String.Concat(args[i].ToString(), "  -- Default")));
+                    
+                }
+                else
+                {
+                    Util.Invoke(OptionsList, () => OptionsList.Items.Add(args[i].ToString()));
+                }
+            }
+
+            // Write the message to the label.
+            Util.Invoke(MessageLabel, () => MessageLabel.Text = message);
+
+            // Now show the dialog and get the return values.
+            DialogResult result = ShowDialog();
+            if (result == DialogResult.Yes)
+            {
+                // If pressed Defaultbutton
+                return defaultSelection;
+            }
+            else if (result == DialogResult.Cancel)
+            {
+                // If pressed CancelButton
+                return return_cancel;
+            }
+            else
+            {
+                return currentSelected;
+            }
+        }
+
+        public void HideYesNoDialog ()
+        {
+            Util.Invoke(this, Close);
+        }
+
+        private void OptionsList_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            currentSelected = OptionsList.SelectedIndex;
+        }
+    }
+}

--- a/GUI/SelectionDialog.resx
+++ b/GUI/SelectionDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -27,6 +27,15 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/>
+        /// should show confirmation prompts. Depends on <see cref="T:CKAN.CmdLine.ConsoleUser.Headless"/>.
+        /// </summary>
+        public bool ConfirmPrompt
+        {
+            get { return !Headless; }
+        }
+
+        /// <summary>
         /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/> is headless.
         /// </summary>
         /// <value><c>true</c> if headless; otherwise, <c>false</c>.</value>

--- a/Tests/Core/KSP.cs
+++ b/Tests/Core/KSP.cs
@@ -12,13 +12,15 @@ namespace Tests.Core
     {
         private CKAN.KSP ksp;
         private string ksp_dir;
+        private IUser nullUser;
 
         [SetUp]
         public void Setup()
         {
             ksp_dir = TestData.NewTempDir();
+            nullUser = new NullUser();
             TestData.CopyDirectory(TestData.good_ksp_dir(), ksp_dir);
-            ksp = new CKAN.KSP(ksp_dir, "test", NullUser.User);
+            ksp = new CKAN.KSP(ksp_dir, "test", nullUser);
         }
 
         [TearDown]
@@ -138,7 +140,7 @@ namespace Tests.Core
             File.WriteAllText(jsonpath, compatible_ksp_versions_json);
 
             // Act
-            CKAN.KSP my_ksp = new CKAN.KSP(gamedir, "missing-ver-test", NullUser.User);
+            CKAN.KSP my_ksp = new CKAN.KSP(gamedir, "missing-ver-test", nullUser);
 
             // Assert
             Assert.IsFalse(my_ksp.Valid);
@@ -170,7 +172,7 @@ namespace Tests.Core
             // Act & Assert
             Assert.DoesNotThrow(() =>
             {
-                CKAN.KSP my_ksp = new CKAN.KSP(gamedir, "null-compat-ver-test", NullUser.User);
+                CKAN.KSP my_ksp = new CKAN.KSP(gamedir, "null-compat-ver-test", nullUser);
             });
         }
 

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -25,6 +25,8 @@ namespace Tests.Core
         private string mission_zip;
         private CkanModule mission_mod;
 
+        private IUser nullUser;
+
         [SetUp]
         public void Setup()
         {
@@ -40,6 +42,8 @@ namespace Tests.Core
 
             mission_zip = TestData.MissionZip();
             mission_mod = TestData.MissionModule();
+
+            nullUser = new NullUser();
         }
 
         [Test]
@@ -434,7 +438,7 @@ namespace Tests.Core
                 Assert.Throws<ModNotInstalledKraken>(delegate
                 {
                     // This should throw, as our tidy KSP has no mods installed.
-                    CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, NullUser.User).UninstallList("Foo");
+                    CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList("Foo");
                 });
 
                 manager.CurrentInstance = null; // I weep even more.
@@ -480,7 +484,7 @@ namespace Tests.Core
                 // Attempt to install it.
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
@@ -511,13 +515,13 @@ namespace Tests.Core
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
 
                 // Attempt to uninstall it.
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, NullUser.User).UninstallList(modules);
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules);
 
                 // Check that the module is not installed.
                 Assert.IsFalse(File.Exists(mod_file_path));
@@ -549,7 +553,7 @@ namespace Tests.Core
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
 
                 modules.Clear();
 
@@ -559,7 +563,7 @@ namespace Tests.Core
 
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
 
                 modules.Clear();
 
@@ -571,7 +575,7 @@ namespace Tests.Core
                 modules.Add(TestData.DogeCoinFlag_101_module().identifier);
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, NullUser.User).UninstallList(modules);
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules);
 
                 // Check that the directory has been deleted.
                 Assert.IsFalse(Directory.Exists(directoryPath));
@@ -607,7 +611,7 @@ namespace Tests.Core
                         // Attempt to install it.
                         List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                        CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, NullUser.User).InstallList(modules, new RelationshipResolverOptions());
+                        CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
 
                         // Check that the module is installed.
                         string mod_file_path = Path.Combine(ksp.KSP.GameData(), mod_file_name);

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -23,6 +23,7 @@ namespace Tests.Core
         private CKAN.ModuleInstaller _installer;
         private CkanModule           _testModule;
         private string               _gameDataDir;
+        private IUser                _nullUser;
 
         /// <summary>
         /// Prep environment by setting up a single mod in
@@ -33,10 +34,12 @@ namespace Tests.Core
         {
             _testModule = TestData.DogeCoinFlag_101_module();
 
-            _manager   = new KSPManager(NullUser.User);
+            _nullUser  = new NullUser();
+
+            _manager   = new KSPManager(_nullUser);
             _instance  = new DisposableKSP();
             _registry  = CKAN.RegistryManager.Instance(_instance.KSP).registry;
-            _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, NullUser.User);
+            _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _nullUser);
 
             _gameDataDir = _instance.KSP.GameData();
             _registry.AddAvailable(_testModule);

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -38,7 +38,7 @@ namespace Tests.Data
                 File.Copy(registryFile, registryPath, true);
             }
 
-            KSP = new KSP(_disposableDir, "disposable", NullUser.User);
+            KSP = new KSP(_disposableDir, "disposable", new NullUser());
             Logging.Initialize();
         }
 


### PR DESCRIPTION
Problem:
---
Our UI specific `(I)User` classes for interacting with the... user are pretty messy.
Besides to the consoleUI all of them are inheriting from `NullUser` instead of directly extending the `IUser` interface, which kinda misses the point of having an interface.
Also the `NullUser` implements a `Display...()` method for each `IUser` method _on top_ of the existing `Raise...()` methods, just to let the `Raise..()` ones call the `Display...()` ones without any reason to do so.

Solution:
---
Now all `User` classes inherit directly from `IUser`.
`NullUser` is now only used in tests. 
All `Display...()` methods are removed.
Added LOTS of code documentation, because I could have needed them...

And i implemented the selection dialog for the GUI.