### PR TITLE
Show all recommendations of metapackages in GUI

### DIFF
--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -149,7 +149,7 @@ namespace CKAN
                     opts, registry, versionCriteria
                 );
 
-                if (resolver.ModList().Count() >= toInstall.Count)
+                if (resolver.ModList().Count() >= toInstall.Count(m => !m.IsMetapackage))
                 {
                     // We can install with no further dependencies
                     string recipe = resolver.ModList()


### PR DESCRIPTION
## Problem

If you use the "Install from .ckan..." menu option in GUI, as of #2577 some modules may be missing.

## Cause

`CanInstall` decides whether a list of modules can be installed by creating a `RelationshipResolver` and checking whether its mod list has at least as many elements as it's trying to install:

https://github.com/KSP-CKAN/CKAN/blob/1bbd2fddcc9fc3663a62db90835d4d2d04ae2708/GUI/MainRecommendations.cs#L152

The list on the right includes the .ckan file itself, which has `IsMetapackage = true`.

Unfortunately `RelationshipResolver` excludes metapackages from `ModList()`, so such modules would **not** be included on the left:

https://github.com/KSP-CKAN/CKAN/blob/1bbd2fddcc9fc3663a62db90835d4d2d04ae2708/Core/Relationships/RelationshipResolver.cs#L490-L493

So `CanInstall`'s check will fail when installing a metapackage, unless it has a bunch of extra dependencies.

## Changes

Now we exclude metapackages from the right side of that comparison, and all recommendations from the .ckan file are shown in GUI.

Fixes #2652.