### PR TITLE
Don't try to update filters if mod list missing

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -99,7 +99,7 @@ namespace CKAN
 
         private void _UpdateFilters()
         {
-            if (ModList == null)
+            if (ModList == null || mainModList?.full_list_of_mod_rows == null)
                 return;
 
             // Each time a row in DataGridViewRow is changed, DataGridViewRow updates the view. Which is slow.


### PR DESCRIPTION
## Problem

Since #2617, we occasionally get exceptions at startup:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.Main._UpdateFilters()
   at CKAN.Util.Invoke[T](T obj, Action action)
   at CKAN.Main.UpdateFilters(Main control)
   at CKAN.Main.<.ctor>b__37_0(MainModList source)
   at CKAN.MainModList.set_ModFilter(GUIModFilter value)
   at CKAN.Main.Filter(GUIModFilter filter)
   at CKAN.Main.CurrentInstanceUpdated()
   at CKAN.Main.OnLoad(EventArgs e)
   at System.Windows.Forms.Form.OnCreateControl()
   at System.Windows.Forms.Control.CreateControl(Boolean fIgnoreVisible)
   at System.Windows.Forms.Control.CreateControl()
   at System.Windows.Forms.Control.WmShowWindow(Message& m)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.Form.WmShowWindow(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Cause

Now that `UpdateModsList` runs in a background thread, things that formerly happened afterwards can now run alongside it, including several places that populate the mod filters in the GUI. This calls `UpdateFilters`, which crashes here if `UpdateModsList` hasn't set `mainModList.full_list_of_mod_rows` yet:

https://github.com/KSP-CKAN/CKAN/blob/1bbd2fddcc9fc3663a62db90835d4d2d04ae2708/GUI/MainModList.cs#L109

## Changes

Now `UpdateFilters` treats the existence of `mainModList.full_list_of_mod_rows` as a prerequisite and quits if it's null.

Fixes #2650.