### PR TITLE
Set focus to mod list after loading

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -258,6 +258,7 @@ namespace CKAN
             tabController.HideTab("WaitTabPage");
             tabController.SetTabLock(false);
             Util.Invoke(this, SwitchEnabledState);
+            Util.Invoke(this, () => Main.Instance.ModList.Focus());
         }
 
         public void MarkModForInstall(string identifier, bool uncheck = false)


### PR DESCRIPTION
## Problem

On loading GUI, the focus is somewhere invisible (the splitter or the tab control, from some debugging). It should be on the mod list.

## Cause

Not clear exactly what caused this. Possibilities:

- #2617 moved the mod list loading process into a background process and switched the GUI into the progress bar screen while it runs. The extra switching between tabs may have confused WinForms.
- #2556 made the mod info sidebar show/hide when mods are focused, and also rearranged the hierarchy of controls so the main tabs are inside the splitter. Some of this happens during load, so that may also have confused WinForms.

## Changes

Now we explicitly set the focus to the mod list at the end of `UpdateModsList`, after we switch back to that tab.
(I'd like to find a more generic fix, but none of the solutions I tried worked.)

Fixes #2651.