### PR TITLE
Small text/number formatting changes to mod list

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -737,11 +737,11 @@ namespace CKAN
             if (bytes < K) {
                 return $"{bytes} B";
             } else if (bytes < K * K) {
-                return $"{bytes / K :N1} KB";
+                return $"{bytes / K :N1} KiB";
             } else if (bytes < K * K * K) {
-                return $"{bytes / K / K :N1} MB";
+                return $"{bytes / K / K :N1} MiB";
             } else {
-                return $"{bytes / K / K / K :N1} GB";
+                return $"{bytes / K / K / K :N1} GiB";
             }
         }
     }

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -612,6 +612,7 @@
             this.SizeCol.Name = "SizeCol";
             this.SizeCol.ReadOnly = true;
             this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.SizeCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             // 
             // InstallDate
             //
@@ -627,6 +628,7 @@
             this.DownloadCount.Name = "DownloadCount";
             this.DownloadCount.ReadOnly = true;
             this.DownloadCount.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.DownloadCount.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             this.DownloadCount.Width = 70;
             //
             // Description

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -810,11 +810,11 @@ namespace CKAN
                         : mod.LatestVersion)
             };
 
-            var compat        = new DataGridViewTextBoxCell() { Value = mod.KSPCompatibility };
-            var size          = new DataGridViewTextBoxCell() { Value = mod.DownloadSize     };
-            var installDate   = new DataGridViewTextBoxCell() { Value = mod.InstallDate      };
-            var downloadCount = new DataGridViewTextBoxCell() { Value = mod.DownloadCount    };
-            var desc          = new DataGridViewTextBoxCell() { Value = mod.Abstract         };
+            var downloadCount = new DataGridViewTextBoxCell() { Value = String.Format("{0:N0}", mod.DownloadCount) };
+            var compat        = new DataGridViewTextBoxCell() { Value = mod.KSPCompatibility                       };
+            var size          = new DataGridViewTextBoxCell() { Value = mod.DownloadSize                           };
+            var installDate   = new DataGridViewTextBoxCell() { Value = mod.InstallDate                            };
+            var desc          = new DataGridViewTextBoxCell() { Value = mod.Abstract                               };
 
             item.Cells.AddRange(selecting, updating, name, author, installVersion, latestVersion, compat, size, installDate, downloadCount, desc);
 


### PR DESCRIPTION
* Align the download count number to the right
* Align the size text to the right
* Format the download count number with thousands separators.
* Change size appendages to binary prefixes following [ISO/IEC 80000-13:2008](https://en.wikipedia.org/wiki/ISO/IEC_80000) and  [IEEE 1541-2002](https://en.wikipedia.org/wiki/IEEE_1541-2002) ;)