### PR TITLE
Remove ConfirmPrompt from IUser

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -31,15 +31,6 @@ namespace CKAN.CmdLine
         public bool Headless { get; }
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/>
-        /// should show confirmation prompts. Depends on <see cref="T:CKAN.CmdLine.ConsoleUser.Headless"/>.
-        /// </summary>
-        public bool ConfirmPrompt
-        {
-            get { return !Headless; }
-        }
-
-        /// <summary>
         /// Ask the user for a yes or no input.
         /// </summary>
         /// <param name="question">Question.</param>

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -79,12 +79,6 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         public bool Headless { get { return false; } }
 
-        /// <summary>
-        /// Show confirmation prompts.
-        /// Atm used to ask for confirmation prior to installing mods.
-        /// </summary>
-        public bool ConfirmPrompt { get { return true; } }
-
         // These functions can be implemented the same on all screens,
         // so they are not virtual.
 

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -147,7 +147,7 @@ namespace CKAN
         /// Propagates a FileExistsKraken if we were going to overwrite a file.
         /// Propagates a CancelledActionKraken if the user cancelled the install.
         /// </summary>
-        public void InstallList(ICollection<CkanModule> modules, RelationshipResolverOptions options, IDownloader downloader = null)
+        public void InstallList(ICollection<CkanModule> modules, RelationshipResolverOptions options, IDownloader downloader = null, bool ConfirmPrompt = true)
         {
             // TODO: Break this up into smaller pieces! It's huge!
             var resolver = new RelationshipResolver(modules, null, options, registry_manager.registry, ksp.VersionCriteria());
@@ -178,7 +178,7 @@ namespace CKAN
             }
 
             bool ok;
-            if (User.ConfirmPrompt)
+            if (ConfirmPrompt)
             {
                 ok = User.RaiseYesNoDialog("\r\nContinue?");
             }
@@ -752,7 +752,7 @@ namespace CKAN
         /// This *DOES* save the registry.
         /// Preferred over Uninstall.
         /// </summary>
-        public void UninstallList(IEnumerable<string> mods)
+        public void UninstallList(IEnumerable<string> mods, bool ConfirmPrompt = true)
         {
             // Pre-check, have they even asked for things which are installed?
 
@@ -779,7 +779,7 @@ namespace CKAN
             }
 
             bool ok;
-            if (User.ConfirmPrompt)
+            if (ConfirmPrompt)
             {
                 ok = User.RaiseYesNoDialog("\r\nContinue?");
             }

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -8,7 +8,6 @@ namespace CKAN
     public interface IUser
     {
         bool Headless { get; }
-        bool ConfirmPrompt { get; }
 
         bool RaiseYesNoDialog(string question);
         int  RaiseSelectionDialog(string message, params object[] args);
@@ -30,16 +29,6 @@ namespace CKAN
         public bool Headless
         {
             get { return true; }
-        }
-
-        /// <summary>
-        /// Indicates if a confirmation prompt should be shown for this type of User.
-        /// NullUser returns false.
-        /// </summary>
-        /// <value><c>true</c> if confirm prompt should be shown; <c>false</c> if not.</value>
-        public bool ConfirmPrompt
-        {
-            get { return false; }
         }
 
         /// <summary>

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -16,17 +16,6 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Indicates if a confirmation prompt should be shown for this type of User.
-        /// E.g. don't ask for confirmation prior to installing mods in the GUI,
-        /// because it's already done in a different way.
-        /// </summary>
-        /// <value><c>true</c> if confirm prompt should be shown; <c>false</c> if not.</value>
-        public bool ConfirmPrompt
-        {
-            get { return false; }
-        }
-
-        /// <summary>
         /// Shows a small form with the question.
         /// User can select yes or no (ya dont say).
         /// </summary>

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -162,7 +162,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.UninstallList(toUninstall);
+                            installer.UninstallList(toUninstall, false);
                             processSuccessful = true;
                         }
                     }
@@ -180,7 +180,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.InstallList(toInstall, opts.Value, downloader);
+                            installer.InstallList(toInstall, opts.Value, downloader, false);
                             processSuccessful = true;
                         }
                     }

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -27,15 +27,6 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/>
-        /// should show confirmation prompts. Depends on <see cref="T:CKAN.CmdLine.ConsoleUser.Headless"/>.
-        /// </summary>
-        public bool ConfirmPrompt
-        {
-            get { return !Headless; }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/> is headless.
         /// </summary>
         /// <value><c>true</c> if headless; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
#2648 added a `IUser.ConfirmPrompt` property. This doesn't belong there because it's just a way for two core functions to avoid raising specific yes/no prompts in GUI (which prior to #2648 was done with a hack of setting `GUIUser.displayYesNo = null`). There is no general concept of "confirm prompt" that needs to be represented at this level.

Now this is removed and replaced with parameters in `ModuleInstaller.InstallList` and `ModuleInstaller.UninstallList`, where they're actually used. GUI passes false, everyone else uses the default of true.