### PR TITLE
Support depends on any_of lists

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -338,12 +338,12 @@
                     {
                         "type": "object",
                         "properties": {
-                            "any-of": {
+                            "any_of": {
                                 "description": "List of modules that can satisfy this relationship",
                                 "$ref": "#/definitions/relationship"
                             }
                         },
-                        "required": [ "any-of" ]
+                        "required": [ "any_of" ]
                     }
                 ]
             }

--- a/CKAN.schema
+++ b/CKAN.schema
@@ -312,26 +312,40 @@
             "description" : "A relationship to a list of mods",
             "type" : "array",
             "items" : {
-                "type" : "object",
-                "properties" : {
-                    "name" : {
-                        "description" : "Identifier of the mod",
-                        "$ref"        : "#/definitions/identifier"
+                "oneOf": [
+                    {
+                        "type" : "object",
+                        "properties" : {
+                            "name" : {
+                                "description" : "Identifier of the mod",
+                                "$ref"        : "#/definitions/identifier"
+                            },
+                            "version" : {
+                                "description" : "Optional version",
+                                "$ref"        : "#/definitions/version"
+                            },
+                            "min_version" : {
+                                "description" : "Optional minimum version",
+                                "$ref"        : "#/definitions/version"
+                            },
+                            "max_version" : {
+                                "description" : "Optional maximum version",
+                                "$ref"        : "#/definitions/version"
+                            }
+                        },
+                        "required" : [ "name" ]
                     },
-                    "version" : {
-                        "description" : "Optional version",
-                        "$ref"        : "#/definitions/version"
-                    },
-                    "min_version" : {
-                        "description" : "Optional minimum version",
-                        "$ref"        : "#/definitions/version"
-                    },
-                    "max_version" : {
-                        "description" : "Optional maximum version",
-                        "$ref"        : "#/definitions/version"
+                    {
+                        "type": "object",
+                        "properties": {
+                            "any-of": {
+                                "description": "List of modules that can satisfy this relationship",
+                                "$ref": "#/definitions/relationship"
+                            }
+                        },
+                        "required": [ "any-of" ]
                     }
-                },
-                "required" : [ "name" ]
+                ]
             }
         },
         "install_to" : {

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -155,7 +155,7 @@ namespace CKAN.CmdLine
             }
 
             user.RaiseMessage("- status:\t{0}", module.release_status);
-            user.RaiseMessage("- license:\t{0}", string.Join(", ", module.license)); 
+            user.RaiseMessage("- license:\t{0}", string.Join(", ", module.license));
             #endregion
 
             #region Relationships
@@ -185,7 +185,7 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("\r\nProvides:");
                 foreach (string prov in module.ProvidesList)
                     user.RaiseMessage("- {0}", prov);
-            } 
+            }
             #endregion
 
             user.RaiseMessage("\r\nResources:");
@@ -219,12 +219,8 @@ namespace CKAN.CmdLine
         private static string RelationshipToPrintableString(RelationshipDescriptor dep)
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append(dep.name);
-            if (dep.version != null) sb.Append(", version: " + dep.version);
-            if (dep.min_version != null) sb.Append(", min: " + dep.min_version);
-            if (dep.max_version != null) sb.Append(", max: " + dep.max_version);
+            sb.Append(dep.ToString());
             return sb.ToString();
         }
     }
 }
-

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -151,11 +151,10 @@ namespace CKAN.ConsoleUI {
         {
             if (source != null) {
                 foreach (RelationshipDescriptor dependency in source) {
-                    if (!rejected.Contains(dependency.name)) {
-                        List<CkanModule> opts = registry.LatestAvailableWithProvides(
-                            dependency.name,
-                            manager.CurrentInstance.VersionCriteria(),
-                            dependency
+                    if (dependency.ContainsAny(rejected)) {
+                        List<CkanModule> opts = dependency.LatestAvailableWithProvides(
+                            registry,
+                            manager.CurrentInstance.VersionCriteria()
                         );
                         foreach (CkanModule provider in opts) {
                             if (!registry.IsInstalled(provider.identifier)

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -261,8 +261,8 @@ namespace CKAN.ConsoleUI {
                     foreach (RelationshipDescriptor rd in mod.depends) {
                         tb.AddLine(ScreenObject.FormatExactWidth(
                             // Show install status
-                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.name))
-                                + rd.name,
+                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.ToString()))
+                                + rd.ToString(),
                             nameW
                         ));
                     }
@@ -286,8 +286,8 @@ namespace CKAN.ConsoleUI {
                     foreach (RelationshipDescriptor rd in mod.conflicts) {
                         tb.AddLine(ScreenObject.FormatExactWidth(
                             // Show install status
-                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.name))
-                            + rd.name,
+                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.ToString()))
+                            + rd.ToString(),
                             nameW
                         ));
                     }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -77,7 +77,7 @@ namespace CKAN.ConsoleUI {
                                     string conflictsWith = filter.Substring(2);
                                     // Search for mods depending on a given mod
                                     foreach (var rel in m.conflicts) {
-                                        if (rel.name.IndexOf(conflictsWith, StringComparison.CurrentCultureIgnoreCase) == 0) {
+                                        if (rel.StartsWith(conflictsWith)) {
                                             return true;
                                         }
                                     }
@@ -88,7 +88,7 @@ namespace CKAN.ConsoleUI {
                                     string dependsOn = filter.Substring(2);
                                     // Search for mods depending on a given mod
                                     foreach (var rel in m.depends) {
-                                        if (rel.name.IndexOf(dependsOn, StringComparison.CurrentCultureIgnoreCase) == 0) {
+                                        if (rel.StartsWith(dependsOn)) {
                                             return true;
                                         }
                                     }

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Converters\JsonOldResourceUrlConverter.cs" />
     <Compile Include="Converters\JsonSimpleStringConverter.cs" />
     <Compile Include="Converters\JsonSingleOrArrayConverter.cs" />
+    <Compile Include="Converters\JsonRelationshipConverter.cs" />
     <Compile Include="DLC\IDlcDetector.cs" />
     <Compile Include="DLC\MakingHistoryDlcDetector.cs" />
     <Compile Include="Exporters\BbCodeExporter.cs" />

--- a/Core/Converters/JsonRelationshipConverter.cs
+++ b/Core/Converters/JsonRelationshipConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using log4net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CKAN
+{
+    public class JsonRelationshipConverter : JsonConverter
+    {
+        public override bool CanConvert(Type object_type)
+        {
+            // Only convert when we're an explicit attribute
+            return false;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JToken token = JToken.Load(reader);
+            if (token.Type == JTokenType.Array)
+            {
+                List<RelationshipDescriptor> rels = new List<RelationshipDescriptor>();
+                foreach (JObject child in token.Children<JObject>())
+                {
+                    if (child["any-of"] != null)
+                    {
+                        // Catch confused/invalid metadata
+                        if (child.Properties().Count() > 1)
+                        {
+                            throw new Kraken("`any-of` should not be combined with other properties");
+                        }
+                        rels.Add(child.ToObject<AnyOfRelationshipDescriptor>());
+                    }
+                    else if (child["name"] != null)
+                    {
+                        rels.Add(child.ToObject<ModuleRelationshipDescriptor>());
+                    }
+
+                }
+                return rels;
+            }
+            return null;
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Core/Converters/JsonRelationshipConverter.cs
+++ b/Core/Converters/JsonRelationshipConverter.cs
@@ -23,12 +23,12 @@ namespace CKAN
                 List<RelationshipDescriptor> rels = new List<RelationshipDescriptor>();
                 foreach (JObject child in token.Children<JObject>())
                 {
-                    if (child["any-of"] != null)
+                    if (child["any_of"] != null)
                     {
                         // Catch confused/invalid metadata
                         if (child.Properties().Count() > 1)
                         {
-                            throw new Kraken("`any-of` should not be combined with other properties");
+                            throw new Kraken("`any_of` should not be combined with other properties");
                         }
                         rels.Add(child.ToObject<AnyOfRelationshipDescriptor>());
                     }

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -301,61 +301,17 @@ Do you wish to reinstall now?", sb)))
                 return false;
 
             // Sort the lists so we can compare each relationship
-            var aSorted = a.OrderBy(i => i.name).ToList();
-            var bSorted = b.OrderBy(i => i.name).ToList();
+            var aSorted = a.OrderBy(i => i.ToString()).ToList();
+            var bSorted = b.OrderBy(i => i.ToString()).ToList();
 
             for (var i = 0; i < a.Count; i++)
             {
                 var aRel = aSorted[i];
                 var bRel = bSorted[i];
 
-                if (aRel.name != bRel.name)
+                if (!aRel.Same(bRel))
                 {
-                    // If corresponding relationships are the same they must not be equivalent
                     return false;
-                }
-
-                // Calculate min/max for each based on explicit min/max or the bare version
-                var aMinVersion = aRel.min_version ?? aRel.version;
-                var aMaxVersion = aRel.max_version ?? aRel.version;
-                var bMinVersion = bRel.min_version ?? bRel.version;
-                var bMaxVersion = bRel.max_version ?? bRel.version;
-
-                if (!ReferenceEquals(aMinVersion, bMinVersion))
-                {
-                    // If they're not the same object they may not be equivalent
-
-                    if (aMinVersion != null && bMinVersion != null)
-                    {
-                        if (aMinVersion.CompareTo(bMinVersion) != 0)
-                        {
-                            // If they're not equal then they must not be equivalent
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        // If one or the other is null they must not be equivalent
-                        return false;
-                    }
-                }
-
-                if (!ReferenceEquals(aMaxVersion, bMaxVersion))
-                {
-                    // If they're not the same object they may not be equivalent
-                    if (aMaxVersion != null && bMaxVersion != null)
-                    {
-                        if (aMaxVersion.CompareTo(bMaxVersion) != 0)
-                        {
-                            // If they're not equal then they must not be equivalent
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        // If one or the other is null they must not be equivalent
-                        return false;
-                    }
                 }
             }
 

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -75,55 +75,62 @@ namespace CKAN
         /// </summary>
         /// <param name="ksp_version">If not null only consider mods which match this ksp version.</param>
         /// <param name="relationship">If not null only consider mods which satisfy the RelationshipDescriptor.</param>
+        /// <param name="installed">Modules that are already installed</param>
+        /// <param name="toInstall">Modules that are planned to be installed</param>
         /// <returns></returns>
-        public CkanModule Latest(KspVersionCriteria ksp_version = null, RelationshipDescriptor relationship = null)
+        public CkanModule Latest(
+            KspVersionCriteria      ksp_version  = null,
+            RelationshipDescriptor  relationship = null,
+            IEnumerable<CkanModule> installed    = null,
+            IEnumerable<CkanModule> toInstall    = null
+        )
         {
-            var available_versions = new List<ModuleVersion>(module_version.Keys);
-            CkanModule module;
             log.DebugFormat("Our dictionary has {0} keys", module_version.Keys.Count);
-            log.DebugFormat("Choosing between {0} available versions", available_versions.Count);
-
-            // Uh oh, nothing available. Maybe this existed once, but not any longer.
-            if (available_versions.Count == 0)
+            IEnumerable<CkanModule> modules = module_version.Values;
+            if (relationship != null)
             {
-                return null;
+                modules = modules.Where(relationship.WithinBounds);
             }
-
-            // No restrictions? Great, we can just pick the latest one!
-            if (ksp_version == null && relationship == null)
+            if (ksp_version != null)
             {
-                module = module_version[available_versions.Last()];
-
-                log.DebugFormat("No KSP version restriction, {0} is most recent", module);
-                return module;
+                modules = modules.Where(m => m.IsCompatibleKSP(ksp_version));
             }
-
-            // If there's no relationship to satisfy, we can just pick the latest that is
-            // compatible with our version of KSP.
-            if (relationship == null)
+            if (installed != null)
             {
-                // Time to check if there's anything that we can satisfy.
-                var version =
-                    available_versions.LastOrDefault(v => module_version[v].IsCompatibleKSP(ksp_version));
-                if (version != null)
-                    return module_version[version];
-
-                log.DebugFormat("No version of {0} is compatible with KSP {1}",
-                    module_version[available_versions[0]].identifier, ksp_version);
-
-                return null;
+                modules = modules.Where(m => DependsAndConflictsOK(m, installed));
             }
-
-            // If we're here, then we have a relationship to satisfy, so things get more complex.
-            if (ksp_version == null)
+            if (toInstall != null)
             {
-                return module_version.Values.LastOrDefault(relationship.WithinBounds);
+                modules = modules.Where(m => DependsAndConflictsOK(m, toInstall));
             }
-            else
+            return modules.LastOrDefault();
+        }
+
+        private static bool DependsAndConflictsOK(CkanModule module, IEnumerable<CkanModule> others)
+        {
+            if (module.depends != null)
             {
-                return module_version.Values.LastOrDefault(v =>
-                    relationship.WithinBounds(v) && v.IsCompatibleKSP(ksp_version));
+                foreach (RelationshipDescriptor rel in module.depends)
+                {
+                    // If 'others' matches an identifier, it must also match the versions, else fail
+                    if (rel.ContainsAny(others.Select(m => m.identifier)) && !rel.MatchesAny(others, null, null))
+                    {
+                        return false;
+                    }
+                }
             }
+            if (module.conflicts != null)
+            {
+                foreach (RelationshipDescriptor rel in module.conflicts)
+                {
+                    // If any of the conflicts are present, fail
+                    if (rel.MatchesAny(others, null, null))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
 
         /// <summary>

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -76,7 +76,7 @@ namespace CKAN
         /// <param name="ksp_version">If not null only consider mods which match this ksp version.</param>
         /// <param name="relationship">If not null only consider mods which satisfy the RelationshipDescriptor.</param>
         /// <returns></returns>
-        public CkanModule Latest(KspVersionCriteria ksp_version = null, RelationshipDescriptor relationship=null)
+        public CkanModule Latest(KspVersionCriteria ksp_version = null, RelationshipDescriptor relationship = null)
         {
             var available_versions = new List<ModuleVersion>(module_version.Keys);
             CkanModule module;
@@ -117,15 +117,12 @@ namespace CKAN
             // If we're here, then we have a relationship to satisfy, so things get more complex.
             if (ksp_version == null)
             {
-                var version = available_versions.LastOrDefault(relationship.WithinBounds);
-                return version == null ? null : module_version[version];
+                return module_version.Values.LastOrDefault(relationship.WithinBounds);
             }
             else
             {
-                var version = available_versions.LastOrDefault(v =>
-                    relationship.WithinBounds(v) &&
-                    module_version[v].IsCompatibleKSP(ksp_version));
-                return version == null ? null : module_version[version];
+                return module_version.Values.LastOrDefault(v =>
+                    relationship.WithinBounds(v) && v.IsCompatibleKSP(ksp_version));
             }
         }
 

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -58,7 +58,12 @@ namespace CKAN
         ///     Returns an empty list if nothing is available for our system, which includes if no such module exists.
         ///     If no KSP version is provided, the latest module for *any* KSP version is given.
         /// </summary>
-        List<CkanModule> LatestAvailableWithProvides(string identifier, KspVersionCriteria ksp_version, RelationshipDescriptor relationship_descriptor = null);
+        List<CkanModule> LatestAvailableWithProvides(
+            string                  identifier,
+            KspVersionCriteria      ksp_version,
+            RelationshipDescriptor  relationship_descriptor = null,
+            IEnumerable<CkanModule> toInstall               = null
+        );
 
         /// <summary>
         ///     Checks the sanity of the registry, to ensure that all dependencies are met,

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -563,7 +563,7 @@ namespace CKAN
         public CkanModule LatestAvailable(
             string module,
             KspVersionCriteria ksp_version,
-            RelationshipDescriptor relationship_descriptor =null)
+            RelationshipDescriptor relationship_descriptor = null)
         {
             log.DebugFormat("Finding latest available for {0}", module);
 
@@ -690,15 +690,22 @@ namespace CKAN
         /// <see cref="IRegistryQuerier.LatestAvailableWithProvides" />
         /// </summary>
         public List<CkanModule> LatestAvailableWithProvides(
-            string                 module,
-            KspVersionCriteria     ksp_version,
-            RelationshipDescriptor relationship_descriptor = null)
+            string                  module,
+            KspVersionCriteria      ksp_version,
+            RelationshipDescriptor  relationship_descriptor = null,
+            IEnumerable<CkanModule> toInstall               = null)
         {
             HashSet<AvailableModule> provs;
             if (providers.TryGetValue(module, out provs))
             {
                 // For each AvailableModule, we want the latest one matching our constraints
-                return provs.Select(am => am.Latest(ksp_version, relationship_descriptor))
+                return provs
+                    .Select(am => am.Latest(
+                        ksp_version,
+                        relationship_descriptor,
+                        InstalledModules.Select(im => im.Module),
+                        toInstall
+                    ))
                     .Where(m => m?.ProvidesList?.Contains(module) ?? false)
                     .ToList();
             }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -535,14 +535,14 @@ namespace CKAN
                     try
                     {
                         if (!dependency.MatchesAny(null, InstalledDlls.ToHashSet(), InstalledDlc)
-                            && !LatestAvailableWithProvides(dependency.name, ksp_version).Any())
+                            && !dependency.LatestAvailableWithProvides(this, ksp_version).Any())
                         {
                             return false;
                         }
                     }
                     catch (KeyNotFoundException e)
                     {
-                        log.ErrorFormat("Cannot find available version with provides for {0} in registry", dependency.name);
+                        log.ErrorFormat("Cannot find available version with provides for {0} in registry", dependency.ToString());
                         throw e;
                     }
                     catch (ModuleNotFoundKraken)

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -407,7 +407,7 @@ namespace CKAN
 
                 var descriptor1 = descriptor;
                 List<CkanModule> candidates = descriptor
-                    .LatestAvailableWithProvides(registry, kspversion)
+                    .LatestAvailableWithProvides(registry, kspversion, modlist.Values)
                     .Where(mod => descriptor1.WithinBounds(mod) && MightBeInstallable(mod))
                     .ToList();
 

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -23,7 +23,7 @@ namespace CKAN
 
         public abstract bool WithinBounds(CkanModule otherModule);
 
-        public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit);
+        public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit, IEnumerable<CkanModule> toInstall = null);
 
         public abstract bool Same(RelationshipDescriptor other);
 
@@ -144,9 +144,9 @@ namespace CKAN
             return false;
         }
 
-        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit)
+        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit, IEnumerable<CkanModule> toInstall = null)
         {
-            return registry.LatestAvailableWithProvides(name, crit, this);
+            return registry.LatestAvailableWithProvides(name, crit, this, toInstall);
         }
 
         public override bool Same(RelationshipDescriptor other)
@@ -231,9 +231,9 @@ namespace CKAN
                 ?? false;
         }
 
-        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit)
+        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit, IEnumerable<CkanModule> toInstall = null)
         {
-            return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit)).ToList();
+            return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit, toInstall)).ToList();
         }
 
         public override bool Same(RelationshipDescriptor other)

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -211,7 +211,7 @@ namespace CKAN
 
     public class AnyOfRelationshipDescriptor : RelationshipDescriptor
     {
-        [JsonProperty("any-of", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("any_of", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> any_of;
 

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -6,14 +6,35 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using Autofac;
-using CKAN.Extensions;
-using CKAN.Versioning;
 using log4net;
 using Newtonsoft.Json;
+using CKAN.Extensions;
+using CKAN.Versioning;
 
 namespace CKAN
 {
-    public class RelationshipDescriptor
+    public abstract class RelationshipDescriptor
+    {
+        public abstract bool MatchesAny(
+            IEnumerable<CkanModule> modules,
+            HashSet<string> dlls,
+            IDictionary<string, UnmanagedModuleVersion> dlc
+        );
+
+        public abstract bool WithinBounds(CkanModule otherModule);
+
+        public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit);
+
+        public abstract bool Same(RelationshipDescriptor other);
+
+        public abstract bool ContainsAny(IEnumerable<string> identifiers);
+
+        public abstract bool StartsWith(string prefix);
+
+        // virtual ToString() already present in 'object'
+    }
+
+    public class ModuleRelationshipDescriptor : RelationshipDescriptor
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public ModuleVersion max_version;
@@ -23,6 +44,13 @@ namespace CKAN
         public /* required */ string name;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public ModuleVersion version;
+
+
+        public override bool WithinBounds(CkanModule otherModule)
+        {
+            return otherModule.ProvidesList.Contains(name)
+                && WithinBounds(otherModule.version);
+        }
 
         /// <summary>
         /// Returns if the other version satisfies this RelationshipDescriptor.
@@ -69,7 +97,7 @@ namespace CKAN
         /// <returns>
         /// true if any of the modules match this descriptor, false otherwise.
         /// </returns>
-        public bool MatchesAny(
+        public override bool MatchesAny(
             IEnumerable<CkanModule> modules,
             HashSet<string> dlls,
             IDictionary<string, UnmanagedModuleVersion> dlc
@@ -95,7 +123,7 @@ namespace CKAN
                 // See if the real thing is there
                 foreach (var m in modules.Where(m => m.identifier == name))
                 {
-                    if (WithinBounds(m.version))
+                    if (WithinBounds(m))
                     {
                         return true;
                     }
@@ -115,6 +143,32 @@ namespace CKAN
 
             return false;
         }
+
+        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit)
+        {
+            return registry.LatestAvailableWithProvides(name, crit, this);
+        }
+
+        public override bool Same(RelationshipDescriptor other)
+        {
+            ModuleRelationshipDescriptor modRel = other as ModuleRelationshipDescriptor;
+            return modRel != null
+                && name        == modRel.name
+                && version     == modRel.version
+                && min_version == modRel.min_version
+                && max_version == modRel.max_version;
+        }
+
+        public override bool ContainsAny(IEnumerable<string> identifiers)
+        {
+            return identifiers.Contains(name);
+        }
+
+        public override bool StartsWith(string prefix)
+        {
+            return name.IndexOf(prefix, StringComparison.CurrentCultureIgnoreCase) == 0;
+        }
+
 
         /// <summary>
         /// A user friendly message for what versions satisfies this descriptor.
@@ -153,6 +207,59 @@ namespace CKAN
                 : name;
         }
 
+    }
+
+    public class AnyOfRelationshipDescriptor : RelationshipDescriptor
+    {
+        [JsonProperty("any-of", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRelationshipConverter))]
+        public List<RelationshipDescriptor> any_of;
+
+        public override bool WithinBounds(CkanModule otherModule)
+        {
+            return any_of?.Any(r => r.WithinBounds(otherModule))
+                ?? false;
+        }
+
+        public override bool MatchesAny(
+            IEnumerable<CkanModule> modules,
+            HashSet<string> dlls,
+            IDictionary<string, UnmanagedModuleVersion> dlc
+        )
+        {
+            return any_of?.Any(r => r.MatchesAny(modules, dlls, dlc))
+                ?? false;
+        }
+
+        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit)
+        {
+            return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit)).ToList();
+        }
+
+        public override bool Same(RelationshipDescriptor other)
+        {
+            AnyOfRelationshipDescriptor anyRel = other as AnyOfRelationshipDescriptor;
+            return anyRel != null
+                && (any_of?.SequenceEqual(anyRel.any_of) ?? anyRel.any_of == null);
+        }
+
+        public override bool ContainsAny(IEnumerable<string> identifiers)
+        {
+            return any_of?.Any(r => r.ContainsAny(identifiers))
+                ?? false;
+        }
+
+        public override bool StartsWith(string prefix)
+        {
+            return any_of?.Any(r => r.StartsWith(prefix))
+                ?? false;
+        }
+
+        public override string ToString()
+        {
+            return any_of?.Select(r => r.ToString())
+                .Aggregate((a, b) => $"{a} OR {b}");
+        }
     }
 
     public class ResourcesDescriptor
@@ -246,9 +353,11 @@ namespace CKAN
         public string comment;
 
         [JsonProperty("conflicts", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> conflicts;
 
         [JsonProperty("depends", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> depends;
 
         [JsonProperty("download")]
@@ -291,6 +400,7 @@ namespace CKAN
         public List<string> provides;
 
         [JsonProperty("recommends", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> recommends;
 
         [JsonProperty("release_status", NullValueHandling = NullValueHandling.Ignore)]
@@ -300,12 +410,14 @@ namespace CKAN
         public ResourcesDescriptor resources;
 
         [JsonProperty("suggests", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> suggests;
 
         [JsonProperty("version", Required = Required.Always)]
         public ModuleVersion version;
 
         [JsonProperty("supports", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> supports;
 
         [JsonProperty("install", NullValueHandling = NullValueHandling.Ignore)]

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -69,10 +69,9 @@ namespace CKAN
                 return;
             foreach (RelationshipDescriptor rel in relations)
             {
-                List<CkanModule> providers = registry.LatestAvailableWithProvides(
-                    rel.name,
-                    CurrentInstance.VersionCriteria(),
-                    rel
+                List<CkanModule> providers = rel.LatestAvailableWithProvides(
+                    registry,
+                    CurrentInstance.VersionCriteria()
                 );
                 foreach (CkanModule provider in providers)
                 {

--- a/Spec.md
+++ b/Spec.md
@@ -454,7 +454,7 @@ to treat them as if they were absent. (**v1.8**) Clients implementing the
 present.
 
 (**v1.26**) Clients implementing version `v1.26` or later of the spec *must* support
-an alternate form of relationship consisting of an `any-of` key with a
+an alternate form of relationship consisting of an `any_of` key with a
 value containing an array of relationships. This relationship is considered
 satisfied if **any** of the specified modules are installed. It is intended for
 situations in which a module supports multiple ways of providing functionality,
@@ -462,7 +462,7 @@ which are not in themselves mutually compatible enough to use the `"provides"` p
 
     "depends": [
         {
-            "any-of": [
+            "any_of": [
                 { "name": "TextureReplacer"          },
                 { "name": "TextureReplacerReplaced"  },
                 { "name": "SigmaReplacements-Skybox" },

--- a/Spec.md
+++ b/Spec.md
@@ -453,6 +453,24 @@ to treat them as if they were absent. (**v1.8**) Clients implementing the
 `v1.8` spec and above *must* respect the optional version fields if
 present.
 
+(**v1.26**) Clients implementing version `v1.26` or later of the spec *must* support
+an alternate form of relationship consisting of an `any-of` key with a
+value containing an array of relationships. This relationship is considered
+satisfied if **any** of the specified modules are installed. It is intended for
+situations in which a module supports multiple ways of providing functionality,
+which are not in themselves mutually compatible enough to use the `"provides"` property.
+
+    "depends": [
+        {
+            "any-of": [
+                { "name": "TextureReplacer"          },
+                { "name": "TextureReplacerReplaced"  },
+                { "name": "SigmaReplacements-Skybox" },
+                { "name": "DiRT"                     }
+            ]
+        }
+    ]
+
 ##### depends
 
 A list of mods which are *required* for the current mod to operate.

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -25,6 +25,7 @@ namespace Tests.Core
         [TearDown]
         public void TearDown()
         {
+            manager.Dispose();
             tidy.Dispose();
         }
 
@@ -122,7 +123,7 @@ namespace Tests.Core
                 manager.CloneInstance(badKSP, badName, tempdir));
             Assert.IsFalse(manager.HasInstance(badName));
 
-            // Tidy up                        
+            // Tidy up
             System.IO.Directory.Delete(tempdir, true);
         }
 

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -442,6 +442,7 @@ namespace Tests.Core
                 });
 
                 manager.CurrentInstance = null; // I weep even more.
+                manager.Dispose();
             }
         }
 
@@ -488,6 +489,8 @@ namespace Tests.Core
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
+
+                manager.Dispose();
             }
         }
 
@@ -525,6 +528,8 @@ namespace Tests.Core
 
                 // Check that the module is not installed.
                 Assert.IsFalse(File.Exists(mod_file_path));
+
+                manager.Dispose();
             }
         }
 
@@ -579,6 +584,8 @@ namespace Tests.Core
 
                 // Check that the directory has been deleted.
                 Assert.IsFalse(Directory.Exists(directoryPath));
+
+                manager.Dispose();
             }
         }
 
@@ -617,6 +624,8 @@ namespace Tests.Core
                         string mod_file_path = Path.Combine(ksp.KSP.GameData(), mod_file_name);
 
                         Assert.IsTrue(File.Exists(mod_file_path));
+
+                        manager.Dispose();
                     }
                 }
             });

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -51,6 +51,12 @@ namespace Tests.Core
             );
         }
 
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            _manager.Dispose();
+        }
+
         /// <summary>
         /// Make sure that the GameData directory is not included.
         /// </summary>

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -49,6 +49,7 @@ namespace Tests.Core.Net
         public void TearDown()
         {
             Curl.CleanUp();
+            manager.Dispose();
             ksp.Dispose();
         }
 

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -47,7 +47,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule();
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier}
             });
 
             list.Add(mod_a.identifier);
@@ -79,7 +79,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule();
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, version=mod_a.version}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, version=mod_a.version}
             });
 
             list.Add(mod_a.identifier);
@@ -104,7 +104,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min)}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min)}
             });
 
             list.Add(mod_a.identifier);
@@ -129,7 +129,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, max_version=new ModuleVersion(conf_max)}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, max_version=new ModuleVersion(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -155,7 +155,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min), max_version=new ModuleVersion(conf_max)}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min), max_version=new ModuleVersion(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -180,7 +180,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, version=new ModuleVersion(conf)}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, version=new ModuleVersion(conf)}
             });
 
             list.Add(mod_a.identifier);
@@ -204,7 +204,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min)}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min)}
             });
 
             list.Add(mod_a.identifier);
@@ -228,7 +228,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, max_version=new ModuleVersion(conf_max)}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, max_version=new ModuleVersion(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -253,7 +253,7 @@ namespace Tests.Core.Relationships
             var mod_a = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min), max_version=new ModuleVersion(conf_max)}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min), max_version=new ModuleVersion(conf_max)}
             });
 
             list.Add(mod_a.identifier);
@@ -285,7 +285,7 @@ namespace Tests.Core.Relationships
             });
             var mod_d = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=mod_a.identifier}
+                new ModuleRelationshipDescriptor {name=mod_a.identifier}
             });
 
             list.Add(mod_d.identifier);
@@ -341,7 +341,7 @@ namespace Tests.Core.Relationships
             var suggested = generator.GeneratorRandomModule();
             var suggester = generator.GeneratorRandomModule(suggests: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = suggested.identifier}
+                new ModuleRelationshipDescriptor {name = suggested.identifier}
             });
 
             list.Add(suggester.identifier);
@@ -360,11 +360,11 @@ namespace Tests.Core.Relationships
             var suggested = generator.GeneratorRandomModule();
             var mod = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = suggested.identifier}
+                new ModuleRelationshipDescriptor {name = suggested.identifier}
             });
             var suggester = generator.GeneratorRandomModule(suggests: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = suggested.identifier}
+                new ModuleRelationshipDescriptor {name = suggested.identifier}
             });
 
             list.Add(suggester.identifier);
@@ -382,11 +382,11 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule();
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier}
+                new ModuleRelationshipDescriptor {name = dependant.identifier}
             });
             var conflicts_with_dependant = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name=dependant.identifier}
+                new ModuleRelationshipDescriptor {name=dependant.identifier}
             });
 
 
@@ -410,7 +410,7 @@ namespace Tests.Core.Relationships
             var suggested = generator.GeneratorRandomModule();
             var suggester = generator.GeneratorRandomModule(suggests: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = suggested.identifier}
+                new ModuleRelationshipDescriptor {name = suggested.identifier}
             });
 
             list.Add(suggester.identifier);
@@ -429,13 +429,13 @@ namespace Tests.Core.Relationships
             var suggested = generator.GeneratorRandomModule(
                 suggests: new List<RelationshipDescriptor>
                 {
-                    new RelationshipDescriptor { name = suggested2.identifier }
+                    new ModuleRelationshipDescriptor { name = suggested2.identifier }
                 }
             );
             var suggester = generator.GeneratorRandomModule(
                 suggests: new List<RelationshipDescriptor>
                 {
-                    new RelationshipDescriptor { name = suggested.identifier }
+                    new ModuleRelationshipDescriptor { name = suggested.identifier }
                 }
             );
 
@@ -462,7 +462,7 @@ namespace Tests.Core.Relationships
             });
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = mod_a.identifier}
+                new ModuleRelationshipDescriptor {name = mod_a.identifier}
             });
             list.Add(depender.identifier);
             AddToRegistry(mod_b, depender);
@@ -482,7 +482,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule();
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier}
+                new ModuleRelationshipDescriptor {name = dependant.identifier}
             });
             list.Add(depender.identifier);
             registry.AddAvailable(depender);
@@ -507,7 +507,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, version = new ModuleVersion(dep)}
+                new ModuleRelationshipDescriptor {name = dependant.identifier, version = new ModuleVersion(dep)}
             });
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant);
@@ -529,7 +529,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min)}
+                new ModuleRelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min)}
             });
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant);
@@ -558,7 +558,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, max_version = new ModuleVersion(dep_max)}
+                new ModuleRelationshipDescriptor {name = dependant.identifier, max_version = new ModuleVersion(dep_max)}
             });
             list.Add(depender.identifier);
             list.Add(dependant.identifier);
@@ -582,7 +582,7 @@ namespace Tests.Core.Relationships
             var dependant = generator.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor
+                new ModuleRelationshipDescriptor
                 {
                     name = dependant.identifier,
                     min_version = new ModuleVersion(dep_min),
@@ -613,7 +613,7 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, version = new ModuleVersion(dep)}
+                new ModuleRelationshipDescriptor {name = dependant.identifier, version = new ModuleVersion(dep)}
             });
 
             list.Add(depender.identifier);
@@ -640,7 +640,7 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min)}
+                new ModuleRelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min)}
             });
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
@@ -666,7 +666,7 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, max_version = new ModuleVersion(dep_max)}
+                new ModuleRelationshipDescriptor {name = dependant.identifier, max_version = new ModuleVersion(dep_max)}
             });
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
@@ -692,7 +692,7 @@ namespace Tests.Core.Relationships
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min), max_version = new ModuleVersion(dep_max)}
+                new ModuleRelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min), max_version = new ModuleVersion(dep_max)}
             });
             list.Add(depender.identifier);
             AddToRegistry(depender, dependant, other_dependant);
@@ -759,7 +759,7 @@ namespace Tests.Core.Relationships
             var suggested = generator.GeneratorRandomModule();
             var mod =
                 generator.GeneratorRandomModule(suggests:
-                    new List<RelationshipDescriptor> {new RelationshipDescriptor {name = suggested.identifier}});
+                    new List<RelationshipDescriptor> {new ModuleRelationshipDescriptor {name = suggested.identifier}});
             list.Add(mod.identifier);
             AddToRegistry(mod, suggested);
 
@@ -781,14 +781,14 @@ namespace Tests.Core.Relationships
             var mod = generator.GeneratorRandomModule(
                 suggests: new List<RelationshipDescriptor>
                 {
-                    new RelationshipDescriptor { name = suggested.identifier }
+                    new ModuleRelationshipDescriptor { name = suggested.identifier }
                 }
             );
             list.Add(mod.identifier);
             suggested.recommends = new List<RelationshipDescriptor>
             {
-                new RelationshipDescriptor { name = recommendedA.identifier },
-                new RelationshipDescriptor { name = recommendedB.identifier }
+                new ModuleRelationshipDescriptor { name = recommendedA.identifier },
+                new ModuleRelationshipDescriptor { name = recommendedB.identifier }
             };
 
             AddToRegistry(mod, suggested, recommendedA, recommendedB);
@@ -816,7 +816,7 @@ namespace Tests.Core.Relationships
                 registry.RegisterDll(ksp.KSP, Path.Combine(ksp.KSP.GameData(), "ModuleManager.dll"));
 
                 var depends = new List<CKAN.RelationshipDescriptor>();
-                depends.Add(new CKAN.RelationshipDescriptor { name = "ModuleManager" });
+                depends.Add(new CKAN.ModuleRelationshipDescriptor { name = "ModuleManager" });
 
                 CkanModule mod = generator.GeneratorRandomModule(depends: depends);
 

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -108,7 +108,7 @@ namespace Tests.Core.Relationships
             mods.Add(registry.LatestAvailable("CustomBiomes", null));
             Assert.Contains(
                 "CustomBiomesData",
-                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Value.name).ToList(),
+                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Value.ToString()).ToList(),
                 "Missing CustomBiomesData"
             );
 
@@ -120,7 +120,7 @@ namespace Tests.Core.Relationships
 
             Assert.Contains(
                 "CustomBiomes",
-                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Value.name).ToList(),
+                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Value.ToString()).ToList(),
                 "Missing CustomBiomes"
             );
         }
@@ -136,8 +136,8 @@ namespace Tests.Core.Relationships
             };
 
             // Make sure some of our expectations regarding dependencies are correct.
-            Assert.Contains("CustomBiomes", registry.LatestAvailable("CustomBiomesKerbal",null).depends.Select(x => x.name).ToList());
-            Assert.Contains("CustomBiomesData", registry.LatestAvailable("CustomBiomes",null).depends.Select(x => x.name).ToList());
+            Assert.Contains("CustomBiomes", registry.LatestAvailable("CustomBiomesKerbal",null).depends.Select(x => x.ToString()).ToList());
+            Assert.Contains("CustomBiomesData", registry.LatestAvailable("CustomBiomes",null).depends.Select(x => x.ToString()).ToList());
 
             // Removing DCF should only remove itself.
             var to_remove = new List<string> {"DogeCoinFlag"};

--- a/Tests/Core/Types/RelationshipDescriptor.cs
+++ b/Tests/Core/Types/RelationshipDescriptor.cs
@@ -16,7 +16,7 @@ namespace Tests.Core.Types
         [TestCase("wibble","wobble", false)]
         public void VersionWithinBounds_ExactFalse(string version, string other_version, bool expected)
         {
-            var rd = new CKAN.RelationshipDescriptor { version = new ModuleVersion(version) };
+            var rd = new CKAN.ModuleRelationshipDescriptor { version = new ModuleVersion(version) };
             Assert.AreEqual(expected, rd.WithinBounds(new ModuleVersion(other_version)));
         }
 
@@ -26,7 +26,7 @@ namespace Tests.Core.Types
         [TestCase("0.20","0.23","0.23", true)]
         public void VersionWithinBounds_MinMax(string min, string max, string compare_to, bool expected)
         {
-            var rd = new CKAN.RelationshipDescriptor
+            var rd = new CKAN.ModuleRelationshipDescriptor
             {
                 min_version = new ModuleVersion(min),
                 max_version = new ModuleVersion(max)
@@ -39,7 +39,7 @@ namespace Tests.Core.Types
         [TestCase("0.23")]
         public void VersionWithinBounds_vs_AutoDetectedMod(string version)
         {
-            var rd = new CKAN.RelationshipDescriptor { version = new ModuleVersion(version) };
+            var rd = new CKAN.ModuleRelationshipDescriptor { version = new ModuleVersion(version) };
 
             Assert.True(rd.WithinBounds(autodetected));
         }
@@ -48,12 +48,12 @@ namespace Tests.Core.Types
         [TestCase("0.20","0.23")]
         public void VersionWithinBounds_MinMax_vs_AutoDetectedMod(string min, string max)
         {
-            var rd = new CKAN.RelationshipDescriptor
+            var rd = new CKAN.ModuleRelationshipDescriptor
             {
                 min_version = new ModuleVersion(min),
                 max_version = new ModuleVersion(max)
             };
-            
+
             Assert.True(rd.WithinBounds(autodetected));
         }
 
@@ -61,7 +61,7 @@ namespace Tests.Core.Types
         [TestCase("wibble")]
         public void VersionWithinBounds_Null(string version)
         {
-            var rd = new CKAN.RelationshipDescriptor();
+            var rd = new CKAN.ModuleRelationshipDescriptor();
 
             Assert.True(rd.WithinBounds(new ModuleVersion(version)));
         }
@@ -69,9 +69,8 @@ namespace Tests.Core.Types
         [Test]
         public void VersionWithinBounds_AllNull()
         {
-            var rd = new CKAN.RelationshipDescriptor();
+            var rd = new CKAN.ModuleRelationshipDescriptor();
 
             Assert.True(rd.WithinBounds(null));        }
     }
 }
-

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -93,6 +93,7 @@ namespace Tests.GUI
         public void Down()
         {
             _instance.Dispose();
+            _manager.Dispose();
         }
 
         [Test]

--- a/Tests/GUI/GUIMod.cs
+++ b/Tests/GUI/GUIMod.cs
@@ -29,6 +29,8 @@ namespace Tests.GUI
                 registry.AddAvailable(ckan_mod);
                 var mod = new GUIMod(ckan_mod, registry, manager.CurrentInstance.VersionCriteria());
                 Assert.False(mod.IsUpgradeChecked);
+
+                manager.Dispose();
             }
         }
 

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -61,7 +61,7 @@ namespace Tests.GUI
             {
                 var registry = Registry.Empty();
                 var module = TestData.FireSpitterModule();
-                module.conflicts = new List<RelationshipDescriptor> { new RelationshipDescriptor { name = "kOS" } };
+                module.conflicts = new List<RelationshipDescriptor> { new ModuleRelationshipDescriptor { name = "kOS" } };
                 registry.AddAvailable(module);
                 registry.AddAvailable(TestData.kOS_014_module());
                 registry.RegisterModule(module, Enumerable.Empty<string>(), tidy.KSP);
@@ -97,6 +97,8 @@ namespace Tests.GUI
                 registry.AddAvailable(ckan_mod);
                 var item = new MainModList(delegate { }, null);
                 Assert.That(item.IsVisible(new GUIMod(ckan_mod, registry, manager.CurrentInstance.VersionCriteria())));
+
+                manager.Dispose();
             }
         }
 
@@ -133,6 +135,8 @@ namespace Tests.GUI
                     new GUIMod(TestData.kOS_014_module(), registry, manager.CurrentInstance.VersionCriteria())
                 });
                 Assert.That(mod_list, Has.Count.EqualTo(2));
+
+                manager.Dispose();
             }
         }
 
@@ -149,7 +153,7 @@ namespace Tests.GUI
                 var ksp_version = tidy.KSP.Version();
                 var mod = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
                 {
-                    new RelationshipDescriptor {name = provide_ident}
+                    new ModuleRelationshipDescriptor {name = provide_ident}
                 },ksp_version:ksp_version);
                 var moda = generator.GeneratorRandomModule(provides: new List<string> { provide_ident }
                 , ksp_version: ksp_version);
@@ -173,6 +177,7 @@ namespace Tests.GUI
                         new ModChange(new GUIMod(modb,registry,new KspVersionCriteria(ksp_version)),GUIModChangeType.Install, null)
                     }, mod_list);
 
+                manager.Dispose();
             }
         }
 


### PR DESCRIPTION
## Background

Sometimes a mod needs some functionality to be provided by a third party dependency, and there are several choices available, but they have different APIs, so the dependent mod has to implement support for each one separately.

For example, TextureReplacer, TextureReplacerReplaced, SigmaReplacements-SkyBox, and DiRT can all be used to replace the stock SkyBox with a custom one, but they're all mutually incompatible and so a dependent mod has to implement support for them separately one by one.

The `provides` property can't handle this (well), since there is no baseline abstract concept that they could sensibly `provide`. Consider if we had all four of the above mentioned mods `provide` something like SkyBoxReplacer; then we would not have a solution for a dependent mod that only implemented compatibility with 2 or 3 of them. We would need one `provides` tag for each possible permutation of supports that a mod could implement, which would be unworkable.

## Changes

**NOTE: This is a high risk change. Core pieces of `RelationshipResolver` are modified, which risks breaking common tasks. Please review with care!**

Now a new `any_of` format for relationships is allowed:

```json
    "depends": [
        {
            "any_of": [
                { "name": "SigmaReplacements-Heads" },
                { "name": "TextureReplacerReplaced" }
            ]
        },
        { "name": "ModuleManager" }
    ],
```

This creates a requirement that can be satisfied by any of the specified modules. If the user installs a module with the above syntax, they are prompted to choose which dependency to use:

```
$ ~/Downloads/KSP/CKAN/_build/ckan.exe install -c ScottManleyHeadPack-1.0.0.ckan 
Too many mods provide SigmaReplacements-Heads OR TextureReplacerReplaced. Please pick from the following:

1) SigmaReplacements-Heads (Sigma Replacements: Heads)
2) TextureReplacerReplaced (TextureReplacerReplaced)
Enter a number between 1 and 2 (To cancel press "c" or "n".): 
1
About to install...

 * Scott Manley Head Pack 1.0.0 (cached)
 * Sigma Replacements: Heads H_v0.2.4 (cached)

Continue? [Y/n] 


Installing mod "ScottManleyHeadPack 1.0.0"
Installing mod "SigmaReplacements-Heads H_v0.2.4"
Updating registry
Committing filesystem changes
Rescanning GameData
Done!
```

(It works in GUI too.)

The schema and spec are updated to incorporate this syntax.

`RelationshipDescriptor` is now an abstract base class (let me know if an interface would be better somehow) with two child classes, `ModuleRelationshipDescriptor` (formerly known as `RelationshipDescriptor`) and `AnyOfRelationshipDescriptor` which models the new syntax and mainly holds a `List<RelationshipDescriptor>` and multiplexes access to it.

Various tests are updated to instantiate `ModuleRelationshipDescriptor` now that `RelationshipDescriptor` is abstract.

A new `JsonRelationshipConverter` class handles parsing .ckan files, populating lists of `RelationshipDescriptor` with instances of the appropriate child classes based on the contained properties.

Parts of `RelationshipResolver` are refactored to handle the new syntax, mainly by calling virtual members of `RelationshipDescriptor`.

Fixes #2522.

## Reverse dependencies fix

Previously if you installed a mod that depended on another mod, but the latest of version of the dependency conflicts with or depends on a different version of the original mod, then you'd get an error.

Now older versions of the dependency will be checked to see whether they're compatible.

Includes tests to make sure this works.

Fixes #1693.

## Tests fix

I was still getting the error from #2628, I think because the cache objects in KSPManager weren't being disposed. Now this is added to the affected tests.