### PR TITLE
Get license from GitHub

### DIFF
--- a/Netkan/Sources/Github/GithubRepo.cs
+++ b/Netkan/Sources/Github/GithubRepo.cs
@@ -18,5 +18,14 @@ namespace CKAN.NetKAN.Sources.Github
 
         [JsonProperty("homepage")]
         public string Homepage { get; set; }
+
+        [JsonProperty("license")]
+        public GithubLicense License { get; set; }
+    }
+
+    public class GithubLicense
+    {
+        [JsonProperty("spdx_id")]
+        public string Id;
     }
 }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -66,6 +66,11 @@ namespace CKAN.NetKAN.Transformers
                 if (!string.IsNullOrWhiteSpace(ghRepo.Description))
                     json.SafeAdd("abstract", ghRepo.Description);
 
+                // GitHub says NOASSERTION if it can't figure out the repo's license
+                if (!string.IsNullOrWhiteSpace(ghRepo.License?.Id)
+                    && ghRepo.License.Id != "NOASSERTION")
+                    json.SafeAdd("license", ghRepo.License.Id);
+
                 if (!string.IsNullOrWhiteSpace(ghRepo.Homepage))
                     resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
 

--- a/Spec.md
+++ b/Spec.md
@@ -648,6 +648,7 @@ For example: `#/ckan/github/pjf/DogeCoinFlag`.
 When used, the following fields will be auto-filled if not already present:
 
 - `name`
+- `license`
 - `abstract`
 - `author`
 - `version`


### PR DESCRIPTION
## Motivation

The GitHub API provides license data:

https://api.github.com/repos/Starstrider42/Custom-Asteroids-Extras

```json
  "license": {
    "key": "mit",
    "name": "MIT License",
    "spdx_id": "MIT",
    "url": "https://api.github.com/licenses/mit",
    "node_id": "MDc6TGljZW5zZTEz"
  },
```

But currently Netkan doesn't use this info.
We do use API license data from Curse and SpaceDock.

## Changes

Now Netkan sets the API's `license.spdx_id` value to the module's `license` property.

Fixes #2662.