### PR TITLE
Handle manually installed mods in ConsoleUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,7 +519,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [GUI] The CKAN Identifer for each mod is now shown in their metadata panel. (plague006, #1476)
+- [GUI] The CKAN Identifier for each mod is now shown in their metadata panel. (plague006, #1476)
 - [GUI] Double-clicking on a filename in the 'Contents' panel now opens the directory containing that file. (Postremus, #1443)
 - [GUI] The progress bar now shows the progress of downloading to the cache. (Postremus, #1445)
 - [GUI] Mods can now be searched by their CKAN identifier in the name textbox (Postremus, #1475)

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -297,9 +297,10 @@ namespace CKAN.ConsoleUI {
             return top - 1;
         }
 
-        private DateTime InstalledOn(string identifier)
+        private DateTime? InstalledOn(string identifier)
         {
-            return registry.InstalledModule(identifier).InstallTime;
+            // This can be null for manually installed mods
+            return registry.InstalledModule(identifier)?.InstallTime;
         }
 
         private int addVersionDisplay()
@@ -323,13 +324,13 @@ namespace CKAN.ConsoleUI {
 
                 if (installed) {
 
-                    DateTime instTime = InstalledOn(mod.identifier);
+                    DateTime? instTime = InstalledOn(mod.identifier);
 
                     if (latestIsInstalled) {
 
                         addVersionBox(
                             boxLeft, boxTop, boxRight, boxTop + boxH - 1,
-                            () => $"Latest/Installed {instTime.ToString("d")}",
+                            () => $"Latest/Installed {instTime?.ToString("d") ?? "manually"}",
                             () => ConsoleTheme.Current.ActiveFrameFg,
                             true,
                             new List<CkanModule>() {inst}
@@ -349,7 +350,7 @@ namespace CKAN.ConsoleUI {
 
                         addVersionBox(
                             boxLeft, boxTop, boxRight, boxTop + boxH - 1,
-                            () => $"Installed {instTime.ToString("d")}",
+                            () => $"Installed {instTime?.ToString("d") ?? "manually"}",
                             () => ConsoleTheme.Current.ActiveFrameFg,
                             true,
                             new List<CkanModule>() {inst}
@@ -385,12 +386,12 @@ namespace CKAN.ConsoleUI {
 
             } else {
 
-                DateTime instTime = InstalledOn(mod.identifier);
+                DateTime? instTime = InstalledOn(mod.identifier);
                 // Mod is no longer indexed, but we can generate a display
                 // of the old info about it from when we installed it
                 addVersionBox(
                     boxLeft, boxTop, boxRight, boxTop + boxH - 1,
-                    () => $"UNAVAILABLE/Installed {instTime.ToString("d")}",
+                    () => $"UNAVAILABLE/Installed {instTime?.ToString("d") ?? "manually"}",
                     () => ConsoleTheme.Current.AlertFrameFg,
                     true,
                     new List<CkanModule>() {mod}
@@ -413,14 +414,14 @@ namespace CKAN.ConsoleUI {
 
             if (releases != null && releases.Count > 0) {
 
-                ModuleVersion    minMod = null, maxMod = null;
-                KspVersion minKsp = null, maxKsp = null;
+                ModuleVersion minMod = null, maxMod = null;
+                KspVersion    minKsp = null, maxKsp = null;
                 Registry.GetMinMaxVersions(releases, out minMod, out maxMod, out minKsp, out maxKsp);
                 AddObject(new ConsoleLabel(
                     l + 2, t + 1, r - 2,
                     () => minMod == maxMod
-                        ? $"{ModuleInstaller.WithAndWithoutEpoch(minMod.ToString())}"
-                        : $"{ModuleInstaller.WithAndWithoutEpoch(minMod.ToString())} - {ModuleInstaller.WithAndWithoutEpoch(maxMod.ToString())}",
+                        ? $"{ModuleInstaller.WithAndWithoutEpoch(minMod?.ToString() ?? "???")}"
+                        : $"{ModuleInstaller.WithAndWithoutEpoch(minMod?.ToString() ?? "???")} - {ModuleInstaller.WithAndWithoutEpoch(maxMod?.ToString() ?? "???")}",
                     null,
                     color
                 ));

--- a/ConsoleUI/ModListHelpDialog.cs
+++ b/ConsoleUI/ModListHelpDialog.cs
@@ -29,9 +29,10 @@ namespace CKAN.ConsoleUI {
             AddObject(symbolTb);
             symbolTb.AddLine("Status Symbols");
             symbolTb.AddLine("==============");
-            symbolTb.AddLine($"{installed}    Installed");
-            symbolTb.AddLine($"{upgradable}  Upgradeable");
-            symbolTb.AddLine($"!  Unavailable");
+            symbolTb.AddLine($"{installed}           Installed");
+            symbolTb.AddLine($"{upgradable}         Upgradeable");
+            symbolTb.AddLine($"{autodetected}  Manually installed");
+            symbolTb.AddLine($"!         Unavailable");
             symbolTb.AddLine(" ");
             symbolTb.AddLine("Basic Keys");
             symbolTb.AddLine("==========");
@@ -65,6 +66,7 @@ namespace CKAN.ConsoleUI {
 
         private static readonly string installed    = Symbols.checkmark;
         private static readonly string upgradable   = Symbols.greaterEquals;
+        private static readonly string autodetected = Symbols.infinity;
     }
 
 }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -185,10 +185,13 @@ namespace CKAN.ConsoleUI {
 
             moduleList.AddTip("-", "Remove",
                 () => moduleList.Selection != null
-                    && (registry.IsInstalled(moduleList.Selection.identifier, false))
+                    && registry.IsInstalled(moduleList.Selection.identifier, false)
+                    && !registry.IsAutodetected(moduleList.Selection.identifier)
             );
             moduleList.AddBinding(Keys.Minus, (object sender) => {
-                if (moduleList.Selection != null && registry.IsInstalled(moduleList.Selection.identifier, false)) {
+                if (moduleList.Selection != null
+                    && registry.IsInstalled(moduleList.Selection.identifier, false)
+                    && !registry.IsAutodetected(moduleList.Selection.identifier)) {
                     plan.ToggleRemove(moduleList.Selection);
                 }
                 return true;
@@ -547,6 +550,7 @@ namespace CKAN.ConsoleUI {
                 case InstallStatus.Installed:    return installed;
                 case InstallStatus.Installing:   return installing;
                 case InstallStatus.NotInstalled: return notinstalled;
+                case InstallStatus.AutoDetected: return autodetected;
                 default:                         return "";
             }
         }
@@ -581,6 +585,7 @@ namespace CKAN.ConsoleUI {
         private static readonly string upgradable   = Symbols.greaterEquals;
         private static readonly string upgrading    = "^";
         private static readonly string removing     = "-";
+        private static readonly string autodetected = Symbols.infinity;
     }
 
     /// <summary>
@@ -659,7 +664,9 @@ namespace CKAN.ConsoleUI {
         public InstallStatus GetModStatus(KSPManager manager, IRegistryQuerier registry, string identifier)
         {
             if (registry.IsInstalled(identifier, false)) {
-                if (Remove.Contains(identifier)) {
+                if (registry.IsAutodetected(identifier)) {
+                    return InstallStatus.AutoDetected;
+                } else if (Remove.Contains(identifier)) {
                     return InstallStatus.Removing;
                 } else if (registry.HasUpdate(identifier, manager.CurrentInstance.VersionCriteria())) {
                     if (Upgrade.Contains(identifier)) {
@@ -789,5 +796,10 @@ namespace CKAN.ConsoleUI {
         /// This mod is installed and we are planning to upgrade it
         /// </summary>
         Upgrading,
+
+        /// <summary>
+        /// This mod was installed manually
+        /// </summary>
+        AutoDetected,
     };
 }

--- a/ConsoleUI/Toolkit/Symbols.cs
+++ b/ConsoleUI/Toolkit/Symbols.cs
@@ -26,6 +26,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// >= symbol
         /// </summary>
         public static readonly string greaterEquals    = cp437s(0xf2);
+        /// <summary>
+        /// Infinity symbol
+        /// </summary>
+        public static readonly string infinity         = cp437s(0xec);
 
         /// <summary>
         /// Hashed square box for drawing scrollbars

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -77,7 +77,7 @@ namespace CKAN
         /// Gets the installed version of a mod. Does not check for provided or autodetected mods.
         /// </summary>
         /// <returns>The module or null if not found</returns>
-        CkanModule GetInstalledVersion(string identifer);
+        CkanModule GetInstalledVersion(string identifier);
 
         /// <summary>
         /// Attempts to find a module with the given identifier and version.

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -633,24 +633,29 @@ namespace CKAN
         /// <param name="minKsp">Return parameter for the lowest  game version</param>
         /// <param name="maxKsp">Return parameter for the highest game version</param>
         public static void GetMinMaxVersions(IEnumerable<CkanModule> modVersions,
-                out ModuleVersion    minMod, out ModuleVersion    maxMod,
-                out KspVersion minKsp, out KspVersion maxKsp)
+                out ModuleVersion minMod, out ModuleVersion maxMod,
+                out KspVersion    minKsp, out KspVersion    maxKsp)
         {
             minMod = maxMod = null;
             minKsp = maxKsp = null;
-            foreach (CkanModule rel in modVersions) {
-                if (minMod == null || minMod > rel.version) {
+            foreach (CkanModule rel in modVersions.Where(v => v != null))
+            {
+                if (minMod == null || minMod > rel.version)
+                {
                     minMod = rel.version;
                 }
-                if (maxMod == null || maxMod < rel.version) {
+                if (maxMod == null || maxMod < rel.version)
+                {
                     maxMod = rel.version;
                 }
                 KspVersion relMin = rel.EarliestCompatibleKSP();
                 KspVersion relMax = rel.LatestCompatibleKSP();
-                if (minKsp == null || !minKsp.IsAny && (minKsp > relMin || relMin.IsAny)) {
+                if (minKsp == null || !minKsp.IsAny && (minKsp > relMin || relMin.IsAny))
+                {
                     minKsp = relMin;
                 }
-                if (maxKsp == null || !maxKsp.IsAny && (maxKsp < relMax || relMax.IsAny)) {
+                if (maxKsp == null || !maxKsp.IsAny && (maxKsp < relMax || relMax.IsAny))
+                {
                     maxKsp = relMax;
                 }
             }
@@ -1010,10 +1015,10 @@ namespace CKAN
         /// <summary>
         /// <see cref = "IRegistryQuerier.GetInstalledVersion" />
         /// </summary>
-        public CkanModule GetInstalledVersion(string mod_identifer)
+        public CkanModule GetInstalledVersion(string mod_identifier)
         {
             InstalledModule installedModule;
-            return installed_modules.TryGetValue(mod_identifer, out installedModule)
+            return installed_modules.TryGetValue(mod_identifier, out installedModule)
                 ? installedModule.Module
                 : null;
         }

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -107,7 +107,7 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Returns a default install stanza for the identifer provided.
+        /// Returns a default install stanza for the identifier provided.
         /// </summary>
         public static ModuleInstallDescriptor DefaultInstallStanza(string ident, ZipFile zipfile)
         {

--- a/Core/Versioning/KspVersionRange.cs
+++ b/Core/Versioning/KspVersionRange.cs
@@ -86,7 +86,9 @@ namespace CKAN.Versioning
 
         private static string SameVersionString(KspVersion v)
         {
-            return v.IsAny ? "all versions" : v.ToString();
+            return v == null ? "???"
+                :  v.IsAny   ? "all versions"
+                :              v.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
## Problems

Manually installed mods (or "auto detected" or "AD") are not handled well in ConsoleUI.

- They're shown as simply installed (check mark symbol)
- You can try to uninstall them
- The mod info screen crashes if you try to view them

## Causes

I tend not to use AD mods, so I didn't test it in ConsoleUI.
Now I have some symlinks set up for the dev versions of my mods, so I stumbled across this.

## Changes

- AD mods now have their own status symbol in the mod list: infinity
  - Added to the help screen
- The key tip and hotkey for uninstallation are disabled for AD mods
- The mod info screen now doesn't crash and shows AD mods with a "Installed manually" header and "???" for the version and game version compatibility
- Several occurrences of "identifer" in the code are corrected to "identif**i**er".

![image](https://user-images.githubusercontent.com/1559108/51703647-810eae80-1fdc-11e9-80ee-43cc6ac8503f.png)

![image](https://user-images.githubusercontent.com/1559108/51703711-b0252000-1fdc-11e9-9e02-252eaacb38e9.png)

![image](https://user-images.githubusercontent.com/1559108/51703665-8f5cca80-1fdc-11e9-9973-5d1035baa507.png)