### PR TITLE
Add AD mods back into GUI's installed filter

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -129,6 +129,10 @@ namespace CKAN
             IsIncompatible = incompatible;
             IsAutodetected = registry.IsAutodetected(identifier);
             DownloadCount  = registry.DownloadCount(identifier);
+            if (registry.IsAutodetected(identifier))
+            {
+                IsInstalled = true;
+            }
 
             ModuleVersion latest_version = null;
             try


### PR DESCRIPTION
## Problem

AD mods were unintentionally removed from GUI's Installed filter in #2514.

## Changes

Now `GUIMod.IsInstalled` will be set to true for AD mods.

Fixes #2667.