### PR TITLE
Cleanly switch versions of installed mod

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -752,7 +752,7 @@ namespace CKAN
         /// This *DOES* save the registry.
         /// Preferred over Uninstall.
         /// </summary>
-        public void UninstallList(IEnumerable<string> mods, bool ConfirmPrompt = true)
+        public void UninstallList(IEnumerable<string> mods, bool ConfirmPrompt = true, IEnumerable<string> installing = null)
         {
             // Pre-check, have they even asked for things which are installed?
 
@@ -762,7 +762,9 @@ namespace CKAN
             }
 
             // Find all the things which need uninstalling.
-            IEnumerable<string> goners = registry_manager.registry.FindReverseDependencies(mods);
+            IEnumerable<string> goners = mods.Union(
+                registry_manager.registry.FindReverseDependencies(
+                    mods.Except(installing ?? new string[] {})));
 
             // If there us nothing to uninstall, skip out.
             if (!goners.Any())
@@ -802,7 +804,9 @@ namespace CKAN
                     Uninstall(mod);
                 }
 
-                registry_manager.Save();
+                // Enforce consistency if we're not installing anything,
+                // otherwise consistency will be enforced after the installs
+                registry_manager.Save(installing == null);
 
                 transaction.Complete();
             }

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -308,5 +308,10 @@ namespace CKAN
             return Identifier?.GetHashCode() ?? 0;
         }
 
+        public override string ToString()
+        {
+            return $"{ToModule()}";
+        }
+
     }
 }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -255,7 +255,7 @@ namespace CKAN
 
                 UpdateAllToolButton.Enabled = has_any_updates;
             });
-                                    
+
             UpdateFilters(this);
 
             AddLogMessage("Updating tray...");
@@ -687,7 +687,11 @@ namespace CKAN
                 }
             }
 
-            foreach (var dependency in registry.FindReverseDependencies(modules_to_remove.Select(mod=>mod.identifier)))
+            foreach (var dependency in registry.FindReverseDependencies(
+                modules_to_remove
+                    .Select(mod => mod.identifier)
+                    .Except(modules_to_install.Select(m => m.identifier))
+            ))
             {
                 //TODO This would be a good place to have a event that alters the row's graphics to show it will be removed
                 CkanModule module_by_version = registry.GetModuleByVersion(installed_modules[dependency].identifier,
@@ -702,7 +706,6 @@ namespace CKAN
             changeSet.UnionWith(
                 resolver.ModList()
                     .Select(m => new ModChange(new GUIMod(m, registry, version), GUIModChangeType.Install, resolver.ReasonFor(m))));
-
 
             return changeSet;
         }

--- a/GUI/ModChange.cs
+++ b/GUI/ModChange.cs
@@ -35,7 +35,15 @@ namespace CKAN
 
         public override int GetHashCode()
         {
-            return Mod != null ? Mod.Identifier.GetHashCode() : 0;
+            // Distinguish between installing and removing
+            return Mod == null
+                ? 0
+                : (4 * Mod.GetHashCode() + (int)ChangeType);
+        }
+
+        public override string ToString()
+        {
+            return $"{ChangeType} {Mod} ({Reason})";
         }
     }
 }


### PR DESCRIPTION
## Problem

GUI lets you install an old version of a mod by double clicking in the Versions tab of mod info.

If another version of the mod is already installed, then the progress screen will appear and announce that the mod is being skipped because it's already installed. This means that to switch to a different version of an installed mod, you have to uninstall it explicitly and *then* install the other version. If other mods depend on it, they will be uninstalled, and you have to remember to re-install them afterwards.

This was a pain point recently with ModuleManager 4.0.0, which apparently broke loading of "custom tech tree and ﻿physics﻿". Impatient users who upgraded to this version and didn't want to wait for a fix (4.0.1 came out ~26 hours later) were stuck either with a broken install or with uninstalling many mods, rolling back MM, and then re-installing everything.

## Changes

If a mod to be installed is already installed, `Main.InstallModuleDriver` will add a `ModChange` to the change set to uninstall the installed version first.

`ModChange.GetHashCode` is updated to consider installing a mod and removing it to be different concepts (previously it only considered the mod's identifier, so if you tried to add an Install and Remove step for the same mod to a `HashSet`, the second one would be discarded).

You can tell `ModuleInstaller.UninstallList` that you're planning to install mods later via a new `installing` parameter. The mods in this list will not have their reverse dependencies uninstalled, and if this list is passed, then consistency will not be enforced on the assumption that a later installation step needs to be completed first. `Main.InstallMods` passes its mods-to-install in this parameter.

`MainModList.ComputeChangeSetFromModList` is updated similarly; mods to be both removed and installed will no longer have their reverse dependencies removed.

`ModChange.ToString` is created to ease debugging.
`GUIMod.ToString` is created to ease debugging.

After all of these changes, you can install a bunch of mods depending on ModuleManager, then replace ModuleManager with a different version, and everything will work out.

(This will probably conflict with #2660. I'll resolve that if/when we get to that point.)