### PR TITLE
Use Core.Utilities.CopyDirectory in tests

### DIFF
--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -51,18 +51,21 @@ namespace CKAN
                 file.CopyTo(temppath, false);
             }
 
-            // If copying subdirectories, copy them and their contents to new location.
-            if (copySubDirs)
-            {
-                // Get the subdirectories for the specified directory.
-                DirectoryInfo[] dirs = sourceDir.GetDirectories();
+            // Create all first level subdirectories
+            DirectoryInfo[] dirs = sourceDir.GetDirectories();
 
-                foreach (DirectoryInfo subdir in dirs)
+            foreach (DirectoryInfo subdir in dirs)
+            {
+                string temppath = Path.Combine(destDirPath, subdir.Name);
+                Directory.CreateDirectory(temppath);
+
+                // If copying subdirectories, copy their contents to new location.
+                if (copySubDirs)
                 {
-                    string temppath = Path.Combine(destDirPath, subdir.Name);
                     _CopyDirectory(subdir.FullName, temppath, copySubDirs);
                 }
             }
+
         }
     }
 }

--- a/Tests/Core/KSP.cs
+++ b/Tests/Core/KSP.cs
@@ -19,7 +19,7 @@ namespace Tests.Core
         {
             ksp_dir = TestData.NewTempDir();
             nullUser = new NullUser();
-            TestData.CopyDirectory(TestData.good_ksp_dir(), ksp_dir);
+            Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, true);
             ksp = new CKAN.KSP(ksp_dir, "test", nullUser);
         }
 
@@ -131,7 +131,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            TestData.CopyDirectory(TestData.good_ksp_dir(), gamedir);
+            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
             File.Delete(buildid);
             File.Delete(readme);
 
@@ -161,7 +161,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            TestData.CopyDirectory(TestData.good_ksp_dir(), gamedir);
+            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
             File.Delete(buildid);
             File.Delete(readme);
 

--- a/Tests/Core/KSP.cs
+++ b/Tests/Core/KSP.cs
@@ -19,7 +19,7 @@ namespace Tests.Core
         {
             ksp_dir = TestData.NewTempDir();
             nullUser = new NullUser();
-            Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, true);
+            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, true);
             ksp = new CKAN.KSP(ksp_dir, "test", nullUser);
         }
 
@@ -131,7 +131,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
+            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
             File.Delete(buildid);
             File.Delete(readme);
 
@@ -161,7 +161,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
+            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
             File.Delete(buildid);
             File.Delete(readme);
 

--- a/Tests/Core/Utilities.cs
+++ b/Tests/Core/Utilities.cs
@@ -71,7 +71,7 @@ namespace Tests.Core
         {
             File.WriteAllText(Path.Combine(tempDir, "thatsafile"), "not empty");
 
-            Assert.Throws<IOException>(() => CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, true));
+            Assert.Throws<PathErrorKraken>(() => CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, true));
         }
     }
 }

--- a/Tests/Core/Utilities.cs
+++ b/Tests/Core/Utilities.cs
@@ -1,0 +1,77 @@
+﻿using System.IO;
+using CKAN;
+using NUnit.Framework;
+using Tests.Data;
+
+namespace Tests.Core
+{
+    [TestFixture] public class Utilities
+    {
+        string tempDir;
+        string goodKspDir = TestData.good_ksp_dir();
+
+        [SetUp]
+        public void CreateTempDir()
+        {
+            tempDir = TestData.NewTempDir();
+        }
+
+        [TearDown]
+        public void EmptyTempDir()
+        {
+            Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        public void CopyDirectory_Recursive_DestHasAllContents()
+        {
+            CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, true);
+
+            Assert.IsTrue(UtilStatic.CompareFiles(
+                Path.Combine(goodKspDir, "GameData", "README.md"),
+                Path.Combine(tempDir,   "GameData", "README.md")));
+            Assert.IsTrue(UtilStatic.CompareFiles(
+                Path.Combine(goodKspDir, "buildID.txt"),
+                Path.Combine(tempDir,   "buildID.txt")));
+            Assert.IsTrue(UtilStatic.CompareFiles(
+                Path.Combine(goodKspDir, "readme.txt"),
+                Path.Combine(tempDir,   "readme.txt")));
+        }
+
+        [Test]
+        public void CopyDirectory_NotRecursive_DestHasOnlyFirstLevelFiles()
+        {
+            CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, false);
+
+            Assert.IsFalse(File.Exists(Path.Combine(tempDir, "GameData", "README.md")));
+            // The following assertion is per se already included in the above assertion,
+            // but this also tests CompareFiles, so no harm in including this.
+            Assert.IsFalse(UtilStatic.CompareFiles(
+                Path.Combine(goodKspDir, "GameData", "README.md"),
+                Path.Combine(tempDir, "GameData", "README.md")));
+            Assert.IsTrue(UtilStatic.CompareFiles(
+                Path.Combine(goodKspDir, "buildID.txt"),
+                Path.Combine(tempDir, "buildID.txt")));
+            Assert.IsTrue(UtilStatic.CompareFiles(
+                Path.Combine(goodKspDir, "readme.txt"),
+                Path.Combine(tempDir, "readme.txt")));
+        }
+
+        [Test]
+        public void CopyDirectory_SourceNotExisting_ThrowsDirectoryNotFoundKraken()
+        {
+            var sourceDir = "/gibberish/DOESNTEXIST/hopefully";
+
+            // Act and Assert
+            Assert.Throws<DirectoryNotFoundKraken>(() => CKAN.Utilities.CopyDirectory(sourceDir, tempDir, true));
+        }
+
+        [Test]
+        public void CopyDirectory_DestNotEmpty_ThrowsException()
+        {
+            File.WriteAllText(Path.Combine(tempDir, "thatsafile"), "not empty");
+
+            Assert.Throws<IOException>(() => CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, true));
+        }
+    }
+}

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -25,7 +25,7 @@ namespace Tests.Data
         {
             directoryToClone = directoryToClone ?? _goodKsp;
             _disposableDir = TestData.NewTempDir();
-            TestData.CopyDirectory(directoryToClone, _disposableDir);
+            Utilities.CopyDirectory(directoryToClone, _disposableDir, true);
 
             // If we've been given a registry file, then copy it into position before
             // creating our KSP object.

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -618,22 +618,6 @@ namespace Tests.Data
             return temp_folder;
         }
 
-        // Ugh, this is awful.
-        public static void CopyDirectory(string src, string dst)
-        {
-            // Create directory structure
-            foreach (string path in Directory.GetDirectories(src, "*", SearchOption.AllDirectories))
-            {
-                Directory.CreateDirectory(path.Replace(src, dst));
-            }
-
-            // Copy files.
-            foreach (string file in Directory.GetFiles(src, "*", SearchOption.AllDirectories))
-            {
-                File.Copy(file, file.Replace(src, dst));
-            }
-        }
-
         public static string ConfigurationFile()
         {
             return @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="NetKAN\Validators\NetkanValidatorTests.cs" />
     <Compile Include="NetKAN\Validators\KrefValidatorTests.cs" />
     <Compile Include="Util.cs" />
+    <Compile Include="Core\Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Tests/Util.cs
+++ b/Tests/Util.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -14,6 +15,29 @@ namespace Tests
         public void AssembliesHaveNoAsyncVoids()
         {
             UtilStatic.AssertNoAsyncVoidMethods(GetType().Assembly);
+        }
+
+        [Test]
+        public void CompareFiles_EqualFiles_ReturnsTrue()
+        {
+            string f1 = Path.GetTempFileName();
+            string f2 = Path.GetTempFileName();
+
+            File.WriteAllText(f1, "TestLorem IpsumThats SomeCrap");
+            File.WriteAllText(f2, "TestLorem IpsumThats SomeCrap");
+
+            Assert.IsTrue(UtilStatic.CompareFiles(f1, f2));
+        }
+
+        [Test]
+        public void CompareFiles_DifferentFiles_ReturnsFalse()
+        {
+            string f1 = Path.GetTempFileName();
+            string f2 = Path.GetTempFileName();
+            File.WriteAllText(f1, "Heyo");
+            File.WriteAllText(f2, "-");
+
+            Assert.IsFalse(UtilStatic.CompareFiles(f1, f2));
         }
     }
 
@@ -73,6 +97,49 @@ namespace Tests
             catch (T)
             {
                 return;
+            }
+        }
+
+        /// <summary>
+        /// Compares two files regarding size and content.
+        /// File names are neglected.
+        /// For the content it compares byte by byte.
+        /// Found here: https://stackoverflow.com/questions/7931304/comparing-two-files-in-c-sharp
+        /// </summary>
+        /// <returns><c>true</c>, if files are content-wise equal, <c>false</c> otherwise.</returns>
+        public static bool CompareFiles(string file1, string file2)
+        {
+            // Determine if the same file was referenced two times.
+            if (file1 == file2)
+                return true;
+
+            if (!File.Exists(file1) || !File.Exists(file2))
+                return false;
+
+            using (FileStream fs1 = new FileStream(file1, FileMode.Open, FileAccess.Read),
+                              fs2 = new FileStream(file2, FileMode.Open, FileAccess.Read))
+            {
+                //// Check the file sizes. If they are not the same, the files 
+                //// are not the same.
+                if (fs1.Length != fs2.Length)
+                    return false;
+
+                // Read and compare a byte from each file until either a
+                // non-matching set of bytes is found or until the end of
+                // file1 is reached.
+                int file1byte;
+                int file2byte;
+                do
+                {
+                    // Read one byte from each file.
+                    file1byte = fs1.ReadByte();
+                    file2byte = fs2.ReadByte();
+                }
+                while ((file1byte == file2byte) && (file1byte != -1));
+
+                // Make sure that file2 has not more bytes than file1.
+                // If not, the files are the same, after all these checks.
+                return ((file1byte - file2byte) == 0);
             }
         }
     }


### PR DESCRIPTION
In #2627 I created a new, more robust `CopyDirectory()` than the existing one in `TestData`.

Replaced all calls to `TestData.CopyDirectory()` with `Utilities.CopyDirectory()`.
Removed `TestData.CopyDirectory()`.

All tests still run successful.