### PR TITLE
Allow installation of missing dependencies in GUI

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1069,6 +1069,12 @@ namespace CKAN
             IDictionary<string, UnmanagedModuleVersion> dlc
         )
         {
+            if (!modules_to_remove.Any())
+            {
+                // The empty list has no reverse dependencies
+                // (Don't remove broken modules if we're only installing)
+                return new HashSet<string>();
+            }
             while (true)
             {
                 // Make our hypothetical install, and remove the listed modules from it.


### PR DESCRIPTION
## Problem

If you:

1. Install some module manually that can be Autodetected (ModuleManager is a good choice)
2. Use CKAN to install mods that depend on that module
3. Manually delete that module
4. Attempt to install the module in CKAN GUI

... then GUI will try to remove all the reverse dependencies from step 2.

The equivalent operation in CmdLine (`ckan install modulemanager`) works without removing anything.

## Changes

Now GUI won't try to remove reverse dependencies if you're not uninstalling anything. This will allow installation of missing dependencies.

Fixes #2672.