### PR TITLE
Make the download button more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Comprehensive Kerbal Archive Network (CKAN)
 
-[![Downloads](https://img.shields.io/github/downloads/KSP-CKAN/CKAN/latest/total.svg)](https://github.com/KSP-CKAN/CKAN/releases/latest)
+[<img src="https://img.shields.io/github/downloads/KSP-CKAN/CKAN/latest/total.svg?label=%E2%A4%93Download&style=plastic" height="48px" />](https://github.com/KSP-CKAN/CKAN/releases/latest)
 
 [Click here to open a new CKAN issue][6]
 


### PR DESCRIPTION
I glanced at the IRC channel and found this in the scrollback:

> Hi all.
> I'm using linux and would like to use CKAN.  I've cloned the repo and built with no errors, what do I do next?
> I can't seem to locate an obvious binary to run.
> Oh is it the debian folder (even though I'm not deb)?
> has a makefile
> hm nope, that requires dpkg-deb
> gonna try WINE with the windows executable
> 
> that doesn't work either, guess there's some requirements for certs

If you're not fluent in GitHub it may not be obvious where the releases are. There's a download button in the README, but it's kind of easy to miss. Changes:

| Before | After |
| --- | --- |
| Text said "downloads" which looks like it's just a counter | Label says "Download" to indicate an action |
| No icon | Added a unicode ⤓ symbol |
| Small | Huge |