### PR TITLE
Fix window position on MacOSX

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -40,21 +40,11 @@ namespace CKAN
         /// </summary>
         public bool IsWindowMaximised = false;
 
-        private Point windowLocation = new Point(0,0);
-        //Workaround for bug which mis-sets the window location.
-        // Here instead of in Main_FormClosing due to the mistaken
-        // value possibly being written out to config file. After some time
-        // it should be save to move. RLake 2015/05
+        private Point windowLocation = new Point(-1, -1);
+
         public Point WindowLoc
         {
-            get
-            {
-                if (windowLocation.X < 0 && windowLocation.Y < 0)
-                {
-                    windowLocation = new Point(60, 30);
-                }
-                return windowLocation;
-            }
+            get { return windowLocation;  }
             set { windowLocation = value; }
         }
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -329,7 +329,24 @@ namespace CKAN
 
         protected override void OnLoad(EventArgs e)
         {
-            Location = configuration.WindowLoc;
+            if (configuration.WindowLoc.X == -1 && configuration.WindowLoc.Y == -1)
+            {
+                // Center on screen for first launch
+                StartPosition = FormStartPosition.CenterScreen;
+            }
+            else if (Platform.IsMac)
+            {
+                // Make sure there's room at the top for the MacOSX menu bar
+                Location = Util.ClampedLocationWithMargins(
+                    configuration.WindowLoc, configuration.WindowSize,
+                    new Size(0, 30), new Size(0, 0)
+                );
+            }
+            else
+            {
+                // Just make sure it's fully on screen
+                Location = Util.ClampedLocation(configuration.WindowLoc, configuration.WindowSize);
+            }
             Size = configuration.WindowSize;
             WindowState = configuration.IsWindowMaximised ? FormWindowState.Maximized : FormWindowState.Normal;
 

--- a/GUI/MainTrayIcon.cs
+++ b/GUI/MainTrayIcon.cs
@@ -116,34 +116,10 @@ namespace CKAN
         {
             // The menu location can be partly off-screen by default.
             // Fix it.
-            minimizedContextMenuStrip.Location = ClampedLocation(
+            minimizedContextMenuStrip.Location = Util.ClampedLocation(
                 minimizedContextMenuStrip.Location,
                 minimizedContextMenuStrip.Size
             );
-        }
-
-        private Point ClampedLocation(Point location, Size size)
-        {
-            var rect = new Rectangle(location, size);
-            // Find a screen that the default position overlaps
-            foreach (Screen screen in Screen.AllScreens)
-            {
-                if (screen.WorkingArea.IntersectsWith(rect))
-                {
-                    // Slide the whole menu fully onto the screen
-                    if (location.X < screen.WorkingArea.Top)
-                        location.X = screen.WorkingArea.Top;
-                    if (location.Y < screen.WorkingArea.Left)
-                        location.Y = screen.WorkingArea.Left;
-                    if (location.X + size.Width > screen.WorkingArea.Right)
-                        location.X = screen.WorkingArea.Right - size.Width;
-                    if (location.Y + size.Height > screen.WorkingArea.Bottom)
-                        location.Y = screen.WorkingArea.Bottom - size.Height;
-                    // Stop checking screens
-                    break;
-                }
-            }
-            return location;
         }
 
         #endregion

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-
+using System.Drawing;
 
 namespace CKAN
 {
@@ -115,5 +115,58 @@ namespace CKAN
                 return false;
             }
         }
+
+        /// <summary>
+        /// Adjust position of a box so it fits entirely on one screen
+        /// </summary>
+        /// <param name="location">Top left corner of box</param>
+        /// <param name="size">Width and height of box</param>
+        /// <returns>
+        /// Original location if already fully on-screen, otherwise
+        /// a position representing sliding it onto the screen
+        /// </returns>
+        public static Point ClampedLocation(Point location, Size size)
+        {
+            var rect = new Rectangle(location, size);
+            // Find a screen that the default position overlaps
+            foreach (Screen screen in Screen.AllScreens)
+            {
+                if (screen.WorkingArea.IntersectsWith(rect))
+                {
+                    // Slide the whole rectangle fully onto the screen
+                    if (location.X < screen.WorkingArea.Top)
+                        location.X = screen.WorkingArea.Top;
+                    if (location.Y < screen.WorkingArea.Left)
+                        location.Y = screen.WorkingArea.Left;
+                    if (location.X + size.Width > screen.WorkingArea.Right)
+                        location.X = screen.WorkingArea.Right - size.Width;
+                    if (location.Y + size.Height > screen.WorkingArea.Bottom)
+                        location.Y = screen.WorkingArea.Bottom - size.Height;
+                    // Stop checking screens
+                    break;
+                }
+            }
+            return location;
+        }
+
+        /// <summary>
+        /// Adjust position of a box so it fits on one screen with a margin around it
+        /// </summary>
+        /// <param name="location">Top left corner of box</param>
+        /// <param name="size">Width and height of box</param>
+        /// <param name="topLeftMargin">Size of space between window and top left edge of screen</param>
+        /// <param name="bottomRightMargin">Size of space between window and bottom right edge of screen</param>
+        /// <returns>
+        /// Original location if already fully on-screen plus margins, otherwise
+        /// a position representing sliding it onto the screen
+        /// </returns>
+        public static Point ClampedLocationWithMargins(Point location, Size size, Size topLeftMargin, Size bottomRightMargin)
+        {
+            // Imagine drawing a larger box around the window, the size of the desired margin.
+            // We pass that box to ClampedLocation to make sure it fits on screen,
+            // then place our window at an offset within the box
+            return ClampedLocation(location - topLeftMargin, size + topLeftMargin + bottomRightMargin) + topLeftMargin;
+        }
+
     }
 }


### PR DESCRIPTION
## Problem

MacOSX users have experienced problems with CKAN's title bar appearing behind the OS menu bar, such that it cannot be used to move the window.

## Cause

https://github.com/KSP-CKAN/CKAN/blob/aba8b02098f5491caa59a3fd7613e8cdc68f2a6e/GUI/Configuration.cs#L43

That value is used as the window location if the position isn't saved in `CKAN/GUIConfig.xml`. So the first time you run CKAN, it tries to appear at the upper left corner of the screen.

## Changes

`Configuration` is changed to treat the default window position as -1,-1 instead of 0,0. This is so we can distinguish between the default and values the user might choose (0,0 could be either one). Some other weird workaround stuff around the `WindowLoc` property is removed.

Now if `Configuration.WindowLoc` is -1,-1, we don't bother restoring it but instead set `StartPosition` to `CenterScreen`, so the GUI window will be centered on the first run.

In #2587 we created a `ClampedLocation` function that finds a safe location for a box where it's entirely on one screen. That pull request used it for the tray icon popup menu. Now this function is moved to the `Util` static class, and we also use it when we restore the window position on non-MacOSX platforms. This will ensure that the window is always fully on screen when it appears.

A new `Util.ClampedLocationWithMargins` function is created that works like `ClampedLocation` but allows padding around the window to be specified. We use this when restoring the window position on MacOSX, with a 30px top margin and 0px everywhere else. This will ensure that the window doesn't overlap the menu bar on MacOSX.

Fixes #1838.