### PR TITLE
Fix upgrading and installing from .ckan in GUI

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -503,6 +503,9 @@ namespace CKAN
             modlist.Add(module.identifier, module);
             if (!reasons.ContainsKey(module))
                 reasons.Add(module, reason);
+            // Override Installed for upgrades
+            else if (reasons[module] is SelectionReason.Installed)
+                reasons[module] = reason;
 
             log.DebugFormat("Added {0}", module.identifier);
             // Stop here if it doesn't have any provide aliases.

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -898,11 +898,15 @@ namespace CKAN
                 // We'll need to make some registry changes to do this.
                 RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
 
-                // Remove this version of the module in the registry, if it exists.
-                registry_manager.registry.RemoveAvailable(module);
+                // Don't add metapacakges to the registry
+                if (!module.IsMetapackage)
+                {
+                    // Remove this version of the module in the registry, if it exists.
+                    registry_manager.registry.RemoveAvailable(module);
 
-                // Sneakily add our version in...
-                registry_manager.registry.AddAvailable(module);
+                    // Sneakily add our version in...
+                    registry_manager.registry.AddAvailable(module);
+                }
 
                 menuStrip1.Enabled = false;
 

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -49,9 +49,11 @@ namespace CKAN
                 CkanModule m = change.Mod.ToModule();
                 ListViewItem item = new ListViewItem()
                 {
-                    Text = Manager.Cache.IsMaybeCachedZip(m)
-                        ? $"{m.name} {m.version} (cached)"
-                        : $"{m.name} {m.version} ({m.download.Host ?? ""}, {CkanModule.FmtSize(m.download_size)})",
+                    Text = m.IsMetapackage
+                        ? $"{m.name} {m.version} (metapackage)"
+                        : Manager.Cache.IsMaybeCachedZip(m)
+                            ? $"{m.name} {m.version} (cached)"
+                            : $"{m.name} {m.version} ({m.download.Host ?? ""}, {CkanModule.FmtSize(m.download_size)})",
                     Tag  = change.Mod.ToModule()
                 };
 

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -81,7 +81,6 @@ namespace CKAN
             tabController.HideTab("ChangesetTabPage");
             AddLogMessage(logMsg);
             SetDescription(description);
-            ApplyToolButton.Enabled = !success;
         }
 
         public void SetProgress(int progress)


### PR DESCRIPTION
## Problems

Upgrading modules in GUI is broken as of #2669. On Windows it throws an exception and crashes, on Linux the Apply changes button doesn't enable.

Cancelling out of a "recommends" based install from .ckan operation in GUI causes assorted issues. In addition to those detailed in #2676, the Apply changes button is enabled despite there being no change set.

## Causes

See #2669 for details of the upgrade problem; to sum up, there's now an extra entry in an upgrade change set that throws exceptions when we try to use it. This entry says that its selection reason is `Installed`, even though the user asked us to upgrade / install it.

GUI's install-from-ckan function can add a Metapackage to the registry (if that's what's in the .ckan file), which thereafter can appear in the mod list, change sets, etc. This can cause problems because it's missing properties that are otherwise always set such as `CkanModule.download`, and it's not useful to have it there.

`FailWaitDialog` was enabling the Apply changes button for cancelled installs.

## Changes

Now `RelationshipResolver` will not say the selection reason is `Installed` when we're installing an upgrade. This avoids the exception that is breaking upgrades.
Fixes #2679.

Now GUI doesn't add Metapackages to the registry. And just in case, the change set logic checks whether a module is a Metapackage before attempting to access the `download` property. Now `FailWaitDialog` allows `ChangeSetUpdated` to govern the enablement of the Apply changes button, so once again it is enabled when there's a change set and disabled when there isn't.
Fixes #2676.
