### PR TITLE
Releases option for Netkan

### DIFF
--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -28,6 +28,9 @@ namespace CKAN.NetKAN
         [Option("net-useragent", DefaultValue = null, HelpText = "Set the default User-Agent string for HTTP requests")]
         public string NetUserAgent { get; set; }
 
+        [Option("backfill", HelpText = "Process all releases instead of only the most recent")]
+        public bool BackFill { get; set; }
+
         [Option("prerelease", HelpText = "Index GitHub prereleases")]
         public bool PreRelease { get; set; }
 

--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -28,8 +28,8 @@ namespace CKAN.NetKAN
         [Option("net-useragent", DefaultValue = null, HelpText = "Set the default User-Agent string for HTTP requests")]
         public string NetUserAgent { get; set; }
 
-        [Option("backfill", HelpText = "Process all releases instead of only the most recent")]
-        public bool BackFill { get; set; }
+        [Option("releases", DefaultValue = "1", HelpText = "Number of releases to inflate, or 'all'")]
+        public string Releases { get; set; }
 
         [Option("prerelease", HelpText = "Index GitHub prereleases")]
         public bool PreRelease { get; set; }

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -73,7 +73,7 @@ namespace CKAN.NetKAN
                         moduleService,
                         Options.GitHubToken,
                         Options.PreRelease,
-                        Options.BackFill
+                        ParseReleases(Options.Releases)
                     );
 
                     IEnumerable<Metadata> ckans = transformer.Transform(netkan);
@@ -113,6 +113,11 @@ namespace CKAN.NetKAN
             }
 
             return ExitOk;
+        }
+
+        private static int? ParseReleases(string val)
+        {
+            return val == "all" ? (int?)null : int.Parse(val);
         }
 
         private static void ProcessArgs(string[] args)

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -1,18 +1,19 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Services;
-using CKAN.NetKAN.Transformers;
-using CKAN.NetKAN.Validators;
 using CommandLine;
 using log4net;
 using log4net.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Transformers;
+using CKAN.NetKAN.Validators;
 
 namespace CKAN.NetKAN
 {
@@ -71,16 +72,19 @@ namespace CKAN.NetKAN
                         fileService,
                         moduleService,
                         Options.GitHubToken,
-                        Options.PreRelease
+                        Options.PreRelease,
+                        Options.BackFill
                     );
 
-                    var ckan = transformer.Transform(netkan);
+                    IEnumerable<Metadata> ckans = transformer.Transform(netkan);
                     Log.Info("Finished transformation");
+                    foreach (Metadata ckan in ckans)
+                    {
+                        new CkanValidator(netkan, http, moduleService).Validate(ckan);
+                        Log.Info("Output successfully passed post-validation");
 
-                    new CkanValidator(netkan, http, moduleService).Validate(ckan);
-                    Log.Info("Output successfully passed post-validation");
-
-                    WriteCkan(ckan);
+                        WriteCkan(ckan);
+                    }
                 }
                 else
                 {

--- a/Netkan/Sources/Curse/CurseMod.cs
+++ b/Netkan/Sources/Curse/CurseMod.cs
@@ -31,6 +31,11 @@ namespace CKAN.NetKAN.Sources.Curse
             return files.First();
         }
 
+        public IEnumerable<CurseFile> All()
+        {
+            return files;
+        }
+
         /// <summary>
         /// Returns the static Url of the project
         /// </summary>

--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -41,7 +41,7 @@ namespace CKAN.NetKAN.Sources.Github
 
         public IEnumerable<GithubRelease> GetAllReleases(GithubRef reference)
         {
-            var json = Call($"repos/{reference.Repository}/releases");
+            var json = Call($"repos/{reference.Repository}/releases?per_page=100");
             Log.Debug("Parsing JSON...");
             var releases = JArray.Parse(json);
 

--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using System.Collections.Generic;
 using log4net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -34,6 +35,11 @@ namespace CKAN.NetKAN.Sources.Github
         }
 
         public GithubRelease GetLatestRelease(GithubRef reference)
+        {
+            return GetAllReleases(reference).FirstOrDefault();
+        }
+
+        public IEnumerable<GithubRelease> GetAllReleases(GithubRef reference)
         {
             var json = Call($"repos/{reference.Repository}/releases");
             Log.Debug("Parsing JSON...");
@@ -81,12 +87,10 @@ namespace CKAN.NetKAN.Sources.Github
 
                     if (download != null)
                     {
-                        return new GithubRelease(author, version, download, updated);
+                        yield return new GithubRelease(author, version, download, updated);
                     }
                 }
             }
-
-            return null;
         }
 
         private string Call(string path)

--- a/Netkan/Sources/Github/IGithubApi.cs
+++ b/Netkan/Sources/Github/IGithubApi.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
+
 namespace CKAN.NetKAN.Sources.Github
 {
     internal interface IGithubApi
     {
         GithubRepo GetRepo(GithubRef reference);
         GithubRelease GetLatestRelease(GithubRef reference);
+        IEnumerable<GithubRelease> GetAllReleases(GithubRef reference);
     }
 }

--- a/Netkan/Sources/Jenkins/IJenkinsApi.cs
+++ b/Netkan/Sources/Jenkins/IJenkinsApi.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
+
 namespace CKAN.NetKAN.Sources.Jenkins
 {
     internal interface IJenkinsApi
     {
         JenkinsBuild GetLatestBuild(JenkinsRef reference, JenkinsOptions options);
+        IEnumerable<JenkinsBuild> GetAllBuilds(JenkinsRef reference, JenkinsOptions options);
     }
 }

--- a/Netkan/Sources/Jenkins/JenkinsBuild.cs
+++ b/Netkan/Sources/Jenkins/JenkinsBuild.cs
@@ -7,6 +7,9 @@ namespace CKAN.NetKAN.Sources.Jenkins
         [JsonProperty("url")]
         public string Url;
 
+        [JsonProperty("result")]
+        public string Result;
+
         [JsonProperty("artifacts")]
         public JenkinsArtifact[] Artifacts;
     }

--- a/Netkan/Sources/Spacedock/SpacedockMod.cs
+++ b/Netkan/Sources/Spacedock/SpacedockMod.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace CKAN.NetKAN.Sources.Spacedock
@@ -32,6 +33,11 @@ namespace CKAN.NetKAN.Sources.Spacedock
 
             // There should only ever be one.
             return latest.First();
+        }
+
+        public IEnumerable<SDVersion> All()
+        {
+            return versions;
         }
 
         /// <summary>

--- a/Netkan/Transformers/AvcKrefTransformer.cs
+++ b/Netkan/Transformers/AvcKrefTransformer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Sources.Avc;
@@ -24,7 +25,7 @@ namespace CKAN.NetKAN.Transformers
             httpSvc = http;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Kref?.Source == "ksp-avc")
             {
@@ -55,10 +56,12 @@ namespace CKAN.NetKAN.Transformers
 
                 Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
-                return new Metadata(json);
+                yield return new Metadata(json);
             }
-
-            return metadata;
+            else
+            {
+                yield return metadata;
+            }
         }
     }
 }

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -31,7 +31,7 @@ namespace CKAN.NetKAN.Transformers
             _moduleService = moduleService;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Vref != null && metadata.Vref.Source == "ksp-avc")
             {
@@ -91,11 +91,11 @@ namespace CKAN.NetKAN.Transformers
                     Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
                 }
 
-                return new Metadata(json);
+                yield return new Metadata(json);
             }
             else
             {
-                return metadata;
+                yield return metadata;
             }
         }
 

--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 ﻿using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
@@ -18,15 +19,17 @@ namespace CKAN.NetKAN.Transformers
         private static readonly ILog Log = LogManager.GetLogger(typeof(CurseTransformer));
 
         private readonly ICurseApi _api;
+        private readonly bool      _backfill;
 
         public string Name { get { return "curse"; } }
 
-        public CurseTransformer(ICurseApi api)
+        public CurseTransformer(ICurseApi api, bool backfill)
         {
-            _api = api;
+            _api      = api;
+            _backfill = backfill;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == "curse")
             {
@@ -37,192 +40,206 @@ namespace CKAN.NetKAN.Transformers
 
                 // Look up our mod on Curse by its Id.
                 var curseMod = _api.GetMod(metadata.Kref.Id);
-                var latestVersion = curseMod.Latest();
-
-                Log.InfoFormat("Found Curse mod: {0} {1}", curseMod.GetName(), latestVersion.GetFileVersion());
-
-                // Only pre-fill version info if there's none already. GH #199
-                if (json["ksp_version_min"] == null && json["ksp_version_max"] == null && json["ksp_version"] == null)
+                if (_backfill)
                 {
-
-                    KspVersion minVer = latestVersion.versions.Min();
-                    KspVersion maxVer = latestVersion.versions.Max();
-                    if (minVer == maxVer)
+                    foreach (CurseFile f in curseMod.All())
                     {
-                        Log.DebugFormat("Writing ksp_version from Curse: {0}", latestVersion.version);
-                        json["ksp_version"] = latestVersion.version.ToString();
-                    }
-                    else
-                    {
-                        Log.DebugFormat("Writing ksp_version_min,_max from Curse: {0}, {1}", minVer, maxVer);
-                        json["ksp_version_min"] = minVer.ToString();
-                        json["ksp_version_max"] = maxVer.ToString();
+                        yield return TransformOne(metadata.Json(), curseMod, f);
                     }
                 }
-
-                var useDownloadNameVersion = false;
-                var useFilenameVersion = false;
-                var useCurseIdVersion = false;
-
-                var curseMetadata = (JObject) json["x_netkan_curse"];
-                if (curseMetadata != null)
+                else
                 {
-                    var useDownloadNameVersionMetadata = (bool?)curseMetadata["use_download_name_version"];
-                    if (useDownloadNameVersionMetadata != null)
-                    {
-                        useDownloadNameVersion = useDownloadNameVersionMetadata.Value;
-                    }
-
-                    var useFilenameVersionMetadata = (bool?) curseMetadata["use_filename_version"];
-                    if (useFilenameVersionMetadata != null)
-                    {
-                        useFilenameVersion = useFilenameVersionMetadata.Value;
-                    }
-
-                    var useCurseIdVersionMetadata = (bool?)curseMetadata["use_curse_id_version"];
-                    if (useCurseIdVersionMetadata != null)
-                    {
-                        useCurseIdVersion = useCurseIdVersionMetadata.Value;
-                    }
-
-                    if ((useDownloadNameVersion ? 1 : 0) + (useFilenameVersion ? 1 : 0) + (useCurseIdVersion ? 1 : 0) > 1)
-                    {
-                        throw new Kraken("Conflicting version options set in x_netkan_curse");
-                    }
+                    yield return TransformOne(json, curseMod, curseMod.Latest());
                 }
+            }
+            else
+            {
+                yield return metadata;
+            }
+        }
 
-                json.SafeAdd("name", curseMod.GetName());
-                json.SafeAdd("abstract", curseMod.description);
+        private Metadata TransformOne(JObject json, CurseMod curseMod, CurseFile latestVersion)
+        {
+            Log.InfoFormat("Found Curse mod: {0} {1}", curseMod.GetName(), latestVersion.GetFileVersion());
 
-                if (useDownloadNameVersion)  json.SafeAdd("version", latestVersion.name);
-                else if (useFilenameVersion) json.SafeAdd("version", latestVersion.GetFilename());
-                else if (useCurseIdVersion)  json.SafeAdd("version", latestVersion.GetCurseIdVersion());
-                else                         json.SafeAdd("version", latestVersion.GetFileVersion());
-
-                json.SafeAdd("author", JToken.FromObject(curseMod.authors));
-                json.SafeAdd("download", Regex.Replace(latestVersion.GetDownloadUrl(), " ", "%20"));
-
-                // Curse provides users with the following default selection of licenses. Let's convert them to CKAN
-                // compatible license strings if possible.
-                //
-                // "Academic Free License v3.0"                               - Becomes "AFL-3.0"
-                // "Ace3 Style BSD"                                           - Becomes "restricted"
-                // "All Rights Reserved"                                      - Becomes "restricted"
-                // "Apache License version 2.0"                               - Becomes "Apache-2.0"
-                // "Apple Public Source License version 2.0 (APSL)"           - Becomes "APSL-2.0"
-                // "BSD License"                                              - Becomes "BSD-3-clause"
-                // "Common Development and Distribution License (CDDL) "      - Becomes "CDDL"
-                // "GNU Affero General Public License version 3 (AGPLv3)"     - Becomes "AGPL-3.0"
-                // "GNU General Public License version 2 (GPLv2)"             - Becomes "GPL-2.0"
-                // "GNU General Public License version 3 (GPLv3)"             - Becomes "GPL-3.0"
-                // "GNU Lesser General Public License version 2.1 (LGPLv2.1)" - Becomes "LGPL-2.1"
-                // "GNU Lesser General Public License version 3 (LGPLv3)"     - Becomes "LGPL-3.0"
-                // "ISC License (ISCL)"                                       - Becomes "ISC"
-                // "Microsoft Public License (Ms-PL)"                         - Becomes "Ms-PL"
-                // "Microsoft Reciprocal License (Ms-RL)"                     - Becomes "Ms-RL"
-                // "MIT License"                                              - Becomes "MIT"
-                // "Mozilla Public License 1.0 (MPL)"                         - Becomes "MPL-1.0"
-                // "Mozilla Public License 1.1 (MPL 1.1)"                     - Becomes "MPL-1.1"
-                // "Public Domain"                                            - Becomes "public-domain"
-                // "WTFPL"                                                    - Becomes "WTFPL"
-                // "zlib/libpng License"                                      - Becomes "Zlib"
-                // "Custom License"                                           - Becomes "unknown"
-
-                var curseLicense = curseMod.license.Trim();
-
-                switch (curseLicense)
+            // Only pre-fill version info if there's none already. GH #199
+            if (json["ksp_version_min"] == null && json["ksp_version_max"] == null && json["ksp_version"] == null)
+            {
+                KspVersion minVer = latestVersion.versions.Min();
+                KspVersion maxVer = latestVersion.versions.Max();
+                if (minVer == maxVer)
                 {
-                    case "Academic Free License v3.0":
-                        json.SafeAdd("license", "AFL-3.0");
-                        break;
-                    case "Ace3 Style BSD":
-                        json.SafeAdd("license", "restricted");
-                        break;
-                    case "All Rights Reserved":
-                        json.SafeAdd("license", "restricted");
-                        break;
-                    case "Apache License version 2.0":
-                        json.SafeAdd("license", "Apache-2.0");
-                        break;
-                    case "Apple Public Source License version 2.0 (APSL)":
-                        json.SafeAdd("license", "APSL-2.0");
-                        break;
-                    case "BSD License":
-                        json.SafeAdd("license", "BSD-3-clause");
-                        break;
-                    case "Common Development and Distribution License (CDDL) ":
-                        json.SafeAdd("license", "CDDL");
-                        break;
-                    case "GNU Affero General Public License version 3 (AGPLv3)":
-                        json.SafeAdd("license", "AGPL-3.0");
-                        break;
-                    case "GNU General Public License version 2 (GPLv2)":
-                        json.SafeAdd("license", "GPL-2.0");
-                        break;
-                    case "GNU General Public License version 3 (GPLv3)":
-                        json.SafeAdd("license", "GPL-3.0");
-                        break;
-                    case "GNU Lesser General Public License version 2.1 (LGPLv2.1)":
-                        json.SafeAdd("license", "LGPL-2.1");
-                        break;
-                    case "GNU Lesser General Public License version 3 (LGPLv3)":
-                        json.SafeAdd("license", "LGPL-3.0");
-                        break;
-                    case "ISC License (ISCL)":
-                        json.SafeAdd("license", "ISC");
-                        break;
-                    case "Microsoft Public License (Ms-PL)":
-                        json.SafeAdd("license", "Ms-PL");
-                        break;
-                    case "Microsoft Reciprocal License (Ms-RL)":
-                        json.SafeAdd("license", "Ms-RL");
-                        break;
-                    case "MIT License":
-                        json.SafeAdd("license", "MIT");
-                        break;
-                    case "Mozilla Public License 1.0 (MPL)":
-                        json.SafeAdd("license", "MPL-1.0");
-                        break;
-                    case "Mozilla Public License 1.1 (MPL 1.1)":
-                        json.SafeAdd("license", "MPL-1.1");
-                        break;
-                    case "Public Domain":
-                        json.SafeAdd("license", "public-domain");
-                        break;
-                    case "WTFPL":
-                        json.SafeAdd("license", "WTFPL");
-                        break;
-                    case "zlib/libpng License":
-                        json.SafeAdd("license", "Zlib");
-                        break;
-                    default:
-                        json.SafeAdd("license", "unknown");
-                        break;
+                    Log.DebugFormat("Writing ksp_version from Curse: {0}", latestVersion.version);
+                    json["ksp_version"] = latestVersion.version.ToString();
                 }
-
-                // Make sure resources exist.
-                if (json["resources"] == null)
+                else
                 {
-                    json["resources"] = new JObject();
+                    Log.DebugFormat("Writing ksp_version_min,_max from Curse: {0}, {1}", minVer, maxVer);
+                    json["ksp_version_min"] = minVer.ToString();
+                    json["ksp_version_max"] = maxVer.ToString();
                 }
-
-                var resourcesJson = (JObject)json["resources"];
-
-                //resourcesJson.SafeAdd("homepage", Normalize(curseMod.website));
-                //resourcesJson.SafeAdd("repository", Normalize(curseMod.source_code));
-                resourcesJson.SafeAdd("curse", curseMod.GetProjectUrl());
-
-                if (curseMod.thumbnail != null)
-                {
-                    resourcesJson.SafeAdd("x_screenshot", Normalize(new Uri(curseMod.thumbnail)));
-                }
-
-                Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
-
-                return new Metadata(json);
             }
 
-            return metadata;
+            var useDownloadNameVersion = false;
+            var useFilenameVersion = false;
+            var useCurseIdVersion = false;
+
+            var curseMetadata = (JObject) json["x_netkan_curse"];
+            if (curseMetadata != null)
+            {
+                var useDownloadNameVersionMetadata = (bool?)curseMetadata["use_download_name_version"];
+                if (useDownloadNameVersionMetadata != null)
+                {
+                    useDownloadNameVersion = useDownloadNameVersionMetadata.Value;
+                }
+
+                var useFilenameVersionMetadata = (bool?) curseMetadata["use_filename_version"];
+                if (useFilenameVersionMetadata != null)
+                {
+                    useFilenameVersion = useFilenameVersionMetadata.Value;
+                }
+
+                var useCurseIdVersionMetadata = (bool?)curseMetadata["use_curse_id_version"];
+                if (useCurseIdVersionMetadata != null)
+                {
+                    useCurseIdVersion = useCurseIdVersionMetadata.Value;
+                }
+
+                if ((useDownloadNameVersion ? 1 : 0) + (useFilenameVersion ? 1 : 0) + (useCurseIdVersion ? 1 : 0) > 1)
+                {
+                    throw new Kraken("Conflicting version options set in x_netkan_curse");
+                }
+            }
+
+            json.SafeAdd("name", curseMod.GetName());
+            json.SafeAdd("abstract", curseMod.description);
+
+            if (useDownloadNameVersion)  json.SafeAdd("version", latestVersion.name);
+            else if (useFilenameVersion) json.SafeAdd("version", latestVersion.GetFilename());
+            else if (useCurseIdVersion)  json.SafeAdd("version", latestVersion.GetCurseIdVersion());
+            else                         json.SafeAdd("version", latestVersion.GetFileVersion());
+
+            json.SafeAdd("author", JToken.FromObject(curseMod.authors));
+            json.SafeAdd("download", Regex.Replace(latestVersion.GetDownloadUrl(), " ", "%20"));
+
+            // Curse provides users with the following default selection of licenses. Let's convert them to CKAN
+            // compatible license strings if possible.
+            //
+            // "Academic Free License v3.0"                               - Becomes "AFL-3.0"
+            // "Ace3 Style BSD"                                           - Becomes "restricted"
+            // "All Rights Reserved"                                      - Becomes "restricted"
+            // "Apache License version 2.0"                               - Becomes "Apache-2.0"
+            // "Apple Public Source License version 2.0 (APSL)"           - Becomes "APSL-2.0"
+            // "BSD License"                                              - Becomes "BSD-3-clause"
+            // "Common Development and Distribution License (CDDL) "      - Becomes "CDDL"
+            // "GNU Affero General Public License version 3 (AGPLv3)"     - Becomes "AGPL-3.0"
+            // "GNU General Public License version 2 (GPLv2)"             - Becomes "GPL-2.0"
+            // "GNU General Public License version 3 (GPLv3)"             - Becomes "GPL-3.0"
+            // "GNU Lesser General Public License version 2.1 (LGPLv2.1)" - Becomes "LGPL-2.1"
+            // "GNU Lesser General Public License version 3 (LGPLv3)"     - Becomes "LGPL-3.0"
+            // "ISC License (ISCL)"                                       - Becomes "ISC"
+            // "Microsoft Public License (Ms-PL)"                         - Becomes "Ms-PL"
+            // "Microsoft Reciprocal License (Ms-RL)"                     - Becomes "Ms-RL"
+            // "MIT License"                                              - Becomes "MIT"
+            // "Mozilla Public License 1.0 (MPL)"                         - Becomes "MPL-1.0"
+            // "Mozilla Public License 1.1 (MPL 1.1)"                     - Becomes "MPL-1.1"
+            // "Public Domain"                                            - Becomes "public-domain"
+            // "WTFPL"                                                    - Becomes "WTFPL"
+            // "zlib/libpng License"                                      - Becomes "Zlib"
+            // "Custom License"                                           - Becomes "unknown"
+
+            var curseLicense = curseMod.license.Trim();
+
+            switch (curseLicense)
+            {
+                case "Academic Free License v3.0":
+                    json.SafeAdd("license", "AFL-3.0");
+                    break;
+                case "Ace3 Style BSD":
+                    json.SafeAdd("license", "restricted");
+                    break;
+                case "All Rights Reserved":
+                    json.SafeAdd("license", "restricted");
+                    break;
+                case "Apache License version 2.0":
+                    json.SafeAdd("license", "Apache-2.0");
+                    break;
+                case "Apple Public Source License version 2.0 (APSL)":
+                    json.SafeAdd("license", "APSL-2.0");
+                    break;
+                case "BSD License":
+                    json.SafeAdd("license", "BSD-3-clause");
+                    break;
+                case "Common Development and Distribution License (CDDL) ":
+                    json.SafeAdd("license", "CDDL");
+                    break;
+                case "GNU Affero General Public License version 3 (AGPLv3)":
+                    json.SafeAdd("license", "AGPL-3.0");
+                    break;
+                case "GNU General Public License version 2 (GPLv2)":
+                    json.SafeAdd("license", "GPL-2.0");
+                    break;
+                case "GNU General Public License version 3 (GPLv3)":
+                    json.SafeAdd("license", "GPL-3.0");
+                    break;
+                case "GNU Lesser General Public License version 2.1 (LGPLv2.1)":
+                    json.SafeAdd("license", "LGPL-2.1");
+                    break;
+                case "GNU Lesser General Public License version 3 (LGPLv3)":
+                    json.SafeAdd("license", "LGPL-3.0");
+                    break;
+                case "ISC License (ISCL)":
+                    json.SafeAdd("license", "ISC");
+                    break;
+                case "Microsoft Public License (Ms-PL)":
+                    json.SafeAdd("license", "Ms-PL");
+                    break;
+                case "Microsoft Reciprocal License (Ms-RL)":
+                    json.SafeAdd("license", "Ms-RL");
+                    break;
+                case "MIT License":
+                    json.SafeAdd("license", "MIT");
+                    break;
+                case "Mozilla Public License 1.0 (MPL)":
+                    json.SafeAdd("license", "MPL-1.0");
+                    break;
+                case "Mozilla Public License 1.1 (MPL 1.1)":
+                    json.SafeAdd("license", "MPL-1.1");
+                    break;
+                case "Public Domain":
+                    json.SafeAdd("license", "public-domain");
+                    break;
+                case "WTFPL":
+                    json.SafeAdd("license", "WTFPL");
+                    break;
+                case "zlib/libpng License":
+                    json.SafeAdd("license", "Zlib");
+                    break;
+                default:
+                    json.SafeAdd("license", "unknown");
+                    break;
+            }
+
+            // Make sure resources exist.
+            if (json["resources"] == null)
+            {
+                json["resources"] = new JObject();
+            }
+
+            var resourcesJson = (JObject)json["resources"];
+
+            //resourcesJson.SafeAdd("homepage", Normalize(curseMod.website));
+            //resourcesJson.SafeAdd("repository", Normalize(curseMod.source_code));
+            resourcesJson.SafeAdd("curse", curseMod.GetProjectUrl());
+
+            if (curseMod.thumbnail != null)
+            {
+                resourcesJson.SafeAdd("x_screenshot", Normalize(new Uri(curseMod.thumbnail)));
+            }
+
+            Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
+
+            return new Metadata(json);
         }
 
         private static string Normalize(Uri uri)

--- a/Netkan/Transformers/DownloadAttributeTransformer.cs
+++ b/Netkan/Transformers/DownloadAttributeTransformer.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using log4net;
+using Newtonsoft.Json.Linq;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Extensions;
-using log4net;
-using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -25,7 +26,7 @@ namespace CKAN.NetKAN.Transformers
             _fileService = fileService;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Download != null)
             {
@@ -51,10 +52,12 @@ namespace CKAN.NetKAN.Transformers
 
                 Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
-                return new Metadata(json);
+                yield return new Metadata(json);
             }
-
-            return metadata;
+            else
+            {
+                yield return metadata;
+            }
         }
     }
 }

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using CKAN.NetKAN.Model;
 using log4net;
 using Newtonsoft.Json.Linq;
@@ -14,7 +15,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "epoch"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             Log.Debug("Fixing version strings (if required)...");
 
@@ -42,7 +43,7 @@ namespace CKAN.NetKAN.Transformers
                 }
             }
 
-            return new Metadata(json);
+            yield return new Metadata(json);
         }
     }
 }

--- a/Netkan/Transformers/ForcedVTransformer.cs
+++ b/Netkan/Transformers/ForcedVTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using CKAN.NetKAN.Model;
 using log4net;
 using Newtonsoft.Json.Linq;
@@ -14,7 +15,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "forced_v"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             var json = metadata.Json();
 
@@ -39,7 +40,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
             }
 
-            return new Metadata(json);
+            yield return new Metadata(json);
         }
     }
 }

--- a/Netkan/Transformers/GeneratedByTransformer.cs
+++ b/Netkan/Transformers/GeneratedByTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using CKAN.NetKAN.Model;
 using log4net;
 
@@ -14,7 +15,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "generated_by"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             var json = metadata.Json();
 
@@ -25,7 +26,7 @@ namespace CKAN.NetKAN.Transformers
 
             Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
-            return new Metadata(json);
+            yield return new Metadata(json);
         }
     }
 }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Collections.Generic;
+using log4net;
+using Newtonsoft.Json.Linq;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Sources.Github;
-using log4net;
-using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -15,20 +16,22 @@ namespace CKAN.NetKAN.Transformers
         private static readonly ILog Log = LogManager.GetLogger(typeof(GithubTransformer));
 
         private readonly IGithubApi _api;
-        private readonly bool _matchPreleases;
+        private readonly bool       _matchPreleases;
+        private readonly bool       _backfill;
 
         public string Name { get { return "github"; } }
 
-        public GithubTransformer(IGithubApi api, bool matchPreleases)
+        public GithubTransformer(IGithubApi api, bool matchPreleases, bool backfill)
         {
             if (api == null)
                 throw new ArgumentNullException("api");
 
-            _api = api;
+            _api            = api;
             _matchPreleases = matchPreleases;
+            _backfill       = backfill;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == "github")
             {
@@ -54,72 +57,90 @@ namespace CKAN.NetKAN.Transformers
 
                 // Get the GitHub repository
                 var ghRepo = _api.GetRepo(ghRef);
-                // Get the GitHub release
-                var ghRelease = _api.GetLatestRelease(ghRef);
 
-                // Make sure resources exist.
-                if (json["resources"] == null)
-                    json["resources"] = new JObject();
-
-                var resourcesJson = (JObject)json["resources"];
-
-                if (!string.IsNullOrWhiteSpace(ghRepo.Description))
-                    json.SafeAdd("abstract", ghRepo.Description);
-
-                // GitHub says NOASSERTION if it can't figure out the repo's license
-                if (!string.IsNullOrWhiteSpace(ghRepo.License?.Id)
-                    && ghRepo.License.Id != "NOASSERTION")
-                    json.SafeAdd("license", ghRepo.License.Id);
-
-                if (!string.IsNullOrWhiteSpace(ghRepo.Homepage))
-                    resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
-
-                resourcesJson.SafeAdd("repository", ghRepo.HtmlUrl);
-
-                if (ghRelease != null)
+                if (_backfill)
                 {
-                    json.SafeAdd("version",  ghRelease.Version.ToString());
-                    json.SafeAdd("author",   ghRelease.Author);
-                    json.SafeAdd("download", ghRelease.Download.ToString());
-                    json.SafeAdd(Model.Metadata.UpdatedPropertyName, ghRelease.AssetUpdated);
-
-                    if (ghRef.Project.Contains("_"))
+                    foreach (GithubRelease rel in _api.GetAllReleases(ghRef))
                     {
-                        json.SafeAdd("name", ghRef.Project.Replace("_", " "));
+                        yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel);
                     }
-                    else if (ghRef.Project.Contains("-"))
-                    {
-                        json.SafeAdd("name", ghRef.Project.Replace("-", " "));
-                    }
-                    else if (ghRef.Project.Contains("."))
-                    {
-                        json.SafeAdd("name", ghRef.Project.Replace(".", " "));
-                    }
-                    else
-                    {
-                        var repoName = ghRef.Project;
-                        for (var i = 1; i < repoName.Length - 1; ++i)
-                        {
-                            if (char.IsLower(repoName[i - 1]) && char.IsUpper(repoName[i]) || repoName[i - 1] != ' ' && char.IsUpper(repoName[i]) && char.IsLower(repoName[i + 1]))
-                            {
-                                repoName = repoName.Insert(i, " ");
-                            }
-                        }
-
-                        json.SafeAdd("name", repoName);
-                    }
-
-                    Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
-
-                    return new Metadata(json);
                 }
                 else
                 {
-                    Log.WarnFormat("No releases found for {0}", ghRef.Repository);
+                    // Get the GitHub release
+                    yield return TransformOne(metadata, json, ghRef, ghRepo, _api.GetLatestRelease(ghRef));
                 }
             }
-
-            return metadata;
+            else
+            {
+                yield return metadata;
+            }
         }
+
+        private Metadata TransformOne(Metadata metadata, JObject json, GithubRef ghRef, GithubRepo ghRepo, GithubRelease ghRelease)
+        {
+            // Make sure resources exist.
+            if (json["resources"] == null)
+                json["resources"] = new JObject();
+
+            var resourcesJson = (JObject)json["resources"];
+
+            if (!string.IsNullOrWhiteSpace(ghRepo.Description))
+                json.SafeAdd("abstract", ghRepo.Description);
+
+            // GitHub says NOASSERTION if it can't figure out the repo's license
+            if (!string.IsNullOrWhiteSpace(ghRepo.License?.Id)
+                && ghRepo.License.Id != "NOASSERTION")
+                json.SafeAdd("license", ghRepo.License.Id);
+
+            if (!string.IsNullOrWhiteSpace(ghRepo.Homepage))
+                resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
+
+            resourcesJson.SafeAdd("repository", ghRepo.HtmlUrl);
+
+            if (ghRelease != null)
+            {
+                json.SafeAdd("version",  ghRelease.Version.ToString());
+                json.SafeAdd("author",   ghRelease.Author);
+                json.SafeAdd("download", ghRelease.Download.ToString());
+                json.SafeAdd(Model.Metadata.UpdatedPropertyName, ghRelease.AssetUpdated);
+
+                if (ghRef.Project.Contains("_"))
+                {
+                    json.SafeAdd("name", ghRef.Project.Replace("_", " "));
+                }
+                else if (ghRef.Project.Contains("-"))
+                {
+                    json.SafeAdd("name", ghRef.Project.Replace("-", " "));
+                }
+                else if (ghRef.Project.Contains("."))
+                {
+                    json.SafeAdd("name", ghRef.Project.Replace(".", " "));
+                }
+                else
+                {
+                    var repoName = ghRef.Project;
+                    for (var i = 1; i < repoName.Length - 1; ++i)
+                    {
+                        if (char.IsLower(repoName[i - 1]) && char.IsUpper(repoName[i]) || repoName[i - 1] != ' ' && char.IsUpper(repoName[i]) && char.IsLower(repoName[i + 1]))
+                        {
+                            repoName = repoName.Insert(i, " ");
+                        }
+                    }
+
+                    json.SafeAdd("name", repoName);
+                }
+
+                Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
+
+                return new Metadata(json);
+            }
+            else
+            {
+                Log.WarnFormat("No releases found for {0}", ghRef.Repository);
+                return metadata;
+            }
+        }
+
     }
 }

--- a/Netkan/Transformers/HttpTransformer.cs
+++ b/Netkan/Transformers/HttpTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using CKAN.NetKAN.Model;
 using log4net;
 
@@ -13,7 +14,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "http"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == "http")
             {
@@ -34,7 +35,7 @@ namespace CKAN.NetKAN.Transformers
 
                         Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
-                        return new Metadata(json);
+                        yield return new Metadata(json);
                     }
                     else
                     {
@@ -48,7 +49,7 @@ namespace CKAN.NetKAN.Transformers
             }
             else
             {
-                return metadata;
+                yield return metadata;
             }
         }
     }

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 ﻿using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Transformers
@@ -17,6 +18,6 @@ namespace CKAN.NetKAN.Transformers
         /// </summary>
         /// <param name="metadata">The metadata to transform.</param>
         /// <returns>The transformed metadata.</returns>
-        Metadata Transform(Metadata metadata);
+        IEnumerable<Metadata> Transform(Metadata metadata);
     }
 }

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using log4net;
+using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
-using CKAN.Versioning;
-using log4net;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -25,7 +26,7 @@ namespace CKAN.NetKAN.Transformers
             _moduleService = moduleService;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Download != null)
             {
@@ -51,10 +52,12 @@ namespace CKAN.NetKAN.Transformers
                     Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
                 }
 
-                return new Metadata(json);
+                yield return new Metadata(json);
             }
-
-            return metadata;
+            else
+            {
+                yield return metadata;
+            }
         }
     }
 }

--- a/Netkan/Transformers/JenkinsTransformer.cs
+++ b/Netkan/Transformers/JenkinsTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using log4net;
 using Newtonsoft.Json.Linq;
@@ -13,14 +14,15 @@ namespace CKAN.NetKAN.Transformers
     /// </summary>
     internal sealed class JenkinsTransformer : ITransformer
     {
-        public JenkinsTransformer(IJenkinsApi api)
+        public JenkinsTransformer(IJenkinsApi api, bool backfill)
         {
-            _api = api;
+            _api      = api;
+            _backfill = backfill;
         }
 
         public string Name { get { return "jenkins"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == "jenkins")
             {
@@ -31,58 +33,73 @@ namespace CKAN.NetKAN.Transformers
 
                 JenkinsOptions options = json["x_netkan_jenkins"]?.ToObject<JenkinsOptions>()
                     ?? new JenkinsOptions();
+                JenkinsRef jRef = new JenkinsRef(metadata.Kref);
 
-                JenkinsBuild build = _api.GetLatestBuild(
-                    new JenkinsRef(metadata.Kref),
-                    options
-                );
-
-                JenkinsArtifact[] artifacts = build.Artifacts
-                    .Where(a => options.AssetMatchPattern.IsMatch(a.FileName))
-                    .ToArray();
-
-                switch (artifacts.Length)
+                if (_backfill)
                 {
-                    case 1:
-                        JenkinsArtifact artifact = artifacts.Single();
-
-                        string download = Uri.EscapeUriString(
-                            $"{build.Url}artifact/{artifact.RelativePath}"
-                        );
-                        Log.DebugFormat("Using download URL: {0}", download);
-                        json.SafeAdd("download", download);
-
-                        if (options.UseFilenameVersion)
-                        {
-                            Log.DebugFormat("Using filename as version: {0}", artifact.FileName);
-                            json.SafeAdd("version", artifact.FileName);
-                        }
-
-                        // Make sure resources exist.
-                        if (json["resources"] == null)
-                        {
-                            json["resources"] = new JObject();
-                        }
-
-                        var resourcesJson = (JObject)json["resources"];
-                        resourcesJson.SafeAdd("ci", Uri.EscapeUriString(metadata.Kref.Id));
-
-                        Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
-
-                        return new Metadata(json);
-                        break;
-
-                    case 0:
-                        throw new Exception("Could not find any matching artifacts");
-
-                    default:
-                        throw new Exception("Found too many matching artifacts");
+                    foreach (JenkinsBuild build in _api.GetAllBuilds(jRef, options))
+                    {
+                        yield return TransformOne(metadata, metadata.Json(), build, options);
+                    }
+                }
+                else
+                {
+                    yield return TransformOne(metadata, json, _api.GetLatestBuild(jRef, options), options);
                 }
             }
-            return metadata;
+            else
+            {
+                yield return metadata;
+            }
+        }
+
+        private Metadata TransformOne(Metadata metadata, JObject json, JenkinsBuild build, JenkinsOptions options)
+        {
+            JenkinsArtifact[] artifacts = build.Artifacts
+                .Where(a => options.AssetMatchPattern.IsMatch(a.FileName))
+                .ToArray();
+
+            switch (artifacts.Length)
+            {
+                case 1:
+                    JenkinsArtifact artifact = artifacts.Single();
+
+                    string download = Uri.EscapeUriString(
+                        $"{build.Url}artifact/{artifact.RelativePath}"
+                    );
+                    Log.DebugFormat("Using download URL: {0}", download);
+                    json.SafeAdd("download", download);
+
+                    if (options.UseFilenameVersion)
+                    {
+                        Log.DebugFormat("Using filename as version: {0}", artifact.FileName);
+                        json.SafeAdd("version", artifact.FileName);
+                    }
+
+                    // Make sure resources exist.
+                    if (json["resources"] == null)
+                    {
+                        json["resources"] = new JObject();
+                    }
+
+                    var resourcesJson = (JObject)json["resources"];
+                    resourcesJson.SafeAdd("ci", Uri.EscapeUriString(metadata.Kref.Id));
+
+                    Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
+
+                    return new Metadata(json);
+                    break;
+
+                case 0:
+                    throw new Exception("Could not find any matching artifacts");
+
+                default:
+                    throw new Exception("Found too many matching artifacts");
+            }
         }
 
         private readonly IJenkinsApi _api;
+        private readonly bool        _backfill;
         private static readonly ILog Log = LogManager.GetLogger(typeof(JenkinsTransformer));
     }
 }

--- a/Netkan/Transformers/MetaNetkanTransformer.cs
+++ b/Netkan/Transformers/MetaNetkanTransformer.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using log4net;
+using Newtonsoft.Json.Linq;
+using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
-using CKAN.Versioning;
-using log4net;
-using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -26,7 +27,7 @@ namespace CKAN.NetKAN.Transformers
             _http = http;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == KrefSource)
             {
@@ -64,15 +65,17 @@ namespace CKAN.NetKAN.Transformers
 
                     Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
-                    return new Metadata(json);
+                    yield return new Metadata(json);
                 }
                 else
                 {
                     throw new Kraken("The target of a metanetkan may not also be a metanetkan.");
                 }
             }
-
-            return metadata;
+            else
+            {
+                yield return metadata;
+            }
         }
     }
 }

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -24,17 +24,17 @@ namespace CKAN.NetKAN.Transformers
             IModuleService moduleService,
             string githubToken,
             bool prerelease,
-            bool backfill
+            int? releases
         )
         {
             _transformers = InjectVersionedOverrideTransformers(new List<ITransformer>
             {
                 new MetaNetkanTransformer(http),
-                new SpacedockTransformer(new SpacedockApi(http), backfill),
-                new CurseTransformer(new CurseApi(http), backfill),
-                new GithubTransformer(new GithubApi(http, githubToken), prerelease, backfill),
+                new SpacedockTransformer(new SpacedockApi(http), releases),
+                new CurseTransformer(new CurseApi(http), releases),
+                new GithubTransformer(new GithubApi(http, githubToken), prerelease, releases),
                 new HttpTransformer(),
-                new JenkinsTransformer(new JenkinsApi(http), backfill),
+                new JenkinsTransformer(new JenkinsApi(http), releases),
                 new AvcKrefTransformer(http),
                 new InternalCkanTransformer(http, moduleService),
                 new AvcTransformer(http, moduleService),

--- a/Netkan/Transformers/OptimusPrimeTransformer.cs
+++ b/Netkan/Transformers/OptimusPrimeTransformer.cs
@@ -1,6 +1,7 @@
-﻿using CKAN.NetKAN.Model;
+using System.Collections.Generic;
 using log4net;
 using Newtonsoft.Json.Linq;
+using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -10,7 +11,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "optimus_prime"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             var json = metadata.Json();
 
@@ -20,7 +21,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.Info("Autobots roll out!");
             }
 
-            return metadata;
+            yield return metadata;
         }
     }
 }

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -61,7 +61,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "property_sort"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             var json = metadata.Json();
             var sortedJson = new JObject();
@@ -101,7 +101,7 @@ namespace CKAN.NetKAN.Transformers
 
             Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, sortedJson);
 
-            return new Metadata(sortedJson);
+            yield return new Metadata(sortedJson);
         }
 
         private static double GetPropertySortOrder(string propertyName)

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -18,15 +18,17 @@ namespace CKAN.NetKAN.Transformers
         private static readonly ILog Log = LogManager.GetLogger(typeof(SpacedockTransformer));
 
         private readonly ISpacedockApi _api;
+        private readonly bool          _backfill;
 
         public string Name { get { return "spacedock"; } }
 
-        public SpacedockTransformer(ISpacedockApi api)
+        public SpacedockTransformer(ISpacedockApi api, bool backfill)
         {
-            _api = api;
+            _api      = api;
+            _backfill = backfill;
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             if (metadata.Kref != null && metadata.Kref.Source == "spacedock")
             {
@@ -37,76 +39,92 @@ namespace CKAN.NetKAN.Transformers
 
                 // Look up our mod on SD by its Id.
                 var sdMod = _api.GetMod(Convert.ToInt32(metadata.Kref.Id));
-                var latestVersion = sdMod.Latest();
 
-                Log.InfoFormat("Found SpaceDock mod: {0} {1}", sdMod.name, latestVersion.friendly_version);
-
-                // Only pre-fill version info if there's none already. GH #199
-                if (json["ksp_version_min"] == null && json["ksp_version_max"] == null && json["ksp_version"] == null)
+                if (_backfill)
                 {
-                    Log.DebugFormat("Writing ksp_version from SpaceDock: {0}", latestVersion.KSP_version);
-                    json["ksp_version"] = latestVersion.KSP_version.ToString();
+                    foreach (SDVersion vers in sdMod.All())
+                    {
+                        yield return TransformOne(metadata, metadata.Json(), sdMod, vers);
+                    }
                 }
-
-                json.SafeAdd("name", sdMod.name);
-                json.SafeAdd("abstract", sdMod.short_description);
-                json.SafeAdd("version", latestVersion.friendly_version.ToString());
-                json.SafeAdd("download", latestVersion.download_path.OriginalString);
-
-                var authors = GetAuthors(sdMod);
-
-                if (authors.Count == 1)
-                    json.SafeAdd("author", sdMod.author);
-                else if (authors.Count > 1)
-                    json.SafeAdd("author", new JArray(authors));
-
-                // SD provides users with the following default selection of licenses. Let's convert them to CKAN
-                // compatible license strings if possible.
-                //
-                // "MIT" - OK
-                // "BSD" - Specific version is indeterminate
-                // "GPLv2" - Becomes "GPL-2.0"
-                // "GPLv3" - Becomes "GPL-3.0"
-                // "LGPL" - Specific version is indeterminate
-
-                var sdLicense = sdMod.license.Trim();
-
-                switch (sdLicense)
+                else
                 {
-                    case "GPLv2":
-                        json.SafeAdd("license", "GPL-2.0");
-                        break;
-                    case "GPLv3":
-                        json.SafeAdd("license", "GPL-3.0");
-                        break;
-                    default:
-                        json.SafeAdd("license", sdLicense);
-                        break;
+                    yield return TransformOne(metadata, json, sdMod, sdMod.Latest());
                 }
+            }
+            else
+            {
+                yield return metadata;
+            }
+        }
 
-                // Make sure resources exist.
-                if (json["resources"] == null)
-                {
-                    json["resources"] = new JObject();
-                }
+        private Metadata TransformOne(Metadata metadata, JObject json, SpacedockMod sdMod, SDVersion latestVersion)
+        {
+            Log.InfoFormat("Found SpaceDock mod: {0} {1}", sdMod.name, latestVersion.friendly_version);
 
-                var resourcesJson = (JObject)json["resources"];
-
-                TryAddResourceURL(metadata.Identifier, resourcesJson, "homepage",   sdMod.website);
-                TryAddResourceURL(metadata.Identifier, resourcesJson, "repository", sdMod.source_code);
-                resourcesJson.SafeAdd("spacedock", sdMod.GetPageUrl().OriginalString);
-
-                if (sdMod.background != null)
-                {
-                    TryAddResourceURL(metadata.Identifier, resourcesJson, "x_screenshot", sdMod.background.ToString());
-                }
-
-                Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
-
-                return new Metadata(json);
+            // Only pre-fill version info if there's none already. GH #199
+            if (json["ksp_version_min"] == null && json["ksp_version_max"] == null && json["ksp_version"] == null)
+            {
+                Log.DebugFormat("Writing ksp_version from SpaceDock: {0}", latestVersion.KSP_version);
+                json["ksp_version"] = latestVersion.KSP_version.ToString();
             }
 
-            return metadata;
+            json.SafeAdd("name", sdMod.name);
+            json.SafeAdd("abstract", sdMod.short_description);
+            json.SafeAdd("version", latestVersion.friendly_version.ToString());
+            json.SafeAdd("download", latestVersion.download_path.OriginalString);
+
+            var authors = GetAuthors(sdMod);
+
+            if (authors.Count == 1)
+                json.SafeAdd("author", sdMod.author);
+            else if (authors.Count > 1)
+                json.SafeAdd("author", new JArray(authors));
+
+            // SD provides users with the following default selection of licenses. Let's convert them to CKAN
+            // compatible license strings if possible.
+            //
+            // "MIT" - OK
+            // "BSD" - Specific version is indeterminate
+            // "GPLv2" - Becomes "GPL-2.0"
+            // "GPLv3" - Becomes "GPL-3.0"
+            // "LGPL" - Specific version is indeterminate
+
+            var sdLicense = sdMod.license.Trim();
+
+            switch (sdLicense)
+            {
+                case "GPLv2":
+                    json.SafeAdd("license", "GPL-2.0");
+                    break;
+                case "GPLv3":
+                    json.SafeAdd("license", "GPL-3.0");
+                    break;
+                default:
+                    json.SafeAdd("license", sdLicense);
+                    break;
+            }
+
+            // Make sure resources exist.
+            if (json["resources"] == null)
+            {
+                json["resources"] = new JObject();
+            }
+
+            var resourcesJson = (JObject)json["resources"];
+
+            TryAddResourceURL(metadata.Identifier, resourcesJson, "homepage",   sdMod.website);
+            TryAddResourceURL(metadata.Identifier, resourcesJson, "repository", sdMod.source_code);
+            resourcesJson.SafeAdd("spacedock", sdMod.GetPageUrl().OriginalString);
+
+            if (sdMod.background != null)
+            {
+                TryAddResourceURL(metadata.Identifier, resourcesJson, "x_screenshot", sdMod.background.ToString());
+            }
+
+            Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
+
+            return new Metadata(json);
         }
 
         private void TryAddResourceURL(string identifier, JObject resources, string key, string rawURL)

--- a/Netkan/Transformers/StripNetkanMetadataTransformer.cs
+++ b/Netkan/Transformers/StripNetkanMetadataTransformer.cs
@@ -16,7 +16,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "strip_netkan_metadata"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             var json = metadata.Json();
 
@@ -27,7 +27,7 @@ namespace CKAN.NetKAN.Transformers
 
             Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
-            return new Metadata(json);
+            yield return new Metadata(json);
         }
 
         private static void Strip(JObject metadata)

--- a/Netkan/Transformers/VersionEditTransformer.cs
+++ b/Netkan/Transformers/VersionEditTransformer.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using CKAN.NetKAN.Model;
 using log4net;
 using Newtonsoft.Json.Linq;
+using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -15,7 +16,7 @@ namespace CKAN.NetKAN.Transformers
 
         public string Name { get { return "version_edit"; } }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             var json = metadata.Json();
 
@@ -43,7 +44,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
             }
 
-            return new Metadata(json);
+            yield return new Metadata(json);
         }
 
         private static VersionEditInfo GetVersionEditInfo(JObject json)

--- a/Netkan/Transformers/VersionedOverrideTransformer.cs
+++ b/Netkan/Transformers/VersionedOverrideTransformer.cs
@@ -37,7 +37,7 @@ namespace CKAN.NetKAN.Transformers
             _after.Add(after);
         }
 
-        public Metadata Transform(Metadata metadata)
+        public IEnumerable<Metadata> Transform(Metadata metadata)
         {
             var json = metadata.Json();
 
@@ -62,7 +62,7 @@ namespace CKAN.NetKAN.Transformers
 
                     Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
-                    return new Metadata(json);
+                    yield return new Metadata(json);
                 }
                 else
                 {
@@ -72,8 +72,10 @@ namespace CKAN.NetKAN.Transformers
                             overrideList));
                 }
             }
-
-            return metadata;
+            else
+            {
+                yield return metadata;
+            }
         }
 
         /// <summary>

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -1,10 +1,11 @@
-﻿using CKAN;
-using CKAN.NetKAN;
-using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Tests.Data;
+using CKAN;
+using CKAN.NetKAN;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN
 {
@@ -18,7 +19,7 @@ namespace Tests.NetKAN
 
             Assert.AreEqual("1.01", (string)metadata["version"], "Original version as expected");
 
-            metadata = new EpochTransformer().Transform(new Metadata(metadata)).Json();
+            metadata = new EpochTransformer().Transform(new Metadata(metadata)).First().Json();
             Assert.AreEqual("1.01", (string)metadata["version"], "Version unharmed without x_netkan_force_v");
         }
 
@@ -35,7 +36,7 @@ namespace Tests.NetKAN
 
             Assert.AreEqual(orig_version, (string)metadata["version"], "JSON parsed as expected");
 
-            metadata = new ForcedVTransformer().Transform(new Metadata(metadata)).Json();
+            metadata = new ForcedVTransformer().Transform(new Metadata(metadata)).First().Json();
 
             Assert.AreEqual(new_version, (string)metadata["version"], "Output string as expected");
         }
@@ -49,7 +50,7 @@ namespace Tests.NetKAN
         {
             JObject metadata = JObject.Parse(json);
             Assert.AreEqual(orig_version, (string)metadata["version"], "JSON parsed as expected");
-            metadata = new EpochTransformer().Transform(new Metadata(metadata)).Json();
+            metadata = new EpochTransformer().Transform(new Metadata(metadata)).First().Json();
             Assert.AreEqual(new_version, (string)metadata["version"], "Output string as expected");
         }
 
@@ -59,7 +60,7 @@ namespace Tests.NetKAN
         [TestCase(@"{""spec_version"": 1, ""version"" : ""1.01"", ""x_netkan_epoch"" : ""5.5""}", true)]
         public void Invaild(string json, bool expected_to_throw)
         {
-            TestDelegate test_delegate = () => new EpochTransformer().Transform(new Metadata(JObject.Parse(json))).Json();
+            TestDelegate test_delegate = () => new EpochTransformer().Transform(new Metadata(JObject.Parse(json))).First().Json();
             if (expected_to_throw)
                 Assert.Throws<BadMetadataKraken>(test_delegate);
             else

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -1,8 +1,9 @@
-﻿using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Tests.Data;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN
 {
@@ -145,8 +146,8 @@ namespace Tests.NetKAN
             var earlyTransformer = new VersionedOverrideTransformer(new[] { "$all" }, new[] { "$none" });
             var lateTransformer = new VersionedOverrideTransformer(new[] { "$none" }, new[] { "$all" });
 
-            var transformedMetadata1 = earlyTransformer.Transform(new Metadata(metadata)).Json();
-            var transformedMetadata2 = lateTransformer.Transform(new Metadata(transformedMetadata1));
+            var transformedMetadata1 = earlyTransformer.Transform(new Metadata(metadata)).First().Json();
+            var transformedMetadata2 = lateTransformer.Transform(new Metadata(transformedMetadata1)).First();
 
             Assert.AreEqual((string)transformedMetadata2.Json()["name"], "LATE");
         }
@@ -169,7 +170,7 @@ namespace Tests.NetKAN
                 after: new string[] { null }
             );
 
-            return transformer.Transform(new Metadata(metadata)).Json();
+            return transformer.Transform(new Metadata(metadata)).First().Json();
         }
 
         /// <summary>
@@ -182,4 +183,3 @@ namespace Tests.NetKAN
         }
     }
 }
-

--- a/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using Moq;
@@ -65,7 +66,7 @@ namespace Tests.NetKAN.Transformers
 
             // Act
             var tran = new AvcKrefTransformer(http);
-            return tran.Transform(new Metadata(json));
+            return tran.Transform(new Metadata(json)).First();
         }
 
     }

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -1,12 +1,13 @@
-﻿using CKAN;
+using System.Linq;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using CKAN;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Sources.Avc;
 using CKAN.NetKAN.Transformers;
 using CKAN.Versioning;
-using Moq;
-using Newtonsoft.Json.Linq;
-using NUnit.Framework;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -38,7 +39,7 @@ namespace Tests.NetKAN.Transformers
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -76,7 +77,7 @@ namespace Tests.NetKAN.Transformers
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -208,7 +209,7 @@ namespace Tests.NetKAN.Transformers
             var sut = new AvcTransformer(mHttp.Object, mModuleService.Object);
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -247,7 +248,7 @@ namespace Tests.NetKAN.Transformers
             json["version"] = "9001";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -279,7 +280,7 @@ namespace Tests.NetKAN.Transformers
             json["x_netkan_trust_version_file"] = true;
 
             // Act
-            Metadata result          = sut.Transform(new Metadata(json));
+            Metadata result          = sut.Transform(new Metadata(json)).First();
             JObject  transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -21,7 +21,7 @@ namespace Tests.NetKAN.Transformers
             mApi.Setup(i => i.GetMod(It.IsAny<string>()))
                 .Returns(MakeTestMod());
 
-            var sut = new CurseTransformer(mApi.Object, false);
+            var sut = new CurseTransformer(mApi.Object, 1);
 
             var json = new JObject();
             json["spec_version"] = 1;

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
-using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Sources.Curse;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Sources.Curse;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -20,7 +21,7 @@ namespace Tests.NetKAN.Transformers
             mApi.Setup(i => i.GetMod(It.IsAny<string>()))
                 .Returns(MakeTestMod());
 
-            var sut = new CurseTransformer(mApi.Object);
+            var sut = new CurseTransformer(mApi.Object, false);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -28,7 +29,7 @@ namespace Tests.NetKAN.Transformers
             json["ksp_version_min"] = "0.23.5";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Linq;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Transformers;
-using Moq;
-using Newtonsoft.Json.Linq;
-using NUnit.Framework;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -47,7 +48,7 @@ namespace Tests.NetKAN.Transformers
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -82,7 +83,7 @@ namespace Tests.NetKAN.Transformers
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -104,7 +105,7 @@ namespace Tests.NetKAN.Transformers
             json["spec_version"] = 1;
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
@@ -1,7 +1,8 @@
-﻿using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -17,7 +18,7 @@ namespace Tests.NetKAN.Transformers
             json["spec_version"] = 1;
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -37,7 +37,15 @@ namespace Tests.NetKAN.Transformers
                     null
                 ));
 
-            var sut = new GithubTransformer(mApi.Object, false, false);
+            mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>()))
+                .Returns(new GithubRelease[] { new GithubRelease(
+                    "ExampleProject",
+                    new ModuleVersion("1.0"),
+                    new Uri("http://github.example/download"),
+                    null
+                )});
+
+            var sut = new GithubTransformer(mApi.Object, false, 1);
 
             // Act
             var result = sut.Transform(new Metadata(json)).First();
@@ -73,7 +81,15 @@ namespace Tests.NetKAN.Transformers
                     null
                 ));
 
-            ITransformer sut = new GithubTransformer(mApi.Object, false, false);
+            mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>()))
+                .Returns(new GithubRelease[] { new GithubRelease(
+                    "DestructionEffects",
+                    new ModuleVersion("v1.8,0"),
+                    new Uri("https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip"),
+                    null
+                )});
+
+            ITransformer sut = new GithubTransformer(mApi.Object, false, 1);
 
             // Act
             Metadata result = sut.Transform(new Metadata(json)).First();

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -1,12 +1,13 @@
 ﻿using System;
-using CKAN;
-using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Sources.Github;
-using CKAN.NetKAN.Transformers;
-using CKAN.Versioning;
+using System.Linq;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using CKAN;
+using CKAN.Versioning;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Sources.Github;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -36,10 +37,10 @@ namespace Tests.NetKAN.Transformers
                     null
                 ));
 
-            var sut = new GithubTransformer(mApi.Object, matchPreleases: false);
+            var sut = new GithubTransformer(mApi.Object, false, false);
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -72,10 +73,10 @@ namespace Tests.NetKAN.Transformers
                     null
                 ));
 
-            ITransformer sut = new GithubTransformer(mApi.Object, matchPreleases: false);
+            ITransformer sut = new GithubTransformer(mApi.Object, false, false);
 
             // Act
-            Metadata result = sut.Transform(new Metadata(json));
+            Metadata result = sut.Transform(new Metadata(json)).First();
             JObject transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/HttpTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/HttpTransformerTests.cs
@@ -1,7 +1,8 @@
-﻿using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -22,7 +23,7 @@ namespace Tests.NetKAN.Transformers
             json["$kref"] = kref;
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Services;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -37,7 +38,7 @@ namespace Tests.NetKAN.Transformers
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -73,7 +74,7 @@ namespace Tests.NetKAN.Transformers
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -110,7 +111,7 @@ namespace Tests.NetKAN.Transformers
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Linq;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
 using CKAN;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Transformers;
-using Moq;
-using Newtonsoft.Json.Linq;
-using NUnit.Framework;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -25,7 +26,7 @@ namespace Tests.NetKAN.Transformers
             json["$kref"] = "#/ckan/foo";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -54,7 +55,7 @@ namespace Tests.NetKAN.Transformers
             json["$kref"] = "#/ckan/netkan/http://awesomemod.example/AwesomeMod.netkan";
 
             // Act
-            TestDelegate act = () => sut.Transform(new Metadata(json));
+            TestDelegate act = () => sut.Transform(new Metadata(json)).First();
 
             // Assert
             Assert.That(act, Throws.Exception.InstanceOf<Kraken>(),
@@ -82,7 +83,7 @@ namespace Tests.NetKAN.Transformers
             json["$kref"] = "#/ckan/netkan/http://awesomemod.example/AwesomeMod.netkan";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -112,7 +113,7 @@ namespace Tests.NetKAN.Transformers
             json["foo"] = "baz";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -141,7 +142,7 @@ namespace Tests.NetKAN.Transformers
             json["$kref"] = "#/ckan/netkan/http://awesomemod.example/AwesomeMod.netkan";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Linq;
+using CKAN.Versioning;
 using CKAN.NetKAN;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Sources.Spacedock;
 using CKAN.NetKAN.Transformers;
-using CKAN.Versioning;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -36,7 +37,7 @@ namespace Tests.NetKAN.Transformers
                     }
                 });
 
-            ITransformer sut = new SpacedockTransformer(mApi.Object);
+            ITransformer sut = new SpacedockTransformer(mApi.Object, false);
 
             JObject json            = new JObject();
             json["spec_version"]    = 1;
@@ -44,7 +45,7 @@ namespace Tests.NetKAN.Transformers
             json["ksp_version_min"] = "0.23.5";
 
             // Act
-            Metadata result          = sut.Transform(new Metadata(json));
+            Metadata result          = sut.Transform(new Metadata(json)).First();
             JObject  transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -37,7 +37,7 @@ namespace Tests.NetKAN.Transformers
                     }
                 });
 
-            ITransformer sut = new SpacedockTransformer(mApi.Object, false);
+            ITransformer sut = new SpacedockTransformer(mApi.Object, 1);
 
             JObject json            = new JObject();
             json["spec_version"]    = 1;

--- a/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
-using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -16,7 +17,7 @@ namespace Tests.NetKAN.Transformers
             var sut = new StripNetkanMetadataTransformer();
 
             // Act
-            var result = sut.Transform(new Metadata(JObject.Parse(json)));
+            var result = sut.Transform(new Metadata(JObject.Parse(json))).First();
             var transformedJson = result.Json();
 
             // Assert

--- a/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
@@ -1,8 +1,9 @@
-﻿using CKAN;
-using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Transformers;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using CKAN;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Transformers;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -20,7 +21,7 @@ namespace Tests.NetKAN.Transformers
             json["version"] = "1.2.3";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -41,7 +42,7 @@ namespace Tests.NetKAN.Transformers
             json["x_netkan_version_edit"] = "^v?(?<version>.+)$";
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -63,7 +64,7 @@ namespace Tests.NetKAN.Transformers
             json["x_netkan_version_edit"] = edit;
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -86,7 +87,7 @@ namespace Tests.NetKAN.Transformers
             json["x_netkan_version_edit"] = edit;
 
             // Act
-            var result = sut.Transform(new Metadata(json));
+            var result = sut.Transform(new Metadata(json)).First();
             var transformedJson = result.Json();
 
             // Assert
@@ -108,7 +109,7 @@ namespace Tests.NetKAN.Transformers
             json["x_netkan_version_edit"] = edit;
 
             // Act
-            TestDelegate act = () => sut.Transform(new Metadata(json));
+            TestDelegate act = () => sut.Transform(new Metadata(json)).First();
 
             // Assert
             Assert.That(act, Throws.Exception.TypeOf<Kraken>());
@@ -130,7 +131,7 @@ namespace Tests.NetKAN.Transformers
             json["x_netkan_version_edit"] = edit;
 
             // Act
-            TestDelegate act = () => sut.Transform(new Metadata(json));
+            TestDelegate act = () => sut.Transform(new Metadata(json)).First();
 
             // Assert
             Assert.That(act, Throws.Nothing);


### PR DESCRIPTION
## Motivation

KSP-CKAN/NetKAN#7003 pointed out that two versions of UniversalStorage2 are missing from CKAN-meta. This happened because multiple versions were uploaded within the same bot pass, so only the most recent release was indexed, and the other was skipped. This has always been a risk, but it was mitigated for a while by the SpaceDock-CKAN web hook. Now with KSP-SpaceDock/SpaceDock#192 it is a bigger problem.

Currently the easiest way I know to fix this is to create fake .netkan files with hardcoded `download` properties, and then run Netkan once on each of them. This could miss things, but it's usually safe and can be checked by diffing against other versions.

It would be nice to be able to generate older .ckan files with less hassle.

## Changes

Now Netkan has a new `--releases` option that accepts a parameter of either `all` or a number (the default is 1). If passed, Netkan will process the specified number of releases of a module, starting with the most recent, and generate a .ckan file for each one when the `$kref` uses one of the following:

- Curse
- GitHub
- SpaceDock
- Jenkins

To make this happen, `ITransformer.Transform` now returns `IEnumerable<Metadata>` instead of just `Metadata`, which means transformers can generate multiple outputs from one input. All existing transformers are updated to `yield return` their previous outputs to generate a single-element sequence. Existing tests are updated to use `.First()` to get the first `Metadata` object in the returned lists.

For the transformers that process the `$kref` values listed above, their source APIs now have some form of `All` or `AllReleases` property that includes everything in the given repository for that module. When `--releases` is passed, we parse it into an `int?` with `null` representing `"all"` and pass this value in a new `releases` parameter of their constructors, and these transformers will generate and return one new `Metadata` object for each release up to the specified number, which will then be subjected to all normal further downstream processing.

```
$ netkan.exe ~/Downloads/KSP/NetKAN/NetKAN/UniversalStorage2.netkan --releases all
$ ls -gG U*
-rw-r--r-- 1 1435 Feb 10 00:53 UniversalStorage2-1.3.1.2.ckan
-rw-r--r-- 1 1435 Feb 10 00:52 UniversalStorage2-1.3.1.3.ckan
-rw-r--r-- 1 1435 Feb 10 00:51 UniversalStorage2-1.3.1.4.ckan
-rw-r--r-- 1 1435 Feb 10 00:50 UniversalStorage2-1.3.1.5.ckan
-rw-r--r-- 1 1435 Feb 10 00:49 UniversalStorage2-1.3.1.6.ckan
-rw-r--r-- 1 1435 Feb 10 00:49 UniversalStorage2-1.3.1.7.ckan
-rw-r--r-- 1 1435 Feb 10 00:48 UniversalStorage2-1.3.1.8.ckan
-rw-r--r-- 1 1435 Feb 10 00:47 UniversalStorage2-1.3.1.9.ckan
-rw-r--r-- 1 1435 Feb 10 00:53 UniversalStorage2-1.4.5.2.ckan
-rw-r--r-- 1 1435 Feb 10 00:51 UniversalStorage2-1.4.5.3.ckan
-rw-r--r-- 1 1435 Feb 10 00:50 UniversalStorage2-1.4.5.4.ckan
-rw-r--r-- 1 1435 Feb 10 00:50 UniversalStorage2-1.5.1.5.ckan
-rw-r--r-- 1 1435 Feb 10 00:49 UniversalStorage2-1.5.1.6.ckan
-rw-r--r-- 1 1435 Feb 10 00:48 UniversalStorage2-1.5.1.7.ckan
-rw-r--r-- 1 1435 Feb 10 00:48 UniversalStorage2-1.5.1.8.ckan
-rw-r--r-- 1 1435 Feb 10 00:47 UniversalStorage2-1.6.0.9.ckan
```