### PR TITLE
Avoid redundant metadata downloads

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -150,7 +150,7 @@ namespace CKAN.CmdLine
             RegistryManager registry_manager = RegistryManager.Instance(ksp);
 
             var updated = repository == null
-                ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, manager.Cache, user)
+                ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, manager.Cache, user) != CKAN.RepoUpdateResult.Failed
                 : CKAN.Repo.Update(registry_manager, ksp, user, repository);
 
             user.RaiseMessage("Updated information on {0} available modules",

--- a/Core/Types/Repository.cs
+++ b/Core/Types/Repository.cs
@@ -10,9 +10,10 @@ namespace CKAN
         [JsonIgnore] public static readonly Uri default_ckan_repo_uri = new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz");
         [JsonIgnore] public static readonly Uri default_repo_master_list = new Uri("https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/repositories.json");
 
-        public string name;
-        public Uri uri;
-        public int priority = 0;
+        public string  name;
+        public Uri     uri;
+        public string  last_server_etag;
+        public int     priority = 0;
         public Boolean ckan_mirror = false;
 
         public Repository()

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -82,17 +82,25 @@ namespace CKAN
 
         private void PostUpdateRepo(object sender, RunWorkerCompletedEventArgs e)
         {
-            if (e.Result as bool? ?? true)
+            switch (e.Result as RepoUpdateResult?)
             {
-                UpdateModsList(true, ChangeSet);
-                AddStatusMessage("Repositories successfully updated.");
-                ShowRefreshQuestion();
-                HideWaitDialog(true);
-                UpgradeNotification();
-            }
-            else
-            {
-                AddStatusMessage("Repository update failed!");
+                case RepoUpdateResult.NoChanges:
+                    AddStatusMessage("Repositories already up to date.");
+                    HideWaitDialog(true);
+                    break;
+
+                case RepoUpdateResult.Failed:
+                    AddStatusMessage("Repository update failed!");
+                    break;
+
+                case RepoUpdateResult.Updated:
+                default:
+                    UpdateModsList(true, ChangeSet);
+                    AddStatusMessage("Repositories successfully updated.");
+                    ShowRefreshQuestion();
+                    HideWaitDialog(true);
+                    UpgradeNotification();
+                    break;
             }
 
             Util.Invoke(this, SwitchEnabledState);


### PR DESCRIPTION
## Motivation

Updating the registry can be slow, as it requires downloading a 2.5 MB ZIP or tar.gz file, then extracting it and parsing the JSON of all the modules and populating the registry with them. In GUI there's a further delay as the mod list and filters are updated.

If there haven't been any metadata changes since the last time you refreshed, then all of this is done for naught. It would be nice to skip it in that case.

## Changes

Now we use the `ETag` HTTP response header to determine when a repo's metadata is already up to date. This is an opaque hexadecimal string (with quotes around it) that changes when the `master.tar.gz` file does. It is returned when the file is downloaded, but it can also be retrieved with a much quicker HEAD request. In my testing, this value does indeed change when something in the CKAN-meta repo is modified.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag

The `Repository` objects stored in the registry now have a `last_server_etag` property corresponding to the most recent value received for their URLs.

`Repo.UpdateAllRepositories`'s return type is changed from `bool` to an enum with three options: Updated (formerly true), Failed (formerly false), and NoChanges. If all of our repos have the same `ETag` that they had the last time we downloaded them, then it returns NoChanges without updating anything, which is much quicker than doing a full update. Otherwise an update is performed as normal, and the `ETag`s are captured from `WebClient` and saved into the `Repository` objects. (We don't attempt to suppress individual repo updates because we don't have the ability to identify which modules are from which repos. To keep the list complete, updates have to be all or nothing.)

When it encounters a NoChanges return value, GUI skips rebuilding the mod list, which further speeds up redundant refreshes.

Fixes #854.