### PR TITLE
Force redraw of versions ListView on Mono

### DIFF
--- a/GUI/MainAllModVersions.cs
+++ b/GUI/MainAllModVersions.cs
@@ -35,6 +35,15 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// Make the ListView redraw itself.
+        /// Works around a problem where the headers aren't drawn when this tab activates.
+        /// </summary>
+        public void ForceRedraw()
+        {
+            VersionsListView.EndUpdate();
+        }
+
         public GUIMod SelectedModule
         {
             set

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -107,13 +107,6 @@ namespace CKAN
             Main.Instance.ResetFilterAndSelectModOnList(e.Node.Name);
         }
 
-        private void ModuleRelationshipType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            GUIMod module = SelectedModule;
-            if (module == null) return;
-            UpdateModDependencyGraph(module);
-        }
-
         private void ContentsPreviewTree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
         {
             OpenFileBrowser(e.Node);
@@ -383,10 +376,26 @@ namespace CKAN
         // When switching tabs ensure that the resulting tab is updated.
         private void ModInfoIndexChanged(object sender, EventArgs e)
         {
-            if (ModInfoTabControl.SelectedIndex == ContentTabPage.TabIndex)
-                UpdateModContentsTree(null);
-            if (ModInfoTabControl.SelectedIndex == RelationshipTabPage.TabIndex)
-                UpdateModDependencyGraph(null);
+            switch (ModInfoTabControl.SelectedTab.Name)
+            {
+
+                case "ContentTabPage":
+                    UpdateModContentsTree(null);
+                    break;
+
+                case "RelationshipTabPage":
+                    UpdateModDependencyGraph(null);
+                    break;
+
+                case "AllModVersionsTabPage":
+                    if (Platform.IsMono)
+                    {
+                        // Workaround: make sure the ListView headers are drawn
+                        AllModVersions.ForceRedraw();
+                    }
+                    break;
+
+            }
         }
 
         public void UpdateModContentsTree(CkanModule module, bool force = false)


### PR DESCRIPTION
## Problem

If you do this under Mono:

1. Open GUI
2. Click any mod
3. Open the Versions tab in mod info
4. Open any other tab in mod info
5. Click another mod
6. Open the Versions tab

... then the column headers won't be drawn:

![screenshot](https://user-images.githubusercontent.com/28812678/52887227-403b2d00-3177-11e9-9813-67dff54cf595.png)

## Cause

Unclear, but CKAN's GUI doesn't do anything particularly tricky with these controls. There's a `TabControl` with a `TabPage` that has a `ListView`, and we mostly let the runtime worry about handling them.

It looks a Mono bug, but I wasn't able to pin down exactly how or where. So we'll be going with a workaround.

## Changes

Now when you switch to the Versions tab, we call `VersionsListView.EndUpdate()` on Mono. This ensures that drawing is enabled and forces a full redraw. In my testing this addresses the problem with drawing the headers.

@DasSkelett, can you please test this and report whether it's fixed for you?

Fixes #2684.

### Side change

The method used by `ModInfoIndexChanged` of comparing `SelectedIndex` to `TabIndex` wasn't robust and required properties to be set up just so; for example, the `TabIndex` of the Versions tab was 1, while its `SelectedIndex` value was 3, so extending that pattern would not have worked without updating the `TabIndex` value. Add to this the complication that the runtime can change `TabIndex` values automatically, and it's just not good.

Now we key off of `TabPage.Name`, which is reliably known and can be compared to constant values.