### PR TITLE
Fix RefreshPreLabel overlapping RefreshTextBox in Settings

### DIFF
--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -471,7 +471,7 @@
             // RefreshTextBox
             // 
             this.RefreshTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.RefreshTextBox.Location = new System.Drawing.Point(117, 64);
+            this.RefreshTextBox.Location = new System.Drawing.Point(122, 64);
             this.RefreshTextBox.Name = "RefreshTextBox";
             this.RefreshTextBox.Size = new System.Drawing.Size(25, 20);
             this.RefreshTextBox.TabIndex = 3;
@@ -482,7 +482,7 @@
             // RefreshPostLabel
             // 
             this.RefreshPostLabel.AutoSize = true;
-            this.RefreshPostLabel.Location = new System.Drawing.Point(142, 66);
+            this.RefreshPostLabel.Location = new System.Drawing.Point(150, 66);
             this.RefreshPostLabel.Name = "RefreshPostLabel";
             this.RefreshPostLabel.Size = new System.Drawing.Size(49, 13);
             this.RefreshPostLabel.TabIndex = 4;


### PR DESCRIPTION
`RefreshPreLabel` overlaps `RefreshTextBox` in the settings window.
Moved `RefreshTextBox` and `RefreshPostLabel` some pixels to the right.

Before:
![ckan1](https://user-images.githubusercontent.com/28812678/53043561-06c13500-3489-11e9-84c1-b2463b11ef7d.png)
After:
![ckan2](https://user-images.githubusercontent.com/28812678/53043568-0a54bc00-3489-11e9-89d7-581fac39057d.png)
