### PR TITLE
Don't auto-install recommendations when reinstalling

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1169,7 +1169,7 @@ namespace CKAN
             installWorker.RunWorkerAsync(
                 new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                     toReinstall,
-                    RelationshipResolver.DefaultOpts()
+                    RelationshipResolver.DependsOnlyOpts()
                 )
             );
         }


### PR DESCRIPTION
## Problem

If you right click to reinstall an installed module, all of its recommendations will be installed even if you de-select them.

## Cause

See #2604; `RelationshipResolver.DefaultOpts()` causes all recommendations to be installed. Reinstall was using this as of #2233.

## Changes

Now the reinstall flow uses `DependsOnlyOpts`, which was created in #2606 for just this sort of situation. Recommendations will only be installed if the user chooses them.

Fixes #2688.