### PR TITLE
Customisable columns in GUI Modlist

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -32,6 +32,8 @@ namespace CKAN
         public int SortByColumnIndex = 2;
         public bool SortDescending = false;
 
+        public bool[] VisibleColumns = { true, true, true, true, true, true, true, true, true };
+
         private string path = "";
 
         /// <summary>

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using System.Drawing;
 using System.IO;
 using System.Xml.Serialization;
+using System.Collections.Generic;
 
 namespace CKAN
 {
@@ -32,7 +33,25 @@ namespace CKAN
         public int SortByColumnIndex = 2;
         public bool SortDescending = false;
 
-        public bool[] VisibleColumns = { true, true, true, true, true, true, true, true, true };
+        [XmlArray, XmlArrayItem(ElementName = "ColumnName")]
+        public List<string> HiddenColumnNames = new List<string>();
+
+        /// <summary>
+        /// Set whether a column name is in the visible list
+        /// </summary>
+        /// <param name="name">Name property of the column</param>
+        /// <param name="vis">true if visible, false if hidden</param>
+        public void SetColumnVisibility(string name, bool vis)
+        {
+            if (vis)
+            {
+                HiddenColumnNames.RemoveAll(n => n == name);
+            }
+            else if (!HiddenColumnNames.Contains(name))
+            {
+                HiddenColumnNames.Add(name);
+            }
+        }
 
         private string path = "";
 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -84,6 +84,7 @@
             this.DownloadCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.ModListHeaderContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ModInfoTabControl = new CKAN.MainModInfo();
@@ -148,6 +149,7 @@
             this.splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).BeginInit();
             this.ModListContextMenuStrip.SuspendLayout();
+            this.ModListHeaderContextMenuStrip.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.MainTabControl.SuspendLayout();
             this.ManageModsTabPage.SuspendLayout();
@@ -543,7 +545,6 @@
             this.InstallDate,
             this.DownloadCount,
             this.Description});
-            this.ModList.ContextMenuStrip = this.ModListContextMenuStrip;
             this.ModList.Location = new System.Drawing.Point(0, 111);
             this.ModList.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ModList.MultiSelect = false;
@@ -630,7 +631,7 @@
             this.SizeCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             // 
             // InstallDate
-            //
+            // 
             this.InstallDate.HeaderText = "Install Date";
             this.InstallDate.Name = "InstallDate";
             this.InstallDate.ReadOnly = true;
@@ -638,7 +639,7 @@
             this.InstallDate.Width = 140;
             //
             // DownloadCount
-            //
+            // 
             this.DownloadCount.HeaderText = "Downloads";
             this.DownloadCount.Name = "DownloadCount";
             this.DownloadCount.ReadOnly = true;
@@ -675,6 +676,13 @@
             this.downloadContentsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.downloadContentsToolStripMenuItem.Text = "Download Contents";
             this.downloadContentsToolStripMenuItem.Click += new System.EventHandler(this.downloadContentsToolStripMenuItem_Click);
+            // 
+            // ModListHeaderContextMenuStrip
+            // 
+            this.ModListHeaderContextMenuStrip.Name = "ModListHeaderContextMenuStrip";
+            this.ModListHeaderContextMenuStrip.AutoSize = true;
+            this.ModListHeaderContextMenuStrip.ShowCheckMargin = true;
+            this.ModListHeaderContextMenuStrip.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(ModListHeaderContextMenuStrip_ItemClicked);
             // 
             // ModInfoTabControl
             // 
@@ -1282,6 +1290,7 @@
             this.splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).EndInit();
             this.ModListContextMenuStrip.ResumeLayout(false);
+            this.ModListHeaderContextMenuStrip.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.MainTabControl.ResumeLayout(false);
@@ -1358,6 +1367,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn DownloadCount;
         private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.ContextMenuStrip ModListContextMenuStrip;
+        private System.Windows.Forms.ContextMenuStrip ModListHeaderContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
         private CKAN.MainModInfo ModInfoTabControl;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -174,6 +174,7 @@ namespace CKAN
                 FilterToolButton.DropDown.Renderer = new FlatToolStripRenderer();
                 minimizedContextMenuStrip.Renderer = new FlatToolStripRenderer();
                 ModListContextMenuStrip.Renderer = new FlatToolStripRenderer();
+                ModListHeaderContextMenuStrip.Renderer = new FlatToolStripRenderer();
             }
 
             // Initialize all user interaction dialogs.
@@ -755,20 +756,38 @@ namespace CKAN
             Filter(GUIModFilter.All);
         }
 
+        /// <summary>
+        /// Called when the modlist filter (all, compatible, incompatible...) is changed.
+        /// </summary>
+        /// <param name="filter">Filter.</param>
         private void Filter(GUIModFilter filter)
         {
+            // Triggers mainModList.ModFiltersUpdated()
             mainModList.ModFilter = filter;
+
+            // Ask the configuration which columns to show.
+            // Start with the third column, because the first one is alwas shown
+            // and the 2nd/3rd are handled by UpdateModsList().
+            for (int i = 3; i < ModList.Columns.Count; i++)
+            {
+                ModList.Columns[i].Visible = configuration.VisibleColumns[i-3];
+            }
 
             switch (filter)
             {
-                case GUIModFilter.All:                      FilterToolButton.Text = "Filter (All)";          break;
+                // Some columns really do / don't make sense to be visible on certain filter settings.
+                // Hide / Show them, without writing to config, so once the user changes tab again,
+                // they are shown / hidden again, as before.
+                case GUIModFilter.All:                      FilterToolButton.Text = "Filter (All)";           break;
                 case GUIModFilter.Incompatible:             FilterToolButton.Text = "Filter (Incompatible)";  break;
                 case GUIModFilter.Installed:                FilterToolButton.Text = "Filter (Installed)";     break;
                 case GUIModFilter.InstalledUpdateAvailable: FilterToolButton.Text = "Filter (Upgradeable)";   break;
                 case GUIModFilter.Replaceable:              FilterToolButton.Text = "Filter (Replaceable)";   break;
                 case GUIModFilter.Cached:                   FilterToolButton.Text = "Filter (Cached)";        break;
                 case GUIModFilter.NewInRepository:          FilterToolButton.Text = "Filter (New)";           break;
-                case GUIModFilter.NotInstalled:             FilterToolButton.Text = "Filter (Not installed)"; break;
+                case GUIModFilter.NotInstalled:             FilterToolButton.Text = "Filter (Not installed)";
+                                                            ModList.Columns[5].Visible = false;
+                                                            ModList.Columns[9].Visible = false;               break;
                 default:                                    FilterToolButton.Text = "Filter (Compatible)";    break;
             }
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -766,11 +766,14 @@ namespace CKAN
             mainModList.ModFilter = filter;
 
             // Ask the configuration which columns to show.
-            // Start with the third column, because the first one is alwas shown
-            // and the 2nd/3rd are handled by UpdateModsList().
-            for (int i = 3; i < ModList.Columns.Count; i++)
+            foreach (DataGridViewColumn col in ModList.Columns)
             {
-                ModList.Columns[i].Visible = configuration.VisibleColumns[i-3];
+                // Start with the third column, because the first one is always shown
+                // and the 2nd/3rd are handled by UpdateModsList().
+                if (col.Index > 2)
+                {
+                    col.Visible = !configuration.HiddenColumnNames.Contains(col.Name);
+                }
             }
 
             switch (filter)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -278,9 +278,7 @@ namespace CKAN
             // Write it to the configuration, else they are hidden agian after a filter change.
             // After the update / replacement, they are hidden again.
             ModList.Columns[1].Visible = has_any_updates;
-            configuration.VisibleColumns[1] = has_any_updates;
             ModList.Columns[2].Visible = has_any_replacements;
-            configuration.VisibleColumns[2] = has_any_replacements;
 
             AddLogMessage("Updating tray...");
             UpdateTrayInfo();
@@ -397,7 +395,8 @@ namespace CKAN
 
             if (col != null)
             {
-                configuration.VisibleColumns[col.Index - 3] = col.Visible = !clickedItem.Checked;
+                col.Visible = !clickedItem.Checked;
+                configuration.SetColumnVisibility(col.Name, !clickedItem.Checked);
                 if (col.Index == 0)
                 {
                     InstallAllCheckbox.Visible = col.Visible;


### PR DESCRIPTION
**This PR adds the option to hide columns in the modlist.** as asked by @politas in #2687.

This happens via a right click context menu on the header row of the modlist:
![ckan1](https://user-images.githubusercontent.com/28812678/53442172-f3721480-3a08-11e9-97fb-fe0186f4ad16.png)

The columns are hidden with `column.Visibility = false`, which seems to work perfectly fine in my testing. This doesn't need a reload of the modlist or anything, so it's fast.
On every change of the visibility of a column it is saved to the GUIconfig, which means it's persistend across ckan restarts.

The `Update` and the `Replace` checkbox columns are hidden by default, and only shown if an update / a replacement is available. I could only test updates yet, but replacements should work the same.
Once all updates / replacements have been done, the columns are hidden again.
This all happens in `UpdateModsList()`.

Furthermore, the `Installed version` and the `Install date` columns are hidden with the `Not Installed` filter setting selected, there's no sense in showing them. This happens *without* a GUIconfig change, so once the filter is changed again, those two columns reappear (or stay hidden) based on the previous setting.

<img src="https://user-images.githubusercontent.com/28812678/53582637-25f24d80-3b80-11e9-98c1-d7014d07a4bc.png"  alt="many columns hidden" width="340"/> <img src="https://user-images.githubusercontent.com/28812678/53582888-b597fc00-3b80-11e9-8134-64f751da2a39.png" alt="updates available" width="320"/>


Closes #2687 

---
Small sidefix: if you right-clicked on the modlist header bar before, the context menu for the mod rows opened, despite it shouldn't. It's fixed now by not assigning `ModList.ContextMenuStrip = ModListContextMenuStrip`. Instead, the new column selection menu opens, obviously.