### PR TITLE
Sort AD above empty checkboxes

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -565,6 +565,7 @@
             this.Installed.HeaderText = "    Inst";
             this.Installed.Name = "Installed";
             this.Installed.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.Installed.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.Installed.Width = 50;
             // 
             // UpdateCol
@@ -572,6 +573,7 @@
             this.UpdateCol.HeaderText = "Update";
             this.UpdateCol.Name = "UpdateCol";
             this.UpdateCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.UpdateCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.UpdateCol.Width = 46;
             //
             // ReplaceCol
@@ -579,6 +581,7 @@
             this.ReplaceCol.HeaderText = "Replace";
             this.ReplaceCol.Name = "ReplaceCol";
             this.ReplaceCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.ReplaceCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.ReplaceCol.Width = 46;
             //
             // ModName

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -79,10 +79,14 @@ namespace CKAN
             var cell = row.Cells[this.configuration.SortByColumnIndex];
             if (cell.ValueType == typeof(bool))
             {
-                return (bool)cell.Value ? "a" : "b";
+                return (bool)cell.Value ? "a" : "c";
             }
-            // It's a "-" cell so let it be ordered last
-            return "c";
+            else
+            {
+                // If it's a "-" cell, let it be ordered last
+                // Otherwise put it after the checked boxes
+                return (string)cell.Value == "-" ? "d" : "b";
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

If you have manually installed mods, the Inst column shows up as "AD" for them. If you sort by the Inst checkbox column, AD mods appear at the very end of the list, far away from the CKAN-installed mods represented by a checked box.

And the "AD" and "-" strings are left aligned while the checkboxes are centered, which doesn't look great.

![image](https://user-images.githubusercontent.com/1559108/53753979-3ce2b980-3e78-11e9-93bb-c27c2bf2b385.png)

## Changes

Now the sort goes:

1. CKAN-installed mods (checked checkboxes)
2. AD mods
3. Non-installed compatible mods (unchecked checkboxes)
4. Incompatible mods ("-")

Also the checkbox columns are centered now so the "-" aligns better with the checkboxes.

![image](https://user-images.githubusercontent.com/1559108/53753860-ed9c8900-3e77-11e9-9c2c-e5045cba8904.png)