### PR TITLE
Reinstate no releases warnings for Netkan

### DIFF
--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -45,9 +45,17 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(_releases.Value);
                 }
-                foreach (CurseFile f in versions)
+                if (versions.Any())
                 {
-                    yield return TransformOne(metadata.Json(), curseMod, f);
+                    foreach (CurseFile f in versions)
+                    {
+                        yield return TransformOne(metadata.Json(), curseMod, f);
+                    }
+                }
+                else
+                {
+                    Log.WarnFormat("No releases found for {0}", curseMod.ToString());
+                    yield return metadata;
                 }
             }
             else

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -63,9 +63,17 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(_releases.Value);
                 }
-                foreach (GithubRelease rel in versions)
+                if (versions.Any())
                 {
-                    yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel);
+                    foreach (GithubRelease rel in versions)
+                    {
+                        yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel);
+                    }
+                }
+                else
+                {
+                    Log.WarnFormat("No releases found for {0}", ghRef.Repository);
+                    yield return metadata;
                 }
             }
             else

--- a/Netkan/Transformers/JenkinsTransformer.cs
+++ b/Netkan/Transformers/JenkinsTransformer.cs
@@ -40,9 +40,17 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(_releases.Value);
                 }
-                foreach (JenkinsBuild build in versions)
+                if (versions.Any())
                 {
-                    yield return TransformOne(metadata, metadata.Json(), build, options);
+                    foreach (JenkinsBuild build in versions)
+                    {
+                        yield return TransformOne(metadata, metadata.Json(), build, options);
+                    }
+                }
+                else
+                {
+                    Log.WarnFormat("No releases found for {0}", jRef.BaseUri);
+                    yield return metadata;
                 }
             }
             else

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -44,9 +44,17 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(_releases.Value);
                 }
-                foreach (SDVersion vers in versions)
+                if (versions.Any())
                 {
-                    yield return TransformOne(metadata, metadata.Json(), sdMod, vers);
+                    foreach (SDVersion vers in versions)
+                    {
+                        yield return TransformOne(metadata, metadata.Json(), sdMod, vers);
+                    }
+                }
+                else
+                {
+                    Log.WarnFormat("No releases found for {0}", sdMod.ToString());
+                    yield return metadata;
                 }
             }
             else


### PR DESCRIPTION
## Problem

Currently running netkan for a repository with no releases generates no error message. It used to output a message like:

> No releases found for PorktoberRevolution/ReStocked

Noticed while taking a look at PorktoberRevolution/ReStocked#492.

## Cause

In #2681 we updated Netkan to be able to generate multiple .ckan files in one pass. The no-release check and message were moved to the `TransformOne` functions, which are called within a `foreach` loop over the list of releases. But if that list is empty, then `TransformOne` is not called at all, so the error is never printed.

## Changes

Now we explicitly check whether the list of releases is empty in the main `Transform` function and print the error in that case. This is done for Jenkins, GitHub, SpaceDock, and Curse.