### PR TITLE
Only update mod list once at GUI startup

### DIFF
--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -87,6 +87,11 @@ namespace CKAN
                 case RepoUpdateResult.NoChanges:
                     AddStatusMessage("Repositories already up to date.");
                     HideWaitDialog(true);
+                    // Load rows if grid empty, otherwise keep current
+                    if (ModList.Rows.Count < 1)
+                    {
+                        UpdateModsList(true, ChangeSet);
+                    }
                     break;
 
                 case RepoUpdateResult.Failed:


### PR DESCRIPTION
## Problem

Currently if you enable auto repo updates at startup, GUI can exhibit some visual oddities, such as showing a blank disabled mod list for a few seconds, or flashing multiple times between the mod list and the progress bar screen.

As far as I can tell none of these cases causes a functional problem or leaves the UI unusable; they just look weird. (Except for performance, see below.)

## Cause

`UpdateModsList` can be called twice at startup in this configuration, once by `Main.CurrentInstanceUpdated` during the normal load process and once by `Main.PostUpdateRepo` after updating the repo (though this can be suppressed as of #2682). When this happens, one of those updates is unnecessary. Since `UpdateModsList` is one of the longest/slowest steps we have, this represents a big performance hit.

In #2617, `UpdateModsList` was updated to show the progress bar while loading. This allows the two semi-simultaneous calls to interfere with one another, producing the odd UI artifacts described above.

## Changes

Now we guarantee only a single mod list update during startup:

- `PostUpdateRepo` is updated to call `UpdateModsList` if there are no mods loaded currently, so we can rely on it to leave the list in a loaded state
- The `UpdateRepo` call is moved from `Main.OnLoad` to `CurrentInstanceUpdated`
- `CurrentInstanceUpdated` will call either `UpdateModsList` or `UpdateRepo`, but never both, depending on settings and its parameter

Side fix: The `Main.Text` property representing the title bar is set by `CurrentInstanceUpdated`, but was also being set redundantly just before the initial call to it. The redundant set is removed.