### PR TITLE
Handle non-raw GitHub URLs for metanetkans and avc krefs

### DIFF
--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -300,6 +300,70 @@ namespace CKAN
             return null;
         }
 
+        /// <summary>
+        /// Translate a URL into a form that returns the raw contents of a file
+        /// Only changes GitHub URLs, others are left as-is
+        /// </summary>
+        /// <param name="remoteUri">URL to handle</param>
+        /// <returns>
+        /// URL pointing to the raw contents of the input URL
+        /// </returns>
+        public static Uri GetRawUri(Uri remoteUri)
+        {
+            // Authors may use the URI of the GitHub file page instead of the URL to the actual raw file.
+            // Detect that case and automatically transform the remote URL to one we can use.
+            // This is hacky and fragile but it's basically what KSP-AVC itself does in its
+            // FormatCompatibleUrl(string) method so we have to go along with the flow:
+            // https://github.com/CYBUTEK/KSPAddonVersionChecker/blob/ff94000144a666c8ff637c71b802e1baee9c15cd/KSP-AVC/AddonInfo.cs#L199
+            // However, this implementation is more robust as it actually parses the URI rather than doing
+            // basic string replacements.
+            if (string.Compare(remoteUri.Host, "github.com", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                // We expect a non-raw URI to be in one of two forms:
+                //  1. https://github.com/<USER>/<PROJECT>/blob/<BRANCH>/<PATH>
+                //  2. https://github.com/<USER>/<PROJECT>/tree/<BRANCH>/<PATH>
+                //
+                // Therefore, we expect at least six segments in the path:
+                //  1. "/"
+                //  2. "<USER>/"
+                //  3. "<PROJECT>/"
+                //  4. "blob/" or "tree/"
+                //  5. "<BRANCH>/"
+                //  6+. "<PATH>"
+                //
+                // And that the fourth segment (index 3) is either "blob/" or "tree/"
+
+                var remoteUriBuilder = new UriBuilder(remoteUri)
+                {
+                    // Replace host with raw host
+                    Host = "raw.githubusercontent.com"
+                };
+
+                // Check that the path is what we expect
+                var segments = remoteUri.Segments.ToList();
+
+                if (segments.Count < 6 ||
+                    string.Compare(segments[3], "blob/", StringComparison.OrdinalIgnoreCase) != 0 &&
+                    string.Compare(segments[3], "tree/", StringComparison.OrdinalIgnoreCase) != 0)
+                {
+                    log.WarnFormat("Remote non-raw GitHub URL is in an unknown format, using as is.");
+                    return remoteUri;
+                }
+
+                // Remove "blob/" or "tree/" segment from raw URI
+                segments.RemoveAt(3);
+                remoteUriBuilder.Path = string.Join("", segments);
+
+                log.InfoFormat("Canonicalized non-raw GitHub URL to: {0}", remoteUriBuilder.Uri);
+
+                return remoteUriBuilder.Uri;
+            }
+            else
+            {
+                return remoteUri;
+            }
+        }
+
         private static WebClient MakeDefaultHttpClient()
         {
             var client = new WebClient();

--- a/Netkan/Transformers/AvcKrefTransformer.cs
+++ b/Netkan/Transformers/AvcKrefTransformer.cs
@@ -35,7 +35,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
                 AvcVersion remoteAvc = JsonConvert.DeserializeObject<AvcVersion>(
-                    httpSvc.DownloadText(new Uri(metadata.Kref.Id))
+                    httpSvc.DownloadText(CKAN.Net.GetRawUri(new Uri(metadata.Kref.Id)))
                 );
 
                 json.SafeAdd("name",     remoteAvc.Name);

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -67,7 +67,7 @@ namespace CKAN.NetKAN.Transformers
                     {
                         try
                         {
-                            var remoteJson = Net.DownloadText(remoteUri);
+                            var remoteJson = _http.DownloadText(remoteUri);
                             var remoteAvc = JsonConvert.DeserializeObject<AvcVersion>(remoteJson);
 
                             if (avc.version.CompareTo(remoteAvc.version) == 0)
@@ -206,56 +206,7 @@ namespace CKAN.NetKAN.Transformers
 
             Log.InfoFormat("Remote AVC version file at: {0}", remoteUri);
 
-            // Authors may use the URI of the GitHub file page instead of the URL to the actual raw file.
-            // Detect that case and automatically transform the remote URL to one we can use.
-            // This is hacky and fragile but it's basically what KSP-AVC itself does in its
-            // FormatCompatibleUrl(string) method so we have to go along with the flow:
-            // https://github.com/CYBUTEK/KSPAddonVersionChecker/blob/ff94000144a666c8ff637c71b802e1baee9c15cd/KSP-AVC/AddonInfo.cs#L199
-            // However, this implementation is more robust as it actually parses the URI rather than doing
-            // basic string replacements.
-            if (string.Compare(remoteUri.Host, "github.com", StringComparison.OrdinalIgnoreCase) == 0)
-            {
-                // We expect a non-raw URI to be in one of two forms:
-                //  1. https://github.com/<USER>/<PROJECT>/blob/<BRANCH>/<PATH>
-                //  2. https://github.com/<USER>/<PROJECT>/tree/<BRANCH>/<PATH>
-                //
-                // Therefore, we expect at least six segments in the path:
-                //  1. "/"
-                //  2. "<USER>/"
-                //  3. "<PROJECT>/"
-                //  4. "blob/" or "tree/"
-                //  5. "<BRANCH>/"
-                //  6+. "<PATH>"
-                //
-                // And that the forth segment (index 3) is either "blob/" or "tree/"
-
-                var remoteUriBuilder = new UriBuilder(remoteUri)
-                {
-                    // Replace host with raw host
-                    Host = "raw.githubusercontent.com"
-                };
-
-                // Check that the path is what we expect
-                var segments = remoteUri.Segments.ToList();
-
-                if (segments.Count < 6 ||
-                    string.Compare(segments[3], "blob/", StringComparison.OrdinalIgnoreCase) != 0 &&
-                    string.Compare(segments[3], "tree/", StringComparison.OrdinalIgnoreCase) != 0)
-                {
-                    Log.WarnFormat("Remote non-raw GitHub URL is in an unknown format, using as is.");
-                    return remoteUri;
-                }
-
-                // Remove "blob/" or "tree/" segment from raw URI
-                segments.RemoveAt(3);
-                remoteUriBuilder.Path = string.Join("", segments);
-
-                Log.InfoFormat("Canonicalized non-raw GitHub URL to: {0}", remoteUriBuilder.Uri);
-
-                return remoteUriBuilder.Uri;
-            }
-
-            return remoteUri;
+            return CKAN.Net.GetRawUri(remoteUri);
         }
     }
 }

--- a/Netkan/Transformers/MetaNetkanTransformer.cs
+++ b/Netkan/Transformers/MetaNetkanTransformer.cs
@@ -37,7 +37,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
                 var uri = new Uri(metadata.Kref.Id);
-                var targetFileText = _http.DownloadText(uri);
+                var targetFileText = _http.DownloadText(CKAN.Net.GetRawUri(uri));
 
                 Log.DebugFormat("Target netkan:{0}{1}", Environment.NewLine, targetFileText);
 


### PR DESCRIPTION
## Problem

When KSP-CKAN/NetKAN#7050 tried this:

```json
    "$kref"         : "#/ckan/netkan/https://github.com/PorktoberRevolution/ReStocked/blob/prod/CKAN/ReStock.netkan"
```

It got this error:

```
Running NetKAN for NetKAN/ReStock.netkan
1426 [1] FATAL CKAN.NetKAN.Program (null) - Unexpected character encountered while parsing value: <. Path '', line 0, position 0.
Build step 'Execute shell' marked build as failure
```

## Cause

That URL points to the rich GitHub page about that file rather than the raw JSON file contents. We have some special logic in place to translate such URLs, but it's only applied to KSP-AVC files' `URL` property:

https://github.com/KSP-CKAN/CKAN/blob/6b4cd143996f029b94162ec89a2e0cb86f9a7c3f/Netkan/Transformers/AvcTransformer.cs#L209-L256

## Changes

Now the logic that was previously used only by the remote AVC lookup is moved to the `Net` static class and called in the other places that might contain URLs referencing files on GitHub:

- Meta-netkans
- KSP-AVC krefs (see #2517)

This makes the original `/blob/` meta-netkan URL work as intended.