### PR TITLE
Only show replace col if a replaced module is installed

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -245,7 +245,7 @@ namespace CKAN
             AddLogMessage("Updating filters...");
 
             var has_any_updates = gui_mods.Any(mod => mod.HasUpdate);
-            var has_any_replacements = gui_mods.Any(mod => mod.HasReplacement);
+            var has_any_replacements = gui_mods.Any(mod => mod.IsInstalled && mod.HasReplacement);
 
             //TODO Consider using smart enumeration pattern so stuff like this is easier
             Util.Invoke(menuStrip2, () =>


### PR DESCRIPTION
## Problem

#2690 was supposed to hide the Replace column if it didn't contain any checkboxes. When we tested that PR, there were no modules with replacements. When some were added in KSP-CKAN/NetKAN#7049 and KSP-CKAN/NetKAN#7048, the column became always visible.

## Cause

This line returns true if *any* mod in the list has a `replaced_by` property, including those not installed:

https://github.com/KSP-CKAN/CKAN/blob/4f3b3d7cdf9c65afd17283fd0631bd1749aa3f3a/GUI/MainModList.cs#L248

The `GUIMod.HasReplacement` property is set unconditionally alongside `HasUpdate`, so if an uninstalled module's latest version has a replacement, it will be true:

https://github.com/KSP-CKAN/CKAN/blob/4f3b3d7cdf9c65afd17283fd0631bd1749aa3f3a/GUI/GUIMod.cs#L105-L106

## Changes

Now the code that hides the column first checks whether the module is installed.
Not changing the `HasReplacement` property because it might be useful in the future to be able to filter out uninstalled modules that have been replaced (for example).