### PR TITLE
Right click copy option for mod info links

### DIFF
--- a/GUI/AboutDialog.cs
+++ b/GUI/AboutDialog.cs
@@ -13,27 +13,27 @@ namespace CKAN
 
         private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("https://github.com/KSP-CKAN/CKAN/blob/master/LICENSE.md");
+            Util.HandleLinkClicked("https://github.com/KSP-CKAN/CKAN/blob/master/LICENSE.md", e);
         }
 
         private void linkLabel2_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("https://github.com/KSP-CKAN/CKAN/graphs/contributors");
+            Util.HandleLinkClicked("https://github.com/KSP-CKAN/CKAN/graphs/contributors", e);
         }
 
         private void linkLabel3_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("https://github.com/KSP-CKAN/CKAN/");
+            Util.HandleLinkClicked("https://github.com/KSP-CKAN/CKAN/", e);
         }
 
         private void linkLabel4_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("http://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan");
+            Util.HandleLinkClicked("http://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan", e);
         }
 
         private void linkLabel5_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("http://ksp-ckan.space");
+            Util.HandleLinkClicked("http://ksp-ckan.space", e);
         }
     }
 }

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -124,7 +124,16 @@ namespace CKAN
 
         private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Util.OpenLinkFromLinkLabel(sender as LinkLabel);
+            switch (e.Button)
+            {
+                case MouseButtons.Left:
+                    Util.OpenLinkFromLinkLabel(sender as LinkLabel);
+                    break;
+
+                case MouseButtons.Right:
+                    Util.LinkContextMenu(sender as LinkLabel, e);
+                    break;
+            }
         }
 
         private void UpdateModInfo(GUIMod gui_module)

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -124,16 +124,7 @@ namespace CKAN
 
         private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            switch (e.Button)
-            {
-                case MouseButtons.Left:
-                    Util.OpenLinkFromLinkLabel(sender as LinkLabel);
-                    break;
-
-                case MouseButtons.Right:
-                    Util.LinkContextMenu(sender as LinkLabel, e);
-                    break;
-            }
+            Util.HandleLinkClicked((sender as LinkLabel).Text, e);
         }
 
         private void UpdateModInfo(GUIMod gui_module)

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -73,14 +73,18 @@ namespace CKAN
             return Uri.TryCreate(source, UriKind.Absolute, out uri_result) && uri_result.Scheme == Uri.UriSchemeHttp;
         }
 
-        public static void OpenLinkFromLinkLabel(LinkLabel link_label)
+        /// <summary>
+        /// Open a URL, unless it's "N/A"
+        /// </summary>
+        /// <param name="url">The URL</param>
+        public static void OpenLinkFromLinkLabel(string url)
         {
-            if (link_label.Text == "N/A")
+            if (url == "N/A")
             {
                 return;
             }
 
-            TryOpenWebPage(link_label.Text);
+            TryOpenWebPage(url);
         }
 
         /// <summary>
@@ -117,21 +121,32 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// React to the user clicking a mouse button on a link.
+        /// Opens the URL in browser on left click, presents a
+        /// right click menu on right click.
+        /// </summary>
+        /// <param name="url">The link's URL</param>
+        /// <param name="e">The click event</param>
         public static void HandleLinkClicked(string url, LinkLabelLinkClickedEventArgs e)
         {
             switch (e.Button)
             {
                 case MouseButtons.Left:
-                    Util.OpenLinkFromLinkLabel(sender as LinkLabel);
+                    Util.OpenLinkFromLinkLabel(url);
                     break;
 
                 case MouseButtons.Right:
-                    Util.LinkContextMenu(url, e);
+                    Util.LinkContextMenu(url);
                     break;
             }
         }
 
-        public static void LinkContextMenu(string url, LinkLabelLinkClickedEventArgs e)
+        /// <summary>
+        /// Show a context menu when the user right clicks a link
+        /// </summary>
+        /// <param name="url">The URL of the link</param>
+        public static void LinkContextMenu(string url)
         {
             ToolStripMenuItem copyLink = new ToolStripMenuItem("&Copy link address");
             copyLink.Click += new EventHandler((sender, ev) => Clipboard.SetText(url));

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -117,10 +117,24 @@ namespace CKAN
             }
         }
 
-        public static void LinkContextMenu(LinkLabel link_label, LinkLabelLinkClickedEventArgs e)
+        public static void HandleLinkClicked(string url, LinkLabelLinkClickedEventArgs e)
+        {
+            switch (e.Button)
+            {
+                case MouseButtons.Left:
+                    Util.OpenLinkFromLinkLabel(sender as LinkLabel);
+                    break;
+
+                case MouseButtons.Right:
+                    Util.LinkContextMenu(url, e);
+                    break;
+            }
+        }
+
+        public static void LinkContextMenu(string url, LinkLabelLinkClickedEventArgs e)
         {
             ToolStripMenuItem copyLink = new ToolStripMenuItem("&Copy link address");
-            copyLink.Click += new EventHandler((sender, ev) => Clipboard.SetText(link_label?.Text));
+            copyLink.Click += new EventHandler((sender, ev) => Clipboard.SetText(url));
 
             ContextMenuStrip menu = new ContextMenuStrip();
             if (Platform.IsMono)

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+﻿using System.Windows.Forms;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -114,6 +115,20 @@ namespace CKAN
                 // We tried all prefixes, and still no luck.
                 return false;
             }
+        }
+
+        public static void LinkContextMenu(LinkLabel link_label, LinkLabelLinkClickedEventArgs e)
+        {
+            ToolStripMenuItem copyLink = new ToolStripMenuItem("&Copy link address");
+            copyLink.Click += new EventHandler((sender, ev) => Clipboard.SetText(link_label?.Text));
+
+            ContextMenuStrip menu = new ContextMenuStrip();
+            if (Platform.IsMono)
+            {
+                menu.Renderer = new FlatToolStripRenderer();
+            }
+            menu.Items.Add(copyLink);
+            menu.Show(Cursor.Position);
         }
 
         /// <summary>


### PR DESCRIPTION
## Motivation

It may sometimes be desirable to access a mod's home page URL without opening it in the default browser, for instance you might want to open it in another browser or paste it into a forum post.

Currently right clicking the links works just like left clicking, the URL is opened in the system default browser.

![screenshot](https://user-images.githubusercontent.com/1559108/54478188-82d74000-47dd-11e9-8771-e7f6ad4865bf.png)

## Changes

Now if you right click one of the mod info links, a context menu appears with a "Copy link address" option. Clicking this option copies the URL to the clipboard.

![image](https://user-images.githubusercontent.com/1559108/54479781-a48cf300-47ee-11e9-96c8-8e4d4f88602b.png)

Fixes #2698.