### PR TITLE
Update all CKAN URL references

### DIFF
--- a/GUI/AboutDialog.cs
+++ b/GUI/AboutDialog.cs
@@ -33,7 +33,7 @@ namespace CKAN
 
         private void linkLabel5_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("http://ksp-ckan.org");
+            System.Diagnostics.Process.Start("http://ksp-ckan.space");
         }
     }
 }

--- a/Tests/GUI/GUIMod.cs
+++ b/Tests/GUI/GUIMod.cs
@@ -62,13 +62,13 @@ namespace Tests.GUI
                     ""identifier"":  ""OutOfOrderMod"",
                     ""version"":     ""1.2.0"",
                     ""ksp_version"": ""0.90"",
-                    ""download"":    ""http://www.ksp-ckan.org""
+                    ""download"":    ""http://www.ksp-ckan.space""
                 }");
                 CkanModule prevVersion = CkanModule.FromJson(@"{
                     ""identifier"":  ""OutOfOrderMod"",
                     ""version"":     ""1.1.0"",
                     ""ksp_version"": ""1.4.2"",
-                    ""download"":    ""http://www.ksp-ckan.org""
+                    ""download"":    ""http://www.ksp-ckan.space""
                 }");
 
                 Registry registry = Registry.Empty();

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,4 @@ ckan (1.24.0) unstable; urgency=low
 
   * Initial release.
 
- -- The CKAN Authors <debian@ksp-ckan.org>  Wed, 15 Nov 2017 18:22:00 +0600
+ -- The CKAN Authors <debian@ksp-ckan.space>  Wed, 15 Nov 2017 18:22:00 +0600

--- a/debian/control.in
+++ b/debian/control.in
@@ -4,7 +4,7 @@ Architecture: all
 Section: utils
 Priority: optional
 Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, liblog4net1.2-cil, libnewtonsoft-json5.0-cil, libmono-system-net-http-webrequest4.0-cil
-Maintainer: The CKAN authors <debian@ksp-ckan.org>
+Maintainer: The CKAN authors <debian@ksp-ckan.space>
 Description: KSP-CKAN official client.
  Official client for the Comprehensive Kerbal Archive Network (CKAN).
  Acts as a mod manager for Kerbal Space Program mods.


### PR DESCRIPTION
There were some references to the old .org url in the code, thanks @mvconners and @HebaruSan!

Now they all point to the new `http://ksp-ckan.space`.

Closes #2701.