### PR TITLE
Select 2nd instead of 3rd cell on `MarkAllUpdatesToolButton_Click`

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -572,10 +572,8 @@ namespace CKAN
                 configuration.SortByColumnIndex = new_sort_column.Index;
                 UpdateFilters(this);
 
-                // Selects the top row and scrolls the list to it.
-                DataGridViewCell cell = ModList.Rows[0].Cells[2];
-                ModList.CurrentCell = cell;
-
+                // Select the top row and scroll the list to it.
+                ModList.CurrentCell = ModList.Rows[0].Cells[1];
             }
 
             ModList.Refresh();


### PR DESCRIPTION
## Problem
After the `MarkAllUpdatesToolButton` is clicked, the modlist scrolls to the top by selecting the third (index 2) cell of the first row.
With v1.26, this column is no longer the mod name, but the `replace` checkbox.
If this one is hidden, CKAN throws an error (because you cant select hidden cells), and it is in most cases.

## Solution
Now the second cell instead of the third cell is selected, which is shown if there are updates available (otherwise you can't even click the button to mark all updatable mods), and which can't be hidden by the user, so the same error can't repeat with other columns.

Fixes #2703 