### PR TITLE
Prevent Null entry in CompatibleKSPVersions

### DIFF
--- a/GUI/CompatibleKspVersionsDialog.cs
+++ b/GUI/CompatibleKspVersionsDialog.cs
@@ -86,6 +86,11 @@ namespace CKAN
             {
                 return;
             }
+            if (AddVersionToListTextBox.Text.ToLower() == "any") 
+            {
+                MessageBox.Show("Version has invalid format", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
             try
             {
                 var version = KspVersion.Parse(AddVersionToListTextBox.Text);


### PR DESCRIPTION
CKAN treats a null KSP version in a modversion as "Any", so that a .ckan file with no version information does what we would expect.

The CompatibleKSPVersions dialog allows users to add arbitrary version strings, and then uses the same KSP version parsing that we use for calculating modversion compatibility. This results in a null return value for the text string "any", which does not get caught as an invalid string, allowing the JSON file to be saved with a <null> entry in the CompatibleVersionsList.

On next launch of CKAN, the null entry causes an error.

Now, attempts to add the string "any" to the CompatibleKSPVersionsList are captured and prevented.

Closes #2705