### PR TITLE
Ignore spaces and special chars in mod search

### DIFF
--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -514,7 +514,17 @@ namespace CKAN.CmdLine
 
     internal class SearchOptions : InstanceSpecificOptions
     {
-        [ValueOption(0)] public string search_term { get; set; }
+        [Option("detail", HelpText = "Show full name, latest compatible version and short description of each module")]
+        public bool detail { get; set; }
+
+        [Option("all", HelpText = "Show incompatible mods too")]
+        public bool all { get; set; }
+
+        [Option("author", HelpText = "Limit search results to mods by matching authors")]
+        public string author_term { get; set; }
+
+        [ValueOption(0)]
+        public string search_term { get; set; }
     }
 
     internal class CompareOptions : CommonOptions

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.ComponentModel;
 using CKAN.ConsoleUI.Toolkit;
+using System.Linq;
 
 namespace CKAN.ConsoleUI {
 
@@ -48,18 +49,17 @@ namespace CKAN.ConsoleUI {
                 },
                 1, 0, ListSortDirection.Descending,
                 (CkanModule m, string filter) => {
+                    // Search for author
                     if (filter.StartsWith("@")) {
                         string authorFilt = filter.Substring(1);
                         if (string.IsNullOrEmpty(authorFilt)) {
                             return true;
-                        } else if (m.author != null) {
-                            foreach (string auth in m.author) {
-                                if (auth.IndexOf(authorFilt, StringComparison.CurrentCultureIgnoreCase) == 0) {
-                                    return true;
-                                }
-                            }
+                        } else {
+                            // Remove special characters from search term
+                            authorFilt = CkanModule.nonAlphaNums.Replace(authorFilt, "");
+                            return m.SearchableAuthors.Any((author) => author.IndexOf(authorFilt, StringComparison.CurrentCultureIgnoreCase) == 0);
                         }
-                        return false;
+                    // Other special search params: installed, updatable, new, conflicting and dependends
                     } else if (filter.StartsWith("~")) {
                         if (filter.Length <= 1) {
                             // Don't blank the list for just "~" by itself
@@ -97,9 +97,12 @@ namespace CKAN.ConsoleUI {
                         }
                         return false;
                     } else {
-                        return m.identifier.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0
-                            || m.name.IndexOf(      filter, StringComparison.CurrentCultureIgnoreCase) >= 0
-                            || m.@abstract.IndexOf( filter, StringComparison.CurrentCultureIgnoreCase) >= 0;
+                        filter = CkanModule.nonAlphaNums.Replace(filter, "");
+
+                        return m.SearchableIdentifier.IndexOf( filter, StringComparison.CurrentCultureIgnoreCase) >= 0
+                            || m.SearchableName.IndexOf(       filter, StringComparison.CurrentCultureIgnoreCase) >= 0
+                            || m.SearchableAbstract.IndexOf(   filter, StringComparison.CurrentCultureIgnoreCase) >= 0
+                            || m.SearchableDescription.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0;
                     }
                 }
             );

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -28,8 +28,9 @@ namespace CKAN
         }
 
         [OnDeserialized]
-        internal void SetIdentifier(StreamingContext context)
+        internal void DeserialisationFixes(StreamingContext context)
         {
+            // Set identifier
             var mod = module_version.Values.LastOrDefault();
             identifier = mod.identifier;
             Debug.Assert(module_version.Values.All(m=>identifier.Equals(m.identifier)));

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -248,7 +248,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="SelectionDialog.cs">
-      <Subtype>Form</Subtype>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="SelectionDialog.Designer.cs">
       <DependentUpon>SelectionDialog.cs</DependentUpon>

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Linq;
 using CKAN.Versioning;
-using CKAN.GameVersionProviders;
 
 namespace CKAN
 {
@@ -32,6 +31,7 @@ namespace CKAN
         public string KSPCompatibilityLong { get; private set; }
 
         public string Abstract { get; private set; }
+        public string Description { get; private set; }
         public string Homepage { get; private set; }
         public string Identifier { get; private set; }
         public bool IsInstallChecked { get; set; }
@@ -40,6 +40,12 @@ namespace CKAN
         public bool IsNew { get; set; }
         public bool IsCKAN { get; private set; }
         public string Abbrevation { get; private set; }
+
+        public string SearchableName { get; private set; }
+        public string SearchableIdentifier { get; private set; }
+        public string SearchableAbstract { get; private set; }
+        public string SearchableDescription { get; private set; }
+        public List<string> SearchableAuthors { get; private set; }
 
         /// <summary>
         /// Return whether this mod is installable.
@@ -99,6 +105,7 @@ namespace CKAN
 
             Name          = mod.name.Trim();
             Abstract      = mod.@abstract.Trim();
+            Description   = mod.description?.Trim() ?? string.Empty;
             Abbrevation   = new string(Name.Split(' ').Where(s => s.Length > 0).Select(s => s[0]).ToArray());
             Authors       = mod.author == null ? "N/A" : String.Join(",", mod.author);
 
@@ -115,6 +122,12 @@ namespace CKAN
                         ?? mod.resources.repository?.ToString()
                         ?? "N/A";
             }
+
+            // Get the Searchables.
+            SearchableName        = mod.SearchableName;
+            SearchableAbstract    = mod.SearchableAbstract;
+            SearchableDescription = mod.SearchableDescription;
+            SearchableAuthors     = mod.SearchableAuthors;
 
             UpdateIsCached();
         }
@@ -186,8 +199,9 @@ namespace CKAN
             }
 
             // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
-
             Homepage = "N/A";
+
+            SearchableIdentifier = CkanModule.nonAlphaNums.Replace(Identifier, "");
         }
 
         /// <summary>

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -135,9 +135,9 @@ namespace CKAN
             Util.Invoke(MetadataModuleVersionTextBox, () => MetadataModuleVersionTextBox.Text = gui_module.LatestVersion.ToString());
             Util.Invoke(MetadataModuleLicenseTextBox, () => MetadataModuleLicenseTextBox.Text = string.Join(", ", module.license));
             Util.Invoke(MetadataModuleAuthorTextBox, () => MetadataModuleAuthorTextBox.Text = gui_module.Authors);
-            Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = module.@abstract);
-            Util.Invoke(MetadataModuleDescriptionTextBox, () => MetadataModuleDescriptionTextBox.Text = module.description);
-            Util.Invoke(MetadataIdentifierTextBox, () => MetadataIdentifierTextBox.Text = module.identifier);
+            Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = gui_module.Abstract);
+            Util.Invoke(MetadataModuleDescriptionTextBox, () => MetadataModuleDescriptionTextBox.Text = gui_module.Description);
+            Util.Invoke(MetadataIdentifierTextBox, () => MetadataIdentifierTextBox.Text = gui_module.Identifier);
 
             // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
             Util.Invoke(MetadataModuleHomePageLinkLabel, () => MetadataModuleHomePageLinkLabel.Text = gui_module.Homepage.ToString());

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -802,7 +802,7 @@ namespace CKAN
         public bool IsVisible(GUIMod mod)
         {
             var nameMatchesFilter = IsNameInNameFilter(mod);
-            var authorMatchesFilter = IsAuthorInauthorFilter(mod);
+            var authorMatchesFilter = IsAuthorInAuthorFilter(mod);
             var abstractMatchesFilter = IsAbstractInDescriptionFilter(mod);
             var modMatchesType = IsModInFilter(ModFilter, mod);
             var isVisible = nameMatchesFilter && modMatchesType && authorMatchesFilter && abstractMatchesFilter;
@@ -934,19 +934,26 @@ namespace CKAN
 
         private bool IsNameInNameFilter(GUIMod mod)
         {
-            return mod.Name.IndexOf(ModNameFilter, StringComparison.InvariantCultureIgnoreCase) != -1
-                || mod.Abbrevation.IndexOf(ModNameFilter, StringComparison.InvariantCultureIgnoreCase) != -1
-                || mod.Identifier.IndexOf(ModNameFilter, StringComparison.InvariantCultureIgnoreCase) != -1;
+            string sanitisedModNameFilter = CkanModule.nonAlphaNums.Replace(ModNameFilter, "");
+
+            return mod.Abbrevation.IndexOf(ModNameFilter, StringComparison.InvariantCultureIgnoreCase) != -1
+                || mod.SearchableName.IndexOf(sanitisedModNameFilter, StringComparison.InvariantCultureIgnoreCase) != -1
+                || mod.SearchableIdentifier.IndexOf(sanitisedModNameFilter, StringComparison.InvariantCultureIgnoreCase) != -1;
         }
 
-        private bool IsAuthorInauthorFilter(GUIMod mod)
+        private bool IsAuthorInAuthorFilter(GUIMod mod)
         {
-            return mod.Authors.IndexOf(ModAuthorFilter, StringComparison.InvariantCultureIgnoreCase) != -1;
+            string sanitisedModAuthorFilter = CkanModule.nonAlphaNums.Replace(ModAuthorFilter, "");
+
+            return mod.SearchableAuthors.Any((author) => author.IndexOf(sanitisedModAuthorFilter, StringComparison.InvariantCultureIgnoreCase) != -1);
         }
 
         private bool IsAbstractInDescriptionFilter(GUIMod mod)
         {
-            return mod.Abstract.IndexOf(ModDescriptionFilter, StringComparison.InvariantCultureIgnoreCase) != -1;
+            string sanitisedModDescriptionFilter = CkanModule.nonAlphaNums.Replace(ModDescriptionFilter, "");
+
+            return mod.SearchableAbstract.IndexOf(sanitisedModDescriptionFilter, StringComparison.InvariantCultureIgnoreCase) != -1
+                || mod.SearchableDescription.IndexOf(sanitisedModDescriptionFilter, StringComparison.InvariantCultureIgnoreCase) != -1;
         }
 
         private static bool IsModInFilter(GUIModFilter filter, GUIMod m)

--- a/GUI/SelectionDialog.cs
+++ b/GUI/SelectionDialog.cs
@@ -3,7 +3,7 @@ using System.Windows.Forms;
 
 namespace CKAN
 {
-    public partial class SelectionDialog : FormCompatibility
+    public partial class SelectionDialog : Form
     {
         int currentSelected;
 


### PR DESCRIPTION
## Problem
If you want to search the mod list (in GUI, commandline or consoleUI), you have to know the name/identifier/author/description exactly, even spaces and special character.
There are **a lot** of mods with spaces and special characters in their name, sometimes even in the identifier indexed in the CKAN.
Examples:
* aati-flags (name) - AATI-Flags (identifier)
(special char)
* [1.3] Capsule Corporation Endeavour (Mars Base Camp)
(special chars and spaces)
* BetterBurnTime
(no spaces)
* and on and on

It's nearly impossible to find a mod on the first try right now, if you don't know the exact name including all spaces, hyphens, brackets, dots...

## Solution
On startup, more precisely during the deserialization of `CkanModule`s on load of registry, 'Searchables' are calculated for every mo and mod version, and saved during runtime in `CkanModule`. The don't get serialized!
Those 'Searchables' are
```
SearchableIdentifier
SearchableName
SearchableAbstract
SearchableDescription
SearchableAuthors (this one is a List<string>)
```
and represent special-characterless versions of their respective counterparts.
This means no spaces, no hyphens, no brackets and so on. Only alphanumerics remain.
They are calculated by removing each non-alphanumeric char from the source strings (regex `[^a-zA-Z0-9]`.
If a mod search is done, the search term gets treated the same way.

This applies to all three interfaces, for all search types (author, description, name...).

---
Furthermore, I've improved the console search a bit. There's now also a `--detail` option (similar to the one in `available`, see #2286) to list more than just the identifier, including the compatibility for KSP versions of the last mod version.
The new `--all` option lists incompatible mods too. Without `--detail`, they're mixed up in the compatibles, but with they are printed as two separate lists.
Third, the `--author <authorName>` option allows to search for mods by a specific author. An empty `search_term` is possible, to list all the mods of an author.

So the search command can now range from
`ckan search kerbal` to
`ckan search --all --detail --author linuxguru RecycledPartsFTmNImprovedAtomicRockets`,
something for everyone.

---
## tl;dr:
* aatiflags or aati flags finds aati-flags
* capsulecorporation endeavour Mars Base Camp finds [1.3] Capsule Corporation Endeavour (Mars Base Camp)
* better burn time finds BetterBurnTime
* `ckan search --all --detail --author linuxguru RecycledPartsFTmNImprovedAtomicRock` finds RecycledPartsFTmNImprovedAtomicRockets by LGG in commandline
* ...

Closes #2708 