### PR TITLE
Save restore position when minimized

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -307,9 +307,16 @@ namespace CKAN
             base.OnFormClosed(e);
         }
 
-        protected override void OnLoad(EventArgs e)
+        private void SetStartPosition()
         {
-            if (configuration.WindowLoc.X == -1 && configuration.WindowLoc.Y == -1)
+            Screen screen = Util.FindScreen(configuration.WindowLoc, configuration.WindowSize);
+            if (screen == null)
+            {
+                // Start at center of screen if we have an invalid location saved in the config
+                // (such as -32000,-32000, which Windows uses when you're minimized)
+                StartPosition = FormStartPosition.CenterScreen;
+            }
+            else if (configuration.WindowLoc.X == -1 && configuration.WindowLoc.Y == -1)
             {
                 // Center on screen for first launch
                 StartPosition = FormStartPosition.CenterScreen;
@@ -319,14 +326,20 @@ namespace CKAN
                 // Make sure there's room at the top for the MacOSX menu bar
                 Location = Util.ClampedLocationWithMargins(
                     configuration.WindowLoc, configuration.WindowSize,
-                    new Size(0, 30), new Size(0, 0)
+                    new Size(0, 30), new Size(0, 0),
+                    screen
                 );
             }
             else
             {
                 // Just make sure it's fully on screen
-                Location = Util.ClampedLocation(configuration.WindowLoc, configuration.WindowSize);
+                Location = Util.ClampedLocation(configuration.WindowLoc, configuration.WindowSize, screen);
             }
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            SetStartPosition();
             Size = configuration.WindowSize;
             WindowState = configuration.IsWindowMaximised ? FormWindowState.Maximized : FormWindowState.Normal;
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -470,7 +470,7 @@ namespace CKAN
             }
 
             // Copy window location to app settings
-            configuration.WindowLoc = Location;
+            configuration.WindowLoc = WindowState == FormWindowState.Normal ? Location : RestoreBounds.Location;
 
             // Copy window size to app settings if not maximized
             configuration.WindowSize = WindowState == FormWindowState.Normal ? Size : RestoreBounds.Size;

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -117,6 +117,20 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Find a screen that the given box overlaps
+        /// </summary>
+        /// <param name="location">Upper left corner of box</param>
+        /// <param name="size">Width and height of box</param>
+        /// <returns>
+        /// The first screen that overlaps the box if any, otherwise null
+        /// </returns>
+        public static Screen FindScreen(Point location, Size size)
+        {
+            var rect = new Rectangle(location, size);
+            return Screen.AllScreens.FirstOrDefault(sc => sc.WorkingArea.IntersectsWith(rect));
+        }
+
+        /// <summary>
         /// Adjust position of a box so it fits entirely on one screen
         /// </summary>
         /// <param name="location">Top left corner of box</param>
@@ -125,26 +139,23 @@ namespace CKAN
         /// Original location if already fully on-screen, otherwise
         /// a position representing sliding it onto the screen
         /// </returns>
-        public static Point ClampedLocation(Point location, Size size)
+        public static Point ClampedLocation(Point location, Size size, Screen screen = null)
         {
-            var rect = new Rectangle(location, size);
-            // Find a screen that the default position overlaps
-            foreach (Screen screen in Screen.AllScreens)
+            if (screen == null)
             {
-                if (screen.WorkingArea.IntersectsWith(rect))
-                {
-                    // Slide the whole rectangle fully onto the screen
-                    if (location.X < screen.WorkingArea.Top)
-                        location.X = screen.WorkingArea.Top;
-                    if (location.Y < screen.WorkingArea.Left)
-                        location.Y = screen.WorkingArea.Left;
-                    if (location.X + size.Width > screen.WorkingArea.Right)
-                        location.X = screen.WorkingArea.Right - size.Width;
-                    if (location.Y + size.Height > screen.WorkingArea.Bottom)
-                        location.Y = screen.WorkingArea.Bottom - size.Height;
-                    // Stop checking screens
-                    break;
-                }
+                screen = FindScreen(location, size);
+            }
+            if (screen != null)
+            {
+                // Slide the whole rectangle fully onto the screen
+                if (location.X < screen.WorkingArea.Top)
+                    location.X = screen.WorkingArea.Top;
+                if (location.Y < screen.WorkingArea.Left)
+                    location.Y = screen.WorkingArea.Left;
+                if (location.X + size.Width > screen.WorkingArea.Right)
+                    location.X = screen.WorkingArea.Right - size.Width;
+                if (location.Y + size.Height > screen.WorkingArea.Bottom)
+                    location.Y = screen.WorkingArea.Bottom - size.Height;
             }
             return location;
         }
@@ -160,12 +171,12 @@ namespace CKAN
         /// Original location if already fully on-screen plus margins, otherwise
         /// a position representing sliding it onto the screen
         /// </returns>
-        public static Point ClampedLocationWithMargins(Point location, Size size, Size topLeftMargin, Size bottomRightMargin)
+        public static Point ClampedLocationWithMargins(Point location, Size size, Size topLeftMargin, Size bottomRightMargin, Screen screen = null)
         {
             // Imagine drawing a larger box around the window, the size of the desired margin.
             // We pass that box to ClampedLocation to make sure it fits on screen,
             // then place our window at an offset within the box
-            return ClampedLocation(location - topLeftMargin, size + topLeftMargin + bottomRightMargin) + topLeftMargin;
+            return ClampedLocation(location - topLeftMargin, size + topLeftMargin + bottomRightMargin, screen) + topLeftMargin;
         }
 
     }


### PR DESCRIPTION
## Problem

If you:

1. Open CKAN with the tray icon enabled
2. Minimize it
3. Right click the tray icon
4. Exit

... then the following is saved to `GUIConfig.xml`:

![config](https://user-images.githubusercontent.com/4104564/55571010-8edb6100-56fc-11e9-8dc4-4f92aca9634d.png)

And the next time CKAN runs, its window will not appear.

## Cause

Apparently Windows moves minimized windows to (-32000,-32000).

https://stackoverflow.com/questions/1478765/location-coordinates-on-computer-showing-x-32000-y-32000

So when we exit and save the `Location` property while minimized, we're saving that value.

## Changes

Now we ignore `Location` if the window state isn't normal (i.e., we're minimized or maximized), and instead we check `RestoreBounds.Location`, which is where the window's former location to which it will be returned lives. This mirrors how we handle the window size on the next line of code (though in that case the problem was with maximization).

Fixes #2717.