### PR TITLE
Fix home/end, url handler, typing nav, and dependency double click

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -564,7 +564,7 @@ namespace CKAN
             if (Main.Instance.configuration.AutoSortByUpdate)
             {
                 // set new sort column
-                var new_sort_column = ModList.Columns[1];
+                var new_sort_column = ModList.Columns[UpdateCol.Index];
                 var current_sort_column = ModList.Columns[configuration.SortByColumnIndex];
 
                 // Reset the glyph.
@@ -573,7 +573,7 @@ namespace CKAN
                 UpdateFilters(this);
 
                 // Select the top row and scroll the list to it.
-                ModList.CurrentCell = ModList.Rows[0].Cells[1];
+                ModList.CurrentCell = ModList.Rows[0].Cells[SelectableColumnIndex()];
             }
 
             ModList.Refresh();
@@ -1052,9 +1052,7 @@ namespace CKAN
             {
                 match.Selected = true;
 
-                // Setting this to the 'Name' cell prevents the checkbox from being toggled
-                // by pressing 'Space' while the row is not indicated as active.
-                ModList.CurrentCell = match.Cells[2];
+                ModList.CurrentCell = match.Cells[SelectableColumnIndex()];
                 if (showAsFirst)
                     ModList.FirstDisplayedScrollingRowIndex = match.Index;
             }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -418,13 +418,13 @@ namespace CKAN
             {
                 case Keys.Home:
                     // First row.
-                    ModList.CurrentCell = ModList.Rows[0].Cells[2];
+                    ModList.CurrentCell = ModList.Rows[0].Cells[SelectableColumnIndex()];
                     e.Handled = true;
                     break;
 
                 case Keys.End:
                     // Last row.
-                    ModList.CurrentCell = ModList.Rows[ModList.Rows.Count - 1].Cells[2];
+                    ModList.CurrentCell = ModList.Rows[ModList.Rows.Count - 1].Cells[SelectableColumnIndex()];
                     e.Handled = true;
                     break;
 
@@ -448,6 +448,25 @@ namespace CKAN
                     }
                     break;
             }
+        }
+
+        /// <summary>
+        /// Find a column of the grid that can contain the CurrentCell.
+        /// Can't be hidden or an exception is thrown.
+        /// Shouldn't be a checkbox because we don't want the space bar to toggle.
+        /// </summary>
+        /// <returns>
+        /// Index of the column to use.
+        /// </returns>
+        private int SelectableColumnIndex()
+        {
+            // First try the currently active cell's column
+            return ModList.CurrentCell?.ColumnIndex
+                // If there's no currently active cell, use the first visible non-checkbox column
+                ?? ModList.Columns.Cast<DataGridViewColumn>()
+                    .FirstOrDefault(c => c is DataGridViewTextBoxColumn && c.Visible)?.Index
+                // Otherwise use the Installed checkbox column since it can't be hidden
+                ?? Installed.Index;
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

If you do any of the following:

- Press Home on the mod list
- Press End on the mod list
- Invoke the URL handler
- Start typing a mod name on the mod list
- Double click a mod in the mod info dependency tree

... this exception occurs:

```
System.InvalidOperationException: Die aktuelle Zelle kann nicht auf eine unsichtbare Zelle festgelegt werden. (Rough translation: the current cell can't be set to an invisible cell)
   bei System.Windows.Forms.DataGridView.set_CurrentCell(DataGridViewCell value)
   bei CKAN.Main.ModList_KeyDown(Object sender, KeyEventArgs e)
   bei System.Windows.Forms.Control.OnKeyDown(KeyEventArgs e)
   bei System.Windows.Forms.DataGridView.OnKeyDown(KeyEventArgs e)
   bei System.Windows.Forms.Control.ProcessKeyEventArgs(Message& m)
   bei System.Windows.Forms.DataGridView.ProcessKeyEventArgs(Message& m)
   bei System.Windows.Forms.Control.WmKeyChar(Message& m)
   bei System.Windows.Forms.Control.WndProc(Message& m)
   bei System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Cause

These all work by setting `ModList.CurrentCell` to a row's third cell, for reasons explained here:

https://github.com/KSP-CKAN/CKAN/blob/3bc537637e8f4452c9787699045d61b4d869061f/GUI/Main.cs#L1055-L1056

However, as of #2671, the third cell is Replace instead of Name, and as of #2690, it's hidden most of the time. A hidden cell cannot be the current cell, so an exception is thrown. This is essentially the same problem as #2703, but it's not specific to the mark-all-updates operation.

## Changes

Now we look for usable columns in this order:

1. The current column, if any, to avoid scrolling horizontally
2. The first visible non-checkbox column, if any
3. The Installed checkbox column (always visible fallback)

In addition, the fix for #2704 is modified to use this same logic. I think the original reasoning from the comment quoted above applies here, and so we should avoid setting focus to checkboxes when we can.

Fixes KSP-CKAN/NetKAN#7108.