### PR TITLE
Fix size of relationships list

### DIFF
--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -481,7 +481,7 @@
             this.DependsGraphTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.DependsGraphTree.Location = new System.Drawing.Point(3, 96);
             this.DependsGraphTree.Name = "DependsGraphTree";
-            this.DependsGraphTree.Size = new System.Drawing.Size(345, 489);
+            this.DependsGraphTree.Size = new System.Drawing.Size(345, 400);
             this.DependsGraphTree.TabIndex = 0;
             this.DependsGraphTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.DependsGraphTree_NodeMouseDoubleClick);
             this.DependsGraphTree.ShowNodeToolTips = true;


### PR DESCRIPTION
## Problem

The relationships tree doesn't fit in the available space:

![image](https://user-images.githubusercontent.com/1559108/56073472-f300c380-5d93-11e9-9438-4d34da00c574.png)

## Cause

#2592 moved the top of the tree control down 92 pixels without changing its height, so the bottom slid down as well, past the bottom of the available space. The parent control starts at 502 pixels tall, while the tree's top is 96 and height is 489, so the bottom is at 96+489 =585:

https://github.com/KSP-CKAN/CKAN/blob/3bc537637e8f4452c9787699045d61b4d869061f/GUI/MainModInfo.Designer.cs#L471-L484

## Changes

Now the relationships tree is 400 pixels tall, which allows it to fit in the available space since 96+400 < 502:

![image](https://user-images.githubusercontent.com/1559108/56073474-fd22c200-5d93-11e9-84e5-e13e5b123380.png)

Fixes #2722.