### PR TITLE
Auto size yes no dialog

### DIFF
--- a/GUI/YesNoDialog.Designer.cs
+++ b/GUI/YesNoDialog.Designer.cs
@@ -37,6 +37,9 @@
             // 
             // panel1
             // 
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel1.Controls.Add(this.DescriptionLabel);
             this.panel1.Location = new System.Drawing.Point(13, 13);
             this.panel1.Name = "panel1";
@@ -55,6 +58,8 @@
             // 
             // YesButton
             // 
+            this.YesButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Right));
             this.YesButton.DialogResult = System.Windows.Forms.DialogResult.Yes;
             this.YesButton.Location = new System.Drawing.Point(250, 92);
             this.YesButton.Name = "YesButton";
@@ -65,6 +70,8 @@
             // 
             // NoButton
             // 
+            this.NoButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Right));
             this.NoButton.DialogResult = System.Windows.Forms.DialogResult.No;
             this.NoButton.Location = new System.Drawing.Point(331, 92);
             this.NoButton.Name = "NoButton";
@@ -81,7 +88,7 @@
             this.Controls.Add(this.NoButton);
             this.Controls.Add(this.YesButton);
             this.Controls.Add(this.panel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.Name = "YesNoDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "CKAN";

--- a/GUI/YesNoDialog.cs
+++ b/GUI/YesNoDialog.cs
@@ -1,8 +1,10 @@
+using System;
+using System.Drawing;
 ﻿using System.Windows.Forms;
 
 namespace CKAN
 {
-    public partial class YesNoDialog : FormCompatibility
+    public partial class YesNoDialog : Form
     {
         public YesNoDialog()
         {
@@ -11,8 +13,26 @@ namespace CKAN
 
         public DialogResult ShowYesNoDialog(string text)
         {
-            Util.Invoke(DescriptionLabel, () => DescriptionLabel.Text = text);
+            Util.Invoke(DescriptionLabel, () =>
+            {
+                DescriptionLabel.Text = text;
+                ClientSize = new Size(ClientSize.Width, StringHeight(text, ClientSize.Width - 25) + 2 * 54);
+            });
+
             return ShowDialog();
+        }
+
+        /// <summary>
+        /// Simple syntactic sugar around Graphics.MeasureString
+        /// </summary>
+        /// <param name="text">String to measure size of</param>
+        /// <param name="maxWidth">Number of pixels allowed horizontally</param>
+        /// <returns>
+        /// Number of pixels needed vertically to fit the string
+        /// </returns>
+        private int StringHeight(string text, int maxWidth)
+        {
+            return (int)CreateGraphics().MeasureString(text, DescriptionLabel.Font, maxWidth).Height;
         }
 
         public void HideYesNoDialog()


### PR DESCRIPTION
## Problem

If the `YesNoDialog` needs to display a long string, it can be truncated:

![screenshot](https://user-images.githubusercontent.com/40007416/55574108-e1704980-570b-11e9-8e48-87eb196d8c30.png)

## Cause

It's just a statically sized form, so only short strings will fit.

## Changes

Now the form is resizable, so if it's unreadable, the user has the option to resize it. The controls have the `Anchor` property set to make them move correctly.

Now when a message is set, the form uses `Graphics.MeasureString` to determine the required height of the label, and uses this to set the size of the form. This ensures that the full message will be visible.

`YesNoDialog` no longer inherits from `FormCompatibility` because it wasn't calling `ApplyFormCompatibilityFixes` anyway. This will have no effect.

Fixes #2718.