### PR TITLE
Don't apply previous change set to checkboxes after successful install

### DIFF
--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -364,7 +364,7 @@ namespace CKAN
             if (result.Key && !installCanceled)
             {
                 // Rebuilds the list of GUIMods
-                UpdateModsList(false, result.Value);
+                UpdateModsList(false, null);
 
                 if (modChangedCallback != null)
                 {
@@ -381,11 +381,11 @@ namespace CKAN
                 RetryCurrentActionButton.Visible = false;
                 UpdateChangesDialog(null, installWorker);
             }
-            else if(installCanceled)
+            else if (installCanceled)
             {
                 // User cancelled the installation
                 // Rebuilds the list of GUIMods
-                UpdateModsList(false, result.Value);
+                UpdateModsList(false, ChangeSet);
                 UpdateChangesDialog(null, installWorker);
                 if (result.Key) {
                     FailWaitDialog("Cancellation to late, process complete!", "User canceled the process manually, but all mods already (un)installed/upgraded.", "Process complete!", result.Key);


### PR DESCRIPTION
## Problem

If you install a module, and then install a different version of it by double clicking in the Versions tab of mod info, its Installed checkbox becomes unchecked even though it's still installed.

## Cause

`UpdateModsList` has a change set parameter to keep the mod list in sync with the active change set. If you pass a change set in this parameter, the function will apply each change in it to the freshly loaded mod list. When you install by double clicking an older version, we don't go through the main change set, but instead jump directly to installing the module.

We were passing the just-completed change set to `UpdateModsList` after installation. This isn't necessary because the changes will be picked up directly from the registry, but until recently it was at least benign since the boxes it would check or uncheck were already in that state.

After double clicking in the Versions tab, that call re-applies the uninstall-reinstall change set even though it's already been completed, *and* it isn't the active change set. And after #2669 it has a *remove* action for the module, which makes `UpdateModsList` think that it's been or being removed, when in reality it was immediately reinstalled.

## Changes

The right thing to do is to apply *no* change set on success, and to apply `Main.ChangeSet` on failure. Now we do that. This will ensure that our weird uninstall-reinstall change sets don't confuse `UpdateModsList`.

Fixes #2713.