### PR TITLE
Fix Newly Compatible filter with repo autoupdate

### DIFF
--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -364,7 +364,7 @@ namespace CKAN
             if (result.Key && !installCanceled)
             {
                 // Rebuilds the list of GUIMods
-                UpdateModsList(false, null);
+                UpdateModsList(null);
 
                 if (modChangedCallback != null)
                 {
@@ -385,7 +385,7 @@ namespace CKAN
             {
                 // User cancelled the installation
                 // Rebuilds the list of GUIMods
-                UpdateModsList(false, ChangeSet);
+                UpdateModsList(ChangeSet);
                 UpdateChangesDialog(null, installWorker);
                 if (result.Key) {
                     FailWaitDialog("Cancellation to late, process complete!", "User canceled the process manually, but all mods already (un)installed/upgraded.", "Process complete!", result.Key);


### PR DESCRIPTION
## Problem

If you have repository auto updates enabled, then the Newly Compatible filter will show all modules:

![screenshot](https://camo.githubusercontent.com/533a34cff2135ce450f704e369d9de494a4db092/68747470733a2f2f692e696d6775722e636f6d2f6c71565253695a2e706e67)

## Cause

Before #2694, GUI performed two mod list updates at startup if repository auto updates were enabled: one with the existing registry data (which the user will never see), and one with the registry data after the repo update. This is not great because mod list updates are one of our slower operations.

After #2694, GUI performed only one mod list update at startup, using the data after the repo update. This improved performance, but it broke the Newly Compatible filter because that filter was based on a comparison of the mod list before and after the repo update. With only do one mod list update, the "before" list in the comparison is empty, and every mod seems to be newly added.

## Changes

Now the "before" part of the before-and-after comparison is generated based on the registry before the repositories are updated, and then passed to the mod list updating code after the repo update. This allows us to populate the filter properly without performing multiple mod list updates.

Fixes #2716.