### PR TITLE
Compare RelationshipDescriptors with Equals instead of Same

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -323,7 +323,7 @@ Do you wish to reinstall now?", sb)))
                 var aRel = aSorted[i];
                 var bRel = bSorted[i];
 
-                if (!aRel.Same(bRel))
+                if (!aRel.Equals(bRel))
                 {
                     return false;
                 }

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -13,7 +13,7 @@ using CKAN.Versioning;
 
 namespace CKAN
 {
-    public abstract class RelationshipDescriptor
+    public abstract class RelationshipDescriptor : IEquatable<RelationshipDescriptor>
     {
         public abstract bool MatchesAny(
             IEnumerable<CkanModule> modules,
@@ -25,7 +25,7 @@ namespace CKAN
 
         public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, KspVersionCriteria crit, IEnumerable<CkanModule> toInstall = null);
 
-        public abstract bool Same(RelationshipDescriptor other);
+        public abstract bool Equals(RelationshipDescriptor other);
 
         public abstract bool ContainsAny(IEnumerable<string> identifiers);
 
@@ -149,7 +149,7 @@ namespace CKAN
             return registry.LatestAvailableWithProvides(name, crit, this, toInstall);
         }
 
-        public override bool Same(RelationshipDescriptor other)
+        public override bool Equals(RelationshipDescriptor other)
         {
             ModuleRelationshipDescriptor modRel = other as ModuleRelationshipDescriptor;
             return modRel != null
@@ -236,7 +236,7 @@ namespace CKAN
             return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit, toInstall)).ToList();
         }
 
-        public override bool Same(RelationshipDescriptor other)
+        public override bool Equals(RelationshipDescriptor other)
         {
             AnyOfRelationshipDescriptor anyRel = other as AnyOfRelationshipDescriptor;
             return anyRel != null


### PR DESCRIPTION
## Problem

@Poodmund reported an issue on the forum where this popup appears every time CKAN is launched, even after you click Yes to reinstall:

![screenshot](https://i.imgur.com/4WYnzgD.png)

https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1260-baikonur/&do=findComment&comment=3586115

## Cause

At the top level, `Repo.RelationshipsAreEquivalent` uses `RelationshipDescriptor.Same` to compare the relationships of an installed module with those of its freshly updated available counterpart:

https://github.com/KSP-CKAN/CKAN/blob/5331bf9344f6729a6b96f52bea45bdec245a3bb3/Core/Net/Repo.cs#L321-L330

Child class `ModuleRelationshipDescriptor` implements `Same` as a comparison of the name and versions:

https://github.com/KSP-CKAN/CKAN/blob/5331bf9344f6729a6b96f52bea45bdec245a3bb3/Core/Types/CkanModule.cs#L152-L160

Child class `AnyOfRelationshipDescriptor` implements `Same` by comparing the lists contained in the `any_of` property using `SequenceEqual`:

https://github.com/KSP-CKAN/CKAN/blob/5331bf9344f6729a6b96f52bea45bdec245a3bb3/Core/Types/CkanModule.cs#L239-L244

However, when `SequenceEqual` checks the pairs of values in the two lists, [it uses `Equals`, not `Same`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.sequenceequal)! This means the nested relationships aren't compared the same way as regular ones, so they might not produce the correct result. This causes CKAN to think an `any_of` relationship has changed when it hasn't, and mistakenly alert @Poodmund to it.

## Changes

Now `RelationshipDescriptor` implements `IEquatable<RelationshipDescriptor>`, and it and its child classes implement `Equals` instead of `Same`, with the same logic as before. Calling code is updated to use `Equals` instead. This will ensure that the intended comparison logic is used when we call `SequenceEqual`.

Fixes @Poodmund's issue.