### PR TITLE
Relabel Yes/No buttons for some questions

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -451,7 +451,7 @@ namespace CKAN
                     string confDescrip = Conflicts
                         .Select(kvp => kvp.Value)
                         .Aggregate((a, b) => $"{a}, {b}");
-                    if (!YesNoDialog($"There are conflicts. Really quit?\r\n\r\n{confDescrip}"))
+                    if (!YesNoDialog($"There are conflicts. Really quit?\r\n\r\n{confDescrip}", "Quit", "Go Back"))
                     {
                         e.Cancel = true;
                         return;
@@ -460,7 +460,7 @@ namespace CKAN
                 else
                 {
                     // The Conflicts dictionary is empty even when there are unmet dependencies.
-                    if (!YesNoDialog("There are unmet dependencies. Really quit?"))
+                    if (!YesNoDialog("There are unmet dependencies. Really quit?", "Quit", "Go Back"))
                     {
                         e.Cancel = true;
                         return;
@@ -475,7 +475,7 @@ namespace CKAN
                     .Select(grp => $"{grp.Key}: "
                         + grp.Aggregate((a, b) => $"{a}, {b}"))
                     .Aggregate((a, b) => $"{a}\r\n{b}");
-                if (!YesNoDialog($"You have unapplied changes. Really quit?\r\n\r\n{changeDescrip}"))
+                if (!YesNoDialog($"You have unapplied changes. Really quit?\r\n\r\n{changeDescrip}", "Quit", "Go Back"))
                 {
                     e.Cancel = true;
                     return;
@@ -832,7 +832,7 @@ namespace CKAN
                 string incompatDescrip = incomp
                     .Select(m => $"{m.Module} ({registry.CompatibleGameVersions(m.Module)})")
                     .Aggregate((a, b) => $"{a}, {b}");
-                if (!YesNoDialog($"Some installed modules are incompatible! It might not be safe to launch KSP. Really launch?\r\n\r\n{incompatDescrip}"))
+                if (!YesNoDialog($"Some installed modules are incompatible! It might not be safe to launch KSP. Really launch?\r\n\r\n{incompatDescrip}", "Launch", "Go Back"))
                 {
                     return;
                 }

--- a/GUI/MainAllModVersions.cs
+++ b/GUI/MainAllModVersions.cs
@@ -26,7 +26,7 @@ namespace CKAN
             CkanModule          module = item.Tag as CkanModule;
 
             if (module.IsCompatibleKSP(Main.Instance.Manager.CurrentInstance.VersionCriteria())
-                && Main.Instance.YesNoDialog($"Install {module}?"))
+                && Main.Instance.YesNoDialog($"Install {module}?", "Install", "Cancel"))
             {
                 Main.Instance.InstallModuleDriver(
                     RegistryManager.Instance(Main.Instance.Manager.CurrentInstance).registry,

--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -37,9 +37,9 @@ namespace CKAN
             errorDialog.ShowErrorDialog(String.Format(text, args));
         }
 
-        public bool YesNoDialog(string text)
+        public bool YesNoDialog(string text, string yesText = null, string noText = null)
         {
-            return yesNoDialog.ShowYesNoDialog(text) == DialogResult.Yes;
+            return yesNoDialog.ShowYesNoDialog(text, yesText, noText) == DialogResult.Yes;
         }
 
         public int SelectionDialog(string message, params object[] args)

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -306,7 +306,7 @@ namespace CKAN
                 {
                     string msg = kraken.ToString();
                     GUI.user.RaiseMessage(msg);
-                    if (YesNoDialog($"{msg}\r\n\r\nOpen settings now?"))
+                    if (YesNoDialog($"{msg}\r\n\r\nOpen settings now?", "Open Settings", "No"))
                     {
                         // Launch the URL describing this host's throttling practices, if any
                         if (kraken.infoUrl != null)

--- a/GUI/YesNoDialog.cs
+++ b/GUI/YesNoDialog.cs
@@ -11,11 +11,19 @@ namespace CKAN
             InitializeComponent();
         }
 
-        public DialogResult ShowYesNoDialog(string text)
+        public DialogResult ShowYesNoDialog(string text, string yesText = null, string noText = null)
         {
             Util.Invoke(DescriptionLabel, () =>
             {
                 DescriptionLabel.Text = text;
+                if (yesText != null)
+                {
+                    YesButton.Text = yesText;
+                }
+                if (noText != null)
+                {
+                    NoButton.Text = noText;
+                }
                 ClientSize = new Size(ClientSize.Width, StringHeight(text, ClientSize.Width - 25) + 2 * 54);
             });
 


### PR DESCRIPTION
## Motivation

Currently if CKAN needs to confirm certain actions with the user, it uses a Yes/No popup:

![screenshot](https://user-images.githubusercontent.com/1559108/56472141-58b31680-644a-11e9-8de9-40c9ee0696cb.png)

This is not great for usability, since it requires the user to read the text carefully in order to understand the exact meaning of "Yes" and "No". For all the user knows, we might be asking whether to continue, or we might be asking whether to abort.

## Changes

Now we have the ability to override the labels of the Yes and No buttons in order to make the choice you're making more clear. The following dialogs are updated to take advantage:

- Unapplied changes: Quit / Go Back
- Incompatible installed: Launch / Go Back
- Install specific module version: Install / Cancel
- Add an auth token for GitHub: Open Settings / No

![image](https://user-images.githubusercontent.com/1559108/56472540-47203d80-644f-11e9-8f1e-6cba5f62a83b.png)

Note that this is not done for **all** questions, because some of them come from inside Core and would require modifying `IUser` to transmit the button labels. This change only applies to questions that originate from GUI code.