### PR TITLE
Fix issues when `provides` is removed

### DIFF
--- a/GUI/MainDialogs.cs
+++ b/GUI/MainDialogs.cs
@@ -83,9 +83,6 @@ namespace CKAN
                 tabController.ShowTab("ManageModsTabPage");
             });
 
-            if (module != null)
-                MarkModForInstall(module.identifier);
-
             last_mod_to_have_install_toggled.TryPop(out mod);
             return module;
         }


### PR DESCRIPTION
## Problem

If a module `provides` another module and then later we remove that property, installing a mod that depends on the provided mod can prompt you to make the same decision multiple times and raise exceptions like this:

```
Unhandled Exception: System.ArgumentException: Already contains module:TextureReplacerReplaced
   at CKAN.RelationshipResolver.Add(CkanModule module, SelectionReason reason)
   at CKAN.RelationshipResolver.AddModulesToInstall(IEnumerable`1 modules)
   at CKAN.RelationshipResolver..ctor(IEnumerable`1 modulesToInstall, IEnumerable`1 modulesToRemove, RelationshipResolverOptions options, IRegistryQuerier registry, KspVersionCriteria kspversion)
   at CKAN.RelationshipResolver..ctor(IEnumerable`1 modulesToInstall, IEnumerable`1 modulesToRemove, RelationshipResolverOptions options, IRegistryQuerier registry, KspVersionCriteria kspversion)
   at CKAN.ModuleInstaller.InstallList(List`1 modules, RelationshipResolverOptions options, IDownloader downloader)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.MainClass.RunSimpleAction(Options cmdline, CommonOptions options, String[] args, IUser user, KSPManager manager)
   at CKAN.CmdLine.MainClass.Execute(KSPManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

## Cause

See KSP-CKAN/NetKAN#7149 for full details of the situation that brought this to our attention.

After the user chooses a `CkanModule`, CmdLine discards the full `CkanModule` in favor of just the identifier here:

https://github.com/KSP-CKAN/CKAN/blob/7b9da8c6bb167cb64dd7f2f7836d5d16b41e6826/Cmdline/Action/Install.cs#L203-L204

When we next try to resolve that install command, it uses the latest version of the module rather than the one the user selected.

GUI is slightly more complicated. When you check the box for a module that depends on a virtual module, the prompt to choose a module appears immediately, and the checkbox of the user's choice is checked in the mod list.

https://github.com/KSP-CKAN/CKAN/blob/7b9da8c6bb167cb64dd7f2f7836d5d16b41e6826/GUI/MainDialogs.cs#L86-L87

**This approach can't work in the general case**, because there is no checkbox for installing an older version of a module (related to why I haven't taken a stab at #2715). Instead, this can only ever install the latest version, even if it's not what the relationship resolver gave us to select.

(ConsoleUI already handles this mostly correctly, except that the user is allowed to upgrade into an inconsistent state, which I'm not attempting to address here.)

## Changes

Now CmdLine tracks its list of mods to install as a list of `CkanModule`s, and if the user needs to choose a providing mod, the exact `CkanModule` they chose is added to that list and we try again.

Now GUI won't prompt you to choose providing mods until you apply the changes, and it will install the version of the modules that the relationship resolver gives it.

Fixes #2738.

Two tests are deleted:

- `ComputeChangeSetFromModList_WithConflictingMods_ThrowsInconsistentKraken` wasn't working as intended, see #2741. It was trying to test that conflicts between installed and installing mods are caught, which is not broken in these changes:
  ![image](https://user-images.githubusercontent.com/1559108/56483628-aff0cf80-64ba-11e9-9b56-18f68d68f211.png)
- `TooManyProvidesCallsHandlers` was trying to confirm that the provides-resolution prompt would appear when you click a mod with a virtual dependency, but that's just not how it works anymore. Now we handle them at install time.

Fixes #2741.