### PR TITLE
Fix freeze on non CKAN files in cache folder

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -30,6 +30,7 @@ namespace CKAN
         private Dictionary<string, string> cachedFiles;
         private string cachePath;
         private KSPManager manager;
+        private static readonly Regex cacheFileRegex = new Regex("^[0-9A-F]{8}-", RegexOptions.Compiled);
         private static readonly ILog log = LogManager.GetLogger(typeof (NetFileCache));
 
         /// <summary>
@@ -377,7 +378,10 @@ namespace CKAN
                 DirectoryInfo legDir = new DirectoryInfo(legacyDir);
                 files = files.Union(legDir.EnumerateFiles());
             }
-            return files.ToList();
+            return files
+                // Require 8 digit hex prefix followed by dash; any else was not put there by CKAN
+                .Where(fi => cacheFileRegex.IsMatch(fi.Name))
+                .ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

Some users reported that CKAN freezes while trying to load the registry at startup.

## Cause

This exception is thrown:

```
System.ArgumentOutOfRangeException: 인덱스 및 길이는 문자열 내의 위치를 참조해야 합니다.
매개 변수 이름: length (Rough translation: The index and length must refer to the position within the string. Parameter name: length)
   위치: System.String.Substring(Int32 startIndex, Int32 length)
   위치: System.Linq.Lookup`2.Create[TSource](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   위치: System.Linq.GroupedEnumerable`3.GetEnumerator()
   위치: System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   위치: System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   위치: CKAN.NetFileCache.GetCachedFilename(Uri url, Nullable`1 remoteTimestamp)
```

... which means that this block from #2563 tried to get a substring of a filename shorter than 8 characters:

https://github.com/KSP-CKAN/CKAN/blob/44d44ea5cd38e2f568d95f2af6d24674e01f7a45/Core/Net/NetFileCache.cs#L175-L180

It appears that some users may have chosen a CKAN cache folder that is not exclusive to CKAN:

![screeenshot](https://user-images.githubusercontent.com/1559108/56853964-94ece800-691e-11e9-9109-4971be6beab0.png)

## Changes

Now that block will ignore any filenames that don't start with 8 hex digits and a dash. This will both fix the problem with short filenames **and** exclude other files that were not created by CKAN even if they have long names.

Fixes #2711 (I think).