### PR TITLE
Combine recommendation and suggestion screens

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -117,6 +117,8 @@
             this.RecommendedModsToggleCheckbox = new System.Windows.Forms.CheckBox();
             this.RecommendedDialogLabel = new System.Windows.Forms.Label();
             this.RecommendedModsListView = new System.Windows.Forms.ListView();
+            this.RecommendationsGroup = new System.Windows.Forms.ListViewGroup();
+            this.SuggestionsGroup = new System.Windows.Forms.ListViewGroup();
             this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -1069,6 +1071,20 @@
             this.RecommendedModsListView.UseCompatibleStateImageBehavior = false;
             this.RecommendedModsListView.View = System.Windows.Forms.View.Details;
             this.RecommendedModsListView.SelectedIndexChanged += new System.EventHandler(RecommendedModsListView_SelectedIndexChanged);
+            this.RecommendedModsListView.Groups.Add(this.RecommendationsGroup);
+            this.RecommendedModsListView.Groups.Add(this.SuggestionsGroup);
+            //
+            // RecommendationsGroup
+            //
+            this.RecommendationsGroup.Header = "Recommendations";
+            this.RecommendationsGroup.Name = "Recommendations";
+            this.RecommendationsGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            //
+            // SuggestionsGroup
+            //
+            this.SuggestionsGroup.Header = "Suggestions";
+            this.SuggestionsGroup.Name = "Suggestions";
+            this.SuggestionsGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
             //
             // columnHeader3
             // 
@@ -1402,6 +1418,8 @@
         private System.Windows.Forms.CheckBox RecommendedModsToggleCheckbox;
         private System.Windows.Forms.Label RecommendedDialogLabel;
         private System.Windows.Forms.ListView RecommendedModsListView;
+        private System.Windows.Forms.ListViewGroup RecommendationsGroup;
+        private System.Windows.Forms.ListViewGroup SuggestionsGroup;
         private System.Windows.Forms.ColumnHeader columnHeader3;
         private System.Windows.Forms.ColumnHeader columnHeader4;
         private System.Windows.Forms.ColumnHeader columnHeader5;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -1035,7 +1035,7 @@
             this.RecommendedModsToggleCheckbox.Name = "RecommendedModsToggleCheckbox";
             this.RecommendedModsToggleCheckbox.Size = new System.Drawing.Size(131, 24);
             this.RecommendedModsToggleCheckbox.TabIndex = 9;
-            this.RecommendedModsToggleCheckbox.Text = "Toggle * Mods";
+            this.RecommendedModsToggleCheckbox.Text = "(De-)select all recommended or suggested mods.";
             this.RecommendedModsToggleCheckbox.UseVisualStyleBackColor = true;
             this.RecommendedModsToggleCheckbox.CheckedChanged += new System.EventHandler(this.RecommendedModsToggleCheckbox_CheckedChanged);
             // 
@@ -1047,9 +1047,8 @@
             this.RecommendedDialogLabel.Name = "RecommendedDialogLabel";
             this.RecommendedDialogLabel.Size = new System.Drawing.Size(627, 20);
             this.RecommendedDialogLabel.TabIndex = 6;
-            this.RecommendedDialogLabel.Text = "The following modules have been recommended by one or more of the chosen modules:" +
-    "";
             // 
+            this.RecommendedDialogLabel.Text = "The following modules have been recommended or suggested by one or more of the chosen modules:";
             // RecommendedModsListView
             // 
             this.RecommendedModsListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -1078,7 +1077,7 @@
             // 
             // columnHeader4
             // 
-            this.columnHeader4.Text = "Recommended by";
+            this.columnHeader4.Text = "Recommended or suggested by:";
             this.columnHeader4.Width = 180;
             // 
             // columnHeader5

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -124,22 +124,16 @@ namespace CKAN
                 }
             }
 
-            // Now work on satisifying dependencies.
-
-            var recommended = new Dictionary<CkanModule, List<string>>();
-            var suggested   = new Dictionary<CkanModule, List<string>>();
-
-            foreach (var change in opts.Key)
+            // Prompt for recommendations and suggestions, if any
+            var recRows = getRecSugRows(
+                opts.Key.Where(ch => ch.ChangeType == GUIModChangeType.Install)
+                    .Select(ch => ch.Mod.ToModule()),
+                registry, toInstall
+            );
+            if (recRows.Any())
             {
-                if (change.ChangeType == GUIModChangeType.Install)
-                {
-                    AddMod(change.Mod.ToModule().recommends, recommended, change.Mod.Identifier, registry, toInstall);
-                    AddMod(change.Mod.ToModule().suggests,   suggested,   change.Mod.Identifier, registry, toInstall);
-                }
+                ShowRecSugDialog(recRows, toInstall);
             }
-
-            ShowSelection(recommended, toInstall);
-            ShowSelection(suggested,   toInstall, true);
 
             tabController.HideTab("ChooseRecommendedModsTabPage");
 

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -86,6 +86,7 @@ namespace CKAN
                             yield return getRecSugItem(
                                 provider,
                                 string.Join(", ", dependers),
+                                RecommendationsGroup,
                                 providers.Count <= 1 || provider.identifier == (rel as ModuleRelationshipDescriptor)?.name
                             );
                         }
@@ -114,6 +115,7 @@ namespace CKAN
                             yield return getRecSugItem(
                                 provider,
                                 string.Join(", ", dependers),
+                                SuggestionsGroup,
                                 false
                             );
                         }
@@ -148,12 +150,13 @@ namespace CKAN
             tabController.SetTabLock(false);
         }
 
-        private ListViewItem getRecSugItem(CkanModule module, string descrip, bool check)
+        private ListViewItem getRecSugItem(CkanModule module, string descrip, ListViewGroup group, bool check)
         {
             ListViewItem item = new ListViewItem()
             {
                 Tag     = module,
                 Checked = check,
+                Group   = group,
                 Text    = Manager.Cache.IsMaybeCachedZip(module)
                     ? $"{module.name} {module.version} (cached)"
                     : $"{module.name} {module.version} ({module.download.Host ?? ""}, {CkanModule.FmtSize(module.download_size)})"


### PR DESCRIPTION
*(a.k.a., "Rewrite recommendations... again")*

## Problem

If you import a .ckan file that recommends CustomBarnKit, it'll try to install two mods by default:

- CustomBarnKit
- CustomBarnKit-RO

These conflict with one another, so if the user simply accepts the recommendation, the install will fail with an error.

## Cause

CustomBarnKit-RO `provides` CustomBarnKit, so recommending one pulls in both.

This is important for something like FerramAerospaceResearchContinued, which we want to match a recommendation for FAR.

## Changes

We need the ability to present a recommendation as unchecked. This is impossible within the current code structure, since all recommendations are handled the same way in one big group, and there's no conduit through which we could pass an indication of whether to check the checkbox.

Now the recommendations and suggestions prompts are merged into one big prompt, containing some items that are checked by default (the recommendations) and others that are unchecked by default (the suggestions). This reduces the number of clicks needed to get through an install.

To make this work, the recommendations code is refactored to generate a single sequence of `ListViewItem`s, each of which represents a recommendation or suggestion, and the checked state of which is controlled by more subtle logic. If only one module matches the recommendation, or if there's an exact identifier match, then it'll be checked, otherwise it'll be unchecked. In the original CustomBarnKit scenario, CustomBarnKit will be checked while CustomBarnKit-RO is unchecked. This allows the user to change it if they really want to, while still providing something that will work by default.

Using the new code is somewhat simpler for calling code, since it no longer needs to loop over modules or generate lists of recommendations and suggestions. Instead we can now simply pass the list of source modules and receive back the rows that would go to the dialog as input.

Fixes #2724.