### PR TITLE
Throw errors happening in UpdateModsList()

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -156,10 +156,11 @@ namespace CKAN
             }
         }
 
-        public void UpdateModsList(IEnumerable<ModChange> mc = null, Dictionary<string, bool> old_modules = null)
+        public async void UpdateModsList(IEnumerable<ModChange> mc = null, Dictionary<string, bool> old_modules = null)
         {
             // Run the update in the background so the UI thread can appear alive
-            Task.Factory.StartNew(() =>
+            // Await it so potential (fatal) errors are thrown, not swallowed.
+            await Task.Factory.StartNew(() =>
                 _UpdateModsList(mc ?? new List<ModChange>(), old_modules)
             );
         }


### PR DESCRIPTION
## Problem
Since #2617 errors which are thrown during startup, that means in `UpdateModLists()`, are 'swallowed', and the GUI just stopps working and is stuck in a infinite loop-like state.
#2617 changed the call of `_UpdateModsList()` to a `Task`.
Because the main thread waits for the Task to finish, but the Task in fact stopped executing if an error happened, CKAN is stuck.

## Solution
Only if you add an `await` operator in front of Tasks (and thus an `async` in the method declaration) the errors are finally thrown in the main thread. This way CKAN crashes properly on fatal/not catched errors, and the stack trace and error message are shown to the user.