### PR TITLE
Ignore dependency self conflicts

### DIFF
--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -122,10 +122,12 @@ namespace CKAN
             }
             if (module.conflicts != null)
             {
+                // Skip self-conflicts (but catch other modules providing self)
+                var othersMinusSelf = others.Where(m => m.identifier != module.identifier);
                 foreach (RelationshipDescriptor rel in module.conflicts)
                 {
                     // If any of the conflicts are present, fail
-                    if (rel.MatchesAny(others, null, null))
+                    if (rel.MatchesAny(othersMinusSelf, null, null))
                     {
                         return false;
                     }


### PR DESCRIPTION
## Problem

- On a completely fresh install, AstronomersVisualPack shows as compatible
- If you install Scatterer, AstronomersVisualPack (which depends on Scatterer) shows as incompatible

That doesn't make sense. Installing a dependency shouldn't ever mark the depending module as incompatible.

## Cause

- AstronomersVisualPack depends on Scatterer
- Scatterer conflicts with itself (see KSP-CKAN/NetKAN#4541 and #1870)

Scatterer's self-conflict relationship trips this check:

https://github.com/KSP-CKAN/CKAN/blob/2119b5802494a8e1fa7f9250dfe834a27da64fdf/Core/Registry/AvailableModule.cs#L123-L133

... but only when it's installed, via this block:

https://github.com/KSP-CKAN/CKAN/blob/2119b5802494a8e1fa7f9250dfe834a27da64fdf/Core/Registry/AvailableModule.cs#L99-L102

... passed from here:

https://github.com/KSP-CKAN/CKAN/blob/2119b5802494a8e1fa7f9250dfe834a27da64fdf/Core/Registry/Registry.cs#L708-L713

... while checking dependencies for compatibility here:

https://github.com/KSP-CKAN/CKAN/blob/2119b5802494a8e1fa7f9250dfe834a27da64fdf/Core/Registry/Registry.cs#L537-L541

## Changes

Now when checking that conflicts are OK for an available module, we filter any copies of itself (i.e., with matching identifier) out of the list of potential conflicting modules. This prevents the Scatterer self conflict from breaking modules that depend on Scatterer.

We could try ignoring the self conflict *relationships* instead, but that would miss other modules that provide the conflicting identifier, which presumably would be part of why such conflicts would be set up in the first place.

Fixes #2719 (the part of it that can't be explained as expected behavior).