### PR TITLE
Auto-uninstall auto-installed modules

### DIFF
--- a/Cmdline/Action/AuthToken.cs
+++ b/Cmdline/Action/AuthToken.cs
@@ -19,6 +19,8 @@ namespace CKAN.CmdLine
         /// <summary>
         /// Run the subcommand
         /// </summary>
+        /// <param name="mgr">Manager to provide game instances</param>
+        /// <param name="opts">Command line parameters paritally handled by parser</param>
         /// <param name="unparsed">Command line parameters not yet handled by parser</param>
         /// <returns>
         /// Exit code

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -72,6 +72,7 @@ namespace CKAN.CmdLine
                             log.DebugFormat("Check if upgrades are available for {0}", mod.Key);
                             CkanModule latest = registry.LatestAvailable(mod.Key, ksp.VersionCriteria());
                             CkanModule current = registry.GetInstalledVersion(mod.Key);
+                            InstalledModule inst = registry.InstalledModule(mod.Key);
 
                             if (latest == null)
                             {
@@ -80,13 +81,13 @@ namespace CKAN.CmdLine
                                 bullet = "X";
                                 if ( current == null ) log.DebugFormat( " {0} installed version not found in registry", mod.Key);
                                     
-                                //Check if mod is replaceable
-                                if ( current.replaced_by != null )
+                                // Check if mod is replaceable
+                                if (current.replaced_by != null)
                                 {
                                     ModuleReplacement replacement = registry.GetReplacement(mod.Key, ksp.VersionCriteria());
-                                    if ( replacement != null )
+                                    if (replacement != null)
                                     {
-                                        //Replaceable!
+                                        // Replaceable!
                                         bullet = ">";
                                         modInfo = string.Format("{0} > {1} {2}", modInfo, replacement.ReplaceWith.name, replacement.ReplaceWith.version);
                                     }
@@ -96,14 +97,14 @@ namespace CKAN.CmdLine
                             {
                                 // Up to date
                                 log.InfoFormat("Latest {0} is {1}", mod.Key, latest.version);
-                                bullet = "-";
-                                //Check if mod is replaceable
-                                if ( current.replaced_by != null )
+                                bullet = (inst?.AutoInstalled ?? false) ? "+" : "-";
+                                // Check if mod is replaceable
+                                if (current.replaced_by != null)
                                 {
                                     ModuleReplacement replacement = registry.GetReplacement(latest.identifier, ksp.VersionCriteria());
-                                    if ( replacement != null )
+                                    if (replacement != null)
                                     {
-                                        //Replaceable!
+                                        // Replaceable!
                                         bullet = ">";
                                         modInfo = string.Format("{0} > {1} {2}", modInfo, replacement.ReplaceWith.name, replacement.ReplaceWith.version);
                                     }
@@ -134,7 +135,7 @@ namespace CKAN.CmdLine
 
             if (!(options.porcelain) && exportFileType == null)
             {
-                user.RaiseMessage("\r\nLegend: -: Up to date. X: Incompatible. ^: Upgradable. >: Replaceable\r\n        A: Autodetected. ?: Unknown. *: Broken. ");
+                user.RaiseMessage("\r\nLegend: -: Up to date. +:Auto-installed. X: Incompatible. ^: Upgradable. >: Replaceable\r\n        A: Autodetected. ?: Unknown. *: Broken. ");
                 // Broken mods are in a state that CKAN doesn't understand, and therefore can't handle automatically
             }
 

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using CommandLine;
+using CommandLine.Text;
+using log4net;
+
+namespace CKAN.CmdLine
+{
+    /// <summary>
+    /// Subcommand for setting flags on modules,
+    /// currently the auto-installed flag
+    /// </summary>
+    public class Mark : ISubCommand
+    {
+        /// <summary>
+        /// Initialize the subcommand
+        /// </summary>
+        public Mark() { }
+
+        /// <summary>
+        /// Run the subcommand
+        /// </summary>
+        /// <param name="mgr">Manager to provide game instances</param>
+        /// <param name="opts">Command line parameters paritally handled by parser</param>
+        /// <param name="unparsed">Command line parameters not yet handled by parser</param>
+        /// <returns>
+        /// Exit code
+        /// </returns>
+        public int RunSubCommand(KSPManager mgr, CommonOptions opts, SubCommandOptions unparsed)
+        {
+            string[] args = unparsed.options.ToArray();
+            int exitCode = Exit.OK;
+            // Parse and process our sub-verbs
+            Parser.Default.ParseArgumentsStrict(args, new MarkSubOptions(), (string option, object suboptions) =>
+            {
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions options = (CommonOptions)suboptions;
+                    options.Merge(opts);
+                    user     = new ConsoleUser(options.Headless);
+                    manager  = mgr ?? new KSPManager(user);
+                    exitCode = options.Handle(manager, user);
+                    if (exitCode != Exit.OK)
+                        return;
+
+                    switch (option)
+                    {
+                        case "auto":
+                            exitCode = MarkAuto((MarkAutoOptions)suboptions, true, option, "auto-installed");
+                            break;
+
+                        case "user":
+                            exitCode = MarkAuto((MarkAutoOptions)suboptions, false, option, "user-selected");
+                            break;
+
+                        default:
+                            user.RaiseMessage("Unknown command: mark {0}", option);
+                            exitCode = Exit.BADOPT;
+                            break;
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+            return exitCode;
+        }
+
+        private int MarkAuto(MarkAutoOptions opts, bool value, string verb, string descrip)
+        {
+            if (opts.modules.Count < 1)
+            {
+                user.RaiseMessage("Usage: ckan mark {0} Mod [Mod2 ...]", verb);
+                return Exit.BADOPT;
+            }
+
+            int exitCode = opts.Handle(manager, user);
+            if (exitCode != Exit.OK)
+            {
+                return exitCode;
+            }
+
+            var  ksp      = MainClass.GetGameInstance(manager);
+            var  regMgr   = RegistryManager.Instance(ksp);
+            bool needSave = false;
+            Search.AdjustModulesCase(ksp, opts.modules);
+            foreach (string id in opts.modules)
+            {
+                InstalledModule im = regMgr.registry.InstalledModule(id);
+                if (im == null)
+                {
+                    user.RaiseError("{0} is not installed.", id);
+                }
+                else if (im.AutoInstalled == value)
+                {
+                    user.RaiseError("{0} is already marked as {1}.", id, descrip);
+                }
+                else
+                {
+                    user.RaiseMessage("Marking {0} as {1}...", id, descrip);
+                    im.AutoInstalled = value;
+                    needSave = true;
+                }
+            }
+            if (needSave)
+            {
+                regMgr.Save(false);
+                user.RaiseMessage("Changes made!");
+            }
+            return Exit.OK;
+        }
+
+        private KSPManager manager { get; set; }
+        private IUser      user    { get; set; }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(Mark));
+    }
+
+    internal class MarkSubOptions : VerbCommandOptions
+    {
+        [VerbOption("auto", HelpText = "Mark modules as auto installed")]
+        public MarkAutoOptions MarkAutoOptions { get; set; }
+
+        [VerbOption("user", HelpText = "Mark modules as user selected (opposite of auto installed)")]
+        public MarkAutoOptions MarkUserOptions { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            HelpText ht = HelpText.AutoBuild(this, verb);
+            // Add a usage prefix line
+            ht.AddPreOptionsLine(" ");
+            if (string.IsNullOrEmpty(verb))
+            {
+                ht.AddPreOptionsLine("ckan mark - Edit flags on modules");
+                ht.AddPreOptionsLine($"Usage: ckan mark <command> [options]");
+            }
+            else
+            {
+                ht.AddPreOptionsLine("ksp " + verb + " - " + GetDescription(verb));
+                switch (verb)
+                {
+                    case "auto":
+                        ht.AddPreOptionsLine($"Usage: ckan mark {verb} [options] Mod [Mod2 ...]");
+                        break;
+
+                    case "user":
+                        ht.AddPreOptionsLine($"Usage: ckan mark {verb} [options] Mod [Mod2 ...]");
+                        break;
+                }
+            }
+            return ht;
+        }
+    }
+
+    internal class MarkAutoOptions : InstanceSpecificOptions
+    {
+        [ValueList(typeof(List<string>))]
+        public List<string> modules { get; set; }
+    }
+}

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Action\ISubCommand.cs" />
     <Compile Include="Action\KSP.cs" />
     <Compile Include="Action\List.cs" />
+    <Compile Include="Action\Mark.cs" />
     <Compile Include="Action\Remove.cs" />
     <Compile Include="Action\Prompt.cs" />
     <Compile Include="Action\Repair.cs" />

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -90,7 +90,9 @@ namespace CKAN.CmdLine
 
                     case "cache":
                         return (new Cache()).RunSubCommand(manager, opts, new SubCommandOptions(args));
-
+                        
+                    case "mark":
+                        return (new Mark()).RunSubCommand(manager, opts, new SubCommandOptions(args));
                 }
             }
             catch (NoGameInstanceKraken)

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -94,6 +94,9 @@ namespace CKAN.CmdLine
         [VerbOption("repo", HelpText = "Manage CKAN repositories")]
         public SubCommandOptions Repo { get; set; }
 
+        [VerbOption("mark", HelpText = "Edit flags on modules")]
+        public SubCommandOptions Mark { get; set; }
+
         [VerbOption("ksp", HelpText = "Manage KSP installs")]
         public SubCommandOptions KSP { get; set; }
 

--- a/ConsoleUI/ModListHelpDialog.cs
+++ b/ConsoleUI/ModListHelpDialog.cs
@@ -30,6 +30,7 @@ namespace CKAN.ConsoleUI {
             symbolTb.AddLine("Status Symbols");
             symbolTb.AddLine("==============");
             symbolTb.AddLine($"{installed}           Installed");
+            symbolTb.AddLine($"{autoInstalled}      Auto-installed");
             symbolTb.AddLine($"{upgradable}         Upgradeable");
             symbolTb.AddLine($"{autodetected}  Manually installed");
             symbolTb.AddLine($"{replaceable}         Replaceable");
@@ -65,10 +66,11 @@ namespace CKAN.ConsoleUI {
             ));
         }
 
-        private static readonly string installed    = Symbols.checkmark;
-        private static readonly string upgradable   = Symbols.greaterEquals;
-        private static readonly string autodetected = Symbols.infinity;
-        private static readonly string replaceable  = Symbols.doubleGreater;
+        private static readonly string installed     = Symbols.checkmark;
+        private static readonly string autoInstalled = Symbols.feminineOrdinal;
+        private static readonly string upgradable    = Symbols.greaterEquals;
+        private static readonly string autodetected  = Symbols.infinity;
+        private static readonly string replaceable   = Symbols.doubleGreater;
     }
 
 }

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -54,6 +54,13 @@ namespace CKAN.ConsoleUI.Toolkit {
         );
 
         /// <summary>
+        /// Representation of F8 for key bindings
+        /// </summary>
+        public static readonly ConsoleKeyInfo F8 = new ConsoleKeyInfo(
+            (System.Char)0, ConsoleKey.F8, false, false, false
+        );
+
+        /// <summary>
         /// Representation of F9 for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo F9 = new ConsoleKeyInfo(

--- a/ConsoleUI/Toolkit/Symbols.cs
+++ b/ConsoleUI/Toolkit/Symbols.cs
@@ -23,6 +23,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         public static readonly string checkmark        = cp437s(0xfb);
         /// <summary>
+        /// Double tilde
+        /// </summary>
+        public static readonly string feminineOrdinal  = cp437s(0xa6);
+        /// <summary>
         /// >= symbol
         /// </summary>
         public static readonly string greaterEquals    = cp437s(0xf2);

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -77,6 +77,17 @@ namespace CKAN
         /// </summary>
         HashSet<string> FindReverseDependencies(IEnumerable<string> modules);
 
+        /// <summary>
+        /// Find auto-installed modules that have no depending modules
+        /// or only auto-installed depending modules.
+        /// installedModules is a parameter so we can experiment with
+        /// changes that have not yet been made, such as removing other modules.
+        /// </summary>
+        /// <param name="installedModules">The modules currently installed</param>
+        /// <returns>
+        /// Sequence of removable auto-installed modules, if any
+        /// </returns>
+        IEnumerable<InstalledModule> FindRemovableAutoInstalled(IEnumerable<InstalledModule> installedModules);
 
         /// <summary>
         /// Gets the installed version of a mod. Does not check for provided or autodetected mods.

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -83,7 +84,9 @@ namespace CKAN
 
         [JsonProperty] private CkanModule source_module;
 
-//        private static readonly ILog log = LogManager.GetLogger(typeof(InstalledModule));
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        private bool auto_installed;
 
         // TODO: Our InstalledModuleFile already knows its path, so this could just
         // be a list. However we've left it as a dictionary for now to maintain
@@ -110,15 +113,22 @@ namespace CKAN
             get { return install_time; }
         }
 
+        public bool AutoInstalled
+        {
+            get { return auto_installed;  }
+            set { auto_installed = value; }
+        }
+
         #endregion
 
         #region Constructors
 
-        public InstalledModule(KSP ksp, CkanModule module, IEnumerable<string> relative_files)
+        public InstalledModule(KSP ksp, CkanModule module, IEnumerable<string> relative_files, bool autoInstalled)
         {
             install_time = DateTime.Now;
             source_module = module;
             installed_files = new Dictionary<string, InstalledModuleFile>();
+            auto_installed = autoInstalled;
 
             foreach (string file in relative_files)
             {

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -673,6 +673,14 @@ namespace CKAN
                 get { return "  Requested by user.\r\n"; }
             }
         }
+        
+        public class NoLongerUsed: SelectionReason
+        {
+            public override string Reason
+            {
+                get { return "  Auto-installed, depending modules removed.\r\n"; }
+            }
+        }
 
         public class Replacement : SelectionReason
         {

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -8,10 +8,12 @@ namespace CKAN
 {
     public sealed class GUIMod
     {
-        private CkanModule Mod { get; set; }
+        private CkanModule      Mod          { get; set; }
+        private InstalledModule InstalledMod { get; set; }
 
         public string Name { get; private set; }
         public bool IsInstalled { get; private set; }
+        public bool IsAutoInstalled { get; private set; }
         public bool HasUpdate { get; private set; }
         public bool HasReplacement { get; private set; }
         public bool IsIncompatible { get; private set; }
@@ -82,6 +84,8 @@ namespace CKAN
         {
             IsInstalled      = true;
             IsInstallChecked = true;
+            InstalledMod     = instMod;
+            IsAutoInstalled  = instMod.AutoInstalled;
             InstallDate      = instMod.InstallTime;
             InstalledVersion = instMod.Module.version.ToString();
             if (LatestVersion == null || LatestVersion.Equals("-"))
@@ -282,10 +286,9 @@ namespace CKAN
             return mod.ToModule();
         }
 
-        public void SetUpgradeChecked(DataGridViewRow row, bool? set_value_to = null)
+        public void SetUpgradeChecked(DataGridViewRow row, DataGridViewColumn col, bool? set_value_to = null)
         {
-            //Contract.Requires<ArgumentException>(row.Cells[1] is DataGridViewCheckBoxCell);
-            var update_cell = row.Cells[1] as DataGridViewCheckBoxCell;
+            var update_cell = row.Cells[col.Index] as DataGridViewCheckBoxCell;
             if (update_cell != null)
             {
                 var old_value = (bool) update_cell.Value;
@@ -297,10 +300,9 @@ namespace CKAN
             }
         }
 
-        public void SetInstallChecked(DataGridViewRow row, bool? set_value_to = null)
+        public void SetInstallChecked(DataGridViewRow row, DataGridViewColumn col, bool? set_value_to = null)
         {
-            //Contract.Requires<ArgumentException>(row.Cells[0] is DataGridViewCheckBoxCell);
-            var install_cell = row.Cells[0] as DataGridViewCheckBoxCell;
+            var install_cell = row.Cells[col.Index] as DataGridViewCheckBoxCell;
             if (install_cell != null)
             {
                 bool changeTo = set_value_to ?? (bool)install_cell.Value;
@@ -324,9 +326,9 @@ namespace CKAN
             }
         }
 
-        public void SetReplaceChecked(DataGridViewRow row, bool? set_value_to = null)
+        public void SetReplaceChecked(DataGridViewRow row, DataGridViewColumn col, bool? set_value_to = null)
         {
-            var replace_cell = row.Cells[2] as DataGridViewCheckBoxCell;
+            var replace_cell = row.Cells[col.Index] as DataGridViewCheckBoxCell;
             if (replace_cell != null)
             {
                 var old_value = (bool) replace_cell.Value;
@@ -335,6 +337,24 @@ namespace CKAN
                 IsReplaceChecked = value;
                 if (old_value != value)
                     replace_cell.Value = value;
+            }
+        }
+        
+        public void SetAutoInstallChecked(DataGridViewRow row, DataGridViewColumn col, bool? set_value_to = null)
+        {
+            var auto_cell = row.Cells[col.Index] as DataGridViewCheckBoxCell;
+            if (auto_cell != null)
+            {
+                var old_value = (bool) auto_cell.Value;
+
+                bool value = set_value_to ?? old_value;
+                IsAutoInstalled = value;
+                InstalledMod.AutoInstalled = value;
+
+                if (old_value != value)
+                {
+                    auto_cell.Value = value;
+                }
             }
         }
 

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -72,6 +72,7 @@
             this.ModList = new CKAN.MainModListGUI();
             this.InstallAllCheckbox = new System.Windows.Forms.CheckBox();
             this.Installed = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.AutoInstalled = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.UpdateCol = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ReplaceCol = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.ModName = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -536,6 +537,7 @@
             this.ModList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.ModList.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Installed,
+            this.AutoInstalled,
             this.UpdateCol,
             this.ReplaceCol,
             this.ModName,
@@ -570,6 +572,14 @@
             this.Installed.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.Installed.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.Installed.Width = 50;
+            // 
+            // AutoInstalled
+            //
+            this.AutoInstalled.HeaderText = "Auto-installed";
+            this.AutoInstalled.Name = "AutoInstalled";
+            this.AutoInstalled.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.AutoInstalled.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.AutoInstalled.Width = 50;
             // 
             // UpdateCol
             // 
@@ -1373,6 +1383,7 @@
         public CKAN.MainModListGUI ModList;
         private System.Windows.Forms.CheckBox InstallAllCheckbox;
         private System.Windows.Forms.DataGridViewCheckBoxColumn Installed;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn AutoInstalled;
         private System.Windows.Forms.DataGridViewCheckBoxColumn UpdateCol;
         private System.Windows.Forms.DataGridViewCheckBoxColumn ReplaceCol;
         private System.Windows.Forms.DataGridViewTextBoxColumn ModName;

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -85,11 +85,10 @@ namespace CKAN
                 GUIMod mod = row.Tag as GUIMod;
                 if (mod.IsInstallChecked != mod.IsInstalled)
                 {
-                    mod.SetInstallChecked(row, mod.IsInstalled);
-
+                    mod.SetInstallChecked(row, Installed, mod.IsInstalled);
                 }
-                mod.SetUpgradeChecked(row, false);
-                mod.SetReplaceChecked(row, false);
+                mod.SetUpgradeChecked(row, UpdateCol, false);
+                mod.SetReplaceChecked(row, ReplaceCol, false);
             }
         }
 
@@ -139,7 +138,7 @@ namespace CKAN
             // TODO Work out why this is.
             installWorker.RunWorkerAsync(
                 new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                    mainModList.ComputeUserChangeSet().ToList(),
+                    mainModList.ComputeUserChangeSet(RegistryManager.Instance(Main.Instance.CurrentInstance).registry).ToList(),
                     RelationshipResolver.DependsOnlyOpts()
                 )
             );

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -64,7 +64,7 @@ namespace Tests.GUI
 
             // install it and set it as pre-installed
             _manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
-            _registry.RegisterModule(_anyVersionModule, new string[] { }, _instance.KSP);
+            _registry.RegisterModule(_anyVersionModule, new string[] { }, _instance.KSP, false);
             _registry.AddAvailable(_anyVersionModule);
 
             ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
@@ -83,7 +83,9 @@ namespace Tests.GUI
             // todo: refactor the column header code to allow mocking of the GUI without creating columns
             _listGui.Columns.Add(new DataGridViewCheckBoxColumn());
             _listGui.Columns.Add(new DataGridViewCheckBoxColumn());
-            for (int i = 0; i < 10; i++)
+            _listGui.Columns.Add(new DataGridViewCheckBoxColumn());
+            _listGui.Columns.Add(new DataGridViewCheckBoxColumn());
+            for (int i = 0; i < 9; i++)
             {
                 _listGui.Columns.Add(i.ToString(), "Column" + i);
             }
@@ -121,7 +123,7 @@ namespace Tests.GUI
             // the header row adds one to the count
             Assert.AreEqual(modules.Count + 1, _listGui.Rows.Count);
 
-            // sort by version, this is the fuse-lighting
+            // sort by a text column, this is the fuse-lighting
             _listGui.Sort(_listGui.Columns[6], ListSortDirection.Descending);
 
             // mark the mod for install, after completion we will get an exception
@@ -135,7 +137,7 @@ namespace Tests.GUI
             {
                 // perform the install of the "other" module - now we need to sort
                 ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
-                    _modList.ComputeUserChangeSet().Select(change => change.Mod.ToCkanModule()).ToList(),
+                    _modList.ComputeUserChangeSet(null).Select(change => change.Mod.ToCkanModule()).ToList(),
                     new RelationshipResolverOptions(),
                     new NetAsyncModulesDownloader(_manager.User)
                 );

--- a/Tests/GUI/GUIMod.cs
+++ b/Tests/GUI/GUIMod.cs
@@ -44,7 +44,7 @@ namespace Tests.GUI
                 var new_version = generatror.GeneratorRandomModule(version: new ModuleVersion("0.25"), ksp_version: tidy.KSP.Version(),
                     identifier:old_version.identifier);
                 var registry = Registry.Empty();
-                registry.RegisterModule(old_version, Enumerable.Empty<string>(), null);
+                registry.RegisterModule(old_version, Enumerable.Empty<string>(), null, false);
                 registry.AddAvailable(new_version);
 
                 var mod = new GUIMod(old_version, registry, tidy.KSP.VersionCriteria());

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -50,7 +50,7 @@ namespace Tests.GUI
         public void ComputeChangeSetFromModList_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new MainModList(delegate { }, delegate { return null; });
-            Assert.That(item.ComputeUserChangeSet(), Is.Empty);
+            Assert.That(item.ComputeUserChangeSet(null), Is.Empty);
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace Tests.GUI
                 module.conflicts = new List<RelationshipDescriptor> { new ModuleRelationshipDescriptor { name = "kOS" } };
                 registry.AddAvailable(module);
                 registry.AddAvailable(TestData.kOS_014_module());
-                registry.RegisterModule(module, Enumerable.Empty<string>(), tidy.KSP);
+                registry.RegisterModule(module, Enumerable.Empty<string>(), tidy.KSP, false);
 
                 var mainList = new MainModList(null, null, new GUIUser());
                 var mod = new GUIMod(module, registry, tidy.KSP.VersionCriteria());
@@ -73,7 +73,7 @@ namespace Tests.GUI
                 mainList.ConstructModList(mods, null, true);
                 mainList.Modules = new ReadOnlyCollection<GUIMod>(mods);
                 mod2.IsInstallChecked = true;
-                var computeTask = mainList.ComputeChangeSetFromModList(registry, mainList.ComputeUserChangeSet(), null,
+                var computeTask = mainList.ComputeChangeSetFromModList(registry, mainList.ComputeUserChangeSet(registry), null,
                     tidy.KSP.VersionCriteria());
 
                 await UtilStatic.Throws<InconsistentKraken>(() => computeTask);


### PR DESCRIPTION
## Motivation

Installing a module pulls in its dependencies automatically. If the user later uninstalls that module, they may wish to remove the dependencies as well, but there's no easy way to identify them.

Debian's APT package management system has a concept of "automatically installed packages," which handles this situation nicely:

> To install one package, it is often necessary to install several others (to fulfill its dependencies). For instance, if you wish to install the clanbomber package, you must also install the package libclanlib2. If you remove clanbomber again, you probably no longer need the libclanlib2 package; aptitude will attempt to detect this and automatically remove the libclanlib2 package.
> 
> It works like this: when you install a package, aptitude will automatically install any other packages on which it depends. These packages are marked as having been “automatically installed”; aptitude will monitor them and remove them when they are no longer depended upon by any manually installed package [10] . They will appear in the preview as “packages being removed because they are no longer used.”
> 
> As with any automatic process, there is a potential for things to go haywire. For instance, even if a package was automatically installed to start with, it might turn out to be useful in its own right. You can cancel the “automatic” flag at any time by pressing m; if the package is already being removed, you can use Package → Install (+) to cancel the removal and clear the “automatic” flag.

https://www.debian.org/doc/manuals/aptitude/ch02s02s06.en.html

## Changes

Now CKAN supports a concept of automatically installed modules.

Fixes KSP-CKAN/NetKAN#6825 (because the motivation behind that issue was cleaning up dependencies that are no longer needed).

## GUI

When you install a mod:

![image](https://user-images.githubusercontent.com/1559108/57205560-fcee9e80-6fae-11e9-8e89-aab3b4b56b49.png)

![image](https://user-images.githubusercontent.com/1559108/57205635-71294200-6faf-11e9-8fca-2021947b5daf.png)

![image](https://user-images.githubusercontent.com/1559108/57205629-69699d80-6faf-11e9-8407-9704d17c305d.png)

![image](https://user-images.githubusercontent.com/1559108/57205623-6373bc80-6faf-11e9-8b86-db3d9c473d18.png)

... a new checkbox column appears called "Auto-installed":

![image](https://user-images.githubusercontent.com/1559108/57205616-55be3700-6faf-11e9-9aa5-87c95edfb176.png)

This will be checked for mods that were installed due to dependencies, and unchecked for mods the user chose to install. Recommendations and suggestions are considered as user-chosen. Any modules installed before the user upgraded to this version of CKAN will be treated as user-chosen.

When you remove a mod, we check for any auto-installed modules that will no longer be needed, and automatically add them to the change set:

![image](https://user-images.githubusercontent.com/1559108/57205596-2dced380-6faf-11e9-9532-601443090a1a.png)

The user can toggle the checkboxes to control whether a module should be considered auto-installed:

![image](https://user-images.githubusercontent.com/1559108/57205567-05df7000-6faf-11e9-8518-0f824fbf1543.png)

If a module was previously considered auto-installed, unchecking the box will "anchor" it so that it can no longer be auto-removed. If the module was previously not considered auto-installed, checking the box will allow the module to be auto-removed; if it **currently** has no depending mods, it will be added to the changeset for removal immediately:

![image](https://user-images.githubusercontent.com/1559108/57205689-bd748200-6faf-11e9-8b8e-59817d17b4dc.png)

You can hide the new column, since it may not be useful to some users:

![image](https://user-images.githubusercontent.com/1559108/57205524-bb5df380-6fae-11e9-866b-e1e1bd7f3f39.png)

![image](https://user-images.githubusercontent.com/1559108/57205538-d29ce100-6fae-11e9-9eb5-5fb760db128c.png)

To make this work, a new property `InstalledModule.auto_installed` is added that will be saved to `registry.json`. I don't think this requires an update of the schema or the spec, because `InstalledModule` is a private object that CKAN creates and consumes internally.

To make the checkbox column work, we now only reference columns by name instead of by index.

### CmdLine

CmdLine is updated to print "+" as the symbol for auto installed:

```
> _build\ckan list

KSP found at C:/Program Files (x86)/Steam/steamapps/common/Kerbal Space Program

KSP Version: 1.7.1

Installed Modules:

+ ContractConfigurator 1.27.1
- CustomBarnKit 1.1.19.0
- FinalFrontier 1.5.3-3465
- GPP 1:1.6.3.1
+ GPPTextures 4.2.1
- KerbalKonstructs 1.4.5.64
+ Kopernicus 2:release-1.7.0-1
A MakingHistory-DLC 1.7.1 (unmanaged)
+ ModularFlightIntegrator 1.2.6.0
+ ModuleManager 4.0.2
- Strategia 1.7.3
- WaypointManager 2.7.5

Legend: -: Up to date. +:Auto-installed. X: Incompatible. ^: Upgradable. >: Replaceable
        A: Autodetected. ?: Unknown. *: Broken.
```

You can mark modules as auto-installed via CmdLine:

```
> ckan mark auto gpp astrogator
Marking GPP as auto-installed...
Astrogator is not installed.
Changes made!
```

Or unmark them:

```
> ckan mark user gpp astrogator
Marking GPP as user-selected...
Astrogator is not installed.
Changes made!
```

### ConsoleUI

ConsoleUI is updated along the same lines:

![image](https://user-images.githubusercontent.com/1559108/57267234-d55f0b00-706e-11e9-9ea4-1119ab0bef69.png)

- Auto-installed mods are represented with a floating 'a' character with an underline, which codepage 437 charmingly calls the "feminine ordinal" symbol
- The F8 key toggles auto install
- The help screen explains what's up:
  ![image](https://user-images.githubusercontent.com/1559108/57267361-5b7b5180-706f-11e9-8eaa-cc5436d22c90.png)
