### PR TITLE
Save registry inside of scan transaction

### DIFF
--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -438,10 +438,9 @@ namespace CKAN
                 }
 
                 manager.ScanDlc();
-
+                manager.Save(false);
                 tx.Complete();
             }
-            manager.Save(enforce_consistency: false);
         }
 
         #endregion


### PR DESCRIPTION
## Problem

If you run a `ckan scan` command and Ctrl-C out of it at just the right time (towards the end, I had to add a `WriteLine` to get the timing correct), you can end up with a truncated `registry.json` file:

```
-rw-r--r-- 1 16933954 May  7 17:13  registry.json
-rw-r--r-- 1  9207808 May  7 17:11  registry.json_BROKEN
```

Anything you try to do after this will throw exceptions and generally not work.

## Cause

`RegistryManager.Save` is transaction-aware:

https://github.com/KSP-CKAN/CKAN/blob/f2209e215a7e54409b0c2a6f2a2968d347961a9c/Core/Registry/RegistryManager.cs#L413-L455

... but `KSP.ScanGameData` calls it *outside* of its transaction:

https://github.com/KSP-CKAN/CKAN/blob/f2209e215a7e54409b0c2a6f2a2968d347961a9c/Core/KSP.cs#L409-L445

When a `TxFileManager` is used outside of a transaction, it falls back to making live updates to the file system. So if you kill CKAN while it's doing that, it'll just stop after whatever byte happened to be most recently written.

## Changes

Now `KSP.ScanGameData` saves the registry inside of its transaction. This way if you abort the operation, the original `registry.json` file will remain intact.

Fixes #2754.