### PR TITLE
Cache downloads individually upon completion

### DIFF
--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -155,7 +155,7 @@ namespace CKAN.CmdLine
                 // TODO: These instances all need to go.
                 try
                 {
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Replace(to_replace, replace_ops, new NetAsyncModulesDownloader(User));
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Replace(to_replace, replace_ops, new NetAsyncModulesDownloader(User, manager.Cache));
                     User.RaiseMessage("\r\nDone!\r\n");
                 }
                 catch (DependencyNotSatisfiedKraken ex)

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -129,13 +129,13 @@ namespace CKAN.CmdLine
 
                     }
 
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(to_upgrade, new NetAsyncModulesDownloader(User));
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(to_upgrade, new NetAsyncModulesDownloader(User, manager.Cache));
                 }
                 else
                 {
                     // TODO: These instances all need to go.
                     Search.AdjustModulesCase(ksp, options.modules);
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User));
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User, manager.Cache));
                 }
             }
             catch (ModuleNotFoundKraken kraken)

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -61,7 +61,7 @@ namespace CKAN.ConsoleUI {
                             inst.UninstallList(plan.Remove);
                             plan.Remove.Clear();
                         }
-                        NetAsyncModulesDownloader dl = new NetAsyncModulesDownloader(this);
+                        NetAsyncModulesDownloader dl = new NetAsyncModulesDownloader(this, manager.Cache);
                         if (plan.Upgrade.Count > 0) {
                             inst.Upgrade(plan.Upgrade, dl);
                             plan.Upgrade.Clear();

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -512,13 +512,13 @@ namespace CKAN.ConsoleUI {
         private void Download()
         {
             ProgressScreen            ps   = new ProgressScreen($"Downloading {mod.identifier}");
-            NetAsyncModulesDownloader dl   = new NetAsyncModulesDownloader(ps);
+            NetAsyncModulesDownloader dl   = new NetAsyncModulesDownloader(ps, manager.Cache);
             ModuleInstaller           inst = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, ps);
             LaunchSubScreen(
                 ps,
                 () => {
                     try {
-                        dl.DownloadModules(manager.Cache, new List<CkanModule> {mod});
+                        dl.DownloadModules(new List<CkanModule> {mod});
                         if (!manager.Cache.IsMaybeCachedZip(mod)) {
                             ps.RaiseError("Download failed, file is corrupted");
                         }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -199,10 +199,10 @@ namespace CKAN
             {
                 if (downloader == null)
                 {
-                    downloader = new NetAsyncModulesDownloader(User);
+                    downloader = new NetAsyncModulesDownloader(User, Cache);
                 }
 
-                downloader.DownloadModules(Cache, downloads);
+                downloader.DownloadModules(downloads);
             }
 
             // We're about to install all our mods; so begin our transaction.
@@ -1179,7 +1179,7 @@ namespace CKAN
 
             if (downloads.Count > 0)
             {
-                downloader.DownloadModules(Cache, downloads);
+                downloader.DownloadModules(downloads);
             }
         }
 

--- a/Core/Net/IDownloader.cs
+++ b/Core/Net/IDownloader.cs
@@ -11,7 +11,7 @@ namespace CKAN
         /// Even if modules share download URLs, they will only be downloaded once.
         /// Blocks until the downloads are complete, cancelled, or errored.
         /// </summary>
-        void DownloadModules(NetModuleCache cache, IEnumerable<CkanModule> modules);
+        void DownloadModules(IEnumerable<CkanModule> modules);
 
         /// <summary>
         /// Cancel any running downloads.

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -191,12 +191,15 @@ namespace CKAN
         {
             new NetAsyncDownloader(user ?? new NullUser())
             {
-                onCompleted = (urls, filenames, errors) =>
+                onOneCompleted = (url, filename, error) =>
                 {
-                    if (filenames == null || urls == null) return;
-                    for (var i = 0; i < Math.Min(urls.Length, filenames.Length); i++)
+                    if (error != null)
                     {
-                        File.Move(filenames[i], downloadTargets.First(p => p.url == urls[i]).filename);
+                        user?.RaiseError(error.ToString());
+                    }
+                    else
+                    {
+                        File.Move(filename, downloadTargets.First(p => p.url == url).filename);
                     }
                 }
             }.DownloadAndWait(downloadTargets);

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -211,7 +211,7 @@ Do you wish to reinstall now?", sb)))
                     {
                         installer.Upgrade(
                             new[] { changedIdentifier },
-                            new NetAsyncModulesDownloader(new NullUser()),
+                            new NetAsyncModulesDownloader(new NullUser(), cache),
                             enforceConsistency: false
                         );
                     }

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -149,7 +149,7 @@ namespace CKAN
             ShowWaitDialog();
             tabController.SetTabLock(true);
 
-            IDownloader downloader = new NetAsyncModulesDownloader(GUI.user);
+            IDownloader downloader = new NetAsyncModulesDownloader(GUI.user, Manager.Cache);
             cancelCallback = () =>
             {
                 downloader.CancelDownload();

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -447,9 +447,9 @@ namespace CKAN
             Main.Instance.ResetProgress();
             Main.Instance.ClearLog();
 
-            NetAsyncModulesDownloader downloader = new NetAsyncModulesDownloader(Main.Instance.currentUser);
+            NetAsyncModulesDownloader downloader = new NetAsyncModulesDownloader(Main.Instance.currentUser, Main.Instance.Manager.Cache);
 
-            downloader.DownloadModules(Main.Instance.Manager.Cache, new List<CkanModule> { (CkanModule)e.Argument });
+            downloader.DownloadModules(new List<CkanModule> { (CkanModule)e.Argument });
             e.Result = e.Argument;
         }
 

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -39,7 +39,7 @@ namespace Tests.Core.Net
             CKAN.Repo.Update(registry_manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
 
             // Ready our downloader.
-            async = new CKAN.NetAsyncModulesDownloader(new NullUser());
+            async = new CKAN.NetAsyncModulesDownloader(new NullUser(), manager.Cache);
 
             // General shortcuts
             cache = manager.Cache;
@@ -77,7 +77,7 @@ namespace Tests.Core.Net
             log.InfoFormat("Downloading kOS from {0}", kOS.download);
 
             // Download our module.
-            async.DownloadModules(manager.Cache, modules);
+            async.DownloadModules(modules);
 
             // Assert that we have it, and it passes zip validation.
             Assert.IsTrue(cache.IsCachedZip(kOS));
@@ -100,7 +100,7 @@ namespace Tests.Core.Net
             Assert.IsFalse(cache.IsCachedZip(kOS));
             Assert.IsFalse(cache.IsCachedZip(quick_revert));
 
-            async.DownloadModules(cache, modules);
+            async.DownloadModules(modules);
 
             Assert.IsTrue(cache.IsCachedZip(kOS));
             Assert.IsTrue(cache.IsCachedZip(quick_revert));
@@ -120,7 +120,7 @@ namespace Tests.Core.Net
 
             Assert.IsFalse(cache.IsCachedZip(rAndS), "Module not yet downloaded");
 
-            async.DownloadModules(cache, modules);
+            async.DownloadModules(modules);
 
             Assert.IsTrue(cache.IsCachedZip(rAndS),"Module download successful");
         }

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -70,7 +70,7 @@ namespace Tests.GUI
             ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                 new List<CkanModule> { { _anyVersionModule } },
                 new RelationshipResolverOptions(),
-                new NetAsyncModulesDownloader(_manager.User)
+                new NetAsyncModulesDownloader(_manager.User, _manager.Cache)
             );
 
             // this module is not for "any" version, to provide another to sort against
@@ -139,7 +139,7 @@ namespace Tests.GUI
                 ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                     _modList.ComputeUserChangeSet(null).Select(change => change.Mod.ToCkanModule()).ToList(),
                     new RelationshipResolverOptions(),
-                    new NetAsyncModulesDownloader(_manager.User)
+                    new NetAsyncModulesDownloader(_manager.User, _manager.Cache)
                 );
 
                 // trying to refresh the GUI state will throw a NullReferenceException


### PR DESCRIPTION
## Problem

If you select many uncached mods to install, they're all downloaded to temp files in your temp folder before being moved to the CKAN download cache. The temp files remain until *all* of the downloads fail or finish. This consumes disk space in the temp folder for longer than strictly necessary and delays the insertion of individual files into the cache.

![image](https://user-images.githubusercontent.com/1559108/57399006-e5d2cb00-71bf-11e9-9951-bc35cf575506.png)

## Cause

`NetAsyncModulesDownloader` and `NetAsyncDownloader` communicate via a callback function that's only called at the end of the download process. So `NetAsyncModulesDownloader` waits for all downloads to complete before ever calling `cache.Store`.

## Changes

- `NetAsyncDownloader.onCompleted ` is replaced by `onOneCompleted`, which is called once per individual download, when that download fails or finishes
- `NetAsyncModulesDownloader.ModuleDownloadsComplete` is replaced by `ModuleDownloadComplete` which handles one download at a time
- The `cache` parameter of `NetAsyncModuleDownloader.DownloadModules` is moved to that class's constructor, and all calling code is updated to accommodate this (the motivation is to be able to use `ModuleDownloadComplete` cleanly as the callback without a lambda)

Note that this change is not guaranteed to fix any real world problem. If you were having a problem with your temp folder filling up before, that exact problem can still happen if the timing of the downloads works out such that they all last a long time. You will always need enough temp folder space available to handle all downloads that you initiate.

Fixes #2746.
Fixes #1954 (probably fixed a long time ago, but now we can say that the possibility of this happening has been eliminated).