### PR TITLE
Generate RPM packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ addons:
             - fakeroot
             - dpkg
             - lintian
+            # Stuff for building .rpm files
+            - rpm
 
 # These commands simulate having a graphical display, which is needed
 # for our GUI tests.
@@ -51,6 +53,7 @@ script:
 before_deploy:
     - ./build osx
     - ./build deb
+    - ./build rpm
     - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
 deploy:
@@ -64,6 +67,7 @@ deploy:
         - _build/repack/$BUILD_CONFIGURATION/ckan.exe
         - _build/osx/CKAN.dmg
         - _build/deb/ckan_*.deb
+        - _build/rpm/RPMS/noarch/ckan*.rpm
         - _build/out/AutoUpdater/$BUILD_CONFIGURATION/bin/AutoUpdater.exe
       on:
         repo: KSP-CKAN/CKAN

--- a/build.cake
+++ b/build.cake
@@ -81,6 +81,20 @@ Task("deb-clean")
     .Does(() => StartProcess("make",
         new ProcessSettings { Arguments = "clean", WorkingDirectory = "debian" }));
 
+Task("rpm")
+    .IsDependentOn("Ckan")
+    .Does(() => StartProcess("make",
+        new ProcessSettings { WorkingDirectory = "rpm" }));
+
+Task("rpm-test")
+    .IsDependentOn("Ckan")
+    .Does(() => StartProcess("make",
+        new ProcessSettings { Arguments = "test", WorkingDirectory = "rpm" }));
+
+Task("rpm-clean")
+    .Does(() => StartProcess("make",
+        new ProcessSettings { Arguments = "clean", WorkingDirectory = "rpm" }));
+
 Task("Restore-Nuget")
     .Does(() =>
 {

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,0 +1,30 @@
+.PHONY: clean test
+
+# Borrow files from .deb
+DEBDIR:=$(shell pwd)/../debian
+
+TOPDIR:=$(shell pwd)/../_build/rpm
+SCRIPTSRC:=$(DEBDIR)/ckan
+MANSRC:=$(DEBDIR)/ckan.1
+DESKTOPSRC:=$(DEBDIR)/ckan.desktop
+ICONSRC:=$(DEBDIR)/ckan.ico
+EXESRC:=$(shell pwd)/../_build/repack/Release/ckan.exe
+CHANGELOGSRC:=../CHANGELOG.md
+VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
+RPM:=$(shell pwd)/../_build/rpm/RPMS/noarch/ckan-$(VERSION)-1.noarch.rpm
+
+# rpmbuild tries to use $HOME/rpmbuild by default
+# rpmbuild can't handle relative paths for its topdir
+# rpmbuild assumes we'll copy files into its SOURCES dir for it
+
+$(RPM): $(SCRIPTSRC) $(EXESRC) $(MANSRC) $(DESKTOPSRC) $(ICONSRC)
+	mkdir -p "${TOPDIR}/SOURCES"
+	cp $^ "${TOPDIR}/SOURCES"
+	rpmbuild --define "_topdir ${TOPDIR}" --define "_version $(VERSION)" -bb ckan.spec
+
+clean:
+	rm -r "$(TOPDIR)"
+
+test: $(RPM)
+	rpm -qlp $<
+	rpmlint $<

--- a/rpm/ckan.spec
+++ b/rpm/ckan.spec
@@ -1,0 +1,48 @@
+Name: ckan
+Version: %{_version}
+Release: 1%{?dist}
+Summary: Mod manager for Kerbal Space Program
+URL: https://ksp-ckan.space
+Packager: The CKAN authors <rpm@ksp-ckan.space>
+License: MIT
+AutoReqProv: no
+Requires: mono-core >= 5.0
+BuildArch: noarch
+Source0: ckan
+Source1: ckan.exe
+Source2: ckan.1
+Source3: ckan.desktop
+Source4: ckan.ico
+
+%description
+KSP-CKAN official client.
+Official client for the Comprehensive Kerbal Archive Network (CKAN).
+Acts as a mod manager for Kerbal Space Program mods.
+
+%post
+cert-sync /etc/pki/tls/certs/ca-bundle.crt
+cert-sync --user /etc/pki/tls/cert.pem
+
+%install
+umask 0022
+mkdir -p %{buildroot}%{_bindir}
+cp %{SOURCE0} %{buildroot}%{_bindir}
+mkdir -p %{buildroot}/usr/lib/ckan
+cp %{SOURCE1} %{buildroot}/usr/lib/ckan
+mkdir -p %{buildroot}%{_mandir}/man1
+cp %{SOURCE2} %{buildroot}%{_mandir}/man1
+mkdir -p %{buildroot}%{_datadir}/applications
+cp %{SOURCE3} %{buildroot}%{_datadir}/applications
+mkdir -p %{buildroot}%{_datadir}/icons
+cp %{SOURCE4} %{buildroot}%{_datadir}/icons
+
+%files
+%{_bindir}/*
+/usr/lib/ckan
+%{_datadir}/applications/*
+%{_datadir}/icons/*
+%{_mandir}/man1/*
+
+%changelog
+* Thu May 9 2019 The CKAN authors <rpm@ksp-ckan.space> 1.26.3-1
+- Initial RPM release


### PR DESCRIPTION
## Motivation

We generate .deb files as of #2187, but users of Linux distributions that aren't Debian-derived have to use the plain `ckan.exe` file. This means they miss out on:

- Having ckan in the system `$PATH`
- Having a ckan icon in the system app menus
- An out of date man page
- Falling back to ConsoleUI if `$DISPLAY` isn't defined

Some users may even assume that the lack of an .rpm file means they can't use CKAN, even though they can.

## Changes

Now we also generate .rpm files, so Fedora users can enjoy the above benefits. This is done with a simple `Makefile` and a .spec file, sharing a few files with the .deb package. The build system is updated to include the .rpm file as a release asset.

To try it via the command line:

```sh
./build rpm
```

Fixes #2748.