### PR TITLE
Hide auto-installed checkbox for auto-detected mods

### DIFF
--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -893,7 +893,7 @@ namespace CKAN
                     Value = mod.IsAutodetected ? "AD" : "-"
                 };
 
-            var autoInstalled = mod.IsInstalled
+            var autoInstalled = mod.IsInstalled && !mod.IsAutodetected
                 ? (DataGridViewCell) new DataGridViewCheckBoxCell()
                 {
                     Value = mod.IsAutoInstalled


### PR DESCRIPTION
## Problem

Loose end from #2753; "AD" mods have the auto-detected checkbox enabled. This doesn't make sense because CKAN didn't install them and can't uninstall them.

## Changes

Now the disabled "-" state of the auto-installed column is used instead for "AD" mods.