### PR TITLE
Extract locales from downloads

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -118,6 +118,12 @@
                 "pattern" : "^[a-z0-9-]+$"
             }
         },
+        "localizations" : {
+            "description" : "A list of KSP locale strings for which this mod includes localizations",
+            "type"        : "array",
+            "items"       : { "type" : "string" },
+            "uniqueItems" : true
+        },
         "depends" : {
             "description" : "Optional list of dependencies",
             "$ref"        : "#/definitions/relationship"

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -431,6 +431,9 @@ namespace CKAN
 
         [JsonProperty("install", NullValueHandling = NullValueHandling.Ignore)]
         public ModuleInstallDescriptor[] install;
+        
+        [JsonProperty("localizations", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] localizations;
 
         // Used to see if we're compatible with a given game/KSP version or not.
         private readonly IGameComparator _comparator;

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Transformers\InternalCkanTransformer.cs" />
     <Compile Include="Transformers\ITransformer.cs" />
     <Compile Include="Transformers\JenkinsTransformer.cs" />
+    <Compile Include="Transformers\LocalizationsTransformer.cs" />
     <Compile Include="Transformers\MetaNetkanTransformer.cs" />
     <Compile Include="Transformers\NetkanTransformer.cs" />
     <Compile Include="Transformers\OptimusPrimeTransformer.cs" />

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -1,5 +1,7 @@
-﻿using CKAN.NetKAN.Sources.Avc;
+using System.Collections.Generic;
+using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json.Linq;
+﻿using CKAN.NetKAN.Sources.Avc;
 
 namespace CKAN.NetKAN.Services
 {
@@ -8,5 +10,8 @@ namespace CKAN.NetKAN.Services
         AvcVersion GetInternalAvc(CkanModule module, string filePath, string internalFilePath = null);
         JObject GetInternalCkan(string filePath);
         bool HasInstallableFiles(CkanModule module, string filePath);
+        
+        IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip);
+        
     }
 }

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using CKAN.NetKAN.Sources.Avc;
@@ -57,6 +58,18 @@ namespace CKAN.NetKAN.Services
             }
 
             return true;
+        }
+        
+        private static readonly Regex cfgRegex = new Regex(
+            @"\.cfg$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled
+        );
+        
+        public IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip)
+        {
+            return ModuleInstaller
+                .FindInstallableFiles(module, zip, null)
+                .Where(instF => cfgRegex.IsMatch(instF.source.Name));
         }
 
         /// <summary>

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -1,0 +1,81 @@
+using System;
+﻿using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using ICSharpCode.SharpZipLib.Zip;
+using Newtonsoft.Json.Linq;
+using log4net;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Services;
+
+namespace CKAN.NetKAN.Transformers
+{
+    internal sealed class LocalizationsTransformer : ITransformer
+    {
+
+        /// <summary>
+        /// Initialize the transformer for locales
+        /// </summary>
+        /// <param name="http">HTTP service</param>
+        /// <param name="moduleService">Module service</param>
+        public LocalizationsTransformer(IHttpService http, IModuleService moduleService)
+        {
+            _http          = http;
+            _moduleService = moduleService;
+        }
+
+        /// <summary>
+        /// Name of this transformer
+        /// </summary>
+        public string Name { get { return "localizations"; } }
+
+        /// <summary>
+        /// Apply the locale transformation to the metadata
+        /// </summary>
+        /// <param name="metadata">Data about the module</param>
+        /// <returns>
+        /// Updated metadata with the `locales` property set
+        /// </returns>
+        public IEnumerable<Metadata> Transform(Metadata metadata)
+        {
+            JObject    json = metadata.Json();
+            CkanModule mod  = CkanModule.FromJson(json.ToString());
+            ZipFile    zip  = new ZipFile(_http.DownloadPackage(
+                metadata.Download,
+                metadata.Identifier,
+                metadata.RemoteTimestamp
+            ));
+
+            // Extract the locale names from the ZIP's cfg files
+            var locales = _moduleService.GetConfigFiles(mod, zip)
+                .Select(cfg => new StreamReader(zip.GetInputStream(cfg.source)).ReadToEnd())
+                .SelectMany(contents => localizationRegex.Matches(contents).Cast<Match>()
+                    .Select(m => m.Groups["contents"].Value))
+                .SelectMany(contents => localeRegex.Matches(contents).Cast<Match>()
+                    .Select(m => m.Groups["locale"].Value));
+
+            if (locales.Any())
+            {
+                json["localizations"] = new JArray(locales);
+                yield return new Metadata(json);
+            }
+            else
+            {
+                yield return metadata;
+            }
+        }
+
+        private readonly IHttpService   _http;
+        private readonly IModuleService _moduleService;
+
+        private static readonly Regex localizationRegex = new Regex(
+            @"\bLocalization\b.*?{(?<contents>.*?([-a-z]+.*?{.*?}.*?)*?)}",
+            RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
+        );
+        private static readonly Regex localeRegex = new Regex(
+            @"(?<locale>[-a-z]+).*?{.*?}",
+            RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
+        );
+    }
+}

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using log4net;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Extensions;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -57,7 +58,7 @@ namespace CKAN.NetKAN.Transformers
 
             if (locales.Any())
             {
-                json["localizations"] = new JArray(locales);
+                json.SafeAdd("localizations", new JArray(locales));
                 yield return new Metadata(json);
             }
             else

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -38,6 +38,7 @@ namespace CKAN.NetKAN.Transformers
                 new AvcKrefTransformer(http),
                 new InternalCkanTransformer(http, moduleService),
                 new AvcTransformer(http, moduleService),
+                new LocalizationsTransformer(http, moduleService),
                 new VersionEditTransformer(),
                 new ForcedVTransformer(),
                 new EpochTransformer(),

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -13,51 +13,55 @@ namespace CKAN.NetKAN.Transformers
 
         private const int DefaultSortOrder = 1073741823; // int.MaxValue / 2
 
-        private static readonly Dictionary<string, int> PropertySortOrder = new Dictionary<string, int>
+        private static readonly Dictionary<string, int> PropertySortOrder = new string[]
         {
-            { "spec_version", 0 },
-            { "comment", 1 },
-            { "identifier", 2 },
-            { "$kref", 3 },
-            { "$vref", 4 },
-            { "name", 5 },
-            { "abstract", 6 },
-            { "description", 7 },
-            { "author", 8 },
-            { "license", 9 },
-            { "release_status", 10 },
-            { "resources", 11 },
-            { "version", 12 },
-            { "ksp_version", 13 },
-            { "ksp_version_min", 14 },
-            { "ksp_version_max", 15 },
-            { "ksp_version_strict", 16 },
-            { "provides", 17 },
-            { "depends", 18 },
-            { "recommends", 19 },
-            { "suggests", 20 },
-            { "supports", 21 },
-            { "conflicts", 22 },
-            { "install", 23 },
-            { "download", 24 },
-            { "download_size", 25 },
-            { "download_hash", 26 },
-            { "download_content_type", 27 },
+            "spec_version",
+            "comment",
+            "identifier",
+            "$kref",
+            "$vref",
+            "name",
+            "abstract",
+            "description",
+            "author",
+            "license",
+            "release_status",
+            "resources",
+            "version",
+            "ksp_version",
+            "ksp_version_min",
+            "ksp_version_max",
+            "ksp_version_strict",
+            "localizations",
+            "provides",
+            "depends",
+            "recommends",
+            "suggests",
+            "supports",
+            "conflicts",
+            "install",
+            "download",
+            "download_size",
+            "download_hash",
+            "download_content_type"
+        }
+            .Select((str, index) => new {index, str})
+            .Concat(new[] { new { index = int.MaxValue, str = "x_generated_by"} })
+            .ToDictionary(t => t.str, t=> t.index);
 
-            { "x_generated_by", int.MaxValue }
-        };
-
-        private static readonly Dictionary<string, int> ResourcePropertySortOrder = new Dictionary<string, int>
+        private static readonly Dictionary<string, int> ResourcePropertySortOrder = new string[]
         {
-            { "homepage", 0 },
-            { "spacedock", 1 },
-            { "curse", 2 },
-            { "repository", 3 },
-            { "bugtracker", 4 },
-            { "ci", 5 },
-            { "license", 6 },
-            { "manual", 7 }
-        };
+            "homepage",
+            "spacedock",
+            "curse",
+            "repository",
+            "bugtracker",
+            "ci",
+            "license",
+            "manual",
+        }
+            .Select((str, index) => new {index, str})
+            .ToDictionary(t => t.str, t=> t.index);
 
         public string Name { get { return "property_sort"; } }
 

--- a/Spec.md
+++ b/Spec.md
@@ -416,6 +416,22 @@ intended that all included tags will be indexed and searchable.
 Tags have not yet been implemented in the client. They can be added to
 .ckan/.netkan files, but will not be displayed in the client yet.
 
+##### localizations
+
+(**v1.27**)
+
+A list of strings indicating the locales for which this module includes localizations, in KSP's naming convention.
+
+```json
+    "localizations": [
+        "en-us",
+        "es-es",
+        "fr-fr",
+        "zh-cn",
+        "ru"
+    ]
+```
+
 ### Relationships
 
 Relationships are optional fields which describe this mod's relationship


### PR DESCRIPTION
## Motivation

#2113 suggested filtering mods by language. To achieve that, we would need to acquire metadata tracking modules' translations. That would be pretty tedious to do manually.

## Changes

Now Netkan will examine the .cfg files in each download to see if they have translation data using some fancy regular expressions. If any translations are found, their locale names will be added to the module's `localizations` property. This is a list of strings that flows through to the `CkanModules.localizations` property in the application and could be used to implement displays and filters in the future. No UI changes are made yet.

I'm mainly seeking feedback on this at this point. Did I miss anything that would prevent this from working? Would we need additional data to implement filters?