### PR TITLE
Update GUI modlist if scan detects changes

### DIFF
--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -30,8 +30,6 @@ namespace CKAN
         {
             tabController.RenameTab("WaitTabPage", "Updating repositories");
 
-            CurrentInstance.ScanGameData();
-
             try
             {
                 m_UpdateRepoWorker.RunWorkerAsync();
@@ -65,6 +63,9 @@ namespace CKAN
         {
             try
             {
+                AddStatusMessage("Scanning GameData for DLCs and manually installed modules...");
+                bool scanChanged = CurrentInstance.ScanGameData();
+    
                 AddStatusMessage("Updating repositories...");
 
                 // Note the current mods' compatibility for the NewlyCompatible filter
@@ -80,6 +81,10 @@ namespace CKAN
                 RepoUpdateResult result = Repo.UpdateAllRepositories(
                     RegistryManager.Instance(CurrentInstance),
                     CurrentInstance, Manager.Cache, GUI.user);
+                if (result == RepoUpdateResult.NoChanges && scanChanged)
+                {
+                    result = RepoUpdateResult.Updated;
+                }
                 e.Result = new KeyValuePair<RepoUpdateResult, Dictionary<string, bool>>(
                     result, oldModules);
             }


### PR DESCRIPTION
## Problem

If you install a DLL manually while GUI is running, clicking Refresh will not mark that mod as AD.

## Cause

As of #2682, we avoid refreshing the mod list if the repos have not changed.

The DLC/DLL scanning functions are fire-and-forget; they don't tell us whether their data has changed. So either we refresh everything every time, or we miss scan changes. Currently it's the latter.

## Changes

- Now `KSP.ScanGameData` returns a boolean, true if changed and false if same
- Now we call `ScanGameData` from the repo update's background worker, with a status message describing its function
- Now the background worker reports `RepoUpdateResult.Updated` if the scan found changes but the repos were the same, which will cause a mod list update

Fixes #2761.