### PR TITLE
Don't assume string params to Install are identifiers

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -137,7 +137,7 @@ namespace CKAN
         {
             var resolver = new RelationshipResolver(modules, null, options, registry_manager.registry, ksp.VersionCriteria());
             // Only pass the CkanModules of the parameters, so we can tell which are auto
-            InstallList(resolver.ModList().Where(m => modules.Contains(m.identifier)).ToList(), options, downloader);
+            InstallList(resolver.ModList().Where(m => resolver.ReasonFor(m) is SelectionReason.UserRequested).ToList(), options, downloader);
         }
 
         /// <summary>

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -495,6 +495,41 @@ namespace Tests.Core
         }
 
         [Test]
+        public void InstallList_IdentifierEqualsVersionSyntax_InstallsModule()
+        {
+            using (DisposableKSP ksp = new DisposableKSP())
+            {
+                // Arrange
+                KSPManager manager = new KSPManager(
+                    new NullUser(),
+                    new FakeWin32Registry(ksp.KSP, ksp.KSP.Name)
+                ) {
+                    CurrentInstance = ksp.KSP
+                };
+                var registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
+                var inst = CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser);
+
+                const string mod_file_name = "DogeCoinFlag/Flags/dogecoin.png";
+                string mod_file_path = Path.Combine(ksp.KSP.GameData(), mod_file_name);
+                CkanModule mod = TestData.DogeCoinFlag_101_module();
+                registry.AddAvailable(mod);
+                manager.Cache.Store(mod, TestData.DogeCoinFlagZip());
+                List<string> modules = new List<string>()
+                {
+                    $"{mod.identifier}={mod.version}"
+                };
+                
+                // Act
+                inst.InstallList(modules, new RelationshipResolverOptions());
+                
+                // Assert
+                Assert.IsTrue(File.Exists(mod_file_path));
+
+                manager.Dispose();
+            }
+        }
+
+        [Test]
         public void CanUninstallMod()
         {
             string mod_file_name = "DogeCoinFlag/Flags/dogecoin.png";


### PR DESCRIPTION
## Problem

CmdLine's `ckan install identifier=version` syntax is broken:

```
$ ../CKAN/_build/ckan install Astrogator=v0.9.0
About to install...


Continue? [Y/n]
```

(The list of modules to install is missing.)

This also affects the `ckan install -c localfile.ckan` syntax:

```
$ ../CKAN/_build/ckan install -c KerbalAircraftExpansion-3-2.8.0.1.ckan
About to install...


Continue? [Y/n]
```

Which also breaks pull request validation:

https://ci.ksp-ckan.space/job/NetKAN/8294/console

```
Running ckan install -c built/KerbalAircraftExpansion-3-2.8.0.1.ckan
About to install...



Updating registry
Committing filesystem changes
Rescanning GameData
Done!
```

(Nothing gets installed.)

Noticed while checking validation of KSP-CKAN/NetKAN#7194.

## Cause

This line from #2753 assumed that the list of strings passed to `InstallList` are pure identifiers:

https://github.com/KSP-CKAN/CKAN/blob/8eabff480cc7599803c73e0ee73d63bfa434b081/Core/ModuleInstaller.cs#L140

But they can include the version as well, so comparing them to identifiers doesn't work as intended.

## Changes

Now instead of checking that the module's identifier is present in the parameter list, we check that the resolver's `ReasonFor` is `UserRequested`. This has the intended effect of passing only CkanModules that were specified in the parameters (so the rest can be flagged as auto-installed), but does not break the `identifier=version` syntax.

And since it's kind of shocking that functionality this important broke and no one noticed, a new ModuleInstaller test is added for the `identifier=version` syntax, which fails on master and passes on this branch.