### PR TITLE
Don't throw exceptions for dependency conflicts

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -405,11 +405,21 @@ namespace CKAN
                     }
                 }
 
+                // Pass mod list in case an older version of a module is conflict-free while later versions have conflicts
                 var descriptor1 = descriptor;
                 List<CkanModule> candidates = descriptor
                     .LatestAvailableWithProvides(registry, kspversion, modlist.Values)
                     .Where(mod => descriptor1.WithinBounds(mod) && MightBeInstallable(mod))
                     .ToList();
+                if (candidates.Count == 0)
+                {
+                    // Nothing found, try again without mod list
+                    // (conflicts will still be caught below)
+                    candidates = descriptor
+                        .LatestAvailableWithProvides(registry, kspversion)
+                        .Where(mod => descriptor1.WithinBounds(mod) && MightBeInstallable(mod))
+                        .ToList();
+                }
 
                 if (candidates.Count == 0)
                 {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -45,7 +45,7 @@ namespace CKAN
             get { return manager; }
             set { manager = value; }
         }
-        
+
         private bool needRegistrySave = false;
 
         public MainModList mainModList { get; }
@@ -88,43 +88,48 @@ namespace CKAN
                 var orig = conflicts;
                 conflicts = value;
                 if (orig != value)
-                    ConflictsUpdated();
+                    ConflictsUpdated(orig);
             }
         }
 
-        private void ConflictsUpdated()
+        private void ConflictsUpdated(Dictionary<GUIMod, string> prevConflicts)
         {
-            if (Conflicts == null) {
+            if (Conflicts == null)
+            {
                 // Clear status bar if no conflicts
                 AddStatusMessage("");
             }
-            foreach (DataGridViewRow row in ModList.Rows)
+
+            if (prevConflicts != null)
             {
-                GUIMod module = (GUIMod)row.Tag;
-                string value;
-
-                if (Conflicts != null && Conflicts.TryGetValue(module, out value))
+                // Mark old conflicts as non-conflicted
+                // (rows that are _still_ conflicted will be marked as such in the next loop)
+                foreach (GUIMod guiMod in prevConflicts.Keys)
                 {
-                    string conflict_text = value;
-                    foreach (DataGridViewCell cell in row.Cells)
-                    {
-                        cell.ToolTipText = conflict_text;
-                    }
+                    DataGridViewRow row = mainModList.full_list_of_mod_rows[guiMod.Identifier];
 
-                    if (row.DefaultCellStyle.BackColor != Color.LightCoral)
-                    {
-                        row.DefaultCellStyle.BackColor = Color.LightCoral;
-                        ModList.InvalidateRow(row.Index);
-                    }
-                }
-                else if (row.DefaultCellStyle.BackColor != Color.Empty)
-                {
                     foreach (DataGridViewCell cell in row.Cells)
                     {
                         cell.ToolTipText = null;
                     }
-
                     row.DefaultCellStyle.BackColor = Color.Empty;
+                    ModList.InvalidateRow(row.Index);
+                }
+            }
+            if (Conflicts != null)
+            {
+                // Mark current conflicts as conflicted
+                foreach (var kvp in Conflicts)
+                {
+                    GUIMod          guiMod = kvp.Key;
+                    DataGridViewRow row    = mainModList.full_list_of_mod_rows[guiMod.Identifier];
+                    string conflict_text = kvp.Value;
+
+                    foreach (DataGridViewCell cell in row.Cells)
+                    {
+                        cell.ToolTipText = conflict_text;
+                    }
+                    row.DefaultCellStyle.BackColor = Color.LightCoral;
                     ModList.InvalidateRow(row.Index);
                 }
             }


### PR DESCRIPTION
## Problem

If you try to select both RealismOverhaul and KerbalJointReinforcementNext to be installed, this exception is thrown:

![image](https://user-images.githubusercontent.com/1559108/58301795-81c32000-7dd7-11e9-99a9-7dbfb1206f2b.png)

```
CKAN.DependencyNotSatisfiedKraken: Exception of type 'CKAN.DependencyNotSatisfiedKraken' was thrown.
   at CKAN.RelationshipResolver.ResolveStanza(IEnumerable`1 stanza, SelectionReason reason, RelationshipResolverOptions options, Boolean soft_resolve, IEnumerable`1 old_stanza)
   at CKAN.RelationshipResolver.Resolve(CkanModule module, RelationshipResolverOptions options, IEnumerable`1 old_stanza)
   at CKAN.RelationshipResolver.AddModulesToInstall(IEnumerable`1 modules)
   at CKAN.RelationshipResolver..ctor(IEnumerable`1 modulesToInstall, IEnumerable`1 modulesToRemove, RelationshipResolverOptions options, IRegistryQuerier registry, KspVersionCriteria kspversion)
   at CKAN.MainModList.ComputeConflictsFromModList(IRegistryQuerier registry, IEnumerable`1 change_set, KspVersionCriteria ksp_version)
   at CKAN.Main.<UpdateChangeSetAndConflicts>d__63.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at CKAN.Main.<ModList_CellValueChanged>d__281.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
```

Found while looking into KSP-CKAN/NetKAN#7203, though this may or may not be related to the issues described there.

## Cause

RO depends on KJRContinued, which conflicts with KJRNext.

Prior to #2660, a conflict between a module to be installed and a dependency would be caught here:

https://github.com/KSP-CKAN/CKAN/blob/19f730286ae784347d0ab3e33b9279e0a6bf74cc/Core/Relationships/RelationshipResolver.cs#L477-L487

After #2660, we check conflicts in `LatestAvailableWithProvides`, so the conflict with the dependency causes this block to find zero candidates:

https://github.com/KSP-CKAN/CKAN/blob/19f730286ae784347d0ab3e33b9279e0a6bf74cc/Core/Relationships/RelationshipResolver.cs#L409-L412

So this throws:

https://github.com/KSP-CKAN/CKAN/blob/19f730286ae784347d0ab3e33b9279e0a6bf74cc/Core/Relationships/RelationshipResolver.cs#L414-L420

The calling code isn't expecting exceptions because it sets its options to suppress them:

https://github.com/KSP-CKAN/CKAN/blob/19f730286ae784347d0ab3e33b9279e0a6bf74cc/GUI/MainModList.cs#L1026-L1032

## Changes

Now if the initial search for candidates comes up empty, we try again without passing the mod list (which is how it worked prior to #2660, the mod list was ignored until later). This will still allow us to find non-conflicting older versions of a module when necessary (in the first pass), while allowing dependency conflicts to be handled without throwing exceptions (in the second pass).

![image](https://user-images.githubusercontent.com/1559108/58301833-a4edcf80-7dd7-11e9-96ea-c754dbfb9f5f.png)

### Highlighting hidden conflicts

As a side fix, if you filter the list and then select a mod to install that has a conflict with a hidden mod (the RealismOverhaul / KJRNext combo above is easy for this), only the conflicting rows that were currently visible would be highlighted with a red background. The invisible ones would remain white, including after the filter was changed to make them visible again.

Now all conflicts are highlighted red regardless of whether they're visible. As a side effect of this, the conflict marking code is slightly more efficient, because it no longer needs to loop over every visible row.