### PR TITLE
Don't warn that a raw URL is non-raw

### DIFF
--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -345,6 +345,12 @@ namespace CKAN
                 // Check that the path is what we expect
                 var segments = remoteUri.Segments.ToList();
 
+                if (segments.Count >= 4
+                    && string.Compare(segments[3], "raw/", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    log.InfoFormat("Remote GitHub URL is in raw format, using as is.");
+                    return remoteUri;
+                }
                 if (segments.Count < 6 ||
                     string.Compare(segments[3], "blob/", StringComparison.OrdinalIgnoreCase) != 0 &&
                     string.Compare(segments[3], "tree/", StringComparison.OrdinalIgnoreCase) != 0)


### PR DESCRIPTION
## Problem

If you use a metanetkan URL in this format:

- https://github.com/ChrisAdderley/NearFutureConstruction/raw/master/CKAN/NearFutureConstruction.netkan

Netkan will say this:

```
297 [1] WARN CKAN.Net (null) - Remote non-raw GitHub URL is in an unknown format, using as is.
```

This warning is incorrect. That URL **is** in raw format; that's what the "raw" segment means.

Noticed while reviewing KSP-CKAN/NetKAN#7204.

## Changes

Now when the third segment is "raw/", that warning is replaced with a `--verbose` level message:

```
275 [1] INFO CKAN.Net (null) - Remote GitHub URL is in raw format, using as is.
```