### PR TITLE
Detect Breaking Ground DLC

### DIFF
--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -73,7 +73,9 @@
     <Compile Include="Converters\JsonSingleOrArrayConverter.cs" />
     <Compile Include="Converters\JsonRelationshipConverter.cs" />
     <Compile Include="DLC\IDlcDetector.cs" />
+    <Compile Include="DLC\BreakingGroundDlcDetector.cs" />
     <Compile Include="DLC\MakingHistoryDlcDetector.cs" />
+    <Compile Include="DLC\StandardDlcDetectorBase.cs" />
     <Compile Include="Exporters\BbCodeExporter.cs" />
     <Compile Include="Exporters\DelimeterSeperatedValueExporter.cs" />
     <Compile Include="Exporters\Exporter.cs" />

--- a/Core/DLC/BreakingGroundDlcDetector.cs
+++ b/Core/DLC/BreakingGroundDlcDetector.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace CKAN.DLC
+{
+    /// <summary>
+    /// Represents an object that can detect the presence of the official Making History DLC in a KSP installation.
+    /// </summary>
+    public sealed class BreakingGroundDlcDetector : StandardDlcDetectorBase
+    {
+        public BreakingGroundDlcDetector()
+            : base("BreakingGround", "Serenity") { }
+    }
+}

--- a/Core/DLC/MakingHistoryDlcDetector.cs
+++ b/Core/DLC/MakingHistoryDlcDetector.cs
@@ -1,62 +1,17 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Text.RegularExpressions;
-using CKAN.Versioning;
+using System.Collections.Generic;
 
 namespace CKAN.DLC
 {
     /// <summary>
     /// Represents an object that can detect the presence of the official Making History DLC in a KSP installation.
     /// </summary>
-    public sealed class MakingHistoryDlcDetector : IDlcDetector
+    public sealed class MakingHistoryDlcDetector : StandardDlcDetectorBase
     {
-        private const string Identifier = "MakingHistory-DLC";
-
-        private static readonly Dictionary<string, string> CanonicalVersions = new Dictionary<string, string>()
-        {
-            { "1.0", "1.0.0" }
-        };
-
-        private static readonly Regex VersionPattern = new Regex(
-            @"^Version\s+(?<version>\S+)$",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase
-        );
-
-        public bool IsInstalled(KSP ksp, out string identifier, out UnmanagedModuleVersion version)
-        {
-            identifier = Identifier;
-            version = null;
-
-            var directoryPath = Path.Combine(ksp.GameData(), "SquadExpansion", "MakingHistory");
-            if (Directory.Exists(directoryPath))
-            {
-                var readmeFilePath = Path.Combine(directoryPath, "readme.txt");
-
-                if (File.Exists(readmeFilePath))
+        public MakingHistoryDlcDetector()
+            : base("MakingHistory", new Dictionary<string, string>()
                 {
-                    foreach (var line in File.ReadAllLines(readmeFilePath))
-                    {
-                        var match = VersionPattern.Match(line);
-
-                        if (match.Success)
-                        {
-                            var versionStr = match.Groups["version"].Value;
-
-                            if (CanonicalVersions.ContainsKey(versionStr))
-                                versionStr = CanonicalVersions[versionStr];
-
-                            version = new UnmanagedModuleVersion(versionStr);
-                            break;
-                        }
-                    }
+                    { "1.0", "1.0.0" }
                 }
-
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            ) { }
     }
 }

--- a/Core/DLC/StandardDlcDetectorBase.cs
+++ b/Core/DLC/StandardDlcDetectorBase.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using CKAN.Versioning;
+
+namespace CKAN.DLC
+{
+    /// <summary>
+    /// Base class for DLC Detectors that follow standard conventions.
+    /// </summary>
+    /// <remarks>
+    /// "Standard conventions" is defined as detecting installation by the presence of directory with the name
+    /// DirectoryBaseName in the [GameData]/SquadExpansion directory, detecting version by parsing a version line in
+    /// a readme.txt file in the same directory, and having an identifier of IdentifierBaseName-DLC.
+    /// </remarks>
+    public abstract class StandardDlcDetectorBase : IDlcDetector
+    {
+        private readonly string IdentifierBaseName;
+        private readonly string DirectoryBaseName;
+        private readonly Dictionary<string, string> CanonicalVersions;
+
+        private static readonly Regex VersionPattern = new Regex(
+            @"^Version\s+(?<version>\S+)$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase
+        );
+
+        protected StandardDlcDetectorBase(string identifierBaseName, Dictionary<string, string> canonicalVersions = null)
+            : this(identifierBaseName, identifierBaseName, canonicalVersions) { }
+
+        protected StandardDlcDetectorBase(string identifierBaseName, string directoryBaseName, Dictionary<string, string> canonicalVersions = null)
+        {
+            if (string.IsNullOrWhiteSpace(identifierBaseName))
+                throw new ArgumentException("Value must be provided.", nameof(identifierBaseName));
+
+            if (string.IsNullOrWhiteSpace(directoryBaseName))
+                throw new ArgumentException("Value must be provided.", nameof(directoryBaseName));
+
+            IdentifierBaseName = identifierBaseName;
+            DirectoryBaseName = directoryBaseName;
+            CanonicalVersions = canonicalVersions ?? new Dictionary<string, string>();
+        }
+
+        public virtual bool IsInstalled(KSP ksp, out string identifier, out UnmanagedModuleVersion version)
+        {
+            identifier = $"{IdentifierBaseName}-DLC";
+            version = null;
+
+            var directoryPath = Path.Combine(ksp.GameData(), "SquadExpansion", DirectoryBaseName);
+            if (Directory.Exists(directoryPath))
+            {
+                var readmeFilePath = Path.Combine(directoryPath, "readme.txt");
+
+                if (File.Exists(readmeFilePath))
+                {
+                    foreach (var line in File.ReadAllLines(readmeFilePath))
+                    {
+                        var match = VersionPattern.Match(line);
+
+                        if (match.Success)
+                        {
+                            var versionStr = match.Groups["version"].Value;
+
+                            if (CanonicalVersions.ContainsKey(versionStr))
+                                versionStr = CanonicalVersions[versionStr];
+
+                            version = new UnmanagedModuleVersion(versionStr);
+                            break;
+                        }
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -546,7 +546,7 @@ namespace CKAN
         {
             var dlc = new Dictionary<string, UnmanagedModuleVersion>();
 
-            var detectors = new IDlcDetector[] { new MakingHistoryDlcDetector() };
+            var detectors = new IDlcDetector[] { new BreakingGroundDlcDetector(), new MakingHistoryDlcDetector() };
 
             foreach (var d in detectors)
             {


### PR DESCRIPTION
(Probably) Fixes #2765

Refactors the common logic of `MakingHistoryDlcDetector` into a `StandardDlcDetectorBase` and creates a new `BreakingGroundDlcDetector`.

Quoting from the documentation comment:

> Base class for DLC Detectors that follow standard conventions.
>
> "Standard conventions" is defined as detecting installation by the presence of directory with the name `IdentifierBaseName` in the `[GameData]/SquadExpansion` directory, detecting version by parsing a version line in a `readme.txt` file in the same directory, and having an identifier of `IdentifierBaseName-DLC`.

Assuming Breaking Ground in fact does follow these conventions then this should be all that's required to support it. This can probably be merged after Breaking Ground is released and we confirm that it does follow the conventions.