### PR TITLE
Unignore version controlled folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /_build/
 /.vs/
-/Screenshots/
 /tools
 test-results
 *.userprefs
@@ -28,6 +27,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+
+# Don't ignore the root bin folder
+!/bin/
 
 # NuGet Packages
 *.nupkg


### PR DESCRIPTION
CKAN's .gitignore file currently ignores two directories that have files committed in them:

```
bin
├── changes-since-last-release.pl
├── ckan-build-info.py
├── ckan-build.py
├── ckan_github_utils.py
├── ckan-release-maker.py
├── ckan-release-promoter.py
├── ckan-validate.py
├── close-old-support-tickets.pl
├── outdated_metadata.pl
└── requirements.txt

Screenshots
├── ckan-main-1.22.1.png
└── KSP1.18.0.png
```

`bin` is caught by the attempt to ignore Bin folders created by the compiler. Now we re-include the root-level bin folder after that, since it contains scripts rather than compiled C# code.

`Screenshots` just doesn't need to be in there. Now it's removed.