### PR TITLE
Support BreakingGround-DLC in instance faking

### DIFF
--- a/Cmdline/Action/Compare.cs
+++ b/Cmdline/Action/Compare.cs
@@ -22,7 +22,12 @@ namespace CKAN.CmdLine
                 var rightVersion = new ModuleVersion(options.Right);
 
                 int compareResult = leftVersion.CompareTo(rightVersion);
-                if (compareResult == 0)
+
+                if (options.machine_readable)
+                {
+                    user.RaiseMessage(compareResult.ToString());
+                }
+                else if (compareResult == 0)
                 {
                     user.RaiseMessage(
                         "\"{0}\" and \"{1}\" are the same versions.", leftVersion, rightVersion);

--- a/Cmdline/Action/KSP.cs
+++ b/Cmdline/Action/KSP.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CKAN.Versioning;
@@ -54,8 +55,7 @@ namespace CKAN.CmdLine
                     {
                         // First the commands with three string arguments
                         case "fake":
-                            ht.AddPreOptionsLine($"Usage: ckan ksp {verb} [options] name path version dlcVersion");
-                            ht.AddPreOptionsLine($"Choose dlcVersion \"none\" if you want no simulated dlc.");
+                            ht.AddPreOptionsLine($"Usage: ckan ksp {verb} [options] name path version [--MakingHistory <version>] [--BreakingGround <version>]");
                             break;
 
                         case "clone":
@@ -124,8 +124,14 @@ namespace CKAN.CmdLine
             [ValueOption(0)] public string name { get; set; }
             [ValueOption(1)] public string path { get; set; }
             [ValueOption(2)] public string version { get; set; }
-            [ValueOption(3)] public string dlcVersion { get; set; }
-            [Option("set-default", DefaultValue = false, HelpText = "Set the new instance to the default one.")] public bool setToDefault { get; set; }
+
+            [Option("MakingHistory", DefaultValue = "none", HelpText = "The version of the Making History DLC to be faked.")]
+            public string makingHistoryVersion { get; set; }
+            [Option("BreakingGround", DefaultValue = "none", HelpText = "The version of the Breaking Ground DLC to be faked.")]
+            public string breakingGroundVersion { get; set; }
+
+            [Option("set-default", DefaultValue = false, HelpText = "Set the new instance as the default one.")]
+            public bool setDefault { get; set; }
         }
 
         // This is required by ISubCommand
@@ -303,8 +309,8 @@ namespace CKAN.CmdLine
 
             // Parse all options
             string instanceNameOrPath = options.nameOrPath;
-            string new_name = options.new_name;
-            string new_path = options.new_path;
+            string newName = options.new_name;
+            string newPath = options.new_path;
 
 
             log.Info("Cloning the KSP instance: " + options.nameOrPath);
@@ -320,16 +326,16 @@ namespace CKAN.CmdLine
                         if (instance.Name == instanceNameOrPath)
                         {
                             // Found it, now clone it.
-                            Manager.CloneInstance(instance, new_name, new_path);
+                            Manager.CloneInstance(instance, newName, newPath);
                             break;
                         }
                     }
                 }
                 // Try to use instanceNameOrPath as a path and create a new KSP object.
                 // If it's valid, go on.
-                else if (new CKAN.KSP(instanceNameOrPath, new_name, User) is CKAN.KSP instance && instance.Valid)
+                else if (new CKAN.KSP(instanceNameOrPath, newName, User) is CKAN.KSP instance && instance.Valid)
                 {
-                    Manager.CloneInstance(instance, new_name, new_path);
+                    Manager.CloneInstance(instance, newName, newPath);
 
                 }
                 // There is no instance with this name or at this path.
@@ -370,12 +376,16 @@ namespace CKAN.CmdLine
                 ListInstalls();
                 return Exit.ERROR;
             }
-
+            catch (InstanceNameTakenKraken kraken)
+            {
+                User.RaiseError("This instance name is already taken: {0}", kraken.instName);
+                return Exit.BADOPT;
+            }
 
             // Test if the instance was added to the registry.
             // No need to test if valid, because this is done in AddInstance(),
             // so if something went wrong, HasInstance is false.
-            if (Manager.HasInstance(new_name))
+            if (Manager.HasInstance(newName))
             {
                 return Exit.OK;
             }
@@ -506,10 +516,26 @@ namespace CKAN.CmdLine
         /// </summary>
         private int FakeNewKSPInstall (FakeOptions options)
         {
+            int error()
+            {
+                log.Debug("Instance faking failed, see console output for details.");
+                User.RaiseMessage("--Error--");
+                return Exit.ERROR;
+            }
+
+            int badArgument()
+            {
+                log.Debug("Instance faking failed: bad argument(s). See console output for details.");
+                User.RaiseMessage("--Error: bad argument(s)--");
+                return Exit.BADOPT;
+            }
+
+
             if (options.name == null || options.path == null || options.version == null)
             {
-                User.RaiseMessage("ksp fake <name> <path> <version> [dlcVersion] - argument(s) missing");
-                return Exit.BADOPT;
+                User.RaiseMessage("ksp fake <name> <path> <version> " +
+                	"[--MakingHistory <version>] [--BreakingGround <version>] - argument(s) missing");
+                return badArgument();
             }
 
             log.Debug("Parsing arguments...");
@@ -517,16 +543,33 @@ namespace CKAN.CmdLine
             string installName = options.name;
             string path = options.path;
             KspVersion version;
-            bool setToDefault = options.setToDefault;
-            // dlcVersion is null if a user wants no simulated DLC
-            string dlcVersion;
-            if (options.dlcVersion == null || options.dlcVersion.ToLower() == "none")
+            bool setDefault = options.setDefault;
+
+            // options.<DLC>Version is "none" if the DLC should not be simulated.
+            Dictionary<DLC.IDlcDetector, KspVersion> dlcs = new Dictionary<DLC.IDlcDetector, KspVersion>();
+            if (options.makingHistoryVersion != null && options.makingHistoryVersion.ToLower() != "none")
             {
-                dlcVersion = null;
+                if (KspVersion.TryParse(options.makingHistoryVersion, out KspVersion ver))
+                {
+                    dlcs.Add(new DLC.MakingHistoryDlcDetector(), ver);
+                }
+                else
+                {
+                    User.RaiseError("Please check the Making History DLC version argument - Format it like Maj.Min.Patch - e.g. 1.1.0");
+                    return badArgument();
+                }
             }
-            else
+            if (options.breakingGroundVersion != null && options.breakingGroundVersion.ToLower() != "none")
             {
-                dlcVersion = options.dlcVersion;
+                if (KspVersion.TryParse(options.breakingGroundVersion, out KspVersion ver))
+                {
+                    dlcs.Add(new DLC.BreakingGroundDlcDetector(), ver);
+                }
+                else
+                {
+                    User.RaiseError("Please check the Breaking Ground DLC version argument - Format it like Maj.Min.Patch - e.g. 1.1.0");
+                    return badArgument();
+                }
             }
 
             // Parse the choosen KSP version
@@ -538,7 +581,7 @@ namespace CKAN.CmdLine
             {
                 // Thrown if there is anything besides numbers and points in the version string or a different syntactic error.
                 User.RaiseError("Please check the version argument - Format it like Maj.Min.Patch[.Build] - e.g. 1.6.0 or 1.2.2.1622");
-                return Exit.BADOPT;
+                return badArgument();
             }
 
             // Get the full version including build number.
@@ -546,41 +589,54 @@ namespace CKAN.CmdLine
             {
                 version = version.RaiseVersionSelectionDialog(User);
             }
-            catch (IncorrectKSPVersionKraken)
+            catch (BadKSPVersionKraken)
             {
                 User.RaiseError("Couldn't find a valid KSP version for your input.\n" +
                 	"Make sure to enter the at least the version major and minor values in the form Maj.Min - e.g. 1.5");
-                return Exit.BADOPT;
+                return badArgument();
             }
             catch (CancelledActionKraken)
             {
                 User.RaiseError("Selection cancelled! Please call 'ckan ksp fake' again.");
-                return Exit.ERROR;
+                return error();
             }
 
-
             User.RaiseMessage(String.Format("Creating new fake KSP install {0} at {1} with version {2}", installName, path, version.ToString()));
+            log.Debug("Faking instance...");
 
             try
             {
                 // Pass all arguments to CKAN.KSPManager.FakeInstance() and create a new one.
-                Manager.FakeInstance(installName, path, version, dlcVersion);
-                if (setToDefault)
+                Manager.FakeInstance(installName, path, version, dlcs);
+                if (setDefault)
+                {
                     User.RaiseMessage("Setting new instance to default...");
                     Manager.SetAutoStart(installName);
+                }
+            }
+            catch (InstanceNameTakenKraken kraken)
+            {
+                User.RaiseError("This instance name is already taken: {0}", kraken.instName);
+                return badArgument();
             }
             catch (BadInstallLocationKraken kraken)
             {
                 // The folder exists and is not empty.
-                log.Error(kraken);
-                return Exit.ERROR;
+                User.RaiseError(kraken.Message);
+                return badArgument();
+            }
+            catch (WrongKSPVersionKraken kraken)
+            {
+                // Thrown because the specified KSP version is too old for one of the selected DLCs.
+                User.RaiseError(kraken.Message);
+                return badArgument();
             }
             catch (NotKSPDirKraken kraken)
             {
                 // Something went wrong adding the new instance to the registry,
-                // most likely because the newly created directory is not valid.
+                // most likely because the newly created directory is somehow not valid.
                 log.Error(kraken);
-                return Exit.ERROR;
+                return error();
             }
             catch (InvalidKSPInstanceKraken)
             {
@@ -600,7 +656,7 @@ namespace CKAN.CmdLine
             {
                 User.RaiseError("Something went wrong. Try to add the instance yourself with \"ckan ksp add\".",
                     "Also look if the new directory has been created.");
-                return Exit.ERROR;
+                return error();
             }
         }
         #endregion

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -532,6 +532,9 @@ namespace CKAN.CmdLine
 
     internal class CompareOptions : CommonOptions
     {
+        [Option("machine-readable", HelpText = "Output in a machine readable format: -1, 0 or 1")]
+        public bool machine_readable { get; set;}
+
         [ValueOption(0)] public string Left  { get; set; }
         [ValueOption(1)] public string Right { get; set; }
     }

--- a/Core/DLC/BreakingGroundDlcDetector.cs
+++ b/Core/DLC/BreakingGroundDlcDetector.cs
@@ -8,6 +8,6 @@ namespace CKAN.DLC
     public sealed class BreakingGroundDlcDetector : StandardDlcDetectorBase
     {
         public BreakingGroundDlcDetector()
-            : base("BreakingGround", "Serenity") { }
+            : base("BreakingGround", "Serenity", new Versioning.KspVersion(1, 7, 1)) { }
     }
 }

--- a/Core/DLC/IDlcDetector.cs
+++ b/Core/DLC/IDlcDetector.cs
@@ -7,6 +7,9 @@ namespace CKAN.DLC
     /// </summary>
     public interface IDlcDetector
     {
+        string IdentifierBaseName { get; }
+        KspVersion ReleaseGameVersion { get; }
+
         /// <summary>
         /// Checks if the relevant DLC is installed in the specific KSP installation.
         /// </summary>
@@ -34,6 +37,19 @@ namespace CKAN.DLC
         /// </item>
         /// </list>
         /// </returns>
-        bool IsInstalled(KSP ksp, out string identifier, out UnmanagedModuleVersion version);
+        bool IsInstalled (KSP ksp, out string identifier, out UnmanagedModuleVersion version);
+
+        /// <summary>
+        /// Path to the DLC directory relative to GameDir.
+        /// E.g. GameData/SquadExpansion/Serenity
+        /// </summary>
+        /// <returns>The relative path as string.</returns>
+        string InstallPath ();
+
+        /// <summary>
+        /// Determines whether the DLC is allowed to be installed (or faked)
+        /// on the specified base version (i.e. the game version of the KSP instance.)
+        /// </summary>
+        bool AllowedOnBaseVersion (KspVersion baseVersion);
     }
 }

--- a/Core/DLC/MakingHistoryDlcDetector.cs
+++ b/Core/DLC/MakingHistoryDlcDetector.cs
@@ -8,7 +8,7 @@ namespace CKAN.DLC
     public sealed class MakingHistoryDlcDetector : StandardDlcDetectorBase
     {
         public MakingHistoryDlcDetector()
-            : base("MakingHistory", new Dictionary<string, string>()
+            : base("MakingHistory", new Versioning.KspVersion(1, 4, 1), new Dictionary<string, string>()
                 {
                     { "1.0", "1.0.0" }
                 }

--- a/Core/DLC/StandardDlcDetectorBase.cs
+++ b/Core/DLC/StandardDlcDetectorBase.cs
@@ -16,7 +16,9 @@ namespace CKAN.DLC
     /// </remarks>
     public abstract class StandardDlcDetectorBase : IDlcDetector
     {
-        private readonly string IdentifierBaseName;
+        public KspVersion ReleaseGameVersion { get; }
+        public string IdentifierBaseName { get; }
+
         private readonly string DirectoryBaseName;
         private readonly Dictionary<string, string> CanonicalVersions;
 
@@ -25,10 +27,10 @@ namespace CKAN.DLC
             RegexOptions.Compiled | RegexOptions.IgnoreCase
         );
 
-        protected StandardDlcDetectorBase(string identifierBaseName, Dictionary<string, string> canonicalVersions = null)
-            : this(identifierBaseName, identifierBaseName, canonicalVersions) { }
+        protected StandardDlcDetectorBase(string identifierBaseName, KspVersion releaseGameVersion, Dictionary<string, string> canonicalVersions = null)
+            : this(identifierBaseName, identifierBaseName, releaseGameVersion, canonicalVersions) { }
 
-        protected StandardDlcDetectorBase(string identifierBaseName, string directoryBaseName, Dictionary<string, string> canonicalVersions = null)
+        protected StandardDlcDetectorBase(string identifierBaseName, string directoryBaseName, KspVersion releaseGameVersion, Dictionary<string, string> canonicalVersions = null)
         {
             if (string.IsNullOrWhiteSpace(identifierBaseName))
                 throw new ArgumentException("Value must be provided.", nameof(identifierBaseName));
@@ -38,6 +40,7 @@ namespace CKAN.DLC
 
             IdentifierBaseName = identifierBaseName;
             DirectoryBaseName = directoryBaseName;
+            ReleaseGameVersion = releaseGameVersion;
             CanonicalVersions = canonicalVersions ?? new Dictionary<string, string>();
         }
 
@@ -76,6 +79,16 @@ namespace CKAN.DLC
             {
                 return false;
             }
+        }
+
+        public virtual string InstallPath()
+        {
+            return Path.Combine("GameData", "SquadExpansion", DirectoryBaseName);
+        }
+
+        public bool AllowedOnBaseVersion(KspVersion baseVersion)
+        {
+            return baseVersion >= ReleaseGameVersion;
         }
     }
 }

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -497,11 +497,40 @@ namespace CKAN
     /// <summary>
     /// The version is either not in the build map, or incomplete or something like this.
     /// </summary>
-    public class IncorrectKSPVersionKraken : Kraken
+    public class BadKSPVersionKraken : Kraken
     {
-        public IncorrectKSPVersionKraken(string reason = null, Exception inner_exception = null)
+        public BadKSPVersionKraken(string reason = null, Exception inner_exception = null)
             : base(reason, inner_exception)
         {
+        }
+    }
+
+    /// <summary>
+    /// The version is a known and per se a valid KSP version, but is not allowed to be used for an action.
+    /// For example the given base game version is too low to fake a DLC in instance faking.
+    /// </summary>
+    public class WrongKSPVersionKraken : Kraken
+    {
+        public readonly Versioning.KspVersion version;
+
+        public WrongKSPVersionKraken(Versioning.KspVersion version, string reason = null, Exception inner_exception = null)
+            : base(reason, inner_exception)
+        {
+            this.version = version;
+        }
+    }
+
+    /// <summary>
+    /// The instance name is already in use.
+    /// </summary>
+    public class InstanceNameTakenKraken : Kraken
+    {
+        public readonly string instName;
+
+        public InstanceNameTakenKraken(string name, string reason = null)
+            : base(reason)
+        {
+            this.instName = name;
         }
     }
 }

--- a/Core/Versioning/KspVersion.cs
+++ b/Core/Versioning/KspVersion.cs
@@ -487,7 +487,7 @@ namespace CKAN.Versioning
             }
             else if (!IsMajorDefined || !IsMinorDefined)
             {
-                throw new IncorrectKSPVersionKraken("Needs at least Major and Minor");
+                throw new BadKSPVersionKraken("Needs at least Major and Minor");
             }
             else
             {
@@ -533,7 +533,7 @@ namespace CKAN.Versioning
                 if (possibleVersions.Count == 0)
                 {
                     // No version found in the map. Happens for future or other unknown versions.
-                    throw new IncorrectKSPVersionKraken("The version is not known to CKAN.");
+                    throw new BadKSPVersionKraken("The version is not known to CKAN.");
                 }
                 else if (possibleVersions.Count == 1)
                 {

--- a/GUI/CloneFakeKspDialog.Designer.cs
+++ b/GUI/CloneFakeKspDialog.Designer.cs
@@ -41,8 +41,11 @@
             this.fakeGroupBox = new System.Windows.Forms.GroupBox();
             this.labelVersion = new System.Windows.Forms.Label();
             this.comboBoxKspVersion = new System.Windows.Forms.ComboBox();
-            this.labelDlcVersion = new System.Windows.Forms.Label();
-            this.textBoxDlcVersion = new System.Windows.Forms.TextBox();
+            this.labelDlcVersions = new System.Windows.Forms.Label();
+            this.textBoxMHDlcVersion = new System.Windows.Forms.TextBox();
+            this.labelMakingHistory = new System.Windows.Forms.Label();
+            this.textBoxBGDlcVersion = new System.Windows.Forms.TextBox();
+            this.labelBreakingGround = new System.Windows.Forms.Label();
             this.labelNewName = new System.Windows.Forms.Label();
             this.textBoxNewName = new System.Windows.Forms.TextBox();
             this.labelNewPath = new System.Windows.Forms.Label();
@@ -139,13 +142,16 @@
             //
             this.fakeGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fakeGroupBox.Controls.Add(this.labelDlcVersion);
-            this.fakeGroupBox.Controls.Add(this.textBoxDlcVersion);
+            this.fakeGroupBox.Controls.Add(this.labelDlcVersions);
+            this.fakeGroupBox.Controls.Add(this.textBoxMHDlcVersion);
+            this.fakeGroupBox.Controls.Add(this.labelMakingHistory);
+            this.fakeGroupBox.Controls.Add(this.textBoxBGDlcVersion);
+            this.fakeGroupBox.Controls.Add(this.labelBreakingGround);
             this.fakeGroupBox.Controls.Add(this.labelVersion);
             this.fakeGroupBox.Controls.Add(this.comboBoxKspVersion);
             this.fakeGroupBox.Location = new System.Drawing.Point(13, 130);
             this.fakeGroupBox.Name = "fakeGroupBox";
-            this.fakeGroupBox.Size = new System.Drawing.Size(399, 80);
+            this.fakeGroupBox.Size = new System.Drawing.Size(400, 104);
             this.fakeGroupBox.TabIndex = 7;
             this.fakeGroupBox.TabStop = false;
             //
@@ -183,60 +189,85 @@
             this.comboBoxKspVersion.Size = new System.Drawing.Size(83, 21);
             this.comboBoxKspVersion.TabIndex = 10;
             //
-            // labelDlcVersion
+            // labelDlcVersions
             //
-            this.labelDlcVersion.AutoSize = true;
-            this.labelDlcVersion.Location = new System.Drawing.Point(12, 52);
-            this.labelDlcVersion.Name = "labelDlcVersion";
-            this.labelDlcVersion.Size = new System.Drawing.Size(174, 26);
-            this.labelDlcVersion.TabIndex = 11;
-            resources.ApplyResources(this.labelDlcVersion, "labelDlcVersion");
+            this.labelDlcVersions.AutoSize = true;
+            this.labelDlcVersions.Location = new System.Drawing.Point(12, 52);
+            this.labelDlcVersions.Name = "labelDlcVersion";
+            this.labelDlcVersions.Size = new System.Drawing.Size(174, 26);
+            this.labelDlcVersions.TabIndex = 11;
+            resources.ApplyResources(this.labelDlcVersions, "labelDlcVersions");
             //
-            // textBoxDlcVersion
+            // textBoxMHDlcVersion
             //
-            this.textBoxDlcVersion.Location = new System.Drawing.Point(168, 49);
-            this.textBoxDlcVersion.Name = "textBoxDlcVersion";
-            this.textBoxDlcVersion.Size = new System.Drawing.Size(83, 20);
-            this.textBoxDlcVersion.TabIndex = 12;
+            this.textBoxMHDlcVersion.Location = new System.Drawing.Point(170, 49);
+            this.textBoxMHDlcVersion.Name = "textBoxDlcVersion";
+            this.textBoxMHDlcVersion.Size = new System.Drawing.Size(83, 20);
+            this.textBoxMHDlcVersion.TabIndex = 12;
+            //
+            // labelMakingHistory
+            //
+            this.labelMakingHistory.AutoSize = true;
+            this.labelMakingHistory.Location = new System.Drawing.Point(257, 52);
+            this.labelMakingHistory.Name = "labelMakingHistory";
+            this.labelMakingHistory.Size = new System.Drawing.Size(174, 26);
+            this.labelMakingHistory.TabStop = false;
+            resources.ApplyResources(this.labelMakingHistory, "labelMakingHistory");
+            //
+            // textBoxBGDlcVersion
+            //
+            this.textBoxBGDlcVersion.Location = new System.Drawing.Point(170, 71);
+            this.textBoxBGDlcVersion.Name = "textBoxDlcVersion";
+            this.textBoxBGDlcVersion.Size = new System.Drawing.Size(83, 20);
+            this.textBoxBGDlcVersion.TabIndex = 13;
+            //
+            // labelBreakingGround
+            //
+            this.labelBreakingGround.AutoSize = true;
+            this.labelBreakingGround.Location = new System.Drawing.Point(257, 74);
+            this.labelBreakingGround.Name = "labelBreakingGround";
+            this.labelBreakingGround.Size = new System.Drawing.Size(174, 26);
+            this.labelBreakingGround.TabStop = false;
+            resources.ApplyResources(this.labelBreakingGround, "labelBreakingGround");
             //
             // labelNewName
             //
             this.labelNewName.AutoSize = true;
-            this.labelNewName.Location = new System.Drawing.Point(12, 227);
+            this.labelNewName.Location = new System.Drawing.Point(12, 251);
             this.labelNewName.Name = "labelNewName";
             this.labelNewName.Size = new System.Drawing.Size(137, 13);
-            this.labelNewName.TabIndex = 13;
+            this.labelNewName.TabIndex = 14;
             resources.ApplyResources(this.labelNewName, "labelNewName");
             //
             // textBoxNewName
             //
-            this.textBoxNewName.Location = new System.Drawing.Point(181, 224);
+            this.textBoxNewName.Location = new System.Drawing.Point(181, 248);
             this.textBoxNewName.Name = "textBoxNewName";
             this.textBoxNewName.Size = new System.Drawing.Size(218, 20);
-            this.textBoxNewName.TabIndex = 14;
+            this.textBoxNewName.TabIndex = 15;
             //
             // labelNewPath
             //
             this.labelNewPath.AutoSize = true;
-            this.labelNewPath.Location = new System.Drawing.Point(12, 254);
+            this.labelNewPath.Location = new System.Drawing.Point(12, 278);
             this.labelNewPath.Name = "labelNewPath";
             this.labelNewPath.Size = new System.Drawing.Size(131, 13);
-            this.labelNewPath.TabIndex = 15;
+            this.labelNewPath.TabIndex = 16;
             resources.ApplyResources(this.labelNewPath, "labelNewPath");
             //
             // textBoxNewPath
             //
-            this.textBoxNewPath.Location = new System.Drawing.Point(181, 251);
+            this.textBoxNewPath.Location = new System.Drawing.Point(181, 275);
             this.textBoxNewPath.Name = "textBoxNewPath";
             this.textBoxNewPath.Size = new System.Drawing.Size(163, 20);
-            this.textBoxNewPath.TabIndex = 16;
+            this.textBoxNewPath.TabIndex = 17;
             //
             // buttonPathBrowser
             //
-            this.buttonPathBrowser.Location = new System.Drawing.Point(344, 250);
+            this.buttonPathBrowser.Location = new System.Drawing.Point(344, 274);
             this.buttonPathBrowser.Name = "buttonPathBrowser";
             this.buttonPathBrowser.Size = new System.Drawing.Size(55, 22);
-            this.buttonPathBrowser.TabIndex = 17;
+            this.buttonPathBrowser.TabIndex = 18;
             this.buttonPathBrowser.UseVisualStyleBackColor = true;
             this.buttonPathBrowser.Click += new System.EventHandler(this.buttonPathBrowser_Click);
             resources.ApplyResources(this.buttonPathBrowser, "buttonPathBrowser");
@@ -244,10 +275,10 @@
             // checkBoxSetAsDefault
             //
             this.checkBoxSetAsDefault.AutoSize = true;
-            this.checkBoxSetAsDefault.Location = new System.Drawing.Point(12, 286);
+            this.checkBoxSetAsDefault.Location = new System.Drawing.Point(12, 310);
             this.checkBoxSetAsDefault.Name = "checkBoxSetAsDefault";
             this.checkBoxSetAsDefault.Size = new System.Drawing.Size(157, 17);
-            this.checkBoxSetAsDefault.TabIndex = 18;
+            this.checkBoxSetAsDefault.TabIndex = 19;
             this.checkBoxSetAsDefault.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.checkBoxSetAsDefault, "checkBoxSetAsDefault");
             //
@@ -256,29 +287,29 @@
             this.checkBoxSwitchInstance.AutoSize = true;
             this.checkBoxSwitchInstance.Checked = true;
             this.checkBoxSwitchInstance.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxSwitchInstance.Location = new System.Drawing.Point(181, 286);
+            this.checkBoxSwitchInstance.Location = new System.Drawing.Point(181, 310);
             this.checkBoxSwitchInstance.Name = "checkBoxSwitchInstance";
             this.checkBoxSwitchInstance.Size = new System.Drawing.Size(136, 17);
-            this.checkBoxSwitchInstance.TabIndex = 19;
+            this.checkBoxSwitchInstance.TabIndex = 20;
             this.checkBoxSwitchInstance.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.checkBoxSwitchInstance, "checkBoxSwitchInstance");
             //
             // buttonOK
             //
-            this.buttonOK.Location = new System.Drawing.Point(256, 312);
+            this.buttonOK.Location = new System.Drawing.Point(256, 336);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
-            this.buttonOK.TabIndex = 20;
+            this.buttonOK.TabIndex = 21;
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
             resources.ApplyResources(this.buttonOK, "buttonOK");
             //
             // buttonCancel
             //
-            this.buttonCancel.Location = new System.Drawing.Point(337, 312);
+            this.buttonCancel.Location = new System.Drawing.Point(337, 336);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-            this.buttonCancel.TabIndex = 21;
+            this.buttonCancel.TabIndex = 22;
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
             resources.ApplyResources(this.buttonCancel, "buttonCancel");
@@ -287,11 +318,11 @@
             //
             this.progressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressBar.Location = new System.Drawing.Point(13, 312);
+            this.progressBar.Location = new System.Drawing.Point(13, 336);
             this.progressBar.Name = "progressBar";
             this.progressBar.Size = new System.Drawing.Size(230, 23);
             this.progressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-            this.progressBar.TabIndex = 22;
+            this.progressBar.TabIndex = 23;
             this.progressBar.Visible = false;
             //
             // CloneFakeKspDialog
@@ -300,7 +331,7 @@
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(424, 347);
+            this.ClientSize = new System.Drawing.Size(424, 371);
             this.Controls.Add(this.radioButtonClone);
             this.Controls.Add(this.radioButtonFake);
             this.Controls.Add(this.progressBar);
@@ -347,8 +378,11 @@
         private System.Windows.Forms.GroupBox fakeGroupBox;
         private System.Windows.Forms.Label labelVersion;
         private System.Windows.Forms.ComboBox comboBoxKspVersion;
-        private System.Windows.Forms.Label labelDlcVersion;
-        private System.Windows.Forms.TextBox textBoxDlcVersion;
+        private System.Windows.Forms.Label labelDlcVersions;
+        private System.Windows.Forms.TextBox textBoxMHDlcVersion;
+        private System.Windows.Forms.Label labelMakingHistory;
+        private System.Windows.Forms.TextBox textBoxBGDlcVersion;
+        private System.Windows.Forms.Label labelBreakingGround;
         private System.Windows.Forms.Label labelNewName;
         private System.Windows.Forms.TextBox textBoxNewName;
         private System.Windows.Forms.Label labelNewPath;

--- a/GUI/CloneFakeKspDialog.resx
+++ b/GUI/CloneFakeKspDialog.resx
@@ -126,7 +126,9 @@
   <data name="buttonInstancePathSelection.Text" xml:space="preserve"><value>Select...</value></data>
   <data name="radioButtonFake.Text" xml:space="preserve"><value>Fake new KSP instance</value></data>
   <data name="labelVersion.Text" xml:space="preserve"><value>Version:</value></data>
-  <data name="labelDlcVersion.Text" xml:space="preserve"><value>DLC version (empty for none):</value></data>
+  <data name="labelDlcVersions.Text" xml:space="preserve"><value>DLC versions (empty for none):</value></data>
+  <data name="labelMakingHistory.Text" xml:space="preserve"><value>Making History</value></data>
+  <data name="labelBreakingGround.Text" xml:space="preserve"><value>Breaking Ground</value></data>
   <data name="labelNewName.Text" xml:space="preserve"><value>Name for the new instance:</value></data>
   <data name="labelNewPath.Text" xml:space="preserve"><value>Path for the new instance:</value></data>
   <data name="buttonPathBrowser.Text" xml:space="preserve"><value>Select...</value></data>

--- a/GUI/Localization/de-DE/CloneFakeKspDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/CloneFakeKspDialog.de-DE.resx
@@ -125,7 +125,7 @@
   <data name="labelOldPath.Text" xml:space="preserve"><value>Pfad zur zu klonenden Instanz:</value></data>
   <data name="buttonInstancePathSelection.Text" xml:space="preserve"><value>Suchen</value></data>
   <data name="radioButtonFake.Text" xml:space="preserve"><value>Neue Instanz fälschen:</value></data>
-  <data name="labelDlcVersion.Text" xml:space="preserve"><value>DLC-Version (Leer für Keinen):</value></data>
+  <data name="labelDlcVersions.Text" xml:space="preserve"><value>DLC-Versionen (leer für keinen):</value></data>
   <data name="labelNewName.Text" xml:space="preserve"><value>Name der neuen Instanz:</value></data>
   <data name="labelNewPath.Text" xml:space="preserve"><value>Pfad für die neue Instanz:</value></data>
   <data name="buttonPathBrowser.Text" xml:space="preserve"><value>Suchen</value></data>

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -273,6 +273,9 @@ namespace CKAN.Properties {
         internal static string CloneFakeKspDialogInstanceNotValid {
             get { return (string)(ResourceManager.GetObject("CloneFakeKspDialogInstanceNotValid", resourceCulture)); }
         }
+        internal static string CloneFakeKspDialogDlcVersionMalformatted {
+            get { return (string)(ResourceManager.GetObject("CloneFakeKspDialogDlcVersionMalformatted", resourceCulture)); }
+        }
         internal static string CloneFakeKspDialogDestinationNotEmpty {
             get { return (string)(ResourceManager.GetObject("CloneFakeKspDialogDestinationNotEmpty", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -116,13 +116,14 @@
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>Bitte gib einen Namen für die neue Instanz an.</value> </data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>Bitte gib einen Pfad für die neue Instanz an.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>Klone Instanz...</value></data>
+  <data name="CloneFakeKspDialogDlcVersionMalformatted" xml:space="preserve"><value>Die Version für den {0} DLC ist falsch formatiert. Versuche z.B. "1.0.0".</value></data>
   <data name="CloneFakeKspDialogInstanceNotValid" xml:space="preserve"><value>Die zu klonende Instanz ist ungültig: {0}</value></data>
   <data name="CloneFakeKspDialogDestinationNotEmpty" xml:space="preserve"><value>Der Zielordner is nicht leer: {0}</value></data>
   <data name="CloneFakeKspDialogCloneFailed" xml:space="preserve"><value>Klonen fehlgeschlagen: {0}</value></data>
   <data name="CloneFakeKspDialogSuccessfulClone" xml:space="preserve"><value>Instanz erfolgreich geklont.</value></data>
   <data name="CloneFakeKspDialogCreatingInstance" xml:space="preserve"><value>Erstelle neue Instanz...</value></data>
   <data name="CloneFakeKspDialogNameAlreadyUsed" xml:space="preserve"><value>Dieser Name wird bereits verwendet.</value></data>
-  <data name="CloneFakeKspDialogFakeFailed" xml:space="preserve"><value>Die Erstellung einer gefälschten Instanz ist fehlgeschlagen:</value></data>
+  <data name="CloneFakeKspDialogFakeFailed" xml:space="preserve"><value>Die Erstellung einer gefälschten Instanz ist fehlgeschlagen: {0}</value></data>
   <data name="CloneFakeKspDialogSuccessfulCreate" xml:space="preserve"><value>Instanz erfolgreich erstellt.</value></data>
   <data name="CompatibleKspVersionsDialogKSPUpdated" xml:space="preserve"><value>KSP wurde aktualisiert, seit du zuletzt deine kompatiblen KSP-Versionen überprüft hast. Bitte stelle sicher, dass die Einstellungen noch korrekt sind.</value></data>
   <data name="CompatibleKspVersionsDialogVersionDetails" xml:space="preserve"><value>{0} (vorherige Version: {1})</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -6951,6 +6951,7 @@
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>Please enter a name for the new instance.</value></data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>Please enter a path for the new instance.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>"Cloning instance..."</value></data>
+  <data name="CloneFakeKspDialogDlcVersionMalformatted" xml:space="preserve"><value>The version for the {0} DLC is malformatted. Try "1.0.0" for example.</value></data>
   <data name="CloneFakeKspDialogInstanceNotValid" xml:space="preserve"><value>The instance you wanted to clone is not valid: {0}</value></data>
   <data name="CloneFakeKspDialogDestinationNotEmpty" xml:space="preserve"><value>The destination folder is not empty: {0}</value></data>
   <data name="CloneFakeKspDialogCloneFailed" xml:space="preserve"><value>Clone failed: {0}</value></data>


### PR DESCRIPTION
Got a bit bigger than I thought.
(And it's getting bigger and bigger)

Changes
-----
Important stuff first:
Console command for faking changed!
It is now `ckan ksp fake <name> <path> <version> [--MakingHistory <version>] [--BreakingGround <version>]`
instead of previous `ckan ksp fake <name> <path> <version> [MakingHistoryVersion]`.
I think this is more future-proof.
I am going to try my luck adjusting KSP-CKAN/xKAN-meta_testing.


**`IDlcDetector`**:
I added `string InstallPath()`, it returns the install path relative to the GameDir, that means for example `"GameData/SquadExpansion/Serenity"`.
Depending on how [this idea of mine](https://github.com/KSP-CKAN/CKAN/issues/2770#issuecomment-498413897) will be implemented (if at all), we might restructure the whole thing again. But I think this is the best solution for now, I'm open for feedback.

I added `bool AllowedOnBaseVersion(KspVersion)`, it returns whether a DLC is allowed to be installed or faked on a given basegame version.

I added
```csharp
string IdentifierBaseName { get; }
KspVersion ReleaseGameVersion { get; }
```
to allow accessing those two from outside the interface implementations.
I changed the two fields with these names inside `StandardDlcDetectorBase` to getter without setter (this effectively is like the `readonly` modificator before).

**`CloneFakeInstanceDialog`**:
The GUI `CloneFakeInstanceDialog` has been adjusted:
![CloneFakeInstanceDialog](https://user-images.githubusercontent.com/28812678/59028367-c4ffa300-885b-11e9-84cf-6bcaa0442e4e.png)
If Squad releases another 10 DLCs we might get out of space and need a new system, but for now it works.

**`FakeInstance()`**:
`FakeInstance()` is now a transaction.
Before the DLC just wasn't faked if f.e. the KSP version was < 1.4.0.
This left the user in an unfavorable situation, he had to delete the new folder and run `ckan ksp forget` once and try again to include the DLC. now it's all or nothing.

`FakeInstance()` takes the DLCs that should be faked as `Dictionary<IDlcDetector, KspVersion>`. Future DLC releases _shouldn't_ need a change in this fuction.

Also `CopyDirectory()` is now a real transaction that includes IO operations, if I understand stock .NET transactions right they don't include them, but using `ChinhDo.Transactions` with `TxFileManager` should fix this.
Correct me if I got something wrong there (or anywhere else too of course).

Fixes #2791 

~Oh yeah, #2749 needs another rebase ^^~