### PR TITLE
Suppress autostart warning

### DIFF
--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -24,7 +24,12 @@ namespace CKAN
 
         public string AutoStartInstance
         {
-            get { return Win32Registry.AutoStartInstance; }
+            get
+            {
+                return HasInstance(Win32Registry.AutoStartInstance)
+                    ? Win32Registry.AutoStartInstance
+                    : null;
+            }
             private set
             {
                 if (!String.IsNullOrEmpty(value) && !HasInstance(value))
@@ -94,7 +99,6 @@ namespace CKAN
             // We check both null and "" as we can't write NULL to the registry, so we write an empty string instead
             // This is necessary so we can indicate that the user wants to reset the current AutoStartInstance without clearing the windows registry keys!
             if (!string.IsNullOrEmpty(AutoStartInstance)
-                    && HasInstance(AutoStartInstance)
                     && instances[AutoStartInstance].Valid)
             {
                 return instances[AutoStartInstance];
@@ -143,7 +147,7 @@ namespace CKAN
             {
                 string name = ksp_instance.Name;
                 instances.Add(name, ksp_instance);
-                Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);
+                Win32Registry.SetRegistryToInstances(instances);
             }
             else
             {
@@ -313,7 +317,7 @@ namespace CKAN
         public void RemoveInstance(string name)
         {
             instances.Remove(name);
-            Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);
+            Win32Registry.SetRegistryToInstances(instances);
         }
 
         /// <summary>
@@ -326,7 +330,7 @@ namespace CKAN
             instances.Remove(from);
             ksp.Name = to;
             instances.Add(to, ksp);
-            Win32Registry.SetRegistryToInstances(instances, AutoStartInstance);
+            Win32Registry.SetRegistryToInstances(instances);
         }
 
         /// <summary>
@@ -418,16 +422,6 @@ namespace CKAN
             }
             string failReason;
             TrySetupCache(Win32Registry.DownloadCacheDir, out failReason);
-
-            try
-            {
-                AutoStartInstance = Win32Registry.AutoStartInstance;
-            }
-            catch (InvalidKSPInstanceKraken e)
-            {
-                log.WarnFormat("Auto-start instance was invalid: {0}", e.Message);
-                AutoStartInstance = null;
-            }
         }
 
         /// <summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -394,7 +394,6 @@ namespace CKAN
                 }
                 else if (enlisted_tx != current_tx)
                 {
-                    log.Error("CKAN registry does not support nested transactions.");
                     throw new TransactionalKraken("CKAN registry does not support nested transactions.");
                 }
 

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -562,7 +562,6 @@ namespace CKAN
 
                     string error = String.Format("{0} missing required field {1}", identifier, field);
 
-                    log.Error(error);
                     throw new BadMetadataKraken(null, error);
                 }
             }

--- a/Core/Win32Registry.cs
+++ b/Core/Win32Registry.cs
@@ -9,7 +9,7 @@ namespace CKAN
     public interface IWin32Registry
     {
         string AutoStartInstance { get; set; }
-        void SetRegistryToInstances(SortedList<string, KSP> instances, string autoStartInstance);
+        void SetRegistryToInstances(SortedList<string, KSP> instances);
         IEnumerable<Tuple<string, string>> GetInstances();
         string GetKSPBuilds();
         void SetKSPBuilds(string buildMap);
@@ -121,9 +121,8 @@ namespace CKAN
                 GetRegistryValue("KSPInstancePath_" + i, string.Empty));
         }
 
-        public void SetRegistryToInstances(SortedList<string, KSP> instances, string autoStartInstance)
+        public void SetRegistryToInstances(SortedList<string, KSP> instances)
         {
-            SetAutoStartInstance(autoStartInstance ?? string.Empty);
             SetNumberOfInstances(instances.Count);
 
             foreach (var instance in instances.Select((instance,i)=>

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -38,7 +38,6 @@ namespace CKAN.NetKAN.Transformers
                 }
                 else
                 {
-                    Log.Error("Invalid epoch: " + epoch);
                     throw new BadMetadataKraken(null, "Invalid epoch: " + epoch + "In " + json["identifier"]);
                 }
             }

--- a/Tests/Core/FakeWin32Registry.cs
+++ b/Tests/Core/FakeWin32Registry.cs
@@ -95,11 +95,10 @@ namespace Tests.Core
         /// <returns>
         /// Returns
         /// </returns>
-        public void SetRegistryToInstances(SortedList<string, CKAN.KSP> instances, string autoStartInstance)
+        public void SetRegistryToInstances(SortedList<string, CKAN.KSP> instances)
         {
             Instances =
                 instances.Select(kvpair => new Tuple<string, string>(kvpair.Key, kvpair.Value.GameDir())).ToList();
-            AutoStartInstance = autoStartInstance;
         }
 
         /// <summary>

--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -43,9 +43,9 @@ namespace Tests.Core
         }
 
         [Test]
-        public void SetAutoStart_VaildName_SetsAutoStart()
+        public void SetAutoStart_ValidName_SetsAutoStart()
         {
-            Assert.That(manager.AutoStartInstance, Is.EqualTo(string.Empty));
+            Assert.That(manager.AutoStartInstance, Is.EqualTo(null));
 
             manager.SetAutoStart(nameInReg);
             Assert.That(manager.AutoStartInstance, Is.EqualTo(nameInReg));

--- a/Tests/Core/Net/Net.cs
+++ b/Tests/Core/Net/Net.cs
@@ -18,7 +18,7 @@ namespace Tests.Core.Net
 
         [Test]
         [Category("Online")]
-        public void DownloadThrowsOnInvaildURL()
+        public void DownloadThrowsOnInvalidURL()
         {
             // Download should throw an exception on an invalid URL.
             Assert.That(BadDownload, Throws.Exception);

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -55,10 +55,12 @@ namespace Tests.NetKAN
         }
 
         [TestCase(@"{""spec_version"": 1, ""version"" : ""1.01""}", false)]
+        [TestCase(@"{""spec_version"": 1, ""version"" : ""1.01"", ""x_netkan_epoch"" : ""1""}", false)]
+        [TestCase(@"{""spec_version"": 1, ""version"" : ""1.01"", ""x_netkan_epoch"" : ""3""}", false)]
         [TestCase(@"{""spec_version"": 1, ""version"" : ""1.01"", ""x_netkan_epoch"" : ""a""}", true)]
         [TestCase(@"{""spec_version"": 1, ""version"" : ""1.01"", ""x_netkan_epoch"" : ""-1""}", true)]
         [TestCase(@"{""spec_version"": 1, ""version"" : ""1.01"", ""x_netkan_epoch"" : ""5.5""}", true)]
-        public void Invaild(string json, bool expected_to_throw)
+        public void Invalid(string json, bool expected_to_throw)
         {
             TestDelegate test_delegate = () => new EpochTransformer().Transform(new Metadata(JObject.Parse(json))).First().Json();
             if (expected_to_throw)


### PR DESCRIPTION
## Problem

If your auto start instance is not valid and you run `ckan compare 1.2.3 4.5.6`, you get an extra warning message in addition to the expected output:

```
342 [1] WARN CKAN.KSPManager (null) - Auto-start instance was invalid: Exception of type 'CKAN.InvalidKSPInstanceKraken' was thrown.
"1.2.3" is lower than "4.5.6".
```

This isn't useful because we're not trying to do anything with auto start instances, we're just comparing version strings.

The same message is printed by many of the tests.

## Cause

When we instantiate a `KSPManager`, its constructor calls `LoadInstancesFromRegistry`, which sets `AutoStartInstance`:

https://github.com/KSP-CKAN/CKAN/blob/00211bd8f288b5a2ea8054f953b184d632640c58/Core/KSPManager.cs#L422-L430

However, the value passed is what `AutoStartInstance` would already return!

https://github.com/KSP-CKAN/CKAN/blob/ad32e9ed8ad8b95c440252005d0d405d27ce0a9f/Core/KSPManager.cs#L25-L36

So that assignment doesn't accomplish anything. It does throw an exception if the current auto start instance isn't valid, however, which is just caught and printed as a warning.

## Changes

- `LoadInstancesFromRegistry` no longer pointlessly assigns to `AutoStartInstance`
- To guarantee identical behavior, `AutoStartInstance` now returns null if the value in the registry isn't the name of an instance
- `Win32Registry.SetRegistryToInstances` no longer accepts the auto start instance as a parameter since all calls to it were just passing the value already in the registry
- Some log messages that were redundant with exceptions are now removed to clean up test output
- Spelling of "invalid" is fixed in a few places

Fixes #2774.