### PR TITLE
Fix fake/clone tests on Windows

### DIFF
--- a/Tests/Core/KSPManager.cs
+++ b/Tests/Core/KSPManager.cs
@@ -128,13 +128,13 @@ namespace Tests.Core
         }
 
         [Test]
-        public void CloneInstance_ToNotEmptyFolder_ThrowsIOException()
+        public void CloneInstance_ToNotEmptyFolder_ThrowsPathErrorKraken()
         {
             using (var KSP = new DisposableKSP())
             {
                 string instanceName = "newInstance";
                 string tempdir = TestData.NewTempDir();
-                System.IO.File.Create(System.IO.Path.Combine(tempdir, "shouldntbehere.txt"));
+                System.IO.File.Create(System.IO.Path.Combine(tempdir, "shouldntbehere.txt")).Close();
 
                 Assert.Throws<PathErrorKraken>(() =>
                     manager.CloneInstance(KSP.KSP, instanceName, tempdir));
@@ -184,7 +184,7 @@ namespace Tests.Core
             string name = "testname";
             string tempdir = TestData.NewTempDir();
             CKAN.Versioning.KspVersion version = CKAN.Versioning.KspVersion.Parse("1.5.1");
-            System.IO.File.Create(System.IO.Path.Combine(tempdir, "shouldntbehere.txt"));
+            System.IO.File.Create(System.IO.Path.Combine(tempdir, "shouldntbehere.txt")).Close();
 
             Assert.Throws<BadInstallLocationKraken>(() =>
                 manager.FakeInstance(name, tempdir, version));
@@ -211,6 +211,7 @@ namespace Tests.Core
             Assert.IsTrue(dlcVersionObject.ToString().Contains(dlcVersion));
 
             // Tidy up.
+            CKAN.RegistryManager.Instance(newKSP).ReleaseLock();
             System.IO.Directory.Delete(tempdir, true);
         }
 


### PR DESCRIPTION
## Problem

Running `.\build.ps1 test` on Windows:

```
1) Error : Tests.Core.KSPManagerTests.CloneInstance_ToNotEmptyFolder_ThrowsIOException
System.IO.IOException : The process cannot access the file 'shouldntbehere.txt' because it is being used by another process.
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at Tests.Core.KSPManagerTests.CloneInstance_ToNotEmptyFolder_ThrowsIOException() in C:\Users\Paul\github\CKAN\Tests\Core\KSPManager.cs:line 144

2) Error : Tests.Core.KSPManagerTests.FakeInstance_InNotEmptyFolder_ThrowsBadInstallLocationKraken
System.IO.IOException : The process cannot access the file 'shouldntbehere.txt' because it is being used by another process.
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at Tests.Core.KSPManagerTests.FakeInstance_InNotEmptyFolder_ThrowsBadInstallLocationKraken() in C:\Users\Paul\github\CKAN\Tests\Core\KSPManager.cs:line 194

3) Error : Tests.Core.KSPManagerTests.FakeInstance_ValidArgumentsWithDLC_ManagerHasValidInstance
System.IO.IOException : The process cannot access the file 'registry.locked' because it is being used by another process.
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at Tests.Core.KSPManagerTests.FakeInstance_ValidArgumentsWithDLC_ManagerHasValidInstance() in C:\Users\Paul\github\CKAN\Tests\Core\KSPManager.cs:line 214
```

## Causes

https://github.com/KSP-CKAN/CKAN/blob/df8fb70fc054a488409e2d04915fe6719b1ea128/quotes.txt#L11-L16

Errors 1 and 2: `System.IO.File.Create` returns an open file handle, which on Windows includes a lock. Deleting the locked file's parent folder isn't allowed.

Error 3: `KSP` loads its `registry.json` file and creates a `registry.locked` file to lock it. On Windows the `registry.locked` file is itself locked. Deleting this locked file's parent folder also isn't allowed.

## Changes

Errors 1 and 2: Now we close the file handle returned by `System.IO.File.Create`, which releases the lock and allows the folder to be deleted.

Error 3: Now we call `RegistryManager.ReleaseLock` for the `KSP` instance, which allows the folder to be deleted.

`CloneInstance_ToNotEmptyFolder_ThrowsIOException` is also renamed to `CloneInstance_ToNotEmptyFolder_ThrowsPathErrorKraken` to reflect the exception that is expected.

Fixes #2752.