### PR TITLE
Fix ZipValid test on non-English Windows systems

### DIFF
--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
-using CKAN;
+using System.Threading;
+using System.Globalization;
 using NUnit.Framework;
 using Tests.Data;
+using CKAN;
 
 namespace Tests.Core
 {
@@ -183,6 +185,11 @@ namespace Tests.Core
         [Test]
         public void ZipValid_ContainsFilenameWithBadChars_NoException()
         {
+            // We want to inspect a localized error message below.
+            // Switch to English to ensure it's what we expect.
+            CultureInfo origUICulture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
             bool valid = false;
             string reason = "";
             Assert.DoesNotThrow(() =>
@@ -194,6 +201,9 @@ namespace Tests.Core
             {
                 Assert.AreEqual(reason, "Illegal characters in path.");
             }
+
+            // Switch back to the original locale
+            Thread.CurrentThread.CurrentUICulture = origUICulture;
         }
 
         [Test]


### PR DESCRIPTION
## Problem

If your Windows computer's locale is non-English, this test will fail:

```
1) Failed : Tests.Core.Cache.ZipValid_ContainsFilenameWithBadChars_NoException
  Expected string length 26 but was 27. Strings differ at index 7.
  Expected: "Illegales Zeichen im Pfad."
  But was:  "Illegal characters in path."
  ------------------^
   bei Tests.Core.Cache.ZipValid_ContainsFilenameWithBadChars_NoException() in C:\path\to\ckan-git\Tests\Core\Cache.cs:Zeile 195.
```

(I was able to reproduce this on an English computer by installing the German language pack for .NET and setting `Thread.CurrentThread.CurrentUICulture = new CultureInfo("de-DE");` within the test.)

## Cause

That error message is localized. It will appear in whatever language is selected in `Thread.CurrentThread.CurrentUICulture`.

## Changes

Now we set `Thread.CurrentThread.CurrentUICulture` to `CultureInfo.InvariantCulture` for that test. This forces the error message to appear in English.

Fixes #2780.