### PR TITLE
Only list each locale once

### DIFF
--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -63,7 +63,8 @@ namespace CKAN.NetKAN.Transformers
                     .SelectMany(contents => localizationRegex.Matches(contents).Cast<Match>()
                         .Select(m => m.Groups["contents"].Value))
                     .SelectMany(contents => localeRegex.Matches(contents).Cast<Match>()
-                        .Select(m => m.Groups["locale"].Value));
+                        .Select(m => m.Groups["locale"].Value))
+                    .Distinct();
                 log.Debug("Locales extracted");
     
                 if (locales.Any())


### PR DESCRIPTION
## Problem

Right now some mods that should be re-indexing with localizations metadata are failing in the bot.

```
$ wget -O - http://status.ksp-ckan.space/status/netkan.json | python -m json.tool | grep 'Schema validation failed' -A 3 -B 3

...
    "AntennaHelper": {
        "failed": true,
        "last_checked": "2019-06-15T00:02:53Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2018-10-30T20:02:41Z",
        "last_inflated": "2019-06-15T00:02:56Z"
    },
--
    "BDArmoryContinued": {
        "failed": true,
        "last_checked": "2019-06-15T00:05:55Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-05-12T12:04:54Z",
        "last_inflated": "2019-06-15T00:05:59Z"
    },
--
    "CommunityPartsTitles": {
        "failed": true,
        "last_checked": "2019-06-15T00:10:45Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-05-25T12:10:41Z",
        "last_inflated": "2019-06-15T00:10:47Z"
    },
--
    "FelineUtilityRovers": {
        "failed": true,
        "last_checked": "2019-06-15T00:20:23Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-05-25T20:19:50Z",
        "last_inflated": "2019-06-15T00:20:27Z"
    },
--
    "GPP": {
        "failed": true,
        "last_checked": "2019-06-15T00:23:27Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2018-08-03T16:24:53Z",
        "last_inflated": "2019-06-15T00:23:45Z"
    },
--
    "InterstellarFuelSwitch-Core": {
        "failed": true,
        "last_checked": "2019-06-15T00:34:39Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-05-26T12:28:52Z",
        "last_inflated": "2019-06-15T00:34:48Z"
    },
--
    "KSPInterstellarExtended": {
        "failed": true,
        "last_checked": "2019-06-15T01:53:51Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-05-26T00:39:50Z",
        "last_inflated": "2019-06-15T01:54:36Z"
    },
--
    "KerbalAircraftExpansion": {
        "failed": true,
        "last_checked": "2019-06-15T00:45:20Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2018-01-23T00:24:09Z",
        "last_inflated": "2019-06-15T00:45:23Z"
    },
--
    "KerbalScienceInnovation": {
        "failed": true,
        "last_checked": "2019-06-15T00:50:59Z",
        "last_error": "Schema validation failed",
        "last_indexed": null,
        "last_inflated": "2019-06-15T00:51:04Z"
    },
--
    "Kerbalism": {
        "failed": true,
        "last_checked": "2019-06-15T00:49:51Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-06-08T20:32:33Z",
        "last_inflated": "2019-06-15T00:49:59Z"
    },
--
    "KerbinElectric": {
        "failed": true,
        "last_checked": "2019-06-15T00:52:39Z",
        "last_error": "Schema validation failed",
        "last_indexed": null,
        "last_inflated": "2019-06-15T00:52:46Z"
    },
--
    "MissionController2": {
        "failed": true,
        "last_checked": "2019-06-15T02:05:34Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-01-31T08:41:38Z",
        "last_inflated": "2019-06-15T02:05:37Z"
    },
--
    "MkerbIncOxidizerTank": {
        "failed": true,
        "last_checked": "2019-06-15T02:20:28Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2018-04-01T12:40:37Z",
        "last_inflated": "2019-06-15T02:20:30Z"
    },
    "MkerbIncScienceInstruments": {
        "failed": true,
        "last_checked": "2019-06-15T02:20:30Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2018-03-26T01:20:00Z",
        "last_inflated": "2019-06-15T02:20:33Z"
    },
--
    "NehemiahEngineeringOrbitalScience": {
        "failed": true,
        "last_checked": "2019-06-15T02:46:00Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-04-01T16:54:34Z",
        "last_inflated": "2019-06-15T02:46:12Z"
    },
--
    "OuterPlanetsMod": {
        "failed": true,
        "last_checked": "2019-06-15T02:55:01Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-05-27T16:55:14Z",
        "last_inflated": "2019-06-15T02:55:12Z"
    },
--
    "PatchManager": {
        "failed": true,
        "last_checked": "2019-06-15T02:55:56Z",
        "last_error": "Schema validation failed",
        "last_indexed": "2019-01-09T16:51:01Z",
        "last_inflated": "2019-06-15T02:55:59Z"
    },
```

## Cause

The schema requires the locale strings to be unique:

https://github.com/KSP-CKAN/CKAN/blob/e8f510defeb78c483be93ebf9aeb5c92f45ba6bd/CKAN.schema#L121-L126

The mods that are failing have multiple sections of strings for the same locale in their config files, each of which currently results in one entry in the list:

```
$ netkan.exe NetKAN/BDArmoryContinued.netkan
$ cat BDArmoryContinued-1-v1.3.1.ckan
...
    "localizations": [
        "en-us",
        "es-es",
        "ja",
        "ru",
        "zh-cn",
        "en-us",
        "es-es",
        "zh-cn"
    ],
```

This causes the bot to reject the .ckan file for not conforming to the schema.

## Changes

Now we use `.Distinct()` to eliminate duplicates from the list. This will allow the generated metadata to pass schema validation.