### PR TITLE
Only react to Localization keyword at start of line

### DIFF
--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -89,7 +89,7 @@ namespace CKAN.NetKAN.Transformers
         private static readonly ILog log = LogManager.GetLogger(typeof(LocalizationsTransformer));
 
         private static readonly Regex localizationRegex = new Regex(
-            @"\bLocalization\b.*?{(?<contents>.*?([-a-zA-Z]+.*?{.*?}.*?)*?)}",
+            @"^\s*Localization\b.*?{(?<contents>.*?([-a-zA-Z]+.*?{.*?}.*?)*?)}",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
         private static readonly Regex localeRegex = new Regex(


### PR DESCRIPTION
## Problem

The localization metadata has been rolling in, and it's mostly good (https://github.com/KSP-CKAN/CKAN-meta/compare/3df71eeb09...331d41132b)! I've found two modules with bad metadata so far:

### Kerbalism

https://github.com/KSP-CKAN/CKAN-meta/blob/331d41132bd87ba029927468475c1c1eaf76b087/Kerbalism/Kerbalism-3.0.2.ckan

```json
    "localizations": [
        "de-de",
        "ru",
        "pt-br",
        "en-us",
        "version",
        "VERSION"
    ],
```

### NehemiahEngineeringOrbitalScience

https://github.com/KSP-CKAN/CKAN-meta/blob/331d41132bd87ba029927468475c1c1eaf76b087/NehemiahEngineeringOrbitalScience/NehemiahEngineeringOrbitalScience-0.8.0.ckan

```json
    "localizations": [
        "de-de",
        "en-us",
        "es-es",
        "model",
        "MODULE"
    ],
```

## Cause

These modules have cfg files with the word `Localization` as part of a string value rather than as a keyword, and the next BLOCK{} after that is interpreted as a locale. The localization translator parser looks for it anywhere in a line as long as it's a separate word.

### Kerbalism

`Kerbalism-3.0.2/GameData/Kerbalism/CHANGELOG.cfg`:

```
        change = Localization translations added (Sir Mortimer [GRUMP])
        change = MM errors fixed (Gordon Dry)
        change = Added a title parameter to the PlannerController that shows in the buttons text (PiezPiedPy)
    }

    VERSION {
```

### NehemiahEngineeringOrbitalScience

`NehemiahEngineeringOrbitalScience_0.8.0/NehemiahInc/KEES/Parts/Experiment/TEST.cfg`:

```
        // MKW TODO Localization
        title = KEES Test Exposure Experiment
        manufacturer = #ne_manufacturer_name
        description = The KEES Test Exposure Experiment is designed to test the Passive Experiment Carrier module and demonstrate viability of running these kinds of exposure experiments with real samples.

        // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision, allowDock, allowRotate
        attachRules = 1,0,0,0,0
        mass = 0.02
        dragModelType = default
        maximum_drag = 0.2
        minimum_drag = 0.3
        angularDrag = 1
        crashTolerance = 10
        breakingForce = 200
        breakingTorque = 200
        maxTemp = 800
        fuelCrossFeed = false
        bulkheadProfiles = srf
        tags = #ne_kees_experiment_tags

        MODEL
        {
                model =  NehemiahInc/KEES/Parts/Experiment/model
                position = 0, 0, 0
                scale = .625,.625,.625
                rotation = 0, 0, 0
                texture = KEES_Experiment_Texture, NehemiahInc/KEES/Parts/Experiment/KEES_Experiment_Texture
                texture = KEES_Experiment_Normal, NehemiahInc/KEES/Parts/Experiment/KEES_Experiment_Normal
        }

        MODULE
        {
                name = KEES_Lab
                ExposureTimePerHour= 1.0
                minimumCrew = 0
        }
```

## Changes

Now we require the `Localization` keyword to be at the start of a line, optionally preceded only by whitespace. This prunes the above lists to only valid locale strings in my testing.