### PR TITLE
Fix 'ManageKspInstances' dialog logic

### DIFF
--- a/GUI/Localization/de-DE/ManageKSPInstances.de-DE.resx
+++ b/GUI/Localization/de-DE/ManageKSPInstances.de-DE.resx
@@ -121,6 +121,7 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="openDirectoryMenuItem.Text" xml:space="preserve"><value>Verzeichnis öffnen</value></data>
   <data name="KSPInstallName.Text" xml:space="preserve"><value>Name</value></data>
   <data name="KSPInstallPath.Text" xml:space="preserve"><value>Pfad</value></data>
   <data name="SelectButton.Text" xml:space="preserve"><value>Wählen</value></data>

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -557,6 +557,7 @@ namespace CKAN
                 || !RegistryManager.Instance(CurrentInstance).registry.HasAnyAvailable();
             if (allowRepoUpdate && repoUpdateNeeded)
             {
+                ModList.Rows.Clear();
                 UpdateRepo();
 
                 // Update the filters after UpdateRepo() completed.
@@ -575,6 +576,7 @@ namespace CKAN
                 UpdateModsList();
                 Filter((GUIModFilter)configuration.ActiveFilter);
             }
+
             ChangeSet = null;
             Conflicts = null;
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -530,8 +530,8 @@ namespace CKAN
         /// <summary>
         /// React to switching to a new game instance
         /// </summary>
-        /// <param name="onStartup">true if this is the initial load and should trigger auto repo updates, false otherwise</param>
-        private void CurrentInstanceUpdated(bool onStartup)
+        /// <param name="allowRepoUpdate">true if a repo update is allowed if needed (e.g. on initial load), false otherwise</param>
+        private void CurrentInstanceUpdated(bool allowRepoUpdate)
         {
             Util.Invoke(this, () =>
             {
@@ -555,18 +555,28 @@ namespace CKAN
 
             bool repoUpdateNeeded = configuration.RefreshOnStartup
                 || !RegistryManager.Instance(CurrentInstance).registry.HasAnyAvailable();
-            if (onStartup && repoUpdateNeeded)
+            if (allowRepoUpdate && repoUpdateNeeded)
             {
                 UpdateRepo();
+
+                // Update the filters after UpdateRepo() completed.
+                // Since this happens with a backgroundworker, Filter() is added as callback for RunWorkerCompleted.
+                // Remove it again after it ran, else it stays there and is added again and again.
+                void filterUpdate (object sender, RunWorkerCompletedEventArgs e)
+                {
+                    Filter((GUIModFilter)configuration.ActiveFilter);
+                    m_UpdateRepoWorker.RunWorkerCompleted -= filterUpdate;
+                }
+
+                m_UpdateRepoWorker.RunWorkerCompleted += filterUpdate;
             }
             else
             {
                 UpdateModsList();
+                Filter((GUIModFilter)configuration.ActiveFilter);
             }
             ChangeSet = null;
             Conflicts = null;
-
-            Filter((GUIModFilter)configuration.ActiveFilter);
         }
 
         public void UpdateCKAN()
@@ -818,6 +828,10 @@ namespace CKAN
             // Triggers mainModList.ModFiltersUpdated()
             mainModList.ModFilter = filter;
 
+            // Save new filter to the configuration.
+            configuration.ActiveFilter = (int)mainModList.ModFilter;
+            configuration.Save();
+
             // Ask the configuration which columns to show.
             foreach (DataGridViewColumn col in ModList.Columns)
             {
@@ -1031,11 +1045,13 @@ namespace CKAN
 
         private void manageKspInstancesMenuItem_Click(object sender, EventArgs e)
         {
-            Instance.Manager.ClearAutoStart();
             var old_instance = Instance.CurrentInstance;
             var result = new ManageKspInstances(!actuallyVisible).ShowDialog();
             if (result == DialogResult.OK && !Equals(old_instance, Instance.CurrentInstance))
-                Instance.CurrentInstanceUpdated(false);
+            {
+                ModList.ClearSelection();
+                CurrentInstanceUpdated(true);
+            }
         }
 
         private void openKspDirectoryToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -204,8 +204,7 @@ namespace CKAN
             {
                 foreach (GUIMod gm in gui_mods)
                 {
-                    bool oldIncompat;
-                    if (old_modules.TryGetValue(gm.Identifier, out oldIncompat))
+                    if (old_modules.TryGetValue(gm.Identifier, out bool oldIncompat))
                     {
                         // Found it; check if newly compatible
                         if (!gm.IsIncompatible && oldIncompat)

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -32,6 +32,7 @@ namespace CKAN
 
             try
             {
+                // The argument will be accessed with (bool)e.Argument in private UpdateRepo()
                 m_UpdateRepoWorker.RunWorkerAsync();
             }
             catch { }

--- a/GUI/ManageKSPInstances.resx
+++ b/GUI/ManageKSPInstances.resx
@@ -110,6 +110,7 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="openDirectoryMenuItem.Text" xml:space="preserve"><value>Open directory</value></data>
   <data name="KSPInstallName.Text" xml:space="preserve"><value>Name</value></data>
   <data name="KSPInstallVersion.Text" xml:space="preserve"><value>Version</value></data>
   <data name="KSPInstallPath.Text" xml:space="preserve"><value>Path</value></data>

--- a/GUI/ManageKspInstances.Designer.cs
+++ b/GUI/ManageKspInstances.Designer.cs
@@ -41,6 +41,8 @@
             this.SelectButton = new System.Windows.Forms.Button();
             this.AddNewButton = new CKAN.DropdownMenuButton();
             this.AddNewMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.InstanceListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.openDirectoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AddToCKANMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.CloneFakeInstanceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.RenameButton = new System.Windows.Forms.Button();
@@ -72,6 +74,20 @@
             this.KSPInstancesListView.View = System.Windows.Forms.View.Details;
             this.KSPInstancesListView.SelectedIndexChanged += new System.EventHandler(this.KSPInstancesListView_SelectedIndexChanged);
             this.KSPInstancesListView.DoubleClick += new System.EventHandler(this.KSPInstancesListView_DoubleClick);
+            this.KSPInstancesListView.MouseClick += new System.Windows.Forms.MouseEventHandler(this.KSPInstancesListView_Click);
+            //
+            // InstanceListContextMenuStrip
+            //
+            this.InstanceListContextMenuStrip.Items.Add(this.openDirectoryMenuItem);
+            this.InstanceListContextMenuStrip.Name = "InstanceListContextMenuStrip";
+            this.InstanceListContextMenuStrip.Size = new System.Drawing.Size(180, 30);
+            //
+            // openDirectoryToolStripMenuItem
+            //
+            this.openDirectoryMenuItem.Name = "openDirectoryMenuItem";
+            this.openDirectoryMenuItem.Size = new System.Drawing.Size(180, 30);
+            this.openDirectoryMenuItem.Click += new System.EventHandler(this.OpenDirectoryMenuItem_Click);
+            resources.ApplyResources(this.openDirectoryMenuItem, "openDirectoryMenuItem");
             //
             // KSPInstallName
             //
@@ -151,11 +167,13 @@
             //
             this.SetAsDefaultCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.SetAsDefaultCheckbox.AutoSize = true;
+            this.SetAsDefaultCheckbox.AutoCheck = false;
             this.SetAsDefaultCheckbox.Location = new System.Drawing.Point(12, 324);
             this.SetAsDefaultCheckbox.Name = "SetAsDefaultCheckbox";
             this.SetAsDefaultCheckbox.Size = new System.Drawing.Size(91, 17);
             this.SetAsDefaultCheckbox.TabIndex = 4;
             this.SetAsDefaultCheckbox.UseVisualStyleBackColor = true;
+            this.SetAsDefaultCheckbox.Click += new System.EventHandler(this.SetAsDefaultCheckbox_Click);
             resources.ApplyResources(this.SetAsDefaultCheckbox, "SetAsDefaultCheckbox");
             //
             // ForgetButton
@@ -187,6 +205,7 @@
             this.Name = "ManageKspInstances";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
+            this.InstanceListContextMenuStrip.ResumeLayout(false);
             this.AddNewMenu.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -202,6 +221,8 @@
         private System.Windows.Forms.Button SelectButton;
         private DropdownMenuButton AddNewButton;
         private System.Windows.Forms.ContextMenuStrip AddNewMenu;
+        private System.Windows.Forms.ContextMenuStrip InstanceListContextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem openDirectoryMenuItem;
         private System.Windows.Forms.ToolStripMenuItem AddToCKANMenuItem;
         private System.Windows.Forms.ToolStripMenuItem CloneFakeInstanceMenuItem;
         private System.Windows.Forms.Button RenameButton;

--- a/GUI/ManageKspInstances.cs
+++ b/GUI/ManageKspInstances.cs
@@ -39,17 +39,18 @@ namespace CKAN
             {
                 _manager.FindAndRegisterDefaultInstance();
             }
-            
+
             // Set the renderer for the AddNewMenu
             if (Platform.IsMono)
             {
                 this.AddNewMenu.Renderer = new FlatToolStripRenderer();
+                this.InstanceListContextMenuStrip.Renderer = new FlatToolStripRenderer();
             }
 
             UpdateInstancesList();
             UpdateButtonState();
         }
-        
+
         public void UpdateInstancesList()
         {
             KSPInstancesListView.Items.Clear();
@@ -101,8 +102,15 @@ namespace CKAN
 
         private void CloneFakeInstanceMenuItem_Click(object sender, EventArgs e)
         {
-            CloneFakeKspDialog dialog = new CloneFakeKspDialog(_manager);
-            dialog.ShowDialog();
+            var old_instance = Main.Instance.CurrentInstance;
+
+            var result = new CloneFakeKspDialog(_manager).ShowDialog();
+            if (result == DialogResult.OK && !Equals(old_instance, Main.Instance.CurrentInstance))
+            {
+                DialogResult = DialogResult.OK;
+                this.Close();
+            }
+
             UpdateInstancesList();
         }
 
@@ -127,25 +135,52 @@ namespace CKAN
 
             try
             {
-                if (SetAsDefaultCheckbox.Checked)
-                {
-                    _manager.SetAutoStart(instName);
-                }
-
                 _manager.SetCurrentInstance(instName);
                 DialogResult = DialogResult.OK;
                 Close();
             }
             catch (NotKSPDirKraken k)
             {
-                GUI.user.RaiseError(Properties.Resources.ManageKspInstancesNotValid,
-                    new object[] { k.path });
+                GUI.user.RaiseError(Properties.Resources.ManageKspInstancesNotValid, k.path);
+            }
+        }
+
+        private void SetAsDefaultCheckbox_Click(object sender, EventArgs e)
+        {
+            if (SetAsDefaultCheckbox.Checked)
+            {
+                _manager.ClearAutoStart();
+                SetAsDefaultCheckbox.Checked = false;
+                return;
+            }
+
+            var selected = KSPInstancesListView.SelectedItems[0];
+            string instName = selected?.Tag as string;
+            if (instName == null)
+            {
+                return;
+            }
+
+            try
+            {
+                _manager.SetAutoStart(instName);
+                SetAsDefaultCheckbox.Checked = true;
+            }
+            catch (NotKSPDirKraken k)
+            {
+                GUI.user.RaiseError(Properties.Resources.ManageKspInstancesNotValid, k.path);
             }
         }
 
         private void KSPInstancesListView_SelectedIndexChanged(object sender, EventArgs e)
         {
             UpdateButtonState();
+
+            if (KSPInstancesListView.SelectedItems.Count == 0)
+                return;
+
+            string instName = (string)KSPInstancesListView.SelectedItems[0].Tag;
+            SetAsDefaultCheckbox.Checked = _manager.AutoStartInstance?.Equals(instName) ?? false;
         }
 
         private void KSPInstancesListView_DoubleClick(object sender, EventArgs r)
@@ -154,6 +189,27 @@ namespace CKAN
             {
                 UseSelectedInstance();
             }
+        }
+
+        private void KSPInstancesListView_Click(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                InstanceListContextMenuStrip.Show(this, new System.Drawing.Point(e.X, e.Y));
+            }
+        }
+
+        private void OpenDirectoryMenuItem_Click(object sender, EventArgs e)
+        {
+            string path = KSPInstancesListView.SelectedItems[0].SubItems[2].Text;
+
+            if (!Directory.Exists(path))
+            {
+                GUI.user.RaiseError(Properties.Resources.ManageKspInstancesDirectoryDeleted, path);
+                return;
+            }
+
+            System.Diagnostics.Process.Start(path);
         }
 
         private void RenameButton_Click(object sender, EventArgs e)
@@ -181,7 +237,8 @@ namespace CKAN
 
         private void UpdateButtonState()
         {
-            ForgetButton.Enabled = RenameButton.Enabled = SelectButton.Enabled = SetAsDefaultCheckbox.Enabled = HasSelections;
+            RenameButton.Enabled = SelectButton.Enabled = SetAsDefaultCheckbox.Enabled = HasSelections;
+            ForgetButton.Enabled = HasSelections && (string)KSPInstancesListView.SelectedItems[0].Tag != _manager.CurrentInstance.Name;
         }
     }
 }

--- a/GUI/ManageKspInstances.cs
+++ b/GUI/ManageKspInstances.cs
@@ -238,7 +238,7 @@ namespace CKAN
         private void UpdateButtonState()
         {
             RenameButton.Enabled = SelectButton.Enabled = SetAsDefaultCheckbox.Enabled = HasSelections;
-            ForgetButton.Enabled = HasSelections && (string)KSPInstancesListView.SelectedItems[0].Tag != _manager.CurrentInstance.Name;
+            ForgetButton.Enabled = HasSelections && (string)KSPInstancesListView.SelectedItems[0].Tag != _manager.CurrentInstance?.Name;
         }
     }
 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -672,6 +672,10 @@ namespace CKAN.Properties {
             get { return (string)(ResourceManager.GetObject("ManageKspInstancesNotValid", resourceCulture)); }
         }
 
+        internal static string ManageKspInstancesDirectoryDeleted {
+            get { return (string)(ResourceManager.GetObject("ManageKspInstancesDirectoryDeleted", resourceCulture)); }
+        }
+
         internal static string NewRepoDialogFailed {
             get { return (string)(ResourceManager.GetObject("NewRepoDialogFailed", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -287,6 +287,7 @@ Einstellungen jetzt öffnen?</value>
   <data name="MainWaitPleaseWait" xml:space="preserve"><value>Bitte warten</value></data>
   <data name="MainWaitDone" xml:space="preserve"><value>Alles erledigt!</value></data>
   <data name="ManageKspInstancesNotValid" xml:space="preserve"><value>"{0}" ist kein gültiges KSP-Verzeichnis.</value></data>
+  <data name="ManageKspInstancesDirectoryDeleted" xml:space="preserve"><value>Das Verzeichnis "{0}" existiert nicht.</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Die Master-Liste konnte nicht abgerufen werden.</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} Dateien, {1}</value></data>
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Ungültiger Pfad: "{0}"</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -7115,7 +7115,8 @@ Open settings now?</value></data>
   <data name="MainTrayUpdatesAvailable" xml:space="preserve"><value>{0} available update(s)</value></data>
   <data name="MainWaitPleaseWait" xml:space="preserve"><value>Please wait</value></data>
   <data name="MainWaitDone" xml:space="preserve"><value>All done!</value></data>
-  <data name="ManageKspInstancesNotValid" xml:space="preserve"><value>Directory {0} is not valid KSP directory.</value></data>
+  <data name="ManageKspInstancesNotValid" xml:space="preserve"><value>Directory {0} is not a valid KSP directory.</value></data>
+  <data name="ManageKspInstancesDirectoryDeleted" xml:space="preserve"><value>Directory "{0}" doesn't exist.</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Failed to fetch master list.</value></data>
   <data name="PluginsDialogFilter" xml:space="preserve"><value>CKAN Plugins (*.dll)|*.dll</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}</value></data>

--- a/GUI/TabController.cs
+++ b/GUI/TabController.cs
@@ -25,63 +25,27 @@ namespace CKAN
 
         public void ShowTab(string name, int index = 0, bool setActive = true)
         {
-            if (m_TabControl.InvokeRequired)
-            {
-                m_TabControl.Invoke(new MethodInvoker(() => _ShowTab(name, index, setActive)));
-            }
-            else
-            {
-                _ShowTab(name, index, setActive);
-            }
+            Util.Invoke(m_TabControl, () => _ShowTab(name, index, setActive));
         }
 
         public void HideTab(string name)
         {
-            if (m_TabControl.InvokeRequired)
-            {
-                m_TabControl.Invoke(new MethodInvoker(() => _HideTab(name)));
-            }
-            else
-            {
-                _HideTab(name);
-            }
+            Util.Invoke(m_TabControl, () => _HideTab(name));
         }
 
         public void RenameTab(string name, string newDisplayName)
         {
-            if (m_TabControl.InvokeRequired)
-            {
-
-                m_TabControl.Invoke(new MethodInvoker(() => _RenameTab(name, newDisplayName)));
-            }
-            else
-            {
-                _RenameTab(name, newDisplayName);
-            }
+            Util.Invoke(m_TabControl, () => _RenameTab(name, newDisplayName));
         }
 
         public void SetTabLock(bool state)
         {
-            if (m_TabControl.InvokeRequired)
-            {
-                m_TabControl.Invoke(new MethodInvoker(() => _SetTabLock(state)));
-            }
-            else
-            {
-                _SetTabLock(state);
-            }
+            Util.Invoke(m_TabControl, () => _SetTabLock(state));
         }
 
         public void SetActiveTab(string name)
         {
-            if (m_TabControl.InvokeRequired)
-            {
-                m_TabControl.Invoke(new MethodInvoker(() => _SetActiveTab(name)));
-            }
-            else
-            {
-                _SetActiveTab(name);
-            }
+            Util.Invoke(m_TabControl, () => _SetActiveTab(name));
         }
 
         private void _ShowTab(string name, int index = 0, bool setActive = true)


### PR DESCRIPTION
Problem
-----
The current behavior of `ManageKspInstances` is really weird.
* As soon as you open the dialog, the current `AutostartInstance` is reset to null.
* It saves that instance as default/autostart, that is selected when you click the `Select` button, and not the one where you activate the checkbox, against all intuition.
* What this means is that you can never ever select one instance as your default one, but use a different one for now. You'll always end up setting either the wrong one or none at all as autostart.
* As a result the two checkboxes in `CloneFakeKspDialog` don't work at all.

Solution
------
* Don't call `Instance.Manager.ClearAutoStart()` before opening the instance management dialog.
* Update autostart instance on checkbox click, not on button click.
* Update the checkbox (so whether it shows as checked or not) in `KSPInstancesListView_SelectedIndexChanged()`
* Add a right click context menu to the instance list view to open the root directory of the selected instance (I really wanted that for a long time)
* Close the dialog when `CloneFakeKspDialog` exits with `Switch to new instance` checked and switch to the new instance.