### PR TITLE
Fix UK spelling of licence

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -263,6 +263,9 @@
     <EmbeddedResource Include="Localization\de-DE\AboutDialog.de-DE.resx">
       <DependentUpon>..\..\AboutDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Localization\en-US\AboutDialog.en-US.resx">
+      <DependentUpon>..\..\AboutDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="AboutDialog.resx">
       <DependentUpon>AboutDialog.cs</DependentUpon>
     </EmbeddedResource>
@@ -316,6 +319,9 @@
       <DependentUpon>MainModInfo.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Localization\de-DE\MainModInfo.de-DE.resx">
+      <DependentUpon>..\..\MainModInfo.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Localization\en-US\MainModInfo.en-US.resx">
       <DependentUpon>..\..\MainModInfo.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="ManageKSPInstances.resx">

--- a/GUI/Localization/en-US/AboutDialog.en-US.resx
+++ b/GUI/Localization/en-US/AboutDialog.en-US.resx
@@ -118,12 +118,5 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="versionLabel.Text" xml:space="preserve"><value>Version</value></data>
-  <data name="projectNameLabel.Text" xml:space="preserve"><value>CKAN - The Comprehensive Kerbal Archive Network</value></data>
-  <data name="licenseLabel.Text" xml:space="preserve"><value>Licence</value></data>
-  <data name="authorsLabel.Text" xml:space="preserve"><value>Authors</value></data>
-  <data name="sourceLabel.Text" xml:space="preserve"><value>Source</value></data>
-  <data name="forumthreadLabel.Text" xml:space="preserve"><value>Forum Thread</value></data>
-  <data name="homepageLabel.Text" xml:space="preserve"><value>Homepage</value></data>
-  <data name="$this.Text" xml:space="preserve"><value>About</value></data>
+  <data name="licenseLabel.Text" xml:space="preserve"><value>License</value></data>
 </root>

--- a/GUI/Localization/en-US/MainModInfo.en-US.resx
+++ b/GUI/Localization/en-US/MainModInfo.en-US.resx
@@ -117,13 +117,5 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="versionLabel.Text" xml:space="preserve"><value>Version</value></data>
-  <data name="projectNameLabel.Text" xml:space="preserve"><value>CKAN - The Comprehensive Kerbal Archive Network</value></data>
-  <data name="licenseLabel.Text" xml:space="preserve"><value>Licence</value></data>
-  <data name="authorsLabel.Text" xml:space="preserve"><value>Authors</value></data>
-  <data name="sourceLabel.Text" xml:space="preserve"><value>Source</value></data>
-  <data name="forumthreadLabel.Text" xml:space="preserve"><value>Forum Thread</value></data>
-  <data name="homepageLabel.Text" xml:space="preserve"><value>Homepage</value></data>
-  <data name="$this.Text" xml:space="preserve"><value>About</value></data>
+  <data name="LicenseLabel.Text" xml:space="preserve"><value>License:</value></data>
 </root>

--- a/GUI/MainModInfo.resx
+++ b/GUI/MainModInfo.resx
@@ -128,7 +128,7 @@
   <data name="GitHubLabel.Text" xml:space="preserve"><value>Source code:</value></data>
   <data name="HomePageLabel.Text" xml:space="preserve"><value>Home page:</value></data>
   <data name="AuthorLabel.Text" xml:space="preserve"><value>Author:</value></data>
-  <data name="LicenseLabel.Text" xml:space="preserve"><value>License:</value></data>
+  <data name="LicenseLabel.Text" xml:space="preserve"><value>Licence:</value></data>
   <data name="MetadataModuleVersionTextBox.Text" xml:space="preserve"><value>0.0.0</value></data>
   <data name="MetadataModuleLicenseTextBox.Text" xml:space="preserve"><value>None</value></data>
   <data name="MetadataModuleAuthorTextBox.Text" xml:space="preserve"><value>Nobody</value></data>


### PR DESCRIPTION
## Problem

CKAN uses the word "license" as a noun twice in the GUI:

![image](https://user-images.githubusercontent.com/1559108/59969042-4d43a080-950a-11e9-9d3d-5aacc6172b81.png)

![image](https://user-images.githubusercontent.com/1559108/59969043-546aae80-950a-11e9-905a-272562159393.png)

Today I learned that this is a US-ism; [in the UK and Australia, "license" is a verb and "licence" is a noun](https://grammarist.com/spelling/licence-license/).

![image](https://user-images.githubusercontent.com/1559108/59969200-08216d80-950e-11e9-85a7-aa691d3b774f.png)
*Noah Webster urges you to deal with it*

## Changes

Now the default spelling in our `.resx` files is changed to licence, and `.en-US.resx` files are added to override it to license in the en_US locale.

![image](https://user-images.githubusercontent.com/1559108/59969053-89770100-950a-11e9-9d0e-61fb6b4e5f71.png)

![image](https://user-images.githubusercontent.com/1559108/59969055-8bd95b00-950a-11e9-9b09-5ebfc3623866.png)
