### PR TITLE
Add menu option to report issues in the CKAN repo

### DIFF
--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -177,7 +177,8 @@
   <data name="kSPCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>KSP Befehlszeile</value></data>
   <data name="compatibleKSPVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Kompatible KSP-Versionen</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Hilfe</value></data>
-  <data name="reportAnIssueToolStripMenuItem.Text" xml:space="preserve"><value>Fehler melden</value></data>
+  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Fehler mit dem CKAN Client melden</value></data>
+  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Fehler mit Mod-Metadaten melden</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>Über</value></data>
   <data name="launchKSPToolStripMenuItem.Text" xml:space="preserve"><value>KSP starten</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>Aktualisieren</value></data>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -48,7 +48,8 @@
             this.kSPCommandlineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compatibleKSPVersionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.reportAnIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.reportClientIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.reportMetadataIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.menuStrip2 = new System.Windows.Forms.MenuStrip();
@@ -307,18 +308,26 @@
             // helpToolStripMenuItem
             //
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.reportAnIssueToolStripMenuItem,
+            this.reportClientIssueToolStripMenuItem,
+            this.reportMetadataIssueToolStripMenuItem,
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
             resources.ApplyResources(this.helpToolStripMenuItem, "helpToolStripMenuItem");
             //
-            // reportAnIssueToolStripMenuItem
+            // reportClientIssueToolStripMenuItem
             //
-            this.reportAnIssueToolStripMenuItem.Name = "reportAnIssueToolStripMenuItem";
-            this.reportAnIssueToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
-            this.reportAnIssueToolStripMenuItem.Click += new System.EventHandler(this.reportAnIssueToolStripMenuItem_Click);
-            resources.ApplyResources(this.reportAnIssueToolStripMenuItem, "reportAnIssueToolStripMenuItem");
+            this.reportClientIssueToolStripMenuItem.Name = "reportClientIssueToolStripMenuItem";
+            this.reportClientIssueToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.reportClientIssueToolStripMenuItem.Click += new System.EventHandler(this.reportClientIssueToolStripMenuItem_Click);
+            resources.ApplyResources(this.reportClientIssueToolStripMenuItem, "reportClientIssueToolStripMenuItem");
+            //
+            // reportMetadataIssueToolStripMenuItem
+            //
+            this.reportMetadataIssueToolStripMenuItem.Name = "reportMetadataIssueToolStripMenuItem";
+            this.reportMetadataIssueToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.reportMetadataIssueToolStripMenuItem.Click += new System.EventHandler(this.reportMetadataIssueToolStripMenuItem_Click);
+            resources.ApplyResources(this.reportMetadataIssueToolStripMenuItem, "reportMetadataIssueToolStripMenuItem");
             //
             // aboutToolStripMenuItem
             //
@@ -1356,7 +1365,8 @@
         private System.Windows.Forms.ToolStripMenuItem kSPCommandlineToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem compatibleKSPVersionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem reportAnIssueToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem reportClientIssueToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem reportMetadataIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.MenuStrip menuStrip2;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1163,9 +1163,14 @@ namespace CKAN
             }
         }
 
-        private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)
+        private void reportClientIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/KSP-CKAN/NetKAN/issues/new");
+            Process.Start("https://github.com/KSP-CKAN/CKAN/issues/new/choose");
+        }
+
+        private void reportMetadataIssueToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Process.Start("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
         }
 
         private void ModList_MouseDown(object sender, MouseEventArgs e)

--- a/GUI/Main.resx
+++ b/GUI/Main.resx
@@ -179,7 +179,8 @@
   <data name="kSPCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>KSP command-line</value></data>
   <data name="compatibleKSPVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Compatible KSP versions</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Help</value></data>
-  <data name="reportAnIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue...</value></data>
+  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN client</value></data>
+  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod metadata</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>About</value></data>
   <data name="launchKSPToolStripMenuItem.Text" xml:space="preserve"><value>Launch KSP</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>Refresh</value></data>


### PR DESCRIPTION
Problem
---
Currently you can only report issues in the NetKAN repository in the `Help` menu.
If someone wants to report an error with the client, he either does this in the NetKAN repo, which isn't really the place where those issues should be,
or has to find his way over to the CKAN repo, but there's no hint anywhere to do so.

Solution
---
Create a new menu option, and relabel the existing one:
`Report an issue with the CKAN client` and `Report an issue with mod metadata`, where each one leads to the right repository.

Fixes #2801 