### PR TITLE
Ignore locales with no strings

### DIFF
--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -63,6 +63,7 @@ namespace CKAN.NetKAN.Transformers
                     .SelectMany(contents => localizationRegex.Matches(contents).Cast<Match>()
                         .Select(m => m.Groups["contents"].Value))
                     .SelectMany(contents => localeRegex.Matches(contents).Cast<Match>()
+                        .Where(m => m.Groups["contents"].Value.Contains("="))
                         .Select(m => m.Groups["locale"].Value))
                     .Distinct();
                 log.Debug("Locales extracted");
@@ -93,7 +94,7 @@ namespace CKAN.NetKAN.Transformers
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
         private static readonly Regex localeRegex = new Regex(
-            @"^\s*(?<locale>[-a-zA-Z]+).*?{.*?}",
+            @"^\s*(?<locale>[-a-zA-Z]+).*?{(?<contents>.*?)}",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
     }


### PR DESCRIPTION
## Problem

[A few mods do this](https://github.com/TiktaalikDreaming/KOOSE/blob/master/Localization/dictionary.cfg):

```json
	zh-ch
	{}
	ja
	{}
```

Currently we "give them credit" for that by including such locales in their `localizations` property. But if a user installed such a module expecting it to be localized into one of those languages, they'd be rightfully disappointed.

## Changes

Now we make sure there's at least one "=" between the "{" and "}". This will filter out locales that don't set any strings.