### PR TITLE
Refresh builds.json when validating netkans

### DIFF
--- a/Netkan/Validators/MatchesKnownGameVersionsValidator.cs
+++ b/Netkan/Validators/MatchesKnownGameVersionsValidator.cs
@@ -6,14 +6,22 @@ namespace CKAN.NetKAN.Validators
 {
     internal sealed class MatchesKnownGameVersionsValidator : IValidator
     {
+        public MatchesKnownGameVersionsValidator()
+        {
+            buildMap = new KspBuildMap(new Win32Registry());
+        }
+
         public void Validate(Metadata metadata)
         {
             var mod = CkanModule.FromJson(metadata.Json().ToString());
-            var knownVersions = new KspBuildMap(new Win32Registry()).KnownVersions;
-            if (!mod.IsCompatibleKSP(new KspVersionCriteria(null, knownVersions)))
+            // Get latest builds from server
+            buildMap.Refresh();
+            if (!mod.IsCompatibleKSP(new KspVersionCriteria(null, buildMap.KnownVersions)))
             {
                 throw new Kraken($"{metadata.Identifier} doesn't match any valid game version");
             }
         }
+
+        private KspBuildMap buildMap;
     }
 }


### PR DESCRIPTION
## Problem

After #2788, lots of modules report this error:

[![image](https://user-images.githubusercontent.com/1559108/60145436-a110ec80-978b-11e9-8e04-5f312de45292.png)](http://status.ksp-ckan.space/)

## Cause

We use `KspBuildMap` to generate the list of known game versions. This class loads the list of known game version from the Win32Registry. If the list isn't in the registry, then it will try downloading the remote build map from:

- https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/builds.json

In the regular client, a forced refresh call occurs here when updating the registry, via that weird code-obfuscating `Autofac` stuff that some people like for some reason:

https://github.com/KSP-CKAN/CKAN/blob/9d8c3ed13d464ad009904ab607be39c160db4714/Core/Net/Repo.cs#L100-L103

There's currently no equivalent of that call in Netkan, so the bot has a copy of this file saved in its registry from October 2018, which includes KSP 1.4.1 but not 1.5.1. So all modules compatible with 1.4.1 or earlier are working, and the rest are erroring out.

## Changes

Now we refresh the build map before using it, which forces it to download the remote build map. This will ensure that as soon as we add a build to the above file, the bot will know about it.