### PR TITLE
Fix http kref validation

### DIFF
--- a/Netkan/Transformers/HttpTransformer.cs
+++ b/Netkan/Transformers/HttpTransformer.cs
@@ -31,7 +31,7 @@ namespace CKAN.NetKAN.Transformers
 
                     if (resolvedUri != null)
                     {
-                        json["download"] = resolvedUri;
+                        json["download"] = resolvedUri.ToString();
 
                         Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 


### PR DESCRIPTION
## Problem

Currently some modules are failing with this error:

![image](https://user-images.githubusercontent.com/1559108/60198855-381b8a00-9808-11e9-8792-476e55b96930.png)

```
3470 [1] FATAL CKAN.NetKAN.Program (null) - Object must implement IConvertible.
3471 [1] FATAL CKAN.NetKAN.Program (null) -   at System.Convert.ChangeType (System.Object value, System.Type conversionType, System.IFormatProvider provider) <0x7f7b13af7110 + 0x004d1> in <6649516e5b3542319fb262b421af0adb>:0 
  at Newtonsoft.Json.Linq.Extensions.Convert[T,U] (T token) [0x000f7] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at Newtonsoft.Json.Linq.Extensions.Value[T,U] (System.Collections.Generic.IEnumerable`1[T] value) [0x0000b] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at Newtonsoft.Json.Linq.Extensions.Value[U] (System.Collections.Generic.IEnumerable`1[T] value) [0x00000] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at NJsonSchema.Validation.JsonSchemaValidator.ValidateString (Newtonsoft.Json.Linq.JToken token, NJsonSchema.JsonSchema schema, NJsonSchema.JsonObjectType type, System.String propertyName, System.String propertyPath, System.Collections.Generic.List`1[T] errors) [0x00043] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at NJsonSchema.Validation.JsonSchemaValidator.ValidateType (Newtonsoft.Json.Linq.JToken token, NJsonSchema.JsonSchema schema, System.String propertyName, System.String propertyPath, System.Collections.Generic.List`1[T] errors) [0x001b4] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at NJsonSchema.Validation.JsonSchemaValidator.Validate (Newtonsoft.Json.Linq.JToken token, NJsonSchema.JsonSchema schema, System.String propertyName, System.String propertyPath) [0x00036] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at NJsonSchema.Validation.JsonSchemaValidator.ValidateProperties (Newtonsoft.Json.Linq.JToken token, NJsonSchema.JsonSchema schema, System.String propertyName, System.String propertyPath, System.Collections.Generic.List`1[T] errors) [0x00097] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at NJsonSchema.Validation.JsonSchemaValidator.Validate (Newtonsoft.Json.Linq.JToken token, NJsonSchema.JsonSchema schema, System.String propertyName, System.String propertyPath) [0x0004e] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at NJsonSchema.Validation.JsonSchemaValidator.Validate (Newtonsoft.Json.Linq.JToken token, NJsonSchema.JsonSchema schema) [0x0000f] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at NJsonSchema.JsonSchema.Validate (Newtonsoft.Json.Linq.JToken token) [0x0000c] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at CKAN.NetKAN.Validators.ObeysCKANSchemaValidator.Validate (CKAN.NetKAN.Model.Metadata metadata) [0x0001e] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at CKAN.NetKAN.Validators.CkanValidator.Validate (CKAN.NetKAN.Model.Metadata metadata) [0x00019] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at CKAN.NetKAN.Validators.CkanValidator.ValidateCkan (CKAN.NetKAN.Model.Metadata metadata, CKAN.NetKAN.Model.Metadata netkan) [0x00001] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at CKAN.NetKAN.Processors.Inflator.Inflate (System.String filename, CKAN.NetKAN.Model.Metadata netkan, System.Nullable`1[T] releases) [0x000bf] in <840a99bb54b8423b94f0716f18cfa664>:0 
  at CKAN.NetKAN.Program.Main (System.String[] args) [0x00150] in <840a99bb54b8423b94f0716f18cfa664>:0 
```


## Cause

Looking for commonalities among HyperEdit, Graphotron, and Kethane, they are 3 of the 5 `$kref`s using `#/ckan/http/` (SurveyTransponder and TalisarParts being the others, each last checked by the bot 21 hours ago). `HttpTransformer` is assigning a `Uri` object into the `JToken` structure:

https://github.com/KSP-CKAN/CKAN/blob/1ac6261f0f81a07213c91c967c444ed451324990/Netkan/Transformers/HttpTransformer.cs#L28-L34

https://github.com/KSP-CKAN/CKAN/blob/1ac6261f0f81a07213c91c967c444ed451324990/Core/Net/Net.cs#L263

When NJsonSchema and Newtonsoft try to validate that `Uri` object where they are expecting a string, they fail.

## Changes

Now we convert the `Uri` to a string before storing it in the `JToken` structure, which allows it to validate.