### PR TITLE
Use embedded buildmap in Netkan

### DIFF
--- a/Core/GameVersionProviders/IKspBuildMap.cs
+++ b/Core/GameVersionProviders/IKspBuildMap.cs
@@ -3,12 +3,19 @@ using System.Collections.Generic;
 
 namespace CKAN.GameVersionProviders
 {
+    public enum BuildMapSource
+    {
+        Embedded,
+        Remote,
+        Cache,
+    };
+
     public interface IKspBuildMap
     {
         KspVersion this[string buildId] { get; }
 
         List<KspVersion> KnownVersions { get; }
 
-        void Refresh();
+        void Refresh(BuildMapSource source = BuildMapSource.Remote);
     }
 }

--- a/Netkan/Validators/MatchesKnownGameVersionsValidator.cs
+++ b/Netkan/Validators/MatchesKnownGameVersionsValidator.cs
@@ -9,13 +9,12 @@ namespace CKAN.NetKAN.Validators
         public MatchesKnownGameVersionsValidator()
         {
             buildMap = new KspBuildMap(new Win32Registry());
+            buildMap.Refresh(BuildMapSource.Embedded);
         }
 
         public void Validate(Metadata metadata)
         {
             var mod = CkanModule.FromJson(metadata.Json().ToString());
-            // Get latest builds from server
-            buildMap.Refresh();
             if (!mod.IsCompatibleKSP(new KspVersionCriteria(null, buildMap.KnownVersions)))
             {
                 throw new Kraken($"{metadata.Identifier} doesn't match any valid game version");


### PR DESCRIPTION
## Problem

As of #2808, we now load the remote build map every time netkan.exe runs in order to validate that generated metadata matches at least one known game version. This means that per bot pass, we download https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/builds.json 1800 times. This is much more frequent than necessary considering that weeks or months typically pass between KSP versions.

## Changes

Now `KspBuildMap` is rearranged to allow client code to choose the Remote, Cached, or Embedded build map. The default is the same as before: load Cached with Remote and then Embedded as fallbacks if nothing special is done, otherwise load Remote with Cached and then Embedded as fallbacks if `Refresh` is called. However, now there's also the option to **only** load the Embedded build map, which is used in the Netkan game version validator. This will reduce network usage by the bot.

Fixes #2809.