### PR TITLE
Open ZIP button, instance name in status bar, description scroll bar

### DIFF
--- a/GUI/Localization/de-DE/MainModInfo.de-DE.resx
+++ b/GUI/Localization/de-DE/MainModInfo.de-DE.resx
@@ -137,6 +137,7 @@
   <data name="LegendConflictsLabel.Text" xml:space="preserve"><value>Konflikt</value></data>
   <data name="ContentTabPage.Text" xml:space="preserve"><value>Inhalt</value></data>
   <data name="ContentsDownloadButton.Text" xml:space="preserve"><value>Herunterladen</value></data>
+  <data name="ContentsOpenButton.Text" xml:space="preserve"><value>ZIP öffnen</value></data>
   <data name="NotCachedLabel.Text" xml:space="preserve"><value>Diese Mod ist nicht im Cache, klicke 'Herunterladen' für eine Inhaltsvorschau</value></data>
   <data name="AllModVersionsTabPage.Text" xml:space="preserve"><value>Versionen</value></data>
 </root>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -91,6 +91,7 @@
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ModInfoTabControl = new CKAN.MainModInfo();
             this.StatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.StatusInstanceLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.StatusProgress = new System.Windows.Forms.ToolStripProgressBar();
             this.MainTabControl = new CKAN.MainTabControl();
             this.ManageModsTabPage = new System.Windows.Forms.TabPage();
@@ -345,7 +346,9 @@
             this.statusStrip1.TabIndex = 1;
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[]
             {
-                this.StatusLabel, this.StatusProgress
+                this.StatusLabel,
+                this.StatusInstanceLabel,
+                this.StatusProgress,
             });
             //
             // menuStrip2
@@ -719,12 +722,23 @@
             //
             // StatusLabel
             //
+            this.StatusLabel.AutoSize = true;
             this.StatusLabel.Name = "StatusLabel";
             this.StatusLabel.Font = System.Drawing.SystemFonts.DefaultFont;
             this.StatusLabel.Size = new System.Drawing.Size(1050, 29);
             this.StatusLabel.Spring = true;
             this.StatusLabel.Text = "";
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            //
+            // StatusInstanceLabel
+            //
+            this.StatusInstanceLabel.AutoSize = true;
+            this.StatusInstanceLabel.Name = "StatusInstanceLabel";
+            this.StatusInstanceLabel.Font = System.Drawing.SystemFonts.DefaultFont;
+            this.StatusInstanceLabel.Size = new System.Drawing.Size(1050, 29);
+            this.StatusInstanceLabel.Spring = true;
+            this.StatusInstanceLabel.Text = "";
+            this.StatusInstanceLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             //
             // StatusProgress
             //
@@ -1408,6 +1422,7 @@
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
         private CKAN.MainModInfo ModInfoTabControl;
         private System.Windows.Forms.ToolStripStatusLabel StatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel StatusInstanceLabel;
         private System.Windows.Forms.ToolStripProgressBar StatusProgress;
         private CKAN.MainTabControl MainTabControl;
         private System.Windows.Forms.TabPage ManageModsTabPage;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -535,6 +535,11 @@ namespace CKAN
             Util.Invoke(this, () =>
             {
                 Text = $"CKAN {Meta.GetVersion()} - KSP {CurrentInstance.Version()}    --    {CurrentInstance.GameDir()}";
+                StatusInstanceLabel.Text = string.Format(
+                    Properties.Resources.StatusInstanceLabelText,
+                    CurrentInstance.Name,
+                    CurrentInstance.Version()?.ToString()
+                );
             });
 
             configuration = Configuration.LoadOrCreateConfiguration(

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -71,6 +71,7 @@
             this.ContentTabPage = new System.Windows.Forms.TabPage();
             this.ContentsPreviewTree = new System.Windows.Forms.TreeView();
             this.ContentsDownloadButton = new System.Windows.Forms.Button();
+            this.ContentsOpenButton = new System.Windows.Forms.Button();
             this.NotCachedLabel = new System.Windows.Forms.Label();
             this.AllModVersionsTabPage = new System.Windows.Forms.TabPage();
             this.AllModVersions = new CKAN.MainAllModVersions();
@@ -148,8 +149,8 @@
             this.MetaDataUpperLayoutPanel.Name = "MetaDataUpperLayoutPanel";
             this.MetaDataUpperLayoutPanel.RowCount = 3;
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize, 20F));
-            this.MetaDataUpperLayoutPanel.RowStyles.Add (new System.Windows.Forms.RowStyle (System.Windows.Forms.SizeType.AutoSize, 30F));
-            this.MetaDataUpperLayoutPanel.RowStyles.Add (new System.Windows.Forms.RowStyle (System.Windows.Forms.SizeType.AutoSize, 80F));
+            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize, 30F));
+            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 80F));
             this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(346, 283);
             this.MetaDataUpperLayoutPanel.TabIndex = 0;
             //
@@ -182,9 +183,9 @@
             // MetadataModuleDescriptionTextBox
             //
             this.MetadataModuleDescriptionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleDescriptionTextBox.Location = new System.Drawing.Point (3, 129);
+            this.MetadataModuleDescriptionTextBox.Location = new System.Drawing.Point(3, 129);
             this.MetadataModuleDescriptionTextBox.Name = "MetadataModuleDescriptionLabel";
-            this.MetadataModuleDescriptionTextBox.Size = new System.Drawing.Size (340, 121);
+            this.MetadataModuleDescriptionTextBox.Size = new System.Drawing.Size(340, 121);
             this.MetadataModuleDescriptionTextBox.TabIndex = 28;
             this.MetadataModuleDescriptionTextBox.Text = "";
             this.MetadataModuleDescriptionTextBox.ReadOnly = true;
@@ -576,6 +577,7 @@
             //
             this.ContentTabPage.Controls.Add(this.ContentsPreviewTree);
             this.ContentTabPage.Controls.Add(this.ContentsDownloadButton);
+            this.ContentTabPage.Controls.Add(this.ContentsOpenButton);
             this.ContentTabPage.Controls.Add(this.NotCachedLabel);
             this.ContentTabPage.Location = new System.Drawing.Point(4, 25);
             this.ContentTabPage.Name = "ContentTabPage";
@@ -607,6 +609,16 @@
             this.ContentsDownloadButton.UseVisualStyleBackColor = true;
             this.ContentsDownloadButton.Click += new System.EventHandler(this.ContentsDownloadButton_Click);
             resources.ApplyResources(this.ContentsDownloadButton, "ContentsDownloadButton");
+            //
+            // ContentsOpenButton
+            //
+            this.ContentsOpenButton.Location = new System.Drawing.Point(115, 36);
+            this.ContentsOpenButton.Name = "ContentsOpenButton";
+            this.ContentsOpenButton.Size = new System.Drawing.Size(103, 23);
+            this.ContentsOpenButton.TabIndex = 1;
+            this.ContentsOpenButton.UseVisualStyleBackColor = true;
+            this.ContentsOpenButton.Click += new System.EventHandler(this.ContentsOpenButton_Click);
+            resources.ApplyResources(this.ContentsOpenButton, "ContentsOpenButton");
             //
             // NotCachedLabel
             //
@@ -707,6 +719,7 @@
         private System.Windows.Forms.TabPage ContentTabPage;
         private System.Windows.Forms.TreeView ContentsPreviewTree;
         private System.Windows.Forms.Button ContentsDownloadButton;
+        private System.Windows.Forms.Button ContentsOpenButton;
         private System.Windows.Forms.Label NotCachedLabel;
         private System.Windows.Forms.TabPage AllModVersionsTabPage;
         private MainAllModVersions AllModVersions;

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -122,6 +122,11 @@ namespace CKAN
             m_CacheWorker.RunWorkerAsync(module.ToCkanModule());
         }
 
+        private void ContentsOpenButton_Click(object sender, EventArgs e)
+        {
+            Process.Start(manager.Cache.GetCachedFilename(SelectedModule));
+        }
+
         private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Util.HandleLinkClicked((sender as LinkLabel).Text, e);
@@ -136,7 +141,14 @@ namespace CKAN
             Util.Invoke(MetadataModuleLicenseTextBox, () => MetadataModuleLicenseTextBox.Text = string.Join(", ", module.license));
             Util.Invoke(MetadataModuleAuthorTextBox, () => MetadataModuleAuthorTextBox.Text = gui_module.Authors);
             Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = gui_module.Abstract);
-            Util.Invoke(MetadataModuleDescriptionTextBox, () => MetadataModuleDescriptionTextBox.Text = gui_module.Description);
+            Util.Invoke(MetadataModuleDescriptionTextBox, () =>
+            {
+                MetadataModuleDescriptionTextBox.Text = gui_module.Description;
+                MetadataModuleDescriptionTextBox.ScrollBars =
+                    string.IsNullOrWhiteSpace(gui_module.Description)
+                        ? ScrollBars.None
+                        : ScrollBars.Vertical;
+            });
             Util.Invoke(MetadataIdentifierTextBox, () => MetadataIdentifierTextBox.Text = gui_module.Identifier);
 
             // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
@@ -416,12 +428,14 @@ namespace CKAN
             {
                 NotCachedLabel.Text = Properties.Resources.MainModInfoNotCached;
                 ContentsDownloadButton.Enabled = true;
+                ContentsOpenButton.Enabled = false;
                 ContentsPreviewTree.Enabled = false;
             }
             else
             {
                 NotCachedLabel.Text = Properties.Resources.MainModInfoCached;
                 ContentsDownloadButton.Enabled = false;
+                ContentsOpenButton.Enabled = true;
                 ContentsPreviewTree.Enabled = true;
             }
 

--- a/GUI/MainModInfo.resx
+++ b/GUI/MainModInfo.resx
@@ -143,6 +143,7 @@
   <data name="LegendConflictsLabel.Text" xml:space="preserve"><value>Conflicts</value></data>
   <data name="ContentTabPage.Text" xml:space="preserve"><value>Contents</value></data>
   <data name="ContentsDownloadButton.Text" xml:space="preserve"><value>Download</value></data>
+  <data name="ContentsOpenButton.Text" xml:space="preserve"><value>Open ZIP</value></data>
   <data name="NotCachedLabel.Text" xml:space="preserve"><value>This mod is not in the cache, click 'Download' to preview contents</value></data>
   <data name="AllModVersionsTabPage.Text" xml:space="preserve"><value>Versions</value></data>
 </root>

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -728,5 +728,9 @@ namespace CKAN.Properties {
         internal static string UtilCopyLink {
             get { return (string)(ResourceManager.GetObject("UtilCopyLink", resourceCulture)); }
         }
+
+        internal static string StatusInstanceLabelText {
+            get { return (string)(ResourceManager.GetObject("StatusInstanceLabelText", resourceCulture)); }
+        }
    }
 }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -307,4 +307,5 @@ Möchtest du CKAN dies erlauben?
 Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   </data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Linkadresse kopieren</value></data>
+  <data name="StatusInstanceLabelText" xml:space="preserve"><value>Spielinstanz: {0} (KSP {1})</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -7133,4 +7133,5 @@ Can't update automatically, because ckan.exe is read-only or we are not allowed 
   <data name="URLHandlersPrompt" xml:space="preserve"><value>CKAN requires permission to add a handler for ckan:// URLs.
 Do you want to allow CKAN to do this? If you click no you won't see this message again.</value></data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Copy link address</value></data>
+  <data name="StatusInstanceLabelText" xml:space="preserve"><value>Game instance: {0} (KSP {1})</value></data>
 </root>


### PR DESCRIPTION
This pull request satisfies three minor GUI requests that came in recently.

## Description scroll bar

Now if a module has a description (most don't), it will have a vertical scroll bar in case it's longer than the available space:

![image](https://user-images.githubusercontent.com/1559108/60219195-39b07680-9837-11e9-9708-badf85976d73.png)

![image](https://user-images.githubusercontent.com/1559108/60219200-3cab6700-9837-11e9-8ff7-fa488dbcee39.png)

Fixes #2795.

## Instance name in status bar

Now the status bar will show the game instance name and version:

![image](https://user-images.githubusercontent.com/1559108/60219235-5a78cc00-9837-11e9-8039-97c1da59f357.png)

German translation: Spielinstanz: whatever (KSP whatever)

Fixes #2807.

## Open ZIP button on Contents tab of mod info

Now the Download button has an Open ZIP button next to it:

![image](https://user-images.githubusercontent.com/1559108/60219252-6b294200-9837-11e9-93e1-48dc20a0dbd8.png)

It becomes enabled when the module is cached:

![image](https://user-images.githubusercontent.com/1559108/60219279-7e3c1200-9837-11e9-9090-77da443fc797.png)

Clicking it opens the ZIP file from the cache in your OS's archive browser (in this screenshot, whatever GNOME Shell uses):

![image](https://user-images.githubusercontent.com/1559108/60219290-85632000-9837-11e9-8cd1-f952aff1426f.png)

German translation: ZIP öffnen

Fixes #2800.