### PR TITLE
Fix Netkan schema resource name on Windows

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -159,7 +159,9 @@
     <Compile Include="Validators\VersionStrictValidator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="../CKAN.schema" />
+    <EmbeddedResource Include="../CKAN.schema">
+      <LogicalName>CKAN.NetKAN.CKAN.schema</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
The embedded schema is given a weird name when compiling on Windows:

![image](https://user-images.githubusercontent.com/1559108/60318633-53e77300-9963-11e9-8081-a1f336e64a86.png)

This makes `netkan.exe` fail to run.

Now we set the `LogicalName` to be what it already is on Mono, `CKAN.NetKAN.CKAN.schema`.