### PR TITLE
Fix Netkan localization parser performance

### DIFF
--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Collections.Generic;
 using log4net;
 using CKAN.NetKAN.Model;
@@ -38,10 +39,9 @@ namespace CKAN.NetKAN.Processors
                 netkanValidator.ValidateNetkan(netkan, filename);
                 log.Info("Input successfully passed pre-validation");
 
-                IEnumerable<Metadata> ckans = transformer.Transform(
-                    netkan,
-                    new TransformOptions(releases)
-                );
+                IEnumerable<Metadata> ckans = transformer
+                    .Transform(netkan, new TransformOptions(releases))
+                    .ToList();
                 log.Info("Finished transformation");
 
                 foreach (Metadata ckan in ckans)
@@ -51,7 +51,7 @@ namespace CKAN.NetKAN.Processors
                 log.Info("Output successfully passed post-validation");
                 return ckans;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // Purge anything we download for a failed indexing attempt from the cache to allow re-downloads
                 PurgeDownloads(http, cache);
@@ -70,7 +70,7 @@ namespace CKAN.NetKAN.Processors
             try
             {
                 log.InfoFormat("Using main CKAN meta-cache at {0}", reg.DownloadCacheDir);
-                /// Create a new file cache in the same location so NetKAN can download pure URLs not sourced from CkanModules
+                // Create a new file cache in the same location so NetKAN can download pure URLs not sourced from CkanModules
                 return new NetFileCache(kspManager, reg.DownloadCacheDir);
             }
             catch

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -90,7 +90,7 @@ namespace CKAN.NetKAN.Transformers
         private static readonly ILog log = LogManager.GetLogger(typeof(LocalizationsTransformer));
 
         private static readonly Regex localizationRegex = new Regex(
-            @"^\s*Localization\b.*?{(?<contents>.*?([-a-zA-Z]+.*?{.*?}.*?)*?)}",
+            @"^\s*Localization\b\s*{(?<contents>([^{}]*{[^{}]*})+[^{}]*)}",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
         private static readonly Regex localeRegex = new Regex(

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -90,7 +90,7 @@ namespace CKAN.NetKAN.Transformers
         private static readonly ILog log = LogManager.GetLogger(typeof(LocalizationsTransformer));
 
         private static readonly Regex localizationRegex = new Regex(
-            @"^\s*Localization\b\s*{(?<contents>([^{}]*{[^{}]*})+[^{}]*)}",
+            @"^\s*Localization\b\s*{(?<contents>[^{}]+({[^{}]*}[^{}]*)+)}",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
         private static readonly Regex localeRegex = new Regex(


### PR DESCRIPTION
## Problem

This netkan hangs for a long time, maybe indefinitely:

```bash
mono netkan.exe NetKAN/PolishTranslation.netkan
```

This is inhibiting the functioning of the bot.

## Cause

I think we're experiencing [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html). The regex for parsing a `Localization` block has several instances of the same character potentially being matchable by multiple consecutive pieces of the regex.

A `{` could match the first or second part of this:

```
.*?{
```

A letter could match the first or second part of this:

```
.*?([-a-zA-Z]+
```

And so on. This results in a lot of retries when it reaches the end of the string without a match. In the case of PolishTranslation, I think the issue is simply that its `Localization` blocks are very, very long, so the inherent performance problems of this regex are multiplied.

## Changes

Now the regex for `Localization` is rewritten to be more specific in terms of what's expected. It must start with Localization followed by optional whitespace and an open curly brace. Then some non-brace characters followed by one or more sequences of an open curly brace followed by non-brace characters followed by a close curly brace and any number of non-brace characters. Finally the final close brace. This regex no longer cares about the locale names; it leaves that to the `localeRegex`. This makes it much simpler to determine whether a cfg file's contents match what we're looking for, thus preventing backtracking.

Netkan is now able to inflate PolishTranslation quickly, and other netkans that were the subject of previous fixes are still working.

Fixes #2814.