### PR TITLE
Fix comparison of 1.0.0 to 1.0

### DIFF
--- a/Core/Types/GameComparator/StrictGameComparator.cs
+++ b/Core/Types/GameComparator/StrictGameComparator.cs
@@ -1,5 +1,6 @@
-﻿using CKAN.Versioning;
 using System;
+using log4net;
+using CKAN.Versioning;
 
 namespace CKAN
 {
@@ -23,15 +24,16 @@ namespace CKAN
             {
                 if (module.ksp_version_min != null && module.ksp_version_max != null)
                 {
-                    if (module.ksp_version_min <= module.ksp_version_max)
+                    var minRange = module.ksp_version_min.ToVersionRange();
+                    var maxRange = module.ksp_version_max.ToVersionRange();
+                    if (minRange.Lower.Value <= maxRange.Upper.Value)
                     {
-                        var minRange = module.ksp_version_min.ToVersionRange();
-                        var maxRange = module.ksp_version_max.ToVersionRange();
-
                         moduleRange = new KspVersionRange(minRange.Lower, maxRange.Upper);
                     }
                     else
                     {
+                        log.WarnFormat("{0} is not less or equal to {1}",
+                            module.ksp_version_min, module.ksp_version_max);
                         return false;
                     }
                 }
@@ -55,5 +57,7 @@ namespace CKAN
 
             return gameVersionRange.IntersectWith(moduleRange) != null;
         }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(StrictGameComparator));
     }
 }

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -159,7 +159,7 @@ namespace CKAN.NetKAN.Transformers
                 if (kspMin != null && kspMax != null)
                 {
                     // If we have both a minimum and maximum KSP version...
-                    if (kspMin.CompareTo(kspMax) == 0)
+                    if (kspMin.Equals(kspMax))
                     {
                         // ...and they are equal, then just set ksp_version
                         json["ksp_version"] = kspMin.ToString();


### PR DESCRIPTION
## Problem

The bot says Protractor doesn't match any game versions:

![image](https://user-images.githubusercontent.com/1559108/60369023-e0d11180-99e1-11e9-9694-fbe1cbc29ab8.png)

## Cause

This module has an interesting .version file:

```json
  "KSP_VERSION": {
    "MAJOR": 1,
    "MINOR": 0,
    "PATCH": 2
  },
  "KSP_VERSION_MIN": {
    "MAJOR": 1,
    "MINOR": 0,
    "PATCH": 0
  },
  "KSP_VERSION_MAX": {
    "MAJOR": 1,
    "MINOR": 0,
    "PATCH": -1
  }
```

That `-1` is supposed to mean unbounded, so all 1.0 versions are included.

[Netkan translates this into](https://github.com/KSP-CKAN/CKAN-meta/blob/aacf14a51a603764ddc2cfa4a90db1be7df81fbf/Protractor/Protractor-v2.5.1.ckan#L13-L14):

```json
    "ksp_version_min": "1.0.0",
    "ksp_version_max": "1.0",
```

Internally, CKAN models an undefined value as `-1`, and then blindly compares it to defined values here:

https://github.com/KSP-CKAN/CKAN/blob/cfa28939d68fc983bc77b1e2bfbbd5cf71590684/Core/Versioning/KspVersion.cs#L736-L756

Since -1 is less than 0, the range between 1.0.0 and 1.0 is incorrectly determined to be empty here:

https://github.com/KSP-CKAN/CKAN/blob/cfa28939d68fc983bc77b1e2bfbbd5cf71590684/Core/Types/GameComparator/StrictGameComparator.cs#L26-L36

And no game versions are permitted to match, even though some of them are greater or equal to 1.0.0 and less than or equal to 1.0.

## Changes

Now the `min <= max` check uses `KspVersionRange` to determine whether it's looking at a non-empty interval rather than simply comparing the `KspVersion` objects, since the latter operation cannot return meaningful, unambiguous values for less-or-equal. This will allow such modules to match their game versions properly.

## Considered and not done

We could have changed how version comparisons work when one has an undefined patch, but this would break many many tests, so I looked for another way.