### PR TITLE
Support newlines in GUI description field

### DIFF
--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -143,7 +143,8 @@ namespace CKAN
             Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = gui_module.Abstract);
             Util.Invoke(MetadataModuleDescriptionTextBox, () =>
             {
-                MetadataModuleDescriptionTextBox.Text = gui_module.Description;
+                MetadataModuleDescriptionTextBox.Text = gui_module.Description
+                    ?.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
                 MetadataModuleDescriptionTextBox.ScrollBars =
                     string.IsNullOrWhiteSpace(gui_module.Description)
                         ? ScrollBars.None


### PR DESCRIPTION
## Problem

It was noted in #2796 that line breaks in module descriptions work on Mono but not Windows:

![image](https://user-images.githubusercontent.com/1559108/60372734-29da9300-99ed-11e9-9354-af90573f06fb.png)

## Cause

Mono uses "\n" to split lines because it runs on Unix.
Windows uses "\r\n" to split lines because CP/M did in 1974.
The `TextBox` implementations carry this difference through to 2019.

## Changes

Now we will replace both `\r\n` and `\n` with `Environment.Newline`, which contains the string used by the current platform to break lines. This way authors may include either `\r\n` or `\n` in descriptions and it will always display correctly.

![image](https://user-images.githubusercontent.com/1559108/60372715-13343c00-99ed-11e9-9464-a43ba3499145.png)

Note that this is not a fix for #2796 because that issue also requests bold and italic.