### PR TITLE
Netkan option to validate .ckan file

### DIFF
--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -40,6 +40,9 @@ namespace CKAN.NetKAN
         [Option("queues", HelpText = "Input,Output queue names for Queue Inflator mode")]
         public string Queues { get; set; }
 
+        [Option("validate-ckan", HelpText = "Name of .ckan file to check for errors")]
+        public string ValidateCkan { get; set; }
+
         [Option("version", HelpText = "Display the netkan version number and exit")]
         public bool Version { get; set; }
 

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -58,6 +58,12 @@ namespace CKAN.NetKAN.Processors
                 throw;
             }
         }
+        
+        internal void ValidateCkan(Metadata ckan)
+        {
+            netkanValidator.Validate(ckan);
+            ckanValidator.Validate(ckan);
+        }
 
         private static NetFileCache FindCache(KSPManager kspManager, IWin32Registry reg, string cacheDir)
         {

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -173,7 +173,7 @@ namespace CKAN.NetKAN.Processors
             }
         }
 
-        private string serializeCkan(Metadata ckan)
+        internal static string serializeCkan(Metadata ckan)
         {
             if (ckan == null)
             {

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -30,10 +30,6 @@ namespace CKAN.NetKAN
 
         public static int Main(string[] args)
         {
-            // Keep these for purging downloads in the exception handler
-            NetFileCache cache = null;
-            IHttpService http  = null;
-
             try
             {
                 ProcessArgs(args);
@@ -47,6 +43,22 @@ namespace CKAN.NetKAN
                 if (Options.Version)
                 {
                     Console.WriteLine(Meta.GetVersion(VersionFormat.Full));
+                    return ExitOk;
+                }
+
+                if (!string.IsNullOrEmpty(Options.ValidateCkan))
+                {
+                    var ckan = new Metadata(JObject.Parse(File.ReadAllText(Options.ValidateCkan)));
+                    var inf = new Inflator(
+                        Options.CacheDir,
+                        Options.OverwriteCache,
+                        Options.GitHubToken,
+                        Options.PreRelease
+                    );
+                    inf.ValidateCkan(ckan);
+                    Console.WriteLine(QueueHandler.serializeCkan(
+                        new PropertySortTransformer().Transform(ckan, null).First()
+                    ));
                     return ExitOk;
                 }
 


### PR DESCRIPTION
## Motivation

https://github.com/KSP-CKAN/xKAN-meta_testing/pull/51#issuecomment-506614403

> Also, in theory NetKAN can consume a CKAN and output a validated CKAN. Maybe md5 before/after and we can catch when a CKAN is handcrafted (which we never want to do).

This would help to unify our pull request validation logic, as the CKAN-meta script could use `netkan.exe` for validation just as the NetKAN script does.

## Changes

Now a new command format is supported:

```bash
mono netkan.exe --validate-ckan Astrogator/Astrogator-v0.9.2.ckan
```

This will load the indicated .ckan file and run Netkan's standard validators on it (see #2788). If there are any problems, the usual error will be printed and the process will exit with a failure code.

If the .ckan file is valid, it will be printed with standard pretty formatting and property sorting, as if it had just been generated by `netkan.exe`, and the process will exit with a success code.