### PR TITLE
Queue module version changes in change set

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -150,6 +150,7 @@ namespace CKAN
                 tabController.HideTab("ChangesetTabPage");
                 ApplyToolButton.Enabled = false;
                 auditRecommendationsMenuItem.Enabled = true;
+                InstallAllCheckbox.Checked = true;
             }
         }
 
@@ -483,7 +484,7 @@ namespace CKAN
             {
                 // Ask if they want to discard the change set
                 string changeDescrip = ChangeSet
-                    .GroupBy(ch => ch.ChangeType, ch => ch.Mod.Name)
+                    .GroupBy(ch => ch.ChangeType, ch => ch.Mod.name)
                     .Select(grp => $"{grp.Key}: "
                         + grp.Aggregate((a, b) => $"{a}, {b}"))
                     .Aggregate((a, b) => $"{a}\r\n{b}");
@@ -595,7 +596,7 @@ namespace CKAN
                 var mod = (GUIMod)row.Tag;
                 if (mod.HasUpdate)
                 {
-                    MarkModForUpdate(mod.Identifier);
+                    MarkModForUpdate(mod.Identifier, true);
                 }
             }
 
@@ -713,7 +714,7 @@ namespace CKAN
             filterTimer.Stop();
         }
 
-        private async Task UpdateChangeSetAndConflicts(IRegistryQuerier registry)
+        public async Task UpdateChangeSetAndConflicts(IRegistryQuerier registry)
         {
             IEnumerable<ModChange> full_change_set = null;
             Dictionary<GUIMod, string> new_conflicts = null;
@@ -1230,7 +1231,7 @@ namespace CKAN
             // Build the list of changes, first the mod to remove:
             List<ModChange> toReinstall = new List<ModChange>()
             {
-                new ModChange(module, GUIModChangeType.Remove, null)
+                new ModChange(module.ToModule(), GUIModChangeType.Remove, null)
             };
             // Then everything we need to re-install:
             var revdep = registry.FindReverseDependencies(new List<string>() { module.Identifier });
@@ -1242,7 +1243,7 @@ namespace CKAN
             foreach (string id in goners)
             {
                 toReinstall.Add(new ModChange(
-                    mainModList.full_list_of_mod_rows[id]?.Tag as GUIMod,
+                    (mainModList.full_list_of_mod_rows[id]?.Tag as GUIMod).ToModule(),
                     GUIModChangeType.Install,
                     null
                 ));

--- a/GUI/MainAllModVersions.Designer.cs
+++ b/GUI/MainAllModVersions.Designer.cs
@@ -57,7 +57,7 @@
             //
             // ModVersion
             //
-            this.ModVersion.Width = 73;
+            this.ModVersion.Width = 98;
             resources.ApplyResources(this.ModVersion, "ModVersion");
             //
             // CompatibleKSPVersion
@@ -73,6 +73,7 @@
             this.VersionsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.ModVersion,
             this.CompatibleKSPVersion});
+            this.VersionsListView.CheckBoxes = true;
             this.VersionsListView.FullRowSelect = true;
             this.VersionsListView.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
             listViewItem4});
@@ -82,7 +83,7 @@
             this.VersionsListView.TabIndex = 1;
             this.VersionsListView.UseCompatibleStateImageBehavior = false;
             this.VersionsListView.View = System.Windows.Forms.View.Details;
-            this.VersionsListView.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.VersionsListView_DoubleClick);
+            this.VersionsListView.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.VersionsListView_ItemCheck);
             //
             // label2
             //

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -46,7 +46,7 @@ namespace CKAN
                     continue;
                 }
 
-                CkanModule m = change.Mod.ToModule();
+                CkanModule m = change.Mod;
                 ListViewItem item = new ListViewItem()
                 {
                     Text = m.IsMetapackage
@@ -55,7 +55,7 @@ namespace CKAN
                             ? string.Format(Properties.Resources.MainChangesetCached, m.name, m.version)
                             : string.Format(Properties.Resources.MainChangesetHostSize,
                                 m.name, m.version, m.download.Host ?? "", CkanModule.FmtSize(m.download_size)),
-                    Tag  = change.Mod.ToModule()
+                    Tag  = change.Mod
                 };
 
                 var sub_change_type = new ListViewItem.ListViewSubItem {Text = change.ChangeType.ToString()};
@@ -65,7 +65,7 @@ namespace CKAN
 
                 if (change.ChangeType == GUIModChangeType.Update)
                 {
-                    description.Text = String.Format(Properties.Resources.MainChangesetUpdateSelected, change.Mod.LatestVersion);
+                    description.Text = String.Format(Properties.Resources.MainChangesetUpdateSelected, change.Mod.version);
                 }
 
                 if (change.ChangeType == GUIModChangeType.Install && change.Reason is SelectionReason.UserRequested)
@@ -100,7 +100,7 @@ namespace CKAN
         /// So we get for example "ModuleRCSFX" directly after "USI Exploration Pack"
         ///
         /// It is very likely that this is forward-compatible with new ChangeTypes's,
-        /// like a a "reconfigure" changetype, but only the future will tell
+        /// like a "reconfigure" changetype, but only the future will tell
         /// </summary>
         /// <param name="changes">Every leftover ModChange that should be sorted</param>
         /// <param name="parent"></param>
@@ -108,11 +108,11 @@ namespace CKAN
         {
             foreach (ModChange change in changes)
             {
-                bool goDeeper = parent == null || change.Reason.Parent.identifier == parent.Mod.Identifier;
+                bool goDeeper = parent == null || change.Reason.Parent.identifier == parent.Mod.identifier;
 
                 if (goDeeper)
                 {
-                    if (!changeSet.Any(c => c.Mod.Identifier == change.Mod.Identifier))
+                    if (!changeSet.Any(c => c.Mod.identifier == change.Mod.identifier && c.ChangeType != GUIModChangeType.Remove))
                         changeSet.Add(change);
                     CreateSortedModList(changes.Where(c => !(c.Reason is SelectionReason.UserRequested)), change);
                 }

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -34,14 +34,14 @@ namespace CKAN
                 {
                     // Already installed, remove it first
                     userChangeSet.Add(new ModChange(
-                        new GUIMod(installed.Module, registry, CurrentInstance.VersionCriteria()),
+                        installed.Module,
                         GUIModChangeType.Remove,
                         null
                     ));
                 }
                 // Install the selected mod
                 userChangeSet.Add(new ModChange(
-                    new GUIMod(module, registry, CurrentInstance.VersionCriteria()),
+                    module,
                     GUIModChangeType.Install,
                     null
                 ));
@@ -64,7 +64,7 @@ namespace CKAN
             }
             finally
             {
-                changeSet = null;
+                ChangeSet = null;
             }
         }
 
@@ -94,16 +94,16 @@ namespace CKAN
                 switch (change.ChangeType)
                 {
                     case GUIModChangeType.Remove:
-                        toUninstall.Add(change.Mod.Identifier);
+                        toUninstall.Add(change.Mod.identifier);
                         break;
                     case GUIModChangeType.Update:
-                        toUpgrade.Add(change.Mod.Identifier);
+                        toUpgrade.Add(change.Mod.identifier);
                         break;
                     case GUIModChangeType.Install:
-                        toInstall.Add(change.Mod.ToModule());
+                        toInstall.Add(change.Mod);
                         break;
                     case GUIModChangeType.Replace:
-                        ModuleReplacement repl = registry.GetReplacement(change.Mod.ToModule(), CurrentInstance.VersionCriteria());
+                        ModuleReplacement repl = registry.GetReplacement(change.Mod, CurrentInstance.VersionCriteria());
                         if (repl != null)
                         {
                             toUninstall.Add(repl.ToReplace.identifier);
@@ -116,7 +116,7 @@ namespace CKAN
             // Prompt for recommendations and suggestions, if any
             var recRows = getRecSugRows(
                 opts.Key.Where(ch => ch.ChangeType == GUIModChangeType.Install)
-                    .Select(ch => ch.Mod.ToModule()),
+                    .Select(ch => ch.Mod),
                 registry, toInstall
             );
             if (recRows.Any())

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -46,14 +46,14 @@ namespace CKAN
                 }
                 else
                 {
-                    var module = value;
+                    var module = value.ToModule();
                     ModInfoTabControl.Enabled = module != null;
                     if (module == null) return;
 
-                    UpdateModInfo(module);
+                    UpdateModInfo(value);
                     UpdateModDependencyGraph(module);
                     UpdateModContentsTree(module);
-                    AllModVersions.SelectedModule = module;
+                    AllModVersions.SelectedModule = value;
                 }
             }
             get
@@ -124,7 +124,7 @@ namespace CKAN
 
         private void ContentsOpenButton_Click(object sender, EventArgs e)
         {
-            Process.Start(manager.Cache.GetCachedFilename(SelectedModule));
+            Process.Start(manager.Cache.GetCachedFilename(SelectedModule.ToModule()));
         }
 
         private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -314,7 +314,7 @@ namespace CKAN
                 installWorker.RunWorkerAsync(
                     new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                         toInstall.Select(mod => new ModChange(
-                            new GUIMod(mod, registry, versionCriteria),
+                            mod,
                             GUIModChangeType.Install,
                             null
                         )).ToList(),

--- a/GUI/ModChange.cs
+++ b/GUI/ModChange.cs
@@ -16,11 +16,11 @@ namespace CKAN
     /// </summary>
     public class ModChange
     {
-        public GUIMod           Mod        { get; private set; }
+        public CkanModule       Mod        { get; private set; }
         public GUIModChangeType ChangeType { get; private set; }
         public SelectionReason  Reason     { get; private set; }
 
-        public ModChange(GUIMod mod, GUIModChangeType changeType, SelectionReason reason)
+        public ModChange(CkanModule mod, GUIModChangeType changeType, SelectionReason reason)
         {
             Mod        = mod;
             ChangeType = changeType;
@@ -39,7 +39,7 @@ namespace CKAN
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
-            return (obj as ModChange).Mod.Identifier == Mod.Identifier;
+            return (obj as ModChange).Mod.Equals(Mod);
         }
 
         public override int GetHashCode()

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -177,7 +177,9 @@
   <data name="MainPlainText" xml:space="preserve"><value>Klartext (*.txt)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Nicht gefunden.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Möchtest du {0} neu installieren?</value></data>
-  <data name="MainAllModVersionsInstallPrompt" xml:space="preserve"><value>{0} installieren?</value></data>
+  <data name="MainAllModVersionsInstallPrompt" xml:space="preserve"><value>{0} wird von Ihrer aktuellen Spielversion nicht unterstützt und funktioniert möglicherweise überhaupt nicht. Wenn Sie Probleme damit haben, sollten Sie die Betreuer NICHT um Hilfe bitten.
+
+Möchten Sie es wirklich installieren?</value></data>
   <data name="MainAllModVersionsInstallYes" xml:space="preserve"><value>Installieren</value></data>
   <data name="MainAllModVersionsInstallNo" xml:space="preserve"><value>Abbrechen</value></data>
   <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (Metapacket)</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -7006,7 +7006,9 @@
   <data name="MainTSV" xml:space="preserve"><value>Tab-separated values (*.tsv)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Not found.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Do you want to reinstall {0}?</value></data>
-  <data name="MainAllModVersionsInstallPrompt" xml:space="preserve"><value>Install {0}?</value></data>
+  <data name="MainAllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current game version and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
+
+Do you really want to install it?</value></data>
   <data name="MainAllModVersionsInstallYes" xml:space="preserve"><value>Install</value></data>
   <data name="MainAllModVersionsInstallNo" xml:space="preserve"><value>Cancel</value></data>
   <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -137,7 +137,7 @@ namespace Tests.GUI
             {
                 // perform the install of the "other" module - now we need to sort
                 ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
-                    _modList.ComputeUserChangeSet(null).Select(change => change.Mod.ToCkanModule()).ToList(),
+                    _modList.ComputeUserChangeSet(null).Select(change => change.Mod).ToList(),
                     new RelationshipResolverOptions(),
                     new NetAsyncModulesDownloader(_manager.User, _manager.Cache)
                 );


### PR DESCRIPTION
## Background

Originally, each row in the GUI mod list only allowed the user to install one version of the corresponding module: the most recent version compatible with the user's game version. Installing incompatible modules was completely impossible. Change sets could only handle installing the latest compatible version, because `ModChange` holds a reference to `GUIMod`, which represents **all** versions of a module rather than a particular version.

Later, #2364 added a double click option to compatible versions in the mod info version list to install older versions. To get around the version limitations of change sets, it prompted the user for confirmation and then jumped to the progress screen of the installation flow, skipping the change set confirmation and other early steps. In keeping with the previous total impossibility of installing incompatible modules, double clicking incompatible modules had no effect.

## Motivation

Some users have expressed a preference for queuing module version changes along with normal installation/removal, so they can all be applied together. This makes sense (but is challenging to do).

In addition, the limitation to compatible versions is not particularly popular. Users would prefer to be allowed to install incompatible versions.

## Changes

- The double click installation is removed. See below for what replaces it.
- `ModChange` now holds a reference to a `CkanModule` instead of a `GUIMod`, so you can queue up a specific version of a module in the change set rather than just the identifier abstractly or the latest compatible. Updating the calling code for this was trivial, and in most cases an improvement as a `GUIMod` object was being faked up unnecessarily.
- `GUIMod` is no longer implicitly convertible to `CkanModule`, because there are multiple possible choices and you should think about which one you're using.
- `GUIMod` now has a public `SelectedMod` property that tracks which version the user wants to install and helps to drive the change set logic. This must be stored somewhere outside the UI so we can display the right selection if you switch to another row and back.
- `GUIMod.GetRequestedChange` is replaced by `GUIMod.GetRequestedChanges`, which can return multiple values to handle situations when we want to remove and install versions of the same mod. Conveniently this also simplifies how `ComputeUserChangeSet` collates the changes from multiple rows; instead of checking `.HasValue` and then selecting `.Value`, we simply use `.SelectMany` to join all the lists, which are allowed to be empty.
- The Versions list now has checkboxes that represent the value of `GUIMod.SelectedMod`  (and the column is 25px wider to compensate, not shown in old screenshot below): 
  ![image](https://user-images.githubusercontent.com/1559108/60404681-b1193980-9b9a-11e9-9cc2-be4304605e89.png)
  These can be checked and unchecked to choose versions to install, and those choices will appear in the change set. Switching from an older version to the *latest* version triggers the existing functionality for Upgrading (and vice versa).
- If you try to choose an incompatible module, a very scary confirmation warning appears:
  ![image](https://user-images.githubusercontent.com/1559108/60404781-ac08ba00-9b9b-11e9-84c6-0fafa925ff41.png)
  German translation:
  > {0} wird von Ihrer aktuellen Spielversion nicht unterstützt und funktioniert möglicherweise überhaupt nicht. Wenn Sie Probleme damit haben, sollten Sie die Betreuer NICHT um Hilfe bitten.
  > 
  > Möchten Sie es wirklich installieren?
  
  If you click Install, it will allow you to install whatever:
  ![image](https://user-images.githubusercontent.com/1559108/60404802-c8a4f200-9b9b-11e9-9635-3b9aa1e8f1c8.png)
  Hopefully nobody will complain to mod authors if they break their install with this.
  And hopefully users will still report inaccurate metadata rather than bypassing it and forgetting about it.
- The change set can now show removal of one version of a module and installation of another version, for example:
  ![image](https://user-images.githubusercontent.com/1559108/60404926-9ba50f00-9b9c-11e9-93fa-52d8e81136f1.png)

Fixes #2714. Fixes #2715. Fixes #2822.

### Companion fixes

- Upgrading modules now prints more messages, in the style of installation (also affects CmdLine and ConsoleUI):
  ![image](https://user-images.githubusercontent.com/1559108/60404566-96929080-9b99-11e9-9b53-bcb9b7606a4f.png)
- The installation progress bar now counts up to 60% while mods are being installed, because 70%-100% are for post-install bookkeeping. The jump back from 100% to 70% looked weird.
- The install-all checkbox (in the header of the Install column) now re-checks itself whenever your change set becomes empty, for convenience after you use it to uninstall everything.
- `InstallModuleDriver` now clears `ChangeSet` instead of `changeSet` at the end, see https://github.com/KSP-CKAN/CKAN/issues/2276#issuecomment-506990808.