### PR TITLE
Override V to v with x_netkan_force_v

### DIFF
--- a/Netkan/Transformers/ForcedVTransformer.cs
+++ b/Netkan/Transformers/ForcedVTransformer.cs
@@ -33,7 +33,8 @@ namespace CKAN.NetKAN.Transformers
                 if (!version.StartsWith("v"))
                 {
                     Log.InfoFormat("Force-adding 'v' to start of {0}", version);
-                    version = "v" + version;
+                    version = "v"
+                        + (version.StartsWith("V") ? version.Substring(1) : version);
                     json["version"] = version;
                 }
 


### PR DESCRIPTION
## Background

`x_netkan_force_v` prepends a `v` onto a module's version during inflation. This is helpful for when a mod author releases "v1.1" followed by "1.2", which would otherwise mess up CKAN's version sorting.

## Problem

If a mod author freely switches between lowercase 'v' with capital 'V', we end up with almost as bad of a mess:

https://github.com/KSP-CKAN/CKAN-meta/tree/master/xScience

![image](https://user-images.githubusercontent.com/1559108/60407337-e7aa8080-9ba9-11e9-91ba-895eabd8f508.png)

## Changes

Now `x_netkan_force_v` removes a capital 'V' prefix if found. The above becomes `xScience-v5.17.ckan` as intended.