### PR TITLE
Auto-epoch based on queue message attribute

### DIFF
--- a/Core/Versioning/ModuleVersion.cs
+++ b/Core/Versioning/ModuleVersion.cs
@@ -59,6 +59,14 @@ namespace CKAN.Versioning
             _string = version;
         }
 
+        /// <returns>
+        /// New module version with same version as 'this' but with one greater epoch
+        /// </returns>
+        public ModuleVersion IncrementEpoch()
+        {
+            return new ModuleVersion($"{_epoch + 1}:{_version}");
+        }
+
         /// <summary>
         /// Converts the value of the current <see cref="ModuleVersion"/> object to its equivalent
         /// <see cref="String"/> representation.

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Autofac;
 using log4net;
 using CKAN.Configuration;
+using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Transformers;
@@ -30,7 +31,7 @@ namespace CKAN.NetKAN.Processors
             transformer   = new NetkanTransformer(http, fileService, moduleService, githubToken, prerelease);
         }
 
-        internal IEnumerable<Metadata> Inflate(string filename, Metadata netkan, int? releases)
+        internal IEnumerable<Metadata> Inflate(string filename, Metadata netkan, int? releases, ModuleVersion previousHighVer)
         {
             log.DebugFormat("Inflating {0}", filename);
             try
@@ -42,7 +43,7 @@ namespace CKAN.NetKAN.Processors
                 log.Info("Input successfully passed pre-validation");
 
                 IEnumerable<Metadata> ckans = transformer
-                    .Transform(netkan, new TransformOptions(releases))
+                    .Transform(netkan, new TransformOptions(releases, previousHighVer))
                     .ToList();
                 log.Info("Finished transformation");
 

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -31,7 +31,7 @@ namespace CKAN.NetKAN.Processors
             transformer   = new NetkanTransformer(http, fileService, moduleService, githubToken, prerelease);
         }
 
-        internal IEnumerable<Metadata> Inflate(string filename, Metadata netkan, int? releases, ModuleVersion previousHighVer)
+        internal IEnumerable<Metadata> Inflate(string filename, Metadata netkan, TransformOptions opts)
         {
             log.DebugFormat("Inflating {0}", filename);
             try
@@ -43,7 +43,7 @@ namespace CKAN.NetKAN.Processors
                 log.Info("Input successfully passed pre-validation");
 
                 IEnumerable<Metadata> ckans = transformer
-                    .Transform(netkan, new TransformOptions(releases, previousHighVer))
+                    .Transform(netkan, opts)
                     .ToList();
                 log.Info("Finished transformation");
 

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -9,6 +9,7 @@ using Amazon.SQS.Model;
 using log4net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Processors
@@ -103,13 +104,20 @@ namespace CKAN.NetKAN.Processors
                 releases = int.Parse(releasesAttr.StringValue);
             }
 
+            ModuleVersion highVer = null;
+            MessageAttributeValue highVerAttr;
+            if (msg.MessageAttributes.TryGetValue("HighestVersion", out highVerAttr))
+            {
+                highVer = new ModuleVersion(highVerAttr.StringValue);
+            }
+
             log.InfoFormat("Inflating {0}", netkan.Identifier);
             IEnumerable<Metadata> ckans = null;
             bool   caught        = false;
             string caughtMessage = null;
             try
             {
-                ckans = inflator.Inflate($"{netkan.Identifier}.netkan", netkan, releases);
+                ckans = inflator.Inflate($"{netkan.Identifier}.netkan", netkan, releases, highVer);
             }
             catch (Exception e)
             {

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -87,7 +87,7 @@ namespace CKAN.NetKAN
                         Options.GitHubToken,
                         Options.PreRelease
                     );
-                    var ckans = inf.Inflate(Options.File, netkan, ParseReleases(Options.Releases), null);
+                    var ckans = inf.Inflate(Options.File, netkan, new TransformOptions(ParseReleases(Options.Releases), null));
                     foreach (Metadata ckan in ckans)
                     {
                         WriteCkan(ckan);

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -87,7 +87,7 @@ namespace CKAN.NetKAN
                         Options.GitHubToken,
                         Options.PreRelease
                     );
-                    var ckans = inf.Inflate(Options.File, netkan, ParseReleases(Options.Releases));
+                    var ckans = inf.Inflate(Options.File, netkan, ParseReleases(Options.Releases), null);
                     foreach (Metadata ckan in ckans)
                     {
                         WriteCkan(ckan);

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -56,6 +56,9 @@ namespace CKAN.NetKAN.Transformers
                 {
                     Log.DebugFormat("Auto-epoching out of order version: {0} < {1}",
                         currentV, opts.HighestVersion);
+                    // Tell the Indexer to be careful
+                    opts.Staged = true;
+                    opts.StagingReason = $"Auto-epoching out of order version: {currentV} < {opts.HighestVersion}";
                     // Increment epoch if too small
                     currentV = currentV.IncrementEpoch();
                 }

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using CKAN.NetKAN.Model;
 using log4net;
 using Newtonsoft.Json.Linq;
+using CKAN.Versioning;
+using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -38,8 +39,27 @@ namespace CKAN.NetKAN.Transformers
                 }
                 else
                 {
-                    throw new BadMetadataKraken(null, "Invalid epoch: " + epoch + "In " + json["identifier"]);
+                    throw new BadMetadataKraken(null, "Invalid epoch: " + epoch + " In " + json["identifier"]);
                 }
+            }
+
+            JToken allowOOO;
+            if (json.TryGetValue("x_netkan_allow_out_of_order", out allowOOO) && (bool)allowOOO)
+            {
+                Log.Debug("Out of order versions enabled in netkan, skipping OOO check");
+            }
+            else if (opts.HighestVersion != null)
+            {
+                // Ensure we are greater or equal to the previous max
+                ModuleVersion currentV = new ModuleVersion((string)json["version"]);
+                while (currentV < opts.HighestVersion)
+                {
+                    Log.DebugFormat("Auto-epoching out of order version: {0} < {1}",
+                        currentV, opts.HighestVersion);
+                    // Increment epoch if too small
+                    currentV = currentV.IncrementEpoch();
+                }
+                json["version"] = currentV.ToString();
             }
 
             yield return new Metadata(json);

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -14,6 +14,8 @@ namespace CKAN.NetKAN.Transformers
 
         public readonly int?          Releases;
         public readonly ModuleVersion HighestVersion;
+        public          bool          Staged;
+        public          string        StagingReason;
     }
 
     /// <summary>

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -1,16 +1,19 @@
 using System.Collections.Generic;
 using CKAN.NetKAN.Model;
+using CKAN.Versioning;
 
 namespace CKAN.NetKAN.Transformers
 {
     internal class TransformOptions
     {
-        public TransformOptions(int? releases)
+        public TransformOptions(int? releases, ModuleVersion highVer)
         {
-            Releases = releases;
+            Releases       = releases;
+            HighestVersion = highVer;
         }
 
-        public readonly int? Releases;
+        public readonly int?          Releases;
+        public readonly ModuleVersion HighestVersion;
     }
 
     /// <summary>

--- a/Spec.md
+++ b/Spec.md
@@ -855,13 +855,32 @@ If (and only if) no mod version number has been identified (eg a `#/ckan/http/:u
 
 ##### `x_netkan_epoch`
 
-The `x_netkan_epoch` field is used to specify a particular `epoch` number in the `version` field. Its value should be
+The `x_netkan_epoch` field is used to specify a minimum `epoch` number manually in the `version` field. Its value should be
 an unsigned 32-bit integer.
+
+Note that an epoch can be added without this property or incremented automatically, if the auto-indexer detects an out-of-order
+release.
 
 An example `.netkan` excerpt:
 ```json
 {
     "x_netkan_epoch": 1
+}
+```
+
+##### `x_netkan_allow_out_of_order`
+
+If true, then this module allows a freshly released version to have a version number smaller than previously existing releases.
+
+This should be used for modules that intentionally release "backport" versions, to disable automatic incrementing of epochs for
+out of order releases.
+Typical mods should not use this property, to allow their version epochs to be automatically incremented if they release an out
+of order version.
+
+An example `.netkan` excerpt:
+```json
+{
+    "x_netkan_allow_out_of_order": true
 }
 ```
 

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN
     [TestFixture]
     public class MainClassTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test]
         public void FixVersionStringsUnharmed()

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -11,7 +11,7 @@ namespace Tests.NetKAN
     public class NetkanOverride
     {
         JObject such_metadata;
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [SetUp]
         public void Setup()

--- a/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcKrefTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test,
             TestCase(

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test]
         public void AddsMissingVersionInfo()

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class CurseTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
@@ -13,7 +13,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class DownloadAttributeTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test]
         public void AddsDownloadAttributes()

--- a/Tests/NetKAN/Transformers/EpochTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/EpochTransformerTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using CKAN.Versioning;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Transformers;
+
+namespace Tests.NetKAN.Transformers
+{
+    [TestFixture]
+    public sealed class EpochTransformerTests
+    {
+        [Test,
+            TestCase("1.1",     null,    "1.1"),
+            TestCase("1.1",    "1.1",    "1.1"),
+            TestCase("1.1",    "1.2",  "1:1.1"),
+            TestCase("1.1",  "5:1.1",  "5:1.1"),
+            TestCase("1.1",  "5:1.2",  "6:1.1"),
+            TestCase("0.7",   "0.65",  "1:0.7"),
+            TestCase("2.5",   "v2.4",  "1:2.5"),
+            TestCase("2.5",   "V2.4",  "1:2.5"),
+            TestCase("v2.5", "vV2.4", "1:v2.5"),
+        ]
+        public void Transform_WithHighVersionParam_MatchesExpected(string version, string highVer, string expected)
+        {
+            // Arrange
+            var json = new JObject()
+            {
+                { "spec_version", "v1.4"       },
+                { "identifier",   "AwesomeMod" },
+                { "version",      version      },
+            };
+            ITransformer     sut  = new EpochTransformer();
+            TransformOptions opts = new TransformOptions(
+                1,
+                string.IsNullOrEmpty(highVer)
+                    ? null
+                    : new ModuleVersion(highVer)
+            );
+
+            // Act
+            var result = sut.Transform(new Metadata(json), opts).First();
+            var transformedJson = result.Json();
+
+            // Assert
+            Assert.AreEqual(expected, (string)transformedJson["version"]);
+        }
+    }
+}

--- a/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
@@ -9,7 +9,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GeneratedByTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
         
         [Test]
         public void AddsGeneratedByProperty()

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GithubTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test]
         public void CalculatesRepositoryUrlCorrectly()

--- a/Tests/NetKAN/Transformers/HttpTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/HttpTransformerTests.cs
@@ -9,7 +9,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class HttpTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [TestCase("#/ckan/github/foo/bar")]
         [TestCase("#/ckan/netkan/http://awesomemod.example/awesomemod.netkan")]

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class InternalCkanTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test]
         public void AddsMiddingProperties()

--- a/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
@@ -13,7 +13,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class MetaNetkanTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class SpacedockTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class StripNetkanMetadataTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [TestCaseSource("StripNetkanMetadataTestCaseSource")]
         public void StripNetkanMetadata(string json, string expected)

--- a/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class VersionEditTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1);
+        private TransformOptions opts = new TransformOptions(1, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()


### PR DESCRIPTION
This PR grew out of a sidebar discussion on #2789. Please discuss it here instead of there, to allow that issue to stay focused on its main goals.

## Problem

As things stand, CKAN-meta will inevitably accumulate inaccurate metadata every time a mod author releases an out-of-order version, which includes things like dropping a 'v' prefix or changing it to/from capital 'V', numbering like `["0.6", "0.65", "0.7"]`, accidentally dropping the `0.` prefix of a version, fat-fingering an extra '.' in a version number, etc, Users will get "stuck" on older versions because the newer release isn't considered newer by CKAN.

There are no safeguards against such things (and no alerts that it has happened), and all require manual clean-up in the form of updating the `x_netkan_epoch` property in .netkan files and sometimes manually updating versions and filenames of .ckan files. It also relies on someone to *notice* the problem in the first place, which often takes a while. Recent examples of such manual fixes:

- KSP-CKAN/NetKAN#7260
- KSP-CKAN/NetKAN#7275
- KSP-CKAN/NetKAN#7278
- KSP-CKAN/CKAN-meta#1477
- KSP-CKAN/NetKAN#7280
- KSP-CKAN/NetKAN#7284
- KSP-CKAN/NetKAN#7285
- KSP-CKAN/CKAN-meta#1481
- KSP-CKAN/NetKAN#7286
- KSP-CKAN/CKAN-meta#1482
- KSP-CKAN/NetKAN#7288
- KSP-CKAN/NetKAN#7289
- KSP-CKAN/CKAN-meta#1484
- KSP-CKAN/NetKAN#7290
- KSP-CKAN/CKAN-meta#1485
- KSP-CKAN/CKAN-meta#1486
- KSP-CKAN/NetKAN#7291
- KSP-CKAN/NetKAN#7292
- KSP-CKAN/CKAN-meta#1488
- KSP-CKAN/NetKAN#7293
- KSP-CKAN/CKAN-meta#1489
- KSP-CKAN/NetKAN#7294
- KSP-CKAN/CKAN-meta#1490
- KSP-CKAN/NetKAN#7295
- KSP-CKAN/CKAN-meta#1491
- KSP-CKAN/NetKAN#7296
- KSP-CKAN/CKAN-meta#1492
- KSP-CKAN/NetKAN#7297
- KSP-CKAN/CKAN-meta#1493
- KSP-CKAN/NetKAN#7298
- KSP-CKAN/CKAN-meta#1494
- KSP-CKAN/NetKAN#7299
- KSP-CKAN/CKAN-meta#1495
- KSP-CKAN/NetKAN#7300
- KSP-CKAN/NetKAN#7301
- KSP-CKAN/NetKAN#7302
- KSP-CKAN/CKAN-meta#1496
- KSP-CKAN/NetKAN#7306
- KSP-CKAN/CKAN-meta#1498
- https://github.com/KSP-CKAN/NetKAN/issues/7318#issuecomment-513243948
- KSP-CKAN/NetKAN#7520
- KSP-CKAN/CKAN-meta#1554

This property is also prone to errors, as a few times an author has re-homed a netkan via a metanetkan and dropped `x_netkan_epoch` entirely because they don't know what it does, and we had to tell them to add it back because it's important.

## Changes

Now the Netkan queue Inflator from #2798 supports an additional optional input attribute:

```
Attr HighestVersion: The highest version string of this module that is currently indexed
```

The `version` property of a newly inflated module will be compared to this value:
- If it is higher, then we are indexing a new release with a good version string
- If it is the same, then we are updating an existing release
- If it is lower, then **we have detected an out of order release**!

When we detect an out of order release, the version epoch is increased automatically until the new release's version is greater (new version) or equal (same version update). The "main" part of the version remains the same.

If/when the scheduler component chooses to set this attribute (by checking the existing files in CKAN-meta), then this method will index out-of-order releases with correct epochs automatically. This will fix the above-mentioned problems with bad metadata.

Tests are included.

## Caveats

We will need a way to suppress this behavior. It makes sense for the typical mod, but a few mods (KSPInterstellarExtended and Kopernicus-Backports) intentionally post "older" releases that are meant to be treated as such. I imagine this would take the form of a new .netkan property:

```json
    "x_netkan_allow_out_of_order": true,
```

If set, the scheduler would skip checking the CKAN-meta files to find the highest version and not set the HighestVersion attribute. The Inflator would then fall back to using the `x_netkan_epoch` property as it does today.