### PR TITLE
Fix Curse API download URLs

### DIFF
--- a/Netkan/Sources/Curse/CurseFile.cs
+++ b/Netkan/Sources/Curse/CurseFile.cs
@@ -36,7 +36,7 @@ namespace CKAN.NetKAN.Sources.Curse
         {
             if (string.IsNullOrWhiteSpace(_downloadUrl))
             {
-                _downloadUrl = CurseApi.ResolveRedirect(new Uri(ModPageUrl + "/files/" + id + "/download")).ToString();
+                _downloadUrl = CurseApi.ResolveRedirect(new Uri(url + "/file")).ToString();
             }
             return _downloadUrl;
         }


### PR DESCRIPTION
## Problem

Curse-hosted modules aren't inflating:

![image](https://user-images.githubusercontent.com/1559108/60559988-d09c9780-9d3d-11e9-975e-243b0eecb214.png)

## Cause

This URL is a 404 as of some recent change to Curse or its API or something:

https://github.com/KSP-CKAN/CKAN/blob/5323e54cee3279e85ad199cc172f6488b8ae8cfd/Netkan/Sources/Curse/CurseFile.cs#L39

In #2189, this was briefly changed to:

https://github.com/KSP-CKAN/CKAN/blob/b643d129b242081fbfe3742bea0d802ffc61274f/Netkan/Sources/Curse/CurseFile.cs#L32

... which still works! But this was reverted during code review.

## Changes

Now we use that `url + "/file"` formula again.

Fixes KSP-CKAN/NetKAN#7268. (I didn't think it was possible!)