### PR TITLE
Fix clearing of changeset after install

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -135,7 +135,7 @@ namespace CKAN
             IsInstalled      = true;
             IsInstallChecked = true;
             InstalledMod     = instMod;
-            SelectedMod      = instMod.Module;
+            selectedMod      = instMod.Module;
             IsAutoInstalled  = instMod.AutoInstalled;
             InstallDate      = instMod.InstallTime;
             InstalledVersion = instMod.Module.version.ToString();

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -341,16 +341,13 @@ namespace CKAN
                 // install successful
                 AddStatusMessage(Properties.Resources.MainInstallSuccess);
                 HideWaitDialog(true);
-                ChangeSet = null;
                 RetryCurrentActionButton.Visible = false;
-                UpdateChangesDialog(null, installWorker);
             }
             else if (installCanceled)
             {
                 // User cancelled the installation
                 // Rebuilds the list of GUIMods
                 UpdateModsList(ChangeSet);
-                UpdateChangesDialog(null, installWorker);
                 if (result.Key) {
                     FailWaitDialog(
                         Properties.Resources.MainInstallCancelTooLate,
@@ -376,7 +373,6 @@ namespace CKAN
                     Properties.Resources.MainInstallFailed,
                     result.Key
                 );
-                UpdateChangesDialog(result.Value, installWorker);
             }
 
             Util.Invoke(this, () => Enabled = true);

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -236,6 +236,8 @@ namespace CKAN
             mainModList.ConstructModList(gui_mods.ToList(), mc, configuration.HideEpochs, configuration.HideV);
             mainModList.Modules = new ReadOnlyCollection<GUIMod>(
                 mainModList.full_list_of_mod_rows.Values.Select(row => row.Tag as GUIMod).ToList());
+            
+            UpdateChangeSetAndConflicts(registry);                
 
             AddLogMessage(Properties.Resources.MainModListUpdatingFilters);
 
@@ -276,7 +278,7 @@ namespace CKAN
             Util.Invoke(ModList, () =>
             {
                 ModList.Columns["UpdateCol"].Visible     = has_any_updates;
-                ModList.Columns["AutoInstalled"].Visible = has_any_installed &&             !configuration.HiddenColumnNames.Contains("AutoInstalled");
+                ModList.Columns["AutoInstalled"].Visible = has_any_installed && !configuration.HiddenColumnNames.Contains("AutoInstalled");
                 ModList.Columns["ReplaceCol"].Visible    = has_any_replacements;
             });
 
@@ -595,7 +597,7 @@ namespace CKAN
 
         private void InstallAllCheckbox_CheckChanged(object sender, EventArgs e)
         {
-            if (this.InstallAllCheckbox.Checked)
+            if (InstallAllCheckbox.Checked)
             {
                 // Reset changeset
                 ClearChangeSet();


### PR DESCRIPTION
## Problem

If you install mods in current master HEAD GUI, the change set is not cleared after installation. You can try applying the same change set again if you want to see some errors. If you toggle another checkbox instead, the change set will fix itself and show the correct changes.

## Causes

First, as of #2821, `GUIMod`'s constructor for installed modules was setting `SelectedMod`. This is a public property, and setting it causes its change-reaction code to run, which can trigger changes in the grid and updates of the change set. During post-install, this happens via `UpdateModsList`, but it happens before the mod list is fully updated, so there is interaction between the "old" and "new" copies of a mod's `GUIMod` instances. This has the effect of regenerating the change set based on the old mod list.

Second, `PostInstallMods` has been a bit naïve in its handling of changesets. It was setting `ChangeSet` to null and refreshing the change set dialog directly, which isn't appropriate because the change set is really a property of the mod list; the state of the mod list's checkboxes (and `SelectedMod` properties!) determines the change set, and attempting to bypass this is like trying to set another class's private member variable.

## Changes

Now `GUIMod`'s constructor sets `selectedMod` instead (first letter lower case, the private state variable around which `SelectedMod` is a wrapper). This prevents its change-reaction code from running, so the old `GUIMod` instances will not be queried for a change set during refreshes.

Now `PostInstallMods` doesn't mess with the change set, but `UpdateModsList` refreshes the change set as soon as it is done generating the new mod list. This ensures that it will be accurate.

Fixes #2828.