### PR TITLE
Fix for building with VS 2019

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.26.1" />
+  <package id="Cake" version="0.34.1" />
 </packages>


### PR DESCRIPTION
With the new release of Visual Studio 2019 it broke the ability to build the project with `ToolsVersion="15.0"` on Windows. This changes the building process to use Cake 0.34.1 so it can build again.

This change will print the following error on building:
```
The assembly 'Cake.SemVer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'
is referencing an older version of Cake.Core (0.26.1).
For best compatibility it should target Cake.Core version 0.33.0.
```

Because the fix is released in 0.34.0, we need to ignore that warning.