### PR TITLE
Send staging reason to SQS queue

### DIFF
--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -6,13 +6,14 @@ namespace CKAN.NetKAN.Model
 {
     internal sealed class Metadata
     {
-        private const string KrefPropertyName        = "$kref";
-        private const string VrefPropertyName        = "$vref";
-        private const string SpecVersionPropertyName = "spec_version";
-        private const string VersionPropertyName     = "version";
-        private const string DownloadPropertyName    = "download";
-        public  const string UpdatedPropertyName     = "x_netkan_asset_updated";
-        private const string StagedPropertyName      = "x_netkan_staging";
+        private const string KrefPropertyName          = "$kref";
+        private const string VrefPropertyName          = "$vref";
+        private const string SpecVersionPropertyName   = "spec_version";
+        private const string VersionPropertyName       = "version";
+        private const string DownloadPropertyName      = "download";
+        public  const string UpdatedPropertyName       = "x_netkan_asset_updated";
+        private const string StagedPropertyName        = "x_netkan_staging";
+        private const string StagingReasonPropertyName = "x_netkan_staging_reason";
 
         private readonly JObject _json;
 
@@ -24,6 +25,7 @@ namespace CKAN.NetKAN.Model
         public Uri           Download        { get; private set; }
         public DateTime?     RemoteTimestamp { get; private set; }
         public bool          Staged          { get; private set; }
+        public string        StagingReason   { get; private set; }
 
         public Metadata(JObject json)
         {
@@ -98,6 +100,12 @@ namespace CKAN.NetKAN.Model
             if (json.TryGetValue(StagedPropertyName, out stagedToken))
             {
                 Staged = (bool)stagedToken;
+            }
+            
+            JToken stagingReasonToken;
+            if (json.TryGetValue(StagingReasonPropertyName, out stagingReasonToken))
+            {
+                StagingReason = (string)stagingReasonToken;
             }
 
             JToken   updatedToken;

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -154,6 +154,17 @@ namespace CKAN.NetKAN.Processors
                     }
                 );
             }
+            if (netkan.Staged && !string.IsNullOrEmpty(netkan.StagingReason))
+            {
+                attribs.Add(
+                    "StagingReason",
+                    new MessageAttributeValue()
+                    {
+                        DataType    = "String",
+                        StringValue = netkan.StagingReason
+                    }
+                );
+            }
 
             SendMessageRequest msg = new SendMessageRequest()
             {

--- a/Spec.md
+++ b/Spec.md
@@ -957,3 +957,18 @@ When any metadata changes occur which are version specific, for example a new de
 recommended means of specifying them. Overrides may also be used to *stage* metadata changes, for example when new
 dependencies are anticipated to be added in yet unreleased versions of a mod. This allows mod metadata to be
 up-to-date as soon as possible without requiring excessive coordination.
+
+##### `x_netkan_staging` and `x_netkan_staging_reason`
+
+These properties alter the way the NetKAN-bot pushes updated metadata for a module. Normally, a new or changed .ckan file
+will be committed and pushed to CKAN-meta's `master` branch, which makes it immediately available to users. If there is a
+chance that such an update will contain incorrect metadata, for example if the game compatibility is hard-coded in the
+netkan and changes upstream, then a manual review step may be advisable.
+
+If `x_netkan_staging` is set to `true`, changed metadata files for this module will be committed to a separate
+module-specific branch and a pull request will be created to merge this branch to `master`. This allows CKAN team members
+to check manually that the changes are correct before they are released to users.
+
+To make the review process easier, set `x_netkan_staging_reason` to a string explaining why staging is enabled. This will
+be inserted into the body of the pull request as a reminder of the manual checks that should be performed before merging.
+For example, you may advise reviewers to check a module's game compatibility metadata against its forum thread.


### PR DESCRIPTION
## Motivation

In https://github.com/KSP-CKAN/CKAN/issues/2789#issuecomment-513427895, @techman83 pointed out that the SQS queue code in #2798 does not handle the `x_netkan_staging_reason` property from KSP-CKAN/NetKAN-bot#88.

## Changes

Now the `x_netkan_staging_reason` property flows through into a `Metadata.StagingReason` property, which will be passed to a new message attribute if set:

```
Attr StagingReason: The reason that staging is enabled for this module (if it is enabled), to help pull request reviewers determine whether to merge
```

Notes:

- If the module is staged but `x_netkan_staging_reason` is not set, the attribute will not be set
- If the module is **not** staged but `x_netkan_staging_reason` **is** set, the attribute will **not** be set

So the downstream code should be prepared to handle a staged module without this attribute.

`x_netkan_staging` and `x_netkan_staging_reason` are added to the spec (according to their current behavior).