### PR TITLE
Add Dockerfile + Deployment for NetKAN Inflator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: csharp
 
 sudo: required
 
+services:
+    - docker
+
 env:
     global:
         - BUILD_RELEASE_MONO_VERSION=5.16.0
+        - DOCKERHUB_USERNAME=kspckanbuilder
+        - secure: "UGXJG9jB9tGwjJXxG0Beu4Poz0leuiCBItnfTTKRm1a/NxXf1eoOH9p9icY5Ur2xHwqh0uWSznuL2aNr58CXtzTcMpXrcUhRsO63FB3Cz6tSdZEb+pKQJ23zmC9929DklKRGUT2D/eBcJcnV+/eAtkarrfLBU1avUQAVJgqXvMI="
     matrix:
         - BUILD_CONFIGURATION=Debug
         - BUILD_CONFIGURATION=Release
@@ -46,6 +51,7 @@ script:
 before_deploy:
     - ./build osx
     - ./build deb
+    - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
 deploy:
     # Releases (which are tagged) go to github
@@ -76,6 +82,15 @@ deploy:
       bucket: ckan-travis
       acl: public_read
       local_dir: _build/repack/$BUILD_CONFIGURATION
+      on:
+        repo: KSP-CKAN/CKAN
+        branch: master
+        condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\d+\.\d+\.\d+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
+
+    # Rebuild + Publish Netkan on every merge to master
+    - provider: script
+      skip_cleanup: true
+      script: bin/build_netkan_container.sh
       on:
         repo: KSP-CKAN/CKAN
         branch: master

--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -1,0 +1,7 @@
+FROM mono:5.20.1
+RUN useradd -ms /bin/bash netkan
+USER netkan
+WORKDIR /home/netkan
+ADD netkan.exe .
+ENTRYPOINT /usr/bin/mono netkan.exe --queues $QUEUES \
+  --github-token $GH_Token --cachedir ckan_cache -v

--- a/bin/build_netkan_container.sh
+++ b/bin/build_netkan_container.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cp -v Dockerfile.netkan _build/repack/$BUILD_CONFIGURATION/.
+(cd _build/repack/$BUILD_CONFIGURATION/ && docker build . -f Dockerfile.netkan -t kspckan/inflator)
+docker tag "kspckan/inflator" "kspckan/inflator:latest"
+docker push "kspckan/inflator:latest"


### PR DESCRIPTION
This is in support of #2789, building and pushing the NetKAN Inflator container to Docker Hub when changes are pushed to master, keeping our container up to date.

A future PR will contain the service redeployment as well, but that requires a few more things to be finished off first and can be easily added.