### PR TITLE
Replace bash script with Cake.Docker task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ deploy:
     # Rebuild + Publish Netkan on every merge to master
     - provider: script
       skip_cleanup: true
-      script: bin/build_netkan_container.sh
+      script: ./build docker-inflator
       on:
         repo: KSP-CKAN/CKAN
         branch: master

--- a/bin/build_netkan_container.sh
+++ b/bin/build_netkan_container.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cp -v Dockerfile.netkan _build/repack/$BUILD_CONFIGURATION/.
-(cd _build/repack/$BUILD_CONFIGURATION/ && docker build . -f Dockerfile.netkan -t kspckan/inflator)
-docker tag "kspckan/inflator" "kspckan/inflator:latest"
-docker push "kspckan/inflator:latest"


### PR DESCRIPTION
## Motivation

#2838 is setting up build triggers to rebuild an inflator container for #2789. This pull request targets that PR's branch with a suggestion for changing it.

Currently it:

- Relies on a bash script
- Uses the `_build/repack/Release` folder as its working folder
- Hard-codes paths that are defined as variables in other places, meaning extra maintenance if those ever change

## Changes

Now the bash script is replaced with a new task in the `build.cake` file, which:

- Uses the standard variables to get the path to `netkan.exe` and `_build`
- Works out of `_build/docker/inflator`
- Might work on systems without bash, depending on how portable `Cake.Docker` is
- Otherwise does the same things the bash script did

The Travis config is updated to rebuild the container with `./build docker-inflator`.

This way the new docker logic will fit into the existing build system.