### PR TITLE
Put Dockerfile.netkan in build context

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -40,16 +40,19 @@ Task("docker-inflator")
 {
     var dockerDirectory   = buildDirectory.Combine("docker");
     var inflatorDirectory = dockerDirectory.Combine("inflator");
+    // Versions of Docker prior to 18.03.0-ce require the Dockerfile to be within the build context
+    var dockerFile        = inflatorDirectory.CombineWithFilePath("Dockerfile.netkan");
     CreateDirectory(inflatorDirectory);
     CopyFile(buildDirectory.CombineWithFilePath("netkan.exe"),
           inflatorDirectory.CombineWithFilePath("netkan.exe"));
+    CopyFile(rootDirectory.CombineWithFilePath("Dockerfile.netkan"), dockerFile);
 
     var mainTag   = "kspckan/inflator";
     var latestTag = mainTag + ":latest";
     DockerBuild(
         new DockerImageBuildSettings()
         {
-            File = "Dockerfile.netkan",
+            File = dockerFile.ToString(),
             Tag  = new string[] { mainTag }
         },
         inflatorDirectory.ToString()


### PR DESCRIPTION
## Problem

#2838 added a build process to rebuild and push a Docker inflator container, but it failed:

https://travis-ci.org/KSP-CKAN/CKAN/jobs/569174846#L4638-L4642

```
========================================
docker-inflator
========================================
unable to prepare context: the Dockerfile (/home/travis/build/KSP-CKAN/CKAN/Dockerfile.netkan) must be within the build context
An error occurred when executing task 'docker-inflator'.
```

## Cause

Prior to docker/cli#886, the Dockerfile specified by the `-f` parameter had to be in the build directory for... *some* reason.

That requirement was removed in Docker 18.03.0-ce. Travis has 17.09.0-ce. I have 18.09.7. So when I tested #2839 locally, it worked fine, then failed when pushed to master.

## Changes

Now we copy `Dockerfile.netkan` into `_build/docker/inflator` before building.
If Travis ever upgrades to Docker 18.03.0-ce or later, we can revert this.