### PR TITLE
Switch to new Travis xvfb syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+dist: xenial
 language: csharp
 
 sudo: required
 
 services:
     - docker
+    # XVFB simulates having a graphical display, which is needed for our GUI tests.
+    - xvfb
 
 env:
     global:
@@ -47,12 +50,6 @@ addons:
             - lintian
             # Stuff for building .rpm files
             - rpm
-
-# These commands simulate having a graphical display, which is needed
-# for our GUI tests.
-before_install:
-    - "export DISPLAY=:99.0"
-    - sh -e /etc/init.d/xvfb start
 
 script:
     - ./build --configuration=$BUILD_CONFIGURATION


### PR DESCRIPTION
## Problem

The NetCore builds are failing:

https://api.travis-ci.org/v3/job/571858879/log.txt

```
[0K$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
travis_time:end:0d500080:start=1565794793416049556,finish=1565794793421102477,duration=5052921
[0K[31;1mThe command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .[0m

Your build has been stopped.
```

## Cause

The Travis syntax for starting xvfb is different in trusty vs xenial; now it's a proper service rather than a command that we have to run ourselves. Apparently Travis is migrating the default build environment from trusty to xenial, but they're doing it "gradually":

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

> Since Ubuntu 14.04 reaches End of Life on April 30th, 2019, we’ll be gradually setting the default distribution for builds to Linux, Ubuntu Xenial 16.04.

Maybe that means individual builds get migrated one at a time? If true, that means the existing builds will also randomly fail with this error eventually.

## Changes

Now all our builds use xenial, and start xvfb as a service.

Fixes #2844.