### PR TITLE
Use Debian machine-readable copyright format

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: http://webchat.esper.net/?channels=ckan
 Source: https://github.com/KSP-CKAN/CKAN/
 
 Files: *
-Copyright: 2014-2017, the Comprehensive Kerbal Archive Network (CKAN) Authors:
+Copyright: 2014-2019, the Comprehensive Kerbal Archive Network (CKAN) Authors:
     https://github.com/KSP-CKAN/CKAN/graphs/contributors
 Comment: You can use the CKAN and its associated files under the MIT license,
     reproduced below. This includes the right to sublicense under compatible

--- a/debian/copyright
+++ b/debian/copyright
@@ -6,10 +6,10 @@ Source: https://github.com/KSP-CKAN/CKAN/
 Files: *
 Copyright: 2014-2017, the Comprehensive Kerbal Archive Network (CKAN) Authors:
     https://github.com/KSP-CKAN/CKAN/graphs/contributors
-License: Expat
-    You can use the CKAN and its associated files under the MIT license,
+Comment: You can use the CKAN and its associated files under the MIT license,
     reproduced below. This includes the right to sublicense under compatible
     licenses.
+License: Expat
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,14 +1,15 @@
-Copyright 2014-2017 the Comprehensive Kerbal Archive Network (CKAN) Authors.
-https://github.com/KSP-CKAN/CKAN/graphs/contributors
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: CKAN
+Upstream-Contact: http://webchat.esper.net/?channels=ckan
+Source: https://github.com/KSP-CKAN/CKAN/
 
-You can use the CKAN and its associated files under the MIT license,
-reproduced below. This includes the right to sublicense under compatible
-licenses.
-
----
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Files: *
+Copyright: 2014-2017, the Comprehensive Kerbal Archive Network (CKAN) Authors:
+    https://github.com/KSP-CKAN/CKAN/graphs/contributors
+License: Expat
+    You can use the CKAN and its associated files under the MIT license,
+    reproduced below. This includes the right to sublicense under compatible
+    licenses.
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
As discussed under #2851, we aren't aware of any standard tool that parses the `copyright` file from inside a .deb package. But the CKAN metadata specification references the list of well-known license names from the Debian machine-readable license spec (https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/), so it seems like good citizenship to follow the upstream spec ourselves.

Fixes #2851.