### PR TITLE
Don't invalidate invisible rows

### DIFF
--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -113,7 +113,10 @@ namespace CKAN
                         cell.ToolTipText = null;
                     }
                     row.DefaultCellStyle.BackColor = Color.Empty;
-                    ModList.InvalidateRow(row.Index);
+                    if (row.Visible)
+                    {
+                        ModList.InvalidateRow(row.Index);
+                    }
                 }
             }
             if (Conflicts != null)
@@ -130,7 +133,10 @@ namespace CKAN
                         cell.ToolTipText = conflict_text;
                     }
                     row.DefaultCellStyle.BackColor = Color.LightCoral;
-                    ModList.InvalidateRow(row.Index);
+                    if (row.Visible)
+                    {
+                        ModList.InvalidateRow(row.Index);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

1. Install `EnvironmentalVisualEnhancements-HR` (or any other module providing `EnvironmentalVisualEnhancements-Config` other than AVP)
2. Filter by mod names containing "astrono"
3. Check the box for Astronomers Visual Pack
4. An exception is thrown

![screenshot](https://user-images.githubusercontent.com/1559108/63656667-7bea2b80-c786-11e9-9ddb-2114b88f35c9.png)

## Cause

When you try to install a mod that conflicts with one that's already installed, we highlight both of their rows red. This is done by setting the row's background and then calling `ModList.InvalidateRow` to force the GUI to obey that change immediately.

![screenshot2](https://user-images.githubusercontent.com/1559108/58358317-0186d400-7e44-11e9-9cb6-93b67d6c32f4.png)

In this case, one of the rows is not visible due to the filter; the thrown exception indicates that `InvalidateRow` is being called for a row that isn't in the grid, and .NET doesn't like that.

In #2766 we specifically updated this code to cover hidden conflicts. How was this missed? My guess currently is that Mono's `InvalidateRow` has some sanity checks that .NET lacks. The screenshots pertaining to discussion of that change are from Linux.

## Changes

Now we only attempt `InvalidateRow` if the row is visible. This will avoid the exception.
(We will still set the color unconditionally, which should ensure we don't lose #2766's fix.)

Fixes #2852.