### PR TITLE
Find portable installs when enforcing cache limits

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -295,7 +295,11 @@ namespace CKAN
                 KspVersionCriteria aggregateCriteria = manager?.Instances.Values
                     .Where(ksp => ksp.Valid)
                     .Select(ksp => ksp.VersionCriteria())
-                    .Aggregate((a, b) => a.Union(b));
+                    .Aggregate(
+                        manager?.CurrentInstance?.VersionCriteria()
+                            ?? new KspVersionCriteria(null),
+                        (combinedCrit, nextCrit) => combinedCrit.Union(nextCrit)
+                    );
 
                 // This object lets us find the modules associated with a cached file
                 Dictionary<string, List<CkanModule>> hashMap = registry.GetDownloadHashIndex();


### PR DESCRIPTION
## Problem

A user mentioned this exception with a "portable" install:

```
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.Enumerable.Aggregate[TSource](IEnumerable`1 source, Func`3 func)
   at CKAN.NetFileCache.EnforceSizeLimit(Int64 bytes, Registry registry)
   at CKAN.ModuleInstaller.EnforceCacheSizeLimit()
   at CKAN.ModuleInstaller.InstallList(ICollection`1 modules, RelationshipResolverOptions options, IDownloader downloader, Boolean ConfirmPrompt)
   at CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1264-orion/&do=findComment&comment=3660841

## Cause

`NetFileCache.EnforceSizeLimit` assumes that the current instance will be in `manager.Instances`.

https://github.com/KSP-CKAN/CKAN/blob/a162c8b1dfa98fcc9a5d459a2d075737f26a0286/Core/Net/NetFileCache.cs#L294-L298

"Portable" instances are an exception to this:

https://github.com/KSP-CKAN/CKAN/blob/a162c8b1dfa98fcc9a5d459a2d075737f26a0286/Core/KSPManager.cs#L66

If all you have is a portable install, `manager.Instances` will be empty, and `Aggregate` will throw that exception.

## Changes

Now we use `Aggregate`'s optional first parameter to set a default element based on the current instance's version criteria, which should cover portables, falling back to an empty range if not found.