### PR TITLE
Fixes for KSP in Windows drive root

### DIFF
--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -60,6 +60,16 @@ namespace CKAN
             User = user;
             // Make sure our path is absolute and has normalised slashes.
             this.gameDir = KSPPathUtils.NormalizePath(Path.GetFullPath(gameDir));
+            if (Platform.IsWindows)
+            {
+                // Normalized slashes are bad for pure drive letters,
+                // Path.Combine turns them into drive-relative paths like
+                // K:GameData/whatever
+                if (Regex.IsMatch(this.gameDir, @"^[a-zA-Z]:$"))
+                {
+                    this.gameDir = $"{this.gameDir}/";
+                }
+            }
             if (Valid)
             {
                 SetupCkanDirectories(scanGameData);

--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -226,29 +226,16 @@ namespace CKAN
 
             if (!Path.IsPathRooted(path))
             {
-                throw new PathErrorKraken(
-                    path,
-                    String.Format("{0} is not an absolute path", path)
-                );
+                throw new PathErrorKraken(path, $"{path} is not an absolute path");
             }
 
             if (!path.StartsWith(root, StringComparison.CurrentCultureIgnoreCase))
             {
-                throw new PathErrorKraken(
-                    path,
-                    String.Format(
-                        "Oh snap. {0} isn't inside {1}",
-                        path, root
-                    )
-                );
+                throw new PathErrorKraken(path, $"Oh snap. {path} isn't inside {root}");
             }
 
-            // The +1 here is because root will never have
-            // a trailing slash. However, if the strings are
-            // the same, it causes an exception.
-            return path.Length > root.Length
-                ? path.Remove(0, root.Length + 1)
-                : "";
+            // Strip off the root, then remove any slashes at the beginning
+            return path.Remove(0, root.Length).TrimStart('/');
         }
 
         /// <summary>

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -436,9 +436,11 @@ namespace CKAN
             }
 
             file_transaction.WriteAllText(path, Serialize());
+            
+            string sanitizedName = string.Join("", ksp.Name.Split(Path.GetInvalidFileNameChars()));
 
             ExportInstalled(
-                Path.Combine(directoryPath, $"installed-{ksp.Name}.ckan"),
+                Path.Combine(directoryPath, $"installed-{sanitizedName}.ckan"),
                 false, true
             );
             if (!Directory.Exists(ksp.InstallHistoryDir()))
@@ -448,7 +450,7 @@ namespace CKAN
             ExportInstalled(
                 Path.Combine(
                     ksp.InstallHistoryDir(),
-                    $"installed-{ksp.Name}-{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.ckan"
+                    $"installed-{sanitizedName}-{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.ckan"
                 ),
                 false, true
             );

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -540,7 +540,7 @@ namespace CKAN
         {
             Util.Invoke(this, () =>
             {
-                Text = $"CKAN {Meta.GetVersion()} - KSP {CurrentInstance.Version()}    --    {CurrentInstance.GameDir()}";
+                Text = $"CKAN {Meta.GetVersion()} - KSP {CurrentInstance.Version()}    --    {CurrentInstance.GameDir().Replace('/', Path.DirectorySeparatorChar)}";
                 StatusInstanceLabel.Text = string.Format(
                     Properties.Resources.StatusInstanceLabelText,
                     CurrentInstance.Name,

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -451,7 +451,7 @@ namespace CKAN
 
             foreach (string item in contents)
             {
-                ContentsPreviewTree.Nodes[0].Nodes.Add(item);
+                ContentsPreviewTree.Nodes[0].Nodes.Add(item.Replace('/', Path.DirectorySeparatorChar));
             }
 
             ContentsPreviewTree.Nodes[0].ExpandAll();

--- a/GUI/ManageKspInstances.cs
+++ b/GUI/ManageKspInstances.cs
@@ -68,7 +68,7 @@ namespace CKAN
                             Text = instance.Value.Version()?.ToString() ?? Properties.Resources.CompatibleKspVersionsDialogNone
                         },
                         new ListViewItem.ListViewSubItem {
-                            Text = instance.Value.GameDir()
+                            Text = instance.Value.GameDir().Replace('/', Path.DirectorySeparatorChar)
                         }
                     }, 0)
                     {
@@ -87,6 +87,10 @@ namespace CKAN
             try
             {
                 var instanceName = Path.GetFileName(path);
+                if (string.IsNullOrWhiteSpace(instanceName))
+                {
+                    instanceName = path;
+                }
                 instanceName = _manager.GetNextValidInstanceName(instanceName);
                 KSP instance = new KSP(path, instanceName, GUI.user);
                 _manager.AddInstance(instance);

--- a/Tests/Core/KSPPathUtils.cs
+++ b/Tests/Core/KSPPathUtils.cs
@@ -73,6 +73,34 @@ namespace Tests.Core
                 CKAN.KSPPathUtils.ToRelative("/home/fionna/KSP/GameData/Cake/", "/home/fionna/KSP/"),
                 "Trailing slashes for everyone!"
             );
+            
+            // Mono can't handle these tests
+            if (Platform.IsWindows)
+            {
+                Assert.AreEqual(
+                    "GameData/Cake",
+                    CKAN.KSPPathUtils.ToRelative("K:GameData/Cake", "K:"),
+                    "Root of a Windows drive"
+                );
+
+                Assert.AreEqual(
+                    "GameData/Cake",
+                    CKAN.KSPPathUtils.ToRelative("K:GameData/Cake", "K:/"),
+                    "Root of a Windows drive, slash in root"
+                );
+
+                Assert.AreEqual(
+                    "GameData/Cake",
+                    CKAN.KSPPathUtils.ToRelative("K:/GameData/Cake", "K:"),
+                    "Root of a Windows drive, slash in path"
+                );
+
+                Assert.AreEqual(
+                    "GameData/Cake",
+                    CKAN.KSPPathUtils.ToRelative("K:/GameData/Cake", "K:/"),
+                    "Root of a Windows drive, slash in both"
+                );
+            }
 
             Assert.Throws<PathErrorKraken>(delegate
             {
@@ -172,4 +200,3 @@ namespace Tests.Core
 
     }
 }
-


### PR DESCRIPTION
## Problem

If you install KSP into the root folder of a Windows drive (for example a RAM drive) and add that instance to CKAN, installing modules throws an exception:

```
System.IO.DirectoryNotFoundException: Ein Teil des Pfades "R:\ameData" konnte nicht gefunden werden.
   bei System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   bei System.IO.FileSystemEnumerableIterator`1.CommonInit()
   bei System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost)
   bei System.IO.Directory.EnumerateFileSystemEntries(String path)
   bei CKAN.ModuleInstaller.Uninstall(String modName)
   bei CKAN.ModuleInstaller.AddRemove(IEnumerable`1 add, IEnumerable`1 remove, Boolean enforceConsistency)
   bei CKAN.ModuleInstaller.Upgrade(IEnumerable`1 modules, IDownloader netAsyncDownloader, Boolean enforceConsistency)
   bei CKAN.ModuleInstaller.Upgrade(IEnumerable`1 identifiers, IDownloader netAsyncDownloader, Boolean enforceConsistency)
   bei CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   bei System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   bei System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

## Causes

Windows drive letters are a comprehensive technical disaster.

`Path.Combine("K:", "GameData")` returns `K:GameData` instead of `K:/GameData`!!! This is a "drive relative" path which is **not** the same and not what we (or any other programmers) intend. Its behavior depends on the "current directory" of the given drive; remember DOS, and how when you typed "C:" after working with a floppy disk it would remember your path on C:? Same thing.

`KSPPathUtils.ToRelative` removes `root.Length+1` characters from the given path, on the assumption that `root` is something like `/home/user/games/KSP` or `C:/program files/KSP`, which would mean there is a slash between it and the rest of the path. But in the case of a drive root with current code, `root` is something like `K:` and the path is like `K:GameData` without the slash, so removing `root.Length+1` strips an extra character and causes files not to be found.

## Changes

- `KSPPathUtils.ToRelative` no longer removes `root.Length+1` characters, instead it removes `root.Length` characters and then trims slashes from the start, this prevents the "ameData" corruption
  - Tests are added for this
    (EDIT: Apparently Mono's `Path.IsPathRooted` is unaware of Windows-style paths, so these tests can only be run on Windows)
- `KSP.GameDir()` now includes a trailing slash if it's a drive letter root, to make `Path.Combine` behave sensibly and force the other path functions to return proper paths instead of drive-relative paths
- GUI now names drive-root instances after their full path instead of ` (0)`
  - To account for this when we export the mod list to a file name including the instance name, file system illegal characters are excluded
- Places that display paths in GUI now replace slashes with the OS's folder separator character, so we no longer show paths with forward slashes to Windows users

Fixes #2837.