### PR TITLE
Add libcurl dependency to RPM

### DIFF
--- a/rpm/ckan.spec
+++ b/rpm/ckan.spec
@@ -7,6 +7,7 @@ Packager: The CKAN authors <rpm@ksp-ckan.space>
 License: MIT
 AutoReqProv: no
 Requires: mono-core >= 5.0
+Requires: libcurl-devel
 BuildArch: noarch
 Source0: ckan
 Source1: ckan.exe


### PR DESCRIPTION
Our wiki instructions for installing on Fedora say to install `libcurl-devel` manually:

https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-Fedora#libcurl

If this is needed, the RPM should handle it as a dependency. Now it will.