### PR TITLE
Purge stale cache entries for SpaceDock

### DIFF
--- a/Netkan/Sources/Spacedock/SDVersion.cs
+++ b/Netkan/Sources/Spacedock/SDVersion.cs
@@ -17,6 +17,7 @@ namespace CKAN.NetKAN.Sources.Spacedock
         public KspVersion KSP_version;
 
         public string changelog;
+        public DateTime? created;
 
         [JsonConverter(typeof(JsonConvertFromRelativeSdUri))]
         public Uri download_path;

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -79,6 +79,7 @@ namespace CKAN.NetKAN.Transformers
             json.SafeAdd("abstract", sdMod.short_description);
             json.SafeAdd("version", latestVersion.friendly_version.ToString());
             json.SafeAdd("download", latestVersion.download_path.OriginalString);
+            json.SafeAdd(Model.Metadata.UpdatedPropertyName, latestVersion.created);
 
             var authors = GetAuthors(sdMod);
 


### PR DESCRIPTION
This is #2337, but for SpaceDock.

Needs KSP-SpaceDock/SpaceDock#195 to be merged to SpaceDock's production. Currently it's still being tested on the alpha server.