### PR TITLE
Fix NRE on failed queue inflate

### DIFF
--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -133,16 +133,19 @@ namespace CKAN.NetKAN.Processors
                         DataType    = "String",
                         StringValue = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture)
                     }
-                },
-                {
+                }
+            };
+            if (ckan != null)
+            {
+                attribs.Add(
                     "FileName",
                     new MessageAttributeValue()
                     {
                         DataType    = "String",
                         StringValue = Program.CkanFileName(ckan)
                     }
-                }
-            };
+                );
+            }
             if (!string.IsNullOrEmpty(err))
             {
                 attribs.Add(


### PR DESCRIPTION
## Problem

If the queue inflator from #2798 encounters an error while inflating a netkan, an exception is thrown while trying to process the error:

```
544 [1] INFO CKAN.NetKAN.Processors.Inflator (null) - Using user-supplied cache at ckan_cache
1773837 [1] INFO CKAN.NetKAN.Processors.QueueHandler (null) - Inflating CustomDesignSpacesuits-Steampunk
1773840 [1] INFO CKAN.NetKAN.Validators.HasIdentifierValidator (null) - Validating that metadata contains an identifier
1773840 [1] INFO CKAN.NetKAN.Validators.KrefValidator (null) - Validating that metadata contains valid or null $kref
1773848 [1] INFO CKAN.NetKAN.Processors.Inflator (null) - Input successfully passed pre-validation
1774796 [1] INFO CKAN.NetKAN.Processors.QueueHandler (null) - Inflation failed, sending error: Ssl error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED
  at /build/mono-5.20.1.34/external/boringssl/ssl/handshake_client.c:1132
1774797 [1] FATAL CKAN.NetKAN.Program (null) - Object reference not set to an instance of an object
```

(That `Object reference not set to an instance of an object` line shouldn't be there. The rest are fine.)

## Cause

If inflation fails, we don't have a `ckan` object, so we pass null to `sendCkan`:

https://github.com/KSP-CKAN/CKAN/blob/d47a5b79d3eb8bbb29dfcc9d1e63b38b9b1f3019/Netkan/Processors/QueueHandler.cs#L80

https://github.com/KSP-CKAN/CKAN/blob/d47a5b79d3eb8bbb29dfcc9d1e63b38b9b1f3019/Netkan/Processors/QueueHandler.cs#L101

This is passed to `Program.CkanFileName`:

https://github.com/KSP-CKAN/CKAN/blob/d47a5b79d3eb8bbb29dfcc9d1e63b38b9b1f3019/Netkan/Processors/QueueHandler.cs#L142

... which assumes it can't be null:

https://github.com/KSP-CKAN/CKAN/blob/d47a5b79d3eb8bbb29dfcc9d1e63b38b9b1f3019/Netkan/Program.cs#L167-L177

The NRE would be thrown when we try to access `.Identifier` or `.Version`.

## Changes

Now the `FileName` outgoing queue attribute is optional, only sent when the `ckan` parameter is non-null, because without it we don't know what the filename should be.

Fixes #2865.