### PR TITLE
Allow totally incompatible modules in changeset

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -288,16 +288,11 @@ namespace CKAN
 
         public IEnumerable<KeyValuePair<CkanModule, GUIModChangeType>> GetRequestedChanges()
         {
-            if (IsInstalled && !IsInstallChecked)
-            {
-                // Uninstall the version we have installed
-                yield return new KeyValuePair<CkanModule, GUIModChangeType>(InstalledMod.Module, GUIModChangeType.Remove);
-            }
-            else if (!IsInstalled && IsInstallChecked)
-            {
-                yield return new KeyValuePair<CkanModule, GUIModChangeType>(SelectedMod ?? Mod, GUIModChangeType.Install);
-            }
-            else if (IsInstalled && (IsInstallChecked && HasUpdate && IsUpgradeChecked))
+            bool selectedIsInstalled = SelectedMod?.Equals(InstalledMod?.Module)
+                ?? InstalledMod?.Module.Equals(SelectedMod)
+                // Both null
+                ?? true;
+            if (IsInstalled && (IsInstallChecked && HasUpdate && IsUpgradeChecked))
             {
                 yield return new KeyValuePair<CkanModule, GUIModChangeType>(Mod, GUIModChangeType.Update);
             }
@@ -305,12 +300,16 @@ namespace CKAN
             {
                 yield return new KeyValuePair<CkanModule, GUIModChangeType>(Mod, GUIModChangeType.Replace);
             }
-            else if (IsInstalled
-                && SelectedMod != null
-                && !InstalledMod.Module.Equals(SelectedMod))
+            else if (!selectedIsInstalled)
             {
-                yield return new KeyValuePair<CkanModule, GUIModChangeType>(InstalledMod.Module, GUIModChangeType.Remove);
-                yield return new KeyValuePair<CkanModule, GUIModChangeType>(SelectedMod, GUIModChangeType.Install);
+                if (InstalledMod != null)
+                {
+                    yield return new KeyValuePair<CkanModule, GUIModChangeType>(InstalledMod.Module, GUIModChangeType.Remove);
+                }
+                if (SelectedMod != null)
+                {
+                    yield return new KeyValuePair<CkanModule, GUIModChangeType>(SelectedMod, GUIModChangeType.Install);
+                }
             }
         }
 

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -1076,7 +1076,6 @@ namespace CKAN
                 ?? new InstalledModule[] {};
             return new HashSet<ModChange>(
                 Modules
-                    .Where(mod => mod.IsInstallable())
                     .SelectMany(mod => mod.GetRequestedChanges())
                     .Select(change => new ModChange(change.Key, change.Value, null))
                     .Union(removableAuto.Select(im => new ModChange(


### PR DESCRIPTION
## Problem

In #2821 we added the ability to select a specific version of a module to install in GUI rather than only installing the latest compatible. As part of this, incompatible versions were allowed as well.

However, you could only install an incompatible version if at least one other version of the module was compatible. Modules with **no** compatible versions (let's call them "totally incompatible") could be selected but would not show up in the changeset and could not be installed.

## Cause

Totally incompatible modules were excluded in two ways, in line with the old assumptions about installability:

- `MainModList.ComputeUserChangeSet` only checked modules for which `IsInstallable` is true (it's false for totally incompatible modules)
- `GUIMod.GetRequestedChanges` only allowed installing a new module if the install checkbox was visible and checked (it's `-` for totally incompatible modules), and changing from one version to another only worked if the module was already installed

## Changes

- Now `MainModList.ComputeUserChangeSet` checks all modules
- Now `GUIMod.GetRequestedChanges` can return an installation change even if the installation checkbox isn't available, as long as `InstalledMod` and `SelectedMod` aren't the same. As part of this, the old install/uninstall logic and the newer version-switching logic are unified to a single block.

@xZise, if you'd like to try this change, here's a test build:
- [ckan.zip](https://github.com/KSP-CKAN/CKAN/files/3613031/ckan.zip)

Fixes #2868.