### PR TITLE
Add Missing libcurl Dependency for NetKAN

### DIFF
--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -1,5 +1,6 @@
 FROM mono:5.20.1
 RUN useradd -ms /bin/bash netkan
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev
 USER netkan
 WORKDIR /home/netkan
 ADD netkan.exe .


### PR DESCRIPTION
When testing the status page with the status data generated from DynamoDB, I noticed a bunch of errors complaining about `libcurl`.

This adds the dependency to the container.