### PR TITLE
Set 'MessageId' attribute for batch delete

### DIFF
--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -240,7 +240,7 @@ namespace CKAN.NetKAN.Processors
         {
             return new DeleteMessageBatchRequestEntry()
             {
-                Id            = msg.ReceiptHandle,
+                Id            = msg.MessageId,
                 ReceiptHandle = msg.ReceiptHandle,
             };
         }


### PR DESCRIPTION
Small typo fix for Queue Batch deletes, noticed when investigating #2876 