### PR TITLE
Use current metadata for installed module compatibility

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -15,7 +15,7 @@ namespace CKAN.CmdLine
         {
             AvailableOptions opts      = (AvailableOptions)raw_options;
             IRegistryQuerier registry  = RegistryManager.Instance(ksp).registry;
-            List<CkanModule> available = registry.Available(ksp.VersionCriteria());
+            var              available = registry.Available(ksp.VersionCriteria());
 
             user.RaiseMessage("Mods available for KSP {0}", ksp.Version());
             user.RaiseMessage("");

--- a/Cmdline/Action/Search.cs
+++ b/Cmdline/Action/Search.cs
@@ -186,7 +186,7 @@ namespace CKAN.CmdLine
         {
             IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
             // Get the list of all compatible and incompatible mods
-            List<CkanModule> mods = registry.Available(ksp.VersionCriteria());
+            List<CkanModule> mods = registry.Available(ksp.VersionCriteria()).ToList();
             mods.AddRange(registry.Incompatible(ksp.VersionCriteria()));
             for (int i = 0; i < modules.Count; ++i)
             {

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -39,7 +39,7 @@ namespace CKAN.CmdLine
             {
                 // Get a list of available modules prior to the update.
                 var registry = RegistryManager.Instance(ksp).registry;
-                available_prior = registry.Available(ksp.VersionCriteria());
+                available_prior = registry.Available(ksp.VersionCriteria()).ToList();
             }
 
             // If no repository is selected, select all.
@@ -69,7 +69,7 @@ namespace CKAN.CmdLine
             if (options.list_changes)
             {
                 var registry = RegistryManager.Instance(ksp).registry;
-                PrintChanges(available_prior, registry.Available(ksp.VersionCriteria()));
+                PrintChanges(available_prior, registry.Available(ksp.VersionCriteria()).ToList());
             }
 
             return Exit.OK;
@@ -154,7 +154,7 @@ namespace CKAN.CmdLine
                 : CKAN.Repo.Update(registry_manager, ksp, user, repository);
 
             user.RaiseMessage("Updated information on {0} available modules",
-                registry_manager.registry.Available(ksp.VersionCriteria()).Count);
+                registry_manager.registry.Available(ksp.VersionCriteria()).Count());
         }
     }
 }

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Linq;
 using CKAN.Versioning;
 using CKAN.ConsoleUI.Toolkit;
 
@@ -312,7 +313,7 @@ namespace CKAN.ConsoleUI {
 
             if (ChangePlan.IsAnyAvailable(registry, mod.identifier)) {
 
-                List<CkanModule> avail              = registry.AllAvailable(       mod.identifier);
+                List<CkanModule> avail              = registry.AllAvailable(mod.identifier).ToList();
                 CkanModule       inst               = registry.GetInstalledVersion(mod.identifier);
                 CkanModule       latest             = registry.LatestAvailable(    mod.identifier, null);
                 bool             installed          = registry.IsInstalled(mod.identifier, false);

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -165,10 +165,10 @@ namespace CKAN
             return module;
         }
 
-        public List<CkanModule> AllAvailable()
+        public IEnumerable<CkanModule> AllAvailable()
         {
             // Some code may expect this to be sorted in descending order
-            return new List<CkanModule>(module_version.Values.Reverse());
+            return module_version.Values.Reverse();
         }
 
         /// <summary>

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using CKAN.Versioning;
 
 namespace CKAN
@@ -19,7 +20,7 @@ namespace CKAN
         /// the specified version of KSP.
         /// </summary>
         // TODO: This name is misleading. It's more a LatestAvailable's'
-        List<CkanModule> Available(KspVersionCriteria ksp_version);
+        IEnumerable<CkanModule> Available(KspVersionCriteria ksp_version);
 
         /// <summary>
         /// Get full JSON metadata string for a mod's available versions
@@ -49,7 +50,7 @@ namespace CKAN
         ///     Returns all available version of a module.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
-        List<CkanModule> AllAvailable(string identifier);
+        IEnumerable<CkanModule> AllAvailable(string identifier);
 
         /// <summary>
         ///     Returns the latest available version of a module that satisifes the specified version and
@@ -105,7 +106,7 @@ namespace CKAN
         ///     Returns a simple array of all incompatible modules for
         ///     the specified version of KSP.
         /// </summary>
-        List<CkanModule> Incompatible(KspVersionCriteria ksp_version);
+        IEnumerable<CkanModule> Incompatible(KspVersionCriteria ksp_version);
 
         /// <summary>
         /// Returns a dictionary of all modules installed, along with their
@@ -194,7 +195,7 @@ namespace CKAN
         /// </returns>
         public static string CompatibleGameVersions(this IRegistryQuerier querier, string identifier)
         {
-            List<CkanModule> releases = querier.AllAvailable(identifier);
+            List<CkanModule> releases = querier.AllAvailable(identifier).ToList();
             if (releases != null && releases.Count > 0) {
                 ModuleVersion minMod = null, maxMod = null;
                 KspVersion    minKsp = null, maxKsp = null;

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -476,10 +476,9 @@ namespace CKAN
         /// <summary>
         /// <see cref="IRegistryQuerier.Available"/>
         /// </summary>
-        public List<CkanModule> Available(KspVersionCriteria ksp_version)
+        public IEnumerable<CkanModule> Available(KspVersionCriteria ksp_version)
         {
             var candidates = new List<string>(available_modules.Keys);
-            var compatible = new List<CkanModule>();
 
             // It's nice to see things in alphabetical order, so sort our keys first.
             candidates.Sort();
@@ -492,19 +491,17 @@ namespace CKAN
                 if (available != null
                     && allDependenciesCompatible(available, ksp_version))
                 {
-                    compatible.Add(available);
+                    yield return available;
                 }
             }
-            return compatible;
         }
 
         /// <summary>
         /// <see cref="IRegistryQuerier.Incompatible"/>
         /// </summary>
-        public List<CkanModule> Incompatible(KspVersionCriteria ksp_version)
+        public IEnumerable<CkanModule> Incompatible(KspVersionCriteria ksp_version)
         {
             var candidates   = new List<string>(available_modules.Keys);
-            var incompatible = new List<CkanModule>();
 
             // It's nice to see things in alphabetical order, so sort our keys first.
             candidates.Sort();
@@ -518,11 +515,9 @@ namespace CKAN
                 if (available == null
                     || !allDependenciesCompatible(available, ksp_version))
                 {
-                    incompatible.Add(LatestAvailable(candidate, null));
+                    yield return LatestAvailable(candidate, null);
                 }
             }
-
-            return incompatible;
         }
 
         private bool allDependenciesCompatible(CkanModule mod, KspVersionCriteria ksp_version)
@@ -580,7 +575,7 @@ namespace CKAN
         }
 
 
-        public List<CkanModule> AllAvailable(string module)
+        public IEnumerable<CkanModule> AllAvailable(string module)
         {
             log.DebugFormat("Finding all available versions for {0}", module);
             try

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -129,7 +129,7 @@ namespace CKAN
         /// <param name="registry">CKAN registry object for current game instance</param>
         /// <param name="current_ksp_version">Current game version</param>
         /// <param name="incompatible">If true, mark this module as incompatible</param>
-        public GUIMod(InstalledModule instMod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool incompatible = false)
+        public GUIMod(InstalledModule instMod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool? incompatible = null)
             : this(instMod.Module, registry, current_ksp_version, incompatible)
         {
             IsInstalled      = true;
@@ -152,7 +152,7 @@ namespace CKAN
         /// <param name="registry">CKAN registry object for current game instance</param>
         /// <param name="current_ksp_version">Current game version</param>
         /// <param name="incompatible">If true, mark this module as incompatible</param>
-        public GUIMod(CkanModule mod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool incompatible = false)
+        public GUIMod(CkanModule mod, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool? incompatible = null)
             : this(mod.identifier, registry, current_ksp_version, incompatible)
         {
             Mod           = mod;
@@ -167,7 +167,6 @@ namespace CKAN
             HasUpdate      = registry.HasUpdate(mod.identifier, current_ksp_version);
             HasReplacement = registry.GetReplacement(mod, current_ksp_version) != null;
             DownloadSize   = mod.download_size == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.download_size);
-            IsIncompatible = IsIncompatible || !mod.IsCompatibleKSP(current_ksp_version);
 
             if (mod.resources != null)
             {
@@ -194,10 +193,12 @@ namespace CKAN
         /// <param name="registry">CKAN registry object for current game instance</param>
         /// <param name="current_ksp_version">Current game version</param>
         /// <param name="incompatible">If true, mark this module as incompatible</param>
-        public GUIMod(string identifier, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool incompatible = false)
+        public GUIMod(string identifier, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool? incompatible = null)
         {
             Identifier     = identifier;
-            IsIncompatible = incompatible;
+            IsIncompatible = incompatible
+                ?? registry.AllAvailable(identifier)
+                    .All(m => !m.IsCompatibleKSP(current_ksp_version));
             IsAutodetected = registry.IsAutodetected(identifier);
             DownloadCount  = registry.DownloadCount(identifier);
             if (registry.IsAutodetected(identifier))

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -191,7 +191,7 @@ namespace CKAN
             AddLogMessage(Properties.Resources.MainModListLoadingAvailable);
             gui_mods.UnionWith(
                 registry.Available(versionCriteria)
-                    .Select(m => new GUIMod(m, registry, versionCriteria))
+                    .Select(m => new GUIMod(m, registry, versionCriteria, false))
             );
             AddLogMessage(Properties.Resources.MainModListLoadingIncompatible);
             gui_mods.UnionWith(

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -1,5 +1,6 @@
 using System.Transactions;
 using System.Collections.Generic;
+using System.Linq;
 using CKAN;
 using CKAN.Versioning;
 using NUnit.Framework;
@@ -106,7 +107,7 @@ namespace Tests.Core.Registry
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2);
+            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
 
             // Assert
             Assert.IsFalse(avail.Contains(DLCDepender));
@@ -129,7 +130,7 @@ namespace Tests.Core.Registry
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2);
+            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
 
             // Assert
             Assert.IsTrue(avail.Contains(DLCDepender));
@@ -153,7 +154,7 @@ namespace Tests.Core.Registry
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2);
+            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
 
             // Assert
             Assert.IsTrue(avail.Contains(DLCDepender));
@@ -177,7 +178,7 @@ namespace Tests.Core.Registry
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2);
+            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
 
             // Assert
             Assert.IsFalse(avail.Contains(DLCDepender));


### PR DESCRIPTION
## Problem

If a module's compatibility metadata changes after you install it, the GUI filters will always reflect the compatibility at time of install. For example, AblativeAirbrakes 0.3.0 only supported KSP 1.3.1 in March 2018, but now supports 1.2.2–1.7.3. If you installed it back then and kept it installed to the present, it would only be counted as compatible in GUI if you have 1.3.1 marked as compatible, but if you uninstall and/or reinstall, it will be considered compatible with all of 1.2.2–1.7.3.

## Cause

`GUIMod` has multiple layered constructors; at the bottom level you can create a `GUIMod` if you only know the identifier, above that you can create a `GUIMod` from a `CkanModule`, and at the top you can create a `GUIMod` using an `InstalledModule`. Each layer calls the level below it and then fills in extra info; the `InstalledModule` layer passes its source module (metadata from time of install), and the `CkanModule` layer passes its identifier.

The handling of compatibility in this hierarchy had some flaws. By default, everything was assumed to be compatible, which could be overridden by a constructor parameter or based on the `CkanModule` parameter's compatibility info. In the case of an `InstalledModule`, this meant that an incompatible source module would mark the overall module as incompatible, even if its current available module had subsequently been updated in CKAN-meta to be compatible.

## Changes

Now the `incompatible` constructor parameters are nullable and `null` by default. If set to true or false, we use that value. If not passed in (i.e., still `null` by the time we get to the identifier level), then we use the identifier to look up the compatibility from the registry based on the current metadata for all versions of the module.

To avoid paying the cost of this computation for compatible modules, `MainModList` now passes `incompatible`=`false` for known-compatible modules. This saves a few operations per compatible module. This function was already passing `true` for incompatible modules, and it will leave the parameter `null` for installed modules to force a check of the current metadata.

The `CkanModule`-level `GUIMod` constructor no longer checks compatibility because it was not strictly correct and is now redundant. The identifier-level constructor that it calls will set the correct value before the `CkanModule`-level constructor runs.

Several functions are changed to return `IEnumerable` instead of `List` for possible performance improvements when a search stops early (e.g., if the new `.All` call finds a false value early on, the rest of the list does not need to be generated).

Fixes #2883.