### PR TITLE
Normalize install paths

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -409,34 +409,32 @@ namespace CKAN
             var files = new List<InstallableFile>();
 
             // Normalize the path before doing everything else
-            // TODO: This really should happen in the ModuleInstallDescriptor itself.
-            stanza.install_to = KSPPathUtils.NormalizePath(stanza.install_to);
+            string install_to = KSPPathUtils.NormalizePath(stanza.install_to);
 
             // Convert our stanza to a standard `file` type. This is a no-op if it's
             // already the basic type.
-
             stanza = stanza.ConvertFindToFile(zipfile);
 
-            if (stanza.install_to == "GameData" || stanza.install_to.StartsWith("GameData/"))
+            if (install_to == "GameData" || install_to.StartsWith("GameData/"))
             {
                 // The installation path can be either "GameData" or a sub-directory of "GameData"
                 // but it cannot contain updirs
-                if (stanza.install_to.Contains("/../") || stanza.install_to.EndsWith("/.."))
-                    throw new BadInstallLocationKraken("Invalid installation path: " + stanza.install_to);
+                if (install_to.Contains("/../") || install_to.EndsWith("/.."))
+                    throw new BadInstallLocationKraken("Invalid installation path: " + install_to);
 
-                string subDir = stanza.install_to.Substring("GameData".Length);    // remove "GameData"
+                string subDir = install_to.Substring("GameData".Length);    // remove "GameData"
                 subDir = subDir.StartsWith("/") ? subDir.Substring(1) : subDir;    // remove a "/" at the beginning, if present
 
                 // Add the extracted subdirectory to the path of KSP's GameData
                 installDir = ksp == null ? null : (KSPPathUtils.NormalizePath(ksp.GameData() + "/" + subDir));
                 makeDirs = true;
             }
-            else if (stanza.install_to.StartsWith("Ships"))
+            else if (install_to.StartsWith("Ships"))
             {
                 // Don't allow directory creation in ships directory
                 makeDirs = false;
 
-                switch (stanza.install_to)
+                switch (install_to)
                 {
                     case "Ships":
                         installDir = ksp?.Ships();
@@ -457,12 +455,12 @@ namespace CKAN
                         installDir = ksp?.ShipsThumbsSPH();
                         break;
                     default:
-                        throw new BadInstallLocationKraken("Unknown install_to " + stanza.install_to);
+                        throw new BadInstallLocationKraken("Unknown install_to " + install_to);
                 }
             }
             else
             {
-                switch (stanza.install_to)
+                switch (install_to)
                 {
                     case "Tutorial":
                         installDir = ksp?.Tutorial();
@@ -485,7 +483,7 @@ namespace CKAN
                         break;
 
                     default:
-                        throw new BadInstallLocationKraken("Unknown install_to " + stanza.install_to);
+                        throw new BadInstallLocationKraken("Unknown install_to " + install_to);
                 }
             }
 

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -243,7 +243,7 @@ Do you wish to reinstall now?", sb)))
             {
                 for (int i = 0; i < metadata.install.Length; i++)
                 {
-                    if (!InstallStanzaEquals(metadata.install[i], oldMetadata.install[i]))
+                    if (!metadata.install[i].Equals(oldMetadata.install[i]))
                         return false;
                 }
             }
@@ -264,39 +264,6 @@ Do you wish to reinstall now?", sb)))
                 else if (!metadata.provides.OrderBy(i => i).SequenceEqual(oldMetadata.provides.OrderBy(i => i)))
                     return false;
             }
-            return true;
-        }
-
-        private static bool InstallStanzaEquals(ModuleInstallDescriptor newInst, ModuleInstallDescriptor oldInst)
-        {
-            if (newInst.file != oldInst.file)
-                return false;
-            if (newInst.install_to != oldInst.install_to)
-                return false;
-            if (newInst.@as != oldInst.@as)
-                return false;
-            if ((newInst.filter == null) != (oldInst.filter == null))
-                return false;
-            if (newInst.filter != null
-                && !newInst.filter.SequenceEqual(oldInst.filter))
-                return false;
-            if ((newInst.filter_regexp == null) != (oldInst.filter_regexp == null))
-                return false;
-            if (newInst.filter_regexp != null
-                && !newInst.filter_regexp.SequenceEqual(oldInst.filter_regexp))
-                return false;
-            if (newInst.find_matches_files != oldInst.find_matches_files)
-                return false;
-            if ((newInst.include_only == null) != (oldInst.include_only == null))
-                return false;
-            if (newInst.include_only != null
-                && !newInst.include_only.SequenceEqual(oldInst.include_only))
-                return false;
-            if ((newInst.include_only_regexp == null) != (oldInst.include_only_regexp == null))
-                return false;
-            if (newInst.include_only_regexp != null
-                && !newInst.include_only_regexp.SequenceEqual(oldInst.include_only_regexp))
-                return false;
             return true;
         }
 

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -85,6 +85,17 @@ namespace CKAN
             {
                 throw new BadMetadataKraken(null, "Install stanzas can only contain filter or include_only directives, not both");
             }
+            
+            // Normalize paths on load (note, doesn't cover assignment like in tests)
+            install_to = KSPPathUtils.NormalizePath(install_to);
+            if (find != null)
+            {
+                find = KSPPathUtils.NormalizePath(find);
+            }
+            if (file != null)
+            {
+                file = KSPPathUtils.NormalizePath(file);
+            }
         }
 
         #endregion
@@ -104,6 +115,54 @@ namespace CKAN
             // Deep clone our object by running it through a serialisation cycle.
             string json = JsonConvert.SerializeObject(this, Formatting.None);
             return JsonConvert.DeserializeObject<ModuleInstallDescriptor>(json);
+        }
+
+        /// <summary>
+        /// Compare two install stanzas
+        /// </summary>
+        /// <param name="other">The other stanza for comparison</param>
+        /// <returns>
+        /// True if they're equivalent, false if they're different
+        /// </returns>
+        public override bool Equals(object other)
+        {
+            ModuleInstallDescriptor otherStanza = other as ModuleInstallDescriptor;
+            if (otherStanza == null)
+                // Not even the right type!
+                return false;
+            if (KSPPathUtils.NormalizePath(file) != KSPPathUtils.NormalizePath(otherStanza.file))
+                return false;
+            if (KSPPathUtils.NormalizePath(find) != KSPPathUtils.NormalizePath(otherStanza.find))
+                return false;
+            if (find_regexp != otherStanza.find_regexp)
+                return false;
+            if (KSPPathUtils.NormalizePath(install_to) != KSPPathUtils.NormalizePath(otherStanza.install_to))
+                return false;
+            if (@as != otherStanza.@as)
+                return false;
+            if ((filter == null) != (otherStanza.filter == null))
+                return false;
+            if (filter != null
+                && !filter.SequenceEqual(otherStanza.filter))
+                return false;
+            if ((filter_regexp == null) != (otherStanza.filter_regexp == null))
+                return false;
+            if (filter_regexp != null
+                && !filter_regexp.SequenceEqual(otherStanza.filter_regexp))
+                return false;
+            if (find_matches_files != otherStanza.find_matches_files)
+                return false;
+            if ((include_only == null) != (otherStanza.include_only == null))
+                return false;
+            if (include_only != null
+                && !include_only.SequenceEqual(otherStanza.include_only))
+                return false;
+            if ((include_only_regexp == null) != (otherStanza.include_only_regexp == null))
+                return false;
+            if (include_only_regexp != null
+                && !include_only_regexp.SequenceEqual(otherStanza.include_only_regexp))
+                return false;
+            return true;
         }
 
         /// <summary>

--- a/Netkan/Validators/InstallValidator.cs
+++ b/Netkan/Validators/InstallValidator.cs
@@ -42,6 +42,19 @@ namespace CKAN.NetKAN.Validators
                     {
                         throw new Kraken("spec_version v1.18+ required for 'as'");
                     }
+                    // Check for normalized paths
+                    foreach (string propName in pathProperties)
+                    {
+                        if (stanza.ContainsKey(propName))
+                        {
+                            string val  = (string)stanza[propName];
+                            string norm = KSPPathUtils.NormalizePath(val);
+                            if (val != norm)
+                            {
+                                throw new Kraken($"Path \"{val}\" in '{propName}' is not normalized, should be \"{norm}\"");
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -52,5 +65,6 @@ namespace CKAN.NetKAN.Validators
         private static readonly ModuleVersion v1p12 = new ModuleVersion("v1.12");
         private static readonly ModuleVersion v1p16 = new ModuleVersion("v1.16");
         private static readonly ModuleVersion v1p18 = new ModuleVersion("v1.18");
+        private static readonly string[] pathProperties = {"find", "file", "install_to"};
     }
 }


### PR DESCRIPTION
## Problem

If you install a module with an `install_to` that ends with a slash (`/`), you will receive the changed-metadata and reinstallation prompt every time you perform a non-redundant refresh (i.e., something has actually changed in CKAN-meta).

![screenshot](https://camo.githubusercontent.com/31ed56b209be3d6ce15094c1a521faad25f2cddb/68747470733a2f2f692e696d6775722e636f6d2f616b316d43446d2e706e67)

All such extant paths were normalized in KSP-CKAN/NetKAN#7419 and KSP-CKAN/CKAN-meta#1510, but now we will address the root causes.

## Cause

1. The client downloads the non-normalized metadata from CKAN-meta:

| Available module | Installed module |
| --- | --- |
| `GameData/002_CommunityPartsTitles/Extras/` | (none) |

2. The user installs the module, and `ModuleInstaller` normalizes the `install_to` at installation, which affects the instance of the `CkanModule` stored in the registry:

| Available module | Installed module |
| --- | --- |
| `GameData/002_CommunityPartsTitles/Extras` | (none) |

3. The available module is cloned to produce the installed module:

| Available module | Installed module |
| --- | --- |
| `GameData/002_CommunityPartsTitles/Extras` | `GameData/002_CommunityPartsTitles/Extras` |

4. Later, the user updates the registry and again receives the non-normalized metadata:

| Available module | Installed module |
| --- | --- |
| `GameData/002_CommunityPartsTitles/Extras/` | `GameData/002_CommunityPartsTitles/Extras` |

Since these values do not match, CKAN thinks a significant change has been made to this module and prompts for reinstallation.

## Changes

- Now `ModuleInstaller` doesn't change the original install stanza, it just puts the normalized path in a local variable and uses it from there. This will prevent unintentional changes to the registry.
- Now the logic to compare install stanzas normalizes them before comparing. This means that if one stanza has a normalized path and the other has a non-normalized path, they can still be equal if both have the same normalized form.
- Now we normalize `file`, `find`, and `install_to` after deserialization. (But since these values can be set in ways other than deserialization, the existing normalization call is not removed.) This will cause values in the registry to be normalized more consistently.
- Now Netkan will print an error if `file`, `find`, or `install_to` are not normalized in its input. This will ensure that we can catch such metadata in the future at the pull request stage.

Side fixes:

- Now the logic to compare install stanzas is moved from `Repo` to `ModuleInstallDescriptor.Equals`, in the install stanza class. This is where such code usually would go.
- Now the logic to compare install stanzas checks whether `find` or `find_regexp` have changed. These were just missing before and may have allowed some metadata changes to occur without prompting for reinstallation (although I do not recall seeing such a change go through).

Fixes #2880.