### PR TITLE
Show target version for upgrades in change set

### DIFF
--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -43,7 +43,7 @@ namespace CKAN
 
                     Main.Instance.UpdateChangeSetAndConflicts(
                         RegistryManager.Instance(Main.Instance.Manager.CurrentInstance).registry
-                    ).RunSynchronously();
+                    );
 
                     OnPropertyChanged();
                 }

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -43,7 +43,7 @@ namespace CKAN
 
                     Main.Instance.UpdateChangeSetAndConflicts(
                         RegistryManager.Instance(Main.Instance.Manager.CurrentInstance).registry
-                    );
+                    ).RunSynchronously();
 
                     OnPropertyChanged();
                 }
@@ -56,7 +56,7 @@ namespace CKAN
         /// Currently used to tell MainAllModVersions to update its checkboxes.
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        private void OnPropertyChanged([CallerMemberName] string name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
@@ -287,7 +287,7 @@ namespace CKAN
             return Mod;
         }
 
-        public IEnumerable<KeyValuePair<CkanModule, GUIModChangeType>> GetRequestedChanges()
+        public IEnumerable<ModChange> GetModChanges()
         {
             bool selectedIsInstalled = SelectedMod?.Equals(InstalledMod?.Module)
                 ?? InstalledMod?.Module.Equals(SelectedMod)
@@ -295,21 +295,21 @@ namespace CKAN
                 ?? true;
             if (IsInstalled && (IsInstallChecked && HasUpdate && IsUpgradeChecked))
             {
-                yield return new KeyValuePair<CkanModule, GUIModChangeType>(Mod, GUIModChangeType.Update);
+                yield return new ModUpgrade(Mod, GUIModChangeType.Update, null, SelectedMod);
             }
             else if (IsReplaceChecked)
             {
-                yield return new KeyValuePair<CkanModule, GUIModChangeType>(Mod, GUIModChangeType.Replace);
+                yield return new ModChange(Mod, GUIModChangeType.Replace, null);
             }
             else if (!selectedIsInstalled)
             {
                 if (InstalledMod != null)
                 {
-                    yield return new KeyValuePair<CkanModule, GUIModChangeType>(InstalledMod.Module, GUIModChangeType.Remove);
+                    yield return new ModChange(InstalledMod.Module, GUIModChangeType.Remove, null);
                 }
                 if (SelectedMod != null)
                 {
-                    yield return new KeyValuePair<CkanModule, GUIModChangeType>(SelectedMod, GUIModChangeType.Install);
+                    yield return new ModChange(SelectedMod, GUIModChangeType.Install, null);
                 }
             }
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -741,7 +741,7 @@ namespace CKAN
             try
             {
                 var module_installer = ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, GUI.user);
-                full_change_set = await mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer, CurrentInstance.VersionCriteria());
+                full_change_set = mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer, CurrentInstance.VersionCriteria());
             }
             catch (InconsistentKraken k)
             {

--- a/GUI/MainAllModVersions.cs
+++ b/GUI/MainAllModVersions.cs
@@ -18,7 +18,7 @@ namespace CKAN
         private GUIMod visibleGuiModule = null;
         private bool   ignoreItemCheck  = false;
 
-        private async void VersionsListView_ItemCheck(object sender, ItemCheckEventArgs e)
+        private void VersionsListView_ItemCheck(object sender, ItemCheckEventArgs e)
         {
             if (ignoreItemCheck || e.CurrentValue == e.NewValue)
             {

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -47,35 +47,20 @@ namespace CKAN
                 }
 
                 CkanModule m = change.Mod;
-                ListViewItem item = new ListViewItem()
+                ChangesListView.Items.Add(new ListViewItem(new string[]
                 {
-                    Text = m.IsMetapackage
+                    m.IsMetapackage
                         ? string.Format(Properties.Resources.MainChangesetMetapackage, m.name, m.version)
                         : Manager.Cache.IsMaybeCachedZip(m)
                             ? string.Format(Properties.Resources.MainChangesetCached, m.name, m.version)
                             : string.Format(Properties.Resources.MainChangesetHostSize,
                                 m.name, m.version, m.download.Host ?? "", CkanModule.FmtSize(m.download_size)),
-                    Tag  = change.Mod
-                };
-
-                var sub_change_type = new ListViewItem.ListViewSubItem {Text = change.ChangeType.ToString()};
-
-                ListViewItem.ListViewSubItem description = new ListViewItem.ListViewSubItem();
-                description.Text = change.Reason.Reason.Trim();
-
-                if (change.ChangeType == GUIModChangeType.Update)
+                    change.ChangeType.ToString(),
+                    change.Description
+                })
                 {
-                    description.Text = String.Format(Properties.Resources.MainChangesetUpdateSelected, change.Mod.version);
-                }
-
-                if (change.ChangeType == GUIModChangeType.Install && change.Reason is SelectionReason.UserRequested)
-                {
-                    description.Text = Properties.Resources.MainChangesetNewInstall;
-                }
-
-                item.SubItems.Add(sub_change_type);
-                item.SubItems.Add(description);
-                ChangesListView.Items.Add(item);
+                    Tag = m
+                });
             }
         }
 

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -49,12 +49,7 @@ namespace CKAN
                 CkanModule m = change.Mod;
                 ChangesListView.Items.Add(new ListViewItem(new string[]
                 {
-                    m.IsMetapackage
-                        ? string.Format(Properties.Resources.MainChangesetMetapackage, m.name, m.version)
-                        : Manager.Cache.IsMaybeCachedZip(m)
-                            ? string.Format(Properties.Resources.MainChangesetCached, m.name, m.version)
-                            : string.Format(Properties.Resources.MainChangesetHostSize,
-                                m.name, m.version, m.download.Host ?? "", CkanModule.FmtSize(m.download_size)),
+                    change.NameAndStatus,
                     change.ChangeType.ToString(),
                     change.Description
                 })

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -24,7 +24,7 @@ namespace CKAN
         /// </summary>
         /// <param name="registry">Reference to the registry</param>
         /// <param name="module">Module to install</param>
-        public async void InstallModuleDriver(IRegistryQuerier registry, CkanModule module)
+        public void InstallModuleDriver(IRegistryQuerier registry, CkanModule module)
         {
             try
             {
@@ -394,21 +394,17 @@ namespace CKAN
 
             foreach (CkanModule module in tooManyProvides.modules)
             {
-                ListViewItem item = new ListViewItem()
+                ChooseProvidedModsListView.Items.Add(new ListViewItem(new string[]
+                {
+                    Manager.Cache.IsMaybeCachedZip(module)
+                        ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
+                        : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download.Host ?? "", CkanModule.FmtSize(module.download_size)),
+                    module.@abstract
+                })
                 {
                     Tag = module,
-                    Checked = false,
-                    Text = Manager.Cache.IsMaybeCachedZip(module)
-                        ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
-                        : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download.Host ?? "", CkanModule.FmtSize(module.download_size))
-                };
-                ListViewItem.ListViewSubItem description = new ListViewItem.ListViewSubItem()
-                {
-                    Text = module.@abstract
-                };
-
-                item.SubItems.Add(description);
-                ChooseProvidedModsListView.Items.Add(item);
+                    Checked = false
+                });
             }
             ChooseProvidedModsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
             ChooseProvidedModsContinueButton.Enabled = false;

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -236,7 +236,7 @@ namespace CKAN
             mainModList.Modules = new ReadOnlyCollection<GUIMod>(
                 mainModList.full_list_of_mod_rows.Values.Select(row => row.Tag as GUIMod).ToList());
             
-            UpdateChangeSetAndConflicts(registry);                
+            UpdateChangeSetAndConflicts(registry).RunSynchronously();
 
             AddLogMessage(Properties.Resources.MainModListUpdatingFilters);
 
@@ -742,7 +742,7 @@ namespace CKAN
         /// <param name="changeSet"></param>
         /// <param name="installer">A module installer for the current KSP install</param>
         /// <param name="version">The version of the current KSP install</param>
-        public async Task<IEnumerable<ModChange>> ComputeChangeSetFromModList(
+        public IEnumerable<ModChange> ComputeChangeSetFromModList(
             IRegistryQuerier registry, HashSet<ModChange> changeSet, ModuleInstaller installer,
             KspVersionCriteria version)
         {
@@ -1076,8 +1076,7 @@ namespace CKAN
                 ?? new InstalledModule[] {};
             return new HashSet<ModChange>(
                 Modules
-                    .SelectMany(mod => mod.GetRequestedChanges())
-                    .Select(change => new ModChange(change.Key, change.Value, null))
+                    .SelectMany(mod => mod.GetModChanges())
                     .Union(removableAuto.Select(im => new ModChange(
                         im.Module,
                         GUIModChangeType.Remove,

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -236,7 +236,7 @@ namespace CKAN
             mainModList.Modules = new ReadOnlyCollection<GUIMod>(
                 mainModList.full_list_of_mod_rows.Values.Select(row => row.Tag as GUIMod).ToList());
             
-            UpdateChangeSetAndConflicts(registry).RunSynchronously();
+            UpdateChangeSetAndConflicts(registry);
 
             AddLogMessage(Properties.Resources.MainModListUpdatingFilters);
 

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -152,19 +152,19 @@ namespace CKAN
 
         private ListViewItem getRecSugItem(CkanModule module, string descrip, ListViewGroup group, bool check)
         {
-            ListViewItem item = new ListViewItem()
+            return new ListViewItem(new string[]
+            {
+                Manager.Cache.IsMaybeCachedZip(module)
+                    ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
+                    : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download.Host ?? "", CkanModule.FmtSize(module.download_size)),
+                descrip,
+                module.@abstract
+            })
             {
                 Tag     = module,
                 Checked = check,
-                Group   = group,
-                Text    = Manager.Cache.IsMaybeCachedZip(module)
-                    ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
-                    : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download.Host ?? "", CkanModule.FmtSize(module.download_size))
+                Group   = group
             };
-
-            item.SubItems.Add(new ListViewItem.ListViewSubItem() { Text = descrip          });
-            item.SubItems.Add(new ListViewItem.ListViewSubItem() { Text = module.@abstract });
-            return item;
         }
 
         /// <summary>

--- a/GUI/ManageKspInstances.cs
+++ b/GUI/ManageKspInstances.cs
@@ -59,18 +59,12 @@ namespace CKAN
             foreach (var instance in _manager.Instances)
             {
                 KSPInstancesListView.Items.Add(
-                    new ListViewItem(new ListViewItem.ListViewSubItem[]
+                    new ListViewItem(new string[]
                     {
-                        new ListViewItem.ListViewSubItem {
-                            Text = instance.Key
-                        },
-                        new ListViewItem.ListViewSubItem {
-                            Text = instance.Value.Version()?.ToString() ?? Properties.Resources.CompatibleKspVersionsDialogNone
-                        },
-                        new ListViewItem.ListViewSubItem {
-                            Text = instance.Value.GameDir().Replace('/', Path.DirectorySeparatorChar)
-                        }
-                    }, 0)
+                        instance.Key,
+                        instance.Value.Version()?.ToString() ?? Properties.Resources.CompatibleKspVersionsDialogNone,
+                        instance.Value.GameDir().Replace('/', Path.DirectorySeparatorChar)
+                    })
                     {
                         Tag = instance.Key
                     });

--- a/GUI/ModChange.cs
+++ b/GUI/ModChange.cs
@@ -58,6 +58,24 @@ namespace CKAN
         {
             return $"{ChangeType} {Mod} ({Reason})";
         }
+        
+        protected string modNameAndStatus(CkanModule m)
+        {
+            return m.IsMetapackage
+                ? string.Format(Properties.Resources.MainChangesetMetapackage, m.name, m.version)
+                : Main.Instance.Manager.Cache.IsMaybeCachedZip(m)
+                    ? string.Format(Properties.Resources.MainChangesetCached, m.name, m.version)
+                    : string.Format(Properties.Resources.MainChangesetHostSize,
+                        m.name, m.version, m.download.Host ?? "", CkanModule.FmtSize(m.download_size));
+        }
+        
+        public virtual string NameAndStatus
+        {
+            get
+            {
+                return modNameAndStatus(Mod);
+            }
+        }
 
         public virtual string Description
         {
@@ -85,6 +103,14 @@ namespace CKAN
             : base(mod, changeType, reason)
         {
             this.targetMod = targetMod;
+        }
+        
+        public override string NameAndStatus
+        {
+            get
+            {
+                return modNameAndStatus(targetMod);
+            }
         }
         
         public override string Description

--- a/GUI/ModChange.cs
+++ b/GUI/ModChange.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 
 namespace CKAN
 {
@@ -17,6 +19,12 @@ namespace CKAN
     public class ModChange
     {
         public CkanModule       Mod        { get; private set; }
+        /// <summary>
+        /// For changes involving another version in addition to the main one,
+        /// this is that other version.
+        /// When upgrading, the target version.
+        /// Otherwise not used.
+        /// </summary>
         public GUIModChangeType ChangeType { get; private set; }
         public SelectionReason  Reason     { get; private set; }
 
@@ -24,14 +32,8 @@ namespace CKAN
         {
             Mod        = mod;
             ChangeType = changeType;
-            Reason     = reason;
-
-            if (Reason == null)
-            {
-                // Hey, we don't have a Reason
-                // Most likely the user wanted to install it
-                Reason = new SelectionReason.UserRequested();
-            }
+            // If we don't have a Reason, the user probably wanted to install it
+            Reason     = reason ?? new SelectionReason.UserRequested();
         }
 
         public override bool Equals(object obj)
@@ -42,17 +44,60 @@ namespace CKAN
             return (obj as ModChange).Mod.Equals(Mod);
         }
 
+        private static int maxEnumVal = Enum.GetValues(typeof(GUIModChangeType)).Cast<int>().Max();
+
         public override int GetHashCode()
         {
             // Distinguish between installing and removing
             return Mod == null
                 ? 0
-                : (4 * Mod.GetHashCode() + (int)ChangeType);
+                : ((maxEnumVal + 1) * Mod.GetHashCode() + (int)ChangeType);
         }
 
         public override string ToString()
         {
             return $"{ChangeType} {Mod} ({Reason})";
         }
+
+        public virtual string Description
+        {
+            get
+            {
+                switch (ChangeType)
+                {
+                    case GUIModChangeType.Install:
+                        if (Reason is SelectionReason.UserRequested)
+                        {
+                            return Properties.Resources.MainChangesetNewInstall;
+                        }
+                        else goto default;
+
+                    default:
+                        return Reason.Reason.Trim();
+                }
+            }
+        }
+    }
+
+    public class ModUpgrade : ModChange
+    {
+        public ModUpgrade(CkanModule mod, GUIModChangeType changeType, SelectionReason reason, CkanModule targetMod)
+            : base(mod, changeType, reason)
+        {
+            this.targetMod = targetMod;
+        }
+        
+        public override string Description
+        {
+            get
+            {
+                return string.Format(
+                    Properties.Resources.MainChangesetUpdateSelected,
+                    targetMod.version
+                );                
+            }
+        }
+
+        private readonly CkanModule targetMod;        
     }
 }


### PR DESCRIPTION
## Problem

When you upgrade a module, the change set says it is going to "upgrade [...] to" the version that's already installed. That's wrong.

![screenshot](https://camo.githubusercontent.com/d2d179d94f67ca07d75353611fe75982416e160f/68747470733a2f2f692e696d6775722e636f6d2f53697042585a6f2e706e67)

## Cause

The change set is a sequence of `ModChange` objects, each of which holds a reference to just one `CkanModule` object, which is always the one that's currently installed or will be installed. For upgrades, the target version is known inside `GUIMod` (it's `SelectedMod`), but is lost in the shuffle when the change set is generated until it's finally recalculated in `ModuleInstaller`. Since the `ModChange` representing an upgrade only has a reference to the version that's installed, that's what displays on screen.

## Changes

Now `GUIMod.GetRequestedChanges` is replaced with `GUIMod.GetModChanges` which directly returns a sequence of `ModChange` objects. This allows `GUIMod` to pass additional info to these objects that would not have fit into a `KeyValuePair<CkanModule, GUIModChangeType>`, specifically a second `CkanModule` reference for the target version for upgrades sourced from `SelectedMod`, which is then used to populate the change set display.

This change simplifies `ComputeUserChangeSet`, which no longer has to generate its own `ModChange` objects from `KeyValuePair<CkanModule, GUIModChangeType>` objects.

Fixes #2873.

### Request for assistance

I need help improving the new structure of `ModChange`. I do not like the name `OtherMod` at all, but I am drawing a blank as to what to use instead. Or maybe some other overall approach would be better? Feedback solicited!