### PR TITLE
Redeploy Inflator after builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
         - BUILD_RELEASE_MONO_VERSION=5.16.0
         - DOCKERHUB_USERNAME=kspckanbuilder
         - secure: "UGXJG9jB9tGwjJXxG0Beu4Poz0leuiCBItnfTTKRm1a/NxXf1eoOH9p9icY5Ur2xHwqh0uWSznuL2aNr58CXtzTcMpXrcUhRsO63FB3Cz6tSdZEb+pKQJ23zmC9929DklKRGUT2D/eBcJcnV+/eAtkarrfLBU1avUQAVJgqXvMI="
+        - AWS_DEFAULT_REGION=us-west-2
+        - AWS_ACCESS_KEY_ID=AKIAZA4K6RW77XSCAMI2
+        - secure: "F4Ee6zQoAjG8a7n7c+wbeWMMzx00bQ/ci5rhKE7EZeMTYsvuiMSorUb4ShvRqbnuLKQH7NxOibnsQHXuQqUw6ZYyESU1xnFAYwhDRQrTdwPOrAOOiUzOhjB4yp3mdzMa8VOcFUUzk+QyrYpds3EUQAqE1a3Ht9Aji586QgK+sY8="
     matrix:
         - BUILD_CONFIGURATION=Debug
         - BUILD_CONFIGURATION=Release

--- a/build.cake
+++ b/build.cake
@@ -61,6 +61,24 @@ Task("docker-inflator")
     );
     DockerTag(mainTag, latestTag);
     DockerPush(latestTag);
+
+    // Restart the Inflator
+    var netkanImage = "kspckan/netkan";
+    DockerPull(netkanImage);
+    DockerRun(new DockerContainerRunSettings()
+        {
+            Env = new string[]
+            {
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_DEFAULT_REGION"
+            }
+        },
+        netkanImage,
+        "redeploy-service",
+        "--cluster",      "NetKANCluster",
+        "--service-name", "Inflator"
+    );
 });
 
 Task("osx")


### PR DESCRIPTION
## Motivation

Currently the Inflator's image is rebuilt after commits to master, but it still has to be redeployed manually. It would be quicker and more convenient to redeploy automatically.

## Changes

Now @techman83's command to redeploy the Inflator is added after the image rebuild. It pulls the Docker image for the NetKAN-Infra project and uses it to run the `redeploy-service` command. Ideally we might do this without downloading the image, but there is no Cake package for ECS.

These environment variables should be set on Travis:

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_DEFAULT_REGION`