### PR TITLE
Notify when falling back to archive.org URL

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -480,6 +480,11 @@ namespace CKAN
                 if (!downloads[index].triedFallback && downloads[index].fallbackUrl != null)
                 {
                     log.InfoFormat("Trying fallback URL: {0}", downloads[index].fallbackUrl);
+                    // Encode spaces to avoid confusing URL parsers
+                    User.RaiseMessage("Failed to download \"{0}\", trying fallback \"{1}\"",
+                        downloads[index].url.ToString().Replace(" ", "%20"),
+                        downloads[index].fallbackUrl.ToString().Replace(" ", "%20")
+                    );
                     // Try the fallbackUrl
                     downloads[index].triedFallback = true;
                     downloads[index].Download(downloads[index].fallbackUrl, downloads[index].path);


### PR DESCRIPTION
## Problem

If a mod fails to download but it has a redistributable license, we silently fall back to its archive.org URL. Going by the messages printed, it looks like we're still downloading the original URL. While our file hashes ensure that only the proper ZIP will be installed, it would be nice to inform users when this happens.

## Changes

Now we print a message when we start a fallback URL.

```
$ _build/ckan.exe install opentree --allow-incompatible
About to install...

 * OpenTree 2.5 (spacedock.info, 62.3 KiB)
 * Module Manager 4.0.3 (cached)

Continue? [Y/n] 

Downloading "https://spacedock.info/mod/1623/OpenTree/download/2.5"
Failed to download "https://spacedock.info/mod/1623/OpenTree/download/2.5", trying fallback "https://archive.org/download/OpenTree-2.5/8BD18970-OpenTree-2.5.zip"
0 B/sec - downloading - 0 B left - 100%               
Installing mod "OpenTree 2.5"
Installing mod "ModuleManager 4.0.3"
Updating registry
Committing filesystem changes
Rescanning GameData
Done!
```

Fixes #2891.