### PR TITLE
[macOS] Only run Mono in 32bit mode when the GUI is launched

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -22,6 +22,18 @@ else
     # Mono found, so we can run CKAN
     # The exe is called ckan.exe
     ASSEMBLY=ckan.exe
+
+    MONO_ARGS="--arch=32"
+    for ARG in "$@"
+    do
+        # If we want to run the GUI, set mono to 32bit mode. If not, go 64bit.
+        if [[ ! $ARG =~ ^- && $ARG != gui ]]
+        then
+            MONO_ARGS="--arch=64"
+            break
+        fi
+    done
+
     # The script and ckan.exe are in the same folder, go there now
     MACOS_PATH="$(cd "$(dirname "$0")" && pwd)"
     cd "$MACOS_PATH"
@@ -29,5 +41,6 @@ else
     export MONO_MWF_USE_CARBON_BACKEND=1
     export GDIPLUS_NOX=1
     export DYLD_FALLBACK_LIBRARY_PATH="$MACOS_PATH:$MONO_FRAMEWORK_PATH/lib:/lib:/usr/lib"
-    "$MONO" --arch=32 "$ASSEMBLY" "$@"
+
+    "$MONO" "$MONO_ARGS" "$ASSEMBLY" "$@"
 fi


### PR DESCRIPTION
## Motivation
The release of macOS Catalina marked the death of 32-bit applications on Apple's platform.
This means, our GUI is no longer runnable on macOS due to Mono's WinForms implementation being 32-bit only: 

#2270 hardcoded `--arch=32` as argument for Mono, which now prevents users from using the CUI or TUI, if they want to.

## Changes
Now there's a check for arguments in the launch script for macOS. If it's none or `gui`, the flag `--arch=32` is used for Mono, else it's `--arch=64`.

Mono's man page says the following, just FYI:
```
--arch=32, --arch=64
(Mac  OS  X only): Selects the bitness of the Mono binary used, if available.
If the binary used is already for the selected bitness, nothing changes.
If not, the execution switches to a binary with the selected bitness suffix installed side by side
(for example, '/bin/mono --arch=64' will switch to '/bin/mono64' if '/bin/mono' is a 32-bit build).
```

If I understood it right that .apps behave like executables, it should enable to run `ckan.app consoleui` and more again.
Correct me if I'm wrong please.

## Problems
This breaks commands like `ckan --verbose` (on macOS only, of course), which normally should run the GUI with verbose logging in the console. But I don't think a lot of people used this, and they can still add `gui` in the middle to make it work again, so `ckan gui --verbose`.

Also, I did NOT test this, since I'm lacking Apple hardware and as far as I know does Apple a good job preventing macOS to work in VMs.