### PR TITLE
Fix minor errors in registry updating

### DIFF
--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -174,7 +174,7 @@ namespace CKAN
         /// <param name="path">The path to normalize.</param>
         public static string NormalizePath(string path)
         {
-            return path.Replace('\\', '/').TrimEnd('/');
+            return path?.Replace('\\', '/').TrimEnd('/');
         }
 
         /// <summary>

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -387,6 +387,7 @@ Do you wish to reinstall now?", sb)))
                                 downloadCounts = JsonConvert.DeserializeObject<SortedDictionary<string, int>>(
                                     tarStreamString(tarStream, entry)
                                 );
+                                continue;
                             }
                             else if (!Regex.IsMatch(filename, filter))
                             {


### PR DESCRIPTION
## Problem

@DasSkelett found two bugs while investigating #2895:

```
Unhandled Exception:
System.NullReferenceException: Object reference not set to an instance of an object
at CKAN.KSPPathUtils.NormalizePath (System.String path) [0x00001] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.ModuleInstallDescriptor.Equals (System.Object other) [0x00017] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.Repo.MetadataEquals (CKAN.CkanModule metadata, CKAN.CkanModule oldMetadata) [0x00057] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.Repo.GetChangedInstalledModules (CKAN.Registry registry) [0x000ac] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.Repo.UpdateAllRepositories (CKAN.RegistryManager registry_manager, CKAN.KSP ksp, CKAN.NetModuleCache cache, CKAN.IUser user) [0x00153] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.Update.UpdateRepository (CKAN.KSP ksp, System.String repository) [0x0002e] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.Update.RunCommand (CKAN.KSP ksp, System.Object raw_options) [0x0006e] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.MainClass.RunSimpleAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user,CKAN.KSPManager manager) [0x00347] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.MainClass.Execute (CKAN.KSPManager manager, CKAN.CmdLine.CommonOptions opts, System.String[] args) [0x0028b] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x000a1] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
at CKAN.KSPPathUtils.NormalizePath (System.String path) [0x00001] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.ModuleInstallDescriptor.Equals (System.Object other) [0x00017] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.Repo.MetadataEquals (CKAN.CkanModule metadata, CKAN.CkanModule oldMetadata) [0x00057] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.Repo.GetChangedInstalledModules (CKAN.Registry registry) [0x000ac] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.Repo.UpdateAllRepositories (CKAN.RegistryManager registry_manager, CKAN.KSP ksp, CKAN.NetModuleCache cache, CKAN.IUser user) [0x00153] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.Update.UpdateRepository (CKAN.KSP ksp, System.String repository) [0x0002e] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.Update.RunCommand (CKAN.KSP ksp, System.Object raw_options) [0x0006e] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.MainClass.RunSimpleAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user,CKAN.KSPManager manager) [0x00347] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.MainClass.Execute (CKAN.KSPManager manager, CKAN.CmdLine.CommonOptions opts, System.String[] args) [0x0028b] in <192bdff602a04c98ba5c3e8f7028e03e>:0 
at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x000a1] in <192bdff602a04c98ba5c3e8f7028e03e>:0
```

```
73128 [Thread Pool Worker] INFO CKAN.Repo (null) - Skipping CKAN-meta-master/download_counts.json : JSON deserialization error: No JSON content found. Path '', line 1, position 53961.
```

## Cause

- #2887 uses `KSPPathUtils.NormalizePath` to compare install stanza properties, some of which are `null`, and that makes the function throw.
- After we parse `download_counts.json`, `Repo` goes on to try to parse it as a `CkanModule`, which fails harmlessly but doesn't need to happen at all.

## Changes

- Now `KSPPathUtils.NormalizePath(null)` is `null`.
- Now we move on to the next file after parsing `download_counts.json`.