### PR TITLE
Force logical name for generated resources

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -355,13 +355,13 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.de-DE.resx">
-      <LogicalName>CKAN.Properties.Resources.resources</LogicalName>
+      <LogicalName>CKAN.Properties.Resources.de-DE.resources</LogicalName>
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.en-US.resx">
-      <LogicalName>CKAN.Properties.Resources.resources</LogicalName>
+      <LogicalName>CKAN.Properties.Resources.en-US.resources</LogicalName>
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -349,16 +349,19 @@
       <DependentUpon>..\..\PluginsDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
+      <LogicalName>CKAN.Properties.Resources.resources</LogicalName>
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.de-DE.resx">
+      <LogicalName>CKAN.Properties.Resources.resources</LogicalName>
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.en-US.resx">
+      <LogicalName>CKAN.Properties.Resources.resources</LogicalName>
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
## Problem
I'm trying out JetBrain's .NET IDE, "Idea" (thanks free student license ;) )
I couldn't run CKAN built with it, it always threw `MissingManifestResourceException` exceptions.

## Cause
When Rider builds the GUI, it uses a different naming scheme for generated .resources file (.resources files are generated from .resx files before bundling them in the final assembly). To be exact, it appears that it uses `AssemblyName.ResourceFileNameBase` instead of `FullNamespace.ResourceFileNameBase` > `CKAN.Resources*.resources` instead of `CKAN.Properties.Resources*.resources`.
But not for all .resx/.resources files, only for those in the `CKAN-GUI/Properties/` directory, so `CKAN-GUI/Properties/Resources*.resx`.

However, this only affects runtime, not compile time.
When the first resource (ksp.png) should be loaded, `Resources.ResourceManager` is accessed, which tries to find the embedded resource.
https://github.com/KSP-CKAN/CKAN/blob/cbcd3ac559581c9eabf82ee3b40487118a09935d/GUI/Properties/Resources.Designer.cs#L37-L46
It can't find it because of the wrong name, but doesn't care and returns a valid ResourceManager object.
mscorlib tries to find ksp.png with the returned ResourceManager, but can't find it either, because there's nothing "in" it.

An exception similar to this one will be thrown:
```
System.Resources.MissingManifestResourceException: Could not find any resources appropriate for the specified culture or the neutral culture.  Make sure "CKAN.Properties.Resources.resources" was correctly embedded or linked into assembly "CKAN-GUI" at compile time, or that all the satellite assemblies required are loadable and fully signed.
  at System.Resources.ManifestBasedResourceGroveler.HandleResourceStreamMissing (System.String fileName) [0x000bf] in <285579f54af44a2ca048dad6be20e190>:0
  [...]
  at CKAN.Properties.Resources.get_ksp () [0x00001] in /home/DasSkelett/git/CKAN/GUI/Properties/Resources.Designer.cs:172
  at CKAN.MainModInfo.InitializeComponent () [0x0194a] in /home/DasSkelett/git/CKAN/GUI/MainModInfo.Designer.cs:499
  at CKAN.MainModInfo..ctor () [0x0000f] in /home/DasSkelett/git/CKAN/GUI/MainModInfo.cs:29
  at at (wrapper remoting-invoke-with-check) CKAN.MainModInfo..ctor()
  at CKAN.Main.InitializeComponent () [0x002b1] in /home/DasSkelett/git/CKAN/GUI/Main.Designer.cs:92
  at CKAN.Main..ctor (System.String[] cmdlineArgs, CKAN.KSPManager mgr, CKAN.GUIUser user, System.Boolean showConsole) [0x000a3] in /home/DasSkelett/git/CKAN/GUI/Main.cs:178
  at at (wrapper remoting-invoke-with-check) CKAN.Main..ctor(string[],CKAN.KSPManager,CKAN.GUIUser,bool)
  at CKAN.GUI.Main_ (System.String[] args, CKAN.KSPManager manager, System.Boolean showConsole) [0x00047] in /home/DasSkelett/git/CKAN/GUI/Program.cs:36
  at CKAN.GUI.Main (System.String[] args) [0x00001] in /home/DasSkelett/git/CKAN/GUI/Program.cs:16
```

## Solution
Thanks to https://blogs.msdn.microsoft.com/msbuild/2007/10/19/manifest-resource-names-changed-for-resources-files/
and especially https://stackoverflow.com/a/7090337 I found a way to force specific names for the generated resources.
They are now forced to `FullNamespace.ResourceFileNameBase`, as specified here: https://docs.microsoft.com/en-us/dotnet/api/system.resources.resourcemanager?view=netframework-4.8#exception
> The baseName parameter in the ResourceManager(String, Assembly) constructor does not specify the name of a .resources file. The name should include the resource file's fully qualified namespace but not its file name extension. Typically, resource files that are created in Visual Studio include namespace names, but resource files that are created and compiled at the command prompt do not.

This won't change the name of the .resources files itself (see `_build/out/CKAN-GUI/Debug/obj/`), they are still named differently if generated by Rider. But the logical name does, and that's the one important to `new SingleAssemblyResourceManager()`.

---

The normal build with the build script / cake still works on my system ;).
But it would be nice if someone using a different IDE (@HebaruSan with Visual Studio?) can test if it's still building fine too.