### PR TITLE
Replace temp filename with URL in netkan ZIP error

### DIFF
--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using log4net;
 
 namespace CKAN.NetKAN.Services
 {
@@ -57,7 +58,8 @@ namespace CKAN.NetKAN.Services
                         string invalidReason;
                         if (!NetFileCache.ZipValid(downloadedFile, out invalidReason))
                         {
-                            throw new Kraken($"{downloadedFile} is not a valid ZIP file: {invalidReason}");
+                            log.Debug($"{downloadedFile} is not a valid ZIP file: {invalidReason}");
+                            throw new Kraken($"{url} is not a valid ZIP file: {invalidReason}");
                         }
                         break;
                     default:
@@ -89,5 +91,6 @@ namespace CKAN.NetKAN.Services
             _requestedURLs?.Clear();
         }
 
+        private static readonly ILog log = LogManager.GetLogger(typeof(CachingHttpService));
     }
 }


### PR DESCRIPTION
## Problem

These ZIP file format errors include temp file names, which are not useful for investigation because we can't access the temp files on the bot server:

![image](https://user-images.githubusercontent.com/1559108/67588761-84c29380-f71c-11e9-95b2-7b4537f03859.png)

They are also different every time. Ideally an error message should be consistent. As of KSP-CKAN/NetKAN-Infra#68, these messages will be sent to Discord when they change, so it will be more annoying to have them re-sent every time when the underlying error condition is the same.

## Changes

Now the message will print the source URL instead of the temp file name:

`2755 [1] FATAL CKAN.NetKAN.Program (null) - https://github.com/formicant/TrimIndicator/releases/download/1.8.0.0/TrimIndicator-1.8.0.0.zip is not a valid ZIP file: Error in step EntryHeader for TrimIndicator/TrimIndicator.dll: Exception during test - 'Central header and local header file name mismatch'`

This will be constant from one pass to the next, as well as being more useful for investigation.