### PR TITLE
Restructure Net.Download and Net.DownloadText

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -154,7 +154,7 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Download all our files using the native .NET hanlders.
+        /// Download all our files using the native .NET handlers.
         /// </summary>
         /// <returns>The native.</returns>
         private void DownloadNative()

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -274,7 +274,41 @@ namespace CKAN
         {
             return "Uh oh, the following things went wrong when downloading...\r\n\r\n" + String.Join("\r\n", exceptions);
         }
+    }
 
+    /// <summary>
+    /// We often try downloading using native .NET methods and CurlSharp as a fallback.
+    /// If both downloads fail, use this Kraken to combine the exceptions.
+    /// It assumes that both methods got an equal response.
+    /// Has a nice ToString() method including the response header and content.
+    /// </summary>
+    public class NativeAndCurlDownloadFailedKraken : Kraken
+    {
+        public readonly List<Exception> exceptions;
+        public readonly string URL;
+        public readonly string responseHeader;
+        public readonly string responseContent;
+        public readonly int    responseStatus;
+
+        public NativeAndCurlDownloadFailedKraken(List<Exception> errors, string URL, string responseHeader, string responseContent, int responseStatus)
+            : this($"Native and cURL download failed downloading from {URL}, status {responseStatus}", errors, URL, responseHeader, responseContent, responseStatus)
+        {}
+
+        public NativeAndCurlDownloadFailedKraken(string message, List<Exception> errors, string URL, string responseHeader, string responseContent, int responseStatus)
+            : base(message)
+        {
+            exceptions = errors;
+            this.URL = URL;
+            this.responseHeader = responseHeader;
+            this.responseContent = responseContent;
+            this.responseStatus = responseStatus;
+        }
+
+        public override string ToString()
+        {
+            return $"Native and cURL download failed downloading from {URL}, status {responseStatus}:\r\n" +
+                   $"{String.Join("\r\n\r\n", exceptions)}\r\n{responseHeader}\r\n{responseContent}";
+        }
     }
 
     /// <summary>

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Diagnostics;
 using System.IO;
@@ -11,9 +10,7 @@ using log4net.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using CKAN.NetKAN.Model;
-using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Transformers;
-using CKAN.NetKAN.Validators;
 using CKAN.NetKAN.Processors;
 
 namespace CKAN.NetKAN
@@ -106,7 +103,7 @@ namespace CKAN.NetKAN
             }
             catch (Exception e)
             {
-                e = e.GetBaseException() ?? e;
+                e = e.GetBaseException();
 
                 Log.Fatal(e.Message);
 

--- a/Netkan/Sources/Curse/CurseApi.cs
+++ b/Netkan/Sources/Curse/CurseApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using CKAN.NetKAN.Services;
 using log4net;
@@ -22,15 +22,21 @@ namespace CKAN.NetKAN.Sources.Curse
 
         public CurseMod GetMod(string nameOrId)
         {
-            var json = Call(nameOrId);
+            string json;
+            try
+            {
+                json = Call(nameOrId);
+            }
+            catch (NativeAndCurlDownloadFailedKraken e)
+            {
+                // CurseForge returns a valid json with an error message in some cases.
+                json = e.responseContent;
+            }
             // Check if the mod has been removed from Curse and if it corresponds to a KSP mod.
             var error = JsonConvert.DeserializeObject<CurseError>(json);
             if (!string.IsNullOrWhiteSpace(error.error))
             {
-                throw new Kraken(string.Format(
-                    "Could not get the mod from Curse, reason: {0}.",
-                    error.message
-                ));
+                throw new Kraken($"Could not get the mod from Curse, reason: {error.message}.");
             }
             return CurseMod.FromJson(json);
         }

--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -102,9 +102,12 @@ namespace CKAN.NetKAN.Sources.Github
             {
                 return _http.DownloadText(url, _oauthToken);
             }
-            catch (WebException webEx)
+            catch (NativeAndCurlDownloadFailedKraken k)
             {
-                Log.ErrorFormat("WebException while accessing {0}: {1}", url, webEx);
+                if (k.responseStatus == 403 && k.responseHeader.Contains("X-RateLimit-Remaining: 0"))
+                {
+                    throw new Kraken("GitHub API rate limit exceeded.");
+                }
                 throw;
             }
         }

--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-﻿using System.Linq;
+using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
## Motivation
#2879 tried to get better insights why calls to GitHub by the bot were failing.
It was a partial success, we got the returned status code, but it also broke the custom error handling for SpaceDock for example.

## Changes
First, I enabled the possibility to pass a header writeback function to CurlSharp. This allows catching the header of the response for logging purposes.
Passing it is optional.

Secondly, I created a new Kraken, `NativeAndCurlDownloadFailedKraken`. This one is used in both above mentioned download methods. It has some nice additions to a plain Kraken/Exception (like accessing the response (header and/or content) or the status code) and is more usable than `WebException`s.

Thirdly, I added some logging to the two download methods. If the debug-flag is set, the entire header and the content (in case of `DownloadText`) is written to the output. Plus, it is save in the `NativeAndCurlDownloadFailedKraken`, so accessing and deciding based on them higher up in the stack is easier.
Also , parsing the returned json containing a error message from SpaceDock/CurseForge now works again. This fixes a failing unit test.

Furthermore in the two last commits, I introduced two custom error messages for GitHub if the rate limit is exceeded (based on return code 403 + `X-RateLimit-Remaining` header),
and if CurseForge is blocking CKAN (based on return code 403).