### PR TITLE
Default to consoleui on MacOSX Catalina

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+supports_32_bit() {
+    MACOS_VER=$(sw_vers -productVersion)
+    MAJOR=$(echo $MACOS_VER | cut -d. -f1)
+    MINOR=$(echo $MACOS_VER | cut -d. -f2)
+    # 9.X => true
+    if (( $MAJOR < 10 ))
+    then
+        return 0
+    fi
+    # 11.X => false
+    if (( $MAJOR > 10 ))
+    then
+        return 1
+    fi
+    # 10.15+ => false
+    if (( $MINOR >= 15 ))
+    then
+        return 1
+    fi
+    return 0
+}
+
 # Check El Capitan's Mono install location
 # And Mono 5's install location
 # And the configured location in /etc/paths.d
@@ -42,5 +64,15 @@ else
     export GDIPLUS_NOX=1
     export DYLD_FALLBACK_LIBRARY_PATH="$MACOS_PATH:$MONO_FRAMEWORK_PATH/lib:/lib:/usr/lib"
 
-    "$MONO" "$MONO_ARGS" "$ASSEMBLY" "$@"
+    # Default to consoleui on Catalina and later if they double click
+    if ! supports_32_bit && [[ "$@" == "" ]]
+    then
+        osascript <<END
+tell application "Terminal"
+    do script "cd \"`pwd`\"; \"$MONO\" \"$ASSEMBLY\" consoleui"
+end tell
+END
+    else
+        "$MONO" "$MONO_ARGS" "$ASSEMBLY" "$@"
+    fi
 fi


### PR DESCRIPTION
## Problem

#2272 is now a live issue. MacOSX Catalina users who download CKAN.dmg and double click CKAN.app will just get errors.

## Causes

- CKAN's GUI uses WinForms.
- Mono only implemented WinForms in 32 bit mode for MacOSX (see mono/mono#6701).
- Apple decided to stop supporting 32 bit applications.

## Changes

Now the launch script attempts to check the OS version; if 10.15 or later, if the user gives no command line parameters, instead of launching the GUI, it will launch `consoleui` in Terminal.

I don't have a Mac (this work is based on StackExchange answers), so we will need to find a volunteer Mac user to test this.
Test build:

- [CKAN.zip](https://github.com/KSP-CKAN/CKAN/files/3800610/CKAN.zip)