### PR TITLE
Merge resources and include metanetkan

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -212,6 +212,11 @@
                     "description" : "Mod's manual",
                     "type"        : "string",
                     "format"      : "uri"
+                },
+                "metanetkan" : {
+                    "description" : "Mod's remote hosted netkan",
+                    "type"        : "string",
+                    "format"      : "uri"
                 }
             }
         },

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -289,6 +289,10 @@ namespace CKAN
         [JsonProperty("curse", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri curse;
+
+        [JsonProperty("metanetkan", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonOldResourceUrlConverter))]
+        public Uri metanetkan;
     }
 
     public class DownloadHashesDescriptor

--- a/Netkan/Extensions/JObjectExtensions.cs
+++ b/Netkan/Extensions/JObjectExtensions.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Linq;
 ﻿using log4net;
 using Newtonsoft.Json.Linq;
-using System;
 
 namespace CKAN.NetKAN.Extensions
 {
@@ -27,5 +28,37 @@ namespace CKAN.NetKAN.Extensions
                 jobject[propertyName] = jobject[propertyName] ?? token;
             }
         }
+        
+        /// <summary>
+        /// Merge an object's properties into one of our child objects
+        /// E.g., the "resources" object should accumulate values from all levels
+        /// </summary>
+        /// <param name="jobject">The object to write to</param>
+        /// <param name="propertyName">The name of the property to write to</param>
+        /// <param name="token">The object containing properties to merge</param>
+        /// <returns>
+        /// Returns
+        /// </returns>
+        public static void SafeMerge(this JObject jobject, string propertyName, JToken token)
+        {
+            JObject srcObj = token as JObject;
+            // No need to do anything if source object is null or empty
+            if (srcObj?.Properties().Any() ?? false)
+            {
+                if (!jobject.ContainsKey(propertyName))
+                {
+                    jobject[propertyName] = new JObject();
+                }
+                JObject targetJson = jobject[propertyName] as JObject;
+                if (targetJson != null)
+                {
+                    foreach (JProperty property in srcObj.Properties())
+                    {
+                        targetJson.SafeAdd(property.Name, property.Value);
+                    }
+                }
+            }
+        }
+        
     }
 }

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -48,6 +48,8 @@ namespace CKAN.NetKAN.Transformers
 
                     json["spec_version"] = ModuleVersion.Max(metadata.SpecVersion, new Metadata(internalJson).SpecVersion)
                         .ToSpecVersionJson();
+                        
+                    json.SafeMerge("resources", internalJson["resources"]);
 
                     Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
                 }

--- a/Netkan/Transformers/MetaNetkanTransformer.cs
+++ b/Netkan/Transformers/MetaNetkanTransformer.cs
@@ -36,6 +36,12 @@ namespace CKAN.NetKAN.Transformers
                 Log.InfoFormat("Executing MetaNetkan transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
+                // Make sure resources exist, save metanetkan
+                if (json["resources"] == null)
+                    json["resources"] = new JObject();
+                var resourcesJson = (JObject)json["resources"];
+                resourcesJson.SafeAdd("metanetkan", metadata.Kref.Id);
+
                 var uri = new Uri(metadata.Kref.Id);
                 var targetFileText = _http.DownloadText(CKAN.Net.GetRawUri(uri));
 
@@ -57,6 +63,8 @@ namespace CKAN.NetKAN.Transformers
                     {
                         json.Remove("$kref");
                     }
+                    
+                    json.SafeMerge("resources", targetJson["resources"]);
 
                     foreach (var property in targetJson.Properties())
                     {

--- a/Spec.md
+++ b/Spec.md
@@ -547,6 +547,7 @@ are described. Unless specified otherwise, these are URLs:
 - `spacedock` : The mod on SpaceDock.
 - `curse` :  (**v1.20**) The mod on Curse.
 - `manual` : The mod's manual, if it exists.
+- `metanetkan` :  (**v1.27**) URL of the module's remote hosted netkan
 
 Example resources:
 


### PR DESCRIPTION
## Motivation

In KSP-CKAN/NetKAN-Infra#70 we are saving the `resources` object from mod metadata into the status page's JSON objects, and in KSP-CKAN/NetKAN-status#9 these will be rendered as links on the status page for more convenient investigation of inflation errors.

Currently most `$kref` variants populate a property in `resources` (e.g. `spacedock`, `repository`, `curse`), except for `netkan`, the kref source for metanetkans. This info would be nice to have as well since metanetkans have a big impact on how issues are investigated and fixed.

## Problem

Astrogator defines its `resources` in an ["internal ckan"](https://github.com/KSP-CKAN/CKAN/blob/master/Netkan/Transformers/InternalCkanTransformer.cs), but all that appears in its .ckan file is "repository".

- https://github.com/HebaruSan/Astrogator/blob/master/Astrogator.ckan
- https://github.com/KSP-CKAN/CKAN-meta/blob/master/Astrogator/Astrogator-v0.9.2.ckan

## Cause

The `resources` property is populated with `SafeAdd`, which doesn't overwrite existing data on a property-by-property basis. The GitHub transformer populates `resources.repository`, which counts as populating the `resources` property, so the entire `resources` object of the internal ckan is dropped, even the properties that do not conflict with the one set by the GitHub transformer.

Note that this would be disruptive for the metanetkan feature suggested above, since setting `resources.metanetkan` before processing the remote netkan would override `resources` and block any downstream sources from setting values in it.

## Changes

Now `resources.metanetkan` is added to the schema and spec and populated by the metanetkan transformer. This will allow us to click it on the status page once it is updated.

Now `resources` is populated with `SafeMerge`, a new function that effectively does `SafeAdd` on all of the properties of the given object. This will allow downstream transformers to add properties to `resources` (but they still can't change properties set by upstream transformers). This will fix mods with missing `resources` metadata and prevent the metanetkan resource from blocking other resources.