### PR TITLE
Apply netkan validators to ckans

### DIFF
--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -48,6 +48,7 @@ namespace CKAN.NetKAN.Processors
 
                 foreach (Metadata ckan in ckans)
                 {
+                    netkanValidator.Validate(ckan);
                     ckanValidator.ValidateCkan(ckan, netkan);
                 }
                 log.Info("Output successfully passed post-validation");


### PR DESCRIPTION
## Problem

KerbalAtomics-1-1.1.0.ckan used `any_of` with a `spec_version` of `v1.4`: https://github.com/KSP-CKAN/CKAN-meta/commit/967423fbfe09bdd1d8af4a42ea46fa716b2d92bb

This means this module loads in CKAN versions that don't support `any_of` and crashes them, see #2914.

This should have failed with this error:

> spec_version v1.26+ required for 'any_of'

But it got through.

## Cause

When we inflate a module, we:

1. Load the netkan
2. Apply the netkan validators
3. Inflate
4. Apply the ckan validators

The `any_of` check is in the netkan validators, so any netkan with a `spec_version` below `v1.26` that tries to use `any_of` will be flagged.

But KerbalAtomics' relationships aren't in its netkan, they're in its *meta*netkan! Metanetkans are loaded and applied in the inflation stage, after netkan validators have already been checked. So the `any_of` check is missed, and metanetkans are allowed to engage in shenanigans.

## Changes

Now we apply the netkan validators to the final ckans. This will prevent metanetkans from bypassing validation.