### PR TITLE
Force redraw of recommendation listview headers on Mono

### DIFF
--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -137,6 +137,12 @@ namespace CKAN
 
             tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
             tabController.SetTabLock(true);
+            
+            if (Platform.IsMono)
+            {
+                // Workaround: make sure the ListView headers are drawn
+                RecommendedModsListView.EndUpdate();
+            }
 
             lock (this)
             {


### PR DESCRIPTION
## Problem

Sometimes (inconsistently) on Mono, the headers of the recommendations list view do not appear. This prevents the user from resizing the columns to read longer cells.

Installing SmartTank:

![image](https://user-images.githubusercontent.com/1559108/68693105-4ad6f700-053c-11ea-8e6c-f9f0fb8d20b6.png)

## Cause

Same as #2684. Mono seems to have a bug with these headers, but I hadn't noticed it with this listview up till now.

## Changes

Now the headers are always shown using the `EndUpdate` workaround from #2685.