### PR TITLE
Add owners of parent GitHub repos to authors

### DIFF
--- a/Netkan/Extensions/JObjectExtensions.cs
+++ b/Netkan/Extensions/JObjectExtensions.cs
@@ -30,6 +30,26 @@ namespace CKAN.NetKAN.Extensions
         }
         
         /// <summary>
+        /// Write a property to a <see cref="JObject"/> only if it does not already exist and the value is not null.
+        /// The value is generated on-demand by calling tokenCallback, only when we need it.
+        /// </summary>
+        /// <param name="jobject">The <see cref="JObject"/> to write to</param>
+        /// <param name="propertyName">The name of the property to write</param>
+        /// <param name="tokenCallback">Function to generate value of the property to write if it does not exist</param>
+        public static void SafeAdd(this JObject jobject, string propertyName, Func<JToken> tokenCallback)
+        {
+            if (String.IsNullOrWhiteSpace(propertyName))
+            {
+                Log.Warn("Asked to set a property named null on a JSON object!");
+                return;
+            }
+            if (jobject[propertyName] == null)
+            {
+                jobject.SafeAdd(propertyName, tokenCallback());
+            }
+        }
+        
+        /// <summary>
         /// Merge an object's properties into one of our child objects
         /// E.g., the "resources" object should accumulate values from all levels
         /// </summary>

--- a/Netkan/Sources/Github/GithubRepo.cs
+++ b/Netkan/Sources/Github/GithubRepo.cs
@@ -21,11 +21,26 @@ namespace CKAN.NetKAN.Sources.Github
 
         [JsonProperty("license")]
         public GithubLicense License { get; set; }
+        
+        [JsonProperty("parent")]
+        public GithubRepo ParentRepo { get; set; }
+        
+        [JsonProperty("source")]
+        public GithubRepo SourceRepo { get; set; }
+        
+        [JsonProperty("owner")]
+        public GithubUser Owner { get; set; }
     }
 
     public class GithubLicense
     {
         [JsonProperty("spdx_id")]
         public string Id;
+    }
+    
+    public class GithubUser
+    {
+        [JsonProperty("login")]
+        public string Login { get; set; }
     }
 }

--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -123,7 +123,7 @@ namespace CKAN.NetKAN.Transformers
             else if (useCurseIdVersion)  json.SafeAdd("version", latestVersion.GetCurseIdVersion());
             else                         json.SafeAdd("version", latestVersion.GetFileVersion());
 
-            json.SafeAdd("author", JToken.FromObject(curseMod.authors));
+            json.SafeAdd("author",   () => JToken.FromObject(curseMod.authors));
             json.SafeAdd("download", Regex.Replace(latestVersion.GetDownloadUrl(), " ", "%20"));
 
             // Curse provides users with the following default selection of licenses. Let's convert them to CKAN

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -151,8 +151,11 @@ namespace CKAN.NetKAN.Transformers
             var authors = new HashSet<string>() { release.Author };
             for (GithubRepo r = repo; r != null;)
             {
-                // Add repo owner
-                authors.Add(r.Owner.Login);
+                if (r.Owner?.Login != null)
+                {
+                    // Add repo owner
+                    authors.Add(r.Owner.Login);
+                }
                 // Check parent repos
                 r = r.ParentRepo == null
                     ? null 

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -82,12 +82,6 @@ namespace CKAN.NetKAN.Transformers
 
         private Metadata TransformOne(Metadata metadata, JObject json, GithubRef ghRef, GithubRepo ghRepo, GithubRelease ghRelease)
         {
-            // Make sure resources exist.
-            if (json["resources"] == null)
-                json["resources"] = new JObject();
-
-            var resourcesJson = (JObject)json["resources"];
-
             if (!string.IsNullOrWhiteSpace(ghRepo.Description))
                 json.SafeAdd("abstract", ghRepo.Description);
 
@@ -95,6 +89,12 @@ namespace CKAN.NetKAN.Transformers
             if (!string.IsNullOrWhiteSpace(ghRepo.License?.Id)
                 && ghRepo.License.Id != "NOASSERTION")
                 json.SafeAdd("license", ghRepo.License.Id);
+
+            // Make sure resources exist.
+            if (json["resources"] == null)
+                json["resources"] = new JObject();
+
+            var resourcesJson = (JObject)json["resources"];
 
             if (!string.IsNullOrWhiteSpace(ghRepo.Homepage))
                 resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
@@ -104,7 +104,7 @@ namespace CKAN.NetKAN.Transformers
             if (ghRelease != null)
             {
                 json.SafeAdd("version",  ghRelease.Version.ToString());
-                json.SafeAdd("author",   ghRelease.Author);
+                json.SafeAdd("author",   () => getAuthors(ghRepo, ghRelease));
                 json.SafeAdd("download", ghRelease.Download.ToString());
                 json.SafeAdd(Model.Metadata.UpdatedPropertyName, ghRelease.AssetUpdated);
 
@@ -143,6 +143,23 @@ namespace CKAN.NetKAN.Transformers
                 Log.WarnFormat("No releases found for {0}", ghRef.Repository);
                 return metadata;
             }
+        }
+
+        private JToken getAuthors(GithubRepo repo, GithubRelease release)
+        {
+            // Start with the user that published the release
+            var authors = new HashSet<string>() { release.Author };
+            for (GithubRepo r = repo; r != null;)
+            {
+                // Add repo owner
+                authors.Add(r.Owner.Login);
+                // Check parent repos
+                r = r.ParentRepo == null
+                    ? null 
+                    : _api.GetRepo(new GithubRef($"#/ckan/github/{r.ParentRepo.FullName}", false, _matchPreleases));
+            }
+            // Return a string if just one author, else an array
+            return authors.Count == 1 ? (JToken)authors.First() : new JArray(authors);
         }
 
     }

--- a/Tests/NetKAN/Extensions/JObjectExtensionsTests.cs
+++ b/Tests/NetKAN/Extensions/JObjectExtensionsTests.cs
@@ -47,7 +47,7 @@ namespace Tests.NetKAN.Extensions
             sut["foo"] = "bar";
 
             // Act
-            sut.SafeAdd("foo", null);
+            sut.SafeAdd("foo", null as JToken);
 
             // Assert
             Assert.That((string)sut["foo"], Is.EqualTo("bar"),


### PR DESCRIPTION
## Motivation

The `author` property of a module can be a string or an array of strings. It's courteous to credit everyone who has maintained a mod over the years by listing them in an array.

It is somewhat common for a mod on GitHub to go out of maintenance and be adopted by a new maintainer on a fork of the original repo. When this happens, we switch the `$kref` to the new repo, and in order to preserve the full list of authors, we have to manually edit the `author` property to include them. It's better to rely on automatic data generation where possible, or at least to have the option.

## Changes

Now if a repo is a fork-of-a-fork-of-a-fork-of..., we will traverse the parent repository chain all the way to the root and add all of the repository owners as co-authors. This will give a more accurate picture of who has contributed when a repo is forked.

Note that manual overrides of the `author` property still work the same, so this logic will not blow away any manually maintained author lists. To minimize the performance hit, we will not make any extra GitHub API calls when the `author` property is manually set in the netkan.