### PR TITLE
Add language selection option to settings

### DIFF
--- a/Core/Configuration/IConfiguration.cs
+++ b/Core/Configuration/IConfiguration.cs
@@ -26,6 +26,8 @@ namespace CKAN.Configuration
         /// </summary>
         int RefreshRate { get; set; }
 
+        string Language { get; set; }
+
         /// <summary>
         /// Get the hosts that have auth tokens stored in the registry
         /// </summary>

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -17,6 +17,7 @@ namespace CKAN.Configuration
             public string DownloadCacheDir { get; set; }
             public long? CacheSizeLimit { get; set; }
             public int? RefreshRate { get; set; }
+            public string Language { get; set; }
             public JBuilds KSPBuilds { get; set; }
             public IList<KspInstance> KspInstances = new List<KspInstance>();
             public IDictionary<string, string> AuthTokens = new Dictionary<string, string>();
@@ -157,6 +158,29 @@ namespace CKAN.Configuration
                     }
 
                     SaveConfig();
+                }
+            }
+        }
+
+        public string Language
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return config.Language;
+                }
+            }
+
+            set
+            {
+                lock (_lock)
+                {
+                    if (Utilities.AvailableLanguages.Contains(value))
+                    {
+                        config.Language = value;
+                        SaveConfig();
+                    }
                 }
             }
         }

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -94,6 +94,16 @@ namespace CKAN.Configuration
             set { SetAutoStartInstance(value??String.Empty); }
         }
 
+        public string Language
+        {
+            get { return GetRegistryValue<string>("Language", null); }
+            set
+            {
+                if (Utilities.AvailableLanguages.Contains(value))
+                    SetRegistryValue("Language", value);
+            }
+        }
+
         public Win32RegistryConfiguration()
         {
             ConstructKey(CKAN_KEY_NO_PREFIX);

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -7,6 +7,8 @@ namespace CKAN
 {
     public static class Utilities
     {
+        public static readonly string[] AvailableLanguages = { "en-GB", "en-US", "de-DE" };
+
         /// <summary>
         /// Copies a directory and optionally its subdirectories as a transaction.
         /// </summary>
@@ -72,7 +74,6 @@ namespace CKAN
                     _CopyDirectory(subdir.FullName, temppath, copySubDirs, file_transaction);
                 }
             }
-
         }
     }
 }

--- a/GUI/GUIConfiguration.cs
+++ b/GUI/GUIConfiguration.cs
@@ -95,7 +95,7 @@ namespace CKAN
 
         public static GUIConfiguration LoadOrCreateConfiguration(string path)
         {
-            if (!File.Exists(path))
+            if (!File.Exists(path) || new FileInfo(path).Length == 0)
             {
                 var configuration = new GUIConfiguration
                 {

--- a/GUI/Localization/de-DE/SettingsDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/SettingsDialog.de-DE.resx
@@ -158,9 +158,10 @@
   <data name="RefreshPostLabel.Text" xml:space="preserve"><value>Minuten</value></data>
   <data name="PauseRefreshCheckBox.Text" xml:space="preserve"><value>Autom. Aktualisierung aussetzen</value></data>
   <data name="MoreSettingsGroupBox.Text" xml:space="preserve"><value>Weitere Einstellungen</value></data>
-  <data name="AutoSortUpdateCheckBox.Text" xml:space="preserve"><value>Beim Klick auf 'Verfügbare Updates auswählen' aktualisierbare Mods oben anzeigen</value></data>
+  <data name="LanguageSelectionLabel.Text" xml:space="preserve"><value>Sprache (Neustart benötigt!):</value></data>
   <data name="RefreshOnStartupCheckbox.Text" xml:space="preserve"><value>Modliste beim Start von CKAN aktualisieren</value></data>
   <data name="HideEpochsCheckbox.Text" xml:space="preserve"><value>Epoch-Zahlen bei Modversionsnummern in der Modliste verstecken (Neustart benötigt!)</value></data>
   <data name="HideVCheckbox.Text" xml:space="preserve"><value>'v' bei Modversionsnummern in der Modliste verstecken (Neustart benötigt!)</value></data>
+  <data name="AutoSortUpdateCheckBox.Text" xml:space="preserve"><value>Beim Klick auf 'Verfügbare Updates auswählen' aktualisierbare Mods oben anzeigen</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Einstellungen</value></data>
 </root>

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -164,6 +164,22 @@ namespace CKAN
             log.Info("Starting the GUI");
             commandLineArgs = cmdlineArgs;
 
+            Configuration.IConfiguration mainConfig = ServiceLocator.Container.Resolve<Configuration.IConfiguration>();
+
+            // If the language is not set yet in the config, try to save the current language.
+            // If it isn't supported, it'll still be null afterwards. Doesn't matter, .NET handles the resource selection.
+            // Once the user chooses a language in the settings, the string will be no longer null, and we can change
+            // CKAN's language here before any GUI components are initialized.
+            if (string.IsNullOrEmpty(mainConfig.Language))
+            {
+                string runtimeLanguage = Thread.CurrentThread.CurrentUICulture.IetfLanguageTag;
+                mainConfig.Language = runtimeLanguage;
+            }
+            else
+            {
+                Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo(mainConfig.Language);
+            }
+
             manager = mgr ?? new KSPManager(user);
             currentUser = user;
 

--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -69,10 +69,12 @@
             this.RefreshPostLabel = new System.Windows.Forms.Label();
             this.PauseRefreshCheckBox = new System.Windows.Forms.CheckBox();
             this.MoreSettingsGroupBox = new System.Windows.Forms.GroupBox();
-            this.AutoSortUpdateCheckBox = new System.Windows.Forms.CheckBox();
+            this.LanguageSelectionLabel = new System.Windows.Forms.Label();
+            this.LanguageSelectionComboBox = new System.Windows.Forms.ComboBox();
             this.RefreshOnStartupCheckbox = new System.Windows.Forms.CheckBox();
             this.HideEpochsCheckbox = new System.Windows.Forms.CheckBox();
             this.HideVCheckbox = new System.Windows.Forms.CheckBox();
+            this.AutoSortUpdateCheckBox = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.RepositoryGroupBox.SuspendLayout();
             this.AuthTokensGroupBox.SuspendLayout();
@@ -501,6 +503,8 @@
             //
             // MoreSettingsGroupBox
             //
+            this.MoreSettingsGroupBox.Controls.Add(this.LanguageSelectionLabel);
+            this.MoreSettingsGroupBox.Controls.Add(this.LanguageSelectionComboBox);
             this.MoreSettingsGroupBox.Controls.Add(this.AutoSortUpdateCheckBox);
             this.MoreSettingsGroupBox.Controls.Add(this.RefreshOnStartupCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.HideEpochsCheckbox);
@@ -508,21 +512,29 @@
             this.MoreSettingsGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.MoreSettingsGroupBox.Location = new System.Drawing.Point(12, 529);
             this.MoreSettingsGroupBox.Name = "MoreSettingsGroupBox";
-            this.MoreSettingsGroupBox.Size = new System.Drawing.Size(476, 116);
+            this.MoreSettingsGroupBox.Size = new System.Drawing.Size(476, 139);
             this.MoreSettingsGroupBox.TabIndex = 5;
             this.MoreSettingsGroupBox.TabStop = false;
             resources.ApplyResources(this.MoreSettingsGroupBox, "MoreSettingsGroupBox");
             //
-            // AutoSortUpdateCheckBox
+            // LanguageSelectionLabel
             //
-            this.AutoSortUpdateCheckBox.AutoSize = true;
-            this.AutoSortUpdateCheckBox.Location = new System.Drawing.Point(12, 18);
-            this.AutoSortUpdateCheckBox.Name = "AutoSortUpdateCheckBox";
-            this.AutoSortUpdateCheckBox.Size = new System.Drawing.Size(393, 17);
-            this.AutoSortUpdateCheckBox.TabIndex = 0;
-            this.AutoSortUpdateCheckBox.UseVisualStyleBackColor = true;
-            this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
-            resources.ApplyResources(this.AutoSortUpdateCheckBox, "AutoSortUpdateCheckBox");
+            this.LanguageSelectionLabel.AutoSize = true;
+            this.LanguageSelectionLabel.Location = new System.Drawing.Point(12, 18);
+            this.LanguageSelectionLabel.Name = "LanguageSelectionLabel";
+            this.LanguageSelectionLabel.Size = new System.Drawing.Size(220, 17);
+            this.LanguageSelectionLabel.TabStop = false;
+            resources.ApplyResources(this.LanguageSelectionLabel, "LanguageSelectionLabel");
+            //
+            // LanguageSelectionComboBox
+            //
+            this.LanguageSelectionComboBox.AutoSize = true;
+            this.LanguageSelectionComboBox.Location = new System.Drawing.Point(244, 18);
+            this.LanguageSelectionComboBox.Name = "LanguageSelectionComboBox";
+            this.LanguageSelectionComboBox.Size = new System.Drawing.Size(220, 17);
+            this.LanguageSelectionComboBox.TabIndex = 0;
+            this.LanguageSelectionComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.LanguageSelectionComboBox.SelectionChangeCommitted += new System.EventHandler(this.LanguageSelectionComboBox_SelectionChanged);
             //
             // RefreshOnStartupCheckbox
             //
@@ -557,11 +569,23 @@
             this.HideVCheckbox.CheckedChanged += new System.EventHandler(this.HideVCheckbox_CheckedChanged);
             resources.ApplyResources(this.HideVCheckbox, "HideVCheckbox");
             //
+            // AutoSortUpdateCheckBox
+            //
+            this.AutoSortUpdateCheckBox.AutoSize = true;
+            this.AutoSortUpdateCheckBox.Location = new System.Drawing.Point(12, 110);
+            this.AutoSortUpdateCheckBox.Name = "AutoSortUpdateCheckBox";
+            this.AutoSortUpdateCheckBox.Size = new System.Drawing.Size(393, 17);
+            this.AutoSortUpdateCheckBox.TabIndex = 4;
+            this.AutoSortUpdateCheckBox.UseVisualStyleBackColor = true;
+            this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
+            resources.ApplyResources(this.AutoSortUpdateCheckBox, "AutoSortUpdateCheckBox");
+            //
+            //
             // SettingsDialog
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(500, 657);
+            this.ClientSize = new System.Drawing.Size(500, 680);
             this.Controls.Add(this.RepositoryGroupBox);
             this.Controls.Add(this.AuthTokensGroupBox);
             this.Controls.Add(this.CacheGroupBox);
@@ -632,10 +656,12 @@
         private System.Windows.Forms.Label RefreshPostLabel;
         private System.Windows.Forms.CheckBox PauseRefreshCheckBox;
         private System.Windows.Forms.GroupBox MoreSettingsGroupBox;
-        private System.Windows.Forms.CheckBox AutoSortUpdateCheckBox;
+        private System.Windows.Forms.Label LanguageSelectionLabel;
+        private System.Windows.Forms.ComboBox LanguageSelectionComboBox;
         private System.Windows.Forms.CheckBox RefreshOnStartupCheckbox;
         private System.Windows.Forms.CheckBox HideEpochsCheckbox;
         private System.Windows.Forms.CheckBox HideVCheckbox;
+        private System.Windows.Forms.CheckBox AutoSortUpdateCheckBox;
         private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.IO;
 using System.Windows.Forms;
 using System.Drawing;
+using System.Linq;
 using CKAN.Versioning;
 using log4net;
 using CKAN.Configuration;
@@ -43,6 +43,7 @@ namespace CKAN
         {
             RefreshReposListBox();
             RefreshAuthTokensListBox();
+            UpdateLanguageSelectionComboBox();
 
             LocalVersionLabel.Text = Meta.GetVersion();
 
@@ -95,6 +96,16 @@ namespace CKAN
             }
 
             manager.Save();
+        }
+
+        private void UpdateLanguageSelectionComboBox()
+        {
+            LanguageSelectionComboBox.Items.Clear();
+
+            LanguageSelectionComboBox.Items.AddRange(Utilities.AvailableLanguages);
+            // If the current language is supported by CKAN, set is as selected.
+            // Else display a blank field.
+            LanguageSelectionComboBox.SelectedIndex = LanguageSelectionComboBox.FindStringExact(config.Language);
         }
 
         private void UpdateCacheInfo(string newPath)
@@ -527,6 +538,11 @@ namespace CKAN
         {
             Main.Instance.configuration.HideV = HideVCheckbox.Checked;
             Main.Instance.configuration.Save();
+        }
+
+        private void LanguageSelectionComboBox_SelectionChanged(object sender, EventArgs e)
+        {
+            config.Language = LanguageSelectionComboBox.SelectedItem.ToString();
         }
 
         private void AutoSortUpdateCheckBox_CheckedChanged(object sender, EventArgs e)

--- a/GUI/SettingsDialog.resx
+++ b/GUI/SettingsDialog.resx
@@ -160,9 +160,10 @@
   <data name="RefreshPostLabel.Text" xml:space="preserve"><value>minute(s)</value></data>
   <data name="PauseRefreshCheckBox.Text" xml:space="preserve"><value>Pause refreshing</value></data>
   <data name="MoreSettingsGroupBox.Text" xml:space="preserve"><value>More Settings</value></data>
-  <data name="AutoSortUpdateCheckBox.Text" xml:space="preserve"><value>Automatically sort by "Update"-column when clicking "Add available updates"</value></data>
+  <data name="LanguageSelectionLabel.Text" xml:space="preserve"><value>Language (requires restart):</value></data>
   <data name="RefreshOnStartupCheckbox.Text" xml:space="preserve"><value>Update repositories on launch</value></data>
-  <data name="HideEpochsCheckbox.Text" xml:space="preserve"><value>Hide epoch numbers in mod list (Requires Restart)</value></data>
-  <data name="HideVCheckbox.Text" xml:space="preserve"><value>Hide "v" in mod list (Requires Restart)</value></data>
+  <data name="HideEpochsCheckbox.Text" xml:space="preserve"><value>Hide epoch numbers in mod list (requires restart)</value></data>
+  <data name="HideVCheckbox.Text" xml:space="preserve"><value>Hide "v" in mod list (requires restart)</value></data>
+  <data name="AutoSortUpdateCheckBox.Text" xml:space="preserve"><value>Automatically sort by "Update"-column when clicking "Add available updates"</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Settings</value></data>
 </root>

--- a/Tests/Core/Configuration/FakeConfiguration.cs
+++ b/Tests/Core/Configuration/FakeConfiguration.cs
@@ -139,5 +139,22 @@ namespace Tests.Core.Configuration
         {
             throw new NotImplementedException();
         }
+
+        private string _Language;
+        public string Language
+        {
+            get
+            {
+                return _Language;
+            }
+
+            set
+            {
+                if (CKAN.Utilities.AvailableLanguages.Contains(value))
+                {
+                    _Language = value;
+                }
+            }
+         }
     }
 }


### PR DESCRIPTION
## Motivation
Quite a few forum users asked for an option to change the language in CKAN after the release that introduced localization.

## Changes
I added a combobox to the settings that allows changing the language.
The selected language is saved in the "Core's" configuration (so the JSON config and also the Win32Registry, although the second one is no longer in use, but it was easy and fast to do).
It is saved in the [RFC 5646](https://tools.ietf.org/html/rfc5646) / [RFC 4647](https://tools.ietf.org/html/rfc4647) format, the same that is used as appendix for the resource files (=`de-DE`,`en-US`,`en-GB`).

## How it works:
By default, the `Language` field in the config is `null`.
### First start / no language saved in config
When the CKAN GUI starts, it checks the currently saved language. If it's null, it'll try to save whatever language CKAN was launched in the config.
If the launch language is not one that is explicitly supported by CKAN, the config value stays `null`, and the GUI continues in the launch language.
![grafik](https://user-images.githubusercontent.com/28812678/69291712-5a250700-0c04-11ea-8097-054f5dc62730.png)
![grafik](https://user-images.githubusercontent.com/28812678/69291694-4aa5be00-0c04-11ea-9ec3-0ecfaaba52a2.png)

Now when the user opens the settings, he will see a "blank" combobox. When he clicks it and selects on of the currently three supported languages, it is saved in the config. A restart is required to apply the languages (I didn't want to bother with re-initializing **all** GUI controls, and nothing wrong with a restart of the client).
![grafik](https://user-images.githubusercontent.com/28812678/69291739-7032c780-0c04-11ea-9b36-70dd7d27a7ef.png)


### Subsequent starts  / language set in the config
When CKAN starts and finds a language set in the config, it'll apply it as `System.Threading.Thread.CurrentUICulture`, **before** any controls are initialized.
![grafik](https://user-images.githubusercontent.com/28812678/69291857-ba1bad80-0c04-11ea-9769-24b12d1083c5.png)

When the user opens the settings, the current language will be selected by default in the combobox.
![grafik](https://user-images.githubusercontent.com/28812678/69291888-cf90d780-0c04-11ea-83a1-43e1e72eb4ae.png)


The CKAN-supported languages are accessible via `string[] CKAN.Utilities.AvailableLanguages`.

---

I also added an additional check in `GUIConfig.LoadOrCreateConfiguration()`  to create a new config if the file exists but is empty.