### PR TITLE
Ignore CurseForge tests

### DIFF
--- a/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
+++ b/Tests/NetKAN/Sources/Curse/CurseApiTests.cs
@@ -10,6 +10,7 @@ namespace Tests.NetKAN.Sources.Curse
     [TestFixture]
     [Category("FlakyNetwork")]
     [Category("Online")]
+    [Explicit]
     public sealed class CurseApiTests
     {
         private string       _cachePath;


### PR DESCRIPTION
## Motivation
See https://github.com/KSP-CKAN/NetKAN/issues/7446
Failing CurseForge tests are no longer caused by our code, but by CurseForges anti-bot actions.

## Change
Add `[Explicit]` tag to Curse's test class, so it no longer runs during a normal test run, but only if you specifically run them.
They haven't affected the PR validation, because Jenkins is set to ignore all network tests.