### PR TITLE
Disable Upgrade All ConsoleUI menu option when nothing to upgrade

### DIFF
--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -268,7 +268,7 @@ namespace CKAN.ConsoleUI {
                     true, UpdateRegistry),
                 new ConsoleMenuOption("Upgrade all",          "Ctrl+U",
                     "Mark all available updates for installation",
-                    true, UpgradeAll),
+                    true, UpgradeAll, null, null, HasAnyUpgradeable()),
                 new ConsoleMenuOption("Audit recommendations",      "",
                     "List mods suggested and recommended by installed mods",
                     true, ViewSuggestions),
@@ -348,6 +348,16 @@ namespace CKAN.ConsoleUI {
             );
             output.Run();
             return true;
+        }
+
+        private bool HasAnyUpgradeable()
+        {
+            foreach (InstalledModule im in registry.InstalledModules) {
+                if (registry.HasUpdate(im.identifier, manager.CurrentInstance.VersionCriteria())) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private bool UpgradeAll()

--- a/ConsoleUI/Toolkit/ConsolePopupMenu.cs
+++ b/ConsoleUI/Toolkit/ConsolePopupMenu.cs
@@ -51,12 +51,12 @@ namespace CKAN.ConsoleUI.Toolkit {
                     case ConsoleKey.UpArrow:
                         do {
                             selectedOption = (selectedOption + options.Count - 1) % options.Count;
-                        } while (options[selectedOption] == null);
+                        } while (options[selectedOption] == null || !options[selectedOption].Enabled);
                         break;
                     case ConsoleKey.DownArrow:
                         do {
                             selectedOption = (selectedOption + 1) % options.Count;
-                        } while (options[selectedOption] == null);
+                        } while (options[selectedOption] == null || !options[selectedOption].Enabled);
                         break;
                     case ConsoleKey.Enter:
                         if (options[selectedOption].CloseParent) {
@@ -113,6 +113,9 @@ namespace CKAN.ConsoleUI.Toolkit {
                         } else {
                             // Draw menu option
                             Console.Write(Symbols.vertLine);
+                            if (!opt.Enabled) {
+                                Console.ForegroundColor = ConsoleTheme.Current.MenuDisabledFg;
+                            }
                             if (index == selectedOption) {
                                 // Draw highlighted menu option
                                 Console.BackgroundColor = ConsoleTheme.Current.MenuSelectedBg;
@@ -121,6 +124,9 @@ namespace CKAN.ConsoleUI.Toolkit {
                             } else {
                                 // Draw normal menu option
                                 Console.Write(" " + AnnotatedCaption(opt) + " ");
+                            }
+                            if (!opt.Enabled) {
+                                Console.ForegroundColor = ConsoleTheme.Current.MenuFg;
                             }
                             Console.Write(Symbols.vertLine);
                         }
@@ -184,7 +190,8 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="radio">If set, this option is a radio button, and this function returns its value</param>
         /// <param name="submenu">Submenu to open for this option</param>
         public ConsoleMenuOption(string cap, string key, string tt, bool close,
-                Func<bool> exec = null, Func<bool> radio = null, ConsolePopupMenu submenu = null)
+                Func<bool> exec = null, Func<bool> radio = null, ConsolePopupMenu submenu = null,
+                bool enabled = true)
         {
             Caption     = cap;
             Key         = key;
@@ -193,6 +200,7 @@ namespace CKAN.ConsoleUI.Toolkit {
             OnExec      = exec;
             SubMenu     = submenu;
             RadioActive = radio;
+            Enabled     = enabled;
         }
 
         /// <summary>
@@ -223,6 +231,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Submenu to open for this option
         /// </summary>
         public readonly ConsolePopupMenu SubMenu;
+        /// <summary>
+        /// Function to call to check whether this option is enabled
+        /// </summary>
+        public readonly bool             Enabled;
     }
 
 }

--- a/ConsoleUI/Toolkit/ConsoleTheme.cs
+++ b/ConsoleUI/Toolkit/ConsoleTheme.cs
@@ -113,6 +113,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         public readonly ConsoleColor MenuFg         = ConsoleColor.Black;
         /// <summary>
+        /// Foreground for disabled popup menu options
+        /// </summary>
+        public readonly ConsoleColor MenuDisabledFg = ConsoleColor.DarkGray;
+        /// <summary>
         /// Background for selected menu option
         /// </summary>
         public readonly ConsoleColor MenuSelectedBg = ConsoleColor.DarkGreen;


### PR DESCRIPTION
## Motivation

A MacOSX ConsoleUI user [left some feedback on Reddit](https://www.reddit.com/r/KerbalSpaceProgram/comments/dz8j9a/ckan_mac/f8708sm/) which suggests some possible confusion around the Upgrade All option:

> 7. Restarted, selected update all. No noticeable progress bar or indicator that anything is happening.
> 8. Left it for 5 minutes thinking it may have been a static background. Noticed the instructions to hit F9 to apply. Hit F9, and stuff started installing.

When I first read this, I thought he or she may have selected that menu option when there were no upgrades to install, which would close the menu and do nothing. The full text indicates that the problem was something else, but this is still a possible point of confusion worth addressing.

## Changes

Now if you open the mod list menu while there are no upgrades available, the menu option will be draw in gray text and the cursor will skip over it when maneuvering through the menu, to indicate that the option is not available:

![image](https://user-images.githubusercontent.com/1559108/69372395-3e068180-0c67-11ea-91db-8c658f04a83b.png)

This is better than hiding the option because it makes the user aware that such an option is available *sometimes*, so they might try it again later when it's more useful.

For what it's worth, Borland did do this in its UIs:

![turbocpp](http://horstmann.com/ccc/help/tc30d6.jpg)