### PR TITLE
Eliminate duplicate network calls in Netkan

### DIFF
--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -43,14 +43,13 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(opts.Releases.Value);
                 }
-                if (versions.Any())
+                bool returnedAny = false;
+                foreach (CurseFile f in versions)
                 {
-                    foreach (CurseFile f in versions)
-                    {
-                        yield return TransformOne(metadata.Json(), curseMod, f);
-                    }
+                    returnedAny = true;
+                    yield return TransformOne(metadata.Json(), curseMod, f);
                 }
-                else
+                if (!returnedAny)
                 {
                     Log.WarnFormat("No releases found for {0}", curseMod.ToString());
                     yield return metadata;

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -61,14 +61,13 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(opts.Releases.Value);
                 }
-                if (versions.Any())
+                bool returnedAny = false;
+                foreach (GithubRelease rel in versions)
                 {
-                    foreach (GithubRelease rel in versions)
-                    {
-                        yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel);
-                    }
+                    returnedAny = true;
+                    yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel);
                 }
-                else
+                if (!returnedAny)
                 {
                     Log.WarnFormat("No releases found for {0}", ghRef.Repository);
                     yield return metadata;

--- a/Netkan/Transformers/JenkinsTransformer.cs
+++ b/Netkan/Transformers/JenkinsTransformer.cs
@@ -39,14 +39,13 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(opts.Releases.Value);
                 }
-                if (versions.Any())
+                bool returnedAny = false;
+                foreach (JenkinsBuild build in versions)
                 {
-                    foreach (JenkinsBuild build in versions)
-                    {
-                        yield return TransformOne(metadata, metadata.Json(), build, options);
-                    }
+                    returnedAny = true;
+                    yield return TransformOne(metadata, metadata.Json(), build, options);
                 }
-                else
+                if (!returnedAny)
                 {
                     Log.WarnFormat("No releases found for {0}", jRef.BaseUri);
                     yield return metadata;

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -42,14 +42,13 @@ namespace CKAN.NetKAN.Transformers
                 {
                     versions = versions.Take(opts.Releases.Value);
                 }
-                if (versions.Any())
+                bool returnedAny = false;
+                foreach (SDVersion vers in versions)
                 {
-                    foreach (SDVersion vers in versions)
-                    {
-                        yield return TransformOne(metadata, metadata.Json(), sdMod, vers);
-                    }
+                    returnedAny = true;
+                    yield return TransformOne(metadata, metadata.Json(), sdMod, vers);
                 }
-                else
+                if (!returnedAny)
                 {
                     Log.WarnFormat("No releases found for {0}", sdMod.ToString());
                     yield return metadata;


### PR DESCRIPTION
## Problem

Currently Netkan requests mod lists from remote servers twice whenever it inflates a mod hosted on GitHub or Jenkins. The `--debug` flag shows two entries like this (separated by lots of other messages):

```
1199 [1] DEBUG CKAN.Net (null) - About to download https://api.github.com/repos/messierr/SMHPContinued/releases?per_page=100
1383 [1] DEBUG CKAN.Net (null) - About to download https://api.github.com/repos/messierr/SMHPContinued/releases?per_page=100
```

This *might* be related to the "GitHub API rate limit exceeded." errors that we've been tracking for some time. (It might in fact be the exact and sole cause, since GitHub has every reason to think that rapid-fire accesses of the same URL from the same IP aren't legitimate.)

## Cause

I misunderstood (or had an incomplete understanding of) how `IEnumerable<>` and `yield return` work. These language features provide C#'s implementation of lazy evaluation; you can write a function that generates a long list with `yield return`, and then if the calling code only needs a few values, then the generator function will stop early before it creates the full list, saving unnecessary work.

We deployed that pattern for GitHub and Jenkins, since they might return lots of releases. Unfortunately, we ran into a gotcha: If you access the same `IEnumerable<>` again in a separate loop, _it starts executing the generator function again from the beginning_! In our case, this meant that we request the mod lists once when we check whether they're empty with `.Any()`, and then again when we loop over them with `foreach`.

(SpaceDock had the same style of code, but its API implementation did not do the network access inside the `IEnumerable<>`, so it was not affected by this issue.)

## Changes

Now the GitHub, Jenkins, and SpaceDock transformers only evaluate their `IEnumerable<>`s once. The `.Any()` calls are removed, and instead we set a `bool` to false if we end up inside the `foreach` loop's body. If that `bool` never gets set, then we know we need to return the default value.

This should significantly reduce our API calls to GitHub and Jenkins.