### PR TITLE
Bump nuget to 5.3.1 on Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -17,7 +17,7 @@ if (($PSVersionTable.PSVersion -lt $minPSVer)) {
 }
 
 # Globals
-$NugetVersion       = "5.0.2"
+$NugetVersion       = "5.3.1"
 $UseExperimental    = $false
 $RootDir            = "${PSScriptRoot}"
 $ScriptFile         = "${RootDir}/build.cake"


### PR DESCRIPTION
Forgot about `built.ps1` in #2921...

This PR updates it for Windows too to keep it consistent.