### PR TITLE
Multiple manual downloads, uncached filter, purge option

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -124,10 +124,9 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Downloads our files, returning an array of filenames that we're writing to.
-        /// The sole argument is a collection of DownloadTargets.
-        /// The .onCompleted delegate will be called on completion.
+        /// Downloads our files.
         /// </summary>
+        /// <param name="targets">A collection of DownloadTargets</param>
         private void Download(ICollection<Net.DownloadTarget> targets)
         {
             downloads.Clear();

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -162,6 +162,18 @@ namespace CKAN
             return cache.Store(module.download, path, description ?? module.StandardName(), move);
         }
 
+        /// <summary>
+        /// Remove a module's download file from the cache
+        /// </summary>
+        /// <param name="module">Module to purge</param>
+        /// <returns>
+        /// True if purged, false otherwise
+        /// </returns>
+        public bool Purge(CkanModule module)
+        {
+            return cache.Remove(module.download);
+        }
+
         private NetFileCache cache;
     }
 }

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -189,7 +189,8 @@
   <data name="FilterInstalledButton.Text" xml:space="preserve"><value>Installiert</value></data>
   <data name="FilterInstalledUpdateButton.Text" xml:space="preserve"><value>Aktualisierbar</value></data>
   <data name="FilterReplaceableButton.Text" xml:space="preserve"><value>Ersetzbar</value></data>
-  <data name="cachedToolStripMenuItem.Text" xml:space="preserve"><value>Im Cache</value></data>
+  <data name="FilterCachedButton.Text" xml:space="preserve"><value>Im Cache</value></data>
+  <data name="FilterUncachedButton.Text" xml:space="preserve"><value>Nicht im Cache</value></data>
   <data name="FilterNewButton.Text" xml:space="preserve"><value>Neu kompatibel</value></data>
   <data name="FilterNotInstalledButton.Text" xml:space="preserve"><value>Nicht installiert</value></data>
   <data name="FilterIncompatibleButton.Text" xml:space="preserve"><value>Inkompatibel</value></data>
@@ -208,6 +209,7 @@
   <data name="Description.HeaderText" xml:space="preserve"><value>Kurzbeschreibung</value></data>
   <data name="reinstallToolStripMenuItem.Text" xml:space="preserve"><value>Neu installieren</value></data>
   <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Inhalt herunterladen</value></data>
+  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Inhalt löschen</value></data>
   <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Mods verwalten</value></data>
   <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Nach Autorenname filtern:</value></data>
   <data name="FilterByAuthorTextBox.Location" type="System.Drawing.Point, System.Drawing"><value>570, 74</value></data>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -62,7 +62,8 @@
             this.FilterInstalledButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterInstalledUpdateButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterReplaceableButton = new System.Windows.Forms.ToolStripMenuItem();
-            this.cachedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.FilterCachedButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.FilterUncachedButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterNewButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterNotInstalledButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterIncompatibleButton = new System.Windows.Forms.ToolStripMenuItem();
@@ -89,6 +90,7 @@
             this.ModListHeaderContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.purgeContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ModInfoTabControl = new CKAN.MainModInfo();
             this.StatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.StatusInstanceLabel = new System.Windows.Forms.ToolStripStatusLabel();
@@ -416,7 +418,8 @@
             this.FilterInstalledButton,
             this.FilterInstalledUpdateButton,
             this.FilterReplaceableButton,
-            this.cachedToolStripMenuItem,
+            this.FilterCachedButton,
+            this.FilterUncachedButton,
             this.FilterNewButton,
             this.FilterNotInstalledButton,
             this.FilterIncompatibleButton,
@@ -455,12 +458,19 @@
             this.FilterReplaceableButton.Click += new System.EventHandler(this.FilterReplaceableButton_Click);
             resources.ApplyResources(this.FilterReplaceableButton, "FilterReplaceableButton");
             //
-            // cachedToolStripMenuItem
+            // FilterCachedButton
             //
-            this.cachedToolStripMenuItem.Name = "cachedToolStripMenuItem";
-            this.cachedToolStripMenuItem.Size = new System.Drawing.Size(307, 30);
-            this.cachedToolStripMenuItem.Click += new System.EventHandler(this.cachedToolStripMenuItem_Click);
-            resources.ApplyResources(this.cachedToolStripMenuItem, "cachedToolStripMenuItem");
+            this.FilterCachedButton.Name = "FilterCachedButton";
+            this.FilterCachedButton.Size = new System.Drawing.Size(307, 30);
+            this.FilterCachedButton.Click += new System.EventHandler(this.FilterCachedButton_Click);
+            resources.ApplyResources(this.FilterCachedButton, "FilterCachedButton");
+            //
+            // FilterUncachedButton
+            //
+            this.FilterUncachedButton.Name = "FilterUncachedButton";
+            this.FilterUncachedButton.Size = new System.Drawing.Size(307, 30);
+            this.FilterUncachedButton.Click += new System.EventHandler(this.FilterUncachedButton_Click);
+            resources.ApplyResources(this.FilterUncachedButton, "FilterUncachedButton");
             //
             // FilterNewButton
             //
@@ -689,7 +699,8 @@
             //
             this.ModListContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.reinstallToolStripMenuItem,
-            this.downloadContentsToolStripMenuItem});
+            this.downloadContentsToolStripMenuItem,
+            this.purgeContentsToolStripMenuItem});
             this.ModListContextMenuStrip.Name = "ModListContextMenuStrip";
             this.ModListContextMenuStrip.Size = new System.Drawing.Size(180, 70);
             //
@@ -706,6 +717,13 @@
             this.downloadContentsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.downloadContentsToolStripMenuItem.Click += new System.EventHandler(this.downloadContentsToolStripMenuItem_Click);
             resources.ApplyResources(this.downloadContentsToolStripMenuItem, "downloadContentsToolStripMenuItem");
+            //
+            // purgeContentsToolStripMenuItem
+            //
+            this.purgeContentsToolStripMenuItem.Name = "purgeContentsToolStripMenuItem";
+            this.purgeContentsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.purgeContentsToolStripMenuItem.Click += new System.EventHandler(this.purgeContentsToolStripMenuItem_Click);
+            resources.ApplyResources(this.purgeContentsToolStripMenuItem, "purgeContentsToolStripMenuItem");
             //
             // ModListHeaderContextMenuStrip
             //
@@ -1401,7 +1419,8 @@
         private System.Windows.Forms.ToolStripMenuItem FilterInstalledButton;
         private System.Windows.Forms.ToolStripMenuItem FilterInstalledUpdateButton;
         private System.Windows.Forms.ToolStripMenuItem FilterReplaceableButton;
-        private System.Windows.Forms.ToolStripMenuItem cachedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem FilterCachedButton;
+        private System.Windows.Forms.ToolStripMenuItem FilterUncachedButton;
         private System.Windows.Forms.ToolStripMenuItem FilterNewButton;
         private System.Windows.Forms.ToolStripMenuItem FilterNotInstalledButton;
         private System.Windows.Forms.ToolStripMenuItem FilterIncompatibleButton;
@@ -1428,6 +1447,7 @@
         private System.Windows.Forms.ContextMenuStrip ModListHeaderContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem purgeContentsToolStripMenuItem;
         private CKAN.MainModInfo ModInfoTabControl;
         private System.Windows.Forms.ToolStripStatusLabel StatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel StatusInstanceLabel;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1321,6 +1321,7 @@ namespace CKAN
                     Manager.Cache.Purge(mod);
                 }
                 ModInfoTabControl.SelectedModule.UpdateIsCached();
+                UpdateModContentsTree(ModInfoTabControl.SelectedModule.ToCkanModule(), true);
             }
         }
 

--- a/GUI/Main.resx
+++ b/GUI/Main.resx
@@ -191,7 +191,8 @@
   <data name="FilterInstalledButton.Text" xml:space="preserve"><value>Installed</value></data>
   <data name="FilterInstalledUpdateButton.Text" xml:space="preserve"><value>Installed (update available)</value></data>
   <data name="FilterReplaceableButton.Text" xml:space="preserve"><value>Replaceable</value></data>
-  <data name="cachedToolStripMenuItem.Text" xml:space="preserve"><value>Cached</value></data>
+  <data name="FilterCachedButton.Text" xml:space="preserve"><value>Cached</value></data>
+  <data name="FilterUncachedButton.Text" xml:space="preserve"><value>Uncached</value></data>
   <data name="FilterNewButton.Text" xml:space="preserve"><value>Newly compatible</value></data>
   <data name="FilterNotInstalledButton.Text" xml:space="preserve"><value>Not installed</value></data>
   <data name="FilterIncompatibleButton.Text" xml:space="preserve"><value>Incompatible</value></data>
@@ -213,6 +214,7 @@
   <data name="Description.HeaderText" xml:space="preserve"><value>Description</value></data>
   <data name="reinstallToolStripMenuItem.Text" xml:space="preserve"><value>Reinstall</value></data>
   <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Download Contents</value></data>
+  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Purge Contents</value></data>
   <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Manage mods</value></data>
   <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Filter by author name:</value></data>
   <data name="FilterByAuthorTextBox.Location" type="System.Drawing.Point, System.Drawing"><value>543, 74</value></data>

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -23,7 +23,8 @@ namespace CKAN
         Incompatible             = 5,
         All                      = 6,
         Cached                   = 7,
-        Replaceable              = 8
+        Replaceable              = 8,
+        Uncached                 = 9,
     }
 
     public partial class Main
@@ -244,26 +245,27 @@ namespace CKAN
             var has_any_installed    = gui_mods.Any(mod => mod.IsInstalled);
             var has_any_replacements = gui_mods.Any(mod => mod.IsInstalled && mod.HasReplacement);
 
-            //TODO Consider using smart enumeration pattern so stuff like this is easier
             Util.Invoke(menuStrip2, () =>
             {
-                FilterToolButton.DropDownItems[0].Text = String.Format(Properties.Resources.MainModListCompatible,
+                FilterCompatibleButton.Text = String.Format(Properties.Resources.MainModListCompatible,
                     mainModList.CountModsByFilter(GUIModFilter.Compatible));
-                FilterToolButton.DropDownItems[1].Text = String.Format(Properties.Resources.MainModListInstalled,
+                FilterInstalledButton.Text = String.Format(Properties.Resources.MainModListInstalled,
                     mainModList.CountModsByFilter(GUIModFilter.Installed));
-                FilterToolButton.DropDownItems[2].Text = String.Format(Properties.Resources.MainModListUpgradeable,
+                FilterInstalledUpdateButton.Text = String.Format(Properties.Resources.MainModListUpgradeable,
                     mainModList.CountModsByFilter(GUIModFilter.InstalledUpdateAvailable));
-                FilterToolButton.DropDownItems[3].Text = String.Format(Properties.Resources.MainModListReplaceable,
+                FilterReplaceableButton.Text = String.Format(Properties.Resources.MainModListReplaceable,
                     mainModList.CountModsByFilter(GUIModFilter.Replaceable));
-                FilterToolButton.DropDownItems[4].Text = String.Format(Properties.Resources.MainModListCached,
+                FilterCachedButton.Text = String.Format(Properties.Resources.MainModListCached,
                     mainModList.CountModsByFilter(GUIModFilter.Cached));
-                FilterToolButton.DropDownItems[5].Text = String.Format(Properties.Resources.MainModListNewlyCompatible,
+                FilterUncachedButton.Text = String.Format(Properties.Resources.MainModListUncached,
+                    mainModList.CountModsByFilter(GUIModFilter.Uncached));
+                FilterNewButton.Text = String.Format(Properties.Resources.MainModListNewlyCompatible,
                     mainModList.CountModsByFilter(GUIModFilter.NewInRepository));
-                FilterToolButton.DropDownItems[6].Text = String.Format(Properties.Resources.MainModListNotInstalled,
+                FilterNotInstalledButton.Text = String.Format(Properties.Resources.MainModListNotInstalled,
                     mainModList.CountModsByFilter(GUIModFilter.NotInstalled));
-                FilterToolButton.DropDownItems[7].Text = String.Format(Properties.Resources.MainModListIncompatible,
+                FilterIncompatibleButton.Text = String.Format(Properties.Resources.MainModListIncompatible,
                     mainModList.CountModsByFilter(GUIModFilter.Incompatible));
-                FilterToolButton.DropDownItems[8].Text = String.Format(Properties.Resources.MainModListAll,
+                FilterAllButton.Text = String.Format(Properties.Resources.MainModListAll,
                     mainModList.CountModsByFilter(GUIModFilter.All));
 
                 UpdateAllToolButton.Enabled = has_any_updates;
@@ -999,6 +1001,7 @@ namespace CKAN
                 case GUIModFilter.Installed:                return m.IsInstalled;
                 case GUIModFilter.InstalledUpdateAvailable: return m.IsInstalled && m.HasUpdate;
                 case GUIModFilter.Cached:                   return m.IsCached;
+                case GUIModFilter.Uncached:                 return !m.IsCached;
                 case GUIModFilter.NewInRepository:          return m.IsNew;
                 case GUIModFilter.NotInstalled:             return !m.IsInstalled;
                 case GUIModFilter.Incompatible:             return m.IsIncompatible;

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -376,6 +376,9 @@ namespace CKAN.Properties {
         internal static string MainFilterCached {
             get { return (string)(ResourceManager.GetObject("MainFilterCached", resourceCulture)); }
         }
+        internal static string MainFilterUncached {
+            get { return (string)(ResourceManager.GetObject("MainFilterUncached", resourceCulture)); }
+        }
         internal static string MainFilterNew {
             get { return (string)(ResourceManager.GetObject("MainFilterNew", resourceCulture)); }
         }
@@ -585,6 +588,9 @@ namespace CKAN.Properties {
         }
         internal static string MainModListCached {
             get { return (string)(ResourceManager.GetObject("MainModListCached", resourceCulture)); }
+        }
+        internal static string MainModListUncached {
+            get { return (string)(ResourceManager.GetObject("MainModListUncached", resourceCulture)); }
         }
         internal static string MainModListNewlyCompatible {
             get { return (string)(ResourceManager.GetObject("MainModListNewlyCompatible", resourceCulture)); }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -158,6 +158,7 @@
   <data name="MainFilterUpgradeable" xml:space="preserve"><value>Filter (Aktualisierbar)</value></data>
   <data name="MainFilterReplaceable" xml:space="preserve"><value>Filter (Ersetzbar)</value></data>
   <data name="MainFilterCached" xml:space="preserve"><value>Filter (Im Cache)</value></data>
+  <data name="MainFilterUncached" xml:space="preserve"><value>Filter (Nicht im Cache)</value></data>
   <data name="MainFilterNew" xml:space="preserve"><value>Filter (Neu)</value></data>
   <data name="MainFilterNotInstalled" xml:space="preserve"><value>Filter (Nicht installiert)</value></data>
   <data name="MainFilterCompatible" xml:space="preserve"><value>Filter (Kompatibel)</value></data>
@@ -261,6 +262,7 @@ Einstellungen jetzt öffnen?</value>
   <data name="MainModListUpgradeable" xml:space="preserve"><value>Aktualisierbar ({0})</value></data>
   <data name="MainModListReplaceable" xml:space="preserve"><value>Ersetzbar ({0})</value></data>
   <data name="MainModListCached" xml:space="preserve"><value>Im Cache ({0})</value></data>
+  <data name="MainModListUncached" xml:space="preserve"><value>Nicht im Cache ({0})</value></data>
   <data name="MainModListNewlyCompatible" xml:space="preserve"><value>Neu kompatibel ({0})</value></data>
   <data name="MainModListNotInstalled" xml:space="preserve"><value>Nicht installiert ({0})</value></data>
   <data name="MainModListIncompatible" xml:space="preserve"><value>Inkompatibel ({0})</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -180,6 +180,7 @@
   <data name="MainFilterUpgradeable" xml:space="preserve"><value>Filter (Upgradeable)</value></data>
   <data name="MainFilterReplaceable" xml:space="preserve"><value>Filter (Replaceable)</value></data>
   <data name="MainFilterCached" xml:space="preserve"><value>Filter (Cached)</value></data>
+  <data name="MainFilterUncached" xml:space="preserve"><value>Filter (Uncached)</value></data>
   <data name="MainFilterNew" xml:space="preserve"><value>Filter (New)</value></data>
   <data name="MainFilterNotInstalled" xml:space="preserve"><value>Filter (Not installed)</value></data>
   <data name="MainFilterCompatible" xml:space="preserve"><value>Filter (Compatible)</value></data>
@@ -282,6 +283,7 @@ Open settings now?</value></data>
   <data name="MainModListUpgradeable" xml:space="preserve"><value>Upgradeable ({0})</value></data>
   <data name="MainModListReplaceable" xml:space="preserve"><value>Replaceable ({0})</value></data>
   <data name="MainModListCached" xml:space="preserve"><value>Cached ({0})</value></data>
+  <data name="MainModListUncached" xml:space="preserve"><value>Uncached ({0})</value></data>
   <data name="MainModListNewlyCompatible" xml:space="preserve"><value>Newly compatible ({0})</value></data>
   <data name="MainModListNotInstalled" xml:space="preserve"><value>Not installed ({0})</value></data>
   <data name="MainModListIncompatible" xml:space="preserve"><value>Incompatible ({0})</value></data>


### PR DESCRIPTION
## Problem

When you click the Download button in the mod info pane or right click a row and choose Download Contents, the GUI switches to the progress tab and begins downloading the module. The tabstrip is not locked down.

If you switch back to the mod list and initiate a second manual download while the first is still in progress, CKAN crashes with an exception like this:

```
System.InvalidOperationException: This BackgroundWorker is currently busy and cannot run multiple tasks concurrently.
  at System.ComponentModel.BackgroundWorker.RunWorkerAsync (System.Object argument) [0x00008] in <3310c48c8d57467d8dc60ad91e20e6c6>:0 
  at (wrapper remoting-invoke-with-check) System.ComponentModel.BackgroundWorker.RunWorkerAsync(object)
  at CKAN.MainModInfo.StartDownload (CKAN.GUIMod module) [0x00039] in <5434f55888ed4862bbdac3b97deafc6a>:0 
  at (wrapper remoting-invoke-with-check) CKAN.MainModInfo.StartDownload(CKAN.GUIMod)
  at CKAN.Main.downloadContentsToolStripMenuItem_Click (System.Object sender, System.EventArgs e) [0x00012] in <5434f55888ed4862bbdac3b97deafc6a>:0 
  at System.Windows.Forms.ToolStripItem.OnClick (System.EventArgs e) [0x00019] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.ToolStripMenuItem.OnClick (System.EventArgs e) [0x00090] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.ToolStripMenuItem.HandleClick (System.Int32 mouse_clicks, System.EventArgs e) [0x00000] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.ToolStripItem.FireEvent (System.EventArgs e, System.Windows.Forms.ToolStripItemEventType met) [0x00054] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.ToolStripItem.FireEvent(System.EventArgs,System.Windows.Forms.ToolStripItemEventType)
  at System.Windows.Forms.ToolStrip.OnMouseUp (System.Windows.Forms.MouseEventArgs mea) [0x00048] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.ToolStripDropDown.OnMouseUp (System.Windows.Forms.MouseEventArgs mea) [0x00000] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.Control.WmLButtonUp (System.Windows.Forms.Message& m) [0x00078] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.Control.WndProc (System.Windows.Forms.Message& m) [0x001b4] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.ScrollableControl.WndProc (System.Windows.Forms.Message& m) [0x00000] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.ToolStrip.WndProc (System.Windows.Forms.Message& m) [0x00000] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.ToolStripDropDown.WndProc (System.Windows.Forms.Message& m) [0x00017] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.Control+ControlWindowTarget.OnMessage (System.Windows.Forms.Message& m) [0x00000] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.Control+ControlNativeWindow.WndProc (System.Windows.Forms.Message& m) [0x0000b] in <ef4c141df2a64a07af6c70f96a472f03>:0 
  at System.Windows.Forms.NativeWindow.WndProc (System.IntPtr hWnd, System.Windows.Forms.Msg msg, System.IntPtr wParam, System.IntPtr lParam) [0x00085] in <ef4c141df2a64a07af6c70f96a472f03>:0 
```

## Cause

Downloading is done by a `BackgroundWorker`, which can only handle one task at a time. When you start the second download, CKAN attempts to tell its worker to start up again while it's already active, which throws the exception.

## Changes

- `NetAsyncDownloader` is refactored to allow new downloads to be added to an in-progress group of downloads
- The cURL code is removed from `NetAsyncDownloader` because it makes the class harder to maintain, and we have not lately solved any user problems by suggesting the "chicken bits" environment variable (I have **not** attempted to remove **all** of the cURL code from everywhere)
- `NetAsyncModulesDownloader` is updated to exclude modules already being downloaded when starting new downloads, in case the user chooses Download Contents for the same module multiple times in a row
- `MainModInfo.ContentsDownloadButton_Click` and `Main.downloadContentsToolStripMenuItem_Click` now both call `MainModInfo.StartDownload`, which avoids trying to run the background worker if it's already busy and instead asks `NetAsyncModulesDownloader` to add them to the current batch
- The background worker's input and output are now `GUIMod`s instead of `CkanModule`s so their cached status can be updated properly after completion

Minor stuff:

- `MainModInfo._PostModCaching` no longer calls `RecreateDialogs` because this isn't needed and has nothing to do with downloading modules
- `MainModInfo.CacheWorker` is removed because this is private state that's not appropriate to share
- A variety of misnamed variables are renamed for consistency with other variables

To make this more convenient to test:

- A new Uncached filter is added to GUI, which is simply the inverse of the Cached filter
- A new Purge Contents right click menu option is added to the mod list grid, which removes all downloads for the selected identifier when clicked (including previous/incompatible versions)

Note that if you open the Cached filter and Purge Contents for some mod, it remains in the list, and the same goes for opening the Uncached filter and clicking Download Contents. I considered updating the filters after caching, but I think that might be confusing and annoying instead of helpful since a mod that you might have intended to work with further would disappear. The right click menu options should toggle their enabled status appropriately, though.

Fixes #1680.
Fixes #1713.
Fixes #2882.