### PR TITLE
Don't send notification to Discord if build succeeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,10 +109,6 @@ deploy:
         branch: master
         condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\d+\.\d+\.\d+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
 
-after_success:
-  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
-  - chmod +x send.sh
-  - ./send.sh success $WEBHOOK_URL
 after_failure:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh


### PR DESCRIPTION
The `#travis-builds` channel is really spammy, and probably all of us have muted it.

This PR removed the `after_success` hook, so only build failures will be send to the Discord webhook and into the channel.
