### PR TITLE
Handle multiple errors in same ErrorDialog

### DIFF
--- a/GUI/ErrorDialog.Designer.cs
+++ b/GUI/ErrorDialog.Designer.cs
@@ -38,10 +38,13 @@
             //
             // panel1
             //
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel1.Controls.Add(this.ErrorMessage);
             this.panel1.Location = new System.Drawing.Point(13, 13);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(267, 117);
+            this.panel1.Size = new System.Drawing.Size(775, 105);
             this.panel1.TabIndex = 0;
             //
             // ErrorMessage
@@ -50,15 +53,16 @@
             this.ErrorMessage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ErrorMessage.Location = new System.Drawing.Point(0, 0);
             this.ErrorMessage.Name = "ErrorMessage";
-            this.ErrorMessage.Size = new System.Drawing.Size(267, 117);
+            this.ErrorMessage.Size = new System.Drawing.Size(267, 105);
             this.ErrorMessage.TabIndex = 0;
             this.ErrorMessage.ReadOnly = true;
             resources.ApplyResources(this.ErrorMessage, "ErrorMessage");
             //
             // DismissButton
             //
+            this.DismissButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom));
             this.DismissButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.DismissButton.Location = new System.Drawing.Point(205, 136);
+            this.DismissButton.Location = new System.Drawing.Point(387, 124);
             this.DismissButton.Name = "DismissButton";
             this.DismissButton.Size = new System.Drawing.Size(75, 23);
             this.DismissButton.TabIndex = 1;
@@ -70,13 +74,14 @@
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(292, 174);
-            this.ControlBox = false;
+            this.ClientSize = new System.Drawing.Size(800, 160);
+            this.ControlBox = true;
             this.Controls.Add(this.DismissButton);
             this.Controls.Add(this.panel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.Icon = Properties.Resources.AppIcon;
             this.Name = "ErrorDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
             this.panel1.ResumeLayout(false);
             this.ResumeLayout(false);

--- a/GUI/ErrorDialog.resx
+++ b/GUI/ErrorDialog.resx
@@ -118,7 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ErrorMessage.Text" xml:space="preserve"><value>Error!</value></data>
   <data name="DismissButton.Text" xml:space="preserve"><value>Dismiss</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Error!</value></data>
 </root>

--- a/GUI/Localization/de-DE/ErrorDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/ErrorDialog.de-DE.resx
@@ -118,7 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ErrorMessage.Text" xml:space="preserve"><value>Fehler!</value></data>
   <data name="DismissButton.Text" xml:space="preserve"><value>OK</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Fehler!</value></data>
 </root>


### PR DESCRIPTION
## Problem

If you start downloading multiple modules in GUI and more than one of them fail, you'll get an unhandled exception like this:

```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: The form is already displayed as a modal dialog.
  at System.Windows.Forms.Form.ShowDialog (System.Windows.Forms.IWin32Window owner) [0x00081] in <f73fa304d089422f9e23b25394111843>:0 
  at System.Windows.Forms.Form.ShowDialog () [0x00000] in <f73fa304d089422f9e23b25394111843>:0 
  at CKAN.ErrorDialog.ShowErrorDialog (System.String text, System.Object[] args) [0x00071] in <ea98fd2118b84fc7ad1a2141a259ca95>:0 
```

## Cause

In KSP-CKAN/CKAN#2756 we started handling individual module download success or failure immediately, regardless of whether other downloads were still in progress. This opened the possibility of multiple calls to `ErrorDialog.ShowErrorDialog` without the error dialog being closed in between, and `Form.ShowDialog` throws the above exception when the form is already visible.

## Changes

- Now `ErrorDialog.ShowErrorDialog` only calls `ShowDialog` if `Visible` is false, to avoid throwing the exception
- Now if `ErrorDialog` is already visible, additional messages will be appended to the main one
  - The text is cleared when the form is closed
  - The default text is now empty, so the first message won't be appended to "Error!" or "Fehler!"
- Now `ErrorDialog` is resizable and has anchored controls to fit the space
- Now `ErrorDialog` is wider by default
- Now `ErrorDialog.ShowErrorDialog` resizes the form to fit its content, up to a maximum height of 600 pixels, to make it easier to read the messages, just like #2729
- Now `ErrorDialog` will open centered on the main window instead of centered on the screen
- `ErrorDialog` no longer inherits from `FormCompatibility` because it doesn't help and was messing with the size

Fixes #2890.