### PR TITLE
Notify on Deployment Success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,11 @@ deploy:
         branch: master
         condition: $BUILD_CONFIGURATION = Release && $(mono --version | perl -ne'/version (\d+\.\d+\.\d+)/ and print $1') = $BUILD_RELEASE_MONO_VERSION
 
+after_success:
+  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - if [ "$BUILD_CONFIGURATION" = "Release" ] && [ "$(mono --version | perl -ne'/version (\d+\.\d+\.\d+)/ and print $1')" = "$BUILD_RELEASE_MONO_VERSION" ] && [ "$TRAVIS_BRANCH" = "master" ]; then ./send.sh success $WEBHOOK_URL; fi
+
 after_failure:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh


### PR DESCRIPTION
Travis was definitely a little spammy, but the lack having a notification post deployment success is useful.

This limits the notification to the conditions that match our deployment conditions. We could drop the check for master if we want to be notified once per set of builds. Though we should consider moving to [stages](https://docs.travis-ci.com/user/build-stages). Which I might do on NetKAN-infra as an example first.