### PR TITLE
Custom mod labels, favorites, hiding

### DIFF
--- a/Core/Extensions/DictionaryExtensions.cs
+++ b/Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace CKAN.Extensions
+{
+    public static class DictionaryExtensions
+    {
+
+        public static V GetOrDefault<K, V>(this Dictionary<K, V> dict, K key)
+        {
+            V val = default(V);
+            if (key != null)
+            {
+                dict.TryGetValue(key, out val);
+            }
+            return val;
+        }
+
+    }
+}

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -64,7 +64,8 @@ namespace CKAN
         // Index of which mods provide what, format:
         //   providers[provided] = { provider1, provider2, ... }
         // Built by BuildProvidesIndex, makes LatestAvailableWithProvides much faster.
-        [JsonIgnore] private Dictionary<string, HashSet<AvailableModule>> providers
+        [JsonIgnore]
+        private Dictionary<string, HashSet<AvailableModule>> providers
             = new Dictionary<string, HashSet<AvailableModule>>();
 
         /// <summary>
@@ -683,6 +684,16 @@ namespace CKAN
                     else
                         providers.Add(provided, new HashSet<AvailableModule>() { am });
                 }
+            }
+        }
+
+        public void BuildTagIndex(ModuleTagList tags)
+        {
+            tags.Tags.Clear();
+            tags.Untagged.Clear();
+            foreach (AvailableModule am in available_modules.Values)
+            {
+                tags.BuildTagIndexFor(am);
             }
         }
 

--- a/Core/Registry/Tags/ModuleTag.cs
+++ b/Core/Registry/Tags/ModuleTag.cs
@@ -6,6 +6,24 @@ namespace CKAN
     {
         public string          Name;
         public bool            Visible;
-        public HashSet<string> Modules;
+        public HashSet<string> ModuleIdentifiers = new HashSet<string>();
+
+        /// <summary>
+        /// Add a module to this label's group
+        /// </summary>
+        /// <param name="identifier">The identifier of the module to add</param>
+        public void Add(string identifier)
+        {
+            ModuleIdentifiers.Add(identifier);
+        }
+
+        /// <summary>
+        /// Remove a module from this label's group
+        /// </summary>
+        /// <param name="identifier">The identifier of the module to remove</param>
+        public void Remove(string identifier)
+        {
+            ModuleIdentifiers.Remove(identifier);
+        }
     }
 }

--- a/Core/Registry/Tags/ModuleTag.cs
+++ b/Core/Registry/Tags/ModuleTag.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace CKAN
+{
+    public class ModuleTag
+    {
+        public string          Name;
+        public bool            Visible;
+        public HashSet<string> Modules;
+    }
+}

--- a/Core/Registry/Tags/ModuleTagList.cs
+++ b/Core/Registry/Tags/ModuleTagList.cs
@@ -35,13 +35,13 @@ namespace CKAN
                     {
                         ModuleTag tag = null;
                         if (Tags.TryGetValue(tagName, out tag))
-                            tag.Modules.Add(m.identifier);
+                            tag.Add(m.identifier);
                         else
                             Tags.Add(tagName, new ModuleTag()
                             {
-                                Name    = tagName,
-                                Visible = !HiddenTags.Contains(tagName),
-                                Modules = new HashSet<string>() { m.identifier },
+                                Name              = tagName,
+                                Visible           = !HiddenTags.Contains(tagName),
+                                ModuleIdentifiers = new HashSet<string>() { m.identifier },
                             });
                     }
                 }

--- a/Core/Registry/Tags/ModuleTagList.cs
+++ b/Core/Registry/Tags/ModuleTagList.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.IO;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace CKAN
+{
+    public class ModuleTagList
+    {
+        [JsonIgnore]
+        public Dictionary<string, ModuleTag> Tags = new Dictionary<string, ModuleTag>();
+
+        [JsonIgnore]
+        public HashSet<string> Untagged = new HashSet<string>();
+
+        [JsonProperty("hidden_tags")]
+        public HashSet<string> HiddenTags = new HashSet<string>();
+
+        public static readonly string DefaultPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "CKAN",
+            "tags.json"
+        );
+
+        public void BuildTagIndexFor(AvailableModule am)
+        {
+            bool tagged = false;
+            foreach (CkanModule m in am.AllAvailable())
+            {
+                if (m.Tags != null)
+                {
+                    tagged = true;
+                    foreach (string tagName in m.Tags)
+                    {
+                        ModuleTag tag = null;
+                        if (Tags.TryGetValue(tagName, out tag))
+                            tag.Modules.Add(m.identifier);
+                        else
+                            Tags.Add(tagName, new ModuleTag()
+                            {
+                                Name    = tagName,
+                                Visible = !HiddenTags.Contains(tagName),
+                                Modules = new HashSet<string>() { m.identifier },
+                            });
+                    }
+                }
+            }
+            if (!tagged)
+            {
+                Untagged.Add(am.AllAvailable().First().identifier);
+            }
+        }
+        
+        public static ModuleTagList Load(string path)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<ModuleTagList>(File.ReadAllText(path));
+            }
+            catch (FileNotFoundException ex)
+            {
+                return null;
+            }
+        }
+
+        public bool Save(string path)
+        {
+            try
+            {
+                File.WriteAllText(path, JsonConvert.SerializeObject(this, Formatting.Indented));
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -435,7 +435,7 @@ namespace CKAN
 
         [JsonProperty("install", NullValueHandling = NullValueHandling.Ignore)]
         public ModuleInstallDescriptor[] install;
-        
+
         [JsonProperty("localizations", NullValueHandling = NullValueHandling.Ignore)]
         public string[] localizations;
 
@@ -468,6 +468,9 @@ namespace CKAN
                     specVersion = value;
             }
         }
+
+        [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
+        public HashSet<string> Tags;
 
         // A list of eveything this mod provides.
         public List<string> ProvidesList

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -299,6 +299,9 @@
     <EmbeddedResource Include="EditLabelsDialog.resx">
       <DependentUpon>EditLabelsDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Localization\de-DE\EditLabelsDialog.de-DE.resx">
+      <DependentUpon>..\..\EditLabelsDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ErrorDialog.resx">
       <DependentUpon>ErrorDialog.cs</DependentUpon>
     </EmbeddedResource>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -116,6 +116,12 @@
     <Compile Include="DropdownMenuButton.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="EditLabelsDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="EditLabelsDialog.Designer.cs">
+      <DependentUpon>EditLabelsDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="ErrorDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -144,6 +150,8 @@
     <Compile Include="KSPCommandLineOptionsDialog.Designer.cs">
       <DependentUpon>KSPCommandLineOptionsDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Labels\ModuleLabel.cs" />
+    <Compile Include="Labels\ModuleLabelList.cs" />
     <Compile Include="Main.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -168,6 +176,7 @@
     <Compile Include="MainInstall.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="MainLabels.cs" />
     <Compile Include="MainModInfo.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -286,6 +295,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Localization\de-DE\CompatibleKspVersionsDialog.de-DE.resx">
       <DependentUpon>..\..\CompatibleKspVersionsDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="EditLabelsDialog.resx">
+      <DependentUpon>EditLabelsDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="ErrorDialog.resx">
       <DependentUpon>ErrorDialog.cs</DependentUpon>

--- a/GUI/EditLabelsDialog.Designer.cs
+++ b/GUI/EditLabelsDialog.Designer.cs
@@ -285,6 +285,7 @@ namespace CKAN
             this.Name = "EditLabelsDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
+            this.EditDetailsPanel.ResumeLayout(false);
             this.ResumeLayout(false);
         }
 

--- a/GUI/EditLabelsDialog.Designer.cs
+++ b/GUI/EditLabelsDialog.Designer.cs
@@ -1,0 +1,314 @@
+namespace CKAN
+{
+    partial class EditLabelsDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(EditLabelsDialog));
+            this.ToolTip = new System.Windows.Forms.ToolTip();
+            this.LabelSelectionTree = new System.Windows.Forms.TreeView();
+            this.SelectOrCreateLabel = new System.Windows.Forms.Label();
+            this.EditDetailsPanel = new System.Windows.Forms.Panel();
+            this.NameLabel = new System.Windows.Forms.Label();
+            this.NameTextBox = new System.Windows.Forms.TextBox();
+            this.ColorLabel = new System.Windows.Forms.Label();
+            this.ColorButton = new System.Windows.Forms.Button();
+            this.InstanceNameLabel = new System.Windows.Forms.Label();
+            this.InstanceNameComboBox = new System.Windows.Forms.ComboBox();
+            this.HideFromOtherFiltersCheckBox = new System.Windows.Forms.CheckBox();
+            this.NotifyOnChangesCheckBox = new System.Windows.Forms.CheckBox();
+            this.RemoveOnChangesCheckBox = new System.Windows.Forms.CheckBox();
+            this.AlertOnInstallCheckBox = new System.Windows.Forms.CheckBox();
+            this.RemoveOnInstallCheckBox = new System.Windows.Forms.CheckBox();
+            this.CreateButton = new System.Windows.Forms.Button();
+            this.CloseButton = new System.Windows.Forms.Button();
+            this.SaveButton = new System.Windows.Forms.Button();
+            this.CancelButton = new System.Windows.Forms.Button();
+            this.DeleteButton = new System.Windows.Forms.Button();
+            this.EditDetailsPanel.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // ToolTip
+            // 
+            this.ToolTip.AutoPopDelay = 10000;
+            this.ToolTip.InitialDelay = 250;
+            this.ToolTip.ReshowDelay = 250;
+            this.ToolTip.ShowAlways = true;
+            // 
+            // CreateButton
+            // 
+            this.CreateButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.CreateButton.Location = new System.Drawing.Point(10, 10);
+            this.CreateButton.Name = "CreateButton";
+            this.CreateButton.Size = new System.Drawing.Size(75, 23);
+            this.CreateButton.TabIndex = 0;
+            this.CreateButton.UseVisualStyleBackColor = true;
+            this.CreateButton.Click += new System.EventHandler(this.CreateButton_Click);
+            resources.ApplyResources(this.CreateButton, "CreateButton");
+            // 
+            // LabelSelectionTree
+            // 
+            this.LabelSelectionTree.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left))));
+            this.LabelSelectionTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.LabelSelectionTree.FullRowSelect = true;
+            this.LabelSelectionTree.HideSelection = false;
+            this.LabelSelectionTree.Indent = 16;
+            this.LabelSelectionTree.ItemHeight = 24;
+            this.LabelSelectionTree.Location = new System.Drawing.Point(10, 43);
+            this.LabelSelectionTree.Name = "LabelSelectionTree";
+            this.LabelSelectionTree.Size = new System.Drawing.Size(125, 320);
+            this.LabelSelectionTree.ShowPlusMinus = false;
+            this.LabelSelectionTree.ShowRootLines = false;
+            this.LabelSelectionTree.ShowLines = false;
+            this.LabelSelectionTree.TabIndex = 0;
+            this.LabelSelectionTree.BeforeSelect += new System.Windows.Forms.TreeViewCancelEventHandler(LabelSelectionTree_BeforeSelect);
+            this.LabelSelectionTree.BeforeCollapse += new System.Windows.Forms.TreeViewCancelEventHandler(LabelSelectionTree_BeforeCollapse);
+            // 
+            // SelectOrCreateLabel
+            // 
+            this.SelectOrCreateLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.SelectOrCreateLabel.Location = new System.Drawing.Point(160, 50);
+            this.SelectOrCreateLabel.Name = "SelectOrCreateLabel";
+            this.SelectOrCreateLabel.Size = new System.Drawing.Size(300, 23);
+            resources.ApplyResources(this.SelectOrCreateLabel, "SelectOrCreateLabel");
+            // 
+            // EditDetailsPanel
+            // 
+            this.EditDetailsPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.EditDetailsPanel.Controls.Add(this.NameLabel);
+            this.EditDetailsPanel.Controls.Add(this.NameTextBox);
+            this.EditDetailsPanel.Controls.Add(this.ColorLabel);
+            this.EditDetailsPanel.Controls.Add(this.ColorButton);
+            this.EditDetailsPanel.Controls.Add(this.InstanceNameLabel);
+            this.EditDetailsPanel.Controls.Add(this.InstanceNameComboBox);
+            this.EditDetailsPanel.Controls.Add(this.HideFromOtherFiltersCheckBox);
+            this.EditDetailsPanel.Controls.Add(this.NotifyOnChangesCheckBox);
+            this.EditDetailsPanel.Controls.Add(this.RemoveOnChangesCheckBox);
+            this.EditDetailsPanel.Controls.Add(this.AlertOnInstallCheckBox);
+            this.EditDetailsPanel.Controls.Add(this.RemoveOnInstallCheckBox);
+            this.EditDetailsPanel.Controls.Add(this.SaveButton);
+            this.EditDetailsPanel.Controls.Add(this.CancelButton);
+            this.EditDetailsPanel.Controls.Add(this.DeleteButton);
+            this.EditDetailsPanel.Location = new System.Drawing.Point(135, 43);
+            this.EditDetailsPanel.Name = "EditDetailsPanel";
+            this.EditDetailsPanel.Size = new System.Drawing.Size(350, 320);
+            this.EditDetailsPanel.TabIndex = 1;
+            this.EditDetailsPanel.Visible = false;
+            // 
+            // NameLabel
+            // 
+            this.NameLabel.AutoSize = true;
+            this.NameLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.NameLabel.Location = new System.Drawing.Point(10, 13);
+            this.NameLabel.Name = "NameLabel";
+            this.NameLabel.Size = new System.Drawing.Size(75, 23);
+            resources.ApplyResources(this.NameLabel, "NameLabel");
+            // 
+            // NameTextBox
+            // 
+            this.NameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.NameTextBox.Location = new System.Drawing.Point(90, 10);
+            this.NameTextBox.Name = "NameTextBox";
+            this.NameTextBox.Size = new System.Drawing.Size(125, 23);
+            resources.ApplyResources(this.NameTextBox, "NameTextBox");
+            // 
+            // ColorLabel
+            // 
+            this.ColorLabel.AutoSize = true;
+            this.ColorLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.ColorLabel.Location = new System.Drawing.Point(10, 43);
+            this.ColorLabel.Name = "ColorLabel";
+            this.ColorLabel.Size = new System.Drawing.Size(75, 23);
+            resources.ApplyResources(this.ColorLabel, "ColorLabel");
+            // 
+            // ColorButton
+            // 
+            this.ColorButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.ColorButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ColorButton.Location = new System.Drawing.Point(90, 40);
+            this.ColorButton.Name = "ColorButton";
+            this.ColorButton.Size = new System.Drawing.Size(50, 20);
+            this.ColorButton.UseVisualStyleBackColor = false;
+            this.ColorButton.Click += new System.EventHandler(this.ColorButton_Click);
+            resources.ApplyResources(this.ColorButton, "ColorButton");
+            // 
+            // InstanceNameLabel
+            // 
+            this.InstanceNameLabel.AutoSize = true;
+            this.InstanceNameLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.InstanceNameLabel.Location = new System.Drawing.Point(10, 73);
+            this.InstanceNameLabel.Name = "InstanceNameLabel";
+            this.InstanceNameLabel.Size = new System.Drawing.Size(75, 23);
+            resources.ApplyResources(this.InstanceNameLabel, "InstanceNameLabel");
+            // 
+            // InstanceNameComboBox
+            // 
+            this.InstanceNameComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.InstanceNameComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.InstanceNameComboBox.Location = new System.Drawing.Point(90, 70);
+            this.InstanceNameComboBox.Name = "InstanceNameComboBox";
+            this.InstanceNameComboBox.Size = new System.Drawing.Size(125, 23);
+            resources.ApplyResources(this.InstanceNameComboBox, "InstanceNameComboBox");
+            // 
+            // HideFromOtherFiltersCheckBox
+            // 
+            this.HideFromOtherFiltersCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.HideFromOtherFiltersCheckBox.Location = new System.Drawing.Point(90, 100);
+            this.HideFromOtherFiltersCheckBox.Name = "HideFromOtherFiltersCheckBox";
+            this.HideFromOtherFiltersCheckBox.Size = new System.Drawing.Size(200, 23);
+            resources.ApplyResources(this.HideFromOtherFiltersCheckBox, "HideFromOtherFiltersCheckBox");
+            // 
+            // NotifyOnChangesCheckBox
+            // 
+            this.NotifyOnChangesCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.NotifyOnChangesCheckBox.Location = new System.Drawing.Point(90, 130);
+            this.NotifyOnChangesCheckBox.Name = "NotifyOnChangesCheckBox";
+            this.NotifyOnChangesCheckBox.Size = new System.Drawing.Size(200, 23);
+            resources.ApplyResources(this.NotifyOnChangesCheckBox, "NotifyOnChangesCheckBox");
+            // 
+            // RemoveOnChangesCheckBox
+            // 
+            this.RemoveOnChangesCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.RemoveOnChangesCheckBox.Location = new System.Drawing.Point(90, 160);
+            this.RemoveOnChangesCheckBox.Name = "RemoveOnChangesCheckBox";
+            this.RemoveOnChangesCheckBox.Size = new System.Drawing.Size(200, 23);
+            resources.ApplyResources(this.RemoveOnChangesCheckBox, "RemoveOnChangesCheckBox");
+            // 
+            // AlertOnInstallCheckBox
+            // 
+            this.AlertOnInstallCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.AlertOnInstallCheckBox.Location = new System.Drawing.Point(90, 190);
+            this.AlertOnInstallCheckBox.Name = "AlertOnInstallCheckBox";
+            this.AlertOnInstallCheckBox.Size = new System.Drawing.Size(200, 23);
+            resources.ApplyResources(this.AlertOnInstallCheckBox, "AlertOnInstallCheckBox");
+            // 
+            // RemoveOnInstallCheckBox
+            // 
+            this.RemoveOnInstallCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.RemoveOnInstallCheckBox.Location = new System.Drawing.Point(90, 220);
+            this.RemoveOnInstallCheckBox.Name = "RemoveOnInstallCheckBox";
+            this.RemoveOnInstallCheckBox.Size = new System.Drawing.Size(200, 23);
+            resources.ApplyResources(this.RemoveOnInstallCheckBox, "RemoveOnInstallCheckBox");
+            // 
+            // SaveButton
+            // 
+            this.SaveButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.SaveButton.Location = new System.Drawing.Point(10, 290);
+            this.SaveButton.Name = "SaveButton";
+            this.SaveButton.Size = new System.Drawing.Size(75, 23);
+            this.SaveButton.TabIndex = 0;
+            this.SaveButton.UseVisualStyleBackColor = true;
+            this.SaveButton.Click += new System.EventHandler(this.SaveButton_Click);
+            resources.ApplyResources(this.SaveButton, "SaveButton");
+            // 
+            // CancelButton
+            // 
+            this.CancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.CancelButton.Location = new System.Drawing.Point(90, 290);
+            this.CancelButton.Name = "CancelButton";
+            this.CancelButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelButton.TabIndex = 0;
+            this.CancelButton.UseVisualStyleBackColor = true;
+            this.CancelButton.Click += new System.EventHandler(this.CancelButton_Click);
+            resources.ApplyResources(this.CancelButton, "CancelButton");
+            // 
+            // DeleteButton
+            // 
+            this.DeleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.DeleteButton.Location = new System.Drawing.Point(170, 290);
+            this.DeleteButton.Name = "DeleteButton";
+            this.DeleteButton.Size = new System.Drawing.Size(75, 23);
+            this.DeleteButton.TabIndex = 0;
+            this.DeleteButton.UseVisualStyleBackColor = true;
+            this.DeleteButton.Click += new System.EventHandler(this.DeleteButton_Click);
+            resources.ApplyResources(this.DeleteButton, "DeleteButton");
+            // 
+            // CloseButton
+            // 
+            this.CloseButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.CloseButton.Location = new System.Drawing.Point(10, 367);
+            this.CloseButton.Name = "CloseButton";
+            this.CloseButton.Size = new System.Drawing.Size(75, 23);
+            this.CloseButton.TabIndex = 2;
+            this.CloseButton.UseVisualStyleBackColor = true;
+            this.CloseButton.Click += new System.EventHandler(this.CloseButton_Click);
+            resources.ApplyResources(this.CloseButton, "CloseButton");
+            // 
+            // EditLabelsDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(500, 400);
+            this.Controls.Add(this.CreateButton);
+            this.Controls.Add(this.LabelSelectionTree);
+            this.Controls.Add(this.SelectOrCreateLabel);
+            this.Controls.Add(this.EditDetailsPanel);
+            this.Controls.Add(this.CloseButton);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = Properties.Resources.AppIcon;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "EditLabelsDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            resources.ApplyResources(this, "$this");
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ToolTip ToolTip;
+        private System.Windows.Forms.TreeView LabelSelectionTree;
+        private System.Windows.Forms.Label SelectOrCreateLabel;
+        private System.Windows.Forms.Panel EditDetailsPanel;
+        private System.Windows.Forms.Label NameLabel;
+        private System.Windows.Forms.TextBox NameTextBox;
+        private System.Windows.Forms.Label InstanceNameLabel;
+        private System.Windows.Forms.ComboBox InstanceNameComboBox;
+        private System.Windows.Forms.CheckBox HideFromOtherFiltersCheckBox;
+        private System.Windows.Forms.CheckBox NotifyOnChangesCheckBox;
+        private System.Windows.Forms.CheckBox RemoveOnChangesCheckBox;
+        private System.Windows.Forms.CheckBox AlertOnInstallCheckBox;
+        private System.Windows.Forms.CheckBox RemoveOnInstallCheckBox;
+        private System.Windows.Forms.Label ColorLabel;
+        private System.Windows.Forms.Button ColorButton;
+        private System.Windows.Forms.Button CreateButton;
+        private System.Windows.Forms.Button CloseButton;
+        private System.Windows.Forms.Button SaveButton;
+        private System.Windows.Forms.Button CancelButton;
+        private System.Windows.Forms.Button DeleteButton;
+    }
+}

--- a/GUI/EditLabelsDialog.cs
+++ b/GUI/EditLabelsDialog.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using log4net;
+
+namespace CKAN
+{
+    public partial class EditLabelsDialog : Form
+    {
+        public EditLabelsDialog(IUser user, KSPManager manager, ModuleLabelList labels)
+        {
+            InitializeComponent();
+            this.user    = user;
+            this.labels  = labels;
+            InstanceNameComboBox.DataSource = new string[] { "" }
+                .Concat(manager.Instances.Keys).ToArray();
+            LoadTree();
+
+            this.ToolTip.SetToolTip(NameTextBox, Properties.Resources.EditLabelsToolTipName);
+            this.ToolTip.SetToolTip(ColorButton, Properties.Resources.EditLabelsToolTipColor);
+            this.ToolTip.SetToolTip(InstanceNameComboBox, Properties.Resources.EditLabelsToolTipInstance);
+            this.ToolTip.SetToolTip(HideFromOtherFiltersCheckBox, Properties.Resources.EditLabelsToolTipHide);
+            this.ToolTip.SetToolTip(NotifyOnChangesCheckBox, Properties.Resources.EditLabelsToolTipNotifyOnChanges);
+            this.ToolTip.SetToolTip(RemoveOnChangesCheckBox, Properties.Resources.EditLabelsToolTipRemoveOnChanges);
+            this.ToolTip.SetToolTip(AlertOnInstallCheckBox, Properties.Resources.EditLabelsToolTipAlertOnInstall);
+            this.ToolTip.SetToolTip(RemoveOnInstallCheckBox, Properties.Resources.EditLabelsToolTipRemoveOnInstall);
+        }
+
+        private void LoadTree()
+        {
+            LabelSelectionTree.BeginUpdate();
+            LabelSelectionTree.Nodes.Clear();
+            var groups = this.labels.Labels
+                .GroupBy(l => l.InstanceName)
+                .OrderBy(g => g.Key);
+            foreach (var group in groups)
+            {
+                string groupName = string.IsNullOrEmpty(group.Key)
+                    ? Properties.Resources.ModuleLabelListGlobal
+                    : group.Key;
+                var gnd = LabelSelectionTree.Nodes.Add(groupName);
+                gnd.NodeFont = new Font(LabelSelectionTree.Font, FontStyle.Bold);
+                foreach (ModuleLabel mlbl in group.OrderBy(l => l.Name))
+                {
+                    var lblnd = gnd.Nodes.Add(mlbl.Name);
+                    lblnd.Tag = mlbl;
+                }
+            }
+            LabelSelectionTree.ExpandAll();
+            LabelSelectionTree.EndUpdate();
+        }
+
+        private void LabelSelectionTree_BeforeSelect(Object sender, TreeViewCancelEventArgs e)
+        {
+            if (e.Node == null)
+            {
+                e.Cancel = false;
+            }
+            else if (e.Node.Tag == null)
+            {
+                e.Cancel = true;
+            }
+            else if (!TryCloseEdit())
+            {
+                e.Cancel = true;
+            }
+            else
+            {
+                StartEdit(e.Node.Tag as ModuleLabel);
+                e.Cancel = false;
+            }
+        }
+
+        private void LabelSelectionTree_BeforeCollapse(object sender, TreeViewCancelEventArgs e)
+        {
+            e.Cancel = true;
+        }
+
+        private void CreateButton_Click(object sender, EventArgs e)
+        {
+            LabelSelectionTree.SelectedNode = null;
+            StartEdit(new ModuleLabel());
+        }
+
+        private void ColorButton_Click(object sender, EventArgs e)
+        {
+            var dlg = new ColorDialog()
+            {
+                AnyColor       = true,
+                AllowFullOpen  = true,
+                ShowHelp       = true,
+                SolidColorOnly = true,
+                Color          = ColorButton.BackColor,
+            };
+            if (dlg.ShowDialog(this) == DialogResult.OK)
+            {
+                ColorButton.BackColor = dlg.Color;
+            }
+        }
+
+        private void SaveButton_Click(object sender, EventArgs e)
+        {
+            string errMsg;
+            if (TrySave(out errMsg))
+            {
+                LabelSelectionTree.SelectedNode = null;
+            }
+            else
+            {
+                user.RaiseError(errMsg);
+            }
+        }
+
+        private void CancelButton_Click(object sender, EventArgs e)
+        {
+            EditDetailsPanel.Visible = false;
+            currentlyEditing = null;
+            LabelSelectionTree.SelectedNode = null;
+        }
+
+        private void DeleteButton_Click(object sender, EventArgs e)
+        {
+            if (currentlyEditing != null && Main.Instance.YesNoDialog(
+                string.Format(
+                    Properties.Resources.EditLabelsDialogConfirmDelete,
+                    currentlyEditing.Name
+                ),
+                Properties.Resources.EditLabelsDialogDelete,
+                Properties.Resources.EditLabelsDialogCancel
+            ))
+            {
+                labels.Labels = labels.Labels
+                    .Except(new ModuleLabel[] { currentlyEditing })
+                    .ToArray();
+                EditDetailsPanel.Visible = false;
+                currentlyEditing = null;
+                LoadTree();
+            }
+        }
+
+        private void CloseButton_Click(object sender, EventArgs e)
+        {
+            if (TryCloseEdit())
+            {
+                Close();
+            }
+        }
+
+        private void StartEdit(ModuleLabel lbl)
+        {
+            currentlyEditing = lbl;
+
+            NameTextBox.Text                     = lbl.Name;
+            ColorButton.BackColor                = lbl.Color;
+            InstanceNameComboBox.SelectedItem    = lbl.InstanceName;
+            HideFromOtherFiltersCheckBox.Checked = lbl.Hide;
+            NotifyOnChangesCheckBox.Checked      = lbl.NotifyOnChange;
+            RemoveOnChangesCheckBox.Checked      = lbl.RemoveOnChange;
+            AlertOnInstallCheckBox.Checked       = lbl.AlertOnInstall;
+            RemoveOnInstallCheckBox.Checked      = lbl.RemoveOnInstall;
+
+            DeleteButton.Enabled = labels.Labels.Contains(lbl);
+
+            EditDetailsPanel.Visible = true;
+            EditDetailsPanel.BringToFront();
+            NameTextBox.Focus();
+        }
+
+        private bool TryCloseEdit()
+        {
+            if (HasChanges())
+            {
+                if (Main.Instance.YesNoDialog(
+                    Properties.Resources.EditLabelsDialogSavePrompt,
+                    Properties.Resources.EditLabelsDialogSave,
+                    Properties.Resources.EditLabelsDialogDiscard
+                ))
+                {
+                    string errMsg;
+                    if (!TrySave(out errMsg))
+                    {
+                        user.RaiseError(errMsg);
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private bool TrySave(out string errMsg)
+        {
+            if (EditingValid(out errMsg))
+            {
+                if (!labels.Labels.Contains(currentlyEditing))
+                {
+                    labels.Labels = labels.Labels
+                        .Concat(new ModuleLabel[] { currentlyEditing })
+                        .ToArray();
+                }
+                currentlyEditing.Name         = NameTextBox.Text;
+                currentlyEditing.Color        = ColorButton.BackColor;
+                currentlyEditing.InstanceName =
+                    string.IsNullOrWhiteSpace(InstanceNameComboBox.SelectedItem?.ToString())
+                        ? null
+                        : InstanceNameComboBox.SelectedItem.ToString();
+                currentlyEditing.Hide            = HideFromOtherFiltersCheckBox.Checked;
+                currentlyEditing.NotifyOnChange  = NotifyOnChangesCheckBox.Checked;
+                currentlyEditing.RemoveOnChange  = RemoveOnChangesCheckBox.Checked;
+                currentlyEditing.AlertOnInstall  = AlertOnInstallCheckBox.Checked;
+                currentlyEditing.RemoveOnInstall = RemoveOnInstallCheckBox.Checked;
+
+                EditDetailsPanel.Visible = false;
+                currentlyEditing = null;
+                LoadTree();
+                return true;
+            }
+            return false;
+        }
+
+        private bool EditingValid(out string errMsg)
+        {
+            if (currentlyEditing == null)
+            {
+                errMsg = Properties.Resources.EditLabelsDialogNoRecord;
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(NameTextBox.Text))
+            {
+                errMsg = Properties.Resources.EditLabelsDialogNameRequired;
+                return false;
+            }
+            var newInst = string.IsNullOrWhiteSpace(InstanceNameComboBox.SelectedItem?.ToString())
+                ? null
+                : InstanceNameComboBox.SelectedItem.ToString();
+            var found = labels.Labels.FirstOrDefault(l =>
+                   l              != currentlyEditing
+                && l.Name         == NameTextBox.Text
+                && (l.InstanceName == newInst
+                    || newInst == null
+                    || l.InstanceName == null)
+            );
+            if (found != null)
+            {
+                errMsg = string.Format(
+                    Properties.Resources.EditLabelsDialogAlreadyExists,
+                    NameTextBox.Text,
+                    found.InstanceName ?? Properties.Resources.ModuleLabelListGlobal
+                );
+                return false;
+            }
+            errMsg = "";
+            return true;
+        }
+
+        private bool HasChanges()
+        {
+            var newInst = string.IsNullOrWhiteSpace(InstanceNameComboBox.SelectedItem?.ToString())
+                ? null
+                : InstanceNameComboBox.SelectedItem.ToString();
+            return EditDetailsPanel.Visible && currentlyEditing != null
+                && (   currentlyEditing.Name            != NameTextBox.Text
+                    || currentlyEditing.Color           != ColorButton.BackColor
+                    || currentlyEditing.InstanceName    != newInst
+                    || currentlyEditing.Hide            != HideFromOtherFiltersCheckBox.Checked
+                    || currentlyEditing.NotifyOnChange  != NotifyOnChangesCheckBox.Checked
+                    || currentlyEditing.RemoveOnChange  != RemoveOnChangesCheckBox.Checked
+                    || currentlyEditing.AlertOnInstall  != AlertOnInstallCheckBox.Checked
+                    || currentlyEditing.RemoveOnInstall != RemoveOnInstallCheckBox.Checked
+                );
+        }
+
+        private ModuleLabel     currentlyEditing;
+
+        private readonly IUser           user;
+        private readonly ModuleLabelList labels;
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(EditLabelsDialog));
+    }
+}

--- a/GUI/EditLabelsDialog.resx
+++ b/GUI/EditLabelsDialog.resx
@@ -117,7 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="MainFavouritesList" xml:space="preserve"><value>CKAN favorites list (*.ckan)</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="CreateButton.Text" xml:space="preserve"><value>Create</value></data>
+  <data name="SelectOrCreateLabel.Text" xml:space="preserve"><value>Select a label to edit or create a new one</value></data>
+  <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="ColorLabel.Text" xml:space="preserve"><value>Background:</value></data>
+  <data name="ColorButton.Text" xml:space="preserve"><value>Select...</value></data>
+  <data name="InstanceNameLabel.Text" xml:space="preserve"><value>Instance
+(blank for all):</value></data>
+  <data name="HideFromOtherFiltersCheckBox.Text" xml:space="preserve"><value>Hide from other filters</value></data>
+  <data name="NotifyOnChangesCheckBox.Text" xml:space="preserve"><value>Notify on updates</value></data>
+  <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Remove on updates</value></data>
+  <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Alert on install</value></data>
+  <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Remove on install</value></data>
+  <data name="CloseButton.Text" xml:space="preserve"><value>Close</value></data>
+  <data name="SaveButton.Text" xml:space="preserve"><value>Save</value></data>
+  <data name="CancelButton.Text" xml:space="preserve"><value>Cancel</value></data>
+  <data name="DeleteButton.Text" xml:space="preserve"><value>Delete</value></data>
+  <data name="ExportButton.Text" xml:space="preserve"><value>Export...</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Edit Labels</value></data>
 </root>

--- a/GUI/GUIConfiguration.cs
+++ b/GUI/GUIConfiguration.cs
@@ -31,6 +31,11 @@ namespace CKAN
         public int ActiveFilter = 0;
 
         /// <summary>
+        /// Name of the tag filter the user chose, if any
+        /// </summary>
+        public string TagFilter = null;
+
+        /// <summary>
         /// Name of the label filter the user chose, if any
         /// </summary>
         public string CustomLabelFilter = null;

--- a/GUI/GUIConfiguration.cs
+++ b/GUI/GUIConfiguration.cs
@@ -30,6 +30,11 @@ namespace CKAN
 
         public int ActiveFilter = 0;
 
+        /// <summary>
+        /// Name of the label filter the user chose, if any
+        /// </summary>
+        public string CustomLabelFilter = null;
+
         // Sort by the mod name (index = 2) column by default
         public int SortByColumnIndex = 2;
         public bool SortDescending = false;

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -287,18 +287,6 @@ namespace CKAN
             return Mod;
         }
 
-        public bool HasTag(string tag)
-        {
-            if (string.IsNullOrEmpty(tag))
-            {
-                return !Mod?.Tags?.Any() ?? true;
-            }
-            else
-            {
-                return Mod?.Tags?.Contains(tag) ?? false;
-            }
-        }
-
         public IEnumerable<ModChange> GetModChanges()
         {
             bool selectedIsInstalled = SelectedMod?.Equals(InstalledMod?.Module)

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -287,6 +287,18 @@ namespace CKAN
             return Mod;
         }
 
+        public bool HasTag(string tag)
+        {
+            if (string.IsNullOrEmpty(tag))
+            {
+                return !Mod?.Tags?.Any() ?? true;
+            }
+            else
+            {
+                return Mod?.Tags?.Contains(tag) ?? false;
+            }
+        }
+
         public IEnumerable<ModChange> GetModChanges()
         {
             bool selectedIsInstalled = SelectedMod?.Equals(InstalledMod?.Module)

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using System.Drawing;
+using System.ComponentModel;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace CKAN
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ModuleLabel
+    {
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string  Name;
+
+        [JsonProperty("color", NullValueHandling = NullValueHandling.Ignore)]
+        public Color   Color;
+
+        [JsonProperty("instance_name", NullValueHandling = NullValueHandling.Ignore)]
+        public string  InstanceName;
+
+        [JsonProperty("hide", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        public bool    Hide;
+
+        [JsonProperty("notify_on_change", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        public bool    NotifyOnChange;
+
+        [JsonProperty("remove_on_change", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        public bool    RemoveOnChange;
+
+        [JsonProperty("alert_on_install", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        public bool    AlertOnInstall;
+
+        [JsonProperty("remove_on_install", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        public bool    RemoveOnInstall;
+
+        [JsonProperty("module_identifiers", NullValueHandling = NullValueHandling.Ignore)]
+        public HashSet<string> ModuleIdentifiers = new HashSet<string>();
+
+        /// <summary>
+        /// Add a module to this label's group
+        /// </summary>
+        /// <param name="identifier">The identifier of the module to add</param>
+        public void Add(string identifier)
+        {
+            ModuleIdentifiers.Add(identifier);
+        }
+
+        /// <summary>
+        /// Remove a module from this label's group
+        /// </summary>
+        /// <param name="identifier">The identifier of the module to remove</param>
+        public void Remove(string identifier)
+        {
+            ModuleIdentifiers.Remove(identifier);
+        }
+    }
+}

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -43,6 +43,18 @@ namespace CKAN
         public HashSet<string> ModuleIdentifiers = new HashSet<string>();
 
         /// <summary>
+        /// Check whether this label is active for a given game instance
+        /// </summary>
+        /// <param name="instanceName">Name of the instance</param>
+        /// <returns>
+        /// True if active, false otherwise
+        /// </returns>
+        public bool AppliesTo(string instanceName)
+        {
+            return InstanceName == null || InstanceName == instanceName;
+        }
+
+        /// <summary>
         /// Add a module to this label's group
         /// </summary>
         /// <param name="identifier">The identifier of the module to add</param>

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Drawing;
+using Newtonsoft.Json;
+
+namespace CKAN
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ModuleLabelList
+    {
+        [JsonProperty("labels", NullValueHandling = NullValueHandling.Ignore)]
+        public ModuleLabel[] Labels = new ModuleLabel[] {};
+
+        public static readonly string DefaultPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "CKAN",
+            "labels.json"
+        );
+
+        public static ModuleLabelList GetDefaultLabels()
+        {
+            return new ModuleLabelList() {
+                Labels = new ModuleLabel[] {
+                    new ModuleLabel() {
+                        Name  = Properties.Resources.ModuleLabelListFavourites,
+                        Color = Color.PaleGreen,
+                    },
+                    new ModuleLabel() {
+                        Name  = Properties.Resources.ModuleLabelListHidden,
+                        Hide  = true,
+                        Color = Color.PaleVioletRed,
+                    },
+                }
+            };
+        }
+
+        public string[] LabelsMatchingModule(string identifier)
+        {
+            return new string[] {};
+        }
+
+        public static ModuleLabelList Load(string path)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<ModuleLabelList>(File.ReadAllText(path));
+            }
+            catch (FileNotFoundException ex)
+            {
+                return null;
+            }
+        }
+
+        public bool Save(string path)
+        {
+            try
+            {
+                File.WriteAllText(path, JsonConvert.SerializeObject(this, Formatting.Indented));
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 using System.IO;
 using System.Drawing;
 using Newtonsoft.Json;
@@ -10,6 +12,11 @@ namespace CKAN
     {
         [JsonProperty("labels", NullValueHandling = NullValueHandling.Ignore)]
         public ModuleLabel[] Labels = new ModuleLabel[] {};
+
+        public IEnumerable<ModuleLabel> LabelsFor(string instanceName)
+        {
+            return Labels.Where(l => l.AppliesTo(instanceName));
+        }
 
         public static readonly string DefaultPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -19,24 +19,23 @@ namespace CKAN
 
         public static ModuleLabelList GetDefaultLabels()
         {
-            return new ModuleLabelList() {
-                Labels = new ModuleLabel[] {
-                    new ModuleLabel() {
+            return new ModuleLabelList()
+            {
+                Labels = new ModuleLabel[]
+                {
+                    new ModuleLabel()
+                    {
                         Name  = Properties.Resources.ModuleLabelListFavourites,
                         Color = Color.PaleGreen,
                     },
-                    new ModuleLabel() {
+                    new ModuleLabel()
+                    {
                         Name  = Properties.Resources.ModuleLabelListHidden,
                         Hide  = true,
                         Color = Color.PaleVioletRed,
                     },
                 }
             };
-        }
-
-        public string[] LabelsMatchingModule(string identifier)
-        {
-            return new string[] {};
         }
 
         public static ModuleLabelList Load(string path)

--- a/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
@@ -119,20 +119,20 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="CreateButton.Text" xml:space="preserve"><value>Erstellen</value></data>
-  <data name="SelectOrCreateLabel.Text" xml:space="preserve"><value>Wählen Sie eine Bezeichnung zum Bearbeiten oder erstellen Sie eine neue</value></data>
+  <data name="SelectOrCreateLabel.Text" xml:space="preserve"><value>Wähle ein Label zum Bearbeiten oder erstelle ein neues</value></data>
   <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
   <data name="ColorLabel.Text" xml:space="preserve"><value>Hintergrund:</value></data>
-  <data name="ColorButton.Text" xml:space="preserve"><value>Wählen...</value></data>
-  <data name="InstanceNameLabel.Text" xml:space="preserve"><value>Beispiel
+  <data name="ColorButton.Text" xml:space="preserve"><value>Auswahl...</value></data>
+  <data name="InstanceNameLabel.Text" xml:space="preserve"><value>Instanz
 (leer für alle):</value></data>
-  <data name="HideFromOtherFiltersCheckBox.Text" xml:space="preserve"><value>Vor anderen Filtern verstecken</value></data>
-  <data name="NotifyOnChangesCheckBox.Text" xml:space="preserve"><value>Bei Updates benachrichtigen</value></data>
-  <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Bei Updates entfernen</value></data>
-  <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Bei Installation benachrichtigen</value></data>
-  <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Bei der Installation entfernen</value></data>
+  <data name="HideFromOtherFiltersCheckBox.Text" xml:space="preserve"><value>In anderen Filtern verstecken</value></data>
+  <data name="NotifyOnChangesCheckBox.Text" xml:space="preserve"><value>Bei verfügbaren Upgrades benachrichtigen</value></data>
+  <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Label nach Updates entfernen</value></data>
+  <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Vor Installation warnen</value></data>
+  <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Label nach der Installation entfernen</value></data>
   <data name="CloseButton.Text" xml:space="preserve"><value>Schließen</value></data>
   <data name="SaveButton.Text" xml:space="preserve"><value>Speichern</value></data>
-  <data name="CancelButton.Text" xml:space="preserve"><value>Stornieren</value></data>
-  <data name="DeleteButton.Text" xml:space="preserve"><value>Delete</value></data>
+  <data name="CancelButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
+  <data name="DeleteButton.Text" xml:space="preserve"><value>Löschen</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Labels bearbeiten</value></data>
 </root>

--- a/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
@@ -117,7 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="MainFavouritesList" xml:space="preserve"><value>CKAN favorites list (*.ckan)</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="CreateButton.Text" xml:space="preserve"><value>Erstellen</value></data>
+  <data name="SelectOrCreateLabel.Text" xml:space="preserve"><value>Wählen Sie eine Bezeichnung zum Bearbeiten oder erstellen Sie eine neue</value></data>
+  <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="ColorLabel.Text" xml:space="preserve"><value>Hintergrund:</value></data>
+  <data name="ColorButton.Text" xml:space="preserve"><value>Wählen...</value></data>
+  <data name="InstanceNameLabel.Text" xml:space="preserve"><value>Beispiel
+(leer für alle):</value></data>
+  <data name="HideFromOtherFiltersCheckBox.Text" xml:space="preserve"><value>Vor anderen Filtern verstecken</value></data>
+  <data name="NotifyOnChangesCheckBox.Text" xml:space="preserve"><value>Bei Updates benachrichtigen</value></data>
+  <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Bei Updates entfernen</value></data>
+  <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Bei Installation benachrichtigen</value></data>
+  <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Bei der Installation entfernen</value></data>
+  <data name="CloseButton.Text" xml:space="preserve"><value>Schließen</value></data>
+  <data name="SaveButton.Text" xml:space="preserve"><value>Speichern</value></data>
+  <data name="CancelButton.Text" xml:space="preserve"><value>Stornieren</value></data>
+  <data name="DeleteButton.Text" xml:space="preserve"><value>Delete</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Labels bearbeiten</value></data>
 </root>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -195,6 +195,7 @@
   <data name="FilterNotInstalledButton.Text" xml:space="preserve"><value>Nicht installiert</value></data>
   <data name="FilterIncompatibleButton.Text" xml:space="preserve"><value>Inkompatibel</value></data>
   <data name="FilterAllButton.Text" xml:space="preserve"><value>Alle</value></data>
+  <data name="FilterTagsToolButton.Text" xml:space="preserve"><value>Kategorien</value></data>
   <data name="NavBackwardToolButton.ToolTipText" xml:space="preserve"><value>Zuvor ausgewählte Mod...</value></data>
   <data name="NavForwardToolButton.ToolTipText" xml:space="preserve"><value>Danach ausgewählte mod...</value></data>
   <data name="AutoInstalled.HeaderText" xml:space="preserve"><value>Auto-installiert</value></data>
@@ -251,6 +252,5 @@
   <data name="openKSPDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>KSP-Verzeichnis öffnen</value></data>
   <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Einstellungen</value></data>
   <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Beenden</value></data>
-  <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Etiketten</value></data>
-  <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels bearbeiten ...</value></data>
+  <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels bearbeiten...</value></data>
 </root>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -251,4 +251,6 @@
   <data name="openKSPDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>KSP-Verzeichnis öffnen</value></data>
   <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Einstellungen</value></data>
   <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Beenden</value></data>
+  <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Etiketten</value></data>
+  <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels bearbeiten ...</value></data>
 </root>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -436,7 +436,7 @@
             this.tagFilterToolStripSeparator,
             this.FilterTagsToolButton,
             this.FilterLabelsToolButton});
-            this.FilterToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterToolButton_DrodDown_Opening);
+            this.FilterToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterToolButton_DropDown_Opening);
             this.FilterToolButton.Image = global::CKAN.Properties.Resources.filter;
             this.FilterToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.FilterToolButton.Name = "FilterToolButton";
@@ -518,14 +518,14 @@
             this.FilterTagsToolButton.Name = "FilterTagsToolButton";
             this.FilterTagsToolButton.Size = new System.Drawing.Size(179, 22);
             resources.ApplyResources(this.FilterTagsToolButton, "FilterTagsToolButton");
-            this.FilterTagsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterTagsToolButton_DrodDown_Opening);
+            this.FilterTagsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterTagsToolButton_DropDown_Opening);
             // 
             // FilterLabelsToolButton
             // 
             this.FilterLabelsToolButton.Name = "FilterLabelsToolButton";
             this.FilterLabelsToolButton.Size = new System.Drawing.Size(179, 22);
             resources.ApplyResources(this.FilterLabelsToolButton, "FilterLabelsToolButton");
-            this.FilterLabelsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterLabelsToolButton_DrodDown_Opening);
+            this.FilterLabelsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterLabelsToolButton_DropDown_Opening);
             //
             // NavBackwardToolButton
             //

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -93,7 +93,7 @@
             this.ModListHeaderContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.modListToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.tagFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-            this.customFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.untaggedFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.labelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.labelToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.editLabelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1499,7 +1499,7 @@
         private System.Windows.Forms.ContextMenuStrip ModListContextMenuStrip;
         private System.Windows.Forms.ToolStripSeparator modListToolStripSeparator;
         private System.Windows.Forms.ToolStripSeparator tagFilterToolStripSeparator;
-        private System.Windows.Forms.ToolStripSeparator customFilterToolStripSeparator;
+        private System.Windows.Forms.ToolStripSeparator untaggedFilterToolStripSeparator;
         private System.Windows.Forms.ContextMenuStrip LabelsContextMenuStrip;
         private System.Windows.Forms.ContextMenuStrip ModListHeaderContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem labelsToolStripMenuItem;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -87,7 +87,13 @@
             this.DownloadCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.LabelsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.ModListHeaderContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.modListToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.customFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.labelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.labelToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.editLabelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.purgeContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -423,7 +429,9 @@
             this.FilterNewButton,
             this.FilterNotInstalledButton,
             this.FilterIncompatibleButton,
-            this.FilterAllButton});
+            this.FilterAllButton,
+            this.customFilterToolStripSeparator});
+            this.FilterToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterToolButton_DrodDown_Opening);
             this.FilterToolButton.Image = global::CKAN.Properties.Resources.filter;
             this.FilterToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.FilterToolButton.Name = "FilterToolButton";
@@ -698,11 +706,20 @@
             // ModListContextMenuStrip
             //
             this.ModListContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.labelsToolStripMenuItem,
+            this.modListToolStripSeparator,
             this.reinstallToolStripMenuItem,
             this.downloadContentsToolStripMenuItem,
             this.purgeContentsToolStripMenuItem});
             this.ModListContextMenuStrip.Name = "ModListContextMenuStrip";
             this.ModListContextMenuStrip.Size = new System.Drawing.Size(180, 70);
+            //
+            // labelsToolStripMenuItem
+            //
+            this.labelsToolStripMenuItem.Name = "labelsToolStripMenuItem";
+            this.labelsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.labelsToolStripMenuItem.DropDown = this.LabelsContextMenuStrip;
+            resources.ApplyResources(this.labelsToolStripMenuItem, "labelsToolStripMenuItem");
             //
             // reinstallToolStripMenuItem
             //
@@ -724,6 +741,21 @@
             this.purgeContentsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.purgeContentsToolStripMenuItem.Click += new System.EventHandler(this.purgeContentsToolStripMenuItem_Click);
             resources.ApplyResources(this.purgeContentsToolStripMenuItem, "purgeContentsToolStripMenuItem");
+            //
+            // LabelsContextMenuStrip
+            //
+            this.LabelsContextMenuStrip.Name = "LabelsContextMenuStrip";
+            this.LabelsContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+                this.editLabelsToolStripMenuItem});
+            this.LabelsContextMenuStrip.Size = new System.Drawing.Size(180, 70);
+            this.LabelsContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(LabelsContextMenuStrip_Opening);
+            //
+            // editLabelsToolStripMenuItem
+            //
+            this.editLabelsToolStripMenuItem.Name = "editLabelsToolStripMenuItem";
+            this.editLabelsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.editLabelsToolStripMenuItem.Click += new System.EventHandler(this.editLabelsToolStripMenuItem_Click);
+            resources.ApplyResources(this.editLabelsToolStripMenuItem, "editLabelsToolStripMenuItem");
             //
             // ModListHeaderContextMenuStrip
             //
@@ -1444,7 +1476,13 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn DownloadCount;
         private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.ContextMenuStrip ModListContextMenuStrip;
+        private System.Windows.Forms.ToolStripSeparator modListToolStripSeparator;
+        private System.Windows.Forms.ToolStripSeparator customFilterToolStripSeparator;
+        private System.Windows.Forms.ContextMenuStrip LabelsContextMenuStrip;
         private System.Windows.Forms.ContextMenuStrip ModListHeaderContextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem labelsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator labelToolStripSeparator;
+        private System.Windows.Forms.ToolStripMenuItem editLabelsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem purgeContentsToolStripMenuItem;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -68,6 +68,8 @@
             this.FilterNotInstalledButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterIncompatibleButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterAllButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.FilterLabelsToolButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.FilterTagsToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.NavBackwardToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.NavForwardToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
@@ -432,7 +434,8 @@
             this.FilterIncompatibleButton,
             this.FilterAllButton,
             this.tagFilterToolStripSeparator,
-            this.customFilterToolStripSeparator});
+            this.FilterTagsToolButton,
+            this.FilterLabelsToolButton});
             this.FilterToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterToolButton_DrodDown_Opening);
             this.FilterToolButton.Image = global::CKAN.Properties.Resources.filter;
             this.FilterToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
@@ -509,6 +512,20 @@
             this.FilterAllButton.Size = new System.Drawing.Size(307, 30);
             this.FilterAllButton.Click += new System.EventHandler(this.FilterAllButton_Click);
             resources.ApplyResources(this.FilterAllButton, "FilterAllButton");
+            // 
+            // FilterTagsToolButton
+            // 
+            this.FilterTagsToolButton.Name = "FilterTagsToolButton";
+            this.FilterTagsToolButton.Size = new System.Drawing.Size(179, 22);
+            resources.ApplyResources(this.FilterTagsToolButton, "FilterTagsToolButton");
+            this.FilterTagsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterTagsToolButton_DrodDown_Opening);
+            // 
+            // FilterLabelsToolButton
+            // 
+            this.FilterLabelsToolButton.Name = "FilterLabelsToolButton";
+            this.FilterLabelsToolButton.Size = new System.Drawing.Size(179, 22);
+            resources.ApplyResources(this.FilterLabelsToolButton, "FilterLabelsToolButton");
+            this.FilterLabelsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterLabelsToolButton_DrodDown_Opening);
             //
             // NavBackwardToolButton
             //
@@ -1459,6 +1476,8 @@
         private System.Windows.Forms.ToolStripMenuItem FilterNotInstalledButton;
         private System.Windows.Forms.ToolStripMenuItem FilterIncompatibleButton;
         private System.Windows.Forms.ToolStripMenuItem FilterAllButton;
+        private System.Windows.Forms.ToolStripMenuItem FilterLabelsToolButton;
+        private System.Windows.Forms.ToolStripMenuItem FilterTagsToolButton;
         private System.Windows.Forms.ToolStripMenuItem NavBackwardToolButton;
         private System.Windows.Forms.ToolStripMenuItem NavForwardToolButton;
         private System.Windows.Forms.SplitContainer splitContainer1;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -90,6 +90,7 @@
             this.LabelsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.ModListHeaderContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.modListToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.tagFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.customFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.labelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.labelToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
@@ -430,6 +431,7 @@
             this.FilterNotInstalledButton,
             this.FilterIncompatibleButton,
             this.FilterAllButton,
+            this.tagFilterToolStripSeparator,
             this.customFilterToolStripSeparator});
             this.FilterToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterToolButton_DrodDown_Opening);
             this.FilterToolButton.Image = global::CKAN.Properties.Resources.filter;
@@ -1477,6 +1479,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.ContextMenuStrip ModListContextMenuStrip;
         private System.Windows.Forms.ToolStripSeparator modListToolStripSeparator;
+        private System.Windows.Forms.ToolStripSeparator tagFilterToolStripSeparator;
         private System.Windows.Forms.ToolStripSeparator customFilterToolStripSeparator;
         private System.Windows.Forms.ContextMenuStrip LabelsContextMenuStrip;
         private System.Windows.Forms.ContextMenuStrip ModListHeaderContextMenuStrip;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -114,7 +114,7 @@ namespace CKAN
                     {
                         cell.ToolTipText = null;
                     }
-                    row.DefaultCellStyle.BackColor = Color.Empty;
+                    mainModList.ReapplyLabels(guiMod, false);
                     if (row.Visible)
                     {
                         ModList.InvalidateRow(row.Index);
@@ -134,7 +134,7 @@ namespace CKAN
                     {
                         cell.ToolTipText = conflict_text;
                     }
-                    row.DefaultCellStyle.BackColor = Color.LightCoral;
+                    row.DefaultCellStyle.BackColor = mainModList.GetRowBackground(guiMod, true);
                     if (row.Visible)
                     {
                         ModList.InvalidateRow(row.Index);

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -11,6 +11,7 @@ using System.Windows.Forms;
 using System.Linq;
 using CKAN.Versioning;
 using CKAN.Exporters;
+using CKAN.Extensions;
 using CKAN.Properties;
 using CKAN.Types;
 using log4net;
@@ -591,6 +592,7 @@ namespace CKAN
                 {
                     Filter(
                         (GUIModFilter)configuration.ActiveFilter,
+                        mainModList.ModuleTags.Tags.GetOrDefault(configuration.TagFilter),
                         mainModList.ModuleLabels.Labels
                             .FirstOrDefault(l => l.Name == configuration.CustomLabelFilter)
                     );
@@ -604,6 +606,7 @@ namespace CKAN
                 UpdateModsList();
                 Filter(
                     (GUIModFilter)configuration.ActiveFilter,
+                    mainModList.ModuleTags.Tags.GetOrDefault(configuration.TagFilter),
                     mainModList.ModuleLabels.Labels
                         .FirstOrDefault(l => l.Name == configuration.CustomLabelFilter)
                 );
@@ -862,15 +865,17 @@ namespace CKAN
         /// Called when the modlist filter (all, compatible, incompatible...) is changed.
         /// </summary>
         /// <param name="filter">Filter.</param>
-        private void Filter(GUIModFilter filter, ModuleLabel label = null)
+        private void Filter(GUIModFilter filter, ModuleTag tag = null, ModuleLabel label = null)
         {
             // Triggers mainModList.ModFiltersUpdated()
-            mainModList.ModFilter = filter;
+            mainModList.TagFilter = tag;
             mainModList.CustomLabelFilter = label;
+            mainModList.ModFilter = filter;
 
             // Save new filter to the configuration.
             configuration.ActiveFilter = (int)mainModList.ModFilter;
             configuration.CustomLabelFilter = label?.Name;
+            configuration.TagFilter = tag?.Name;
             configuration.Save();
 
             // Ask the configuration which columns to show.
@@ -900,7 +905,12 @@ namespace CKAN
                                                             ModList.Columns["InstallDate"].Visible      = false;
                                                             ModList.Columns["AutoInstalled"].Visible    = false;
                                                             FilterToolButton.Text = Properties.Resources.MainFilterNotInstalled; break;
-                case GUIModFilter.CustomLabel:              FilterToolButton.Text = label?.Name ?? "CUSTOM";                      break;
+                case GUIModFilter.CustomLabel:              FilterToolButton.Text = string.Format(Properties.Resources.MainFilterLabel, label?.Name ?? "CUSTOM"); break;
+                case GUIModFilter.Tag:
+                    FilterToolButton.Text = tag == null
+                        ? Properties.Resources.MainFilterUntagged
+                        : string.Format(Properties.Resources.MainFilterTag, tag.Name);
+                    break;
                 default:                                    FilterToolButton.Text = Properties.Resources.MainFilterCompatible;   break;
             }
         }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -134,7 +134,7 @@ namespace CKAN
                     {
                         cell.ToolTipText = conflict_text;
                     }
-                    row.DefaultCellStyle.BackColor = mainModList.GetRowBackground(guiMod, true);
+                    row.DefaultCellStyle.BackColor = mainModList.GetRowBackground(guiMod, true, CurrentInstance.Name);
                     if (row.Visible)
                     {
                         ModList.InvalidateRow(row.Index);
@@ -204,6 +204,8 @@ namespace CKAN
                 settingsToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
                 helpToolStripMenuItem.DropDown.Renderer = new FlatToolStripRenderer();
                 FilterToolButton.DropDown.Renderer = new FlatToolStripRenderer();
+                FilterTagsToolButton.DropDown.Renderer = new FlatToolStripRenderer();
+                FilterLabelsToolButton.DropDown.Renderer = new FlatToolStripRenderer();
                 minimizedContextMenuStrip.Renderer = new FlatToolStripRenderer();
                 ModListContextMenuStrip.Renderer = new FlatToolStripRenderer();
                 ModListHeaderContextMenuStrip.Renderer = new FlatToolStripRenderer();
@@ -593,7 +595,7 @@ namespace CKAN
                     Filter(
                         (GUIModFilter)configuration.ActiveFilter,
                         mainModList.ModuleTags.Tags.GetOrDefault(configuration.TagFilter),
-                        mainModList.ModuleLabels.Labels
+                        mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                             .FirstOrDefault(l => l.Name == configuration.CustomLabelFilter)
                     );
                     m_UpdateRepoWorker.RunWorkerCompleted -= filterUpdate;
@@ -607,7 +609,7 @@ namespace CKAN
                 Filter(
                     (GUIModFilter)configuration.ActiveFilter,
                     mainModList.ModuleTags.Tags.GetOrDefault(configuration.TagFilter),
-                    mainModList.ModuleLabels.Labels
+                    mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                         .FirstOrDefault(l => l.Name == configuration.CustomLabelFilter)
                 );
             }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -114,7 +114,7 @@ namespace CKAN
                     {
                         cell.ToolTipText = null;
                     }
-                    mainModList.ReapplyLabels(guiMod, false);
+                    mainModList.ReapplyLabels(guiMod, false, CurrentInstance.Name);
                     if (row.Visible)
                     {
                         ModList.InvalidateRow(row.Index);

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -195,6 +195,9 @@ namespace CKAN
 
             InitializeComponent();
 
+            // React when the user clicks a tag or filter link in mod info
+            ModInfoTabControl.OnChangeFilter += Filter;
+
             // Replace mono's broken, ugly toolstrip renderer
             if (Platform.IsMono)
             {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -574,7 +574,7 @@ namespace CKAN
             });
 
             configuration = GUIConfiguration.LoadOrCreateConfiguration(
-                Path.Combine(CurrentInstance.CkanDir (), "GUIConfig.xml")
+                Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml")
             );
 
             if (CurrentInstance.CompatibleVersionsAreFromDifferentKsp)
@@ -583,17 +583,17 @@ namespace CKAN
                     .ShowDialog();
             }
 
+            (RegistryManager.Instance(CurrentInstance).registry as Registry)
+                ?.BuildTagIndex(mainModList.ModuleTags);
+
             bool repoUpdateNeeded = configuration.RefreshOnStartup
                 || !RegistryManager.Instance(CurrentInstance).registry.HasAnyAvailable();
             if (allowRepoUpdate && repoUpdateNeeded)
             {
-                ModList.Rows.Clear();
-                UpdateRepo();
-
                 // Update the filters after UpdateRepo() completed.
                 // Since this happens with a backgroundworker, Filter() is added as callback for RunWorkerCompleted.
                 // Remove it again after it ran, else it stays there and is added again and again.
-                void filterUpdate (object sender, RunWorkerCompletedEventArgs e)
+                void filterUpdate(object sender, RunWorkerCompletedEventArgs e)
                 {
                     Filter(
                         (GUIModFilter)configuration.ActiveFilter,
@@ -605,6 +605,9 @@ namespace CKAN
                 }
 
                 m_UpdateRepoWorker.RunWorkerCompleted += filterUpdate;
+
+                ModList.Rows.Clear();
+                UpdateRepo();
             }
             else
             {

--- a/GUI/Main.resx
+++ b/GUI/Main.resx
@@ -260,4 +260,6 @@
   <data name="openKSPDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Open KSP Directory</value></data>
   <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Settings</value></data>
   <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quit</value></data>
+  <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels</value></data>
+  <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Edit labels...</value></data>
 </root>

--- a/GUI/Main.resx
+++ b/GUI/Main.resx
@@ -197,6 +197,8 @@
   <data name="FilterNotInstalledButton.Text" xml:space="preserve"><value>Not installed</value></data>
   <data name="FilterIncompatibleButton.Text" xml:space="preserve"><value>Incompatible</value></data>
   <data name="FilterAllButton.Text" xml:space="preserve"><value>All</value></data>
+  <data name="FilterTagsToolButton.Text" xml:space="preserve"><value>Tags</value></data>
+  <data name="FilterLabelsToolButton.Text" xml:space="preserve"><value>Labels</value></data>
   <data name="NavBackwardToolButton.ToolTipText" xml:space="preserve"><value>Previous selected mod...</value></data>
   <data name="NavForwardToolButton.ToolTipText" xml:space="preserve"><value>Next selected mod...</value></data>
   <data name="Installed.HeaderText" xml:space="preserve"><value>    Inst</value></data>

--- a/GUI/MainAllModVersions.Designer.cs
+++ b/GUI/MainAllModVersions.Designer.cs
@@ -62,7 +62,7 @@
             //
             // CompatibleKSPVersion
             //
-            this.CompatibleKSPVersion.Width = 248;
+            this.CompatibleKSPVersion.Width = 160;
             resources.ApplyResources(this.CompatibleKSPVersion, "CompatibleKSPVersion");
             //
             // VersionsListView

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+using System;
 using System.Linq;
+using System.Collections.Generic;
+using System.Drawing;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace CKAN
@@ -47,14 +48,18 @@ namespace CKAN
                 }
 
                 CkanModule m = change.Mod;
+                bool warn = AnyLabelAlertsBeforeInstall(m);
                 ChangesListView.Items.Add(new ListViewItem(new string[]
                 {
                     change.NameAndStatus,
                     change.ChangeType.ToString(),
-                    change.Description
+                    warn
+                        ? string.Format(Properties.Resources.MainChangesetWarningInstallingHidden, change.Description)
+                        : change.Description
                 })
                 {
-                    Tag = m
+                    Tag = m,
+                    ForeColor = warn ? Color.Red : SystemColors.WindowText
                 });
             }
         }

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -48,18 +48,22 @@ namespace CKAN
                 }
 
                 CkanModule m = change.Mod;
-                bool warn = AnyLabelAlertsBeforeInstall(m);
+                ModuleLabel warnLbl = FindLabelAlertsBeforeInstall(m);
                 ChangesListView.Items.Add(new ListViewItem(new string[]
                 {
                     change.NameAndStatus,
                     change.ChangeType.ToString(),
-                    warn
-                        ? string.Format(Properties.Resources.MainChangesetWarningInstallingHidden, change.Description)
+                    warnLbl != null
+                        ? string.Format(
+                            Properties.Resources.MainChangesetWarningInstallingHidden,
+                            warnLbl.Name,
+                            change.Description
+                          )
                         : change.Description
                 })
                 {
                     Tag = m,
-                    ForeColor = warn ? Color.Red : SystemColors.WindowText
+                    ForeColor = warnLbl != null ? Color.Red : SystemColors.WindowText
                 });
             }
         }

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -55,7 +55,7 @@ namespace CKAN
                     change.ChangeType.ToString(),
                     warnLbl != null
                         ? string.Format(
-                            Properties.Resources.MainChangesetWarningInstallingHidden,
+                            Properties.Resources.MainChangesetWarningInstallingModuleWithLabel,
                             warnLbl.Name,
                             change.Description
                           )

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -317,6 +317,7 @@ namespace CKAN
         private void OnModInstalled(CkanModule mod)
         {
             AddStatusMessage(string.Format(Properties.Resources.MainInstallModSuccess, mod.name));
+            LabelsAfterInstall(mod);
         }
 
         private void PostInstallMods(object sender, RunWorkerCompletedEventArgs e)

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -26,7 +26,7 @@ namespace CKAN
             foreach (var kvp in mainModList.ModuleTags.Tags.OrderBy(kvp => kvp.Key))
             {
                 FilterToolButton.DropDownItems.Add(new ToolStripMenuItem(
-                    $"{kvp.Key} ({kvp.Value.Modules.Count})",
+                    $"{kvp.Key} ({kvp.Value.ModuleIdentifiers.Count})",
                     null, tagFilterButton_Click
                 )
                 {

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -112,10 +112,10 @@ namespace CKAN
                 {
                     MessageBox.Show(
                         string.Format(
-                            "Some of your watched mods have updated:\r\n\r\n{0}",
+                            Properties.Resources.MainLabelsUpdateMessage,
                             string.Join("\r\n", toNotif)
                         ),
-                        "Update Notifications",
+                        Properties.Resources.MainLabelsUpdateTitle,
                         MessageBoxButtons.OK
                     );
                 }

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Linq;
+using System.ComponentModel;
+using System.Windows.Forms;
+using System.Collections.Generic;
+
+namespace CKAN
+{
+    public partial class Main
+    {
+        #region Filter dropdown
+
+        private void FilterToolButton_DrodDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            // Remove any existing custom labels from the list
+            for (int i = FilterToolButton.DropDownItems.Count - 1; i >= 0; --i)
+            {
+                if (FilterToolButton.DropDownItems[i] is ToolStripSeparator)
+                {
+                    // Stop when we get to the separator
+                    break;
+                }
+                FilterToolButton.DropDownItems.RemoveAt(i);
+            }
+            foreach (ModuleLabel mlbl in mainModList.ModuleLabels.Labels)
+            {
+                FilterToolButton.DropDownItems.Add(new ToolStripMenuItem(
+                    $"{mlbl.Name} ({mlbl.ModuleIdentifiers.Count})",
+                    null, customFilterButton_Click
+                )
+                {
+                    Tag = mlbl
+                });
+            }
+        }
+
+        private void customFilterButton_Click(object sender, EventArgs e)
+        {
+            var clicked = sender as ToolStripMenuItem;
+            Filter(GUIModFilter.CustomLabel, clicked.Tag as ModuleLabel);
+        }
+
+        #endregion
+
+        #region Right click menu
+
+        private void LabelsContextMenuStrip_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            LabelsContextMenuStrip.Items.Clear();
+
+            var module = GetSelectedModule();
+            foreach (ModuleLabel mlbl in mainModList.ModuleLabels.Labels)
+            {
+                if (mlbl.InstanceName == null || mlbl.InstanceName == CurrentInstance.Name)
+                {
+                    LabelsContextMenuStrip.Items.Add(
+                        new ToolStripMenuItem(mlbl.Name, null, labelMenuItem_Click)
+                        {
+                            Checked      = mlbl.ModuleIdentifiers.Contains(module.Identifier),
+                            CheckOnClick = true,
+                            Tag          = mlbl,
+                        }
+                    );
+                }
+            }
+            LabelsContextMenuStrip.Items.Add(labelToolStripSeparator);
+            LabelsContextMenuStrip.Items.Add(editLabelsToolStripMenuItem);
+            e.Cancel = false;
+        }
+
+        private void labelMenuItem_Click(object sender, EventArgs e)
+        {
+            var item   = sender   as ToolStripMenuItem;
+            var mlbl   = item.Tag as ModuleLabel;
+            var module = GetSelectedModule();
+            if (item.Checked)
+            {
+                mlbl.Add(module.Identifier);
+            }
+            else
+            {
+                mlbl.Remove(module.Identifier);
+            }
+            mainModList.ModuleLabels.Save(ModuleLabelList.DefaultPath);
+            mainModList.ReapplyLabels(module);
+        }
+
+        private void editLabelsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            EditLabelsDialog eld = new EditLabelsDialog(currentUser, Manager, mainModList.ModuleLabels);
+            eld.ShowDialog(this);
+            eld.Dispose();
+            mainModList.ModuleLabels.Save(ModuleLabelList.DefaultPath);
+        }
+
+        #endregion
+
+        #region Notifications
+
+        private void LabelsAfterUpdate(IEnumerable<GUIMod> mods)
+        {
+            Util.Invoke(Main.Instance, () =>
+            {
+                var notifLabs = mainModList.ModuleLabels.Labels.Where(l => l.NotifyOnChange);
+                var toNotif = mods
+                    .Where(m =>
+                        notifLabs.Any(l =>
+                            l.ModuleIdentifiers.Contains(m.Identifier)))
+                    .Select(m => m.Name)
+                    .ToArray();
+                if (toNotif.Any())
+                {
+                    MessageBox.Show(
+                        string.Format(
+                            "Some of your watched mods have updated:\r\n\r\n{0}",
+                            string.Join("\r\n", toNotif)
+                        ),
+                        "Update Notifications",
+                        MessageBoxButtons.OK
+                    );
+                }
+
+                foreach (GUIMod mod in mods)
+                {
+                    foreach (ModuleLabel l in mainModList.ModuleLabels.Labels
+                        .Where(l => l.RemoveOnChange
+                            && l.ModuleIdentifiers.Contains(mod.Identifier)))
+                    {
+                        l.Remove(mod.Identifier);
+                    }
+
+                }
+            });
+        }
+
+        private bool AnyLabelAlertsBeforeInstall(CkanModule mod)
+        {
+            return mainModList.ModuleLabels.Labels
+                .Where(l => l.AlertOnInstall)
+                .Any(l => l.ModuleIdentifiers.Contains(mod.identifier));
+        }
+
+        private void LabelsAfterInstall(CkanModule mod)
+        {
+            foreach (ModuleLabel l in mainModList.ModuleLabels.Labels
+                .Where(l => l.RemoveOnInstall
+                    && l.ModuleIdentifiers.Contains(mod.identifier)))
+            {
+                l.Remove(mod.identifier);
+            }
+        }
+
+        #endregion
+	}
+}

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -15,13 +15,33 @@ namespace CKAN
             // Remove any existing custom labels from the list
             for (int i = FilterToolButton.DropDownItems.Count - 1; i >= 0; --i)
             {
-                if (FilterToolButton.DropDownItems[i] is ToolStripSeparator)
+                if (FilterToolButton.DropDownItems[i] == tagFilterToolStripSeparator)
                 {
-                    // Stop when we get to the separator
+                    // Stop when we get to the first separator
                     break;
                 }
                 FilterToolButton.DropDownItems.RemoveAt(i);
             }
+            // Tags
+            foreach (var kvp in mainModList.ModuleTags.Tags.OrderBy(kvp => kvp.Key))
+            {
+                FilterToolButton.DropDownItems.Add(new ToolStripMenuItem(
+                    $"{kvp.Key} ({kvp.Value.Modules.Count})",
+                    null, tagFilterButton_Click
+                )
+                {
+                    Tag = kvp.Value
+                });
+            }
+            FilterToolButton.DropDownItems.Add(new ToolStripMenuItem(
+                string.Format(Properties.Resources.MainLabelsUntagged, mainModList.ModuleTags.Untagged.Count),
+                null, tagFilterButton_Click
+            )
+            {
+                Tag = null
+            });
+            FilterToolButton.DropDownItems.Add(customFilterToolStripSeparator);
+            // Labels
             foreach (ModuleLabel mlbl in mainModList.ModuleLabels.Labels)
             {
                 FilterToolButton.DropDownItems.Add(new ToolStripMenuItem(
@@ -34,10 +54,16 @@ namespace CKAN
             }
         }
 
+        private void tagFilterButton_Click(object sender, EventArgs e)
+        {
+            var clicked = sender as ToolStripMenuItem;
+            Filter(GUIModFilter.Tag, clicked.Tag as ModuleTag, null);
+        }
+
         private void customFilterButton_Click(object sender, EventArgs e)
         {
             var clicked = sender as ToolStripMenuItem;
-            Filter(GUIModFilter.CustomLabel, clicked.Tag as ModuleLabel);
+            Filter(GUIModFilter.CustomLabel, null, clicked.Tag as ModuleLabel);
         }
 
         #endregion

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -10,14 +10,14 @@ namespace CKAN
     {
         #region Filter dropdown
 
-        private void FilterToolButton_DrodDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void FilterToolButton_DropDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             // The menu items' dropdowns can't be accessed if they're empty
-            FilterTagsToolButton_DrodDown_Opening(null, null);
-            FilterLabelsToolButton_DrodDown_Opening(null, null);
+            FilterTagsToolButton_DropDown_Opening(null, null);
+            FilterLabelsToolButton_DropDown_Opening(null, null);
         }
         
-        private void FilterTagsToolButton_DrodDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void FilterTagsToolButton_DropDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             FilterTagsToolButton.DropDownItems.Clear();
             foreach (var kvp in mainModList.ModuleTags.Tags.OrderBy(kvp => kvp.Key))
@@ -39,10 +39,10 @@ namespace CKAN
             });
         }
 
-        private void FilterLabelsToolButton_DrodDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void FilterLabelsToolButton_DropDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             FilterLabelsToolButton.DropDownItems.Clear();
-            foreach (ModuleLabel mlbl in mainModList.ModuleLabels.Labels)
+            foreach (ModuleLabel mlbl in mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name))
             {
                 FilterLabelsToolButton.DropDownItems.Add(new ToolStripMenuItem(
                     $"{mlbl.Name} ({mlbl.ModuleIdentifiers.Count})",
@@ -75,7 +75,7 @@ namespace CKAN
             LabelsContextMenuStrip.Items.Clear();
 
             var module = GetSelectedModule();
-            foreach (ModuleLabel mlbl in mainModList.ModuleLabels.Labels.Where(l => l.AppliesTo(CurrentInstance.Name)))
+            foreach (ModuleLabel mlbl in mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name))
             {
                 LabelsContextMenuStrip.Items.Add(
                     new ToolStripMenuItem(mlbl.Name, null, labelMenuItem_Click)
@@ -128,8 +128,8 @@ namespace CKAN
         {
             Util.Invoke(Main.Instance, () =>
             {
-                var notifLabs = mainModList.ModuleLabels.Labels
-                    .Where(l => l.AppliesTo(CurrentInstance.Name) && l.NotifyOnChange);
+                var notifLabs = mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
+                    .Where(l => l.NotifyOnChange);
                 var toNotif = mods
                     .Where(m =>
                         notifLabs.Any(l =>
@@ -150,7 +150,7 @@ namespace CKAN
 
                 foreach (GUIMod mod in mods)
                 {
-                    foreach (ModuleLabel l in mainModList.ModuleLabels.Labels
+                    foreach (ModuleLabel l in mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                         .Where(l => l.RemoveOnChange
                             && l.ModuleIdentifiers.Contains(mod.Identifier)))
                     {
@@ -163,16 +163,15 @@ namespace CKAN
 
         private bool AnyLabelAlertsBeforeInstall(CkanModule mod)
         {
-            return mainModList.ModuleLabels.Labels
-                .Where(l => l.AppliesTo(CurrentInstance.Name) && l.AlertOnInstall)
+            return mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
+                .Where(l => l.AlertOnInstall)
                 .Any(l => l.ModuleIdentifiers.Contains(mod.identifier));
         }
 
         private void LabelsAfterInstall(CkanModule mod)
         {
-            foreach (ModuleLabel l in mainModList.ModuleLabels.Labels
-                .Where(l => l.AppliesTo(CurrentInstance.Name) && l.RemoveOnInstall
-                    && l.ModuleIdentifiers.Contains(mod.identifier)))
+            foreach (ModuleLabel l in mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
+                .Where(l => l.RemoveOnInstall && l.ModuleIdentifiers.Contains(mod.identifier)))
             {
                 l.Remove(mod.identifier);
             }

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -107,8 +107,8 @@ namespace CKAN
             {
                 mlbl.Remove(module.Identifier);
             }
+            mainModList.ReapplyLabels(module, Conflicts?.ContainsKey(module) ?? false);
             mainModList.ModuleLabels.Save(ModuleLabelList.DefaultPath);
-            mainModList.ReapplyLabels(module);
         }
 
         private void editLabelsToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -161,11 +161,11 @@ namespace CKAN
             });
         }
 
-        private bool AnyLabelAlertsBeforeInstall(CkanModule mod)
+        private ModuleLabel FindLabelAlertsBeforeInstall(CkanModule mod)
         {
             return mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                 .Where(l => l.AlertOnInstall)
-                .Any(l => l.ModuleIdentifiers.Contains(mod.identifier));
+                .FirstOrDefault(l => l.ModuleIdentifiers.Contains(mod.identifier));
         }
 
         private void LabelsAfterInstall(CkanModule mod)

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -30,6 +30,7 @@ namespace CKAN
                     Tag = kvp.Value
                 });
             }
+            FilterTagsToolButton.DropDownItems.Add(untaggedFilterToolStripSeparator);
             FilterTagsToolButton.DropDownItems.Add(new ToolStripMenuItem(
                 string.Format(Properties.Resources.MainLabelsUntagged, mainModList.ModuleTags.Untagged.Count),
                 null, tagFilterButton_Click

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -35,6 +35,7 @@
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.MetaDataUpperLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.MetadataModuleNameTextBox = new TransparentTextBox();
+            this.MetadataTagsLabelsPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.MetadataModuleAbstractLabel = new System.Windows.Forms.Label();
             this.MetadataModuleDescriptionTextBox = new TransparentTextBox();
             this.MetaDataLowerLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
@@ -142,13 +143,15 @@
             this.MetaDataUpperLayoutPanel.ColumnCount = 1;
             this.MetaDataUpperLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleNameTextBox, 0, 0);
-            this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleAbstractLabel, 0, 1);
-            this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleDescriptionTextBox, 0, 2);
+            this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataTagsLabelsPanel, 0, 1);
+            this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleAbstractLabel, 0, 2);
+            this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleDescriptionTextBox, 0, 3);
             this.MetaDataUpperLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataUpperLayoutPanel.Location = new System.Drawing.Point(0, 0);
             this.MetaDataUpperLayoutPanel.Name = "MetaDataUpperLayoutPanel";
-            this.MetaDataUpperLayoutPanel.RowCount = 3;
+            this.MetaDataUpperLayoutPanel.RowCount = 4;
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize, 20F));
+            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize, 30F));
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 80F));
             this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(346, 283);
@@ -168,6 +171,14 @@
             this.MetadataModuleNameTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.MetadataModuleNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             resources.ApplyResources(this.MetadataModuleNameTextBox, "MetadataModuleNameTextBox");
+            // 
+            // MetadataTagsLabelsPanel
+            // 
+            this.MetadataTagsLabelsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataTagsLabelsPanel.Padding = new System.Windows.Forms.Padding(0);
+            this.MetadataTagsLabelsPanel.Location = new System.Drawing.Point(0, 0);
+            this.MetadataTagsLabelsPanel.Name = "MetadataTagsLabelsPanel";
+            this.MetadataTagsLabelsPanel.Size = new System.Drawing.Size(340, 12);
             //
             // MetadataModuleAbstractLabel
             //
@@ -683,6 +694,7 @@
         private System.Windows.Forms.SplitContainer splitContainer2;
         private System.Windows.Forms.TableLayoutPanel MetaDataUpperLayoutPanel;
         private TransparentTextBox MetadataModuleNameTextBox;
+        private System.Windows.Forms.FlowLayoutPanel MetadataTagsLabelsPanel;
         private System.Windows.Forms.Label MetadataModuleAbstractLabel;
         private TransparentTextBox MetadataModuleDescriptionTextBox;
         private System.Windows.Forms.TableLayoutPanel MetaDataLowerLayoutPanel;

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -111,7 +111,7 @@ namespace CKAN
         {
             StartDownload(SelectedModule);
         }
-        
+
         private void ContentsOpenButton_Click(object sender, EventArgs e)
         {
             Process.Start(manager.Cache.GetCachedFilename(SelectedModule.ToModule()));
@@ -127,9 +127,7 @@ namespace CKAN
             CkanModule module = gui_module.ToModule();
 
             Util.Invoke(MetadataModuleNameTextBox, () => MetadataModuleNameTextBox.Text = gui_module.Name);
-            Util.Invoke(MetadataModuleVersionTextBox, () => MetadataModuleVersionTextBox.Text = gui_module.LatestVersion.ToString());
-            Util.Invoke(MetadataModuleLicenseTextBox, () => MetadataModuleLicenseTextBox.Text = string.Join(", ", module.license));
-            Util.Invoke(MetadataModuleAuthorTextBox, () => MetadataModuleAuthorTextBox.Text = gui_module.Authors);
+            UpdateTagsAndLabels(gui_module.ToModule());
             Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = gui_module.Abstract);
             Util.Invoke(MetadataModuleDescriptionTextBox, () =>
             {
@@ -140,6 +138,10 @@ namespace CKAN
                         ? ScrollBars.None
                         : ScrollBars.Vertical;
             });
+
+            Util.Invoke(MetadataModuleVersionTextBox, () => MetadataModuleVersionTextBox.Text = gui_module.LatestVersion.ToString());
+            Util.Invoke(MetadataModuleLicenseTextBox, () => MetadataModuleLicenseTextBox.Text = string.Join(", ", module.license));
+            Util.Invoke(MetadataModuleAuthorTextBox, () => MetadataModuleAuthorTextBox.Text = gui_module.Authors);
             Util.Invoke(MetadataIdentifierTextBox, () => MetadataIdentifierTextBox.Text = gui_module.Identifier);
 
             // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
@@ -148,6 +150,89 @@ namespace CKAN
             Util.Invoke(MetadataModuleReleaseStatusTextBox, () => MetadataModuleReleaseStatusTextBox.Text = module.release_status?.ToString() ?? Properties.Resources.MainModInfoNSlashA);
             Util.Invoke(MetadataModuleKSPCompatibilityTextBox, () => MetadataModuleKSPCompatibilityTextBox.Text = gui_module.KSPCompatibilityLong);
             Util.Invoke(ReplacementTextBox, () => ReplacementTextBox.Text = gui_module.ToModule()?.replaced_by?.ToString() ?? Properties.Resources.MainModInfoNSlashA);
+        }
+
+        private ModuleLabelList ModuleLabels
+        {
+            get
+            {
+                return Main.Instance.mainModList.ModuleLabels;
+            }
+        }
+
+        private ModuleTagList ModuleTags
+        {
+            get
+            {
+                return Main.Instance.mainModList.ModuleTags;
+            }
+        }
+
+        private void UpdateTagsAndLabels(CkanModule mod)
+        {
+            Util.Invoke(MetadataTagsLabelsPanel, () =>
+            {
+                MetadataTagsLabelsPanel.Controls.Clear();
+                var tags = ModuleTags?.Tags
+                    .Where(t => t.Value.ModuleIdentifiers.Contains(mod.identifier))
+                    .Select(t => t.Value);
+                if (tags != null)
+                {
+                    foreach (ModuleTag tag in tags)
+                    {
+                        MetadataTagsLabelsPanel.Controls.Add(TagLabelLink(
+                            tag.Name, tag, new LinkLabelLinkClickedEventHandler(this.TagLinkLabel_LinkClicked)
+                        ));
+                    }
+                }
+                var labels = ModuleLabels?.LabelsFor(manager.CurrentInstance.Name)
+                    .Where(l => l.ModuleIdentifiers.Contains(mod.identifier));
+                if (labels != null)
+                {
+                    foreach (ModuleLabel mlbl in labels)
+                    {
+                        MetadataTagsLabelsPanel.Controls.Add(TagLabelLink(
+                            mlbl.Name, mlbl, new LinkLabelLinkClickedEventHandler(this.LabelLinkLabel_LinkClicked)
+                        ));
+                    }
+                }
+            });
+        }
+
+        private LinkLabel TagLabelLink(string name, object tag, LinkLabelLinkClickedEventHandler onClick)
+        {
+            var link = new LinkLabel()
+            {
+                AutoSize     = true,
+                LinkColor    = SystemColors.GrayText,
+                LinkBehavior = LinkBehavior.HoverUnderline,
+                Margin       = new Padding(2),
+                Text         = name,
+                Tag          = tag,
+            };
+            link.LinkClicked += onClick;
+            return link;
+        }
+
+        public delegate void ChangeFilter(GUIModFilter filter, ModuleTag tag, ModuleLabel label);
+        public event ChangeFilter OnChangeFilter;
+
+        private void TagLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            var link = sender as LinkLabel;
+            if (OnChangeFilter != null)
+            {
+                OnChangeFilter(GUIModFilter.Tag, link.Tag as ModuleTag, null);
+            }
+        }
+
+        private void LabelLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            var link = sender as LinkLabel;
+            if (OnChangeFilter != null)
+            {
+                OnChangeFilter(GUIModFilter.CustomLabel, null, link.Tag as ModuleLabel);
+            }
         }
 
         private void BeforeExpand(object sender, TreeViewCancelEventArgs args)
@@ -453,7 +538,7 @@ namespace CKAN
             Main.Instance.ShowWaitDialog(false);
             if (cacheWorker.IsBusy)
             {
-                Task.Factory.StartNew(() => 
+                Task.Factory.StartNew(() =>
                 {
                     // Just pass to the existing worker
                     downloader.DownloadModules(new List<CkanModule> { module.ToCkanModule() });

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -175,6 +175,7 @@ namespace CKAN
                 MetadataTagsLabelsPanel.Controls.Clear();
                 var tags = ModuleTags?.Tags
                     .Where(t => t.Value.ModuleIdentifiers.Contains(mod.identifier))
+                    .OrderBy(t => t.Key)
                     .Select(t => t.Value);
                 if (tags != null)
                 {
@@ -186,7 +187,8 @@ namespace CKAN
                     }
                 }
                 var labels = ModuleLabels?.LabelsFor(manager.CurrentInstance.Name)
-                    .Where(l => l.ModuleIdentifiers.Contains(mod.identifier));
+                    .Where(l => l.ModuleIdentifiers.Contains(mod.identifier))
+                    .OrderBy(l => l.Name);
                 if (labels != null)
                 {
                     foreach (ModuleLabel mlbl in labels)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -1142,7 +1142,9 @@ namespace CKAN
                 case GUIModFilter.Incompatible:             return m.IsIncompatible;
                 case GUIModFilter.Replaceable:              return m.IsInstalled && m.HasReplacement;
                 case GUIModFilter.All:                      return true;
-                case GUIModFilter.Tag:                      return m.HasTag(tag?.Name);
+                case GUIModFilter.Tag:                      return tag?.ModuleIdentifiers.Contains(m.Identifier)
+                    ?? Main.Instance?.mainModList.ModuleTags.Untagged.Contains(m.Identifier)
+                    ?? false;
                 case GUIModFilter.CustomLabel:              return label?.ModuleIdentifiers?.Contains(m.Identifier) ?? false;
                 default:                                    throw new Kraken(string.Format(Properties.Resources.MainModListUnknownFilter, filter));
             }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -1036,14 +1036,13 @@ namespace CKAN
 
             return item;
         }
-
-        /// <summary>
-        /// Update the color and visible state of the given row
-        /// after it has been added to or removed from a label group
-        /// </summary>
-        /// <param name="mod">The mod that needs an update</param>
-        public void ReapplyLabels(GUIMod mod)
+        
+        public Color GetRowBackground(GUIMod mod, bool conflicted)
         {
+            if (conflicted)
+            {
+                return Color.LightCoral;
+            }
             DataGridViewRow row;
             if (full_list_of_mod_rows.TryGetValue(mod.Identifier, out row))
             {
@@ -1052,8 +1051,23 @@ namespace CKAN
                     ?.Color;
                 if (myColor.HasValue)
                 {
-                    row.DefaultCellStyle.BackColor = myColor.Value;
+                    return myColor.Value;
                 }
+            }
+            return Color.Empty;
+        }
+
+        /// <summary>
+        /// Update the color and visible state of the given row
+        /// after it has been added to or removed from a label group
+        /// </summary>
+        /// <param name="mod">The mod that needs an update</param>
+        public void ReapplyLabels(GUIMod mod, bool conflicted)
+        {
+            DataGridViewRow row;
+            if (full_list_of_mod_rows.TryGetValue(mod.Identifier, out row))
+            {
+                row.DefaultCellStyle.BackColor = GetRowBackground(mod, conflicted);
                 row.Visible = IsVisible(mod);
             }
         }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -276,6 +276,8 @@ namespace CKAN
                 UpdateAllToolButton.Enabled = has_any_updates;
             });
             
+            (registry as Registry)?.BuildTagIndex(mainModList.ModuleTags);
+            
             UpdateFilters(this);
 
             // Hide update and replacement columns if not needed.

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -276,8 +276,6 @@ namespace CKAN
                 UpdateAllToolButton.Enabled = has_any_updates;
             });
             
-            (registry as Registry)?.BuildTagIndex(mainModList.ModuleTags);
-
             UpdateFilters(this);
 
             // Hide update and replacement columns if not needed.

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -428,8 +428,6 @@ namespace CKAN
             else if (tag != null)
             {
                 tag.Visible = !clickedItem.Checked;
-                var regMgr   = RegistryManager.Instance(Manager.CurrentInstance);
-                var registry = regMgr.registry;
                 if (tag.Visible)
                 {
                     mainModList.ModuleTags.HiddenTags.Remove(tag.Name);
@@ -1126,7 +1124,7 @@ namespace CKAN
                 }
                 if (Main.Instance?.mainModList.ModuleTags?.Tags?.Values
                     .Where(t => t.Visible == false)
-                    .Any(t => t.Modules.Contains(m.Identifier))
+                    .Any(t => t.ModuleIdentifiers.Contains(m.Identifier))
                     ?? false)
                 {
                     return false;

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -909,8 +909,8 @@ namespace CKAN
             if (filter != GUIModFilter.CustomLabel)
             {
                 // "Hide" labels apply to all non-custom filters
-                if (ModuleLabels?.Labels
-                    .Where(l => l != label && l.AppliesTo(instanceName) && l.Hide)
+                if (ModuleLabels?.LabelsFor(instanceName)
+                    .Where(l => l != label && l.Hide)
                     .Any(l => l.ModuleIdentifiers.Contains(m.Identifier))
                     ?? false)
                 {
@@ -963,8 +963,7 @@ namespace CKAN
         {
             DataGridViewRow item = new DataGridViewRow() {Tag = mod};
 
-            Color? myColor = ModuleLabels.Labels
-                .Where(l => l.AppliesTo(instanceName))
+            Color? myColor = ModuleLabels.LabelsFor(instanceName)
                 .FirstOrDefault(l => l.ModuleIdentifiers.Contains(mod.Identifier))
                 ?.Color;
             if (myColor.HasValue)
@@ -1060,7 +1059,7 @@ namespace CKAN
             return item;
         }
         
-        public Color GetRowBackground(GUIMod mod, bool conflicted)
+        public Color GetRowBackground(GUIMod mod, bool conflicted, string instanceName)
         {
             if (conflicted)
             {
@@ -1069,7 +1068,7 @@ namespace CKAN
             DataGridViewRow row;
             if (full_list_of_mod_rows.TryGetValue(mod.Identifier, out row))
             {
-                Color? myColor = ModuleLabels.Labels
+                Color? myColor = ModuleLabels.LabelsFor(instanceName)
                     .FirstOrDefault(l => l.ModuleIdentifiers.Contains(mod.Identifier))
                     ?.Color;
                 if (myColor.HasValue)
@@ -1090,7 +1089,7 @@ namespace CKAN
             DataGridViewRow row;
             if (full_list_of_mod_rows.TryGetValue(mod.Identifier, out row))
             {
-                row.DefaultCellStyle.BackColor = GetRowBackground(mod, conflicted);
+                row.DefaultCellStyle.BackColor = GetRowBackground(mod, conflicted, instanceName);
                 row.Visible = IsVisible(mod, instanceName);
             }
         }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -1049,9 +1049,9 @@ namespace CKAN
             if (filter != GUIModFilter.CustomLabel)
             {
                 // "Hide" labels apply to all non-custom filters
-                if (Main.Instance.mainModList.ModuleLabels.Labels
+                if (Main.Instance?.mainModList.ModuleLabels.Labels
                     .Where(l => l.Hide)
-                    .Any(l => l.ModuleIdentifiers.Contains(m.Identifier)))
+                    .Any(l => l.ModuleIdentifiers.Contains(m.Identifier)) ?? false)
                 {
                     return false;
                 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -388,6 +388,15 @@ namespace CKAN.Properties {
         internal static string MainFilterCompatible {
             get { return (string)(ResourceManager.GetObject("MainFilterCompatible", resourceCulture)); }
         }
+        internal static string MainFilterLabel {
+            get { return (string)(ResourceManager.GetObject("MainFilterLabel", resourceCulture)); }
+        }
+        internal static string MainFilterTag {
+            get { return (string)(ResourceManager.GetObject("MainFilterTag", resourceCulture)); }
+        }
+        internal static string MainFilterUntagged {
+            get { return (string)(ResourceManager.GetObject("MainFilterUntagged", resourceCulture)); }
+        }
         internal static string MainLaunchWithIncompatible {
             get { return (string)(ResourceManager.GetObject("MainLaunchWithIncompatible", resourceCulture)); }
         }
@@ -813,6 +822,9 @@ namespace CKAN.Properties {
         }
         internal static string MainLabelsUpdateTitle {
             get { return (string)(ResourceManager.GetObject("MainLabelsUpdateTitle", resourceCulture)); }
+        }
+        internal static string MainLabelsUntagged {
+            get { return (string)(ResourceManager.GetObject("MainLabelsUntagged", resourceCulture)); }
         }
    }
 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -745,5 +745,68 @@ namespace CKAN.Properties {
         internal static string StatusInstanceLabelText {
             get { return (string)(ResourceManager.GetObject("StatusInstanceLabelText", resourceCulture)); }
         }
+        internal static string ModuleLabelListFavourites {
+            get { return (string)(ResourceManager.GetObject("ModuleLabelListFavourites", resourceCulture)); }
+        }
+        internal static string ModuleLabelListHidden {
+            get { return (string)(ResourceManager.GetObject("ModuleLabelListHidden", resourceCulture)); }
+        }
+        internal static string ModuleLabelListGlobal {
+            get { return (string)(ResourceManager.GetObject("ModuleLabelListGlobal", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogConfirmDelete {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogConfirmDelete", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogSavePrompt {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogSavePrompt", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogNoRecord {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogNoRecord", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogNameRequired {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogNameRequired", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogAlreadyExists {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogAlreadyExists", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogDelete {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogDelete", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogCancel {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogCancel", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogSave {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogSave", resourceCulture)); }
+        }
+        internal static string EditLabelsDialogDiscard {
+            get { return (string)(ResourceManager.GetObject("EditLabelsDialogDiscard", resourceCulture)); }
+        }
+        internal static string MainChangesetWarningInstallingHidden {
+            get { return (string)(ResourceManager.GetObject("MainChangesetWarningInstallingHidden", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipName {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipName", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipColor {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipColor", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipInstance {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipInstance", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipHide {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipHide", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipNotifyOnChanges {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipNotifyOnChanges", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipRemoveOnChanges {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipRemoveOnChanges", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipAlertOnInstall {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipAlertOnInstall", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipRemoveOnInstall {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipRemoveOnInstall", resourceCulture)); }
+        }
    }
 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -808,5 +808,11 @@ namespace CKAN.Properties {
         internal static string EditLabelsToolTipRemoveOnInstall {
             get { return (string)(ResourceManager.GetObject("EditLabelsToolTipRemoveOnInstall", resourceCulture)); }
         }
+        internal static string MainLabelsUpdateMessage {
+            get { return (string)(ResourceManager.GetObject("MainLabelsUpdateMessage", resourceCulture)); }
+        }
+        internal static string MainLabelsUpdateTitle {
+            get { return (string)(ResourceManager.GetObject("MainLabelsUpdateTitle", resourceCulture)); }
+        }
    }
 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -790,8 +790,8 @@ namespace CKAN.Properties {
         internal static string EditLabelsDialogDiscard {
             get { return (string)(ResourceManager.GetObject("EditLabelsDialogDiscard", resourceCulture)); }
         }
-        internal static string MainChangesetWarningInstallingHidden {
-            get { return (string)(ResourceManager.GetObject("MainChangesetWarningInstallingHidden", resourceCulture)); }
+        internal static string MainChangesetWarningInstallingModuleWithLabel {
+            get { return (string)(ResourceManager.GetObject("MainChangesetWarningInstallingModuleWithLabel", resourceCulture)); }
         }
         internal static string EditLabelsToolTipName {
             get { return (string)(ResourceManager.GetObject("EditLabelsToolTipName", resourceCulture)); }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -163,8 +163,8 @@
   <data name="MainFilterNotInstalled" xml:space="preserve"><value>Filter (Nicht installiert)</value></data>
   <data name="MainFilterCompatible" xml:space="preserve"><value>Filter (Kompatibel)</value></data>
   <data name="MainFilterLabel" xml:space="preserve"><value>Label ({0})</value></data>
-  <data name="MainFilterTag" xml:space="preserve"><value>Etikett ({0})</value></data>
-  <data name="MainFilterUntagged" xml:space="preserve"><value>Tag (Ohne Tag)</value></data>
+  <data name="MainFilterTag" xml:space="preserve"><value>Kategorie ({0})</value></data>
+  <data name="MainFilterUntagged" xml:space="preserve"><value>Kategorie (Keine)</value></data>
   <data name="MainLaunchWithIncompatible" xml:space="preserve">
     <value>Einige installierte Module sind inkompatibel! Es ist möglicherweise nicht sicher, KSP zu starten. Trotzdem starten?
 
@@ -320,27 +320,27 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoriten</value></data>
   <data name="ModuleLabelListHidden" xml:space="preserve"><value>Versteckt</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
-  <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Möchten Sie {0} wirklich löschen? Dies kann nicht rückgängig gemacht werden!</value></data>
+  <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Möchtest du {0} wirklich löschen? Das kann nicht mehr rückgängig gemacht werden!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Änderungen speichern?</value></data>
-  <data name="EditLabelsDialogNoRecord" xml:space="preserve"><value>Es wird kein Datensatz bearbeitet!</value></data>
+  <data name="EditLabelsDialogNoRecord" xml:space="preserve"><value>Es wird gerade kein Label bearbeitet!</value></data>
   <data name="EditLabelsDialogNameRequired" xml:space="preserve"><value>Name ist erforderlich!</value></data>
   <data name="EditLabelsDialogAlreadyExists" xml:space="preserve"><value>{0} existiert bereits in {1}!</value></data>
   <data name="EditLabelsDialogDelete" xml:space="preserve"><value>Löschen</value></data>
-  <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Stornieren</value></data>
+  <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Abbrechen</value></data>
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Speichern</value></data>
-  <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Verwerfen</value></data>
-  <data name="MainChangesetWarningInstallingModuleWithLabel" xml:space="preserve"><value>WARNUNG: INSTALLIEREN MODULS MIT LABEL {0} ({1})</value></data>
-  <data name="EditLabelsToolTipName" xml:space="preserve"><value>Das Label wird im Menü Labels unter diesem Namen angezeigt und muss pro Installation eindeutig sein</value></data>
-  <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Zeilen für Module mit dieser Bezeichnung werden mit dieser Hintergrundfarbe gezeichnet</value></data>
-  <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Die Instanz, für die dieses Label verfügbar ist, muss für alle leer gelassen werden</value></data>
-  <data name="EditLabelsToolTipHide" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module mit dieser Bezeichnung vor Standardfiltern verborgen</value></data>
-  <data name="EditLabelsToolTipNotifyOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Benachrichtigung angezeigt, wenn dieses Modul von inkompatibel zu kompatibel wechselt</value></data>
-  <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird ein Modul, das von inkompatibel zu kompatibel wechselt, von diesem Label entfernt</value></data>
-  <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Sie auf dem Bildschirm zum Festlegen von Änderungen benachrichtigt, wenn dieser Mod installiert wird</value></data>
-  <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module von diesem Etikett entfernt, wenn sie installiert sind</value></data>
-  <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Einige deiner beobachteten Mods wurden aktualisiert:
+  <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Änderungen verwerfen</value></data>
+  <data name="MainChangesetWarningInstallingModuleWithLabel" xml:space="preserve"><value>WARNUNG: INSTALLATION EINES MODULS MIT LABEL {0} ({1})</value></data>
+  <data name="EditLabelsToolTipName" xml:space="preserve"><value>Das Label wird im Label-Menü unter diesem Namen angezeigt und muss in einer Instanz eindeutig sein</value></data>
+  <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Module mit diesem Label werden haben diese Hintergrundfarbe in der Modliste</value></data>
+  <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Instanz, für welche dieses Label verfügbar ist. Leerlassen, um es in allen Instanzen verfügbar zu haben</value></data>
+  <data name="EditLabelsToolTipHide" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module mit diesem Label ausgeblendet</value></data>
+  <data name="EditLabelsToolTipNotifyOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Benachrichtigung angezeigt, sobald das Modul für deine KSP-Version kompatibel wird</value></data>
+  <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird das Label von Modulen entfernt, sobald sie kompatibel werden</value></data>
+  <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Warnung angezeigt, wenn das Modul installiert werden soll</value></data>
+  <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird das Label von dem Modul entfernt, wenn es installiert wurde</value></data>
+  <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Mods die du beobachtest wurden aktualisiert:
 
 {0}</value></data>
-  <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Benachrichtigungen aktualisieren</value></data>
-  <data name="MainLabelsUntagged" xml:space="preserve"><value>Ohne Tags ({0})</value></data>
+  <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Aktualisierungen für beobachtete Mods</value></data>
+  <data name="MainLabelsUntagged" xml:space="preserve"><value>Ohne Kategorie ({0})</value></data>
 </root>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -329,7 +329,7 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Stornieren</value></data>
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Speichern</value></data>
   <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Verwerfen</value></data>
-  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNUNG: INSTALLIEREN MODULS MIT LABEL {0} ({1})</value></data>
+  <data name="MainChangesetWarningInstallingModuleWithLabel" xml:space="preserve"><value>WARNUNG: INSTALLIEREN MODULS MIT LABEL {0} ({1})</value></data>
   <data name="EditLabelsToolTipName" xml:space="preserve"><value>Das Label wird im Menü Labels unter diesem Namen angezeigt und muss pro Installation eindeutig sein</value></data>
   <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Zeilen für Module mit dieser Bezeichnung werden mit dieser Hintergrundfarbe gezeichnet</value></data>
   <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Die Instanz, für die dieses Label verfügbar ist, muss für alle leer gelassen werden</value></data>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -335,4 +335,8 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird ein Modul, das von inkompatibel zu kompatibel wechselt, von diesem Label entfernt</value></data>
   <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Sie auf dem Bildschirm zum Festlegen von Änderungen benachrichtigt, wenn dieser Mod installiert wird</value></data>
   <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module von diesem Etikett entfernt, wenn sie installiert sind</value></data>
+  <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Einige deiner beobachteten Mods wurden aktualisiert:
+
+{0}</value></data>
+  <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Benachrichtigungen aktualisieren</value></data>
 </root>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -314,4 +314,25 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   </data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Linkadresse kopieren</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Spielinstanz: {0} (KSP {1})</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoriten</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Versteckt</value></data>
+  <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
+  <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Möchten Sie {0} wirklich löschen? Dies kann nicht rückgängig gemacht werden!</value></data>
+  <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Änderungen speichern?</value></data>
+  <data name="EditLabelsDialogNoRecord" xml:space="preserve"><value>Es wird kein Datensatz bearbeitet!</value></data>
+  <data name="EditLabelsDialogNameRequired" xml:space="preserve"><value>Name ist erforderlich!</value></data>
+  <data name="EditLabelsDialogAlreadyExists" xml:space="preserve"><value>{0} existiert bereits in {1}!</value></data>
+  <data name="EditLabelsDialogDelete" xml:space="preserve"><value>Löschen</value></data>
+  <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Stornieren</value></data>
+  <data name="EditLabelsDialogSave" xml:space="preserve"><value>Speichern</value></data>
+  <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Verwerfen</value></data>
+  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNUNG: INSTALLIEREN DES VERSTECKTEN MODULS ({0})</value></data>
+  <data name="EditLabelsToolTipName" xml:space="preserve"><value>The label will appear in the Labels menu under this name, must be unique per install</value></data>
+  <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Zeilen für Module mit dieser Bezeichnung werden mit dieser Hintergrundfarbe gezeichnet</value></data>
+  <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Die Instanz, für die dieses Label verfügbar ist, muss für alle leer gelassen werden</value></data>
+  <data name="EditLabelsToolTipHide" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module mit dieser Bezeichnung vor Standardfiltern verborgen</value></data>
+  <data name="EditLabelsToolTipNotifyOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Benachrichtigung angezeigt, wenn dieses Modul von inkompatibel zu kompatibel wechselt</value></data>
+  <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird ein Modul, das von inkompatibel zu kompatibel wechselt, von diesem Label entfernt</value></data>
+  <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Sie auf dem Bildschirm zum Festlegen von Änderungen benachrichtigt, wenn dieser Mod installiert wird</value></data>
+  <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module von diesem Etikett entfernt, wenn sie installiert sind</value></data>
 </root>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -329,7 +329,7 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Stornieren</value></data>
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Speichern</value></data>
   <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Verwerfen</value></data>
-  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNUNG: INSTALLIEREN DES VERSTECKTEN MODULS ({0})</value></data>
+  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNUNG: INSTALLIEREN MODULS MIT LABEL {0} ({1})</value></data>
   <data name="EditLabelsToolTipName" xml:space="preserve"><value>Das Label wird im Menü Labels unter diesem Namen angezeigt und muss pro Installation eindeutig sein</value></data>
   <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Zeilen für Module mit dieser Bezeichnung werden mit dieser Hintergrundfarbe gezeichnet</value></data>
   <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Die Instanz, für die dieses Label verfügbar ist, muss für alle leer gelassen werden</value></data>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -162,6 +162,9 @@
   <data name="MainFilterNew" xml:space="preserve"><value>Filter (Neu)</value></data>
   <data name="MainFilterNotInstalled" xml:space="preserve"><value>Filter (Nicht installiert)</value></data>
   <data name="MainFilterCompatible" xml:space="preserve"><value>Filter (Kompatibel)</value></data>
+  <data name="MainFilterLabel" xml:space="preserve"><value>Label ({0})</value></data>
+  <data name="MainFilterTag" xml:space="preserve"><value>Etikett ({0})</value></data>
+  <data name="MainFilterUntagged" xml:space="preserve"><value>Tag (Ohne Tag)</value></data>
   <data name="MainLaunchWithIncompatible" xml:space="preserve">
     <value>Einige installierte Module sind inkompatibel! Es ist möglicherweise nicht sicher, KSP zu starten. Trotzdem starten?
 
@@ -327,7 +330,7 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Speichern</value></data>
   <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Verwerfen</value></data>
   <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNUNG: INSTALLIEREN DES VERSTECKTEN MODULS ({0})</value></data>
-  <data name="EditLabelsToolTipName" xml:space="preserve"><value>The label will appear in the Labels menu under this name, must be unique per install</value></data>
+  <data name="EditLabelsToolTipName" xml:space="preserve"><value>Das Label wird im Menü Labels unter diesem Namen angezeigt und muss pro Installation eindeutig sein</value></data>
   <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Zeilen für Module mit dieser Bezeichnung werden mit dieser Hintergrundfarbe gezeichnet</value></data>
   <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Die Instanz, für die dieses Label verfügbar ist, muss für alle leer gelassen werden</value></data>
   <data name="EditLabelsToolTipHide" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module mit dieser Bezeichnung vor Standardfiltern verborgen</value></data>
@@ -339,4 +342,5 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
 
 {0}</value></data>
   <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Benachrichtigungen aktualisieren</value></data>
+  <data name="MainLabelsUntagged" xml:space="preserve"><value>Ohne Tags ({0})</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -348,7 +348,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Cancel</value></data>
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Save</value></data>
   <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Discard</value></data>
-  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNING: INSTALLING MODULE WITH LABEL {0} ({1})</value></data>
+  <data name="MainChangesetWarningInstallingModuleWithLabel" xml:space="preserve"><value>WARNING: INSTALLING MODULE WITH LABEL {0} ({1})</value></data>
   <data name="EditLabelsToolTipName" xml:space="preserve"><value>The label will appear in the Labels menu under this name, must be unique per install</value></data>
   <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Rows for modules with this label will be drawn with this background color</value></data>
   <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>The instance for which this label is available, leave blank for all</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -348,7 +348,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Cancel</value></data>
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Save</value></data>
   <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Discard</value></data>
-  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNING: INSTALLING HIDDEN MODULE ({0})</value></data>
+  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNING: INSTALLING MODULE WITH LABEL {0} ({1})</value></data>
   <data name="EditLabelsToolTipName" xml:space="preserve"><value>The label will appear in the Labels menu under this name, must be unique per install</value></data>
   <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Rows for modules with this label will be drawn with this background color</value></data>
   <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>The instance for which this label is available, leave blank for all</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -354,4 +354,8 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>If checked, a module that changes from incompatible to compatible will be removed from this label</value></data>
   <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>If checked, the change set screen will alert you if this mod is about to be installed</value></data>
   <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>If checked, modules will be removed from this label if they are installed</value></data>
+  <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Some of your watched mods have updated:
+
+{0}</value></data>
+  <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Update Notifications</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -184,6 +184,9 @@
   <data name="MainFilterNew" xml:space="preserve"><value>Filter (New)</value></data>
   <data name="MainFilterNotInstalled" xml:space="preserve"><value>Filter (Not installed)</value></data>
   <data name="MainFilterCompatible" xml:space="preserve"><value>Filter (Compatible)</value></data>
+  <data name="MainFilterLabel" xml:space="preserve"><value>Label ({0})</value></data>
+  <data name="MainFilterTag" xml:space="preserve"><value>Tag ({0})</value></data>
+  <data name="MainFilterUntagged" xml:space="preserve"><value>Tag (Untagged)</value></data>
   <data name="MainLaunchWithIncompatible" xml:space="preserve"><value>Some installed modules are incompatible! It might not be safe to launch KSP. Really launch?
 
 {0}</value></data>
@@ -358,4 +361,5 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
 
 {0}</value></data>
   <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Update Notifications</value></data>
+  <data name="MainLabelsUntagged" xml:space="preserve"><value>Untagged ({0})</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -333,4 +333,25 @@ Can't update automatically, because ckan.exe is read-only or we are not allowed 
 Do you want to allow CKAN to do this? If you click no you won't see this message again.</value></data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Copy link address</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Game instance: {0} (KSP {1})</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favourites</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Hidden</value></data>
+  <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
+  <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Are you sure you want to delete {0}? This can't be undone!</value></data>
+  <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Save changes?</value></data>
+  <data name="EditLabelsDialogNoRecord" xml:space="preserve"><value>No record being edited!</value></data>
+  <data name="EditLabelsDialogNameRequired" xml:space="preserve"><value>Name is required!</value></data>
+  <data name="EditLabelsDialogAlreadyExists" xml:space="preserve"><value>{0} already exists in {1}!</value></data>
+  <data name="EditLabelsDialogDelete" xml:space="preserve"><value>Delete</value></data>
+  <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="EditLabelsDialogSave" xml:space="preserve"><value>Save</value></data>
+  <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Discard</value></data>
+  <data name="MainChangesetWarningInstallingHidden" xml:space="preserve"><value>WARNING: INSTALLING HIDDEN MODULE ({0})</value></data>
+  <data name="EditLabelsToolTipName" xml:space="preserve"><value>The label will appear in the Labels menu under this name, must be unique per install</value></data>
+  <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Rows for modules with this label will be drawn with this background color</value></data>
+  <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>The instance for which this label is available, leave blank for all</value></data>
+  <data name="EditLabelsToolTipHide" xml:space="preserve"><value>If checked, modules with this label will be hidden from standard filters</value></data>
+  <data name="EditLabelsToolTipNotifyOnChanges" xml:space="preserve"><value>If checked, a notification will be displayed if this module changes from incompatible to compatible</value></data>
+  <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>If checked, a module that changes from incompatible to compatible will be removed from this label</value></data>
+  <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>If checked, the change set screen will alert you if this mod is about to be installed</value></data>
+  <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>If checked, modules will be removed from this label if they are installed</value></data>
 </root>

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -118,7 +118,7 @@ namespace Tests.GUI
                 .ToList();
 
             // varargs method signature means we must call .ToArray()
-            _listGui.Rows.AddRange(_modList.ConstructModList(modules, _manager.CurrentInstance.Name).ToArray());
+            _listGui.Rows.AddRange(_modList.ConstructModList(modules, null).ToArray());
             // the header row adds one to the count
             Assert.AreEqual(modules.Count + 1, _listGui.Rows.Count);
 

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -118,7 +118,7 @@ namespace Tests.GUI
                 .ToList();
 
             // varargs method signature means we must call .ToArray()
-            _listGui.Rows.AddRange(_modList.ConstructModList(modules).ToArray());
+            _listGui.Rows.AddRange(_modList.ConstructModList(modules, _manager.CurrentInstance.Name).ToArray());
             // the header row adds one to the count
             Assert.AreEqual(modules.Count + 1, _listGui.Rows.Count);
 

--- a/Tests/GUI/MainModList.cs
+++ b/Tests/GUI/MainModList.cs
@@ -69,7 +69,10 @@ namespace Tests.GUI
                 var registry = Registry.Empty();
                 registry.AddAvailable(ckan_mod);
                 var item = new MainModList(delegate { }, null);
-                Assert.That(item.IsVisible(new GUIMod(ckan_mod, registry, manager.CurrentInstance.VersionCriteria())));
+                Assert.That(item.IsVisible(
+                    new GUIMod(ckan_mod, registry, manager.CurrentInstance.VersionCriteria()),
+                    manager.CurrentInstance.Name
+                ));
 
                 manager.Dispose();
             }
@@ -102,11 +105,14 @@ namespace Tests.GUI
                 registry.AddAvailable(TestData.FireSpitterModule());
                 registry.AddAvailable(TestData.kOS_014_module());
                 var main_mod_list = new MainModList(null, null);
-                var mod_list = main_mod_list.ConstructModList(new List<GUIMod>
-                {
-                    new GUIMod(TestData.FireSpitterModule(), registry, manager.CurrentInstance.VersionCriteria()),
-                    new GUIMod(TestData.kOS_014_module(), registry, manager.CurrentInstance.VersionCriteria())
-                });
+                var mod_list = main_mod_list.ConstructModList(
+                    new List<GUIMod>
+                    {
+                        new GUIMod(TestData.FireSpitterModule(), registry, manager.CurrentInstance.VersionCriteria()),
+                        new GUIMod(TestData.kOS_014_module(), registry, manager.CurrentInstance.VersionCriteria())
+                    },
+                    manager.CurrentInstance.Name
+                );
                 Assert.That(mod_list, Has.Count.EqualTo(2));
 
                 manager.Dispose();


### PR DESCRIPTION
## Motivation

A longstanding common request is to provide additional tools for organizing and managing mods. Some of the use cases from various issue descriptions:

- we may have to remove some mods from our list due to their incompatibilities, but we don't want to forget about it or would like to get and alert when they're updated
- for checking about release new version
- keep tabs on a mod that hasn't been updated yet

- a particular mod that we really want to try out, but just don't feel ready yet for all of their complications, settings, or learning curves
- for look into it later
- for testing in the future
- for keep in list nearby

- single out mods they use for particular playstyles

- mods that I ended up preferring not to have installed
- avoid reevaluating a mod they've already rejected

In short, the request is for a way to associate modules with an arbitrary number of user-defined groups with various configurable side effects.

## Changes

Now the mod list right click has a new Labels submenu at the top:

![image](https://user-images.githubusercontent.com/1559108/69772232-fd21d780-1154-11ea-93e8-ba394163a5d5.png)

The options above the separator are checkbox toggles. If you click one of them, a checkbox appears to indicate membership in the label:

![image](https://user-images.githubusercontent.com/1559108/69772537-d0ba8b00-1155-11ea-8d7a-01ab9f79d216.png)

Each label can have various additional optional properties (and the two default labels can be edited or deleted). If you click Edit labels..., a popup will appear:

![image](https://user-images.githubusercontent.com/1559108/69772299-26dafe80-1155-11ea-9fff-b9bc1ae65bad.png)

Editing controls appear if you click a label name or the Create button, allowing you to define and customize labels that can be applied to groups of modules:

![image](https://user-images.githubusercontent.com/1559108/69772330-3a866500-1155-11ea-8fc5-51dcd67cd9e4.png)

Option | Functionality
 --- | --- 
Background | Background color for rows of modules in this label
Instance | If this is populated, then this label is only available in the selected instance, otherwise it's available everywhere
Hide from other filters | If checked, this label will behave as a "hide" feature, removing its member modules from standard filters
Notify on updates | If checked, the user will receive a visual alert when modules from this label become compatible
Remove on updates | If checked, modules in this label will be removed automatically when they become compatible
Alert on install | If checked, then attempting to install a module in this label will generate a special red warning in the changeset: ![image](https://user-images.githubusercontent.com/1559108/69773072-6d315d00-1157-11ea-8ab9-999f693d0946.png)
Remove on install | If checked, then installing a module will automatically remove it from this label

Each label so defined will appear at the bottom of the filter dropdown as if it was a normal filter:

![image](https://user-images.githubusercontent.com/1559108/69772690-46bef200-1156-11ea-94a7-49f909b083e0.png)

You can click them to view the mods in the associated label:

![image](https://user-images.githubusercontent.com/1559108/69772752-68b87480-1156-11ea-94c6-6b4671e65e7b.png)

With this functionality, if a user finds a module they never wish to see again, they can right click it and select Labels > Hidden, and it will disappear. If they ever want it back, they can visit the Hidden filter and right click to toggle it again. If they want to make sure it isn't installed even as a dependency, they can edit the Hidden label and enable Alert on install.

If a user needs to uninstall a module because they have updated to a game version with which it is not compatible, they can right click it and select Labels > Favorites, and then uninstall without fear of forgetting it. If they edit the Favorites label and enable Notify on updates, then they will be notified when this module becomes compatible again.

UK, US, and German translations are provided, but the German one is from Google Translate and needs review by a fluent speaker. ~~(I think I missed a few strings, will be looking for them shortly.)~~

### Storage

All of the data associated with this functionality—label names, colors, module list, etc.—is stored in `~/.local/share/CKAN/labels.json` or the equivalent path for each OS. I thought it was better to avoid mixing it with the registry or the settings, and the data here will be pretty small even for heavy users. And this way it will be easy for users to copy/transfer their labels.

Fixes #1021.
Fixes #1022.
Fixes #1677.
Fixes #1678.
Fixes #1902.
Fixes #2082.
Fixes #2155.
Fixes #2176.
Fixes #2180 (all that's left is mod marking and AD conversion, which isn't really related).
Fixes #2901.