### PR TITLE
Obey system colors for dark theme support

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -249,6 +249,8 @@
     <Compile Include="SingleAssemblyComponentResourceManager.cs" />
     <Compile Include="SingleAssemblyResourceManager.cs" />
     <Compile Include="TabController.cs" />
+    <Compile Include="ThemedTabControl.cs" />
+    <Compile Include="ThemedListView.cs" />
     <Compile Include="URLHandlers.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="X11.cs" />

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -100,7 +100,7 @@
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.purgeContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ModInfoTabControl = new CKAN.MainModInfo();
+            this.ModInfo = new CKAN.MainModInfo();
             this.StatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.StatusInstanceLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.StatusProgress = new System.Windows.Forms.ToolStripProgressBar();
@@ -115,7 +115,7 @@
             this.ChangesetTabPage = new System.Windows.Forms.TabPage();
             this.CancelChangesButton = new System.Windows.Forms.Button();
             this.ConfirmChangesButton = new System.Windows.Forms.Button();
-            this.ChangesListView = new System.Windows.Forms.ListView();
+            this.ChangesListView = new ThemedListView();
             this.Mod = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChangeType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.Reason = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -130,7 +130,7 @@
             this.RecommendedModsContinueButton = new System.Windows.Forms.Button();
             this.RecommendedModsToggleCheckbox = new System.Windows.Forms.CheckBox();
             this.RecommendedDialogLabel = new System.Windows.Forms.Label();
-            this.RecommendedModsListView = new System.Windows.Forms.ListView();
+            this.RecommendedModsListView = new ThemedListView();
             this.RecommendationsGroup = new System.Windows.Forms.ListViewGroup();
             this.SuggestionsGroup = new System.Windows.Forms.ListViewGroup();
             this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -139,7 +139,7 @@
             this.ChooseProvidedModsTabPage = new System.Windows.Forms.TabPage();
             this.ChooseProvidedModsCancelButton = new System.Windows.Forms.Button();
             this.ChooseProvidedModsContinueButton = new System.Windows.Forms.Button();
-            this.ChooseProvidedModsListView = new System.Windows.Forms.ListView();
+            this.ChooseProvidedModsListView = new ThemedListView();
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChooseProvidedModsLabel = new System.Windows.Forms.Label();
@@ -350,6 +350,8 @@
             //
             // statusStrip1
             //
+            this.statusStrip1.BackColor = System.Drawing.SystemColors.Control;
+            this.statusStrip1.ForeColor = System.Drawing.SystemColors.ControlText;
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Location = new System.Drawing.Point(0, 1016);
             this.statusStrip1.Size = new System.Drawing.Size(1544, 22);
@@ -563,7 +565,7 @@
             //
             // splitContainer1.Panel2
             //
-            this.splitContainer1.Panel2.Controls.Add(this.ModInfoTabControl);
+            this.splitContainer1.Panel2.Controls.Add(this.ModInfo);
             this.splitContainer1.Panel2MinSize = 300;
             this.splitContainer1.Size = new System.Drawing.Size(1544, 981);
             this.splitContainer1.SplitterDistance = 1156;
@@ -579,6 +581,8 @@
             this.ModList.AllowUserToDeleteRows = false;
             this.ModList.AllowUserToResizeRows = false;
             this.ModList.BackgroundColor = System.Drawing.SystemColors.Window;
+            this.ModList.EnableHeadersVisualStyles = false;
+            this.ModList.ColumnHeadersDefaultCellStyle.BackColor = System.Drawing.SystemColors.Control;
             this.ModList.ColumnHeadersDefaultCellStyle.ForeColor = System.Drawing.SystemColors.ControlText;
             this.ModList.DefaultCellStyle.ForeColor = System.Drawing.SystemColors.WindowText;
             this.ModList.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
@@ -783,14 +787,14 @@
             this.ModListHeaderContextMenuStrip.ShowCheckMargin = true;
             this.ModListHeaderContextMenuStrip.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(ModListHeaderContextMenuStrip_ItemClicked);
             //
-            // ModInfoTabControl
+            // ModInfo
             //
-            this.ModInfoTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ModInfoTabControl.Location = new System.Drawing.Point(0, 0);
-            this.ModInfoTabControl.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ModInfoTabControl.Name = "ModInfoTabControl";
-            this.ModInfoTabControl.Size = new System.Drawing.Size(360, 836);
-            this.ModInfoTabControl.TabIndex = 34;
+            this.ModInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ModInfo.Location = new System.Drawing.Point(0, 0);
+            this.ModInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.ModInfo.Name = "ModInfo";
+            this.ModInfo.Size = new System.Drawing.Size(360, 836);
+            this.ModInfo.TabIndex = 34;
             //
             // StatusLabel
             //
@@ -824,6 +828,7 @@
             //
             // MainTabControl
             //
+            this.MainTabControl.BackColor = System.Drawing.SystemColors.Control;
             this.MainTabControl.Controls.Add(this.ManageModsTabPage);
             this.MainTabControl.Controls.Add(this.ChangesetTabPage);
             this.MainTabControl.Controls.Add(this.WaitTabPage);
@@ -932,6 +937,7 @@
             //
             // ChangesetTabPage
             //
+            this.ChangesetTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.ChangesetTabPage.Controls.Add(this.CancelChangesButton);
             this.ChangesetTabPage.Controls.Add(this.ConfirmChangesButton);
             this.ChangesetTabPage.Controls.Add(this.ChangesListView);
@@ -941,7 +947,6 @@
             this.ChangesetTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChangesetTabPage.Size = new System.Drawing.Size(1536, 948);
             this.ChangesetTabPage.TabIndex = 13;
-            this.ChangesetTabPage.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.ChangesetTabPage, "ChangesetTabPage");
             //
             // CancelChangesButton
@@ -953,7 +958,6 @@
             this.CancelChangesButton.Name = "CancelChangesButton";
             this.CancelChangesButton.Size = new System.Drawing.Size(112, 35);
             this.CancelChangesButton.TabIndex = 16;
-            this.CancelChangesButton.UseVisualStyleBackColor = true;
             this.CancelChangesButton.Click += new System.EventHandler(this.CancelChangesButton_Click);
             resources.ApplyResources(this.CancelChangesButton, "CancelChangesButton");
             //
@@ -966,7 +970,6 @@
             this.ConfirmChangesButton.Name = "ConfirmChangesButton";
             this.ConfirmChangesButton.Size = new System.Drawing.Size(112, 35);
             this.ConfirmChangesButton.TabIndex = 15;
-            this.ConfirmChangesButton.UseVisualStyleBackColor = true;
             this.ConfirmChangesButton.Click += new System.EventHandler(this.ConfirmChangesButton_Click);
             resources.ApplyResources(this.ConfirmChangesButton, "ConfirmChangesButton");
             //
@@ -1030,7 +1033,6 @@
             this.CancelCurrentActionButton.Name = "CancelCurrentActionButton";
             this.CancelCurrentActionButton.Size = new System.Drawing.Size(112, 35);
             this.CancelCurrentActionButton.TabIndex = 22;
-            this.CancelCurrentActionButton.UseVisualStyleBackColor = true;
             this.CancelCurrentActionButton.Click += new System.EventHandler(this.CancelCurrentActionButton_Click);
             resources.ApplyResources(this.CancelCurrentActionButton, "CancelCurrentActionButton");
             //
@@ -1043,7 +1045,6 @@
             this.RetryCurrentActionButton.Name = "RetryCurrentActionButton";
             this.RetryCurrentActionButton.Size = new System.Drawing.Size(112, 35);
             this.RetryCurrentActionButton.TabIndex = 21;
-            this.RetryCurrentActionButton.UseVisualStyleBackColor = true;
             this.RetryCurrentActionButton.Visible = false;
             this.RetryCurrentActionButton.Click += new System.EventHandler(this.RetryCurrentActionButton_Click);
             resources.ApplyResources(this.RetryCurrentActionButton, "RetryCurrentActionButton");
@@ -1094,6 +1095,7 @@
             //
             // ChooseRecommendedModsTabPage
             //
+            this.ChooseRecommendedModsTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.ChooseRecommendedModsTabPage.Controls.Add(this.RecommendedModsCancelButton);
             this.ChooseRecommendedModsTabPage.Controls.Add(this.RecommendedModsContinueButton);
             this.ChooseRecommendedModsTabPage.Controls.Add(this.RecommendedModsToggleCheckbox);
@@ -1105,7 +1107,6 @@
             this.ChooseRecommendedModsTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseRecommendedModsTabPage.Size = new System.Drawing.Size(1536, 948);
             this.ChooseRecommendedModsTabPage.TabIndex = 23;
-            this.ChooseRecommendedModsTabPage.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.ChooseRecommendedModsTabPage, "ChooseRecommendedModsTabPage");
             //
             // RecommendedModsCancelButton
@@ -1117,7 +1118,6 @@
             this.RecommendedModsCancelButton.Name = "RecommendedModsCancelButton";
             this.RecommendedModsCancelButton.Size = new System.Drawing.Size(112, 35);
             this.RecommendedModsCancelButton.TabIndex = 27;
-            this.RecommendedModsCancelButton.UseVisualStyleBackColor = true;
             this.RecommendedModsCancelButton.Click += new System.EventHandler(this.RecommendedModsCancelButton_Click);
             resources.ApplyResources(this.RecommendedModsCancelButton, "RecommendedModsCancelButton");
             //
@@ -1130,7 +1130,6 @@
             this.RecommendedModsContinueButton.Name = "RecommendedModsContinueButton";
             this.RecommendedModsContinueButton.Size = new System.Drawing.Size(112, 35);
             this.RecommendedModsContinueButton.TabIndex = 26;
-            this.RecommendedModsContinueButton.UseVisualStyleBackColor = true;
             this.RecommendedModsContinueButton.Click += new System.EventHandler(this.RecommendedModsContinueButton_Click);
             resources.ApplyResources(this.RecommendedModsContinueButton, "RecommendedModsContinueButton");
             //
@@ -1144,7 +1143,6 @@
             this.RecommendedModsToggleCheckbox.Name = "RecommendedModsToggleCheckbox";
             this.RecommendedModsToggleCheckbox.Size = new System.Drawing.Size(131, 24);
             this.RecommendedModsToggleCheckbox.TabIndex = 28;
-            this.RecommendedModsToggleCheckbox.UseVisualStyleBackColor = true;
             this.RecommendedModsToggleCheckbox.CheckedChanged += new System.EventHandler(this.RecommendedModsToggleCheckbox_CheckedChanged);
             resources.ApplyResources(this.RecommendedModsToggleCheckbox, "RecommendedModsToggleCheckbox");
             //
@@ -1210,6 +1208,7 @@
             //
             // ChooseProvidedModsTabPage
             //
+            this.ChooseProvidedModsTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.ChooseProvidedModsTabPage.Controls.Add(this.ChooseProvidedModsCancelButton);
             this.ChooseProvidedModsTabPage.Controls.Add(this.ChooseProvidedModsContinueButton);
             this.ChooseProvidedModsTabPage.Controls.Add(this.ChooseProvidedModsListView);
@@ -1220,7 +1219,6 @@
             this.ChooseProvidedModsTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseProvidedModsTabPage.Size = new System.Drawing.Size(1536, 948);
             this.ChooseProvidedModsTabPage.TabIndex = 29;
-            this.ChooseProvidedModsTabPage.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.ChooseProvidedModsTabPage, "ChooseProvidedModsTabPage");
             //
             // ChooseProvidedModsCancelButton
@@ -1232,7 +1230,6 @@
             this.ChooseProvidedModsCancelButton.Name = "ChooseProvidedModsCancelButton";
             this.ChooseProvidedModsCancelButton.Size = new System.Drawing.Size(112, 35);
             this.ChooseProvidedModsCancelButton.TabIndex = 33;
-            this.ChooseProvidedModsCancelButton.UseVisualStyleBackColor = true;
             this.ChooseProvidedModsCancelButton.Click += new System.EventHandler(this.ChooseProvidedModsCancelButton_Click);
             resources.ApplyResources(this.ChooseProvidedModsCancelButton, "ChooseProvidedModsCancelButton");
             //
@@ -1245,7 +1242,6 @@
             this.ChooseProvidedModsContinueButton.Name = "ChooseProvidedModsContinueButton";
             this.ChooseProvidedModsContinueButton.Size = new System.Drawing.Size(112, 35);
             this.ChooseProvidedModsContinueButton.TabIndex = 32;
-            this.ChooseProvidedModsContinueButton.UseVisualStyleBackColor = true;
             this.ChooseProvidedModsContinueButton.Click += new System.EventHandler(this.ChooseProvidedModsContinueButton_Click);
             resources.ApplyResources(this.ChooseProvidedModsContinueButton, "ChooseProvidedModsContinueButton");
             //
@@ -1508,7 +1504,7 @@
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem purgeContentsToolStripMenuItem;
-        private CKAN.MainModInfo ModInfoTabControl;
+        private CKAN.MainModInfo ModInfo;
         private System.Windows.Forms.ToolStripStatusLabel StatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel StatusInstanceLabel;
         private System.Windows.Forms.ToolStripProgressBar StatusProgress;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -196,7 +196,7 @@ namespace CKAN
             InitializeComponent();
 
             // React when the user clicks a tag or filter link in mod info
-            ModInfoTabControl.OnChangeFilter += Filter;
+            ModInfo.OnChangeFilter += Filter;
 
             // Replace mono's broken, ugly toolstrip renderer
             if (Platform.IsMono)
@@ -334,7 +334,7 @@ namespace CKAN
                 // SplitContainer is mis-designed to throw exceptions
                 // if the min/max limits are exceeded rather than simply obeying them.
             }
-            ModInfoTabControl.ModMetaSplitPosition = configuration.ModInfoPosition;
+            ModInfo.ModMetaSplitPosition = configuration.ModInfoPosition;
 
             base.OnShown(e);
         }
@@ -539,7 +539,7 @@ namespace CKAN
             configuration.PanelPosition = splitContainer1.SplitterDistance;
 
             // Copy metadata panel split height to app settings
-            configuration.ModInfoPosition = ModInfoTabControl.ModMetaSplitPosition;
+            configuration.ModInfoPosition = ModInfo.ModMetaSplitPosition;
 
             // Save the active filter
             configuration.ActiveFilter = (int)mainModList.ModFilter;
@@ -676,7 +676,7 @@ namespace CKAN
 
         public void UpdateModContentsTree(CkanModule module, bool force = false)
         {
-            ModInfoTabControl.UpdateModContentsTree(module, force);
+            ModInfo.UpdateModContentsTree(module, force);
         }
 
         private void ApplyToolButton_Click(object sender, EventArgs e)
@@ -792,7 +792,7 @@ namespace CKAN
             catch (TooManyModsProvideKraken)
             {
                 // Can be thrown by ComputeChangeSetFromModList if the user cancels out of it.
-                // We can just rerun it as the ModInfoTabControl has been removed.
+                // We can just rerun it as the ModInfo has been removed.
                 too_many_provides_thrown = true;
             }
             catch (DependencyNotSatisfiedKraken k)
@@ -1242,7 +1242,7 @@ namespace CKAN
                     {
                         splitContainer1.Panel2Collapsed = false;
                     }
-                    ModInfoTabControl.SelectedModule = value;
+                    ModInfo.SelectedModule = value;
                 }
             }
         }
@@ -1329,7 +1329,7 @@ namespace CKAN
 
         private void reinstallToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            GUIMod module = ModInfoTabControl.SelectedModule;
+            GUIMod module = ModInfo.SelectedModule;
             if (module == null || !module.IsCKAN)
                 return;
 
@@ -1371,23 +1371,23 @@ namespace CKAN
 
         private void downloadContentsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            ModInfoTabControl.StartDownload(ModInfoTabControl.SelectedModule);
+            ModInfo.StartDownload(ModInfo.SelectedModule);
         }
 
         private void purgeContentsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // Purge other versions as well since the user is likely to want that
             // and has no other way to achieve it
-            if (ModInfoTabControl.SelectedModule != null)
+            if (ModInfo.SelectedModule != null)
             {
                 IRegistryQuerier registry = RegistryManager.Instance(CurrentInstance).registry;
-                var allAvail = registry.AllAvailable(ModInfoTabControl.SelectedModule.Identifier);
+                var allAvail = registry.AllAvailable(ModInfo.SelectedModule.Identifier);
                 foreach (CkanModule mod in allAvail)
                 {
                     Manager.Cache.Purge(mod);
                 }
-                ModInfoTabControl.SelectedModule.UpdateIsCached();
-                UpdateModContentsTree(ModInfoTabControl.SelectedModule.ToCkanModule(), true);
+                ModInfo.SelectedModule.UpdateIsCached();
+                UpdateModContentsTree(ModInfo.SelectedModule.ToCkanModule(), true);
             }
         }
 

--- a/GUI/MainAllModVersions.Designer.cs
+++ b/GUI/MainAllModVersions.Designer.cs
@@ -37,7 +37,7 @@
             this.label1 = new System.Windows.Forms.Label();
             this.ModVersion = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.CompatibleKSPVersion = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.VersionsListView = new System.Windows.Forms.ListView();
+            this.VersionsListView = new ThemedListView();
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();

--- a/GUI/MainModInfo.Designer.cs
+++ b/GUI/MainModInfo.Designer.cs
@@ -30,7 +30,7 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(MainModInfo));
-            this.ModInfoTabControl = new System.Windows.Forms.TabControl();
+            this.ModInfoTabControl = new ThemedTabControl();
             this.MetadataTabPage = new System.Windows.Forms.TabPage();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.MetaDataUpperLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
@@ -93,6 +93,7 @@
             // ModInfoTabControl
             //
             this.ModInfoTabControl.Appearance = System.Windows.Forms.TabAppearance.Normal;
+            this.ModInfoTabControl.BackColor = System.Drawing.SystemColors.Control;
             this.ModInfoTabControl.Multiline = true;
             this.ModInfoTabControl.Controls.Add(this.MetadataTabPage);
             this.ModInfoTabControl.Controls.Add(this.RelationshipTabPage);
@@ -107,13 +108,13 @@
             //
             // MetadataTabPage
             //
+            this.MetadataTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.MetadataTabPage.Controls.Add(this.MetaDataLowerLayoutPanel);
             this.MetadataTabPage.Location = new System.Drawing.Point(4, 25);
             this.MetadataTabPage.Name = "MetadataTabPage";
             this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(3);
             this.MetadataTabPage.Size = new System.Drawing.Size(354, 502);
             this.MetadataTabPage.TabIndex = 0;
-            this.MetadataTabPage.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.MetadataTabPage, "MetadataTabPage");
             //
             // splitContainer2
@@ -471,6 +472,7 @@
             //
             // RelationshipTabPage
             //
+            this.RelationshipTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.RelationshipTabPage.Controls.Add(this.DependsGraphTree);
             this.RelationshipTabPage.Controls.Add(this.LegendDependsImage);
             this.RelationshipTabPage.Controls.Add(this.LegendRecommendsImage);
@@ -487,7 +489,6 @@
             this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(3);
             this.RelationshipTabPage.Size = new System.Drawing.Size(354, 502);
             this.RelationshipTabPage.TabIndex = 1;
-            this.RelationshipTabPage.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.RelationshipTabPage, "RelationshipTabPage");
             //
             // DependsGraphTree
@@ -586,6 +587,7 @@
             //
             // ContentTabPage
             //
+            this.ContentTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.ContentTabPage.Controls.Add(this.ContentsPreviewTree);
             this.ContentTabPage.Controls.Add(this.ContentsDownloadButton);
             this.ContentTabPage.Controls.Add(this.ContentsOpenButton);
@@ -595,7 +597,6 @@
             this.ContentTabPage.Padding = new System.Windows.Forms.Padding(3);
             this.ContentTabPage.Size = new System.Drawing.Size(354, 502);
             this.ContentTabPage.TabIndex = 2;
-            this.ContentTabPage.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.ContentTabPage, "ContentTabPage");
             //
             // ContentsPreviewTree
@@ -604,6 +605,9 @@
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ContentsPreviewTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.ContentsPreviewTree.ShowPlusMinus = false;
+            this.ContentsPreviewTree.ShowRootLines = false;
+            this.ContentsPreviewTree.Indent = 12;
             this.ContentsPreviewTree.Enabled = false;
             this.ContentsPreviewTree.Location = new System.Drawing.Point(6, 65);
             this.ContentsPreviewTree.Name = "ContentsPreviewTree";
@@ -644,13 +648,13 @@
             //
             // AllModVersionsTabPage
             //
+            this.AllModVersionsTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.AllModVersionsTabPage.Controls.Add(this.AllModVersions);
             this.AllModVersionsTabPage.Location = new System.Drawing.Point(4, 25);
             this.AllModVersionsTabPage.Margin = new System.Windows.Forms.Padding(2);
             this.AllModVersionsTabPage.Name = "AllModVersionsTabPage";
             this.AllModVersionsTabPage.Size = new System.Drawing.Size(354, 502);
             this.AllModVersionsTabPage.TabIndex = 1;
-            this.AllModVersionsTabPage.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.AllModVersionsTabPage, "AllModVersionsTabPage");
             //
             // AllModVersions

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -294,6 +294,8 @@ namespace CKAN
             CkanModule module = (CkanModule)ModInfoTabControl.Tag;
 
             DependsGraphTree.BeginUpdate();
+            DependsGraphTree.BackColor = SystemColors.Window;
+            DependsGraphTree.LineColor = SystemColors.WindowText;
             DependsGraphTree.Nodes.Clear();
             IRegistryQuerier registry = RegistryManager.Instance(manager.CurrentInstance).registry;
             TreeNode root = new TreeNode($"{module.name} {module.version}", 0, 0)
@@ -408,7 +410,7 @@ namespace CKAN
             {
                 Name        = identifier,
                 ToolTipText = relationship.ToString(),
-                ForeColor   = Color.Gray
+                ForeColor   = SystemColors.GrayText,
             };
         }
 
@@ -422,7 +424,7 @@ namespace CKAN
                 Name        = module.identifier,
                 ToolTipText = relationship.ToString(),
                 Tag         = module,
-                ForeColor   = compatible ? Color.Empty : Color.Red
+                ForeColor   = compatible ? SystemColors.WindowText : Color.Red,
             };
         }
 
@@ -486,6 +488,8 @@ namespace CKAN
 
         private void _UpdateModContentsTree(bool force = false)
         {
+            ContentsPreviewTree.BackColor = SystemColors.Window;
+            ContentsPreviewTree.LineColor = SystemColors.WindowText;
             GUIMod guiMod = SelectedModule;
             if (!guiMod.IsCKAN)
             {

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -331,7 +331,7 @@ namespace CKAN
         {
             // Skip if already disposed (i.e. after the form has been closed).
             // Needed for TransparentTextBoxes
-            if (ModInfoTabControl.IsDisposed)
+            if (ModInfo.IsDisposed)
             {
                 return;
             }

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -132,6 +132,7 @@ namespace CKAN
                 tabController.RenameTab("ChooseRecommendedModsTabPage", Properties.Resources.MainRecommendationsTitle);
 
                 RecommendedModsListView.Items.Clear();
+                ChooseRecommendedModsTabPage.BackColor = System.Drawing.SystemColors.Control;
                 RecommendedModsListView.Items.AddRange(rows.ToArray());
             });
 

--- a/GUI/MainTabControl.cs
+++ b/GUI/MainTabControl.cs
@@ -3,7 +3,7 @@ using System.Windows.Forms;
 
 namespace CKAN
 {
-    public class MainTabControl : TabControl
+    public class MainTabControl : ThemedTabControl
     {
         public MainTabControl() : base() { }
 

--- a/GUI/ManageKspInstances.Designer.cs
+++ b/GUI/ManageKspInstances.Designer.cs
@@ -34,7 +34,7 @@
             "dsadsa",
             "",
             ""}, -1);
-            this.KSPInstancesListView = new System.Windows.Forms.ListView();
+            this.KSPInstancesListView = new ThemedListView();
             this.KSPInstallName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.KSPInstallVersion = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.KSPInstallPath = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));

--- a/GUI/SettingsDialog.Designer.cs
+++ b/GUI/SettingsDialog.Designer.cs
@@ -117,7 +117,6 @@
             this.NewRepoButton.Name = "NewRepoButton";
             this.NewRepoButton.Size = new System.Drawing.Size(56, 23);
             this.NewRepoButton.TabIndex = 1;
-            this.NewRepoButton.UseVisualStyleBackColor = true;
             this.NewRepoButton.Click += new System.EventHandler(this.NewRepoButton_Click);
             resources.ApplyResources(this.NewRepoButton, "NewRepoButton");
             //
@@ -129,7 +128,6 @@
             this.UpRepoButton.Name = "UpRepoButton";
             this.UpRepoButton.Size = new System.Drawing.Size(56, 23);
             this.UpRepoButton.TabIndex = 2;
-            this.UpRepoButton.UseVisualStyleBackColor = true;
             this.UpRepoButton.Click += new System.EventHandler(this.UpRepoButton_Click);
             resources.ApplyResources(this.UpRepoButton, "UpRepoButton");
             //
@@ -141,7 +139,6 @@
             this.DownRepoButton.Name = "DownRepoButton";
             this.DownRepoButton.Size = new System.Drawing.Size(56, 23);
             this.DownRepoButton.TabIndex = 3;
-            this.DownRepoButton.UseVisualStyleBackColor = true;
             this.DownRepoButton.Click += new System.EventHandler(this.DownRepoButton_Click);
             resources.ApplyResources(this.DownRepoButton, "DownRepoButton");
             //
@@ -153,7 +150,6 @@
             this.DeleteRepoButton.Name = "DeleteRepoButton";
             this.DeleteRepoButton.Size = new System.Drawing.Size(56, 23);
             this.DeleteRepoButton.TabIndex = 4;
-            this.DeleteRepoButton.UseVisualStyleBackColor = true;
             this.DeleteRepoButton.Click += new System.EventHandler(this.DeleteRepoButton_Click);
             resources.ApplyResources(this.DeleteRepoButton, "DeleteRepoButton");
             //
@@ -187,7 +183,6 @@
             this.NewAuthTokenButton.Name = "NewAuthTokenButton";
             this.NewAuthTokenButton.Size = new System.Drawing.Size(56, 23);
             this.NewAuthTokenButton.TabIndex = 1;
-            this.NewAuthTokenButton.UseVisualStyleBackColor = true;
             this.NewAuthTokenButton.Click += new System.EventHandler(this.NewAuthTokenButton_Click);
             resources.ApplyResources(this.NewAuthTokenButton, "NewAuthTokenButton");
             //
@@ -199,7 +194,6 @@
             this.DeleteAuthTokenButton.Name = "DeleteAuthTokenButton";
             this.DeleteAuthTokenButton.Size = new System.Drawing.Size(56, 23);
             this.DeleteAuthTokenButton.TabIndex = 2;
-            this.DeleteAuthTokenButton.UseVisualStyleBackColor = true;
             this.DeleteAuthTokenButton.Click += new System.EventHandler(this.DeleteAuthTokenButton_Click);
             resources.ApplyResources(this.DeleteAuthTokenButton, "DeleteAuthTokenButton");
             //
@@ -277,7 +271,6 @@
             this.ChangeCacheButton.Name = "ChangeCacheButton";
             this.ChangeCacheButton.Size = new System.Drawing.Size(75, 23);
             this.ChangeCacheButton.TabIndex = 5;
-            this.ChangeCacheButton.UseVisualStyleBackColor = true;
             this.ChangeCacheButton.Click += new System.EventHandler(this.ChangeCacheButton_Click);
             resources.ApplyResources(this.ChangeCacheButton, "ChangeCacheButton");
             //
@@ -289,7 +282,6 @@
             this.ClearCacheButton.Name = "ClearCacheButton";
             this.ClearCacheButton.Size = new System.Drawing.Size(75, 23);
             this.ClearCacheButton.TabIndex = 6;
-            this.ClearCacheButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.ClearCacheButton, "ClearCacheButton");
             //
             // ClearCacheMenu
@@ -321,7 +313,6 @@
             this.ResetCacheButton.Name = "ResetCacheButton";
             this.ResetCacheButton.Size = new System.Drawing.Size(75, 23);
             this.ResetCacheButton.TabIndex = 7;
-            this.ResetCacheButton.UseVisualStyleBackColor = true;
             this.ResetCacheButton.Click += new System.EventHandler(this.ResetCacheButton_Click);
             resources.ApplyResources(this.ResetCacheButton, "ResetCacheButton");
             //
@@ -332,7 +323,6 @@
             this.OpenCacheButton.Name = "OpenCacheButton";
             this.OpenCacheButton.Size = new System.Drawing.Size(75, 23);
             this.OpenCacheButton.TabIndex = 8;
-            this.OpenCacheButton.UseVisualStyleBackColor = true;
             this.OpenCacheButton.Click += new System.EventHandler(this.OpenCacheButton_Click);
             resources.ApplyResources(this.OpenCacheButton, "OpenCacheButton");
             //
@@ -396,7 +386,6 @@
             this.CheckUpdateOnLaunchCheckbox.Name = "CheckUpdateOnLaunchCheckbox";
             this.CheckUpdateOnLaunchCheckbox.Size = new System.Drawing.Size(195, 17);
             this.CheckUpdateOnLaunchCheckbox.TabIndex = 4;
-            this.CheckUpdateOnLaunchCheckbox.UseVisualStyleBackColor = true;
             this.CheckUpdateOnLaunchCheckbox.CheckedChanged += new System.EventHandler(this.CheckUpdateOnLaunchCheckbox_CheckedChanged);
             resources.ApplyResources(this.CheckUpdateOnLaunchCheckbox, "CheckUpdateOnLaunchCheckbox");
             //
@@ -407,7 +396,6 @@
             this.CheckForUpdatesButton.Name = "CheckForUpdatesButton";
             this.CheckForUpdatesButton.Size = new System.Drawing.Size(112, 23);
             this.CheckForUpdatesButton.TabIndex = 5;
-            this.CheckForUpdatesButton.UseVisualStyleBackColor = true;
             this.CheckForUpdatesButton.Click += new System.EventHandler(this.CheckForUpdatesButton_Click);
             resources.ApplyResources(this.CheckForUpdatesButton, "CheckForUpdatesButton");
             //
@@ -419,7 +407,6 @@
             this.InstallUpdateButton.Name = "InstallUpdateButton";
             this.InstallUpdateButton.Size = new System.Drawing.Size(112, 23);
             this.InstallUpdateButton.TabIndex = 6;
-            this.InstallUpdateButton.UseVisualStyleBackColor = true;
             this.InstallUpdateButton.Click += new System.EventHandler(this.InstallUpdateButton_Click);
             resources.ApplyResources(this.InstallUpdateButton, "InstallUpdateButton");
             //
@@ -446,7 +433,6 @@
             this.EnableTrayIconCheckBox.Name = "EnableTrayIconCheckBox";
             this.EnableTrayIconCheckBox.Size = new System.Drawing.Size(102, 17);
             this.EnableTrayIconCheckBox.TabIndex = 0;
-            this.EnableTrayIconCheckBox.UseVisualStyleBackColor = true;
             this.EnableTrayIconCheckBox.CheckedChanged += new System.EventHandler(this.EnableTrayIconCheckBox_CheckedChanged);
             resources.ApplyResources(this.EnableTrayIconCheckBox, "EnableTrayIconCheckBox");
             //
@@ -457,7 +443,6 @@
             this.MinimizeToTrayCheckBox.Name = "MinimizeToTrayCheckBox";
             this.MinimizeToTrayCheckBox.Size = new System.Drawing.Size(98, 17);
             this.MinimizeToTrayCheckBox.TabIndex = 1;
-            this.MinimizeToTrayCheckBox.UseVisualStyleBackColor = true;
             this.MinimizeToTrayCheckBox.CheckedChanged += new System.EventHandler(this.MinimizeToTrayCheckBox_CheckedChanged);
             resources.ApplyResources(this.MinimizeToTrayCheckBox, "MinimizeToTrayCheckBox");
             //
@@ -497,7 +482,6 @@
             this.PauseRefreshCheckBox.Name = "PauseRefreshCheckBox";
             this.PauseRefreshCheckBox.Size = new System.Drawing.Size(105, 17);
             this.PauseRefreshCheckBox.TabIndex = 5;
-            this.PauseRefreshCheckBox.UseVisualStyleBackColor = true;
             this.PauseRefreshCheckBox.CheckedChanged += new System.EventHandler(this.PauseRefreshCheckBox_CheckedChanged);
             resources.ApplyResources(this.PauseRefreshCheckBox, "PauseRefreshCheckBox");
             //
@@ -543,7 +527,6 @@
             this.RefreshOnStartupCheckbox.Name = "RefreshOnStartupCheckbox";
             this.RefreshOnStartupCheckbox.Size = new System.Drawing.Size(167, 17);
             this.RefreshOnStartupCheckbox.TabIndex = 1;
-            this.RefreshOnStartupCheckbox.UseVisualStyleBackColor = true;
             this.RefreshOnStartupCheckbox.CheckedChanged += new System.EventHandler(this.RefreshOnStartupCheckbox_CheckedChanged);
             resources.ApplyResources(this.RefreshOnStartupCheckbox, "RefreshOnStartupCheckbox");
             //
@@ -554,7 +537,6 @@
             this.HideEpochsCheckbox.Name = "HideEpochsCheckbox";
             this.HideEpochsCheckbox.Size = new System.Drawing.Size(261, 17);
             this.HideEpochsCheckbox.TabIndex = 2;
-            this.HideEpochsCheckbox.UseVisualStyleBackColor = true;
             this.HideEpochsCheckbox.CheckedChanged += new System.EventHandler(this.HideEpochsCheckbox_CheckedChanged);
             resources.ApplyResources(this.HideEpochsCheckbox, "HideEpochsCheckbox");
             //
@@ -565,7 +547,6 @@
             this.HideVCheckbox.Name = "HideVCheckbox";
             this.HideVCheckbox.Size = new System.Drawing.Size(204, 17);
             this.HideVCheckbox.TabIndex = 3;
-            this.HideVCheckbox.UseVisualStyleBackColor = true;
             this.HideVCheckbox.CheckedChanged += new System.EventHandler(this.HideVCheckbox_CheckedChanged);
             resources.ApplyResources(this.HideVCheckbox, "HideVCheckbox");
             //
@@ -576,7 +557,6 @@
             this.AutoSortUpdateCheckBox.Name = "AutoSortUpdateCheckBox";
             this.AutoSortUpdateCheckBox.Size = new System.Drawing.Size(393, 17);
             this.AutoSortUpdateCheckBox.TabIndex = 4;
-            this.AutoSortUpdateCheckBox.UseVisualStyleBackColor = true;
             this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
             resources.ApplyResources(this.AutoSortUpdateCheckBox, "AutoSortUpdateCheckBox");
             //

--- a/GUI/ThemedListView.cs
+++ b/GUI/ThemedListView.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A ListView that obeys system colors to look less awful in a dark theme
+    /// </summary>
+    public class ThemedListView : ListView
+    {
+        public ThemedListView() : base()
+        {
+            // Tell the base class that we want to draw things ourselves
+            OwnerDraw = true;
+        }
+
+        protected override void OnDrawColumnHeader(DrawListViewColumnHeaderEventArgs e)
+        {
+            // Background
+            e.Graphics.FillRectangle(SystemBrushes.Control, e.Bounds);
+            // Borders at the bottom and between header cells
+            Rectangle rect = e.Bounds;
+            rect.Inflate(1, 0);
+            rect.Offset(0, -1);
+            e.Graphics.DrawRectangle(SystemPens.ControlDark, rect);
+            // Text
+            e.DrawText(TextFormatFlags.VerticalCenter | TextFormatFlags.Left);
+            // Alert event subscribers
+            base.OnDrawColumnHeader(e);
+        }
+
+        protected override void OnDrawItem(DrawListViewItemEventArgs e)
+        {
+            // Tell the base class that we changed our mind, it can draw the data rows
+            e.DrawDefault = true;
+        }
+
+        protected override void OnDrawSubItem(DrawListViewSubItemEventArgs e)
+        {
+            // Tell the base class that we changed our mind, it can draw the data rows
+            e.DrawDefault = true;
+        }
+    }
+}

--- a/GUI/ThemedTabControl.cs
+++ b/GUI/ThemedTabControl.cs
@@ -19,7 +19,8 @@ namespace CKAN
         {
             // Background
             Rectangle bgRect = e.Bounds;
-            bgRect.Inflate(-2, -1);
+            bgRect.Inflate(-2, 0);
+            bgRect.Offset(0, 1);
             e.Graphics.FillRectangle(new SolidBrush(BackColor), bgRect);
             // Text
             var tabPage = TabPages[e.Index];

--- a/GUI/ThemedTabControl.cs
+++ b/GUI/ThemedTabControl.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A TabControl that obeys system colors to look less awful in a dark theme
+    /// </summary>
+    public class ThemedTabControl : TabControl
+    {
+        public ThemedTabControl() : base()
+        {
+            // Tell the base class that we want to draw things ourselves
+            DrawMode = TabDrawMode.OwnerDrawFixed;
+        }
+
+        protected override void OnDrawItem(DrawItemEventArgs e)
+        {
+            // Background
+            e.Graphics.FillRectangle(new SolidBrush(BackColor), e.Bounds);
+            // Text
+            var tabPage = TabPages[e.Index];
+            Rectangle rect = e.Bounds;
+            rect.Offset(1, 1);
+            TextRenderer.DrawText(e.Graphics, tabPage.Text, tabPage.Font,
+                rect, tabPage.ForeColor);
+            // Alert event subscribers
+            base.OnDrawItem(e);
+        }
+    }
+}

--- a/GUI/ThemedTabControl.cs
+++ b/GUI/ThemedTabControl.cs
@@ -18,11 +18,12 @@ namespace CKAN
         protected override void OnDrawItem(DrawItemEventArgs e)
         {
             // Background
-            e.Graphics.FillRectangle(new SolidBrush(BackColor), e.Bounds);
+            Rectangle bgRect = e.Bounds;
+            bgRect.Inflate(-2, -1);
+            e.Graphics.FillRectangle(new SolidBrush(BackColor), bgRect);
             // Text
             var tabPage = TabPages[e.Index];
             Rectangle rect = e.Bounds;
-            rect.Offset(1, 1);
             TextRenderer.DrawText(e.Graphics, tabPage.Text, tabPage.Font,
                 rect, tabPage.ForeColor);
             // Alert event subscribers


### PR DESCRIPTION
## Problem

You can configure the legacy system colors on Windows to change how WinForms apps display. In Windows 7:

1. Right click desktop
2. Personalize
3. Window Color (in the bottom middle)
4. Advanced appearance settings...
5. Choose the colors that you want to use

CKAN doesn't look very good in this mode:

![bad](https://user-images.githubusercontent.com/1559108/69890422-794f2300-12ed-11ea-8e43-3d97a8a1ba24.png)

Note that it looks OK if you choose one of the more extreme "high contrast" themes, but these also change your window borders and everything else, so it's not a great solution:

![high contrast](https://user-images.githubusercontent.com/1559108/69889600-c7622780-12e9-11ea-8eb0-8ed6d0a09372.png)

## Causes

- A number of the WinForms controls default to a hard coded style instead of obeying the system theme
- The status bar needed its BackColor/ForeColor properties set

## Changes

- The mod list has visual styles turned off and its header color set to obey the system colors
- `ThemedListView` and `ThemedTabControl` classes are created as drop-in replacements for `ListView` and `TabControl` but tweaked to obey system colors
- The status bar's BackColor and ForeColor are set

This makes dark themes on Windows look better:

![better](https://user-images.githubusercontent.com/1559108/69895028-80435900-1320-11ea-968d-f02b62538d9d.png)

It also results in a minor degradation of appearance in a normal theme because the gradients for inactive tabs and list headers are suppressed:

![light](https://user-images.githubusercontent.com/1559108/69895045-b7196f00-1320-11ea-801b-b1b8916a2475.png)

Needs to be tested on Linux. I think it should look the same, but there could be surprises.

Fixes #2881.