### PR TITLE
Better parsing errors for version files

### DIFF
--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -164,7 +164,18 @@ namespace CKAN.NetKAN.Services
                 var json = stream.ReadToEnd();
 
                 Log.DebugFormat("Parsing {0}", json);
-                return JsonConvert.DeserializeObject<AvcVersion>(json);
+                try
+                {
+                    return JsonConvert.DeserializeObject<AvcVersion>(json);
+                }
+                catch (JsonException exc)
+                {
+                    throw new Kraken(string.Format(
+                        "Error parsing version file {0}: {1}",
+                        files[remoteIndex].Name,
+                        exc.Message
+                    ));
+                }
             }
         }
     }


### PR DESCRIPTION
## Motivation

If a module has a syntax error in its version file, the error in netkan looks like this:

> 2074 [1] FATAL CKAN.NetKAN.Program (null) - After parsing a value an unexpected character was encountered: ". Path 'KSP_VERSION_MAX', line 37, position 4.

It requires some guessing and/or experience to figure out that this is talking about trying to parse the version file.

## Changes

Now we catch that exception and throw a new more descriptive Kraken that explains that it was parsing a version file and gives its path:

> 2046 [1] FATAL CKAN.NetKAN.Program (null) - Error parsing version file GameData/Severedsolo/OhScrap/OhScrap.version: After parsing a value an unexpected character was encountered: ". Path 'KSP_VERSION_MAX', line 37, position 4.

This should help netkan users to investigate errors, and makes it easier to tell different parsing errors apart.