### PR TITLE
Retain URL hash cache, cache file hashes

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1216,7 +1216,7 @@ namespace CKAN
                 int percent = i * 100 / files.Count;
                 user.RaiseProgress($"Importing {f.Name}... ({percent}%)", percent);
                 // Calc SHA-1 sum
-                string sha1 = NetModuleCache.GetFileHashSha1(f.FullName);
+                string sha1 = Cache.GetFileHashSha1(f.FullName);
                 // Find SHA-1 sum in registry (potentially multiple)
                 if (index.ContainsKey(sha1))
                 {

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -502,9 +502,9 @@ namespace CKAN
             }
 
             // We've changed our cache, so signal that immediately.
-            if (!cachedFiles.ContainsKey(hash))
+            if (!cachedFiles?.ContainsKey(hash) ?? false)
             {
-                cachedFiles.Add(hash, targetPath);
+                cachedFiles?.Add(hash, targetPath);
             }
 
             return targetPath;
@@ -526,7 +526,7 @@ namespace CKAN
                 tx_file.Delete(file);
 
                 // We've changed our cache, so signal that immediately.
-                cachedFiles.Remove(CreateURLHash(url));
+                cachedFiles?.Remove(CreateURLHash(url));
                 sha1Cache.Remove(file);
                 sha256Cache.Remove(file);
 

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -86,14 +86,9 @@ namespace CKAN
         /// <returns>
         /// SHA1 hash, in all-caps hexadecimal format
         /// </returns>
-        public static string GetFileHashSha1(string filePath)
+        public string GetFileHashSha1(string filePath)
         {
-            using (FileStream     fs   = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-            using (BufferedStream bs   = new BufferedStream(fs))
-            using (SHA1           sha1 = new SHA1CryptoServiceProvider())
-            {
-                return BitConverter.ToString(sha1.ComputeHash(bs)).Replace("-", "");
-            }
+            return cache.GetFileHashSha1(filePath);
         }
 
         /// <summary>
@@ -103,14 +98,9 @@ namespace CKAN
         /// <returns>
         /// SHA256 hash, in all-caps hexadecimal format
         /// </returns>
-        public static string GetFileHashSha256(string filePath)
+        public string GetFileHashSha256(string filePath)
         {
-            using (FileStream     fs     = new FileStream(@filePath, FileMode.Open, FileAccess.Read))
-            using (BufferedStream bs     = new BufferedStream(fs))
-            using (SHA256Managed  sha256 = new SHA256Managed())
-            {
-                return BitConverter.ToString(sha256.ComputeHash(bs)).Replace("-", "");
-            }
+            return cache.GetFileHashSha256(filePath);
         }
 
         /// <summary>

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -25,7 +25,7 @@ namespace CKAN.NetKAN.Processors
             );
 
             IModuleService moduleService = new ModuleService();
-            IFileService   fileService   = new FileService();
+            IFileService   fileService   = new FileService(cache);
             http          = new CachingHttpService(cache, overwriteCache);
             ckanValidator = new CkanValidator(http, moduleService);
             transformer   = new NetkanTransformer(http, fileService, moduleService, githubToken, prerelease);

--- a/Netkan/Services/FileService.cs
+++ b/Netkan/Services/FileService.cs
@@ -4,6 +4,11 @@ namespace CKAN.NetKAN.Services
 {
     internal sealed class FileService : IFileService
     {
+        public FileService(NetFileCache cache)
+        {
+            this.cache = cache;
+        }
+
         public long GetSizeBytes(string filePath)
         {
             return new FileInfo(filePath).Length;
@@ -13,14 +18,14 @@ namespace CKAN.NetKAN.Services
         {
             // Use shared implementation from Core.
             // Also needs to be an instance method so it can be Moq'd for testing.
-            return NetModuleCache.GetFileHashSha1(filePath);
+            return cache.GetFileHashSha1(filePath);
         }
 
         public string GetFileHashSha256(string filePath)
         {
             // Use shared implementation from Core.
             // Also needs to be an instance method so it can be Moq'd for testing.
-            return NetModuleCache.GetFileHashSha256(filePath);
+            return cache.GetFileHashSha256(filePath);
         }
 
         public string GetMimetype(string filePath)
@@ -51,5 +56,7 @@ namespace CKAN.NetKAN.Services
 
             return mimetype;
         }
+
+        private NetFileCache cache;
     }
 }

--- a/Netkan/Transformers/DownloadAttributeTransformer.cs
+++ b/Netkan/Transformers/DownloadAttributeTransformer.cs
@@ -39,14 +39,18 @@ namespace CKAN.NetKAN.Transformers
 
                 if (file != null)
                 {
+                    Log.Debug("Calculating download size...");
                     json["download_size"] = _fileService.GetSizeBytes(file);
 
                     json["download_hash"] = new JObject();
 
                     var download_hashJson = (JObject)json["download_hash"];
+                    Log.Debug("Calculating download SHA1...");
                     download_hashJson.SafeAdd("sha1", _fileService.GetFileHashSha1(file));
+                    Log.Debug("Calculating download SHA256...");
                     download_hashJson.SafeAdd("sha256", _fileService.GetFileHashSha256(file));
 
+                    Log.Debug("Calculating download MIME type...");
                     json["download_content_type"] = _fileService.GetMimetype(file);
                 }
 

--- a/Tests/NetKAN/Services/FileServiceTests.cs
+++ b/Tests/NetKAN/Services/FileServiceTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using CKAN;
 using CKAN.NetKAN.Services;
 using NUnit.Framework;
 using Tests.Data;
@@ -8,11 +10,23 @@ namespace Tests.NetKAN.Services
     [TestFixture]
     public sealed class FileServiceTests
     {
+        [OneTimeSetUp]
+        public void TestFixtureSetup()
+        {
+            _cachePath = Path.Combine(
+                Path.GetTempPath(),
+                "CKAN",
+                Guid.NewGuid().ToString("N")
+            );
+            Directory.CreateDirectory(_cachePath);
+            _cache = new NetFileCache(_cachePath);
+        }
+
         [Test]
         public void GetsFileSizeCorrectly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetSizeBytes(TestData.DogeCoinFlagZip());
@@ -27,7 +41,7 @@ namespace Tests.NetKAN.Services
         public void GetsFileHashSha1Correctly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetFileHashSha1(TestData.DogeCoinFlagZip());
@@ -42,7 +56,7 @@ namespace Tests.NetKAN.Services
         public void GetsFileHashSha256Correctly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetFileHashSha256(TestData.DogeCoinFlagZip());
@@ -57,7 +71,7 @@ namespace Tests.NetKAN.Services
         public void GetsAsciiMimeCorrectly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetMimetype(TestData.DataDir("FileIdentifier/test_ascii.txt"));
@@ -72,7 +86,7 @@ namespace Tests.NetKAN.Services
         public void GetsGzipMimeCorrectly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetMimetype(TestData.DataDir("FileIdentifier/test_gzip.gz"));
@@ -87,7 +101,7 @@ namespace Tests.NetKAN.Services
         public void GetsTarMimeCorrectly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetMimetype(TestData.DataDir("FileIdentifier/test_tar.tar"));
@@ -102,7 +116,7 @@ namespace Tests.NetKAN.Services
         public void GetsTarGzMimeCorrectly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetMimetype(TestData.DataDir("FileIdentifier/test_targz.tar.gz"));
@@ -117,7 +131,7 @@ namespace Tests.NetKAN.Services
         public void GetsZipMimeCorrectly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
 
             // Act
             var result = sut.GetMimetype(TestData.DogeCoinFlagZip());
@@ -132,7 +146,7 @@ namespace Tests.NetKAN.Services
         public void GetsUnknownMimeCorrectly()
         {
             // Arrange
-            var sut = new FileService();
+            var sut = new FileService(_cache);
             string random_bin = TestData.DataDir("FileIdentifier/random.bin");
             Assert.IsTrue(File.Exists(random_bin));
 
@@ -144,5 +158,8 @@ namespace Tests.NetKAN.Services
                 "FileService should return 'application/octet-stream' for all other file types."
             );
         }
+
+        private string       _cachePath;
+        private NetFileCache _cache;
     }
 }


### PR DESCRIPTION
## Motivation

We'd like to reduce the CPU usage of the Inflator component of the infrastructure. Toward that end, we added some more debug statements and observed `netkan.exe`'s output carefully, which turned up some surprising issues...

## Background

`NetFileCache` uses a `Dictionary` to map from the URL hash (first 8 characters of the download URL's SHA1 interpreted in hexadecimal) to the file path in cache. This is intended to find cached files quickly without checking every single file. To try to protect this mapping from unexpected changes, we listen to events from `FileSystemWatcher` and clear this dictionary whenever they fire, which results in it being regenerated the next time it's needed.

The `DownloadAttributeTransformer` is in charge of populating file hashes and other properties based on the contents of each ZIP, some of which are pretty large:

```json
  "download_size": 273244617,
  "download_hash": {
    "sha1": "316E1DCA70A9544055FFA3C02EE60DB633531C0D",
    "sha256": "8D240471165D302A3ACDAFBB2278362881112AC58F0317AE04853799E20D1BD2"
  },
  "download_content_type": "application/zip",
```

The Inflator's download cache persists across passes, and in a typical pass every download is already cached. If modders have been very active, the number of new or changed downloads may approach the high single digits.

## Problems

1. `FileSystemWatcher.Changed` seems to fire even if you just **read** info about a file in the cache. In one test using my 50 GB download cache to inflate a cached module, it triggered **186499** times!! This means that the `Dictionary` mapping was almost never used more than once; it would be `null` at the start of virtually any cache access, which would force it to be regenerated, then it would be used **once**, and then it would be almost immediately wiped out again. This amounts to searching every file for every access, a waste of CPU and disk.
2. Calculating the SHA1 and SHA256 can take a long-ish time for large files, since every byte has to be read from disk and processed through both hashing algorithms. This work is not necessary if the file has not changed on disk since the last time we calculated the hash.

## Changes

0. Several new `log.Debug` statements are added to `netkan.exe` to make it easier to see what it's doing
1. Now we don't listen to `FileSystemWatcher.Changed` anymore. This will avoid repeated unnecessary purges of the file cache data, hopefully amounting to a significant savings for a long-running Inflator process. Similarly, other operations that previously cleared the cache object are now changed to merely make an appropriate small update to it, such as `Store` and `Remove`.
2. Now after we calculate an SHA1 or SHA256 for a cached file, we store it in a `Dictionary`. If we need the same hash for the same file again, we check the `Dictionary` first and use it if found, skipping the computationally expensive recalculation of the hash from the file on disk. The `Dictionary` objects are also updated or cleared anytime we perform a similar operation for the main cache data.

Overall this should result in a significant savings in the Inflator's CPU consumption.