### PR TITLE
Return failure on failed commands for headless prompt

### DIFF
--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -35,7 +35,13 @@ namespace CKAN.CmdLine
                 {
                     // Parse input as if it was a normal command line,
                     // but with a persistent KSPManager object.
-                    MainClass.Execute(manager, opts, command.Split(' '));
+                    int cmdExitCode = MainClass.Execute(manager, opts, command.Split(' '));
+                    if ((opts?.Headless ?? false) && cmdExitCode != Exit.OK)
+                    {
+                        // Pass failure codes to calling process in headless mode
+                        // (in interactive mode the user can see the error and try again)
+                        return cmdExitCode;
+                    }
                 }
             }
             return Exit.OK;


### PR DESCRIPTION
## Motivation

I want to use `ckan prompt` to speed up the PR validation scripts by combining multiple commands, see KSP-CKAN/xKAN-meta_testing#55.

## Problem

Currently if a command executed via `ckan prompt` fails, errors are printed but the process keeps running and eventually returns success at exit. This makes sense for an interactive mode where a user is reading the errors and can try again, but for what I have in mind it means that failed installations would be ignored and marked as successful.

## Changes

Now if a command fails within `ckan prompt`, and we're running in headless mode, the process will exit with the failed command's return value. This will allow it to be used in scripts that check for success or failure of operations.