### PR TITLE
Coerce GitHub URLs into the authenticated API in Netkan

### DIFF
--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -244,7 +244,7 @@ namespace CKAN
             }.DownloadAndWait(downloadTargets);
         }
 
-        public static string DownloadText(Uri url, string authToken = "")
+        public static string DownloadText(Uri url, string authToken = "", string mimeType = null)
         {
             log.DebugFormat("About to download {0}", url.OriginalString);
 
@@ -260,6 +260,11 @@ namespace CKAN
                     log.InfoFormat("Using auth token for {0}", url.Host);
                     // Send our auth token to the GitHub API (or whoever else needs one)
                     agent.Headers.Add("Authorization", $"token {authToken}");
+                }
+                if (!string.IsNullOrEmpty(mimeType))
+                {
+                    log.InfoFormat("Setting MIME type {0}", mimeType);
+                    agent.Headers.Add("Accept", mimeType);
                 }
 
                 string content = agent.DownloadString(url.OriginalString);

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -80,9 +80,9 @@ namespace CKAN.NetKAN.Services
         {
             return Net.DownloadText(url);
         }
-        public string DownloadText(Uri url, string authToken)
+        public string DownloadText(Uri url, string authToken, string mimeType = null)
         {
-            return Net.DownloadText(url, authToken);
+            return Net.DownloadText(url, authToken, mimeType);
         }
 
         public IEnumerable<Uri> RequestedURLs { get { return _requestedURLs; } }

--- a/Netkan/Services/IHttpService.cs
+++ b/Netkan/Services/IHttpService.cs
@@ -7,7 +7,7 @@ namespace CKAN.NetKAN.Services
     {
         string DownloadPackage(Uri url, string identifier, DateTime? updated);
         string DownloadText(Uri url);
-        string DownloadText(Uri url, string authToken);
+        string DownloadText(Uri url, string authToken, string mimeType);
 
         IEnumerable<Uri> RequestedURLs { get; }
         void ClearRequestedURLs();

--- a/Netkan/Sources/Github/IGithubApi.cs
+++ b/Netkan/Sources/Github/IGithubApi.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace CKAN.NetKAN.Sources.Github
@@ -8,5 +9,6 @@ namespace CKAN.NetKAN.Sources.Github
         GithubRelease GetLatestRelease(GithubRef reference);
         IEnumerable<GithubRelease> GetAllReleases(GithubRef reference);
         List<GithubUser> getOrgMembers(GithubUser organization);
+        string DownloadText(Uri url);
     }
 }

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using log4net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Sources.Avc;
 using CKAN.Versioning;
-using log4net;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using CKAN.NetKAN.Sources.Github;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -20,15 +21,17 @@ namespace CKAN.NetKAN.Transformers
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(AvcTransformer));
 
-        private readonly IHttpService _http;
+        private readonly IHttpService   _http;
         private readonly IModuleService _moduleService;
+        private readonly IGithubApi     _github;
 
         public string Name { get { return "avc"; } }
 
-        public AvcTransformer(IHttpService http, IModuleService moduleService)
+        public AvcTransformer(IHttpService http, IModuleService moduleService, IGithubApi github)
         {
-            _http = http;
+            _http          = http;
             _moduleService = moduleService;
+            _github        = github;
         }
 
         public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
@@ -67,7 +70,8 @@ namespace CKAN.NetKAN.Transformers
                     {
                         try
                         {
-                            var remoteJson = _http.DownloadText(remoteUri);
+                            var remoteJson = _github?.DownloadText(remoteUri)
+                                ?? _http.DownloadText(remoteUri);
                             var remoteAvc = JsonConvert.DeserializeObject<AvcVersion>(remoteJson);
 
                             if (avc.version.CompareTo(remoteAvc.version) == 0)

--- a/Netkan/Transformers/MetaNetkanTransformer.cs
+++ b/Netkan/Transformers/MetaNetkanTransformer.cs
@@ -6,6 +6,7 @@ using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Sources.Github;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -19,12 +20,14 @@ namespace CKAN.NetKAN.Transformers
         private const string KrefSource = "netkan";
 
         private readonly IHttpService _http;
+        private readonly IGithubApi   _github;
 
         public string Name { get { return "metanetkan"; } }
 
-        public MetaNetkanTransformer(IHttpService http)
+        public MetaNetkanTransformer(IHttpService http, IGithubApi github)
         {
-            _http = http;
+            _http   = http;
+            _github = github;
         }
 
         public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
@@ -43,7 +46,8 @@ namespace CKAN.NetKAN.Transformers
                 resourcesJson.SafeAdd("metanetkan", metadata.Kref.Id);
 
                 var uri = new Uri(metadata.Kref.Id);
-                var targetFileText = _http.DownloadText(CKAN.Net.GetRawUri(uri));
+                var targetFileText = _github?.DownloadText(uri)
+                    ?? _http.DownloadText(CKAN.Net.GetRawUri(uri));
 
                 Log.DebugFormat("Target netkan:{0}{1}", Environment.NewLine, targetFileText);
 

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -26,17 +26,18 @@ namespace CKAN.NetKAN.Transformers
             bool prerelease
         )
         {
+            var ghApi = new GithubApi(http, githubToken);
             _transformers = InjectVersionedOverrideTransformers(new List<ITransformer>
             {
-                new MetaNetkanTransformer(http),
+                new MetaNetkanTransformer(http, ghApi),
                 new SpacedockTransformer(new SpacedockApi(http)),
                 new CurseTransformer(new CurseApi(http)),
-                new GithubTransformer(new GithubApi(http, githubToken), prerelease),
+                new GithubTransformer(ghApi, prerelease),
                 new HttpTransformer(),
                 new JenkinsTransformer(new JenkinsApi(http)),
-                new AvcKrefTransformer(http),
+                new AvcKrefTransformer(http, ghApi),
                 new InternalCkanTransformer(http, moduleService),
-                new AvcTransformer(http, moduleService),
+                new AvcTransformer(http, moduleService, ghApi),
                 new LocalizationsTransformer(http, moduleService),
                 new VersionEditTransformer(),
                 new ForcedVTransformer(),

--- a/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
@@ -67,7 +67,7 @@ namespace Tests.NetKAN.Transformers
             }
 
             // Act
-            var tran = new AvcKrefTransformer(http);
+            var tran = new AvcKrefTransformer(http, null);
             return tran.Transform(new Metadata(json), opts).First();
         }
 

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -32,7 +32,7 @@ namespace Tests.NetKAN.Transformers
             mModuleService.Setup(i => i.GetInternalAvc(It.IsAny<CkanModule>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(avcVersion);
 
-            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object);
+            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -70,7 +70,7 @@ namespace Tests.NetKAN.Transformers
             mModuleService.Setup(i => i.GetInternalAvc(It.IsAny<CkanModule>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(avcVersion);
 
-            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object);
+            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -208,7 +208,7 @@ namespace Tests.NetKAN.Transformers
             mModuleService.Setup(i => i.GetInternalAvc(It.IsAny<CkanModule>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(avcVersion);
 
-            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object);
+            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
 
             // Act
             var result = sut.Transform(new Metadata(json), opts).First();
@@ -240,7 +240,7 @@ namespace Tests.NetKAN.Transformers
             mModuleService.Setup(i => i.GetInternalAvc(It.IsAny<CkanModule>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(avcVersion);
 
-            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object);
+            var sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -271,7 +271,7 @@ namespace Tests.NetKAN.Transformers
                     version = new ModuleVersion("1.2.3")
                 });
 
-            ITransformer sut = new AvcTransformer(mHttp.Object, mModuleService.Object);
+            ITransformer sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
 
             JObject json = new JObject();
             json["spec_version"]                = 1;

--- a/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
@@ -21,7 +21,7 @@ namespace Tests.NetKAN.Transformers
             // Arrange
             var mHttp = new Mock<IHttpService>();
 
-            var sut = new MetaNetkanTransformer(mHttp.Object);
+            var sut = new MetaNetkanTransformer(mHttp.Object, null);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -50,7 +50,7 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadText(It.IsAny<Uri>()))
                 .Returns(targetJson.ToString());
 
-            var sut = new MetaNetkanTransformer(mHttp.Object);
+            var sut = new MetaNetkanTransformer(mHttp.Object, null);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -78,7 +78,7 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadText(It.IsAny<Uri>()))
                 .Returns(targetJson.ToString());
 
-            var sut = new MetaNetkanTransformer(mHttp.Object);
+            var sut = new MetaNetkanTransformer(mHttp.Object, null);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -107,7 +107,7 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadText(It.IsAny<Uri>()))
                 .Returns(targetJson.ToString());
 
-            var sut = new MetaNetkanTransformer(mHttp.Object);
+            var sut = new MetaNetkanTransformer(mHttp.Object, null);
 
             var json = new JObject();
             json["spec_version"] = 1;
@@ -137,7 +137,7 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadText(It.IsAny<Uri>()))
                 .Returns(targetJson.ToString());
 
-            var sut = new MetaNetkanTransformer(mHttp.Object);
+            var sut = new MetaNetkanTransformer(mHttp.Object, null);
 
             var json = new JObject();
             json["spec_version"] = specVersion;


### PR DESCRIPTION
## Problem

The bot intermittently reports "GitHub API rate limit exceeded" for various modules, most commonly Telemachus, but also recently many of the KerboKatz utilities and the Half/QuarterRSS textures. This is a custom error message created in #2904 that indicates the server headers include `X-RateLimit-Remaining: 0`.

## Cause

As @techman83 noted in #2945, the rate limit API reported 0 remaining unauthenticated API usages (but we are nowhere near the limit for *authenticated* usages):

```
{
  "resources": {
    "core": {
      "limit": 60,
      "remaining": 0,
      "reset": 1576563098
    },
    "search": {
      "limit": 10,
      "remaining": 10,
      "reset": 1576561641
    },
    "graphql": {
      "limit": 0,
      "remaining": 0,
      "reset": 1576565181
    },
    "integration_manifest": {
      "limit": 5000,
      "remaining": 5000,
      "reset": 1576565181
    }
  },
  "rate": {
    "limit": 60,
    "remaining": 0,
    "reset": 1576563098
  }
}
```

This means that when this error occurs, the bot has accessed too many GitHub URLs without using a token. Normally these would consist of:

- Metanetkans (121 of 122 hosted on GitHub)
- KSP-AVC remote version files (many hosted on GitHub, others on ksp-avc.cybutek.net)
- KSP-AVC version file used as a kref (not hosted on GitHub because we would just use a `github` kref)

Unlike krefs where we construct GitHub API calls from other known properties, these URLs are read out of string properties that can contain **any** full URL, but often one from GitHub. Up to now we only use generic code to retrieve the URL normally, without any special processing.

## Changes

Now when Netkan retrieves such URLs, it checks for the known GItHub hosts and URL patterns. If we find a match, we retrieve the file via the API instead. If we have a token, it will be used. This will reduce the number of unauthenticated GitHub calls we make.

Note that the core and clients are functionally unchanged and will still access all URLs the same way as before. We're just updating Netkan.

Fixes #2945.