### PR TITLE
Only stage auto-epoch when creating new file

### DIFF
--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -40,6 +40,9 @@ namespace CKAN.NetKAN
         [Option("queues", HelpText = "Input,Output queue names for Queue Inflator mode")]
         public string Queues { get; set; }
 
+        [Option("highest-version", HelpText = "Highest known version for auto-epoching")]
+        public string HighestVersion { get; set; }
+
         [Option("validate-ckan", HelpText = "Name of .ckan file to check for errors")]
         public string ValidateCkan { get; set; }
 

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -9,6 +9,7 @@ using log4net;
 using log4net.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Processors;
 using CKAN.NetKAN.Transformers;
@@ -87,7 +88,14 @@ namespace CKAN.NetKAN
                         Options.GitHubToken,
                         Options.PreRelease
                     );
-                    var ckans = inf.Inflate(Options.File, netkan, new TransformOptions(ParseReleases(Options.Releases), null));
+                    var ckans = inf.Inflate(
+                        Options.File,
+                        netkan,
+                        new TransformOptions(
+                            ParseReleases(Options.Releases),
+                            ParseHighestVersion(Options.HighestVersion)
+                        )
+                    );
                     foreach (Metadata ckan in ckans)
                     {
                         WriteCkan(ckan);
@@ -121,6 +129,11 @@ namespace CKAN.NetKAN
         private static int? ParseReleases(string val)
         {
             return val == "all" ? (int?)null : int.Parse(val);
+        }
+
+        private static ModuleVersion ParseHighestVersion(string val)
+        {
+            return val == null ? null : new ModuleVersion(val);
         }
 
         private static void ProcessArgs(string[] args)

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -51,16 +51,20 @@ namespace CKAN.NetKAN.Transformers
             else if (opts.HighestVersion != null)
             {
                 // Ensure we are greater or equal to the previous max
-                ModuleVersion currentV = new ModuleVersion((string)json["version"]);
+                ModuleVersion startV = new ModuleVersion((string)json["version"]);
+                ModuleVersion currentV = startV;
                 while (currentV < opts.HighestVersion)
                 {
                     Log.DebugFormat("Auto-epoching out of order version: {0} < {1}",
                         currentV, opts.HighestVersion);
-                    // Tell the Indexer to be careful
-                    opts.Staged = true;
-                    opts.StagingReason = $"Auto-epoching out of order version: {currentV} < {opts.HighestVersion}";
                     // Increment epoch if too small
                     currentV = currentV.IncrementEpoch();
+                }
+                if (startV < opts.HighestVersion && opts.HighestVersion < currentV)
+                {
+                    // New file, tell the Indexer to be careful
+                    opts.Staged = true;
+                    opts.StagingReason = $"Auto-epoching out of order version: {startV} < {opts.HighestVersion} < {currentV}";
                 }
                 json["version"] = currentV.ToString();
             }


### PR DESCRIPTION
## Motivation

A lot of auto-epoching pull requests have been updates for versions that were created in previous PRs, see KSP-CKAN/CKAN-meta#1621 and KSP-CKAN/CKAN-meta#1694 for an example. In this case we have already confirmed in the first PR that the version should exist, so manual review isn't needed for later ones.

## Changes

Now we only enable staging if the resulting version after auto-epoching is greater than the previous highest version. If we're updating a version that already exists, staging isn't needed.