### PR TITLE
Catch nested GameData folders in Netkan

### DIFF
--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -20,7 +20,7 @@ namespace CKAN
         /// <summary>
         /// Initializes a new instance of the <see cref="T:CKAN.CmdLine.ConsoleUser"/> class.
         /// </summary>
-        /// <param name="headless">If set to <c>true</c>, supress interactive dialogs like Yes/No-Dialog or SelectionDialog.</param>
+        /// <param name="headless">If set to <c>true</c>, suppress interactive dialogs like Yes/No-Dialog or SelectionDialog.</param>
         public ConsoleUser (bool headless)
         {
             Headless = headless;

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -13,5 +13,6 @@ namespace CKAN.NetKAN.Services
         
         IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip);
         
+        IEnumerable<string> FileDestinations(CkanModule module, string filePath);
     }
 }

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -72,6 +72,13 @@ namespace CKAN.NetKAN.Services
                 .Where(instF => cfgRegex.IsMatch(instF.source.Name));
         }
 
+        public IEnumerable<string> FileDestinations(CkanModule module, string filePath)
+        {
+            return ModuleInstaller
+                .FindInstallableFiles(module, filePath, new KSP("/", "dummy", null, false))
+                .Select(f => f.destination);
+        }
+
         /// <summary>
         /// Return a parsed JObject from a stream.
         /// </summary>

--- a/Netkan/Validators/LicensesValidator.cs
+++ b/Netkan/Validators/LicensesValidator.cs
@@ -33,7 +33,7 @@ namespace CKAN.NetKAN.Validators
             {
                 if (licenses == null || licenses.Count < 1)
                 {
-                    throw new Kraken("License should match spec. Set `x_netkan_license_ok` to supress");
+                    throw new Kraken("License should match spec. Set `x_netkan_license_ok` to suppress");
                 }
                 else foreach (var lic in licenses)
                 {
@@ -44,7 +44,7 @@ namespace CKAN.NetKAN.Validators
                     }
                     catch
                     {
-                        throw new Kraken($"License {lic} should match spec. Set `x_netkan_license_ok` to supress");
+                        throw new Kraken($"License {lic} should match spec. Set `x_netkan_license_ok` to suppress");
                     }
                 }
             }


### PR DESCRIPTION
## Motivation

#2788 created Netkan validation checks based on the legacy Perl bot and the pull request validation scripts. There's one remaining check that isn't migrated yet:

https://github.com/KSP-CKAN/xKAN-meta_testing/blob/73cd8a319ae8833e40b52b49976afe49d00db30b/NetKAN/build.sh#L455-L462

```bash
    # Check for Installations that have gone wrong.
    gamedata=($(find dummy_ksp/GameData/. -name GameData -exec sh -c 'if test -d "{}"; then echo "{}";fi' \;))
    if (( ${#gamedata[@]} > 0 ))
    then
      echo "GameData directory found within GameData"
      printf '%s\n' "Path: ${gamedata[@]}"
      exit 1;
    fi
```

In KSP-CKAN/NetKAN#7587 we discovered that MoreHabPlanets' current latest version was blocked by this check. Presumably it was fine when first indexed, then the format of the ZIP changed later. This could have been caught by the bot as soon as that release was inflated if this check was in Netkan.

## Changes

Now the `InstallsFilesValidator` looks for multiple occurrences of GameData in a mod's files' installation paths and throws an exception if found. This will allow us to adjust metadata to fix this problem before such modules are indexed.