### PR TITLE
Make provides a list of identifiers in the schema

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -147,7 +147,9 @@
         "provides" : {
             "description" : "A list of virtual packages this mod provides",
             "type"        : "array",
-            "items"       : { "type" : "string" },
+            "items"       : {
+                "$ref" : "#/definitions/identifier"
+            },
             "uniqueItems" : true
         },
         "replaced_by" : {


### PR DESCRIPTION
## Problem

At one point in KSP-CKAN/NetKAN#7600, a confusing error happened because one module had this:

```json
"provides": [ "AIES-Antenna_Patches" ],
```

And this conflict:
```json
{ "name": "AIES-Antenna-Patches" }
```

`AIES-Antenna-Patches` is depended on by a dependency of this module, but since the `provides` had an underscore, it tried to pull in a conflicting module and got all confused.

## Cause

The schema just has `provides` as a list of strings! But it has to be identifiers to be useful, so this is a missing guardrail that would have helped in this case.

## Changes

Now the schema is updated to consider `provides` a list of identifiers. This will help with validating pull requests; if an element of `provides` has an invalid format, an error will be raised specifically about that.