### PR TITLE
Memoize lazily evaluated sequences

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -29,6 +29,11 @@ namespace CKAN.Extensions
             {
                 throw new ArgumentNullException("source");
             }
+            else if (source is Memoized<T>)
+            {
+                // Already memoized, don't wrap another layer
+                return source;
+            }
             else
             {
                 return new Memoized<T>(source);

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace CKAN.Extensions
 {
-    internal static class EnumerableExtensions
+    public static class EnumerableExtensions
     {
         public static ICollection<T> AsCollection<T>(this IEnumerable<T> source)
         {
@@ -21,5 +22,95 @@ namespace CKAN.Extensions
 
             return new HashSet<T>(source);
         }
+
+        public static IEnumerable<T> Memoize<T>(this IEnumerable<T> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            else
+            {
+                return new Memoized<T>(source);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Memoized lazy evaluation in C#!
+    /// From https://stackoverflow.com/a/12428250/2422988
+    /// </summary>
+    public class Memoized<T> : IEnumerable<T>
+    {
+        public Memoized(IEnumerable<T> source)
+        {
+            this.source = source;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            lock (gate)
+            {
+                if (isCacheComplete)
+                {
+                    return cache.GetEnumerator();
+                }
+                else if (enumerator == null)
+                {
+                    enumerator = source.GetEnumerator();
+                }
+            }
+            return GetMemoizingEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private IEnumerator<T> GetMemoizingEnumerator()
+        {
+            for (Int32 index = 0; TryGetItem(index, out T item); ++index)
+            {
+                yield return item;
+            }
+        }
+
+        private bool TryGetItem(Int32 index, out T item)
+        {
+            lock (gate)
+            {
+                if (!IsItemInCache(index))
+                {
+                    // The iteration may have completed while waiting for the lock
+                    if (isCacheComplete)
+                    {
+                        item = default(T);
+                        return false;
+                    }
+                    if (!enumerator.MoveNext())
+                    {
+                        item = default(T);
+                        isCacheComplete = true;
+                        enumerator.Dispose();
+                        return false;
+                    }
+                    cache.Add(enumerator.Current);
+                }
+                item = cache[index];
+                return true;
+            }
+        }
+
+        private bool IsItemInCache(Int32 index)
+        {
+            return index < cache.Count;
+        }
+
+        private readonly IEnumerable<T> source;
+        private          IEnumerator<T> enumerator;
+        private readonly List<T>        cache = new List<T>();
+        private          bool           isCacheComplete;
+        private readonly object         gate = new object();
     }
 }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -728,6 +728,7 @@ namespace CKAN
         /// </summary>
         public void UninstallList(IEnumerable<string> mods, bool ConfirmPrompt = true, IEnumerable<string> installing = null)
         {
+            mods = mods.Memoize();
             // Pre-check, have they even asked for things which are installed?
 
             foreach (string mod in mods.Where(mod => registry_manager.registry.InstalledModule(mod) == null))
@@ -736,13 +737,14 @@ namespace CKAN
             }
 
             // Find all the things which need uninstalling.
-            IEnumerable<string> revdep = mods.Union(
-                registry_manager.registry.FindReverseDependencies(
-                    mods.Except(installing ?? new string[] {})));
+            IEnumerable<string> revdep = mods
+                .Union(registry_manager.registry.FindReverseDependencies(
+                    mods.Except(installing ?? new string[] {})))
+                .Memoize();
             IEnumerable<string> goners = revdep.Union(
-                registry_manager.registry.FindRemovableAutoInstalled(
-                    registry_manager.registry.InstalledModules.Where(im => !revdep.Contains(im.identifier))
-                ).Select(im => im.identifier))
+                    registry_manager.registry.FindRemovableAutoInstalled(
+                        registry_manager.registry.InstalledModules.Where(im => !revdep.Contains(im.identifier)))
+                    .Select(im => im.identifier))
                 .Memoize();
 
             // If there us nothing to uninstall, skip out.
@@ -985,6 +987,8 @@ namespace CKAN
 
             using (var tx = CkanTransaction.CreateTransactionScope())
             {
+                remove = remove.Memoize();
+                add    = add.Memoize();
                 int totSteps = (remove?.Count() ?? 0)
                              + (add?.Count()    ?? 0);
                 int step = 0;
@@ -1032,6 +1036,7 @@ namespace CKAN
         /// </summary>
         public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader, bool enforceConsistency = true)
         {
+            modules = modules.Memoize();
             User.RaiseMessage("About to upgrade...\r\n");
 
             // Start by making sure we've downloaded everything.
@@ -1095,6 +1100,7 @@ namespace CKAN
         /// </summary>
         public void Replace(IEnumerable<ModuleReplacement> replacements, RelationshipResolverOptions options, IDownloader netAsyncDownloader, bool enforceConsistency = true)
         {
+            replacements = replacements.Memoize();
             log.Debug("Using Replace method");
             List<CkanModule> modsToInstall = new List<CkanModule>();
             var modsToRemove = new List<InstalledModule>();

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -4,14 +4,14 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Transactions;
-using CKAN.Extensions;
 using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
-using CKAN.Versioning;
 using ChinhDo.Transactions.FileManager;
-using CKAN.Configuration;
 using Autofac;
+using CKAN.Extensions;
+using CKAN.Versioning;
+using CKAN.Configuration;
 
 namespace CKAN
 {
@@ -742,7 +742,8 @@ namespace CKAN
             IEnumerable<string> goners = revdep.Union(
                 registry_manager.registry.FindRemovableAutoInstalled(
                     registry_manager.registry.InstalledModules.Where(im => !revdep.Contains(im.identifier))
-                ).Select(im => im.identifier));
+                ).Select(im => im.identifier))
+                .Memoize();
 
             // If there us nothing to uninstall, skip out.
             if (!goners.Any())

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
+using CKAN.Extensions;
 using CKAN.Versioning;
 using log4net;
 using Newtonsoft.Json;
@@ -109,6 +110,7 @@ namespace CKAN
 
         private static bool DependsAndConflictsOK(CkanModule module, IEnumerable<CkanModule> others)
         {
+            others = others.Memoize();
             if (module.depends != null)
             {
                 foreach (RelationshipDescriptor rel in module.depends)
@@ -123,7 +125,7 @@ namespace CKAN
             if (module.conflicts != null)
             {
                 // Skip self-conflicts (but catch other modules providing self)
-                var othersMinusSelf = others.Where(m => m.identifier != module.identifier);
+                var othersMinusSelf = others.Where(m => m.identifier != module.identifier).Memoize();
                 foreach (RelationshipDescriptor rel in module.conflicts)
                 {
                     // If any of the conflicts are present, fail

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -87,7 +87,7 @@ namespace CKAN
         )
         {
             log.DebugFormat("Our dictionary has {0} keys", module_version.Keys.Count);
-            IEnumerable<CkanModule> modules = module_version.Values;
+            IEnumerable<CkanModule> modules = module_version.Values.Reverse();
             if (relationship != null)
             {
                 modules = modules.Where(relationship.WithinBounds);
@@ -104,7 +104,7 @@ namespace CKAN
             {
                 modules = modules.Where(m => DependsAndConflictsOK(m, toInstall));
             }
-            return modules.LastOrDefault();
+            return modules.FirstOrDefault();
         }
 
         private static bool DependsAndConflictsOK(CkanModule module, IEnumerable<CkanModule> others)

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -311,6 +311,8 @@ namespace CKAN
             // is true.
             var sub_options = (RelationshipResolverOptions) options.Clone();
             sub_options.with_suggests = false;
+            
+            old_stanza = old_stanza?.Memoize();
 
             log.DebugFormat("Resolving dependencies for {0}", module.identifier);
             ResolveStanza(module.depends, new SelectionReason.Depends(module), sub_options, false, old_stanza);
@@ -348,6 +350,7 @@ namespace CKAN
             {
                 return;
             }
+            stanza = stanza.Memoize();
 
             foreach (RelationshipDescriptor descriptor in stanza)
             {

--- a/GUI/GUIMod.cs
+++ b/GUI/GUIMod.cs
@@ -196,9 +196,6 @@ namespace CKAN
         public GUIMod(string identifier, IRegistryQuerier registry, KspVersionCriteria current_ksp_version, bool? incompatible = null)
         {
             Identifier     = identifier;
-            IsIncompatible = incompatible
-                ?? registry.AllAvailable(identifier)
-                    .All(m => !m.IsCompatibleKSP(current_ksp_version));
             IsAutodetected = registry.IsAutodetected(identifier);
             DownloadCount  = registry.DownloadCount(identifier);
             if (registry.IsAutodetected(identifier))
@@ -215,6 +212,8 @@ namespace CKAN
             catch (ModuleNotFoundKraken)
             {
             }
+
+            IsIncompatible = incompatible ?? LatestCompatibleMod == null;
 
             // Let's try to find the compatibility for this mod. If it's not in the registry at
             // all (because it's a DarkKAN mod) then this might fail.

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.ComponentModel;
 using System.Windows.Forms;
+using CKAN.Extensions;
 
 namespace CKAN
 {
@@ -93,8 +94,11 @@ namespace CKAN
         /// </summary>
         /// <param name="changes">Every leftover ModChange that should be sorted</param>
         /// <param name="parent"></param>
-        private void CreateSortedModList(IEnumerable<ModChange> changes, ModChange parent=null)
+        private void CreateSortedModList(IEnumerable<ModChange> changes, ModChange parent = null)
         {
+            var notUserReq = changes
+                .Where(c => !(c.Reason is SelectionReason.UserRequested))
+                .Memoize();
             foreach (ModChange change in changes)
             {
                 bool goDeeper = parent == null || change.Reason.Parent.identifier == parent.Mod.identifier;
@@ -103,7 +107,7 @@ namespace CKAN
                 {
                     if (!changeSet.Any(c => c.Mod.identifier == change.Mod.identifier && c.ChangeType != GUIModChangeType.Remove))
                         changeSet.Add(change);
-                    CreateSortedModList(changes.Where(c => !(c.Reason is SelectionReason.UserRequested)), change);
+                    CreateSortedModList(notUserReq, change);
                 }
             }
         }

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using CKAN.Extensions;
 using CKAN.Types;
 
 namespace CKAN
@@ -118,7 +119,7 @@ namespace CKAN
                 opts.Key.Where(ch => ch.ChangeType == GUIModChangeType.Install)
                     .Select(ch => ch.Mod),
                 registry, toInstall
-            );
+            ).Memoize();
             if (recRows.Any())
             {
                 ShowRecSugDialog(recRows, toInstall);

--- a/GUI/MainLabels.cs
+++ b/GUI/MainLabels.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Collections.Generic;
+using CKAN.Extensions;
 
 namespace CKAN
 {
@@ -129,14 +130,16 @@ namespace CKAN
         {
             Util.Invoke(Main.Instance, () =>
             {
+                mods = mods.Memoize();
                 var notifLabs = mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
-                    .Where(l => l.NotifyOnChange);
+                    .Where(l => l.NotifyOnChange)
+                    .Memoize();
                 var toNotif = mods
                     .Where(m =>
                         notifLabs.Any(l =>
                             l.ModuleIdentifiers.Contains(m.Identifier)))
                     .Select(m => m.Name)
-                    .ToArray();
+                    .Memoize();
                 if (toNotif.Any())
                 {
                     MessageBox.Show(
@@ -157,7 +160,6 @@ namespace CKAN
                     {
                         l.Remove(mod.Identifier);
                     }
-
                 }
             });
         }

--- a/GUI/MainRecommendations.cs
+++ b/GUI/MainRecommendations.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
+using CKAN.Extensions;
 using CKAN.Versioning;
 
 namespace CKAN
@@ -302,7 +303,8 @@ namespace CKAN
         private void AuditRecommendations(IRegistryQuerier registry, KspVersionCriteria versionCriteria)
         {
             var toInstall   = new HashSet<CkanModule>();
-            var rows = getRecSugRows(registry.InstalledModules.Select(im => im.Module), registry, toInstall);
+            var rows = getRecSugRows(registry.InstalledModules.Select(im => im.Module), registry, toInstall)
+                .Memoize();
             if (!rows.Any())
             {
                 GUI.user.RaiseError(Properties.Resources.MainRecommendationsNoneFound);

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
 using Newtonsoft.Json.Linq;
+using CKAN.Extensions;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
@@ -64,7 +65,8 @@ namespace CKAN.NetKAN.Transformers
                     .SelectMany(contents => localeRegex.Matches(contents).Cast<Match>()
                         .Where(m => m.Groups["contents"].Value.Contains("="))
                         .Select(m => m.Groups["locale"].Value))
-                    .Distinct();
+                    .Distinct()
+                    .Memoize();
                 log.Debug("Locales extracted");
 
                 if (locales.Any())


### PR DESCRIPTION
## Background

In #2928 I learned how `yield return` works; yes, it pauses execution of the function until we request the next element of the sequence, but if you try to access *earlier* members of the sequence, the whole function will start over again from the beginning, re-running any expensive logic that we were hoping to skip. In other words, it's lazily-evaluated but not memoizing.

This is particularly inconvenient when we want to retrieve and use a sequence and take a special action when it's empty. The idiomatic approach is to use `.Any()` followed by a `foreach`, but this suffers from the duplicate execution problem described above; any expensive steps that we take at the start of the function will be repeated (including network requests!). #2928 worked around this with a `bool foundAny`, which is kind of painful to read.

## Changes

Now a new `.Memoize()` LINQ-style function is added to `CKAN.Extensions` based on some work from StackOverflow. It acts as a memoizing wrapper around another enumerable. Each item of the upstream sequence is requested once and only once the first time a downstream consumer requests it, after which it is stored in a list, from which any subsequent requests for the same item are served without accessing the upstream enumerable. This will allow us to use lazy evaluation safely.

This function is used to clean up some instances I found of duplicated execution of enumerables (I searched for `.Any()` and checked whether there was a `foreach` later for the same variable). If you find more, I'd be happy to add more fixes here.

Separate but related, I noticed when running GUI with `--debug` that we seem to check a **lot** of module compatibilities over and over. I think this is because `AvailableModule.Latest`'s use of `LastOrDefault` requires iterating over its whole sequence. Now we `Reverse` the sequence (which can be done quicly for a `SortedDictionary`) and use `FirstOrDefault` instead to reduce the number of modules checked.