### PR TITLE
Workaround to launch URLs

### DIFF
--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -219,10 +219,7 @@ namespace CKAN.ConsoleUI {
             // then wait 1.5 seconds and refresh the screen when it closes.
             ConsoleMessageDialog d = new ConsoleMessageDialog("Launching...", new List<string>());
             d.Run(() => {
-                Process.Start(new ProcessStartInfo() {
-                    UseShellExecute = true,
-                    FileName        = u.ToString()
-                });
+                Utilities.ProcessStartURL(u.ToString());
                 System.Threading.Thread.Sleep(1500);
             });
             return true;

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -93,17 +93,7 @@ namespace CKAN
         {
             try
             {
-                if (Platform.IsWindows)
-                {
-                    Process.Start(new ProcessStartInfo(
-                        "cmd",
-                        $"/c start {url.Replace("&", "^&")}")
-                    {
-                        CreateNoWindow = true
-                    });
-                    return true;
-                }
-                else if (Platform.IsMac)
+                if (Platform.IsMac)
                 {
                     Process.Start("open", $"\"{url}\"");
                     return true;

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Diagnostics;
 using System.Transactions;
 using ChinhDo.Transactions.FileManager;
+using log4net;
 
 namespace CKAN
 {
@@ -75,5 +77,60 @@ namespace CKAN
                 }
             }
         }
+        
+        /// <summary>
+        /// Launch a URL. For YEARS this was done by Process.Start in a
+        /// cross-platform way, but Microsoft chose to break that,
+        /// so now every .NET app has to write its own custom code for it,
+        /// with special code for each platform.
+        /// https://github.com/dotnet/corefx/issues/10361
+        /// </summary>
+        /// <param name="url">URL to launch</param>
+        /// <returns>
+        /// true if launched, false otherwise
+        /// </returns>
+        public static bool ProcessStartURL(string url)
+        {
+            try
+            {
+                if (Platform.IsWindows)
+                {
+                    Process.Start(new ProcessStartInfo(
+                        "cmd",
+                        $"/c start {url.Replace("&", "^&")}")
+                    {
+                        CreateNoWindow = true
+                    });
+                    return true;
+                }
+                else if (Platform.IsMac)
+                {
+                    Process.Start("open", $"\"{url}\"");
+                    return true;
+                }
+                else if (Platform.IsUnix)
+                {
+                    Process.Start("xdg-open", $"\"{url}\"");
+                    return true;
+                }
+                else
+                {
+                    // Try the old way
+                    Process.Start(new ProcessStartInfo(url)
+                    {
+                        UseShellExecute = true,
+                        Verb            = "open"
+                    });
+                    return true;
+                }
+            }
+            catch (Exception exc)
+            {
+                log.Error($"Exception for URL {url}", exc);
+            }
+            return false;
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(Utilities));
     }
 }

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1151,7 +1151,7 @@ namespace CKAN
 
         private void openKspDirectoryToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Process.Start(Instance.manager.CurrentInstance.GameDir());
+            Utilities.ProcessStartURL(Instance.manager.CurrentInstance.GameDir());
         }
 
         private void CompatibleKspVersionsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1296,12 +1296,12 @@ namespace CKAN
 
         private void reportClientIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/KSP-CKAN/CKAN/issues/new/choose");
+            Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/issues/new/choose");
         }
 
         private void reportMetadataIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
+            Utilities.ProcessStartURL("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
         }
 
         private void ModList_MouseDown(object sender, MouseEventArgs e)

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -275,11 +275,7 @@ namespace CKAN
                         // Launch the URL describing this host's throttling practices, if any
                         if (kraken.infoUrl != null)
                         {
-                            Process.Start(new ProcessStartInfo()
-                            {
-                                UseShellExecute = true,
-                                FileName        = kraken.infoUrl.ToString()
-                            });
+                            Utilities.ProcessStartURL(kraken.infoUrl.ToString());
                         }
                         // Now pretend they clicked the menu option for the settings
                         Enabled = false;
@@ -303,11 +299,7 @@ namespace CKAN
                 {
                     if (GUI.user.RaiseYesNoDialog(Properties.Resources.MainInstallLibCurlMissing))
                     {
-                        Process.Start(new ProcessStartInfo()
-                        {
-                            UseShellExecute = true,
-                            FileName        = "https://github.com/KSP-CKAN/CKAN/wiki/libcurl"
-                        });
+                        Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/wiki/libcurl");
                     }
                     throw;
                 }

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -114,7 +114,7 @@ namespace CKAN
 
         private void ContentsOpenButton_Click(object sender, EventArgs e)
         {
-            Process.Start(manager.Cache.GetCachedFilename(SelectedModule.ToModule()));
+            Utilities.ProcessStartURL(manager.Cache.GetCachedFilename(SelectedModule.ToModule()));
         }
 
         private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -604,7 +604,7 @@ namespace CKAN
                 return;
             }
 
-            Process.Start(location);
+            Utilities.ProcessStartURL(location);
         }
     }
 }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -583,7 +583,7 @@ namespace CKAN
                 DataGridViewLinkCell cell = gridCell as DataGridViewLinkCell;
                 string cmd = cell?.Value.ToString();
                 if (!string.IsNullOrEmpty(cmd))
-                    Process.Start(cmd);
+                    Utilities.ProcessStartURL(cmd);
             }
             else
             {

--- a/GUI/ManageKspInstances.cs
+++ b/GUI/ManageKspInstances.cs
@@ -207,7 +207,7 @@ namespace CKAN
                 return;
             }
 
-            System.Diagnostics.Process.Start(path);
+            Utilities.ProcessStartURL(path);
         }
 
         private void RenameButton_Click(object sender, EventArgs e)

--- a/GUI/SettingsDialog.cs
+++ b/GUI/SettingsDialog.cs
@@ -225,12 +225,7 @@ namespace CKAN
 
         private void OpenCacheButton_Click(object sender, EventArgs e)
         {
-            Process.Start(new ProcessStartInfo()
-            {
-                FileName        = config.DownloadCacheDir,
-                UseShellExecute = true,
-                Verb            = "open"
-            });
+            Utilities.ProcessStartURL(config.DownloadCacheDir);
         }
 
         private void ReposListBox_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Problem

The homepage and repository links in GUI used to work fine, but recently they stopped working for me. Some investigation revealed that this exception was being thrown:

```
System.ComponentModel.Win32Exception (0x80004005): Cannot find the specified file
  at System.Diagnostics.Process.StartWithShellExecuteEx (System.Diagnostics.ProcessStartInfo startInfo) [0x00102] in <dfe42095fd31410e95d8021f755c3557>:0 
  at System.Diagnostics.Process.Start () [0x00032] in <dfe42095fd31410e95d8021f755c3557>:0 
  at (wrapper remoting-invoke-with-check) System.Diagnostics.Process.Start()
  at System.Diagnostics.Process.Start (System.Diagnostics.ProcessStartInfo startInfo) [0x0001b] in <dfe42095fd31410e95d8021f755c3557>:0 
  at CKAN.Util.TryOpenWebPage (System.String url, System.Collections.Generic.IEnumerable`1[T] prefixes) [0x0007a] in <5fbaaea77e3f4034bf234bca04213cd3>:0 
```

## Cause

Somehow `Process.Start` went from launching a URL in the default browser to failing because there isn't a local file named after the URL. The closest thing to an explanation that I was able to find was dotnet/corefx#10361, but I have not been able to confirm it 100%. I tried uninstalling anything that sounded like it was related to corefx, since at some point I had it working fine on Mono, but the problem persists.

Maybe Mono now includes the broken components from corefx? Maybe Mono was updated to be broken in the same way? Maybe corefx is still installed under a package name that I don't recognize? Maybe it's some other totally unrelated problem? Frankly I have no idea, but I'm hoping that someone will explain it in a comment on that issue.

## Changes

Now all of our URL launches are done via `Utilities.ProcessStartURL`, a new function that implements the suggested workaround of launching `cmd`, `open`, or `xdg-open` depending on the platform. This makes it work for me.

While investigating this, I noticed that `Util.CheckURLValid` rejects HTTPS URLs, which doesn't make sense given that `Util.TryOpenWebPage` explicitly generates them. Now it's fixed, and `Util.TryOpenWebPage` tries HTTPS before HTTP since the general trend on the web is to go all-HTTPS.