### PR TITLE
Don't check ZIP health in ModuleInstaller.GetModuleContentsList()

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -255,15 +255,22 @@ namespace CKAN
         // TODO: Return files relative to GameRoot
         public IEnumerable<string> GetModuleContentsList(CkanModule module)
         {
-            string filename = Cache.GetCachedZip(module);
+            string filename = Cache.GetCachedFilename(module);
 
             if (filename == null)
             {
                 return null;
             }
 
-            return FindInstallableFiles(module, filename, ksp)
-                .Select(x => x.destination);
+            try
+            {
+                return FindInstallableFiles(module, filename, ksp)
+                    .Select(x => x.destination);
+            }
+            catch (ZipException)
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -252,7 +252,6 @@ namespace CKAN
         ///
         /// Intended for previews.
         /// </summary>
-        // TODO: Return files relative to GameRoot
         public IEnumerable<string> GetModuleContentsList(CkanModule module)
         {
             string filename = Cache.GetCachedFilename(module);
@@ -265,7 +264,7 @@ namespace CKAN
             try
             {
                 return FindInstallableFiles(module, filename, ksp)
-                    .Select(x => x.destination);
+                    .Select(x => ksp.ToRelativeGameDir(x.destination));
             }
             catch (ZipException)
             {

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using System.IO;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using CKAN.Versioning;
 
@@ -592,7 +591,7 @@ namespace CKAN
         /// <param name="node">A node of the ContentsPreviewTree</param>
         internal void OpenFileBrowser(TreeNode node)
         {
-            string location = node.Text;
+            string location = manager.CurrentInstance.ToAbsoluteGameDir(node.Text);
 
             if (File.Exists(location))
             {

--- a/GUI/MainModInfo.cs
+++ b/GUI/MainModInfo.cs
@@ -1,5 +1,5 @@
 using System;
-﻿using System.Linq;
+using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;


### PR DESCRIPTION
## Problem
When scrolling through the mod list with the arrow keys with the file contents tab opened, the GUI will freeze when you encounter biggish cached mods with a lot of files.
It is noticeable with zips around 3 MiB (depending on count of contained files and PC of course) and really disruptive with mods above 50 MiB.

I traced the issue down to the health checks of the zip files done in `NetFileCache.GetCachedZip()`.

## Changes
Use `GetCachedFilename()` instead of `GetCachedZip()` in `ModuleInstaller.GetModuleContentsList()`, which does the same (searching the file and returning the file name if it is cached) without the checks.
To account for the possibility of bit flips and other data degradation problems, catch possible exceptions when opening the zip and return `null`, which would also be returned if the health checks failed.

`GetModuleContentsList()` is only used in `_UpdateModContentsTree()`, so nothing else will be affected.

I also removed another BOM.