### PR TITLE
Add "supports" relationships to recommendations screen

### DIFF
--- a/ConsoleUI/Toolkit/ConsolePopupMenu.cs
+++ b/ConsoleUI/Toolkit/ConsolePopupMenu.cs
@@ -189,6 +189,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="exec">Function to call if the user chooses this option</param>
         /// <param name="radio">If set, this option is a radio button, and this function returns its value</param>
         /// <param name="submenu">Submenu to open for this option</param>
+        /// <param name="enabled">true if this option should be drawn normally and allowed for selection, false to draw it grayed out and not allow selection</param>
         public ConsoleMenuOption(string cap, string key, string tt, bool close,
                 Func<bool> exec = null, Func<bool> radio = null, ConsolePopupMenu submenu = null,
                 bool enabled = true)

--- a/Core/Registry/Tags/ModuleTagList.cs
+++ b/Core/Registry/Tags/ModuleTagList.cs
@@ -58,7 +58,7 @@ namespace CKAN
             {
                 return JsonConvert.DeserializeObject<ModuleTagList>(File.ReadAllText(path));
             }
-            catch (FileNotFoundException ex)
+            catch (FileNotFoundException)
             {
                 return null;
             }

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -12,7 +12,7 @@ using System.IO;
 namespace CKAN
 {
     [JsonObject(MemberSerialization.OptIn)]
-    public class ModuleInstallDescriptor : ICloneable
+    public class ModuleInstallDescriptor : ICloneable, IEquatable<ModuleInstallDescriptor>
     {
 
         #region Properties
@@ -122,11 +122,23 @@ namespace CKAN
         /// </summary>
         /// <param name="other">The other stanza for comparison</param>
         /// <returns>
-        /// True if they're equivalent, false if they're different
+        /// True if they're equivalent, false if they're different.
         /// </returns>
         public override bool Equals(object other)
         {
-            ModuleInstallDescriptor otherStanza = other as ModuleInstallDescriptor;
+            return Equals(other as ModuleInstallDescriptor);
+        }
+        
+        /// <summary>
+        /// Compare two install stanzas
+        /// </summary>
+        /// <param name="other">The other stanza for comparison</param>
+        /// <returns>
+        /// True if they're equivalent, false if they're different.
+        /// IEquatable<> uses this for more efficient comparisons.
+        /// </returns>
+        public bool Equals(ModuleInstallDescriptor otherStanza)
+        {
             if (otherStanza == null)
                 // Not even the right type!
                 return false;
@@ -163,6 +175,27 @@ namespace CKAN
                 && !include_only_regexp.SequenceEqual(otherStanza.include_only_regexp))
                 return false;
             return true;
+        }
+        
+        public override int GetHashCode()
+        {
+            // Tuple.Create only handles up to 8 params, we have 10+
+            return Tuple.Create(
+                Tuple.Create(
+                    file,
+                    find,
+                    find_regexp,
+                    find_matches_files,
+                    install_to,
+                    @as
+                ),
+                Tuple.Create(                
+                    filter,
+                    filter_regexp,
+                    include_only,
+                    include_only_regexp
+                )
+            ).GetHashCode();
         }
 
         /// <summary>

--- a/GUI/EditLabelsDialog.Designer.cs
+++ b/GUI/EditLabelsDialog.Designer.cs
@@ -48,7 +48,7 @@ namespace CKAN
             this.CreateButton = new System.Windows.Forms.Button();
             this.CloseButton = new System.Windows.Forms.Button();
             this.SaveButton = new System.Windows.Forms.Button();
-            this.CancelButton = new System.Windows.Forms.Button();
+            this.CancelEditButton = new System.Windows.Forms.Button();
             this.DeleteButton = new System.Windows.Forms.Button();
             this.EditDetailsPanel.SuspendLayout();
             this.SuspendLayout();
@@ -116,7 +116,7 @@ namespace CKAN
             this.EditDetailsPanel.Controls.Add(this.AlertOnInstallCheckBox);
             this.EditDetailsPanel.Controls.Add(this.RemoveOnInstallCheckBox);
             this.EditDetailsPanel.Controls.Add(this.SaveButton);
-            this.EditDetailsPanel.Controls.Add(this.CancelButton);
+            this.EditDetailsPanel.Controls.Add(this.CancelEditButton);
             this.EditDetailsPanel.Controls.Add(this.DeleteButton);
             this.EditDetailsPanel.Location = new System.Drawing.Point(135, 43);
             this.EditDetailsPanel.Name = "EditDetailsPanel";
@@ -232,17 +232,17 @@ namespace CKAN
             this.SaveButton.Click += new System.EventHandler(this.SaveButton_Click);
             resources.ApplyResources(this.SaveButton, "SaveButton");
             // 
-            // CancelButton
+            // CancelEditButton
             // 
-            this.CancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            this.CancelEditButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
-            this.CancelButton.Location = new System.Drawing.Point(90, 290);
-            this.CancelButton.Name = "CancelButton";
-            this.CancelButton.Size = new System.Drawing.Size(75, 23);
-            this.CancelButton.TabIndex = 0;
-            this.CancelButton.UseVisualStyleBackColor = true;
-            this.CancelButton.Click += new System.EventHandler(this.CancelButton_Click);
-            resources.ApplyResources(this.CancelButton, "CancelButton");
+            this.CancelEditButton.Location = new System.Drawing.Point(90, 290);
+            this.CancelEditButton.Name = "CancelEditButton";
+            this.CancelEditButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelEditButton.TabIndex = 0;
+            this.CancelEditButton.UseVisualStyleBackColor = true;
+            this.CancelEditButton.Click += new System.EventHandler(this.CancelEditButton_Click);
+            resources.ApplyResources(this.CancelEditButton, "CancelEditButton");
             // 
             // DeleteButton
             // 
@@ -309,7 +309,7 @@ namespace CKAN
         private System.Windows.Forms.Button CreateButton;
         private System.Windows.Forms.Button CloseButton;
         private System.Windows.Forms.Button SaveButton;
-        private System.Windows.Forms.Button CancelButton;
+        private System.Windows.Forms.Button CancelEditButton;
         private System.Windows.Forms.Button DeleteButton;
     }
 }

--- a/GUI/EditLabelsDialog.cs
+++ b/GUI/EditLabelsDialog.cs
@@ -113,7 +113,7 @@ namespace CKAN
             }
         }
 
-        private void CancelButton_Click(object sender, EventArgs e)
+        private void CancelEditButton_Click(object sender, EventArgs e)
         {
             EditDetailsPanel.Visible = false;
             currentlyEditing = null;

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -51,7 +51,7 @@ namespace CKAN
             {
                 return JsonConvert.DeserializeObject<ModuleLabelList>(File.ReadAllText(path));
             }
-            catch (FileNotFoundException ex)
+            catch (FileNotFoundException)
             {
                 return null;
             }

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -237,6 +237,7 @@
   <data name="RecommendedDialogLabel.Text" xml:space="preserve"><value>Die folgenden Module wurden von mindestens einer ausgewählten Mod empfohlen oder vorgeschlagen</value></data>
   <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Empfehlungen</value></data>
   <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Vorschläge</value></data>
+  <data name="SupportedByGroup.Header" xml:space="preserve"><value>Unterstützt durch</value></data>
   <data name="columnHeader4.Text" xml:space="preserve"><value>Empfohlen/vorgeschlagen von:</value></data>
   <data name="columnHeader5.Text" xml:space="preserve"><value>Kurzbeschreibung</value></data>
   <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Wähle Mods</value></data>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -133,6 +133,7 @@
             this.RecommendedModsListView = new ThemedListView();
             this.RecommendationsGroup = new System.Windows.Forms.ListViewGroup();
             this.SuggestionsGroup = new System.Windows.Forms.ListViewGroup();
+            this.SupportedByGroup = new System.Windows.Forms.ListViewGroup();
             this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -1178,6 +1179,7 @@
             this.RecommendedModsListView.SelectedIndexChanged += new System.EventHandler(RecommendedModsListView_SelectedIndexChanged);
             this.RecommendedModsListView.Groups.Add(this.RecommendationsGroup);
             this.RecommendedModsListView.Groups.Add(this.SuggestionsGroup);
+            this.RecommendedModsListView.Groups.Add(this.SupportedByGroup);
             //
             // RecommendationsGroup
             //
@@ -1190,6 +1192,12 @@
             this.SuggestionsGroup.Name = "Suggestions";
             this.SuggestionsGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
             resources.ApplyResources(this.SuggestionsGroup, "SuggestionsGroup");
+            //
+            // SupportedByGroup
+            //
+            this.SupportedByGroup.Name = "SupportedBy";
+            this.SupportedByGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            resources.ApplyResources(this.SupportedByGroup, "SupportedByGroup");
             //
             // columnHeader3
             //
@@ -1537,6 +1545,7 @@
         private System.Windows.Forms.ListView RecommendedModsListView;
         private System.Windows.Forms.ListViewGroup RecommendationsGroup;
         private System.Windows.Forms.ListViewGroup SuggestionsGroup;
+        private System.Windows.Forms.ListViewGroup SupportedByGroup;
         private System.Windows.Forms.ColumnHeader columnHeader3;
         private System.Windows.Forms.ColumnHeader columnHeader4;
         private System.Windows.Forms.ColumnHeader columnHeader5;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -1012,8 +1012,8 @@
             // WaitTabPage
             //
             this.WaitTabPage.BackColor = System.Drawing.SystemColors.Control;
-            this.WaitTabPage.Controls.Add(this.CancelCurrentActionButton);
             this.WaitTabPage.Controls.Add(this.RetryCurrentActionButton);
+            this.WaitTabPage.Controls.Add(this.CancelCurrentActionButton);
             this.WaitTabPage.Controls.Add(this.LogTextBox);
             this.WaitTabPage.Controls.Add(this.DialogProgressBar);
             this.WaitTabPage.Controls.Add(this.MessageTextBox);
@@ -1046,7 +1046,6 @@
             this.RetryCurrentActionButton.Name = "RetryCurrentActionButton";
             this.RetryCurrentActionButton.Size = new System.Drawing.Size(112, 35);
             this.RetryCurrentActionButton.TabIndex = 21;
-            this.RetryCurrentActionButton.Visible = false;
             this.RetryCurrentActionButton.Click += new System.EventHandler(this.RetryCurrentActionButton_Click);
             resources.ApplyResources(this.RetryCurrentActionButton, "RetryCurrentActionButton");
             //

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Linq;
 using CKAN.Versioning;
 using CKAN.Exporters;
 using CKAN.Extensions;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -155,6 +155,7 @@ namespace CKAN
             {
                 tabController.HideTab("ChangesetTabPage");
                 ApplyToolButton.Enabled = false;
+                RetryCurrentActionButton.Enabled = false;
                 auditRecommendationsMenuItem.Enabled = true;
                 InstallAllCheckbox.Checked = true;
             }

--- a/GUI/Main.resx
+++ b/GUI/Main.resx
@@ -244,6 +244,7 @@
   <data name="RecommendedDialogLabel.Text" xml:space="preserve"><value>The following modules have been recommended or suggested by one or more of the chosen modules:</value></data>
   <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Recommendations</value></data>
   <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Suggestions</value></data>
+  <data name="SupportedByGroup.Header" xml:space="preserve"><value>Supported By</value></data>
   <data name="columnHeader3.Text" xml:space="preserve"><value>Mod</value></data>
   <data name="columnHeader4.Text" xml:space="preserve"><value>Recommended or suggested by:</value></data>
   <data name="columnHeader5.Text" xml:space="preserve"><value>Mod description</value></data>

--- a/GUI/MainChangeset.cs
+++ b/GUI/MainChangeset.cs
@@ -125,7 +125,6 @@ namespace CKAN
                 return;
 
             menuStrip1.Enabled = false;
-            RetryCurrentActionButton.Visible = false;
 
             //Using the changeset passed in can cause issues with versions.
             // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.

--- a/GUI/MainInstall.cs
+++ b/GUI/MainInstall.cs
@@ -335,7 +335,6 @@ namespace CKAN
                 // install successful
                 AddStatusMessage(Properties.Resources.MainInstallSuccess);
                 HideWaitDialog(true);
-                RetryCurrentActionButton.Visible = false;
             }
             else if (installCanceled)
             {

--- a/GUI/MainWait.cs
+++ b/GUI/MainWait.cs
@@ -28,6 +28,7 @@ namespace CKAN
                 StatusProgress.Style = ProgressBarStyle.Marquee;
                 StatusProgress.Visible = true;
             });
+            Util.Invoke(RetryCurrentActionButton, () => RetryCurrentActionButton.Enabled = false);
             Util.Invoke(CancelCurrentActionButton, () => CancelCurrentActionButton.Enabled = cancelable);
             Util.Invoke(MessageTextBox, () => MessageTextBox.Text = Properties.Resources.MainWaitPleaseWait);
         }
@@ -48,6 +49,7 @@ namespace CKAN
 
                 tabController.SetActiveTab("ManageModsTabPage");
 
+                RetryCurrentActionButton.Enabled = false;
                 CancelCurrentActionButton.Enabled = false;
                 DialogProgressBar.Value = 0;
                 DialogProgressBar.Style = ProgressBarStyle.Continuous;
@@ -74,11 +76,10 @@ namespace CKAN
             });
             Util.Invoke(WaitTabPage, () => {
                 RecreateDialogs();
-                RetryCurrentActionButton.Visible = !success;
+                RetryCurrentActionButton.Enabled = true;
                 CancelCurrentActionButton.Enabled = false;
                 SetProgress(100);
             });
-            tabController.HideTab("ChangesetTabPage");
             AddLogMessage(logMsg);
             SetDescription(description);
         }
@@ -135,10 +136,7 @@ namespace CKAN
 
         private void RetryCurrentActionButton_Click(object sender, EventArgs e)
         {
-            Util.Invoke(DialogProgressBar, () =>
-            {
-                tabController.ShowTab("ChangesetTabPage", 1);
-            });
+            tabController.ShowTab("ChangesetTabPage", 1);
         }
 
         private void CancelCurrentActionButton_Click(object sender, EventArgs e)

--- a/GUI/TabController.cs
+++ b/GUI/TabController.cs
@@ -25,80 +25,70 @@ namespace CKAN
 
         public void ShowTab(string name, int index = 0, bool setActive = true)
         {
-            Util.Invoke(m_TabControl, () => _ShowTab(name, index, setActive));
-        }
-
-        public void HideTab(string name)
-        {
-            Util.Invoke(m_TabControl, () => _HideTab(name));
-        }
-
-        public void RenameTab(string name, string newDisplayName)
-        {
-            Util.Invoke(m_TabControl, () => _RenameTab(name, newDisplayName));
-        }
-
-        public void SetTabLock(bool state)
-        {
-            Util.Invoke(m_TabControl, () => _SetTabLock(state));
-        }
-
-        public void SetActiveTab(string name)
-        {
-            Util.Invoke(m_TabControl, () => _SetActiveTab(name));
-        }
-
-        private void _ShowTab(string name, int index = 0, bool setActive = true)
-        {
-            if (m_TabControl.TabPages.Contains(m_TabPages[name]))
+            Util.Invoke(m_TabControl, () =>
             {
+                if (m_TabControl.TabPages.Contains(m_TabPages[name]))
+                {
+                    if (setActive)
+                    {
+                        SetActiveTab(name);
+                    }
+
+                    return;
+                }
+
+                if (index > m_TabControl.TabPages.Count)
+                {
+                    index = m_TabControl.TabPages.Count;
+                }
+
+                m_TabControl.TabPages.Insert(index, m_TabPages[name]);
+
                 if (setActive)
                 {
                     SetActiveTab(name);
                 }
+            });
+        }
 
-                return;
-            }
-
-            if (index > m_TabControl.TabPages.Count)
+        public void HideTab(string name)
+        {
+            Util.Invoke(m_TabControl, () =>
             {
-                index = m_TabControl.TabPages.Count;
-            }
+                // Unsafe to hide the active tab as of Mono 5.14
+                if (m_TabControl.SelectedTab.Name == name)
+                {
+                    m_TabControl.DeselectTab(name);
+                }
+                m_TabControl.TabPages.Remove(m_TabPages[name]);
+            });
+        }
 
-            m_TabControl.TabPages.Insert(index, m_TabPages[name]);
-
-            if (setActive)
+        public void RenameTab(string name, string newDisplayName)
+        {
+            Util.Invoke(m_TabControl, () =>
             {
-                SetActiveTab(name);
-            }
+                m_TabPages[name].Text = newDisplayName;
+            });
         }
 
-        private void _HideTab(string name)
+        public void SetTabLock(bool state)
         {
-            // Unsafe to hide the active tab as of Mono 5.14
-            if (m_TabControl.SelectedTab.Name == name)
+            Util.Invoke(m_TabControl, () =>
             {
-                m_TabControl.DeselectTab(name);
-            }
-            m_TabControl.TabPages.Remove(m_TabPages[name]);
+                m_TabLock = state;
+            });
         }
 
-        public void _RenameTab(string name, string newDisplayName)
+        public void SetActiveTab(string name)
         {
-            m_TabPages[name].Text = newDisplayName;
-        }
-
-        private void _SetTabLock(bool state)
-        {
-            m_TabLock = state;
-        }
-
-        private void _SetActiveTab(string name)
-        {
-            var tabLock = m_TabLock;
-            m_TabLock = false;
-            m_TabControl.SelectTab(m_TabPages[name]);
-            m_TabLock = tabLock;
+            Util.Invoke(m_TabControl, () =>
+            {
+                var tabLock = m_TabLock;
+                m_TabLock = false;
+                m_TabControl.SelectTab(m_TabPages[name]);
+                m_TabLock = tabLock;
+            });
         }
 
         private void OnDeselect(object sender, TabControlCancelEventArgs args)
@@ -148,8 +138,5 @@ namespace CKAN
         private bool m_TabLock;
 
         public Dictionary<string, TabPage> m_TabPages = new Dictionary<string, TabPage>();
-
     }
-
-
 }


### PR DESCRIPTION
## Background

The spec includes a [`supports`] relationship for indicating compatibility with another mod, but not a recommendation or suggestion that the mod be installed. For example, a parts mod that includes cfg files that enable its parts to be scaled with TweakScale might do this:

[`supports`]: https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#supports

```json
    "supports": [
        { "name": "TweakScale" }
    ],
```

Other examples include mods that add parts to specific tech trees, mods that create props or multi-function display pages for IVAs, etc.

Currently this relationship does not drive any functionality; it's only displayed in the Relationships tab of mod info, as a smiley face:

![image](https://user-images.githubusercontent.com/1559108/72025100-fcf61b00-326e-11ea-8eb8-b714c28db09d.png)

## Motivation

Since mod authors do sometimes fill in this relationship, it would be nice if it did something (sensible). I think it makes sense to treat it as "inverse suggests," such that:

- If I install a tech tree, I would be able to see which mods integrate with that tech tree
- If I install RPM, I would be able to see mods that provide MFD pages
- If I install TweakScale, I would be able to see part mods that allow scaling

Etc.

## Changes

Now during module installation, the recommendations/suggestions screen can contain a third section, "Supported By". This lists modules that support modules that you're installing, defaulting to unchecked, and the user can check the boxes to install, just like suggestions.

For example, if you install KIS, RemoteTech, and TweakScale, you see the several mods that support them:

![image](https://user-images.githubusercontent.com/1559108/72024651-c075ef80-326d-11ea-931c-6b6324e2c51f.png)

This will make it easier for users to discover mods related to the ones they're installing.

Fixes #1104.