### PR TITLE
Check all dependencies for compatibility checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ matrix:
     include:
         - env: BUILD_CONFIGURATION=Debug_NetCore
           mono: latest
-          dotnet: 2.1
+          dotnet: 2.1.802
         - env: BUILD_CONFIGURATION=Release_NetCore
           mono: latest
-          dotnet: 2.1
+          dotnet: 2.1.802
 
 addons:
     apt:

--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -13,23 +13,23 @@ namespace CKAN.CmdLine
 
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
-            AvailableOptions opts      = (AvailableOptions)raw_options;
-            IRegistryQuerier registry  = RegistryManager.Instance(ksp).registry;
-            var              available = registry.Available(ksp.VersionCriteria());
+            AvailableOptions opts       = (AvailableOptions)raw_options;
+            IRegistryQuerier registry   = RegistryManager.Instance(ksp).registry;
+            var              compatible = registry.CompatibleModules(ksp.VersionCriteria());
 
-            user.RaiseMessage("Mods available for KSP {0}", ksp.Version());
+            user.RaiseMessage("Modules compatible with KSP {0}", ksp.Version());
             user.RaiseMessage("");
 
             if (opts.detail)
             {
-                foreach (CkanModule module in available)
+                foreach (CkanModule module in compatible)
                 {
                     user.RaiseMessage("* {0} ({1}) - {2} - {3}", module.identifier, module.version, module.name, module.@abstract);
                 }
             }
             else
             {
-                foreach (CkanModule module in available)
+                foreach (CkanModule module in compatible)
                 {
                     user.RaiseMessage("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
                 }

--- a/Cmdline/Action/Search.cs
+++ b/Cmdline/Action/Search.cs
@@ -132,7 +132,7 @@ namespace CKAN.CmdLine
             if (!searchIncompatible)
             {
                 return registry
-                    .Available(ksp.VersionCriteria())
+                    .CompatibleModules(ksp.VersionCriteria())
                     .Where((module) =>
                 {
                     // Look for a match in each string.
@@ -146,7 +146,7 @@ namespace CKAN.CmdLine
             else
             {
                 return registry
-                    .Incompatible(ksp.VersionCriteria())
+                    .IncompatibleModules(ksp.VersionCriteria())
                     .Where((module) =>
                 {
                     // Look for a match in each string.
@@ -186,8 +186,8 @@ namespace CKAN.CmdLine
         {
             IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
             // Get the list of all compatible and incompatible mods
-            List<CkanModule> mods = registry.Available(ksp.VersionCriteria()).ToList();
-            mods.AddRange(registry.Incompatible(ksp.VersionCriteria()));
+            List<CkanModule> mods = registry.CompatibleModules(ksp.VersionCriteria()).ToList();
+            mods.AddRange(registry.IncompatibleModules(ksp.VersionCriteria()));
             for (int i = 0; i < modules.Count; ++i)
             {
                 Match match = CkanModule.idAndVersionMatcher.Match(modules[i]);

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -38,7 +38,7 @@ namespace CKAN.CmdLine
             // Module was not installed, look for an exact match in the available modules,
             // either by "name" (the user-friendly display name) or by identifier
             CkanModule moduleToShow = registry
-                                      .Available(ksp.VersionCriteria())
+                                      .CompatibleModules(ksp.VersionCriteria())
                                       .SingleOrDefault(
                                             mod => mod.name == options.Modname
                                                 || mod.identifier == options.Modname
@@ -48,7 +48,7 @@ namespace CKAN.CmdLine
             {
                 // No exact match found. Try to look for a close match for this KSP version.
                 user.RaiseMessage("{0} not found or installed.", options.Modname);
-                user.RaiseMessage("Looking for close matches in available mods for KSP {0}.", ksp.Version());
+                user.RaiseMessage("Looking for close matches in mods compatible with KSP {0}.", ksp.Version());
 
                 Search search = new Search(user);
                 var matches = search.PerformSearch(ksp, options.Modname);

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -31,15 +31,15 @@ namespace CKAN.CmdLine
         {
             UpdateOptions options = (UpdateOptions) raw_options;
 
-            List<CkanModule> available_prior = null;
+            List<CkanModule> compatible_prior = null;
 
             user.RaiseMessage("Downloading updates...");
 
             if (options.list_changes)
             {
-                // Get a list of available modules prior to the update.
+                // Get a list of compatible modules prior to the update.
                 var registry = RegistryManager.Instance(ksp).registry;
-                available_prior = registry.Available(ksp.VersionCriteria()).ToList();
+                compatible_prior = registry.CompatibleModules(ksp.VersionCriteria()).ToList();
             }
 
             // If no repository is selected, select all.
@@ -69,7 +69,7 @@ namespace CKAN.CmdLine
             if (options.list_changes)
             {
                 var registry = RegistryManager.Instance(ksp).registry;
-                PrintChanges(available_prior, registry.Available(ksp.VersionCriteria()).ToList());
+                PrintChanges(compatible_prior, registry.CompatibleModules(ksp.VersionCriteria()).ToList());
             }
 
             return Exit.OK;
@@ -78,8 +78,8 @@ namespace CKAN.CmdLine
         /// <summary>
         /// Locates the changes between the prior and post state of the modules..
         /// </summary>
-        /// <param name="modules_prior">List of the available modules prior to the update.</param>
-        /// <param name="modules_post">List of the available modules after the update.</param>
+        /// <param name="modules_prior">List of the compatible modules prior to the update.</param>
+        /// <param name="modules_post">List of the compatible modules after the update.</param>
         private void PrintChanges(List<CkanModule> modules_prior, List<CkanModule> modules_post)
         {
             var prior = new HashSet<CkanModule>(modules_prior, new NameComparer());
@@ -153,8 +153,7 @@ namespace CKAN.CmdLine
                 ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, manager.Cache, user) != CKAN.RepoUpdateResult.Failed
                 : CKAN.Repo.Update(registry_manager, ksp, user, repository);
 
-            user.RaiseMessage("Updated information on {0} available modules",
-                registry_manager.registry.Available(ksp.VersionCriteria()).Count());
+            user.RaiseMessage("Updated information on {0} compatible modules", updated);
         }
     }
 }

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -310,9 +310,9 @@ namespace CKAN.ConsoleUI {
 
             if (ChangePlan.IsAnyAvailable(registry, mod.identifier)) {
 
-                List<CkanModule> avail              = registry.AllAvailable(mod.identifier).ToList();
-                CkanModule       inst               = registry.GetInstalledVersion(mod.identifier);
-                CkanModule       latest             = registry.LatestAvailable(    mod.identifier, null);
+                List<CkanModule> avail              = registry.AvailableByIdentifier(mod.identifier).ToList();
+                CkanModule       inst               = registry.GetInstalledVersion(  mod.identifier);
+                CkanModule       latest             = registry.LatestAvailable(      mod.identifier, null);
                 bool             installed          = registry.IsInstalled(mod.identifier, false);
                 bool             latestIsInstalled  = inst?.Equals(latest) ?? false;
                 List<CkanModule> others             = avail;

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -426,7 +426,7 @@ namespace CKAN.ConsoleUI {
             d.Run(() => {
                 HashSet<string> availBefore = new HashSet<string>(
                     Array.ConvertAll<CkanModule, string>(
-                        registry.Available(
+                        registry.CompatibleModules(
                             manager.CurrentInstance.VersionCriteria()
                         ).ToArray(),
                         (l => l.identifier)
@@ -445,7 +445,7 @@ namespace CKAN.ConsoleUI {
                     RaiseError(ex.Message + ex.StackTrace);
                 }
                 // Update recent with mods that were updated in this pass
-                foreach (CkanModule mod in registry.Available(
+                foreach (CkanModule mod in registry.CompatibleModules(
                         manager.CurrentInstance.VersionCriteria()
                     )) {
                     if (!availBefore.Contains(mod.identifier)) {
@@ -508,7 +508,7 @@ namespace CKAN.ConsoleUI {
         private List<CkanModule> GetAllMods(bool force = false)
         {
             if (allMods == null || force) {
-                allMods = new List<CkanModule>(registry.Available(manager.CurrentInstance.VersionCriteria()));
+                allMods = new List<CkanModule>(registry.CompatibleModules(manager.CurrentInstance.VersionCriteria()));
                 foreach (InstalledModule im in registry.InstalledModules) {
                     CkanModule m = null;
                     try {

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -79,7 +79,7 @@ namespace CKAN
                     HandleModuleChanges(metadataChanges, user, ksp, cache);
                 }
 
-                // Registry.Available is slow, just return success,
+                // Registry.CompatibleModules is slow, just return success,
                 // caller can check it if it's really needed
                 return RepoUpdateResult.Updated;
             }
@@ -346,7 +346,7 @@ Do you wish to reinstall now?", sb)))
 
             ShowUserInconsistencies(registry_manager.registry, user);
 
-            // Registry.Available is slow, just return success,
+            // Registry.CompatibleModules is slow, just return success,
             // caller can check it if it's really needed
             return true;
         }

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -1,0 +1,222 @@
+using System.Collections.Generic;
+using System.Linq;
+using log4net;
+using CKAN.Versioning;
+
+namespace CKAN
+{
+    /// <summary>
+    /// Class to track which mods are compatible with a given set of versions.
+    /// Handles all levels of dependencies.
+    /// </summary>
+    public class CompatibilitySorter
+    {
+        /// <summary>
+        /// Initialize the sorter and partition the mods.
+        /// </summary>
+        /// <param name="crit">Versions to be considered compatible</param>
+        /// <param name="available">Collection of mods from registry</param>
+        /// <param name="providers">Dictionary mapping every identifier to the modules providing it</param>
+        /// <param name="dlls">Collection of found dlls</param>
+        /// <param name="dlc">Collection of installed DLCs</param>
+        public CompatibilitySorter(
+            KspVersionCriteria crit,
+            Dictionary<string, AvailableModule> available,
+            Dictionary<string, HashSet<AvailableModule>> providers,
+            HashSet<string> dlls,
+            Dictionary<string, UnmanagedModuleVersion> dlc
+        )
+        {
+            CompatibleVersions = crit;
+            this.dlls = dlls;
+            this.dlc  = dlc;
+            PartitionModules(available, providers);
+        }
+
+        /// <summary>
+        /// Version criteria that this partition represents
+        /// </summary>
+        public readonly KspVersionCriteria CompatibleVersions;
+
+        /// <summary>
+        /// Mods that are compatible with our versions
+        /// </summary>
+        public readonly SortedDictionary<string, AvailableModule> Compatible
+            = new SortedDictionary<string, AvailableModule>();
+
+        /// <summary>
+        /// Mods that are incompatible with our versions
+        /// </summary>
+        public readonly SortedDictionary<string, AvailableModule> Incompatible
+            = new SortedDictionary<string, AvailableModule>();
+
+        /// <summary>
+        /// Mods that might be compatible or incompatible based on their dependencies
+        /// </summary>
+        private readonly SortedDictionary<string, AvailableModule> Indeterminate = new SortedDictionary<string, AvailableModule>();
+
+        /// <summary>
+        /// Mods for which we have an active call to CheckDepends right now
+        /// in the call stack, used to avoid infinite recursion on circular deps.
+        /// </summary>
+        private readonly Stack<string> Investigating = new Stack<string>();
+
+        private readonly HashSet<string> dlls;
+        private readonly Dictionary<string, UnmanagedModuleVersion> dlc;
+
+        /// <summary>
+        /// Split the given mods into compatible and incompatible.
+        /// Handles all levels of dependencies.
+        /// </summary>
+        /// <param name="available">All mods available from registry</param>
+        private void PartitionModules(Dictionary<string, AvailableModule> available, Dictionary<string, HashSet<AvailableModule>> providers)
+        {
+            // First get the ones that are trivially [in]compatible.
+            foreach (var kvp in available)
+            {
+                if (kvp.Value.AllAvailable().All(m => !m.IsCompatibleKSP(CompatibleVersions)))
+                {
+                    // No versions compatible == incompatible
+                    log.DebugFormat("Trivially incompatible: {0}", kvp.Key);
+                    Incompatible.Add(kvp.Key, kvp.Value);
+                }
+                else if (kvp.Value.AllAvailable().All(m => m.depends == null))
+                {
+                    // No dependencies == compatible
+                    log.DebugFormat("Trivially compatible: {0}", kvp.Key);
+                    Compatible.Add(kvp.Key, kvp.Value);
+                }
+                else
+                {
+                    // Need to investigate this one more later
+                    log.DebugFormat("Trivially indeterminate: {0}", kvp.Key);
+                    Indeterminate.Add(kvp.Key, kvp.Value);
+                }
+            }
+            // We'll be modifying `indeterminate` during this loop, so `foreach` is out
+            while (Indeterminate.Count > 0)
+            {
+                var kvp = Indeterminate.First();
+                log.DebugFormat("Checking: {0}", kvp.Key);
+                CheckDepends(kvp.Key, kvp.Value, providers);
+            }
+        }
+
+        /// <summary>
+        /// Move an indeterminate module to Compatible or Incompatible
+        /// based on its dependencies.
+        /// </summary>
+        /// <param name="indeterminate">The collection of indeterminate modules</param>
+        /// <param name="identifier">Identifier of the module to check</param>
+        /// <param name="am">The module to check</param>
+        private void CheckDepends(string identifier, AvailableModule am, Dictionary<string, HashSet<AvailableModule>> providers)
+        {
+            Investigating.Push(identifier);
+            foreach (CkanModule m in am.AllAvailable().Where(m => m.IsCompatibleKSP(CompatibleVersions)))
+            {
+                log.DebugFormat("What about {0}?", m.version);
+                bool installable = true;
+                if (m.depends != null)
+                {
+                    foreach (RelationshipDescriptor rel in m.depends)
+                    {
+                        bool foundCompat = false;
+                        if (rel.MatchesAny(null, dlls, dlc))
+                        {
+                            // Matches a DLL or DLC, cool
+                            foundCompat = true;
+                        }
+                        else
+                        {
+                            // Get the list of identifiers that would satisfy this dependency
+                            // (mostly only one, except for any_of relationships).
+                            // For each of those identifiers, if it is provided by at least one module, get all the modules
+                            // that provide it (and make sure each is only once in the list)
+                            var candidates = RelationshipIdentifiers(rel)
+                                .Where(ident => providers.ContainsKey(ident))
+                                .SelectMany(ident => providers[ident])
+                                .Distinct();
+
+                            foreach (AvailableModule provider in candidates)
+                            {
+                                string ident = provider.AllAvailable().First().identifier;
+                                log.DebugFormat("Checking depends: {0}", ident);
+                                if (Investigating.Contains(ident))
+                                {
+                                    // Circular dependency, pretend it's fine for now
+                                    foundCompat = true;
+                                    break;
+                                }
+                                if (Indeterminate.ContainsKey(ident))
+                                {
+                                    CheckDepends(ident, provider, providers);
+                                }
+                                if (Compatible.ContainsKey(ident))
+                                {
+                                    // This one's OK, go to next relationship
+                                    foundCompat = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!foundCompat)
+                        {
+                            // Not satisfiable!! Next CkanModule
+                            installable = false;
+                            break;
+                        }
+                    }
+                }
+                if (installable)
+                {
+                    // Apparently everything is OK, so we are compatible
+                    log.DebugFormat("Complexly compatible: {0}", identifier);
+                    Compatible.Add(identifier, am);
+                    Indeterminate.Remove(identifier);
+                    Investigating.Pop();
+                    return;
+                }
+            }
+            // None of the CkanModules can be installed!
+            log.DebugFormat("Complexly incompatible: {0}", identifier);
+            Incompatible.Add(identifier, am);
+            Indeterminate.Remove(identifier);
+            Investigating.Pop();
+        }
+
+        /// <summary>
+        /// Find the identifiers that could satisfy this relationship.
+        /// Handles the different types of relationships.
+        /// </summary>
+        /// <param name="rel">Relationship to satisfy</param>
+        /// <returns>
+        /// The identifier for a ModuleRelationshipDescriptor,
+        /// multiple for AnyOfRelationshipDescriptor,
+        /// nothing otherwise.
+        /// </returns>
+        private IEnumerable<string> RelationshipIdentifiers(RelationshipDescriptor rel)
+        {
+            var modRel = rel as ModuleRelationshipDescriptor;
+            if (modRel != null)
+            {
+                yield return modRel.name;
+            }
+            else
+            {
+                var anyRel = rel as AnyOfRelationshipDescriptor;
+                if (anyRel != null)
+                {
+                    foreach (RelationshipDescriptor subRel in anyRel.any_of)
+                    {
+                        foreach (string name in RelationshipIdentifiers(subRel))
+                        {
+                            yield return name;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(CompatibilitySorter));
+    }
+}

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -9,18 +9,17 @@ namespace CKAN
     /// </summary>
     public interface IRegistryQuerier
     {
-        IEnumerable<InstalledModule> InstalledModules { get;}
-        IEnumerable<string> InstalledDlls { get; }
+        IEnumerable<InstalledModule> InstalledModules { get; }
+        IEnumerable<string>          InstalledDlls    { get; }
         IDictionary<string, UnmanagedModuleVersion> InstalledDlc { get; }
 
         int? DownloadCount(string identifier);
 
         /// <summary>
-        /// Returns a simple array of all latest available modules for
+        /// Returns a simple array of the latest compatible module for each identifier for
         /// the specified version of KSP.
         /// </summary>
-        // TODO: This name is misleading. It's more a LatestAvailable's'
-        IEnumerable<CkanModule> Available(KspVersionCriteria ksp_version);
+        IEnumerable<CkanModule> CompatibleModules(KspVersionCriteria ksp_version);
 
         /// <summary>
         /// Get full JSON metadata string for a mod's available versions
@@ -32,10 +31,9 @@ namespace CKAN
         string GetAvailableMetadata(string identifier);
 
         /// <summary>
-        ///     Returns the latest available version of a module that
-        ///     satisifes the specified version.
-        ///     Returns null if there's simply no compatible version for this system.
-        ///     If no ksp_version is provided, the latest module for *any* KSP is returned.
+        /// Returns the latest available version of a module that satisfies the specified version.
+        /// Returns null if there's simply no available version for this system.
+        /// If no ksp_version is provided, the latest module for *any* KSP version is returned.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
         CkanModule LatestAvailable(string identifier, KspVersionCriteria ksp_version, RelationshipDescriptor relationship_descriptor = null);
@@ -47,17 +45,17 @@ namespace CKAN
         KspVersion LatestCompatibleKSP(string identifier);
 
         /// <summary>
-        ///     Returns all available version of a module.
+        /// Returns all available versions of a module.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
-        IEnumerable<CkanModule> AllAvailable(string identifier);
+        IEnumerable<CkanModule> AvailableByIdentifier(string identifier);
 
         /// <summary>
-        ///     Returns the latest available version of a module that satisifes the specified version and
-        ///     optionally a RelationshipDescriptor. Takes into account module 'provides', which may
-        ///     result in a list of alternatives being provided.
-        ///     Returns an empty list if nothing is available for our system, which includes if no such module exists.
-        ///     If no KSP version is provided, the latest module for *any* KSP version is given.
+        /// Returns the latest available version of a module that satisfies the specified version and
+        /// optionally a RelationshipDescriptor. Takes into account module 'provides', which may
+        /// result in a list of alternatives being provided.
+        /// Returns an empty list if nothing is available for our system, which includes if no such module exists.
+        /// If no KSP version is provided, the latest module for *any* KSP version is given.
         /// </summary>
         List<CkanModule> LatestAvailableWithProvides(
             string                  identifier,
@@ -67,8 +65,8 @@ namespace CKAN
         );
 
         /// <summary>
-        ///     Checks the sanity of the registry, to ensure that all dependencies are met,
-        ///     and no mods conflict with each other.
+        /// Checks the sanity of the registry, to ensure that all dependencies are met,
+        /// and no mods conflict with each other.
         /// <exception cref="InconsistentKraken">Thrown if a inconsistency is found</exception>
         /// </summary>
         void CheckSanity();
@@ -103,10 +101,10 @@ namespace CKAN
         CkanModule GetModuleByVersion(string identifier, ModuleVersion version);
 
         /// <summary>
-        ///     Returns a simple array of all incompatible modules for
-        ///     the specified version of KSP.
+        /// Returns a simple array of all incompatible modules for
+        /// the specified version of KSP.
         /// </summary>
-        IEnumerable<CkanModule> Incompatible(KspVersionCriteria ksp_version);
+        IEnumerable<CkanModule> IncompatibleModules(KspVersionCriteria ksp_version);
 
         /// <summary>
         /// Returns a dictionary of all modules installed, along with their
@@ -195,7 +193,7 @@ namespace CKAN
         /// </returns>
         public static string CompatibleGameVersions(this IRegistryQuerier querier, string identifier)
         {
-            List<CkanModule> releases = querier.AllAvailable(identifier).ToList();
+            List<CkanModule> releases = querier.AvailableByIdentifier(identifier).ToList();
             if (releases != null && releases.Count > 0) {
                 ModuleVersion minMod = null, maxMod = null;
                 KspVersion    minKsp = null, maxKsp = null;

--- a/Core/Types/GameComparator/BaseGameComparator.cs
+++ b/Core/Types/GameComparator/BaseGameComparator.cs
@@ -2,13 +2,11 @@
 
 namespace CKAN
 {
-    public abstract class BaseGameComparator: IGameComparator
+    public abstract class BaseGameComparator : IGameComparator
     {
-        public BaseGameComparator ()
-        {
-        }
+        public BaseGameComparator() { }
 
-        public virtual bool Compatible (KspVersionCriteria gameVersionCriteria, CkanModule module)
+        public virtual bool Compatible(KspVersionCriteria gameVersionCriteria, CkanModule module)
         {
             if (gameVersionCriteria.Versions.Count == 0)
             {
@@ -24,6 +22,6 @@ namespace CKAN
             return false;
         }
 
-        public abstract bool SingleVersionsCompatible (KspVersion gameVersionCriteria, CkanModule module);
+        public abstract bool SingleVersionsCompatible(KspVersion gameVersionCriteria, CkanModule module);
     }
 }

--- a/Core/Types/GameComparator/GrasGameComparator.cs
+++ b/Core/Types/GameComparator/GrasGameComparator.cs
@@ -9,13 +9,14 @@ namespace CKAN
     /// </summary>
     public class GrasGameComparator : BaseGameComparator
     {
-        static readonly StrictGameComparator strict = new StrictGameComparator ();
-        static readonly KspVersion v103 = KspVersion.Parse ("1.0.3");
+        static readonly StrictGameComparator strict = new StrictGameComparator();
+        static readonly KspVersion v103 = KspVersion.Parse("1.0.3");
+        static readonly KspVersion v104 = KspVersion.Parse("1.0.4");
 
-        public override bool Compatible (KspVersionCriteria gameVersionCriteria, CkanModule module)
+        public override bool Compatible(KspVersionCriteria gameVersionCriteria, CkanModule module)
         {
             // If it's strictly compatible, then it's compatible.
-            if (strict.Compatible (gameVersionCriteria, module))
+            if (strict.Compatible(gameVersionCriteria, module))
                 return true;
 
             // If we're in strict mode, and it's not strictly compatible, then it's
@@ -23,7 +24,7 @@ namespace CKAN
             if (module.ksp_version_strict)
                 return false;
 
-            return base.Compatible (gameVersionCriteria, module);
+            return base.Compatible(gameVersionCriteria, module);
         }
 
         public override bool SingleVersionsCompatible (KspVersion gameVersion, CkanModule module)
@@ -33,8 +34,8 @@ namespace CKAN
 
             // If we're running KSP 1.0.4, then allow the mod to run if we would have
             // considered it compatible under 1.0.3 (as 1.0.4 was "just a hotfix").
-            if (gameVersion.Equals (KspVersion.Parse ("1.0.4")))
-                return strict.SingleVersionsCompatible (v103, module);
+            if (gameVersion.Equals(v104))
+                return strict.SingleVersionsCompatible(v103, module);
 
             return false;
         }

--- a/Core/Versioning/KspVersionCriteria.cs
+++ b/Core/Versioning/KspVersionCriteria.cs
@@ -4,11 +4,11 @@ using System.Linq;
 
 namespace CKAN.Versioning
 {
-    public class KspVersionCriteria
+    public class KspVersionCriteria : IEquatable<KspVersionCriteria>
     {
         private List<KspVersion> _versions = new List<KspVersion>();
 
-        public KspVersionCriteria (KspVersion v)
+        public KspVersionCriteria(KspVersion v)
         {
             if (v != null)
             {
@@ -40,6 +40,25 @@ namespace CKAN.Versioning
                 null,
                 _versions.Union(other.Versions).ToList()
             );
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as KspVersionCriteria);
+        }
+
+        // From IEquatable<KspVersionCriteria>
+        public bool Equals(KspVersionCriteria other)
+        {
+            return other == null
+                ? false
+                : !_versions.Except(other._versions).Any()
+                    && !other._versions.Except(_versions).Any();
+        }
+
+        public override int GetHashCode()
+        {
+            return _versions.Aggregate(19, (code, vers) => code * 31 + vers.GetHashCode());
         }
 
         public override String ToString()

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -1381,7 +1381,7 @@ namespace CKAN
             if (ModInfo.SelectedModule != null)
             {
                 IRegistryQuerier registry = RegistryManager.Instance(CurrentInstance).registry;
-                var allAvail = registry.AllAvailable(ModInfo.SelectedModule.Identifier);
+                var allAvail = registry.AvailableByIdentifier(ModInfo.SelectedModule.Identifier);
                 foreach (CkanModule mod in allAvail)
                 {
                     Manager.Cache.Purge(mod);

--- a/GUI/MainAllModVersions.cs
+++ b/GUI/MainAllModVersions.cs
@@ -114,7 +114,7 @@ namespace CKAN
                 List<CkanModule> allAvailableVersions;
                 try
                 {
-                    allAvailableVersions = registry.AllAvailable(value.Identifier)
+                    allAvailableVersions = registry.AvailableByIdentifier(value.Identifier)
                         .OrderByDescending(m => m.version)
                         .ToList();
                 }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -193,12 +193,12 @@ namespace CKAN
             );
             AddLogMessage(Properties.Resources.MainModListLoadingAvailable);
             gui_mods.UnionWith(
-                registry.Available(versionCriteria)
-                    .Select(m => new GUIMod(m, registry, versionCriteria, false))
+                registry.CompatibleModules(versionCriteria)
+                    .Select(m => new GUIMod(m, registry, versionCriteria))
             );
             AddLogMessage(Properties.Resources.MainModListLoadingIncompatible);
             gui_mods.UnionWith(
-                registry.Incompatible(versionCriteria)
+                registry.IncompatibleModules(versionCriteria)
                     .Select(m => new GUIMod(m, registry, versionCriteria, true))
             );
 

--- a/GUI/MainRepo.cs
+++ b/GUI/MainRepo.cs
@@ -74,9 +74,9 @@ namespace CKAN
                 // Note the current mods' compatibility for the NewlyCompatible filter
                 KspVersionCriteria versionCriteria = CurrentInstance.VersionCriteria();
                 IRegistryQuerier registry = RegistryManager.Instance(CurrentInstance).registry;
-                Dictionary<string, bool> oldModules = registry.Available(versionCriteria)
+                Dictionary<string, bool> oldModules = registry.CompatibleModules(versionCriteria)
                     .ToDictionary(m => m.identifier, m => false);
-                registry.Incompatible(versionCriteria)
+                registry.IncompatibleModules(versionCriteria)
                     .Where(m => !oldModules.ContainsKey(m.identifier))
                     .ToList()
                     .ForEach(m => oldModules.Add(m.identifier, true));

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -478,11 +478,11 @@ namespace Tests.Core
 
                 // Mark it as available in the registry.
                 var registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
-                Assert.AreEqual(0, registry.Available(ksp.KSP.VersionCriteria()).Count());
+                Assert.AreEqual(0, registry.CompatibleModules(ksp.KSP.VersionCriteria()).Count());
 
                 registry.AddAvailable(TestData.DogeCoinFlag_101_module());
 
-                Assert.AreEqual(1, registry.Available(ksp.KSP.VersionCriteria()).Count());
+                Assert.AreEqual(1, registry.CompatibleModules(ksp.KSP.VersionCriteria()).Count());
 
                 // Attempt to install it.
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -93,28 +93,28 @@ namespace Tests.Core.Registry
         }
 
         [Test]
-        public void Available_NoDLCInstalled_ExcludesModulesDependingOnMH()
+        public void CompatibleModules_NoDLCInstalled_ExcludesModulesDependingOnMH()
         {
             // Arrange
             CkanModule DLCDepender = CkanModule.FromJson(@"{
                 ""identifier"": ""DLC-Depender"",
                 ""version"":    ""1.0.0"",
                 ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
-                ""depends"": [ {
-                    ""name"":""MakingHistory-DLC""
-                } ]
+                ""depends"": [
+                    { ""name"": ""MakingHistory-DLC"" }
+                ]
             }");
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
+            List<CkanModule> avail = registry.CompatibleModules(v0_24_2).ToList();
 
             // Assert
             Assert.IsFalse(avail.Contains(DLCDepender));
         }
 
         [Test]
-        public void Available_MHInstalled_IncludesModulesDependingOnMH()
+        public void CompatibleModules_MHInstalled_IncludesModulesDependingOnMH()
         {
             // Arrange
             registry.RegisterDlc("MakingHistory-DLC", new UnmanagedModuleVersion("1.1.0"));
@@ -123,21 +123,21 @@ namespace Tests.Core.Registry
                 ""identifier"": ""DLC-Depender"",
                 ""version"":    ""1.0.0"",
                 ""download"":   ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
-                ""depends"": [ {
-                    ""name"":""MakingHistory-DLC""
-                } ]
+                ""depends"": [
+                    { ""name"": ""MakingHistory-DLC"" }
+                ]
             }");
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
+            List<CkanModule> avail = registry.CompatibleModules(v0_24_2).ToList();
 
             // Assert
             Assert.IsTrue(avail.Contains(DLCDepender));
         }
 
         [Test]
-        public void Available_MH110Installed_IncludesModulesDependingOnMH110()
+        public void CompatibleModules_MH110Installed_IncludesModulesDependingOnMH110()
         {
             // Arrange
             registry.RegisterDlc("MakingHistory-DLC", new UnmanagedModuleVersion("1.1.0"));
@@ -154,14 +154,14 @@ namespace Tests.Core.Registry
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
+            List<CkanModule> avail = registry.CompatibleModules(v0_24_2).ToList();
 
             // Assert
             Assert.IsTrue(avail.Contains(DLCDepender));
         }
 
         [Test]
-        public void Available_MH100Installed_ExcludesModulesDependingOnMH110()
+        public void CompatibleModules_MH100Installed_ExcludesModulesDependingOnMH110()
         {
             // Arrange
             registry.RegisterDlc("MakingHistory-DLC", new UnmanagedModuleVersion("1.0.0"));
@@ -178,7 +178,7 @@ namespace Tests.Core.Registry
             registry.AddAvailable(DLCDepender);
 
             // Act
-            List<CkanModule> avail = registry.Available(v0_24_2).ToList();
+            List<CkanModule> avail = registry.CompatibleModules(v0_24_2).ToList();
 
             // Assert
             Assert.IsFalse(avail.Contains(DLCDepender));


### PR DESCRIPTION
## Problems

The Compatible and Incompatible filters in GUI check dependencies, but only one level. For example, OuterPlanetsMod depends on Kopernicus depends on ModularFlightIntegrator; if the first two are compatible and the third isn't, then OuterPlanetsMod appears to be installable but will fail.

We do extra work when loading the GUI filters, since `Registry.Available` and `Registry.Incompatible` both loop over all modules and check their dependencies, and the results are not re-used. Similarly, various operations that refresh the mod list are slower than they need to be because we re-check all those same relationships over again even if they haven't changed.

Sometimes "Available" includes incompatible modules:

- `Registry.available_modules`
- `Registry.AllAvailable`
- `Registry.SetAllAvailable`
- `Registry.HasAnyAvailable`
- `Registry.AddAvailable`
- `Registry.RemoveAvailable`
- `Registry.GetAvailableMetadata`

And sometimes it excludes them:

- `Registry.Available`
- `ckan available`

This is confusing.

## Changes

Now `Registry` uses a new `CompatibilitySorter` class to track module compatibility, which has public properties `Compatible` and `Incompatible` and a `CompatibleVersions` property to represent which versions they're compatible with. When we need the compatible or incompatible mods, we check whether the compatible versions are the same as last time, and if so, we return the same lists as previously (which solves the problem of `Registry.Available` and `Registry.Incompatible` duplicating work), otherwise we create a new `CompatibilitySorter` to compute the new compatibilities.

`CompatibilitySorter` uses a fully recursive dependency checking algorithm, so modules will only be counted as compatible if all of their dependencies are compatible. It also uses the lists of compatible and incompatible mods to speed up the search as it goes, rather than re-checking over and over whether dependencies are compatible (now that it's recursive, we don't want to re-check all of Kopernicus's dependencies over and over for all of its many depending mods).

Now "Available" means all modules, and anything that excludes incompatible mods is renamed to "Compatible". `AllAvailable` is renamed to `AvailableByIdentifier` since it doesn't return "all" of anything. `ckan available` retains its old name so users don't have to switch to a new command.

Fixes #1105.
Fixes #1646.
Fixes #2231.
Fixes #2849.