### PR TITLE
Use Mono 6.6 and more recent versions of everything else

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: csharp
 
 sudo: required
@@ -10,7 +10,7 @@ services:
 
 env:
     global:
-        - BUILD_RELEASE_MONO_VERSION=5.16.0
+        - BUILD_RELEASE_MONO_VERSION=6.6.0
         - DOCKERHUB_USERNAME=kspckanbuilder
         - secure: "UGXJG9jB9tGwjJXxG0Beu4Poz0leuiCBItnfTTKRm1a/NxXf1eoOH9p9icY5Ur2xHwqh0uWSznuL2aNr58CXtzTcMpXrcUhRsO63FB3Cz6tSdZEb+pKQJ23zmC9929DklKRGUT2D/eBcJcnV+/eAtkarrfLBU1avUQAVJgqXvMI="
         - AWS_DEFAULT_REGION=us-west-2
@@ -21,19 +21,21 @@ env:
         - BUILD_CONFIGURATION=Release
 
 mono:
+    - 6.6.0
+    - 6.4.0
+    - 6.0.0
     - 5.20.1
     - 5.16.0
-    - 5.14.0
-    - 5.12.0
 
 matrix:
     include:
         - env: BUILD_CONFIGURATION=Debug_NetCore
-          mono: latest
-          dotnet: 2.1.802
+          # Cake is broken on Mono 6.8.0
+          mono: 6.6.0
+          dotnet: 3.1.1
         - env: BUILD_CONFIGURATION=Release_NetCore
-          mono: latest
-          dotnet: 2.1.802
+          mono: 6.6.0
+          dotnet: 3.1.1
 
 addons:
     apt:

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -9,7 +9,7 @@
   <Choose>
     <When Condition="$(Configuration.EndsWith('NetCore'))">
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -26,7 +26,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefaultItemExcludes>$(DefaultItemExcludes);NetKAN\**;GUI\**</DefaultItemExcludes>
   </PropertyGroup>
 
@@ -72,7 +72,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Shaman.CurlSharp" Version="0.6.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>

--- a/build
+++ b/build
@@ -19,7 +19,7 @@ if [ $# -gt 1 ]; then
     done
 fi
 
-nugetVersion="5.3.1"
+nugetVersion="5.4.0"
 useExperimental=false
 rootDir=$(dirname $0)
 scriptFile="$rootDir/build.cake"

--- a/build.cake
+++ b/build.cake
@@ -9,7 +9,7 @@ using Semver;
 
 var target = Argument<string>("target", "Default");
 var configuration = Argument<string>("configuration", "Debug");
-var buildFramework = configuration.EndsWith("NetCore") ? "netcoreapp2.1" : "net45";
+var buildFramework = configuration.EndsWith("NetCore") ? "netcoreapp3.1" : "net45";
 var solution = Argument<string>("solution", "CKAN.sln");
 
 var rootDirectory = Context.Environment.WorkingDirectory;
@@ -163,7 +163,7 @@ Task("Build-DotNet")
 
 Task("Restore-DotNetCore")
     .Description("Intermediate - Download dependencies with NuGet when building for .NET Core.")
-    .WithCriteria(() => buildFramework == "netcoreapp2.1")
+    .WithCriteria(() => buildFramework == "netcoreapp3.1")
     .Does(() =>
 {
     DotNetCoreRestore(solution, new DotNetCoreRestoreSettings
@@ -177,7 +177,7 @@ Task("Build-DotNetCore")
     .Description("Intermediate - Call .NET Core's MSBuild to build the ckan.dll.")
     .IsDependentOn("Restore-Dotnetcore")
     .IsDependentOn("Generate-GlobalAssemblyVersionInfo")
-    .WithCriteria(() => buildFramework == "netcoreapp2.1")
+    .WithCriteria(() => buildFramework == "netcoreapp3.1")
     .Does(() =>
 {
     DotNetCoreBuild(solution, new DotNetCoreBuildSettings
@@ -292,7 +292,7 @@ Task("Test-UnitTests+Only")
 
 Task("Test-UnitTests+Only-DotNetCore")
     .Description("Intermediate - Only run CKANs unit tests using DotNetCoreTest, without compiling beforehand.")
-    .WithCriteria(() => buildFramework == "netcoreapp2.1")
+    .WithCriteria(() => buildFramework == "netcoreapp3.1")
     .Does(() =>
 {
     var where = Argument<string>("where", null);
@@ -366,7 +366,7 @@ Setup(context =>
         else if (argConfiguration.StartsWith("Release"))
             configuration = "Release_NetCore";
 
-        buildFramework = "netcoreapp2.1";
+        buildFramework = "netcoreapp3.1";
     }
 });
 

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#addin "nuget:?package=Cake.SemVer&version=3.0.0"
+#addin "nuget:?package=Cake.SemVer&version=4.0.0"
 #addin "nuget:?package=semver&version=2.0.4"
 #addin "nuget:?package=Cake.Docker&version=0.10.0"
 #tool "nuget:?package=ILRepack&version=2.0.17"

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.34.1" />
+  <package id="Cake" version="0.36.0" />
 </packages>


### PR DESCRIPTION
## Problem

Recent net-core builds have been failing.

```
Error: The assembly name is invalid.
```

Today my Ubuntu upgraded from Mono 6.6 to Mono 6.8, and suddenly I was affected locally by the same problem for *all* builds.

## Cause

See cake-build/cake#2695, it looks like a check was added to Mono in mono/mono#16446 to reject full pathnames for assemblies, but unfortunately parts of `Microsoft.CodeAnalysis` (closed source?) appear to pass full pathnames, which breaks Cake. This will probably need to be fixed on the Mono side, but I don't yet have enough information for a useful report.

The net-core builds were set to `mono: latest` instead of a specific version like everything else, so when this (apparently) broken version shipped we started using it immediately.

## Changes

To fix the error:

- Now our net-core builds use Mono 6.6 instead of `latest`

General upkeep:

- Now we build on bionic instead of xenial
- Versions of Mono older than 5.16 are dropped, 6.0 through 6.6 are added, and we'll ship the one from 6.6
- NuGet and Cake and Cake.SemVer versions are updated
- net-core version is updated from 2.1 to 3.1