### PR TITLE
Fix CKAN-installed modules shown as AD in some cases

### DIFF
--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -46,13 +46,15 @@ namespace CKAN.CmdLine
                 {
                     log.InfoFormat("Importing {0} files", toImport.Count);
                     List<string>    toInstall = new List<string>();
+                    RegistryManager regMgr = RegistryManager.Instance(ksp);
                     ModuleInstaller inst      = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
-                    inst.ImportFiles(toImport, user, mod => toInstall.Add(mod.identifier), !opts.Headless);
+                    inst.ImportFiles(toImport, user, mod => toInstall.Add(mod.identifier), regMgr.registry, !opts.Headless);
                     if (toInstall.Count > 0)
                     {
                         inst.InstallList(
                             toInstall,
-                            new RelationshipResolverOptions()
+                            new RelationshipResolverOptions(),
+                            regMgr
                         );
                     }
                     return Exit.OK;

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -127,7 +127,8 @@ namespace CKAN.CmdLine
                 install_ops.without_enforce_consistency = true;
             }
 
-            IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
+            RegistryManager regMgr = RegistryManager.Instance(ksp);
+            IRegistryQuerier registry = regMgr.registry;
             List<string> modules = options.modules;
 
             for (bool done = false; !done; )
@@ -136,7 +137,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
-                    installer.InstallList(modules, install_ops);
+                    installer.InstallList(modules, install_ops, regMgr);
                     user.RaiseMessage("\r\n");
                     done = true;
                 }

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -128,7 +128,6 @@ namespace CKAN.CmdLine
             }
 
             RegistryManager regMgr = RegistryManager.Instance(ksp);
-            IRegistryQuerier registry = regMgr.registry;
             List<string> modules = options.modules;
 
             for (bool done = false; !done; )

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -33,8 +33,8 @@ namespace CKAN.CmdLine
         /// </returns>
         public int RunCommand(CKAN.KSP ksp, object raw_options)
         {
-
             RemoveOptions options = (RemoveOptions) raw_options;
+            RegistryManager regMgr = RegistryManager.Instance(ksp);
 
             // Use one (or more!) regex to select the modules to remove
             if (options.regex)
@@ -47,11 +47,9 @@ namespace CKAN.CmdLine
                 List<string> selectedModules = new List<string>();
 
                 // Get the list of installed modules
-                IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
-
                 // Try every regex on every installed module:
                 // if it matches, select for removal
-                foreach (string mod in registry.InstalledModules.Select(mod => mod.identifier))
+                foreach (string mod in regMgr.registry.InstalledModules.Select(mod => mod.identifier))
                 {
                     if (justins.Any(re => re.IsMatch(mod)))
                         selectedModules.Add(mod);
@@ -66,9 +64,8 @@ namespace CKAN.CmdLine
             {
                 log.Debug("Removing all mods");
                 // Add the list of installed modules to the list that should be uninstalled
-                IRegistryQuerier registry = RegistryManager.Instance(ksp).registry;
                 options.modules.AddRange(
-                    registry.InstalledModules.Select(mod => mod.identifier)
+                    regMgr.registry.InstalledModules.Select(mod => mod.identifier)
                 );
             }
 
@@ -79,7 +76,7 @@ namespace CKAN.CmdLine
                     HashSet<string> possibleConfigOnlyDirs = null;
                     var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                     Search.AdjustModulesCase(ksp, options.modules);
-                    installer.UninstallList(options.modules, ref possibleConfigOnlyDirs);
+                    installer.UninstallList(options.modules, ref possibleConfigOnlyDirs, regMgr);
                 }
                 catch (ModNotInstalledKraken kraken)
                 {

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -46,7 +46,8 @@ namespace CKAN.CmdLine
                     allow_incompatible = options.allow_incompatible
                 };
 
-            var registry = RegistryManager.Instance(ksp).registry;
+            var regMgr = RegistryManager.Instance(ksp);
+            var registry = regMgr.registry;
             var to_replace = new List<ModuleReplacement>();
 
             if (options.replace_all)
@@ -156,7 +157,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Replace(to_replace, replace_ops, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs);
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Replace(to_replace, replace_ops, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
                     User.RaiseMessage("\r\nDone!\r\n");
                 }
                 catch (DependencyNotSatisfiedKraken ex)

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -84,9 +84,10 @@ namespace CKAN.CmdLine
             try
             {
                 HashSet<string> possibleConfigOnlyDirs = null;
+                var regMgr = RegistryManager.Instance(ksp);
+                var registry = regMgr.registry;
                 if (options.upgrade_all)
                 {
-                    var registry = RegistryManager.Instance(ksp).registry;
                     var installed = new Dictionary<string, ModuleVersion>(registry.Installed());
                     var to_upgrade = new List<CkanModule>();
 
@@ -130,13 +131,13 @@ namespace CKAN.CmdLine
 
                     }
 
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(to_upgrade, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs);
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(to_upgrade, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
                 }
                 else
                 {
                     // TODO: These instances all need to go.
                     Search.AdjustModulesCase(ksp, options.modules);
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs);
+                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
                 }
             }
             catch (ModuleNotFoundKraken kraken)

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -151,7 +151,7 @@ namespace CKAN.ConsoleUI {
         private void generateList(HashSet<CkanModule> inst)
         {
             if (installer.FindRecommendations(
-                inst, inst,
+                inst, inst, registry as Registry,
                 out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
                 out Dictionary<CkanModule, List<string>> suggestions,
                 out Dictionary<CkanModule, HashSet<string>> supporters

--- a/ConsoleUI/DownloadImportDialog.cs
+++ b/ConsoleUI/DownloadImportDialog.cs
@@ -31,7 +31,7 @@ namespace CKAN.ConsoleUI {
                 ProgressScreen  ps   = new ProgressScreen("Importing Downloads", "Calculating...");
                 ModuleInstaller inst = ModuleInstaller.GetInstance(gameInst, cache, ps);
                 ps.Run(() => inst.ImportFiles(files, ps,
-                    (CkanModule mod) => cp.Install.Add(mod)));
+                    (CkanModule mod) => cp.Install.Add(mod), RegistryManager.Instance(gameInst).registry));
                 // Don't let the installer re-use old screen references
                 inst.User = null;
             }

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -57,24 +57,25 @@ namespace CKAN.ConsoleUI {
                         
                         HashSet<string> possibleConfigOnlyDirs = null;
 
+                        RegistryManager regMgr = RegistryManager.Instance(manager.CurrentInstance);
                         ModuleInstaller inst = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, this);
                         inst.onReportModInstalled = OnModInstalled;
                         if (plan.Remove.Count > 0) {
-                            inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs);
+                            inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr);
                             plan.Remove.Clear();
                         }
                         NetAsyncModulesDownloader dl = new NetAsyncModulesDownloader(this, manager.Cache);
                         if (plan.Upgrade.Count > 0) {
-                            inst.Upgrade(plan.Upgrade, dl, ref possibleConfigOnlyDirs);
+                            inst.Upgrade(plan.Upgrade, dl, ref possibleConfigOnlyDirs, regMgr);
                             plan.Upgrade.Clear();
                         }
                         if (plan.Install.Count > 0) {
                             List<CkanModule> iList = new List<CkanModule>(plan.Install);
-                            inst.InstallList(iList, resolvOpts, dl);
+                            inst.InstallList(iList, resolvOpts, regMgr, dl);
                             plan.Install.Clear();
                         }
                         if (plan.Replace.Count > 0) {
-                            inst.Replace(AllReplacements(plan.Replace), resolvOpts, dl, ref possibleConfigOnlyDirs, true);
+                            inst.Replace(AllReplacements(plan.Replace), resolvOpts, dl, ref possibleConfigOnlyDirs, regMgr, true);
                         }
 
                         trans.Complete();

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -492,7 +492,7 @@ namespace CKAN
 
         public bool Equals(KSP other)
         {
-            return other != null ? gameDir.Equals(other.GameDir()) : base.Equals(other);
+            return other != null && gameDir.Equals(other.GameDir());
         }
 
         public override bool Equals(object obj)

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -21,7 +21,7 @@ namespace CKAN
     /// <summary>
     /// Everything for dealing with KSP itself.
     /// </summary>
-    public class KSP
+    public class KSP : IEquatable<KSP>
     {
         /// <summary>
         /// List of DLLs that should never be added to the autodetect list.
@@ -490,10 +490,14 @@ namespace CKAN
             return "KSP Install: " + gameDir;
         }
 
+        public bool Equals(KSP other)
+        {
+            return other != null ? gameDir.Equals(other.GameDir()) : base.Equals(other);
+        }
+
         public override bool Equals(object obj)
         {
-            var other = obj as KSP;
-            return other != null ? gameDir.Equals(other.GameDir()) : base.Equals(obj);
+            return Equals(obj as KSP);
         }
 
         public override int GetHashCode()

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -166,7 +166,7 @@ namespace CKAN
         /// <param name="existingInstance">The KSP instance to clone.</param>
         /// <param name="newName">The name for the new instance.</param>
         /// <param name="newPath">The path where the new instance should be located.</param>
-        public void CloneInstance (KSP existingInstance, string newName, string newPath)
+        public void CloneInstance(KSP existingInstance, string newName, string newPath)
         {
             if (HasInstance(newName))
             {
@@ -382,16 +382,11 @@ namespace CKAN
             }
 
             // Don't try to Dispose a null CurrentInstance.
-            if (CurrentInstance != null)
+            if (CurrentInstance != null && !CurrentInstance.Equals(instances[name]))
             {
                 // Dispose of the old registry manager, to release the registry.
-                var manager = RegistryManager.Instance(CurrentInstance);
-                if (manager != null)
-                {
-                    manager.Dispose();
-                }
+                RegistryManager.Instance(CurrentInstance)?.Dispose();
             }
-
             CurrentInstance = instances[name];
         }
 

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -76,7 +76,7 @@ namespace CKAN
                 List<CkanModule> metadataChanges = GetChangedInstalledModules(registry_manager.registry);
                 if (metadataChanges.Count > 0)
                 {
-                    HandleModuleChanges(metadataChanges, user, ksp, cache);
+                    HandleModuleChanges(metadataChanges, user, ksp, cache, registry_manager);
                 }
 
                 // Registry.CompatibleModules is slow, just return success,
@@ -181,7 +181,7 @@ namespace CKAN
         /// <param name="metadataChanges">List of modules that changed</param>
         /// <param name="user">Object for user interaction callbacks</param>
         /// <param name="ksp">Game instance</param>
-        private static void HandleModuleChanges(List<CkanModule> metadataChanges, IUser user, KSP ksp, NetModuleCache cache)
+        private static void HandleModuleChanges(List<CkanModule> metadataChanges, IUser user, KSP ksp, NetModuleCache cache, RegistryManager registry_manager)
         {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < metadataChanges.Count; i++)
@@ -214,6 +214,7 @@ Do you wish to reinstall now?", sb)))
                             new[] { changedIdentifier },
                             new NetAsyncModulesDownloader(new NullUser(), cache),
                             ref possibleConfigOnlyDirs,
+                            registry_manager,
                             enforceConsistency: false
                         );
                     }

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -39,7 +39,8 @@ namespace CKAN
                     ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, currentUser).ImportFiles(
                         GetFiles(dlg.FileNames),
                         currentUser,
-                        (CkanModule mod) => MarkModForInstall(mod.identifier, false)
+                        (CkanModule mod) => MarkModForInstall(mod.identifier, false),
+                        RegistryManager.Instance(CurrentInstance).registry
                     );
                 }
                 finally

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -73,7 +73,8 @@ namespace CKAN
 
             var opts = (KeyValuePair<ModChanges, RelationshipResolverOptions>) e.Argument;
 
-            Registry registry = RegistryManager.Instance(manager.CurrentInstance).registry;
+            RegistryManager registry_manager = RegistryManager.Instance(manager.CurrentInstance);
+            Registry registry = registry_manager.registry;
             ModuleInstaller installer = ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, currentUser);
             // Avoid accumulating multiple event handlers
             installer.onReportModInstalled -= OnModInstalled;
@@ -116,6 +117,7 @@ namespace CKAN
                     .Select(ch => ch.Mod)
                     .ToHashSet(),
                 toInstall,
+                registry,
                 out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
                 out Dictionary<CkanModule, List<string>> suggestions,
                 out Dictionary<CkanModule, HashSet<string>> supporters
@@ -173,7 +175,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.UninstallList(toUninstall, ref possibleConfigOnlyDirs, false, toInstall.Select(m => m.identifier));
+                            installer.UninstallList(toUninstall, ref possibleConfigOnlyDirs, registry_manager, false, toInstall.Select(m => m.identifier));
                             processSuccessful = true;
                         }
                     }
@@ -182,7 +184,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs);
+                            installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager);
                             processSuccessful = true;
                         }
                     }
@@ -191,7 +193,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.InstallList(toInstall, opts.Value, downloader, false);
+                            installer.InstallList(toInstall, opts.Value, registry_manager, downloader, false);
                             processSuccessful = true;
                         }
                     }

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -32,6 +32,7 @@ namespace CKAN
             if (installer.FindRecommendations(
                 registry.InstalledModules.Select(im => im.Module).ToHashSet(),
                 new HashSet<CkanModule>(),
+                registry as Registry,
                 out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
                 out Dictionary<CkanModule, List<string>> suggestions,
                 out Dictionary<CkanModule, HashSet<string>> supporters

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -440,7 +440,7 @@ namespace Tests.Core
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
                     // This should throw, as our tidy KSP has no mods installed.
-                    CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList("Foo", ref possibleConfigOnlyDirs);
+                    CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList("Foo", ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
                 });
 
                 manager.CurrentInstance = null; // I weep even more.
@@ -487,7 +487,7 @@ namespace Tests.Core
                 // Attempt to install it.
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
@@ -522,7 +522,7 @@ namespace Tests.Core
                 };
                 
                 // Act
-                inst.InstallList(modules, new RelationshipResolverOptions());
+                inst.InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
                 
                 // Assert
                 Assert.IsTrue(File.Exists(mod_file_path));
@@ -555,14 +555,14 @@ namespace Tests.Core
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
 
                 // Attempt to uninstall it.
                 HashSet<string> possibleConfigOnlyDirs = null;
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs);
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the module is not installed.
                 Assert.IsFalse(File.Exists(mod_file_path));
@@ -596,7 +596,7 @@ namespace Tests.Core
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 modules.Clear();
 
@@ -606,7 +606,7 @@ namespace Tests.Core
 
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 modules.Clear();
 
@@ -619,7 +619,7 @@ namespace Tests.Core
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
                 HashSet<string> possibleConfigOnlyDirs = null;
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs);
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the directory has been deleted.
                 Assert.IsFalse(Directory.Exists(directoryPath));
@@ -657,7 +657,7 @@ namespace Tests.Core
                         // Attempt to install it.
                         List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                        CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions());
+                        CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                         // Check that the module is installed.
                         string mod_file_path = Path.Combine(ksp.KSP.GameData(), mod_file_name);

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -19,6 +19,7 @@ namespace Tests.Core
     {
         private KSPManager           _manager;
         private DisposableKSP        _instance;
+        private CKAN.RegistryManager _registryManager;
         private CKAN.Registry        _registry;
         private CKAN.ModuleInstaller _installer;
         private CkanModule           _testModule;
@@ -38,7 +39,8 @@ namespace Tests.Core
 
             _manager   = new KSPManager(_nullUser);
             _instance  = new DisposableKSP();
-            _registry  = CKAN.RegistryManager.Instance(_instance.KSP).registry;
+            _registryManager = CKAN.RegistryManager.Instance(_instance.KSP);
+            _registry  = _registryManager.registry;
             _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _nullUser);
 
             _gameDataDir = _instance.KSP.GameData();
@@ -47,7 +49,8 @@ namespace Tests.Core
             _manager.Cache.Store(_testModule, testModFile);
             _installer.InstallList(
                 new List<string>() { _testModule.identifier },
-                new RelationshipResolverOptions()
+                new RelationshipResolverOptions(),
+                _registryManager
             );
         }
 

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -20,6 +20,7 @@ namespace Tests.GUI
         private CkanModule _anyVersionModule;
         private DisposableKSP _instance;
         private KSPManager _manager;
+        private RegistryManager _registryManager;
         private Registry _registry;
         private MainModList _modList;
         private MainModListGUI _listGui;
@@ -52,6 +53,7 @@ namespace Tests.GUI
         public void Up()
         {
             _instance = new DisposableKSP();
+            _registryManager = RegistryManager.Instance(_instance.KSP);
             _registry = Registry.Empty();
             _manager = new KSPManager(
                 new NullUser(),
@@ -69,6 +71,7 @@ namespace Tests.GUI
             ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                 new List<CkanModule> { { _anyVersionModule } },
                 new RelationshipResolverOptions(),
+                _registryManager,
                 new NetAsyncModulesDownloader(_manager.User, _manager.Cache)
             );
 
@@ -138,6 +141,7 @@ namespace Tests.GUI
                 ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                     _modList.ComputeUserChangeSet(null).Select(change => change.Mod).ToList(),
                     new RelationshipResolverOptions(),
+                    _registryManager,
                     new NetAsyncModulesDownloader(_manager.User, _manager.Cache)
                 );
 


### PR DESCRIPTION
## Problems

### Switching installs A-B-A

1. In GUI, start with or switch to any KSP install A
2. Switch to install B
3. Switch back to install A
4. Install modules
5. The modules will appear as either not installed (if they have no DLL) or as "AD" as if they had been manually installed (if they have a DLL)

### Adding portable install to registry

1. Put ckan.exe in the root folder for a KSP install
2. Run that CKAN to work with that KSP as a "portable" instance
3. Open the Manage Instances window and add the portable install's path as a permanent registered instance
4. Switch to it
5. There will be a weird delay when you click a mod list row as the same registry data is re-loaded
6. Install modules
7. The modules will appear as either not installed (if they have no DLL) or as "AD" as if they had been manually installed (if they have a DLL)

### Path case sensitivity

1. On a Linux or Mac system, create two KSP installs that have the same path except for the use of capital and lowercase letters. For example, `/my/games/ksp` and `/my/games/KSP`.
2. Add both to CKAN
3. Install something in each instance
4. Everything you install will be installed to only **one** of the instances, regardless of which one you thought you were in at the time

## Causes

#1828 updated `KSPManager.SetCurrentInstance` to dispose `RegistryManager` instances when switching to a new instance. This releases the registry lock, which makes sense when we're done working with an instance. It also removes the object from the instance cache, so if we try to retrieve a `RegistryManager` later for the same path, a new object is created.

`ModuleInstaller` held a persistent reference to a `RegistryManager` that it acquired itself, and it kept this reference even after the `RegistryManager` object was disposed. So if you asked it to do something with that instance later, it would notify the wrong `Registry` object of its changes, which would not be reflected in the UI or saved to disk. (Technically, the changed registry is saved to disk and then overwritten by the unchanged one, but :man_shrugging: .)

`KSPManager.SetCurrentInstance` disposes the previous current instance even if it has the same path as the new one. This results in an unnecessary unlocking, re-locking, and re-loading of a registry object that will not have changed.

`ModuleInstaller.GetInstance`, uniquely among all of CKAN's instance retrieval functions, casts its path keys to lowercase before using them. This means that `ModuleInstaller.GetInstance("/my/games/ksp")` and `ModuleInstaller.GetInstance("/my/games/KSP")` return the same object. This is not appropriate in a cross-platform application.

## Changes

Now `ModuleInstaller` doesn't retain a persistent reference to `RegistryManager`; instead, each of its functions that requires a `RegistryManager` or a `Registry` now accepts those objects as a parameter. This more clearly reflects the functional dependencies of these operations, and passes responsibility to the calling code to make sure these objects are up to date. Lots of calling code is updated to pass these new parameters.

In addition, `KSPManager.SetCurrentInstance` will no longer dispose an old `RegistryManager` if it shares its gamedir with the new instance. This will eliminate the delay when switching from a portable install to the same folder as a permanent install.

Finally, `ModuleInstaller.instances` is no longer treats its keys as case insensitive. This will fix the case sensitivity problem on Unix-like systems, and no ill effects are expected because `RegistryManager.Instance` already works this way.

Fixes #2262.
Fixes #2864.
Fixes #2967.