### PR TITLE
Stage modules with hardcoded game versions

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Transformers\OptimusPrimeTransformer.cs" />
     <Compile Include="Transformers\PropertySortTransformer.cs" />
     <Compile Include="Transformers\SpacedockTransformer.cs" />
+    <Compile Include="Transformers\StagingTransformer.cs" />
     <Compile Include="Transformers\StripNetkanMetadataTransformer.cs" />
     <Compile Include="Transformers\VersionEditTransformer.cs" />
     <Compile Include="Transformers\VersionedOverrideTransformer.cs" />

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -29,6 +29,7 @@ namespace CKAN.NetKAN.Transformers
             var ghApi = new GithubApi(http, githubToken);
             _transformers = InjectVersionedOverrideTransformers(new List<ITransformer>
             {
+                new StagingTransformer(),
                 new MetaNetkanTransformer(http, ghApi),
                 new SpacedockTransformer(new SpacedockApi(http)),
                 new CurseTransformer(new CurseApi(http)),

--- a/Netkan/Transformers/StagingTransformer.cs
+++ b/Netkan/Transformers/StagingTransformer.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using log4net;
+using CKAN.Extensions;
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Transformers
+{
+    internal sealed class StagingTransformer : ITransformer
+    {
+        public string Name { get { return "staging"; } }
+
+        public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
+        {
+            JObject json = metadata.Json();
+            var matchingKeys = kspVersionKeys.Where(vk => json.ContainsKey(vk)).Memoize();
+            if (matchingKeys.Any())
+            {
+                string msg = string.Join(", ", matchingKeys.Select(mk => $"{mk} = {json[mk]}"));
+                Log.DebugFormat("Enabling staging, found KSP version keys in netkan: {0}", msg);
+                opts.Staged = true;
+                opts.StagingReason = $"Game version keys found in netkan: {msg}.\r\n\r\nPlease check that their values match the forum thread.";
+            }
+            // This transformer never changes the metadata
+            yield return metadata;
+        }
+
+        private static readonly string[] kspVersionKeys = new string[]
+        {
+            "ksp_version",
+            "ksp_version_min",
+            "ksp_version_max",
+        };
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(StagingTransformer));
+    }
+}


### PR DESCRIPTION
## Motivation

Currently we have 29 netkans with `x_netkan_staging` enabled because the KSP version compatibility info is hard coded in the netkan, and hence might be out of date anytime a new version is released. This has been a bit tedious to set manually for each such netkan, and it is pretty much the same thing every time, hence it would be nice to automate.

## Changes

Now a new `StagingTransformer` does this automatically. It runs first so it can see the raw netkan data without interference by other transformers, and if it finds `ksp_version`, `ksp_version_min`, or `ksp_version_max`, it enables staging and sets the reason to a string explaining what keys were found, their values, and how to proceed. This way, **any** netkan with hard coded compatibility info will automatically be staged every time, and we can remove the staging properties from the netkans that have it.