### PR TITLE
Edit modpack before export

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -329,7 +329,7 @@
         "identifier" : {
             "description" : "Unique identifier for this mod.",
             "type"        : "string",
-            "pattern"     : "^[A-Za-z0-9-]*$"
+            "pattern"     : "^[A-Za-z0-9][A-Za-z0-9-]+$"
         },
         "version" : {
             "description" : "A version string",

--- a/Core/Exporters/DelimeterSeparatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeparatedValueExporter.cs
@@ -4,23 +4,23 @@ using System.Linq;
 
 namespace CKAN.Exporters
 {
-    public sealed class DelimeterSeperatedValueExporter : IExporter
+    public sealed class DelimeterSeparatedValueExporter : IExporter
     {
         private const string WritePattern = "{1}{0}{2}{0}{3}{0}{4}{0}{5}" +
                                             "{0}{6}{0}{7}{0}{8}{0}{9}{0}{10}" +
                                             "{0}{11}{0}{12}{0}{13}{0}{14}{0}{15}" +
                                             "{0}{16}{0}{17}{0}{18}";
-        private readonly string _delimter;
+        private readonly string _delimeter;
 
-        public DelimeterSeperatedValueExporter(Delimter delimter)
+        public DelimeterSeparatedValueExporter(Delimeter delimeter)
         {
-            switch (delimter)
+            switch (delimeter)
             {
-                case Delimter.Comma:
-                    _delimter = ",";
+                case Delimeter.Comma:
+                    _delimeter = ",";
                     break;
-                case Delimter.Tab:
-                    _delimter = "\t";
+                case Delimeter.Tab:
+                    _delimeter = "\t";
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -32,7 +32,7 @@ namespace CKAN.Exporters
             using (var writer = new StreamWriter(stream))
             {
                 writer.WriteLine(WritePattern,
-                    _delimter,
+                    _delimeter,
                     "identifier",
                     "version",
                     "name",
@@ -57,7 +57,7 @@ namespace CKAN.Exporters
                 foreach (var mod in registry.InstalledModules.OrderBy(i => i.Module.name))
                 {
                     writer.WriteLine(WritePattern,
-                        _delimter,
+                        _delimeter,
                         mod.Module.identifier,
                         mod.Module.version,
                         QuoteIfNecessary(mod.Module.name),
@@ -139,7 +139,7 @@ namespace CKAN.Exporters
 
         private string QuoteIfNecessary(string value)
         {
-            if (value != null && value.IndexOf(_delimter, StringComparison.Ordinal) >= 0)
+            if (value != null && value.IndexOf(_delimeter, StringComparison.Ordinal) >= 0)
             {
                 return "\"" + value + "\"";
             }
@@ -149,12 +149,11 @@ namespace CKAN.Exporters
             }
         }
 
-        public enum Delimter
+        public enum Delimeter
         {
             Comma,
             Tab
         }
-
 
     }
 }

--- a/Core/Exporters/Exporter.cs
+++ b/Core/Exporters/Exporter.cs
@@ -30,10 +30,10 @@ namespace CKAN.Exporters
                     _exporter = new BbCodeExporter();
                     break;
                 case ExportFileType.Csv:
-                    _exporter = new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Comma);
+                    _exporter = new DelimeterSeparatedValueExporter(DelimeterSeparatedValueExporter.Delimeter.Comma);
                     break;
                 case ExportFileType.Tsv:
-                    _exporter = new DelimeterSeperatedValueExporter(DelimeterSeperatedValueExporter.Delimter.Tab);
+                    _exporter = new DelimeterSeparatedValueExporter(DelimeterSeparatedValueExporter.Delimeter.Tab);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text;
 using System.Text.RegularExpressions;
 using Autofac;
 using log4net;
@@ -270,27 +271,39 @@ namespace CKAN
 
     public class ResourcesDescriptor
     {
-        [JsonProperty("repository", NullValueHandling = NullValueHandling.Ignore)]
-        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
-        public Uri repository;
-
-        [JsonProperty("homepage", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("homepage", Order = 1, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri homepage;
 
-        [JsonProperty("bugtracker", NullValueHandling = NullValueHandling.Ignore)]
-        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
-        public Uri bugtracker;
-
-        [JsonProperty("spacedock", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("spacedock", Order = 2, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri spacedock;
 
-        [JsonProperty("curse", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("curse", Order = 3, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri curse;
 
-        [JsonProperty("metanetkan", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("repository", Order = 4, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
+        public Uri repository;
+
+        [JsonProperty("bugtracker", Order = 5, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
+        public Uri bugtracker;
+
+        [JsonProperty("ci", Order = 6, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
+        public Uri ci;
+
+        [JsonProperty("license", Order = 7, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
+        public Uri license;
+
+        [JsonProperty("manual", Order = 8, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
+        public Uri manual;
+
+        [JsonProperty("metanetkan", Order = 9, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri metanetkan;
     }
@@ -345,98 +358,99 @@ namespace CKAN
         // identifier, license, and version are always required, so we know
         // what we've got.
 
-        [JsonProperty("abstract")]
+        [JsonProperty("abstract", Order = 5)]
         public string @abstract;
 
-        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("description", Order = 6, NullValueHandling = NullValueHandling.Ignore)]
         public string description;
 
         // Package type: in spec v1.6 can be either "package" or "metapackage"
-        [JsonProperty("kind", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("kind", Order = 29, NullValueHandling = NullValueHandling.Ignore)]
         public string kind;
 
-        [JsonProperty("author", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("author", Order = 7, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public List<string> author;
 
-        [JsonProperty("comment", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("comment", Order = 2, NullValueHandling = NullValueHandling.Ignore)]
         public string comment;
 
-        [JsonProperty("conflicts", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("conflicts", Order = 23, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> conflicts;
 
-        [JsonProperty("depends", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("depends", Order = 19, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> depends;
 
         [JsonProperty("replaced_by", NullValueHandling = NullValueHandling.Ignore)]
         public ModuleRelationshipDescriptor replaced_by;
 
-        [JsonProperty("download")]
+        [JsonProperty("download", Order = 25, NullValueHandling = NullValueHandling.Ignore)]
         public Uri download;
 
-        [JsonProperty("download_size")]
+        [JsonProperty("download_size", Order = 26, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [DefaultValue(0)]
         public long download_size;
 
-        [JsonProperty("download_hash", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("download_hash", Order = 27, NullValueHandling = NullValueHandling.Ignore)]
         public DownloadHashesDescriptor download_hash;
 
-        [JsonProperty("download_content_type", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonProperty("download_content_type", Order = 28, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [DefaultValue("application/zip")]
         public string download_content_type;
 
-        [JsonProperty("identifier", Required = Required.Always)]
+        [JsonProperty("identifier", Order = 3, Required = Required.Always)]
         public string identifier;
 
-        [JsonProperty("ksp_version", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("ksp_version", Order = 9, NullValueHandling = NullValueHandling.Ignore)]
         public KspVersion ksp_version;
 
-        [JsonProperty("ksp_version_max", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("ksp_version_max", Order = 11, NullValueHandling = NullValueHandling.Ignore)]
         public KspVersion ksp_version_max;
 
-        [JsonProperty("ksp_version_min", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("ksp_version_min", Order = 10, NullValueHandling = NullValueHandling.Ignore)]
         public KspVersion ksp_version_min;
 
-        [JsonProperty("ksp_version_strict", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonProperty("ksp_version_strict", Order = 12, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [DefaultValue(false)]
         public bool ksp_version_strict = false;
 
-        [JsonProperty("license")]
+        [JsonProperty("license", Order = 13)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<License>))]
         public List<License> license;
 
-        [JsonProperty("name")]
+        [JsonProperty("name", Order = 4)]
         public string name;
 
-        [JsonProperty("provides", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("provides", Order = 18, NullValueHandling = NullValueHandling.Ignore)]
         public List<string> provides;
 
-        [JsonProperty("recommends", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("recommends", Order = 20, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> recommends;
 
-        [JsonProperty("release_status", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("release_status", Order = 14, NullValueHandling = NullValueHandling.Ignore)]
         public ReleaseStatus release_status;
 
-        [JsonProperty("resources", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("resources", Order = 15, NullValueHandling = NullValueHandling.Ignore)]
         public ResourcesDescriptor resources;
 
-        [JsonProperty("suggests", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("suggests", Order = 21, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> suggests;
 
-        [JsonProperty("version", Required = Required.Always)]
+        [JsonProperty("version", Order = 8, Required = Required.Always)]
         public ModuleVersion version;
 
-        [JsonProperty("supports", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("supports", Order = 22, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> supports;
 
-        [JsonProperty("install", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("install", Order = 24, NullValueHandling = NullValueHandling.Ignore)]
         public ModuleInstallDescriptor[] install;
 
-        [JsonProperty("localizations", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("localizations", Order = 17, NullValueHandling = NullValueHandling.Ignore)]
         public string[] localizations;
 
         // Used to see if we're compatible with a given game/KSP version or not.
@@ -451,7 +465,7 @@ namespace CKAN
         // and has the spec_version's in his installed_modules section
         // We should return this to a simple Required.Always field some time in the future
         // ~ Postremus, 03.09.2015
-        [JsonProperty("spec_version")]
+        [JsonProperty("spec_version", Order = 1)]
         public ModuleVersion spec_version
         {
             get
@@ -469,7 +483,7 @@ namespace CKAN
             }
         }
 
-        [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("tags", Order = 16, NullValueHandling = NullValueHandling.Ignore)]
         public HashSet<string> Tags;
 
         // A list of eveything this mod provides.
@@ -682,6 +696,19 @@ namespace CKAN
             File.WriteAllText(filename, json);
         }
 
+        public static string ToJson(CkanModule module)
+        {
+            var sw = new StringWriter(new StringBuilder());
+            using (var writer = new JsonTextWriter(sw))
+            {
+                writer.Formatting  = Formatting.Indented;
+                writer.Indentation = 4;
+                writer.IndentChar  = ' ';
+                new JsonSerializer().Serialize(writer, module);
+            }
+            return sw + Environment.NewLine;
+        }
+
         /// <summary>
         /// Generates a CKAN.META object from a string.
         /// Also validates that all required fields are present.
@@ -818,12 +845,6 @@ namespace CKAN
         bool IEquatable<CkanModule>.Equals(CkanModule other)
         {
             return Equals(other);
-        }
-
-
-        public static string ToJson(CkanModule module)
-        {
-            return JsonConvert.SerializeObject(module);
         }
 
         /// <summary>

--- a/Core/Types/Identifier.cs
+++ b/Core/Types/Identifier.cs
@@ -1,0 +1,18 @@
+using System.Text.RegularExpressions;
+
+namespace CKAN
+{
+    /// <summary>
+    /// Definition of format of `CkanModule.identifier` as per CKAN.schema
+    /// </summary>
+    public static class Identifier
+    {
+        /// <summary>
+        /// A valid identifier must match this pattern
+        /// </summary>
+        public static readonly Regex ValidIdentifierPattern = new Regex(
+            @"^[A-Za-z0-9][A-Za-z0-9-]+$",
+            RegexOptions.Compiled
+        );
+    }
+}

--- a/Core/Types/License.cs
+++ b/Core/Types/License.cs
@@ -13,7 +13,7 @@ namespace CKAN
         public static License UnknownLicense => _unknownLicense ?? (_unknownLicense = new License("unknown"));
 
         // TODO: It would be lovely for our build system to write these for us.
-        private static readonly HashSet<string> valid_licenses = new HashSet<string>()
+        public static readonly HashSet<string> valid_licenses = new HashSet<string>()
         {
             "public-domain",
             "AFL-3.0",

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -200,6 +200,12 @@
     <Compile Include="Controls\DropdownMenuButton.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Controls\EditModpack.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\EditModpack.Designer.cs">
+      <DependentUpon>EditModpack.cs</DependentUpon>
+    </Compile>
     <Compile Include="Controls\HintTextBox.cs">
       <SubType>Component</SubType>
     </Compile>
@@ -244,6 +250,9 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Main\MainDownload.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Main\MainExport.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Main\MainProvides.cs">
@@ -374,6 +383,15 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\EditLabelsDialog.resx">
       <DependentUpon>EditLabelsDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Controls\EditModpack.resx">
+      <DependentUpon>EditModpack.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Localization\de-DE\EditModpack.de-DE.resx">
+      <DependentUpon>..\..\Controls\EditModpack.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Localization\en-US\EditModpack.en-US.resx">
+      <DependentUpon>..\..\Controls\EditModpack.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Localization\de-DE\EditLabelsDialog.de-DE.resx">
       <DependentUpon>..\..\Dialogs\EditLabelsDialog.cs</DependentUpon>

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -50,8 +50,7 @@ namespace CKAN
             }
         }
 
-        public delegate void SelectedItemsChanged(ListView.SelectedListViewItemCollection items);
-        public event SelectedItemsChanged OnSelectedItemsChanged;
+        public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
 
         public event Action OnConfirmChanges;
         public event Action OnCancelChanges;

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -52,8 +52,7 @@ namespace CKAN
             }
         }
 
-        public delegate void SelectedItemsChanged(ListView.SelectedListViewItemCollection items);
-        public event SelectedItemsChanged OnSelectedItemsChanged;
+        public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
 
         private void ChooseProvidedModsListView_SelectedIndexChanged(object sender, EventArgs e)
         {

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -21,11 +21,13 @@ namespace CKAN
             Dictionary<CkanModule, HashSet<string>> supporters
         )
         {
-            RecommendedModsToggleCheckbox.Checked = true;
-            RecommendedModsListView.Items.Clear();
-            RecommendedModsListView.Items.AddRange(
-                getRecSugRows(cache, recommendations, suggestions, supporters).ToArray());
-
+            Util.Invoke(this, () =>
+            {
+                RecommendedModsToggleCheckbox.Checked = true;
+                RecommendedModsListView.Items.Clear();
+                RecommendedModsListView.Items.AddRange(
+                    getRecSugRows(cache, recommendations, suggestions, supporters).ToArray());
+            });
         }
 
         public HashSet<CkanModule> Wait()
@@ -33,7 +35,7 @@ namespace CKAN
             if (Platform.IsMono)
             {
                 // Workaround: make sure the ListView headers are drawn
-                RecommendedModsListView.EndUpdate();
+                Util.Invoke(this, () => RecommendedModsListView.EndUpdate());
             }
             task = new TaskCompletionSource<HashSet<CkanModule>>();
             return task.Task.Result;
@@ -47,8 +49,7 @@ namespace CKAN
             }
         }
 
-        public delegate void SelectedItemsChanged(ListView.SelectedListViewItemCollection items);
-        public event SelectedItemsChanged OnSelectedItemsChanged;
+        public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
 
         private void RecommendedModsListView_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -107,13 +108,13 @@ namespace CKAN
         private void RecommendedModsToggleCheckbox_CheckedChanged(object sender, EventArgs e)
         {
             var state = ((CheckBox)sender).Checked;
+            RecommendedModsListView.BeginUpdate();
             foreach (ListViewItem item in RecommendedModsListView.Items)
             {
                 if (item.Checked != state)
                     item.Checked = state;
             }
-
-            RecommendedModsListView.Refresh();
+            RecommendedModsListView.EndUpdate();
         }
 
         private void RecommendedModsCancelButton_Click(object sender, EventArgs e)

--- a/GUI/Controls/EditModpack.Designer.cs
+++ b/GUI/Controls/EditModpack.Designer.cs
@@ -1,0 +1,437 @@
+namespace CKAN
+{
+    partial class EditModpack
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(EditModpack));
+            this.ToolTip = new System.Windows.Forms.ToolTip();
+            this.TopEditPanel = new System.Windows.Forms.Panel();
+            this.IdentifierLabel = new System.Windows.Forms.Label();
+            this.IdentifierTextBox = new System.Windows.Forms.TextBox();
+            this.NameLabel = new System.Windows.Forms.Label();
+            this.NameTextBox = new System.Windows.Forms.TextBox();
+            this.AbstractLabel = new System.Windows.Forms.Label();
+            this.AbstractTextBox = new System.Windows.Forms.TextBox();
+            this.VersionLabel = new System.Windows.Forms.Label();
+            this.VersionTextBox = new System.Windows.Forms.TextBox();
+            this.KspVersionLabel = new System.Windows.Forms.Label();
+            this.KspVersionMinComboBox = new System.Windows.Forms.ComboBox();
+            this.KspVersionMaxComboBox = new System.Windows.Forms.ComboBox();
+            this.LicenseLabel = new System.Windows.Forms.Label();
+            this.LicenseComboBox = new System.Windows.Forms.ComboBox();
+            this.IncludeVersionsCheckbox = new System.Windows.Forms.CheckBox();
+            this.RelationshipsListView = new ThemedListView();
+            this.ModNameColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.ModVersionColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.ModAbstractColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.DependsGroup = new System.Windows.Forms.ListViewGroup();
+            this.RecommendationsGroup = new System.Windows.Forms.ListViewGroup();
+            this.SuggestionsGroup = new System.Windows.Forms.ListViewGroup();
+            this.IgnoredGroup = new System.Windows.Forms.ListViewGroup();
+            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.DependsRadioButton = new System.Windows.Forms.RadioButton();
+            this.RecommendsRadioButton = new System.Windows.Forms.RadioButton();
+            this.SuggestsRadioButton = new System.Windows.Forms.RadioButton();
+            this.IgnoreRadioButton = new System.Windows.Forms.RadioButton();
+            this.CancelExportButton = new System.Windows.Forms.Button();
+            this.ExportModpackButton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // ToolTip
+            // 
+            this.ToolTip.AutoPopDelay = 10000;
+            this.ToolTip.InitialDelay = 250;
+            this.ToolTip.ReshowDelay = 250;
+            this.ToolTip.ShowAlways = true;
+            // 
+            // TopEditPanel
+            // 
+            this.TopEditPanel.Controls.Add(this.IdentifierLabel);
+            this.TopEditPanel.Controls.Add(this.IdentifierTextBox);
+            this.TopEditPanel.Controls.Add(this.NameLabel);
+            this.TopEditPanel.Controls.Add(this.NameTextBox);
+            this.TopEditPanel.Controls.Add(this.AbstractLabel);
+            this.TopEditPanel.Controls.Add(this.AbstractTextBox);
+            this.TopEditPanel.Controls.Add(this.VersionLabel);
+            this.TopEditPanel.Controls.Add(this.VersionTextBox);
+            this.TopEditPanel.Controls.Add(this.KspVersionLabel);
+            this.TopEditPanel.Controls.Add(this.KspVersionMinComboBox);
+            this.TopEditPanel.Controls.Add(this.KspVersionMaxComboBox);
+            this.TopEditPanel.Controls.Add(this.LicenseLabel);
+            this.TopEditPanel.Controls.Add(this.LicenseComboBox);
+            this.TopEditPanel.Controls.Add(this.IncludeVersionsCheckbox);
+            this.TopEditPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.TopEditPanel.Name = "TopEditPanel";
+            this.TopEditPanel.Size = new System.Drawing.Size(500, 130);
+            // 
+            // IdentifierLabel
+            // 
+            this.IdentifierLabel.AutoSize = true;
+            this.IdentifierLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.IdentifierLabel.Location = new System.Drawing.Point(10, 10);
+            this.IdentifierLabel.Name = "IdentifierLabel";
+            this.IdentifierLabel.Size = new System.Drawing.Size(75, 23);
+            this.IdentifierLabel.TabIndex = 0;
+            resources.ApplyResources(this.IdentifierLabel, "IdentifierLabel");
+            // 
+            // IdentifierTextBox
+            // 
+            this.IdentifierTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.IdentifierTextBox.Location = new System.Drawing.Point(125, 10);
+            this.IdentifierTextBox.Name = "IdentifierTextBox";
+            this.IdentifierTextBox.Size = new System.Drawing.Size(250, 23);
+            this.IdentifierTextBox.TabIndex = 1;
+            resources.ApplyResources(this.IdentifierTextBox, "IdentifierTextBox");
+            // 
+            // NameLabel
+            // 
+            this.NameLabel.AutoSize = true;
+            this.NameLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.NameLabel.Location = new System.Drawing.Point(10, 40);
+            this.NameLabel.Name = "NameLabel";
+            this.NameLabel.Size = new System.Drawing.Size(75, 23);
+            this.NameLabel.TabIndex = 2;
+            resources.ApplyResources(this.NameLabel, "NameLabel");
+            // 
+            // NameTextBox
+            // 
+            this.NameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.NameTextBox.Location = new System.Drawing.Point(125, 40);
+            this.NameTextBox.Name = "NameTextBox";
+            this.NameTextBox.Size = new System.Drawing.Size(250, 23);
+            this.NameTextBox.TabIndex = 3;
+            resources.ApplyResources(this.NameTextBox, "NameTextBox");
+            // 
+            // AbstractLabel
+            // 
+            this.AbstractLabel.AutoSize = true;
+            this.AbstractLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.AbstractLabel.Location = new System.Drawing.Point(10, 70);
+            this.AbstractLabel.Name = "AbstractLabel";
+            this.AbstractLabel.Size = new System.Drawing.Size(75, 23);
+            this.AbstractLabel.TabIndex = 4;
+            resources.ApplyResources(this.AbstractLabel, "AbstractLabel");
+            // 
+            // AbstractTextBox
+            // 
+            this.AbstractTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.AbstractTextBox.Location = new System.Drawing.Point(125, 70);
+            this.AbstractTextBox.Multiline = true;
+            this.AbstractTextBox.Name = "AbstractTextBox";
+            this.AbstractTextBox.Size = new System.Drawing.Size(250, 50);
+            this.AbstractTextBox.TabIndex = 5;
+            resources.ApplyResources(this.AbstractTextBox, "AbstractTextBox");
+            // 
+            // VersionLabel
+            // 
+            this.VersionLabel.AutoSize = true;
+            this.VersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.VersionLabel.Location = new System.Drawing.Point(400, 10);
+            this.VersionLabel.Name = "VersionLabel";
+            this.VersionLabel.Size = new System.Drawing.Size(75, 23);
+            this.VersionLabel.TabIndex = 6;
+            resources.ApplyResources(this.VersionLabel, "VersionLabel");
+            // 
+            // VersionTextBox
+            // 
+            this.VersionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.VersionTextBox.Location = new System.Drawing.Point(515, 10);
+            this.VersionTextBox.Name = "VersionTextBox";
+            this.VersionTextBox.Size = new System.Drawing.Size(250, 23);
+            this.VersionTextBox.TabIndex = 7;
+            resources.ApplyResources(this.VersionTextBox, "VersionTextBox");
+            // 
+            // KspVersionLabel
+            // 
+            this.KspVersionLabel.AutoSize = true;
+            this.KspVersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.KspVersionLabel.Location = new System.Drawing.Point(400, 40);
+            this.KspVersionLabel.Name = "KspVersionLabel";
+            this.KspVersionLabel.Size = new System.Drawing.Size(75, 23);
+            this.KspVersionLabel.TabIndex = 8;
+            resources.ApplyResources(this.KspVersionLabel, "KspVersionLabel");
+            // 
+            // KspVersionMinComboBox
+            // 
+            this.KspVersionMinComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.KspVersionMinComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.KspVersionMinComboBox.Location = new System.Drawing.Point(515, 40);
+            this.KspVersionMinComboBox.Name = "KspVersionMinComboBox";
+            this.KspVersionMinComboBox.Size = new System.Drawing.Size(70, 23);
+            this.KspVersionMinComboBox.TabIndex = 9;
+            resources.ApplyResources(this.KspVersionMinComboBox, "KspVersionMinComboBox");
+            // 
+            // KspVersionMaxComboBox
+            // 
+            this.KspVersionMaxComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.KspVersionMaxComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.KspVersionMaxComboBox.Location = new System.Drawing.Point(595, 40);
+            this.KspVersionMaxComboBox.Name = "KspVersionMaxComboBox";
+            this.KspVersionMaxComboBox.Size = new System.Drawing.Size(70, 23);
+            this.KspVersionMaxComboBox.TabIndex = 10;
+            resources.ApplyResources(this.KspVersionMaxComboBox, "KspVersionMaxComboBox");
+            // 
+            // LicenseLabel
+            // 
+            this.LicenseLabel.AutoSize = true;
+            this.LicenseLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.LicenseLabel.Location = new System.Drawing.Point(400, 70);
+            this.LicenseLabel.Name = "LicenseLabel";
+            this.LicenseLabel.Size = new System.Drawing.Size(75, 23);
+            this.LicenseLabel.TabIndex = 11;
+            resources.ApplyResources(this.LicenseLabel, "LicenseLabel");
+            // 
+            // LicenseComboBox
+            // 
+            this.LicenseComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.LicenseComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.LicenseComboBox.Location = new System.Drawing.Point(515, 70);
+            this.LicenseComboBox.Name = "LicenseComboBox";
+            this.LicenseComboBox.Size = new System.Drawing.Size(150, 23);
+            this.LicenseComboBox.TabIndex = 12;
+            resources.ApplyResources(this.LicenseComboBox, "LicenseComboBox");
+            //
+            // IncludeVersionsCheckbox
+            //
+            this.IncludeVersionsCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            this.IncludeVersionsCheckbox.AutoSize = true;
+            this.IncludeVersionsCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IncludeVersionsCheckbox.Location = new System.Drawing.Point(515, 100);
+            this.IncludeVersionsCheckbox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.IncludeVersionsCheckbox.Name = "IncludeVersionsCheckbox";
+            this.IncludeVersionsCheckbox.Size = new System.Drawing.Size(131, 24);
+            this.IncludeVersionsCheckbox.TabIndex = 13;
+            resources.ApplyResources(this.IncludeVersionsCheckbox, "IncludeVersionsCheckbox");
+            //
+            // RelationshipsListView
+            //
+            this.RelationshipsListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.RelationshipsListView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.RelationshipsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.ModNameColumn,
+            this.ModVersionColumn,
+            this.ModAbstractColumn});
+            this.RelationshipsListView.FullRowSelect = true;
+            this.RelationshipsListView.HideSelection = false;
+            this.RelationshipsListView.Location = new System.Drawing.Point(9, 45);
+            this.RelationshipsListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.RelationshipsListView.Name = "RelationshipsListView";
+            this.RelationshipsListView.Size = new System.Drawing.Size(1510, 841);
+            this.RelationshipsListView.TabIndex = 14;
+            this.RelationshipsListView.UseCompatibleStateImageBehavior = false;
+            this.RelationshipsListView.View = System.Windows.Forms.View.Details;
+            this.RelationshipsListView.Groups.Add(this.DependsGroup);
+            this.RelationshipsListView.Groups.Add(this.RecommendationsGroup);
+            this.RelationshipsListView.Groups.Add(this.SuggestionsGroup);
+            this.RelationshipsListView.Groups.Add(this.IgnoredGroup);
+            this.RelationshipsListView.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(RelationshipsListView_ItemSelectionChanged);
+            // 
+            // ModNameColumn
+            // 
+            this.ModNameColumn.Width = 332;
+            resources.ApplyResources(this.ModNameColumn, "ModNameColumn");
+            // 
+            // ModVersionColumn
+            // 
+            this.ModVersionColumn.Width = 180;
+            resources.ApplyResources(this.ModVersionColumn, "ModVersionColumn");
+            // 
+            // ModAbstractColumn
+            // 
+            this.ModAbstractColumn.Width = 500;
+            resources.ApplyResources(this.ModAbstractColumn, "ModAbstractColumn");
+            // 
+            // DependsGroup
+            // 
+            this.DependsGroup.Name = "DependsGroup";
+            this.DependsGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            resources.ApplyResources(this.DependsGroup, "DependsGroup");
+            // 
+            // RecommendationsGroup
+            // 
+            this.RecommendationsGroup.Name = "RecommendationsGroup";
+            this.RecommendationsGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            resources.ApplyResources(this.RecommendationsGroup, "RecommendationsGroup");
+            // 
+            // SuggestionsGroup
+            // 
+            this.SuggestionsGroup.Name = "SuggestionsGroup";
+            this.SuggestionsGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            resources.ApplyResources(this.SuggestionsGroup, "SuggestionsGroup");
+            // 
+            // IgnoredGroup
+            // 
+            this.IgnoredGroup.Name = "IgnoredGroup";
+            this.IgnoredGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            resources.ApplyResources(this.IgnoredGroup, "IgnoredGroup");
+            // 
+            // BottomButtonPanel
+            // 
+            this.BottomButtonPanel.Controls.Add(this.DependsRadioButton);
+            this.BottomButtonPanel.Controls.Add(this.RecommendsRadioButton);
+            this.BottomButtonPanel.Controls.Add(this.SuggestsRadioButton);
+            this.BottomButtonPanel.Controls.Add(this.IgnoreRadioButton);
+            this.BottomButtonPanel.Controls.Add(this.CancelExportButton);
+            this.BottomButtonPanel.Controls.Add(this.ExportModpackButton);
+            this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.BottomButtonPanel.Name = "BottomButtonPanel";
+            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
+            // 
+            // DependsRadioButton
+            // 
+            this.DependsRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.DependsRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
+            this.DependsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.DependsRadioButton.Location = new System.Drawing.Point(5, 5);
+            this.DependsRadioButton.Name = "DependsRadioButton";
+            this.DependsRadioButton.Size = new System.Drawing.Size(112, 30);
+            this.DependsRadioButton.TabIndex = 16;
+            this.DependsRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.DependsRadioButton.Click += new System.EventHandler(this.DependsRadioButton_CheckedChanged);
+            resources.ApplyResources(this.DependsRadioButton, "DependsRadioButton");
+            // 
+            // RecommendsRadioButton
+            // 
+            this.RecommendsRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.RecommendsRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
+            this.RecommendsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.RecommendsRadioButton.Location = new System.Drawing.Point(116, 5);
+            this.RecommendsRadioButton.Name = "RecommendsRadioButton";
+            this.RecommendsRadioButton.Size = new System.Drawing.Size(112, 30);
+            this.RecommendsRadioButton.TabIndex = 17;
+            this.RecommendsRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.RecommendsRadioButton.Click += new System.EventHandler(this.RecommendsRadioButton_CheckedChanged);
+            resources.ApplyResources(this.RecommendsRadioButton, "RecommendsRadioButton");
+            // 
+            // SuggestsRadioButton
+            // 
+            this.SuggestsRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.SuggestsRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
+            this.SuggestsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.SuggestsRadioButton.Location = new System.Drawing.Point(227, 5);
+            this.SuggestsRadioButton.Name = "SuggestsRadioButton";
+            this.SuggestsRadioButton.Size = new System.Drawing.Size(112, 30);
+            this.SuggestsRadioButton.TabIndex = 18;
+            this.SuggestsRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.SuggestsRadioButton.Click += new System.EventHandler(this.SuggestsRadioButton_CheckedChanged);
+            resources.ApplyResources(this.SuggestsRadioButton, "SuggestsRadioButton");
+            // 
+            // IgnoreRadioButton
+            // 
+            this.IgnoreRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left));
+            this.IgnoreRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
+            this.IgnoreRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IgnoreRadioButton.Location = new System.Drawing.Point(338, 5);
+            this.IgnoreRadioButton.Name = "IgnoreRadioButton";
+            this.IgnoreRadioButton.Size = new System.Drawing.Size(112, 30);
+            this.IgnoreRadioButton.TabIndex = 19;
+            this.IgnoreRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.IgnoreRadioButton.Click += new System.EventHandler(this.IgnoreRadioButton_CheckedChanged);
+            resources.ApplyResources(this.IgnoreRadioButton, "IgnoreRadioButton");
+            // 
+            // CancelExportButton
+            // 
+            this.CancelExportButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Right));
+            this.CancelExportButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.CancelExportButton.Location = new System.Drawing.Point(266, 5);
+            this.CancelExportButton.Name = "CancelExportButton";
+            this.CancelExportButton.Size = new System.Drawing.Size(112, 30);
+            this.CancelExportButton.TabIndex = 20;
+            this.CancelExportButton.UseVisualStyleBackColor = true;
+            this.CancelExportButton.Click += new System.EventHandler(this.CancelExportButton_Click);
+            resources.ApplyResources(this.CancelExportButton, "CancelExportButton");
+            // 
+            // ExportModpackButton
+            // 
+            this.ExportModpackButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Right));
+            this.ExportModpackButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ExportModpackButton.Location = new System.Drawing.Point(383, 5);
+            this.ExportModpackButton.Name = "ExportModpackButton";
+            this.ExportModpackButton.Size = new System.Drawing.Size(112, 30);
+            this.ExportModpackButton.TabIndex = 22;
+            this.ExportModpackButton.UseVisualStyleBackColor = true;
+            this.ExportModpackButton.Click += new System.EventHandler(this.ExportModpackButton_Click);
+            resources.ApplyResources(this.ExportModpackButton, "ExportModpackButton");
+            // 
+            // EditModpack
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.Controls.Add(this.RelationshipsListView);
+            this.Controls.Add(this.TopEditPanel);
+            this.Controls.Add(this.BottomButtonPanel);
+            this.Margin = new System.Windows.Forms.Padding(0,0,0,0);
+            this.Padding = new System.Windows.Forms.Padding(0,0,0,0);
+            this.Name = "EditModpack";
+            this.Size = new System.Drawing.Size(500, 500);
+            resources.ApplyResources(this, "$this");
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ToolTip ToolTip;
+        private System.Windows.Forms.Panel TopEditPanel;
+        private System.Windows.Forms.Label IdentifierLabel;
+        private System.Windows.Forms.TextBox IdentifierTextBox;
+        private System.Windows.Forms.Label NameLabel;
+        private System.Windows.Forms.TextBox NameTextBox;
+        private System.Windows.Forms.Label AbstractLabel;
+        private System.Windows.Forms.TextBox AbstractTextBox;
+        private System.Windows.Forms.Label VersionLabel;
+        private System.Windows.Forms.TextBox VersionTextBox;
+        private System.Windows.Forms.Label KspVersionLabel;
+        private System.Windows.Forms.ComboBox KspVersionMinComboBox;
+        private System.Windows.Forms.ComboBox KspVersionMaxComboBox;
+        private System.Windows.Forms.Label LicenseLabel;
+        private System.Windows.Forms.ComboBox LicenseComboBox;
+        private System.Windows.Forms.CheckBox IncludeVersionsCheckbox;
+        private System.Windows.Forms.ListView RelationshipsListView;
+        private System.Windows.Forms.ColumnHeader ModNameColumn;
+        private System.Windows.Forms.ColumnHeader ModVersionColumn;
+        private System.Windows.Forms.ColumnHeader ModAbstractColumn;
+        private System.Windows.Forms.ListViewGroup DependsGroup;
+        private System.Windows.Forms.ListViewGroup RecommendationsGroup;
+        private System.Windows.Forms.ListViewGroup SuggestionsGroup;
+        private System.Windows.Forms.ListViewGroup IgnoredGroup;
+        private System.Windows.Forms.Panel BottomButtonPanel;
+        private System.Windows.Forms.RadioButton DependsRadioButton;
+        private System.Windows.Forms.RadioButton RecommendsRadioButton;
+        private System.Windows.Forms.RadioButton SuggestsRadioButton;
+        private System.Windows.Forms.RadioButton IgnoreRadioButton;
+        private System.Windows.Forms.Button CancelExportButton;
+        private System.Windows.Forms.Button ExportModpackButton;
+    }
+}

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -1,0 +1,344 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Text.RegularExpressions;
+using Autofac;
+using CKAN.Versioning;
+using CKAN.GameVersionProviders;
+using CKAN.Types;
+
+namespace CKAN
+{
+    public partial class EditModpack : UserControl
+    {
+        public EditModpack()
+        {
+            InitializeComponent();
+
+            this.ToolTip.SetToolTip(IdentifierTextBox,       Properties.Resources.EditModpackTooltipIdentifier);
+            this.ToolTip.SetToolTip(NameTextBox,             Properties.Resources.EditModpackTooltipName);
+            this.ToolTip.SetToolTip(AbstractTextBox,         Properties.Resources.EditModpackTooltipAbstract);
+            this.ToolTip.SetToolTip(VersionTextBox,          Properties.Resources.EditModpackTooltipVersion);
+            this.ToolTip.SetToolTip(KspVersionMinComboBox,   Properties.Resources.EditModpackTooltipKspVersionMin);
+            this.ToolTip.SetToolTip(KspVersionMaxComboBox,   Properties.Resources.EditModpackTooltipKspVersionMax);
+            this.ToolTip.SetToolTip(LicenseComboBox,         Properties.Resources.EditModpackTooltipLicense);
+            this.ToolTip.SetToolTip(IncludeVersionsCheckbox, Properties.Resources.EditModpackTooltipIncludeVersions);
+            this.ToolTip.SetToolTip(DependsRadioButton,      Properties.Resources.EditModpackTooltipDepends);
+            this.ToolTip.SetToolTip(RecommendsRadioButton,   Properties.Resources.EditModpackTooltipRecommends);
+            this.ToolTip.SetToolTip(SuggestsRadioButton,     Properties.Resources.EditModpackTooltipSuggests);
+            this.ToolTip.SetToolTip(IgnoreRadioButton,       Properties.Resources.EditModpackTooltipIgnore);
+            this.ToolTip.SetToolTip(CancelExportButton,      Properties.Resources.EditModpackTooltipCancel);
+            this.ToolTip.SetToolTip(ExportModpackButton,     Properties.Resources.EditModpackTooltipExport);
+        }
+
+        public void LoadModule(CkanModule module, IRegistryQuerier registry)
+        {
+            this.module = module;
+            Util.Invoke(this, () =>
+            {
+                IdentifierTextBox.Text = module.identifier;
+                NameTextBox.Text       = module.name;
+                AbstractTextBox.Text   = module.@abstract;
+                VersionTextBox.Text    = module.version.ToString();
+                var options = new string[] { "" }.Concat(ServiceLocator.Container.Resolve<IKspBuildMap>().KnownVersions
+                    .SelectMany(v => new KspVersion[] {
+                            new KspVersion(v.Major, v.Minor, v.Patch),
+                            new KspVersion(v.Major, v.Minor)
+                        })
+                    .Distinct()
+                    .OrderByDescending(v => v)
+                    .Select(v => v.ToString())
+                );
+                KspVersionMinComboBox.DataSource = options.ToArray();
+                KspVersionMinComboBox.Text = (module.ksp_version_min ?? module.ksp_version)?.ToString();
+                KspVersionMaxComboBox.DataSource = options.ToArray();
+                KspVersionMaxComboBox.Text = (module.ksp_version_max ?? module.ksp_version)?.ToString();
+                LicenseComboBox.DataSource = License.valid_licenses.OrderBy(l => l).ToArray();
+                LicenseComboBox.Text = module.license?.FirstOrDefault()?.ToString();
+                LoadRelationships(registry);
+            });
+        }
+
+        public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
+
+        public bool Wait(IUser user)
+        {
+            if (Platform.IsMono)
+            {
+                // Workaround: make sure the ListView headers are drawn
+                Util.Invoke(this, () => RelationshipsListView.EndUpdate());
+            }
+            this.user = user;
+            task = new TaskCompletionSource<bool>();
+            return task.Task.Result;
+        }
+
+        private void LoadRelationships(IRegistryQuerier registry)
+        {
+            if (module.depends == null)
+            {
+                module.depends = new List<RelationshipDescriptor>();
+            }
+            if (module.recommends == null)
+            {
+                module.recommends = new List<RelationshipDescriptor>();
+            }
+            if (module.suggests == null)
+            {
+                module.suggests = new List<RelationshipDescriptor>();
+            }
+
+            ignored.Clear();
+            RelationshipsListView.Items.Clear();
+            AddGroup(module.depends,    DependsGroup,         registry);
+            AddGroup(module.recommends, RecommendationsGroup, registry);
+            AddGroup(module.suggests,   SuggestionsGroup,     registry);
+            AddGroup(ignored,           IgnoredGroup,         registry);
+            RelationshipsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+
+            GroupToRelationships.Clear();
+            GroupToRelationships.Add(DependsGroup,         module.depends);
+            GroupToRelationships.Add(RecommendationsGroup, module.recommends);
+            GroupToRelationships.Add(SuggestionsGroup,     module.suggests);
+            GroupToRelationships.Add(IgnoredGroup,         ignored);
+
+            RelationshipsListView_ItemSelectionChanged(null, null);
+        }
+
+        private void AddGroup(List<RelationshipDescriptor> relationships, ListViewGroup group, IRegistryQuerier registry)
+        {
+            if (relationships != null)
+            {
+                RelationshipsListView.Items.AddRange(relationships
+                    .OrderBy(r => (r as ModuleRelationshipDescriptor)?.name)
+                    .Select(r => new ListViewItem(new string[]
+                        {
+                            (r as ModuleRelationshipDescriptor)?.name,
+                            (r as ModuleRelationshipDescriptor)?.version?.ToString(),
+                            registry.LatestAvailable((r as ModuleRelationshipDescriptor)?.name, null, null)?.@abstract
+                        })
+                        {
+                            Tag   = r,
+                            Group = group,
+                        })
+                    .ToArray());
+            }
+        }
+
+        private bool TryFieldsToModule(out string error, out Control badField)
+        {
+            if (!Identifier.ValidIdentifierPattern.IsMatch(IdentifierTextBox.Text))
+            {
+                error = Properties.Resources.EditModpackBadIdentifier;
+                badField = IdentifierTextBox;
+                return false;
+            }
+            if (string.IsNullOrEmpty(NameTextBox.Text))
+            {
+                error = Properties.Resources.EditModpackBadName;
+                badField = NameTextBox;
+                return false;
+            }
+            if (string.IsNullOrEmpty(VersionTextBox.Text))
+            {
+                error = Properties.Resources.EditModpackBadVersion;
+                badField = VersionTextBox;
+                return false;
+            }
+            if (!string.IsNullOrEmpty(KspVersionMinComboBox.Text) && !string.IsNullOrEmpty(KspVersionMaxComboBox.Text)
+                && KspVersion.Parse(KspVersionMinComboBox.Text) > KspVersion.Parse(KspVersionMaxComboBox.Text))
+            {
+                error = Properties.Resources.EditModpackBadKspVersions;
+                badField = KspVersionMinComboBox;
+                return false;
+            }
+
+            error = null;
+            badField = null;
+            module.identifier = IdentifierTextBox.Text;
+            module.name       = NameTextBox.Text;
+            module.@abstract  = AbstractTextBox.Text;
+            module.version    = new ModuleVersion(VersionTextBox.Text);
+            module.license    = new List<License>() { new License(LicenseComboBox.Text) };
+            module.ksp_version_min = string.IsNullOrEmpty(KspVersionMinComboBox.Text)
+                ? null
+                : KspVersion.Parse(KspVersionMinComboBox.Text);
+            module.ksp_version_max = string.IsNullOrEmpty(KspVersionMaxComboBox.Text)
+                ? null
+                : KspVersion.Parse(KspVersionMaxComboBox.Text);
+            return true;
+        }
+
+        private void RelationshipsListView_ItemSelectionChanged(Object sender, ListViewItemSelectionChangedEventArgs e)
+        {
+            if (OnSelectedItemsChanged != null)
+            {
+                OnSelectedItemsChanged(RelationshipsListView.SelectedItems);
+            }
+            var kinds = RelationshipsListView.SelectedItems.Cast<ListViewItem>()
+                .Select(lvi => lvi.Group)
+                .Distinct()
+                .ToList();
+            if (kinds.Count == 1)
+            {
+                switch (kinds.First().Name)
+                {
+                    case "DependsGroup":         DependsRadioButton.Checked    = true; break;
+                    case "RecommendationsGroup": RecommendsRadioButton.Checked = true; break;
+                    case "SuggestionsGroup":     SuggestsRadioButton.Checked   = true; break;
+                    case "IgnoredGroup":         IgnoreRadioButton.Checked     = true; break;
+                }
+            }
+            else
+            {
+                DependsRadioButton.Checked    = false;
+                RecommendsRadioButton.Checked = false;
+                SuggestsRadioButton.Checked   = false;
+                IgnoreRadioButton.Checked     = false;
+            }
+            if (RelationshipsListView.SelectedItems.Count > 0)
+            {
+                DependsRadioButton.Enabled    = true;
+                RecommendsRadioButton.Enabled = true;
+                SuggestsRadioButton.Enabled   = true;
+                IgnoreRadioButton.Enabled     = true;
+            }
+            else
+            {
+                DependsRadioButton.Enabled    = false;
+                RecommendsRadioButton.Enabled = false;
+                SuggestsRadioButton.Enabled   = false;
+                IgnoreRadioButton.Enabled     = false;
+            }
+        }
+
+        private void DependsRadioButton_CheckedChanged(object sender, EventArgs e)
+        {
+            MoveItemsTo(RelationshipsListView.SelectedItems.Cast<ListViewItem>(), DependsGroup, module.depends);
+            RelationshipsListView.Focus();
+        }
+
+        private void RecommendsRadioButton_CheckedChanged(object sender, EventArgs e)
+        {
+            MoveItemsTo(RelationshipsListView.SelectedItems.Cast<ListViewItem>(), RecommendationsGroup, module.recommends);
+            RelationshipsListView.Focus();
+        }
+
+        private void SuggestsRadioButton_CheckedChanged(object sender, EventArgs e)
+        {
+            MoveItemsTo(RelationshipsListView.SelectedItems.Cast<ListViewItem>(), SuggestionsGroup, module.suggests);
+            RelationshipsListView.Focus();
+        }
+
+        private void IgnoreRadioButton_CheckedChanged(object sender, EventArgs e)
+        {
+            MoveItemsTo(RelationshipsListView.SelectedItems.Cast<ListViewItem>(), IgnoredGroup, ignored);
+            RelationshipsListView.Focus();
+        }
+
+        private void MoveItemsTo(IEnumerable<ListViewItem> items, ListViewGroup group, List<RelationshipDescriptor> relationships)
+        {
+            foreach (ListViewItem lvi in items.Where(lvi => lvi.Group != group))
+            {
+                // UI
+                var rel = lvi.Tag as RelationshipDescriptor;
+                var fromRel = GroupToRelationships[lvi.Group];
+                fromRel.Remove(rel);
+                relationships.Add(rel);
+                // Model
+                lvi.Group = group;
+            }
+        }
+
+        private void CancelExportButton_Click(object sender, EventArgs e)
+        {
+            task?.SetResult(false);
+        }
+
+        private void ExportModpackButton_Click(object sender, EventArgs e)
+        {
+            if (!TryFieldsToModule(out string error, out Control badField))
+            {
+                badField.Focus();
+                user.RaiseError(error);
+            }
+            else if (TrySavePrompt(modpackExportOptions, out ExportOption selectedOption, out string filename))
+            {
+                CkanModule.ToFile(ApplyVersionsCheckbox(module), filename);
+                task?.SetResult(true);
+            }
+        }
+
+        private CkanModule ApplyVersionsCheckbox(CkanModule input)
+        {
+            if (IncludeVersionsCheckbox.Checked)
+            {
+                return input;
+            }
+            else
+            {
+                // We want to return the relationships without the version properties,
+                // BUT we don't want to purge them from the main module object
+                // in case the user changes the checkbox after cancelling out of the
+                // save popup. So we create a new CkanModule instead.
+                var newMod = CkanModule.FromJson(CkanModule.ToJson(input));
+                foreach (var rels in new List<List<RelationshipDescriptor>>()
+                    {
+                        newMod.depends,
+                        newMod.recommends,
+                        newMod.suggests
+                    })
+                {
+                    if (rels != null)
+                    {
+                        foreach (var rel in rels
+                            .Select(rel => rel as ModuleRelationshipDescriptor)
+                            .Where(rel => rel != null))
+                        {
+                            rel.version     = null;
+                            rel.min_version = null;
+                            rel.max_version = null;
+                        }
+                    }
+                }
+                return newMod;
+            }
+        }
+
+        private bool TrySavePrompt(List<ExportOption> exportOptions, out ExportOption selectedOption, out string filename)
+        {
+            var dlg = new SaveFileDialog()
+            {
+                Filter = string.Join("|", exportOptions.Select(i => i.ToString()).ToArray()),
+                Title  = Properties.Resources.ExportInstalledModsDialogTitle
+            };
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                selectedOption = exportOptions[dlg.FilterIndex - 1];
+                filename       = dlg.FileName;
+                return true;
+            }
+            else
+            {
+                selectedOption = null;
+                filename       = null;
+                return false;
+            }
+        }
+
+        private static readonly List<ExportOption> modpackExportOptions = new List<ExportOption>()
+        {
+            new ExportOption(ExportFileType.Ckan, Properties.Resources.MainModPack, "ckan"),
+        };
+
+        private CkanModule                   module;
+        private IUser                        user;
+        private TaskCompletionSource<bool>   task;
+        private List<RelationshipDescriptor> ignored = new List<RelationshipDescriptor>();
+        private Dictionary<ListViewGroup, List<RelationshipDescriptor>> GroupToRelationships =
+            new Dictionary<ListViewGroup, List<RelationshipDescriptor>>();
+    }
+}

--- a/GUI/Controls/EditModpack.resx
+++ b/GUI/Controls/EditModpack.resx
@@ -117,7 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
-  <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The license for this modpack</value></data>
+  <data name="IdentifierLabel.Text" xml:space="preserve"><value>Identifier:</value></data>
+  <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="AbstractLabel.Text" xml:space="preserve"><value>Abstract:</value></data>
+  <data name="VersionLabel.Text" xml:space="preserve"><value>Version:</value></data>
+  <data name="KspVersionLabel.Text" xml:space="preserve"><value>KSP versions:</value></data>
+  <data name="LicenseLabel.Text" xml:space="preserve"><value>Licence:</value></data>
+  <data name="IncludeVersionsCheckbox.Text" xml:space="preserve"><value>Save mod versions</value></data>
+  <data name="ModNameColumn.Text" xml:space="preserve"><value>Mod</value></data>
+  <data name="ModVersionColumn.Text" xml:space="preserve"><value>Version</value></data>
+  <data name="ModAbstractColumn.Text" xml:space="preserve"><value>Description</value></data>
+  <data name="DependsGroup.Header" xml:space="preserve"><value>Depends</value></data>
+  <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Recommends</value></data>
+  <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Suggests</value></data>
+  <data name="IgnoredGroup.Header" xml:space="preserve"><value>Ignored</value></data>
+  <data name="DependsRadioButton.Text" xml:space="preserve"><value>Depends</value></data>
+  <data name="RecommendsRadioButton.Text" xml:space="preserve"><value>Recommends</value></data>
+  <data name="SuggestsRadioButton.Text" xml:space="preserve"><value>Suggests</value></data>
+  <data name="IgnoreRadioButton.Text" xml:space="preserve"><value>Ignore</value></data>
+  <data name="CancelExportButton.Text" xml:space="preserve"><value>Cancel</value></data>
+  <data name="ExportModpackButton.Text" xml:space="preserve"><value>Export</value></data>
 </root>

--- a/GUI/Localization/de-DE/EditModpack.de-DE.resx
+++ b/GUI/Localization/de-DE/EditModpack.de-DE.resx
@@ -117,7 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
-  <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The license for this modpack</value></data>
+  <data name="IdentifierLabel.Text" xml:space="preserve"><value>Kennung:</value></data>
+  <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="AbstractLabel.Text" xml:space="preserve"><value>Abstrakt:</value></data>
+  <data name="VersionLabel.Text" xml:space="preserve"><value>Modpack-Version:</value></data>
+  <data name="KspVersionLabel.Text" xml:space="preserve"><value>KSP-Versionen:</value></data>
+  <data name="LicenseLabel.Text" xml:space="preserve"><value>Lizenz:</value></data>
+  <data name="IncludeVersionsCheckbox.Text" xml:space="preserve"><value>Mod-Versionen im Pack auf die hier angezeigten festsetzen</value></data>
+  <data name="ModNameColumn.Text" xml:space="preserve"><value>Mod</value></data>
+  <data name="ModVersionColumn.Text" xml:space="preserve"><value>Version</value></data>
+  <data name="ModAbstractColumn.Text" xml:space="preserve"><value>Beschreibung</value></data>
+  <data name="DependsGroup.Header" xml:space="preserve"><value>Abhängigkeiten</value></data>
+  <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Empgehlungen</value></data>
+  <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Vorschläge</value></data>
+  <data name="IgnoredGroup.Header" xml:space="preserve"><value>Nicht Teil des Modpacks</value></data>
+  <data name="DependsRadioButton.Text" xml:space="preserve"><value>Abhängigkeit</value></data>
+  <data name="RecommendsRadioButton.Text" xml:space="preserve"><value>Empfehlung</value></data>
+  <data name="SuggestsRadioButton.Text" xml:space="preserve"><value>Vorschlag</value></data>
+  <data name="IgnoreRadioButton.Text" xml:space="preserve"><value>Ausschließen</value></data>
+  <data name="CancelExportButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
+  <data name="ExportModpackButton.Text" xml:space="preserve"><value>Exportieren</value></data>
 </root>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -167,7 +167,8 @@
   <data name="manageKspInstancesMenuItem.Text" xml:space="preserve"><value>KSP-Instanzen verwalten</value></data>
   <data name="openKspDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Spieleverzeichnis öffnen</value></data>
   <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>Von .ckan installieren</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>Liste installierter Mods &amp;exportieren</value></data>
+  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>Liste installierter Mods speichern...</value></data>
+  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Modpack exportieren ...</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Heruntergeladene Mods &amp;importieren</value></data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Empfehlungen installierter Mods</value></data>
   <data name="ExitToolButton.Text" xml:space="preserve"><value>&amp;Beenden</value></data>
@@ -224,6 +225,7 @@
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Änderungen</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Statuslog</value></data>
   <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Wähle Empfehlungen und Vorschläge aus</value></data>
+  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modpack bearbeiten</value></data>
   <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N verfügbare Updates</value></data>
   <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Aktualisieren</value></data>
   <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Anhalten</value></data>

--- a/GUI/Localization/en-US/EditModpack.en-US.resx
+++ b/GUI/Localization/en-US/EditModpack.en-US.resx
@@ -117,7 +117,5 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
-  <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The license for this modpack</value></data>
+  <data name="LicenseLabel.Text" xml:space="preserve"><value>License:</value></data>
 </root>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -37,6 +37,7 @@
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.installFromckanToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportModListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportModPackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.importDownloadsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
@@ -136,6 +137,8 @@
             this.quitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.DeleteDirectoriesTabPage = new System.Windows.Forms.TabPage();
             this.DeleteDirectories = new CKAN.DeleteDirectories();
+            this.EditModpackTabPage = new System.Windows.Forms.TabPage();
+            this.EditModpack = new CKAN.EditModpack();
             this.menuStrip1.SuspendLayout();
             this.menuStrip2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -154,6 +157,7 @@
             this.ChooseProvidedModsTabPage.SuspendLayout();
             this.minimizedContextMenuStrip.SuspendLayout();
             this.DeleteDirectoriesTabPage.SuspendLayout();
+            this.EditModpackTabPage.SuspendLayout();
             this.SuspendLayout();
             //
             // menuStrip1
@@ -180,6 +184,7 @@
             this.importDownloadsToolStripMenuItem,
             this.toolStripSeparator2,
             this.exportModListToolStripMenuItem,
+            this.exportModPackToolStripMenuItem,
             this.toolStripSeparator3,
             this.auditRecommendationsMenuItem,
             this.toolStripSeparator7,
@@ -220,6 +225,13 @@
             this.exportModListToolStripMenuItem.Size = new System.Drawing.Size(281, 30);
             this.exportModListToolStripMenuItem.Click += new System.EventHandler(this.exportModListToolStripMenuItem_Click);
             resources.ApplyResources(this.exportModListToolStripMenuItem, "exportModListToolStripMenuItem");
+            //
+            // exportModPackToolStripMenuItem
+            //
+            this.exportModPackToolStripMenuItem.Name = "exportModPackToolStripMenuItem";
+            this.exportModPackToolStripMenuItem.Size = new System.Drawing.Size(281, 30);
+            this.exportModPackToolStripMenuItem.Click += new System.EventHandler(this.exportModPackToolStripMenuItem_Click);
+            resources.ApplyResources(this.exportModPackToolStripMenuItem, "exportModPackToolStripMenuItem");
             //
             // toolStripSeparator2
             //
@@ -816,6 +828,7 @@
             this.MainTabControl.Controls.Add(this.ChooseRecommendedModsTabPage);
             this.MainTabControl.Controls.Add(this.ChooseProvidedModsTabPage);
             this.MainTabControl.Controls.Add(this.DeleteDirectoriesTabPage);
+            this.MainTabControl.Controls.Add(this.EditModpackTabPage);
             this.MainTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MainTabControl.Location = new System.Drawing.Point(0, 35);
             this.MainTabControl.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
@@ -1034,6 +1047,29 @@
             this.DeleteDirectories.Size = new System.Drawing.Size(500, 500);
             this.DeleteDirectories.TabIndex = 32;
             //
+            // EditModpackTabPage
+            //
+            this.EditModpackTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.EditModpackTabPage.Controls.Add(this.EditModpack);
+            this.EditModpackTabPage.Location = new System.Drawing.Point(0, 0);
+            this.EditModpackTabPage.Margin = new System.Windows.Forms.Padding(0,0,0,0);
+            this.EditModpackTabPage.Name = "EditModpackTabPage";
+            this.EditModpackTabPage.Padding = new System.Windows.Forms.Padding(0,0,0,0);
+            this.EditModpackTabPage.Size = new System.Drawing.Size(500, 500);
+            this.EditModpackTabPage.TabIndex = 31;
+            resources.ApplyResources(this.EditModpackTabPage, "EditModpackTabPage");
+            //
+            // EditModpack
+            //
+            this.EditModpack.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.EditModpack.Location = new System.Drawing.Point(0, 0);
+            this.EditModpack.Margin = new System.Windows.Forms.Padding(0,0,0,0);
+            this.EditModpack.Padding = new System.Windows.Forms.Padding(0,0,0,0);
+            this.EditModpack.Name = "EditModpack";
+            this.EditModpack.Size = new System.Drawing.Size(500, 500);
+            this.EditModpack.TabIndex = 32;
+            this.EditModpack.OnSelectedItemsChanged += this.EditModpack_OnSelectedItemsChanged;
+            //
             // minimizeNotifyIcon
             //
             this.minimizeNotifyIcon.ContextMenuStrip = this.minimizedContextMenuStrip;
@@ -1175,6 +1211,8 @@
             this.ChooseProvidedModsTabPage.PerformLayout();
             this.DeleteDirectoriesTabPage.ResumeLayout(false);
             this.DeleteDirectoriesTabPage.PerformLayout();
+            this.EditModpackTabPage.ResumeLayout(false);
+            this.EditModpackTabPage.PerformLayout();
             this.minimizedContextMenuStrip.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -1190,6 +1228,7 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem installFromckanToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportModListToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exportModPackToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem importDownloadsToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
@@ -1275,6 +1314,8 @@
         private CKAN.ChooseProvidedMods ChooseProvidedMods;
         private System.Windows.Forms.TabPage DeleteDirectoriesTabPage;
         private CKAN.DeleteDirectories DeleteDirectories;
+        private System.Windows.Forms.TabPage EditModpackTabPage;
+        private CKAN.EditModpack EditModpack;
         private System.Windows.Forms.NotifyIcon minimizeNotifyIcon;
         private System.Windows.Forms.ContextMenuStrip minimizedContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem updatesToolStripMenuItem;

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -169,7 +169,8 @@
   <data name="manageKspInstancesMenuItem.Text" xml:space="preserve"><value>Manage KSP Instances</value></data>
   <data name="openKspDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Open KSP Directory</value></data>
   <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>Install from .ckan...</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Export installed mods...</value></data>
+  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list...</value></data>
+  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Export modpack...</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Import downloaded mods...</value></data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Audit recommendations</value></data>
   <data name="ExitToolButton.Text" xml:space="preserve"><value>E&amp;xit</value></data>
@@ -231,6 +232,7 @@
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Status log</value></data>
   <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choose recommended or suggested mods</value></data>
   <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Delete Directories</value></data>
+  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Edit Modpack</value></data>
   <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
   <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N available updates</value></data>
   <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Refresh</value></data>

--- a/GUI/Main/MainExport.cs
+++ b/GUI/Main/MainExport.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using CKAN.Exporters;
+using CKAN.Types;
+
+namespace CKAN
+{
+    public partial class Main
+    {
+        /// <summary>
+        /// Exports installed mods to a .ckan file.
+        /// </summary>
+        private void exportModPackToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            // Background thread so GUI thread can work with the controls
+            Task.Factory.StartNew(() =>
+            {
+                AddStatusMessage("");
+                Util.Invoke(this, () => menuStrip1.Enabled = false);
+                tabController.ShowTab("EditModpackTabPage", 2);
+                tabController.SetTabLock(true);
+                var mgr = RegistryManager.Instance(CurrentInstance);
+                EditModpack.LoadModule(mgr.GenerateModpack(false, true), mgr.registry);
+                // This will block till the user is done
+                EditModpack.Wait(currentUser);
+                tabController.ShowTab("ManageModsTabPage");
+                tabController.HideTab("EditModpackTabPage");
+                tabController.SetTabLock(false);
+                Util.Invoke(this, () => menuStrip1.Enabled = true);
+            });
+        }
+
+        private void EditModpack_OnSelectedItemsChanged(ListView.SelectedListViewItemCollection items)
+        {
+            var first = items.Cast<ListViewItem>().FirstOrDefault()?.Tag as ModuleRelationshipDescriptor;
+            var ident = first?.name;
+            if (!string.IsNullOrEmpty(ident) && mainModList.full_list_of_mod_rows.TryGetValue(ident, out DataGridViewRow row))
+            {
+                ActiveModInfo = row.Tag as GUIMod;
+            }
+            else
+            {
+                ActiveModInfo = null;
+            }
+        }
+
+        private static readonly List<ExportOption> specialExportOptions = new List<ExportOption>
+        {
+            new ExportOption(ExportFileType.PlainText, Properties.Resources.MainPlainText, "txt"),
+            new ExportOption(ExportFileType.Markdown,  Properties.Resources.MainMarkdown,  "md"),
+            new ExportOption(ExportFileType.BbCode,    Properties.Resources.MainBBCode,    "txt"),
+            new ExportOption(ExportFileType.Csv,       Properties.Resources.MainCSV,       "csv"),
+            new ExportOption(ExportFileType.Tsv,       Properties.Resources.MainTSV,       "tsv"),
+        };
+
+        /// <summary>
+        /// Exports installed mods to a non-.ckan file.
+        /// </summary>
+        private void exportModListToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var dlg = new SaveFileDialog()
+            {
+                Filter = string.Join("|", specialExportOptions.Select(i => i.ToString()).ToArray()),
+                Title  = Properties.Resources.ExportInstalledModsDialogTitle
+            };
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                var fileMode = File.Exists(dlg.FileName) ? FileMode.Truncate : FileMode.CreateNew;
+                using (var stream = new FileStream(dlg.FileName, fileMode))
+                {
+                    new Exporter(specialExportOptions[dlg.FilterIndex - 1].ExportFileType).Export(
+                        RegistryManager.Instance(Main.Instance.CurrentInstance).registry,
+                        stream
+                    );
+                }
+            }
+        }
+
+    }
+}

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -406,9 +406,6 @@ namespace CKAN.Properties {
         internal static string MainLaunchFailed {
             get { return (string)(ResourceManager.GetObject("MainLaunchFailed", resourceCulture)); }
         }
-        internal static string MainFavouritesList {
-            get { return (string)(ResourceManager.GetObject("MainFavouritesList", resourceCulture)); }
-        }
         internal static string MainModPack {
             get { return (string)(ResourceManager.GetObject("MainModPack", resourceCulture)); }
         }
@@ -825,6 +822,61 @@ namespace CKAN.Properties {
         }
         internal static string MainLabelsUntagged {
             get { return (string)(ResourceManager.GetObject("MainLabelsUntagged", resourceCulture)); }
+        }
+
+        internal static string EditModpackBadIdentifier {
+            get { return (string)(ResourceManager.GetObject("EditModpackBadIdentifier", resourceCulture)); }
+        }
+        internal static string EditModpackBadName {
+            get { return (string)(ResourceManager.GetObject("EditModpackBadName", resourceCulture)); }
+        }
+        internal static string EditModpackBadVersion {
+            get { return (string)(ResourceManager.GetObject("EditModpackBadVersion", resourceCulture)); }
+        }
+        internal static string EditModpackBadKspVersions {
+            get { return (string)(ResourceManager.GetObject("EditModpackBadKspVersions", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipIdentifier {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipIdentifier", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipName {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipName", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipAbstract {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipAbstract", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipVersion {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipVersion", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipKspVersionMin {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipKspVersionMin", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipKspVersionMax {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipKspVersionMax", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipLicense {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipLicense", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipIncludeVersions {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipIncludeVersions", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipDepends {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipDepends", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipRecommends {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipRecommends", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipSuggests {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipSuggests", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipIgnore {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipIgnore", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipCancel {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipCancel", resourceCulture)); }
+        }
+        internal static string EditModpackTooltipExport {
+            get { return (string)(ResourceManager.GetObject("EditModpackTooltipExport", resourceCulture)); }
         }
    }
 }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -176,8 +176,7 @@
 
 {0}</value>
   </data>
-  <data name="MainFavouritesList" xml:space="preserve"><value>CKAN Favoritenliste (*.ckan)</value></data>
-  <data name="MainModPack" xml:space="preserve"><value>CKAN Modpack (erzwingt genaue Mod-Versionen) (*.ckan)</value></data>
+  <data name="MainModPack" xml:space="preserve"><value>CKAN Modpack (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Klartext (*.txt)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Nicht gefunden.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Möchtest du {0} neu installieren?</value></data>
@@ -343,4 +342,22 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
 {0}</value></data>
   <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Aktualisierungen für beobachtete Mods</value></data>
   <data name="MainLabelsUntagged" xml:space="preserve"><value>Ohne Kategorie ({0})</value></data>
+  <data name="EditModpackBadIdentifier" xml:space="preserve"><value>Die Kennung darf nur aus Buchstaben, Zahlen und Bindestrichen bestehen, muss mindestens zwei Zeichen lang sein und darf nicht mit einem Bindestrich beginnen.</value></data>
+  <data name="EditModpackBadName" xml:space="preserve"><value>Ein Name für das Modpack ist erforderlich.</value></data>
+  <data name="EditModpackBadVersion" xml:space="preserve"><value>Eine Version für das Modpack ist erforderlich.</value></data>
+  <data name="EditModpackBadKspVersions" xml:space="preserve"><value>Die minimale KSP-Version muss kleiner oder gleich der maximalen KSP-Version sein.</value></data>
+  <data name="EditModpackTooltipIdentifier" xml:space="preserve"><value>Interne Kennung dieses Modpacks; Nur Buchstaben, Zahlen und Bindestriche</value></data>
+  <data name="EditModpackTooltipName" xml:space="preserve"><value>Öffentlich sichtbarer Name dieses Modpacks</value></data>
+  <data name="EditModpackTooltipAbstract" xml:space="preserve"><value>Kurze Zusammenfassung dieses Modpacks</value></data>
+  <data name="EditModpackTooltipVersion" xml:space="preserve"><value>Die Versionsnummer für dieses Modpack, nutze das heutige Datum um es später einfach zuordnen zu können.</value></data>
+  <data name="EditModpackTooltipKspVersionMin" xml:space="preserve"><value>Setze die früheste KSP-Version fest, unter der das Modpack installiert werden kann. Leer für unbeschränkt.</value></data>
+  <data name="EditModpackTooltipKspVersionMax" xml:space="preserve"><value>Setze die neusete KSP-Version fest, unter der das Modpack installiert werden kann. Leer für unbeschränkt.</value></data>
+  <data name="EditModpackTooltipLicense" xml:space="preserve"><value>Die Lizenz für dieses Modpack</value></data>
+  <data name="EditModpackTooltipIncludeVersions" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird bei jeder Mod die unten angezeigte Version mitgespeichert. Beim Importieren des Modpacks werden dann genau diese Versionen installiert.</value></data>
+  <data name="EditModpackTooltipDepends" xml:space="preserve"><value>Speichere die ausgewählten Mods als Abhängigkeiten im Modpack. Diese Mods werden bei der Installation des Modpacks auf jeden Fall installiert.</value></data>
+  <data name="EditModpackTooltipRecommends" xml:space="preserve"><value>Speichere die ausgewählten Mods als Empfehlungen. Beim Installieren des Modpacks kann der Nutzer diese Mods weglassen.</value></data>
+  <data name="EditModpackTooltipSuggests" xml:space="preserve"><value>Speichere die ausgewählten Mods als Vorschläge. Bei der Installation des Modpacks werden diese Mods angezeigt, der Nutzer muss sie jedoch erst explizit zur Installation auswählen.</value></data>
+  <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Speichere die ausgewählten Mods NICHT im Modpack. Diese Mods werden nicht sichtbar sein.</value></data>
+  <data name="EditModpackTooltipCancel" xml:space="preserve"><value>Brich die Modpackerstellung ab</value></data>
+  <data name="EditModpackTooltipExport" xml:space="preserve"><value>Wähle einen Dateinamen und speichere das Modpack</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -194,8 +194,7 @@
   <data name="MainLaunchFailed" xml:space="preserve"><value>Couldn't start KSP.
 
 {0}</value></data>
-  <data name="MainFavouritesList" xml:space="preserve"><value>CKAN favourites list (*.ckan)</value></data>
-  <data name="MainModPack" xml:space="preserve"><value>CKAN modpack (enforces exact mod versions) (*.ckan)</value></data>
+  <data name="MainModPack" xml:space="preserve"><value>CKAN modpack (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Plain text (*.txt)</value></data>
   <data name="MainMarkdown" xml:space="preserve"><value>Markdown (*.md)</value></data>
   <data name="MainBBCode" xml:space="preserve"><value>BBCode (*.txt)</value></data>
@@ -362,4 +361,22 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
 {0}</value></data>
   <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Update Notifications</value></data>
   <data name="MainLabelsUntagged" xml:space="preserve"><value>Untagged ({0})</value></data>
+  <data name="EditModpackBadIdentifier" xml:space="preserve"><value>Identifier must contain one or more letters, numbers, and dashes, and must start with a letter or number</value></data>
+  <data name="EditModpackBadName" xml:space="preserve"><value>Name is required</value></data>
+  <data name="EditModpackBadVersion" xml:space="preserve"><value>Version is required</value></data>
+  <data name="EditModpackBadKspVersions" xml:space="preserve"><value>Min KSP version must be less than or equal to max KSP version</value></data>
+  <data name="EditModpackTooltipIdentifier" xml:space="preserve"><value>Internal name of this modpack; letters, numbers, and dashes only</value></data>
+  <data name="EditModpackTooltipName" xml:space="preserve"><value>Publicly visible name of this modpack</value></data>
+  <data name="EditModpackTooltipAbstract" xml:space="preserve"><value>Short description of this modpack</value></data>
+  <data name="EditModpackTooltipVersion" xml:space="preserve"><value>The version number for this modpack</value></data>
+  <data name="EditModpackTooltipKspVersionMin" xml:space="preserve"><value>Earliest compatible version of KSP, blank for all</value></data>
+  <data name="EditModpackTooltipKspVersionMax" xml:space="preserve"><value>Latest compatible version of KSP, blank for all</value></data>
+  <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The licence for this modpack</value></data>
+  <data name="EditModpackTooltipIncludeVersions" xml:space="preserve"><value>If checked, the modpack will include the specific versions of the mods shown, otherwise any version will do</value></data>
+  <data name="EditModpackTooltipDepends" xml:space="preserve"><value>Move selected mods to the Depends group. These mods will definitely be installed.</value></data>
+  <data name="EditModpackTooltipRecommends" xml:space="preserve"><value>Move selected mods to the Recommends group. A user can drop these mods on installation.</value></data>
+  <data name="EditModpackTooltipSuggests" xml:space="preserve"><value>Move selected mods to the Suggests group. These mods will be available for installation, but you have to explicitly select them.</value></data>
+  <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Move selected mods to the Ignored group. These mods won't be included in the modpack. </value></data>
+  <data name="EditModpackTooltipCancel" xml:space="preserve"><value>Abort modpack creation</value></data>
+  <data name="EditModpackTooltipExport" xml:space="preserve"><value>Choose a filename and save the modpack</value></data>
 </root>

--- a/Netkan/Validators/AlphaNumericIdentifierValidator.cs
+++ b/Netkan/Validators/AlphaNumericIdentifierValidator.cs
@@ -7,15 +7,10 @@ namespace CKAN.NetKAN.Validators
     {
         public void Validate(Metadata metadata)
         {
-            if (!alphanumeric.IsMatch(metadata.Identifier))
+            if (!Identifier.ValidIdentifierPattern.IsMatch(metadata.Identifier))
             {
                 throw new Kraken("CKAN identifiers must consist only of letters, numbers, and dashes, and must start with a letter or number.");
             }
         }
-
-        private static readonly Regex alphanumeric = new Regex(
-            @"^[A-Za-z0-9-]+$",
-            RegexOptions.Compiled
-        );
     }
 }

--- a/Netkan/Validators/RelationshipsValidator.cs
+++ b/Netkan/Validators/RelationshipsValidator.cs
@@ -25,7 +25,7 @@ namespace CKAN.NetKAN.Validators
                             foreach (JObject opt in rel["any_of"])
                             {
                                 string name = (string)opt["name"];
-                                if (!alphanumeric.IsMatch(name))
+                                if (!Identifier.ValidIdentifierPattern.IsMatch(name))
                                 {
                                     throw new Kraken($"{name} in {relName} any_of is not a valid CKAN identifier");
                                 }
@@ -34,7 +34,7 @@ namespace CKAN.NetKAN.Validators
                         else
                         {
                             string name = (string)rel["name"];
-                            if (!alphanumeric.IsMatch(name))
+                            if (!Identifier.ValidIdentifierPattern.IsMatch(name))
                             {
                                 throw new Kraken($"{name} in {relName} is not a valid CKAN identifier");
                             }
@@ -53,10 +53,6 @@ namespace CKAN.NetKAN.Validators
             "conflicts",
             "supports"
         };
-        private static readonly Regex alphanumeric = new Regex(
-            @"^[A-Za-z0-9-]+$",
-            RegexOptions.Compiled
-        );
         private static readonly ModuleVersion v1p26 = new ModuleVersion("v1.26");
     }
 }


### PR DESCRIPTION
## Background

Currently the File menu has an option called "Export installed mods..." that brings up a save window with several options:

![image](https://user-images.githubusercontent.com/1559108/73104755-147c0780-3eef-11ea-81f4-6b10dea209df.png)

![image](https://user-images.githubusercontent.com/1559108/73104761-1940bb80-3eef-11ea-87af-59e6b5b748e0.png)

Two of the options are for .ckan files, with the "modpack" option including mod versions and the favorites/favourites option omitting them. Also one of them treats the mods as dependencies and the other as recommendations; which is which? I don't know and neither do you, because that UI doesn't mention this!

The generated metadata of the .ckan options looks something like this:

```json
{
        "kind": "metapackage",
        "abstract": "A list of modules installed on the ksp-1.8.1 KSP instance",
        "name": "installed-ksp-1.8.1",
        "license": "unknown",
        "version": "2020.01.24.09.25.48",
        "identifier": "installed-ksp-1.8.1",
        "spec_version": "v1.6",
        "recommends": [
                {
                        "name": "ActionGroupManager"
                },
                {
                        "name": "AdjustableModPanel"
                },
                {
                        "name": "AGExt"
                },
                {
                        "name": "AllAboard"
                },
                {
                        "name": "xScienceContinued"
                },
                {
                        "name": "ToolbarController"
                },
                {
                        "name": "ClickThroughBlocker"
                },
                {
                        "name": "ModuleManager"
                }
        ]
}
```

## Motivation

This is kind of confusing and limited.

- What if I want to change whether mod versions are saved without changing whether they're depends/recommends?
- What if I want some mods to be depends, others to be recommends, etc.?
- What if I want to edit the other fields that are saved to my modpack file?
- What if I don't even notice the file type dropdown and assume there's only one option for exporting?
- My user tester felt that "Export installed mods..." sounded like you would be saving *the mods themselves* somehow (imagine a big ZIP of your whole GameData, I guess) rather than just a text listing of them

## Changes

Now the old menu option is split and replaced:

![image](https://user-images.githubusercontent.com/1559108/73105205-4a6dbb80-3ef0-11ea-8a0e-ecf68861b8e1.png)

"Save installed mod list..."  opens the save prompt with the non-.ckan options available:

![image](https://user-images.githubusercontent.com/1559108/73107062-e4376780-3ef4-11ea-9cae-832b52e852b4.png)

"Export modpack..." opens a new Edit Modpack tab with controls to edit the stuff that we save to .ckan files:

![image](https://user-images.githubusercontent.com/1559108/73105288-7db04a80-3ef0-11ea-9f32-4aed8f30a81b.png)

- You can click one of the mods in the central listview to see its mod info at the right
- Then you can click one of the buttons at the bottom left to move it to another section (by default they're all in Depends), with "Ignored" mods being left out of the saved file completely
- Multi-select works (shift- and ctrl-click), so you don't have to click many many times when editing large modpacks
- The "Save mod versions" checkbox determines whether mods' versions are saved to the relationships
- The Export button brings up a save prompt to save your changes to a file and close the tab

To achieve this:

- `RegistryManager.GenerateModpack` creates a `CkanModule` corresponding to the metadata that goes into a .ckan file by default
- A new `EditModpack` control handles editing a `CkanModule` and saving it to disk
- `CkanModule.ToJson` generates a nice JSON string, with the order of properties updated to match `NetKAN.Transformers.PropertySortTransformer`

Fixes #1375.