### PR TITLE
Downgrade to building on Mono 5.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 env:
     global:
-        - BUILD_RELEASE_MONO_VERSION=6.6.0
+        - BUILD_RELEASE_MONO_VERSION=5.20.1
         - DOCKERHUB_USERNAME=kspckanbuilder
         - secure: "UGXJG9jB9tGwjJXxG0Beu4Poz0leuiCBItnfTTKRm1a/NxXf1eoOH9p9icY5Ur2xHwqh0uWSznuL2aNr58CXtzTcMpXrcUhRsO63FB3Cz6tSdZEb+pKQJ23zmC9929DklKRGUT2D/eBcJcnV+/eAtkarrfLBU1avUQAVJgqXvMI="
         - AWS_DEFAULT_REGION=us-west-2
@@ -31,10 +31,10 @@ matrix:
     include:
         - env: BUILD_CONFIGURATION=Debug_NetCore
           # Cake is broken on Mono 6.8.0
-          mono: 6.6.0
+          mono: 5.20.1
           dotnet: 3.1.1
         - env: BUILD_CONFIGURATION=Release_NetCore
-          mono: 6.6.0
+          mono: 5.20.1
           dotnet: 3.1.1
 
 addons:


### PR DESCRIPTION
## Problem

The latest release (1.26.8) on Windows:

```
Unhandled Exception: System.ArgumentException: Object of type 'System.Globalization.CalendarId[]' cannot be converted to type 'System.Int32[]'.
   at System.RuntimeType.TryChangeType(Object value, Binder binder, CultureInfo culture, Boolean needsSpecialCast)
   at System.RuntimeType.CheckValue(Object value, Binder binder, CultureInfo culture, BindingFlags invokeAttr)
   at System.Reflection.RtFieldInfo.UnsafeSetValue(Object obj, Object value, BindingFlags invokeAttr, Binder binder, CultureInfo culture)
   at System.Runtime.Serialization.FormatterServices.SerializationSetValue(MemberInfo fi, Object target, Object value)
   at System.Runtime.Serialization.ObjectManager.CompleteObject(ObjectHolder holder, Boolean bObjectFullyComplete)
   at System.Runtime.Serialization.ObjectManager.DoNewlyRegisteredObjectFixups(ObjectHolder holder)
   at System.Runtime.Serialization.ObjectManager.RegisterObject(Object obj, Int64 objectID, SerializationInfo info, Int64 idOfContainingObj, MemberInfo member, Int32[] arrayIndex)
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.RegisterObject(Object obj, ParseRecord pr, ParseRecord objectPr, Boolean bIsString)
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.ParseObjectEnd(ParseRecord pr)
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Parse(ParseRecord pr)
   at System.Runtime.Serialization.Formatters.Binary.__BinaryParser.Run()
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Deserialize(HeaderHandler handler, __BinaryParser serParser, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(Stream serializationStream, HeaderHandler handler, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Resources.ResourceReader.DeserializeObject(Int32 typeIndex)
   at System.Resources.ResourceReader._LoadObjectV2(Int32 pos, ResourceTypeCode& typeCode)
   at System.Resources.ResourceReader.LoadObjectV2(Int32 pos, ResourceTypeCode& typeCode)
   at System.Resources.ResourceReader.LoadObject(Int32 pos)
   at System.Resources.ResourceReader.ResourceEnumerator.get_Entry()
   at System.Resources.ResourceReader.ResourceEnumerator.get_Current()
   at System.ComponentModel.ComponentResourceManager.FillResources(CultureInfo culture, ResourceSet& resourceSet)
   at System.ComponentModel.ComponentResourceManager.FillResources(CultureInfo culture, ResourceSet& resourceSet)
   at System.ComponentModel.ComponentResourceManager.FillResources(CultureInfo culture, ResourceSet& resourceSet)
   at System.ComponentModel.ComponentResourceManager.ApplyResources(Object value, String objectName, CultureInfo culture)
   at System.ComponentModel.ComponentResourceManager.ApplyResources(Object value, String objectName)
   at CKAN.Main.InitializeComponent()
   at CKAN.Main..ctor(String[] cmdlineArgs, KSPManager mgr, Boolean showConsole)
   at CKAN.GUI.Main_(String[] args, KSPManager manager, Boolean showConsole)
   at CKAN.CmdLine.MainClass.RunSimpleAction(Options cmdline, CommonOptions options, String[] args, IUser user, KSPManager manager)
   at CKAN.CmdLine.MainClass.Execute(KSPManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

The latest release on Ubuntu with Mono 5:

```
exception inside UnhandledException handler: Object reference not set to an instance of an object

[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
  at System.Globalization.DateTimeFormatInfo.InitializeOverridableProperties (System.Globalization.CultureData cultureData, System.Int32 calendarID) [0x0007b] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Globalization.DateTimeFormatInfo.OnDeserialized (System.Runtime.Serialization.StreamingContext ctx) [0x000a7] in <2943701620b54f86b436d3ffad010412>:0 
  at (wrapper delegate-invoke) <Module>.invoke_void_StreamingContext(System.Runtime.Serialization.StreamingContext)
  at System.Runtime.Serialization.ObjectManager.RaiseDeserializationEvent () [0x00008] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Deserialize (System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Runtime.Serialization.Formatters.Binary.__BinaryParser serParser, System.Boolean fCheck, System.Boolean isCrossAppDomain, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) [0x0010d] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize (System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Boolean fCheck, System.Boolean isCrossAppDomain, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) [0x000a2] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize (System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Boolean fCheck, System.Runtime.Remoting.Messaging.IMethodCallMessage methodCallMessage) [0x00000] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize (System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler, System.Boolean fCheck) [0x00000] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize (System.IO.Stream serializationStream, System.Runtime.Remoting.Messaging.HeaderHandler handler) [0x00000] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize (System.IO.Stream serializationStream) [0x00000] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Resources.ResourceReader.DeserializeObject (System.Int32 typeIndex) [0x00019] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Resources.ResourceReader._LoadObjectV2 (System.Int32 pos, System.Resources.ResourceTypeCode& typeCode) [0x0035c] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Resources.ResourceReader.LoadObjectV2 (System.Int32 pos, System.Resources.ResourceTypeCode& typeCode) [0x00000] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Resources.ResourceReader.LoadObject (System.Int32 pos) [0x00011] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Resources.ResourceReader+ResourceEnumerator.get_Entry () [0x000d3] in <2943701620b54f86b436d3ffad010412>:0 
  at System.Resources.ResourceReader+ResourceEnumerator.get_Current () [0x00000] in <2943701620b54f86b436d3ffad010412>:0 
  at System.ComponentModel.ComponentResourceManager.FillResources (System.Globalization.CultureInfo culture, System.Resources.ResourceSet& resourceSet) [0x0006c] in <b3d41b23de534128a4f18a6e1312f79c>:0 
  at System.ComponentModel.ComponentResourceManager.FillResources (System.Globalization.CultureInfo culture, System.Resources.ResourceSet& resourceSet) [0x00024] in <b3d41b23de534128a4f18a6e1312f79c>:0 
  at System.ComponentModel.ComponentResourceManager.FillResources (System.Globalization.CultureInfo culture, System.Resources.ResourceSet& resourceSet) [0x00024] in <b3d41b23de534128a4f18a6e1312f79c>:0 
  at System.ComponentModel.ComponentResourceManager.ApplyResources (System.Object value, System.String objectName, System.Globalization.CultureInfo culture) [0x00039] in <b3d41b23de534128a4f18a6e1312f79c>:0 
  at System.ComponentModel.ComponentResourceManager.ApplyResources (System.Object value, System.String objectName) [0x00000] in <b3d41b23de534128a4f18a6e1312f79c>:0 
  at CKAN.Main.InitializeComponent () [0x00722] in <5016fb43589a4af2af9aed3ff1a8d603>:0 
  at CKAN.Main..ctor (System.String[] cmdlineArgs, CKAN.KSPManager mgr, System.Boolean showConsole) [0x00069] in <5016fb43589a4af2af9aed3ff1a8d603>:0 
  at (wrapper remoting-invoke-with-check) CKAN.Main..ctor(string[],CKAN.KSPManager,bool)
  at CKAN.GUI.Main_ (System.String[] args, CKAN.KSPManager manager, System.Boolean showConsole) [0x0003b] in <5016fb43589a4af2af9aed3ff1a8d603>:0 
  at CKAN.CmdLine.MainClass.Gui (CKAN.KSPManager manager, CKAN.CmdLine.GuiOptions options, System.String[] args) [0x00008] in <5016fb43589a4af2af9aed3ff1a8d603>:0 
  at CKAN.CmdLine.MainClass.RunSimpleAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user, CKAN.KSPManager manager) [0x002d1] in <5016fb43589a4af2af9aed3ff1a8d603>:0 
  at CKAN.CmdLine.MainClass.Execute (CKAN.KSPManager manager, CKAN.CmdLine.CommonOptions opts, System.String[] args) [0x00251] in <5016fb43589a4af2af9aed3ff1a8d603>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x00091] in <5016fb43589a4af2af9aed3ff1a8d603>:0
```

Neither of these appears to be due to anything CKAN itself is doing: note the exception is 20+ levels deep in the stack trace, and building on Windows produces a binary that works fine everywhere.

## Cause

In #2964 we changed the Mono version for the net-core builds from `latest` to `6.6.0` to work around a problem with Cake on Mono 6.8.0.

We also updated versions of Mono and other packages for the regular builds since we hadn't done that in a while, since later versions of software are supposed to have fixes and improvements and we would like to take advantage of those. However, Mono 6.8.0 apparently is not the only release with problems; it looks like Mono 6 can't build an EXE that works on Windows or Mono 5.

## Changes

Now we use the build from Mono 5.20.1. @DasSkelett has tested ckan.exe built with Mono 5.20 and confirmed that it works on Windows.

Fixes #2972.
Fixes #2974.