### PR TITLE
Refresh Info.plist if changelog has changed

### DIFF
--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -37,7 +37,7 @@ $(ICNSDEST): $(ICNSSRC)
 	mkdir -p $(shell dirname $@)
 	ln -f $< $@
 
-$(PLISTDEST): $(PLISTSRC)
+$(PLISTDEST): $(PLISTSRC) $(CHANGELOGSRC)
 	mkdir -p $(shell dirname $@)
 	sed -e 's/@VERSION@/$(VERSION)/' $< > $(PLISTTMP)
 	plistutil -i $(PLISTTMP) -o $@


### PR DESCRIPTION
## Problem

The package for 1.26.8 on OSX apparently includes the right EXE, but the app bundle property says 1.26.6:

![screenshot](https://user-images.githubusercontent.com/1261954/73391093-9e551780-42d7-11ea-88f4-13093cef905c.png)

## Cause

We had a snafu with Mono 6.6.0 in #2972, so all builds were regenerated by hand by @DasSkelett and replaced. Most likely he already had a file at `_build/osx/dmg/CKAN.app/Contents/Info.plist` generated previously with 1.26.6 in it. When he checked out the commit for 1.26.8 and recompiled, this file was not regenerated.

The `Makefile` directive for `Info.plist` uses both `Info.plist.in` and `CHANGELOG.md` (indirectly via the `$(VERSION)` variable) to generate its output, but only `Info.plist.in` is checked for changes currently.

## Changes

Now `Info.plist` also depends on `CHANGELOG.md`, so it will be regenerated when we build a new version.

Fixes #2977.