### PR TITLE
Filter compatible modules by compatibility

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -484,7 +484,7 @@ namespace CKAN
         {
             // Set up our compatibility partition
             SetCompatibleVersion(ksp_version);
-            return sorter.Compatible.Values.Select(pair => pair.Latest(null)).ToList();
+            return sorter.Compatible.Values.Select(avail => avail.Latest(ksp_version)).ToList();
         }
 
         /// <summary>
@@ -494,7 +494,7 @@ namespace CKAN
         {
             // Set up our compatibility partition
             SetCompatibleVersion(ksp_version);
-            return sorter.Incompatible.Values.Select(pair => pair.Latest(null)).ToList();
+            return sorter.Incompatible.Values.Select(avail => avail.Latest(null)).ToList();
         }
 
         /// <summary>

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -185,6 +185,42 @@ namespace Tests.Core.Registry
         }
 
         [Test]
+        public void CompatibleModules_PastAndFutureCompatibility_ReturnsCurrentOnly()
+        {
+            // Arrange
+            CkanModule modFor161 = CkanModule.FromJson(@"{
+                ""identifier"":  ""TypicalMod"",
+                ""version"":     ""0.9.0"",
+                ""download"":    ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                ""ksp_version"": ""1.6.1""
+            }");
+            CkanModule modFor173 = CkanModule.FromJson(@"{
+                ""identifier"":  ""TypicalMod"",
+                ""version"":     ""1.0.0"",
+                ""download"":    ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                ""ksp_version"": ""1.7.3""
+            }");
+            CkanModule modFor181 = CkanModule.FromJson(@"{
+                ""identifier"":  ""TypicalMod"",
+                ""version"":     ""1.1.0"",
+                ""download"":    ""https://kerbalstuff.com/mod/269/Dogecoin%20Flag/download/1.01"",
+                ""ksp_version"": ""1.8.1""
+            }");
+            registry.AddAvailable(modFor161);
+            registry.AddAvailable(modFor173);
+            registry.AddAvailable(modFor181);
+
+            // Act
+            KspVersionCriteria v173 = new KspVersionCriteria(KspVersion.Parse("1.7.3"));
+            List<CkanModule> compat = registry.CompatibleModules(v173).ToList();
+
+            // Assert
+            Assert.IsFalse(compat.Contains(modFor161));
+            Assert.IsTrue(compat.Contains(modFor173));
+            Assert.IsFalse(compat.Contains(modFor181));
+        }
+
+        [Test]
         public void TxEmbeddedCommit()
         {
             // Our registry should work when we initialise it inside our Tx and commit.


### PR DESCRIPTION
## Problem

When you check the mod list checkbox to install a mod, the latest version is chosen regardless of compatibility:

![image](https://user-images.githubusercontent.com/1559108/73543681-1ff29580-43fd-11ea-96e0-d75235629c6f.png)

## Cause

In #2963 we renamed `Registry.Available` to `Registry.CompatibleModules` and rewrote it to share a persistent data structure with `Registry.IncompatibleModules` that stores all the compatible `AvailableModule`s in one list and the incompatible ones in another list. Then all we have to do is return one `CkanModule` per `AvailableModule` in a list.

Previously we returned the latest `CkanModule` regardless of its compatibility. This meant that when a `GUIMod` got constructed for a given row, its `Mod` property could be set to an incompatible `CkanModule`, and this is what is used for the default version to install.

## Changes

Now we pass the version criteria to `AvailableModule.Latest()` when generating the list of `CkanModule`s, so the list will contain actually compatible modules. This will allow `GUIMod` to select the correct `Mod` value.
(And `pair` is renamed to `avail` since these are `AvailableModule` objects rather than the `KeyValuePair`s that we would commonly see when working with a dictionary.)

![image](https://user-images.githubusercontent.com/1559108/73544004-c63e9b00-43fd-11ea-9d6c-551915515db7.png)

Fixes #2979.