### PR TITLE
Detect conflicts on recommendations screen

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -584,23 +584,25 @@ namespace CKAN
         }
 
         /// <summary>
-        ///  Returns a IList consisting of keyValuePairs containing conflicting mods.
-        /// Note: (a,b) in the list should imply that (b,a) is in the list.
+        /// Returns a dictionary consisting of keyValuePairs containing conflicting mods.
         /// </summary>
         public Dictionary<CkanModule, String> ConflictList
         {
             get
             {
-                var dict = new Dictionary<CkanModule, String>();
-                foreach (var conflict in conflicts)
-                {
-                    CkanModule module = conflict.Key;
-                    CkanModule other  = conflict.Value;
-                    dict[module] = string.Format("{0} conflicts with {1}\r\n\r\n{0}:\r\n{2}\r\n{1}:\r\n{3}",
-                        module.identifier, other?.identifier ?? "an unmanaged DLL or DLC",
-                        ReasonStringFor(module), ReasonStringFor(other));
-                }
-                return dict;
+                return conflicts
+                    .GroupBy(kvp => kvp.Key)
+                    .ToDictionary(
+                        group => group.Key,
+                        group => group.Select(kvp => kvp.Value)
+                                      .Where(v => v != null)
+                                      .Distinct())
+                    .ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => $"{kvp.Key} conflicts with " + (
+                            kvp.Value.Count() == 0
+                                ? "an unmanaged DLL or DLC"
+                                : string.Join(", ", kvp.Value)));
             }
         }
 

--- a/GUI/Controls/ChooseRecommendedMods.Designer.cs
+++ b/GUI/Controls/ChooseRecommendedMods.Designer.cs
@@ -72,6 +72,7 @@
             this.RecommendedModsListView.UseCompatibleStateImageBehavior = false;
             this.RecommendedModsListView.View = System.Windows.Forms.View.Details;
             this.RecommendedModsListView.SelectedIndexChanged += new System.EventHandler(RecommendedModsListView_SelectedIndexChanged);
+            this.RecommendedModsListView.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(RecommendedModsListView_ItemChecked);
             this.RecommendedModsListView.Groups.Add(this.RecommendationsGroup);
             this.RecommendedModsListView.Groups.Add(this.SuggestionsGroup);
             this.RecommendedModsListView.Groups.Add(this.SupportedByGroup);

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -1001,6 +1001,7 @@
             this.ChooseRecommendedMods.Size = new System.Drawing.Size(500, 500);
             this.ChooseRecommendedMods.TabIndex = 32;
             this.ChooseRecommendedMods.OnSelectedItemsChanged += ChooseRecommendedMods_OnSelectedItemsChanged;
+            this.ChooseRecommendedMods.OnConflictFound += ChooseRecommendedMods_OnConflictFound;
             //
             // ChooseProvidedModsTabPage
             //

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -124,7 +124,9 @@ namespace CKAN
             ))
             {
                 tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
-                ChooseRecommendedMods.LoadRecommendations(Manager.Cache, recommendations, suggestions, supporters);
+                ChooseRecommendedMods.LoadRecommendations(
+                    registry, CurrentInstance.VersionCriteria(),
+                    Manager.Cache, recommendations, suggestions, supporters);
                 tabController.SetTabLock(true);
                 var result = ChooseRecommendedMods.Wait();
                 if (result == null)

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -17,6 +17,11 @@ namespace CKAN
             ShowSelectionModInfo(items);
         }
 
+        private void ChooseRecommendedMods_OnConflictFound(string message)
+        {
+            AddStatusMessage(message);
+        }
+
         private void auditRecommendationsMenuItem_Click(object sender, EventArgs e)
         {
             // Run in a background task so GUI thread can react to user
@@ -39,7 +44,9 @@ namespace CKAN
             ))
             {
                 tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
-                ChooseRecommendedMods.LoadRecommendations(Manager.Cache, recommendations, suggestions, supporters);
+                ChooseRecommendedMods.LoadRecommendations(
+                    registry, versionCriteria,
+                    Manager.Cache, recommendations, suggestions, supporters);
                 var result = ChooseRecommendedMods.Wait();
                 tabController.HideTab("ChooseRecommendedModsTabPage");
                 if (result != null && result.Any())


### PR DESCRIPTION
## Motivation

On the main mod list, if you select two mods to install that conflict, they'll be highlighted red and a message appears in the status bar.

In the recommendations list, if you select two mods to install that conflict, nothing special happens and you can proceed through to the install screen, where you'll receive an error message. This is frustrating and inconsistent.

## Changes

Now:

- conflicting checked rows on the recommendations screen will be highlighted red
- the conflict will be explained in the status bar
- the Continue button is disabled until the conflict is resolved
- `RelationshipResolver.ConflictList` merges multiple conflicts per module and no longer returns useless information about their reasons for selection which was not used anywhere, so the message can be used in the status bar
- `ChooseRecommendedMods.FindConflicts` sets up a `RelationshipResolver` with the checked mods and returns its `ConflictList`

![image](https://user-images.githubusercontent.com/1559108/73583152-7f49b780-4488-11ea-8f28-1b0b6779194a.png)

This has come up a few times before (see KSP-CKAN/NetKAN#6709 and #2724), but I don't think there's an open issue specifically about it.