### PR TITLE
Fix null reference in recommendations

### DIFF
--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -64,11 +64,16 @@ namespace CKAN
                 OnSelectedItemsChanged(RecommendedModsListView.SelectedItems);
             }
         }
-        
+
         private void RecommendedModsListView_ItemChecked(object sender, EventArgs e)
         {
             var conflicts = FindConflicts();
-            foreach (var item in RecommendedModsListView.Items.Cast<ListViewItem>())
+            foreach (var item in RecommendedModsListView.Items.Cast<ListViewItem>()
+                // Apparently ListView handes AddRange by:
+                //   1. Expanding the Items list to the new size by filling it with nulls
+                //   2. One by one, replace each null with a real item and call _ItemChecked
+                // ... so the Items list can contain null!!
+                .Where(it => it != null))
             {
                 item.BackColor = conflicts.ContainsKey(item.Tag as CkanModule)
                     ? Color.LightCoral
@@ -94,7 +99,7 @@ namespace CKAN
             return new RelationshipResolver(
                 RecommendedModsListView.CheckedItems.Cast<ListViewItem>()
                     .Select(item => item.Tag as CkanModule)
-                    .Distinct(), 
+                    .Distinct(),
                 new CkanModule[] { },
                 conflictOptions, registry, kspVersion
             ).ConflictList;


### PR DESCRIPTION
## Problem

When loading the recommendations screen when it would contain multiple options:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.ChooseRecommendedMods.RecommendedModsListView_ItemChecked(Object sender, EventArgs e)
   at System.Windows.Forms.ListView.OnItemChecked(ItemCheckedEventArgs e)
   at System.Windows.Forms.ListView.WmReflectNotify(Message& m)
   at System.Windows.Forms.ListView.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

I have no idea how I didn't encounter this during development of #2981, since that inherently required loading this screen with multiple options to test. Maybe there's a race condition?

## Cause

Apparently `ListView.Items` can contain `null`, specifically in the `ItemChecked` event while processing an `AddRange` call. Upon reflection this is less surprising than at first blush, since on Windows these are wrappers around C++ components, which probably:

1. Expand the `Items` list with nulls, since it may be a `std::vector` that has to copy its contents every time it is expanded
2. Assign them one by one, triggering `ItemChecked` for each in turn

(Whereas I would expect a C# component to approach this as `foreach (...) { Items.Add(...); }`, which would never insert a null value.)

The code from #2981 assumed `ListView.Items` would not contain nulls.

## Changes

Now `RecommendedModsListView_ItemChecked` skips nulls.