### PR TITLE
Update Cake to 0.37.0

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.36.0" />
+  <package id="Cake" version="0.37.0" />
 </packages>


### PR DESCRIPTION
## Problem
You currently can't build with Cake on Mono 6.8, due to a complex issue I don't want to explain here, you can read it up in https://github.com/cake-build/cake/issues/2695 and all the other issues that are linked there :P
Cake 0.37.0 fixed this.

## Changes
This PR updates the Cake dependency from 0.36.0 to 0.37.0, now that it is released. This allows us to build CKAN using the build script on Mono 6.8 again.
(I guess Kate also automatically removed a BOM)

Note that I don't change back the Mono versions that we're using for the NetCore build on Travis. There's still the other problem, which makes Mono 6 compiled binaries not work on Windows or Mono 5, see #2976. Although we're not using that for anything release-related, let's play it conservatively for now.

I tested the compilation on Mono 6.8 and the exe runs.
We should also test compilation on Windows and running a Mono-compiled exe on Windows before merging, so we cover all the issues we encountered the last days.
I'm going to do this myself tomorrow, too.