### PR TITLE
Fix NRE on download errors in ConsoleUI

### DIFF
--- a/ConsoleUI/CKAN-ConsoleUI.csproj
+++ b/ConsoleUI/CKAN-ConsoleUI.csproj
@@ -63,6 +63,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>

--- a/ConsoleUI/Toolkit/ConsoleTextBox.cs
+++ b/ConsoleUI/Toolkit/ConsoleTextBox.cs
@@ -39,7 +39,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="line">String to add</param>
         public void AddLine(string line)
         {
-            lines.AddRange(Formatting.WordWrap(line, GetRight() - GetLeft() + 1));
+            // AddRange isn't thread-safe, it temporarily pads with nulls
+            foreach (string subLine in Formatting.WordWrap(line, GetRight() - GetLeft() + 1)) {
+                lines.Add(subLine);
+            }
             if (scrollToBottom) {
                 ScrollToBottom();
             } else {
@@ -213,7 +216,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         private bool         scrollToBottom;
         private int          topLine;
         private TextAlign    align;
-        private List<string> lines = new List<string>();
+        private SynchronizedCollection<string> lines = new SynchronizedCollection<string>();
         private Func<ConsoleColor> getBgColor;
         private Func<ConsoleColor> getFgColor;
     }


### PR DESCRIPTION
## Problem

```
Downloading "https://github.com/shadowmage45/TexturesUnlimited/releases/download/1.5.8.23/TexturesUnlimited-1.5.8.23.zip"                                                            ^ │
 │ Downloading "https://github.com/raidernick/BDAnimationModules/releases/download/v0.6.5.7/BDanim_v0.6.5.7.zip"                                                                        ▒ │
 │ Downloading "https://github.com/blowfishpro/B9PartSwitch/releases/download/v2.11.1/B9PartSwitch_v2.11.1.zip"                                                                         ▒ │
 │ Downloading "https://github.com/linuxgurugamer/PatchManager/releases/download/0.0.16.4/PatchManager-0.0.16.4.zip"                                                                    ▒ │
 │ Failed to download "https://github.com/KSP-RO/ROCapsules/releases/download/v1.0.0.0/ROCapsules-v1.0.0.0.zip", trying fallback                                                        ▒ │
Unhandled Exception:org/download/ROCapsules-v1.0.0.0/E962516B-ROCapsules-v1.0.0.0.zip"                                                                                                  ▒ │
System.NullReferenceException: Object reference not set to an instance of an objectownload/1.5.8.23/TexturesUnlimited-1.5.8.23.zip", trying fallback                                    ▒ │
  at CKAN.ConsoleUI.Toolkit.ConsoleTextBox.Draw (System.Boolean focused) [0x000eb] in <b28b520a445343588cb592db267d120a>:0                                                              ▒ │
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Draw () [0x0002d] in <b28b520a445343588cb592db267d120a>:0 Manager-0.0.16.4.zip", trying fallback                                            ▒ │
  at CKAN.ConsoleUI.Toolkit.ConsoleScreen.RaiseMessage (System.String message, System.Object[] args) [0x00008] in <b28b520a445343588cb592db267d120a>:0                                  ▒ │
  at CKAN.NetAsyncDownloader.FileDownloadComplete (System.Int32 index, System.Exception error) [0x000d9] in <b28b520a445343588cb592db267d120a>:0                                        ▒ │
  at CKAN.NetAsyncDownloader+<>c__DisplayClass14_0.<DownloadModule>b__1 (System.Object sender, System.ComponentModel.AsyncCompletedEventArgs args) [0x00012] in <b28b520a445343588cb592db267d120a>:0  to download "https://github.com/KSP-RO/ROCapsules/releases/download/v1.0.0.0/ROCapsules-v1.0.0.0.zip", trying fallback                                                        * │
  at CKAN.NetAsyncDownloader+NetAsyncDownloaderDownloadPart.<ResetAgent>b__21_1 (System.Object sender, System.ComponentModel.AsyncCompletedEventArgs args) [0x00008] in <b28b520a445343588cb592"https://archive.org/download/ROCapsules-v1.0.0.0/E962516B-ROCapsules-v1.0.0.0.zip"                                                                                                    │
  aFailed to download "https://github.com/shadowmage45/TexturesUnlimited/releases/download/1.5.8.23/TexturesUnlimited-1.5.8.23.zip", trying fallback                                    ──┘
  a"https://archive.org/download/TexturesUnlimited-1.5.8.23/B6A71E99-TexturesUnlimited-1.5.8.23.zip"                                                                                       
  aFailed to download "https://github.com/linuxgurugamer/PatchManager/releases/download/0.0.16.4/PatchManager-0.0.16.4.zip", trying fallback                                                
  a"https://archive.org/download/PatchManager-0.0.16.4/CC4C384F-PatchManager-0.0.16.4.zip"                                                                                              reserve[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object                                                                   
  at CKAN.ConsoleUI.Toolkit.ConsoleTextBox.Draw (System.Boolean focused) [0x000eb] in <b28b520a445343588cb592db267d120a>:0 lback callback, System.Object state, System.Boolean preserveSyncC  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Draw () [0x0002d] in <b28b520a445343588cb592db267d120a>:0                                                                                       
  at CKAN.ConsoleUI.Toolkit.ConsoleScreen.RaiseMessage (System.String message, System.Object[] args) [0x00008] in <b28b520a445343588cb592db267d120a>:0 :0                                   
  at CKAN.NetAsyncDownloader.FileDownloadComplete (System.Int32 index, System.Exception error) [0x000d9] in <b28b520a445343588cb592db267d120a>:0                                            
  at CKAN.NetAsyncDownloader+<>c__DisplayClass14_0.<DownloadModule>b__1 (System.Object sender, System.ComponentModel.AsyncCompletedEventArgs args) [0x00012] in <b28b520a445343588cb592db267d120a>:0                                                                                                                                                                                    
  at CKAN.NetAsyncDownloader+NetAsyncDownloaderDownloadPart.<ResetAgent>b__21_1 (System.Object sender, System.ComponentModel.AsyncCompletedEventArgs args) [0x00008] in <b28b520a445343588cb592db267d120a>:0                                                                                                                                                                            
  at System.Net.WebClient.OnDownloadFileCompleted (System.ComponentModel.AsyncCompletedEventArgs e) [0x0000a] in <9bd67acb7e9448b0ae17ea9ad68db84f>:0                                       
  at System.Net.WebClient.<StartAsyncOperation>b__78_4 (System.Object arg) [0x00000] in <9bd67acb7e9448b0ae17ea9ad68db84f>:0                                                                
  at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context (System.Object state) [0x00007] in <c4bddbfe864a4b8191bb818d6b204e9d>:0                                                
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in <c4bddbfe864a4b8191bb818d6b204e9d>:0                                                                                                                               
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <c4bddbfe864a4b8191bb818d6b204e9d>:0                                                                                                                                       
  at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00021] in <c4bddbfe864a4b8191bb818d6b204e9d>:0                                   
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00074] in <c4bddbfe864a4b8191bb818d6b204e9d>:0                                                                                     
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in <c4bddbfe864a4b8191bb818d6b204e9d>:0    
```

## Cause

I think this is a spiritual successor to #2984; this `AddRange`:

https://github.com/KSP-CKAN/CKAN/blob/204ba8b1216c97adc340032c51d5578edcaaedfe/ConsoleUI/Toolkit/ConsoleTextBox.cs#L42

...is temporarily padding the `lines` list with `null`s, which causes an exception here:

https://github.com/KSP-CKAN/CKAN/blob/204ba8b1216c97adc340032c51d5578edcaaedfe/ConsoleUI/Toolkit/ConsoleTextBox.cs#L119

Probably became an issue after #2892, in which multiple threads potentially call `IUser.RaiseMessage`.

## Changes

Now that list is a [`SynchronizedCollection`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.synchronizedcollection-1), which declares itself to be thread-safe, and we update it with `Add` instead of `AddRange`, so there will never be `null`s in it.

Fixes #2986.