### PR TITLE
Only update provides tab from GUI thread

### DIFF
--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -15,27 +15,30 @@ namespace CKAN
 
         public void LoadProviders(string requested, List<CkanModule> modules, NetModuleCache cache)
         {
-            ChooseProvidedModsLabel.Text = String.Format(
-                Properties.Resources.MainInstallProvidedBy,
-                requested
-            );
-
-            ChooseProvidedModsListView.Items.Clear();
-            ChooseProvidedModsListView.Items.AddRange(modules
-                .Select(module => new ListViewItem(new string[]
-                {
-                    cache.IsMaybeCachedZip(module)
-                        ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
-                        : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download.Host ?? "", CkanModule.FmtSize(module.download_size)),
-                    module.@abstract
-                })
-                {
-                    Tag = module,
-                    Checked = false
-                })
-                .ToArray());
-            ChooseProvidedModsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
-            ChooseProvidedModsContinueButton.Enabled = false;
+            Util.Invoke(this, () =>
+            {
+                ChooseProvidedModsLabel.Text = String.Format(
+                    Properties.Resources.MainInstallProvidedBy,
+                    requested
+                );
+    
+                ChooseProvidedModsListView.Items.Clear();
+                ChooseProvidedModsListView.Items.AddRange(modules
+                    .Select(module => new ListViewItem(new string[]
+                    {
+                        cache.IsMaybeCachedZip(module)
+                            ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
+                            : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download.Host ?? "", CkanModule.FmtSize(module.download_size)),
+                        module.@abstract
+                    })
+                    {
+                        Tag = module,
+                        Checked = false
+                    })
+                    .ToArray());
+                ChooseProvidedModsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+                ChooseProvidedModsContinueButton.Enabled = false;
+            });
         }
 
         public CkanModule Wait()

--- a/GUI/Controls/ChooseProvidedMods.resx
+++ b/GUI/Controls/ChooseProvidedMods.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Choose mods</value></data>
   <data name="ChooseProvidedModsCancelButton.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="ChooseProvidedModsContinueButton.Text" xml:space="preserve"><value>Continue</value></data>
   <data name="modNameColumnHeader.Text" xml:space="preserve"><value>Mod</value></data>

--- a/GUI/Localization/de-DE/ChooseProvidedMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ChooseProvidedMods.de-DE.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Wähle Mods</value></data>
   <data name="ChooseProvidedModsCancelButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
   <data name="ChooseProvidedModsContinueButton.Text" xml:space="preserve"><value>Fortfahren</value></data>
   <data name="modDescriptionColumnHeader.Text" xml:space="preserve"><value>Kurzbeschreibung der Mod</value></data>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -224,6 +224,7 @@
   <data name="FilterByDescriptionTextBox.Size" type="System.Drawing.Size, System.Drawing"><value>170, 26</value></data>
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Änderungen</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Statuslog</value></data>
+  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Wähle Mods</value></data>
   <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Wähle Empfehlungen und Vorschläge aus</value></data>
   <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modpack bearbeiten</value></data>
   <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N verfügbare Updates</value></data>

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -230,6 +230,7 @@
   <data name="FilterByDescriptionTextBox.Size" type="System.Drawing.Size, System.Drawing"><value>170, 26</value></data>
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Changeset</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Status log</value></data>
+  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Choose mods</value></data>
   <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choose recommended or suggested mods</value></data>
   <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Delete Directories</value></data>
   <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Edit Modpack</value></data>

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -212,8 +212,12 @@ namespace CKAN
                 catch (TooManyModsProvideKraken k)
                 {
                     // Prompt user to choose which mod to use
-                    CkanModule chosen = TooManyModsProvideCore(k);
+                    tabController.ShowTab("ChooseProvidedModsTabPage", 3);
+                    ChooseProvidedMods.LoadProviders(k.requested, k.modules, Manager.Cache);
+                    tabController.SetTabLock(true);
+                    CkanModule chosen = ChooseProvidedMods.Wait();
                     // Close the selection prompt
+                    tabController.SetTabLock(false);
                     tabController.HideTab("ChooseProvidedModsTabPage");
                     if (chosen != null)
                     {

--- a/GUI/Main/MainProvides.cs
+++ b/GUI/Main/MainProvides.cs
@@ -8,13 +8,5 @@ namespace CKAN
         {
             ShowSelectionModInfo(items);
         }
-
-        private CkanModule TooManyModsProvideCore(TooManyModsProvideKraken kraken)
-        {
-            tabController.ShowTab("ChooseProvidedModsTabPage", 3);
-            ChooseProvidedMods.LoadProviders(kraken.requested, kraken.modules, Manager.Cache);
-            tabController.SetTabLock(true);
-            return ChooseProvidedMods.Wait();
-        }
     }
 }


### PR DESCRIPTION
## Problem

```
$ mono ./ckan.exe 
System.IndexOutOfRangeException: Index was outside the bounds of the array.
  at System.Windows.Forms.ListView.GetItemLocation (System.Int32 index) [0x00018] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.ListView.get_LastVisibleIndex () [0x00043] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.ListView.get_LastVisibleIndex()
  at System.Windows.Forms.ThemeWin32Classic.DrawListViewItems (System.Drawing.Graphics dc, System.Drawing.Rectangle clip, System.Windows.Forms.ListView control) [0x00011] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.ListView+ItemControl.OnPaintInternal (System.Windows.Forms.PaintEventArgs pe) [0x00011] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.Control.WmPaint (System.Windows.Forms.Message& m) [0x0006d] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.Control.WndProc (System.Windows.Forms.Message& m) [0x001a4] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.ListView+ItemControl.WndProc (System.Windows.Forms.Message& m) [0x00071] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.Control+ControlWindowTarget.OnMessage (System.Windows.Forms.Message& m) [0x00000] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.Control+ControlNativeWindow.WndProc (System.Windows.Forms.Message& m) [0x0000b] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
  at System.Windows.Forms.NativeWindow.WndProc (System.IntPtr hWnd, System.Windows.Forms.Msg msg, System.IntPtr wParam, System.IntPtr lParam) [0x00085] in <91b18fcffc5e47d3a5d52c9f469a1a52>:0 
```

![image](https://user-images.githubusercontent.com/1559108/73874827-1f6a5c80-484c-11ea-84db-d772ce87243a.png)

It's the `ChooseProvidedMods` tab, which shows up blank:

![image](https://user-images.githubusercontent.com/1559108/73874930-4c1e7400-484c-11ea-8a70-2dcfb55d0b9f.png)

## Cause

`ChooseProvidedMods.LoadProviders` updates GUI controls from a background thread. WinForms has a special GUI thread where all GUI updates are supposed to happen (presumably because the underlying Win32 C++ controls were originally single-threaded?).

The tab is blank because the `ChooseProvidedModsTabPage.Text` resource was moved into the wrong file in #2966. It belongs in `Main.resx`, because that's where `ChooseProvidedModsTabPage` is defined, but it's currently in `ChooseProvidedMods.resx`.

## Changes

`Util.Invoke(this, () => the updates);`

The `ChooseProvidedModsTabPage.Text` resource is moved back to `Main.resx`.

Fixes #2988.