### PR TITLE
Fix ArgumentException in ConsoleUI recommendations

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1304,7 +1304,9 @@ namespace CKAN
             var candidates = registry.CompatibleModules(ksp.VersionCriteria())
                 .Where(mod => !registry.IsInstalled(mod.identifier)
                     && !toInstall.Any(m => m.identifier == mod.identifier))
-                .Where(m => m?.supports != null);
+                .Where(m => m?.supports != null)
+                .Except(recommendations.Keys)
+                .Except(suggestions.Keys);
             // Find each module that "supports" something we're installing
             foreach (CkanModule mod in candidates)
             {
@@ -1361,8 +1363,7 @@ namespace CKAN
                                 if (!registry.IsInstalled(provider.identifier)
                                     && !toExclude.Any(m => m.identifier == provider.identifier))
                                 {
-                                    List<string> dependers;
-                                    if (dependersIndex.TryGetValue(provider, out dependers))
+                                    if (dependersIndex.TryGetValue(provider, out List<string> dependers))
                                     {
                                         // Add the dependent mod to the list of reasons this dependency is shown.
                                         dependers.Add(mod.identifier);


### PR DESCRIPTION
## Problem

If you have a lot of modules installed, ConsoeUI's "audit recommendations" option can throw an exception:

```
[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: An item with the same key has already been added. Key: NearFutureConstruction 1.1.4
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x0015a] in <c4bddbfe864a4b8191bb818d6b204e9d>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00000] in <c4bddbfe864a4b8191bb818d6b204e9d>:0 
  at CKAN.ConsoleUI.DependencyScreen.generateList (System.Collections.Generic.HashSet`1[T] inst) [0x001f4] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.DependencyScreen..ctor (CKAN.KSPManager mgr, CKAN.ConsoleUI.ChangePlan cp, System.Collections.Generic.HashSet`1[T] rej, System.Boolean dbg) [0x000ee] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.ModListScreen.ViewSuggestions () [0x0008d] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.Toolkit.ConsolePopupMenu.Run (System.Int32 right, System.Int32 top) [0x00162] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.Toolkit.ConsoleScreen.<.ctor>b__0_1 (System.Object sender) [0x00023] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Interact () [0x0003e] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Run (System.Action process) [0x0002b] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.ConsoleCKAN..ctor (CKAN.KSPManager mgr, System.Boolean debug) [0x0005b] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.ConsoleUI.ConsoleUI.Main_ (System.String[] args, CKAN.KSPManager manager, System.Boolean debug) [0x00007] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.CmdLine.MainClass.ConsoleUi (CKAN.KSPManager manager, CKAN.CmdLine.CommonOptions opts, System.String[] args) [0x00019] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.CmdLine.MainClass.RunSimpleAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user, CKAN.KSPManager manager) [0x002ff] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.CmdLine.MainClass.Execute (CKAN.KSPManager manager, CKAN.CmdLine.CommonOptions opts, System.String[] args) [0x0028b] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x000a1] in <ce28b1fd8caa4b339aed683ae3b21ffc>:0 
```

Reported in https://github.com/KSP-CKAN/CKAN/issues/2986#issuecomment-582798569 .

## Cause

`ModuleInstaller.FindRecommendations` can return a module in the suggested-by list that's also in the recommendations or sugggestions.

`ConsoleUI.DependencyScreen` puts all three lists into one dictionary keyed by the `CkanModule`, which causes exceptions to be thrown on duplicates.

## Changes

Now `ModuleInstaller.FindRecommendations` excludes recommended and suggested modules from the supported-by list. No module will appear in more than one of the lists.