### PR TITLE
Don't report an unknown error if it is known

### DIFF
--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -31,7 +31,7 @@ namespace CKAN
         {
             menuStrip1.Enabled = false;
 
-            //Using the changeset passed in can cause issues with versions.
+            // Using the changeset passed in can cause issues with versions.
             // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.
             // TODO Work out why this is.
             installWorker.RunWorkerAsync(

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -12,8 +12,8 @@ namespace CKAN
     {
         private BackgroundWorker installWorker;
 
-        // used to signal the install worker that the user canceled the install process
-        // this may happen on the recommended/suggested mods dialogs
+        // Used to signal the install worker that the user canceled the install process.
+        // This may happen on the recommended/suggested mods dialogs or during the download.
         private volatile bool installCanceled;
 
         /// <summary>
@@ -417,9 +417,19 @@ namespace CKAN
                     );
                 }
             }
+            else if (e.Error == null)
+            {
+                // The install was unsuccessful, but we did catch the exception.
+                FailWaitDialog(
+                    Properties.Resources.MainInstallErrorInstalling,
+                    Properties.Resources.MainInstallKnownError,
+                    Properties.Resources.MainInstallFailed,
+                    result.Key
+                );
+            }
             else
             {
-                // There was an error
+                // An unknown error was thrown which we didn't catch.
                 FailWaitDialog(
                     Properties.Resources.MainInstallErrorInstalling,
                     Properties.Resources.MainInstallUnknownError,

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -530,6 +530,9 @@ namespace CKAN.Properties {
         internal static string MainInstallUnknownError {
             get { return (string)(ResourceManager.GetObject("MainInstallUnknownError", resourceCulture)); }
         }
+        internal static string MainInstallKnownError {
+            get { return (string)(ResourceManager.GetObject("MainInstallKnownError", resourceCulture)); }
+        }
         internal static string MainInstallFailed {
             get { return (string)(ResourceManager.GetObject("MainInstallFailed", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -244,6 +244,9 @@ Einstellungen jetzt öffnen?</value>
   <data name="MainInstallInstallCanceled" xml:space="preserve"><value>(De-)Installation/Aktualisierung abgebrochen!</value></data>
   <data name="MainInstallErrorInstalling" xml:space="preserve"><value>Fehler bei der Installation!</value></data>
   <data name="MainInstallUnknownError" xml:space="preserve"><value>Ein unbekannter Fehler ist aufgetreten, bitte versuche es erneut!</value></data>
+  <data name="MainInstallKnownError" xml:space="preserve"><value>Falls die Fehlermeldung ein Download-Problem andeutet, versuche es bitte erneut. Andernfalls melde bitte den Fehler bei uns.
+Wenn du ein Fehler mit den Mod-Metadaten vermutest: https://github.com/KSP-CKAN/NetKAN/new/choose
+Wenn du ein Fehler mit dem CKAN Client vermutest: https://github.com/KSP-CKAN/CKAN/new/choose</value></data>
   <data name="MainInstallFailed" xml:space="preserve"><value>Installation fehlgeschlagen!</value></data>
   <data name="MainInstallProvidedBy" xml:space="preserve"><value>Modul {0} wird von mehr als einem verfügbaren Modul bereitgestellt, bitte wähle eine der folgenden Mods:</value></data>
   <data name="ModInfoVirtual" xml:space="preserve"><value>{0} (virtuell)</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -264,6 +264,9 @@ Open settings now?</value></data>
   <data name="MainInstallInstallCanceled" xml:space="preserve"><value>(Un)Install/Upgrade canceled!</value></data>
   <data name="MainInstallErrorInstalling" xml:space="preserve"><value>Error during installation!</value></data>
   <data name="MainInstallUnknownError" xml:space="preserve"><value>An unknown error occurred, please try again!</value></data>
+  <data name="MainInstallKnownError" xml:space="preserve"><value>If the above message indicates a download error, please try again. Otherwise, please open a issue for us to investigate.
+If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
+If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose</value></data>
   <data name="MainInstallFailed" xml:space="preserve"><value>Installation failed!</value></data>
   <data name="MainInstallProvidedBy" xml:space="preserve"><value>Module {0} is provided by more than one available module, please choose one of the following mods:</value></data>
   <data name="ModInfoNSlashA" xml:space="preserve"><value>N/A</value></data>


### PR DESCRIPTION
## Problem
When there's an exception thrown during the installation of mods, we catch the usual ones and log an explanation message on the WaitTabPage.
However in `PostInstallMods()` which is called when the background worker completes `InstallMods()`, the message `An unknown error occurred, please try again!` is written to the "log".
This message is actually not true most of the time, because e.g. download errors or inconsistency problems are all catched and a nice explaining error message has already been printed out.

## Changes
Now `PostInstallMods()` distinguishes catched and uncatched errors (the second one will result in `RunWorkerCompletedEventArgs.Error` being set).
It keeps the old message for uncatched errors, but displays a new one for known ones:
```
If the above message indicates a download error, please try again. Otherwise, please open a issue for us to investigate.
If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
```
(Suggestions to change this message are welcome)

This way we don't contradict ourselves, and also encourage the users to report metadata/client problems.