### PR TITLE
Create skip-releases option for NetKAN

### DIFF
--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -31,6 +31,9 @@ namespace CKAN.NetKAN
         [Option("releases", DefaultValue = "1", HelpText = "Number of releases to inflate, or 'all'")]
         public string Releases { get; set; }
 
+        [Option("skip-releases", DefaultValue = "0", HelpText = "Number of releases to skip / index of release to inflate.")]
+        public string SkipReleases { get; set; }
+
         [Option("prerelease", HelpText = "Index GitHub prereleases")]
         public bool PreRelease { get; set; }
 

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -116,7 +116,7 @@ namespace CKAN.NetKAN.Processors
             IEnumerable<Metadata> ckans = null;
             bool   caught        = false;
             string caughtMessage = null;
-            var    opts          = new TransformOptions(releases, highVer);
+            var    opts          = new TransformOptions(releases, null, highVer);
             try
             {
                 ckans = inflator.Inflate($"{netkan.Identifier}.netkan", netkan, opts);
@@ -147,7 +147,7 @@ namespace CKAN.NetKAN.Processors
         private SendMessageBatchRequestEntry inflationMessage(Metadata ckan, Metadata netkan, TransformOptions opts, bool success, string err = null)
         {
             bool staged = netkan.Staged || opts.Staged;
-            string stagingReason = 
+            string stagingReason =
                   !string.IsNullOrEmpty(netkan.StagingReason) ? netkan.StagingReason
                 : !string.IsNullOrEmpty(opts.StagingReason)   ? opts.StagingReason
                 : null;

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -93,6 +93,7 @@ namespace CKAN.NetKAN
                         netkan,
                         new TransformOptions(
                             ParseReleases(Options.Releases),
+                            ParseSkipReleases(Options.SkipReleases),
                             ParseHighestVersion(Options.HighestVersion)
                         )
                     );
@@ -129,6 +130,11 @@ namespace CKAN.NetKAN
         private static int? ParseReleases(string val)
         {
             return val == "all" ? (int?)null : int.Parse(val);
+        }
+
+        private static int? ParseSkipReleases(string val)
+        {
+            return string.IsNullOrWhiteSpace(val) ? (int?)null : int.Parse(val);
         }
 
         private static ModuleVersion ParseHighestVersion(string val)

--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -39,6 +39,10 @@ namespace CKAN.NetKAN.Transformers
                 // Look up our mod on Curse by its Id.
                 var curseMod = _api.GetMod(metadata.Kref.Id);
                 var versions = curseMod.All();
+                if (opts.SkipReleases.HasValue)
+                {
+                    versions = versions.Skip(opts.SkipReleases.Value);
+                }
                 if (opts.Releases.HasValue)
                 {
                     versions = versions.Take(opts.Releases.Value);

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -57,6 +57,10 @@ namespace CKAN.NetKAN.Transformers
                 // Get the GitHub repository
                 var ghRepo = _api.GetRepo(ghRef);
                 var versions = _api.GetAllReleases(ghRef);
+                if (opts.SkipReleases.HasValue)
+                {
+                    versions = versions.Skip(opts.SkipReleases.Value);
+                }
                 if (opts.Releases.HasValue)
                 {
                     versions = versions.Take(opts.Releases.Value);
@@ -168,7 +172,7 @@ namespace CKAN.NetKAN.Transformers
                 }
                 // Check parent repos
                 r = r.ParentRepo == null
-                    ? null 
+                    ? null
                     : _api.GetRepo(new GithubRef($"#/ckan/github/{r.ParentRepo.FullName}", false, _matchPreleases));
             }
             // Return a string if just one author, else an array

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -6,13 +6,15 @@ namespace CKAN.NetKAN.Transformers
 {
     internal class TransformOptions
     {
-        public TransformOptions(int? releases, ModuleVersion highVer)
+        public TransformOptions(int? releases, int? skipReleases, ModuleVersion highVer)
         {
             Releases       = releases;
+            SkipReleases   = skipReleases;
             HighestVersion = highVer;
         }
 
         public readonly int?          Releases;
+        public readonly int?          SkipReleases;
         public readonly ModuleVersion HighestVersion;
         public          bool          Staged;
         public          string        StagingReason;

--- a/Netkan/Transformers/JenkinsTransformer.cs
+++ b/Netkan/Transformers/JenkinsTransformer.cs
@@ -35,6 +35,10 @@ namespace CKAN.NetKAN.Transformers
                 JenkinsRef jRef = new JenkinsRef(metadata.Kref);
 
                 var versions = _api.GetAllBuilds(jRef, options);
+                if (opts.SkipReleases.HasValue)
+                {
+                    versions = versions.Skip(opts.SkipReleases.Value);
+                }
                 if (opts.Releases.HasValue)
                 {
                     versions = versions.Take(opts.Releases.Value);

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -38,6 +38,10 @@ namespace CKAN.NetKAN.Transformers
                 // Look up our mod on SD by its Id.
                 var sdMod = _api.GetMod(Convert.ToInt32(metadata.Kref.Id));
                 var versions = sdMod.All();
+                if (opts.SkipReleases.HasValue)
+                {
+                    versions = versions.Skip(opts.SkipReleases.Value);
+                }
                 if (opts.Releases.HasValue)
                 {
                     versions = versions.Take(opts.Releases.Value);

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN
     [TestFixture]
     public class MainClassTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test]
         public void FixVersionStringsUnharmed()

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -11,7 +11,7 @@ namespace Tests.NetKAN
     public class NetkanOverride
     {
         JObject such_metadata;
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [SetUp]
         public void Setup()

--- a/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcKrefTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test,
             TestCase(

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test]
         public void AddsMissingVersionInfo()

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class CurseTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
@@ -13,7 +13,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class DownloadAttributeTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test]
         public void AddsDownloadAttributes()

--- a/Tests/NetKAN/Transformers/EpochTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/EpochTransformerTests.cs
@@ -33,6 +33,7 @@ namespace Tests.NetKAN.Transformers
             ITransformer     sut  = new EpochTransformer();
             TransformOptions opts = new TransformOptions(
                 1,
+                null,
                 string.IsNullOrEmpty(highVer)
                     ? null
                     : new ModuleVersion(highVer)

--- a/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
@@ -9,8 +9,8 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GeneratedByTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
-        
+        private TransformOptions opts = new TransformOptions(1, null, null);
+
         [Test]
         public void AddsGeneratedByProperty()
         {

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using CKAN;
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Sources.Github;
@@ -14,16 +13,12 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GithubTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null);
 
-        [Test]
-        public void CalculatesRepositoryUrlCorrectly()
+        private Mock<IGithubApi> apiMockUp;
+        [OneTimeSetUp]
+        public void setupApiMockup()
         {
-            // Arrange
-            var json = new JObject();
-            json["spec_version"] = 1;
-            json["$kref"] = "#/ckan/github/ExampleAccount/ExampleProject";
-
             var mApi = new Mock<IGithubApi>();
             mApi.Setup(i => i.GetRepo(It.IsAny<GithubRef>()))
                 .Returns(new GithubRepo
@@ -40,14 +35,37 @@ namespace Tests.NetKAN.Transformers
                 ));
 
             mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>()))
-                .Returns(new GithubRelease[] { new GithubRelease(
-                    "ExampleProject",
-                    new ModuleVersion("1.0"),
-                    new Uri("http://github.example/download"),
-                    null
-                )});
+                .Returns(new GithubRelease[] {
+                    new GithubRelease(
+                        "ExampleProject",
+                        new ModuleVersion("1.0"),
+                        new Uri("http://github.example/download/1.0"),
+                        null
+                    ),
+                    new GithubRelease("ExampleProject",
+                        new ModuleVersion("1.1"),
+                        new Uri("http://github.example/download/1.1"),
+                        null
+                    ),
+                    new GithubRelease("ExampleProject",
+                        new ModuleVersion("1.2"),
+                        new Uri("http://github.example/download/1.2"),
+                        null
+                    ),
+                });
 
-            var sut = new GithubTransformer(mApi.Object, false);
+            apiMockUp = mApi;
+        }
+
+        [Test]
+        public void CalculatesRepositoryUrlCorrectly()
+        {
+            // Arrange
+            var json = new JObject();
+            json["spec_version"] = 1;
+            json["$kref"] = "#/ckan/github/ExampleAccount/ExampleProject";
+
+            var sut = new GithubTransformer(apiMockUp.Object, false);
 
             // Act
             var result = sut.Transform(new Metadata(json), opts).First();
@@ -104,5 +122,60 @@ namespace Tests.NetKAN.Transformers
             );
         }
 
+        [Test]
+        public void Transform_MultipleReleases_TransformsAll()
+        {
+            // Arrange
+            var json = new JObject();
+            json["spec_version"] = 1;
+            json["$kref"] = "#/ckan/github/ExampleAccount/ExampleProject";
+
+            var sut = new GithubTransformer(apiMockUp.Object, false);
+
+            // Act
+            var results = sut.Transform(
+                new Metadata(json),
+                new TransformOptions(2, null, null)
+            );
+            var transformedJsons = results.Select(result => result.Json()).ToArray();
+
+            // Assert
+            Assert.AreEqual(
+                "http://github.example/download/1.0",
+                (string)transformedJsons[0]["download"]
+            );
+            Assert.AreEqual(
+                "http://github.example/download/1.1",
+                (string)transformedJsons[1]["download"]
+            );
+        }
+
+        [Test]
+        public void Transform_SkipReleases_SkipsCorrectly()
+        {
+            // Arrange
+            var json = new JObject();
+            json["spec_version"] = 1;
+            json["$kref"] = "#/ckan/github/ExampleAccount/ExampleProject";
+
+            var sut = new GithubTransformer(apiMockUp.Object, false);
+
+            // Act
+            var results = sut.Transform(
+                new Metadata(json),
+                new TransformOptions(3, 1, null)
+            ).ToArray();
+            // var transformedJsons = results.Select(result => result.Json()).ToArray();
+
+            // Assert
+            Assert.AreEqual(
+                "1.1",
+                results[0].Version.ToString()
+            );
+            Assert.AreEqual(
+                "1.2",
+                results[1].Version.ToString()
+            );
+        }
     }
 }

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GithubTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test]
         public void CalculatesRepositoryUrlCorrectly()

--- a/Tests/NetKAN/Transformers/HttpTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/HttpTransformerTests.cs
@@ -9,7 +9,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class HttpTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [TestCase("#/ckan/github/foo/bar")]
         [TestCase("#/ckan/netkan/http://awesomemod.example/awesomemod.netkan")]

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class InternalCkanTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test]
         public void AddsMiddingProperties()

--- a/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
@@ -13,7 +13,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class MetaNetkanTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class SpacedockTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class StripNetkanMetadataTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [TestCaseSource("StripNetkanMetadataTestCaseSource")]
         public void StripNetkanMetadata(string json, string expected)

--- a/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class VersionEditTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null);
+        private TransformOptions opts = new TransformOptions(1, null, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()


### PR DESCRIPTION
## Motivation
#2681 gave us the great option to inflate multiple releases with netkan.exe.
But sometimes you don't want to begin with the latest release, for example if the folder structure has changed in the history of the mod, and you have to adjust the netkan file for the older releases. Or if one release is failing inflation and you have to skip it.
I had to deal with both of these cases in https://github.com/KSP-CKAN/CKAN-meta/pull/1786, so I finally decided to implement this feature.

## Changes
This PR gives netkan.exe a new commandline option, `--skip-releases <int>`.
This commandline option is fed into the `TransformOptions`, which has a new `int? SkipReleases` property.
It is set with the constructor, the queue handler passes `null`.

Each kref source transformer now skips the given number of releases, and starting from this index, the number of releases given with `opts.Releases` are taken.

This feature may be useful for https://github.com/KSP-CKAN/NetKAN-Infra/issues/5, too.