### PR TITLE
Extend -single-instance fix to 1.9

### DIFF
--- a/Core/Types/GameComparator/StrictGameComparator.cs
+++ b/Core/Types/GameComparator/StrictGameComparator.cs
@@ -24,13 +24,8 @@ namespace CKAN
             {
                 if (module.ksp_version_min != null && module.ksp_version_max != null)
                 {
-                    var minRange = module.ksp_version_min.ToVersionRange();
-                    var maxRange = module.ksp_version_max.ToVersionRange();
-                    if (minRange.Lower.Value <= maxRange.Upper.Value)
-                    {
-                        moduleRange = new KspVersionRange(minRange.Lower, maxRange.Upper);
-                    }
-                    else
+                    moduleRange = new KspVersionRange(module.ksp_version_min, module.ksp_version_max);
+                    if (moduleRange.Lower.Value > moduleRange.Upper.Value)
                     {
                         log.WarnFormat("{0} is not less or equal to {1}",
                             module.ksp_version_min, module.ksp_version_max);
@@ -39,15 +34,11 @@ namespace CKAN
                 }
                 else if (module.ksp_version_min != null)
                 {
-                    var minRange = module.ksp_version_min.ToVersionRange();
-
-                    moduleRange = new KspVersionRange(minRange.Lower, KspVersionBound.Unbounded);
+                    moduleRange = new KspVersionRange(module.ksp_version_min, KspVersion.Any);
                 }
                 else if (module.ksp_version_max != null)
                 {
-                    var maxRange = module.ksp_version_max.ToVersionRange();
-
-                    moduleRange = new KspVersionRange(KspVersionBound.Unbounded, maxRange.Upper);
+                    moduleRange = new KspVersionRange(KspVersion.Any, module.ksp_version_max);
                 }
             }
             else

--- a/Core/Versioning/KspVersionRange.cs
+++ b/Core/Versioning/KspVersionRange.cs
@@ -27,6 +27,9 @@ namespace CKAN.Versioning
             _string = DeriveString(this);
         }
 
+        public KspVersionRange(KspVersion lower, KspVersion upper)
+            : this(lower?.ToVersionRange().Lower, upper?.ToVersionRange().Upper) { }
+
         public override string ToString()
         {
             return _string;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -955,12 +955,15 @@ namespace CKAN
                 }
             }
 
-            // -single-instance crashes KSP 1.8 on Linux
+            // -single-instance crashes KSP 1.8 to KSP 1.9 on Linux
             // https://issuetracker.unity3d.com/issues/linux-segmentation-fault-when-running-a-built-project-with-single-instance-argument
             if (Platform.IsUnix)
             {
-                split = filterCmdLineArgs(split,
-                    new KspVersion(1, 8).ToVersionRange(), "-single-instance");
+                var brokenVersionRange = new KspVersionRange(
+                    new KspVersion(1, 8),
+                    new KspVersion(1, 9)
+                );
+                split = filterCmdLineArgs(split, brokenVersionRange, "-single-instance");
             }
 
             var binary = split[0];
@@ -976,7 +979,7 @@ namespace CKAN
                 currentUser.RaiseError(Properties.Resources.MainLaunchFailed, exception.Message);
             }
         }
-        
+
         /// <summary>
         /// If the installed game version is in the given range,
         /// return the given array without the given parameter,
@@ -1198,7 +1201,7 @@ namespace CKAN
                 CurrentInstance.VersionCriteria()
             );
         }
-        
+
         private void MainTabControl_OnSelectedIndexChanged(object sender, EventArgs e)
         {
             switch (MainTabControl.SelectedTab?.Name)

--- a/Tests/Core/Versioning/KspVersionRangeTests.cs
+++ b/Tests/Core/Versioning/KspVersionRangeTests.cs
@@ -440,6 +440,24 @@ namespace Tests.Core.Versioning
         }
 
         [Test]
+        public void RangeFromVersionsEqualsRangeFromBounds()
+        {
+            // Arrange
+            var lowerBound = new KspVersionBound(new KspVersion(1, 2, 0, 0), true);
+            var upperBound = new KspVersionBound(new KspVersion(2, 4, 7, 0), false);
+            var lowerVersion = new KspVersion(1, 2);
+            var upperVersion = new KspVersion(2, 4, 6);
+
+            // Act
+            var resultFromBounds = new KspVersionRange(lowerBound, upperBound);
+            var resultFromVersions = new KspVersionRange(lowerVersion, upperVersion);
+
+            // Assert
+            Assert.That(resultFromBounds.Lower, Is.EqualTo(resultFromVersions.Lower));
+            Assert.That(resultFromBounds.Upper, Is.EqualTo(resultFromVersions.Upper));
+        }
+
+        [Test]
         public void CtorThrowsOnNullLowerParameter()
         {
             // Act


### PR DESCRIPTION
## Problem
#2902, which was fixed for KSP 1.8 in #2931, still applies to KSP 1.9 unfortunately:
```
Set current directory to /HDD/KubuntuSteamGames/steamapps/common/Kerbal Space Program
Found path: /HDD/KubuntuSteamGames/steamapps/common/Kerbal Space Program/KSP.x86_64
Speicherzugriffsfehler (Speicherabzug geschrieben)
```
(Now you know the German translation for a segmentation fault)

## Changes
The version range for which we remove the `-single-instance` command has been extended to include 1.9.

I created a new helper function which allows to create a `KspVersionRange` from two `KspVersion` objects. The resulting version range extends from the lowest possible version of the first argument to the highest possible version of the second argument.
It uses the `KspVersion`->`KspVersionRange` logic from `kspversion.ToVersionRange()`.