### PR TITLE
Respect installing modules during dependency resolution

### DIFF
--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -7,7 +7,7 @@ using CKAN.ConsoleUI.Toolkit;
 namespace CKAN.ConsoleUI {
 
     /// <summary>
-    /// Screen for letting the user choose additional pacakges to install
+    /// Screen for letting the user choose additional packages to install
     /// based on others they've selected
     /// </summary>
     public class DependencyScreen : ConsoleScreen {

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -54,14 +54,14 @@ namespace CKAN.ConsoleUI {
                         }
 
                         // FUTURE: BackgroundWorker
-                        
+
                         HashSet<string> possibleConfigOnlyDirs = null;
 
                         RegistryManager regMgr = RegistryManager.Instance(manager.CurrentInstance);
                         ModuleInstaller inst = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, this);
                         inst.onReportModInstalled = OnModInstalled;
                         if (plan.Remove.Count > 0) {
-                            inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr);
+                            inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr, true, plan.Install);
                             plan.Remove.Clear();
                         }
                         NetAsyncModulesDownloader dl = new NetAsyncModulesDownloader(this, manager.Cache);

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -727,7 +727,10 @@ namespace CKAN
         /// This *DOES* save the registry.
         /// Preferred over Uninstall.
         /// </summary>
-        public void UninstallList(IEnumerable<string> mods, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool ConfirmPrompt = true, IEnumerable<string> installing = null)
+        public void UninstallList(
+            IEnumerable<string> mods, ref HashSet<string> possibleConfigOnlyDirs,
+            RegistryManager registry_manager, bool ConfirmPrompt = true, IEnumerable<CkanModule> installing = null
+        )
         {
             mods = mods.Memoize();
             // Pre-check, have they even asked for things which are installed?
@@ -740,8 +743,9 @@ namespace CKAN
             // Find all the things which need uninstalling.
             IEnumerable<string> revdep = mods
                 .Union(registry_manager.registry.FindReverseDependencies(
-                    mods.Except(installing ?? new string[] {})))
-                .Memoize();
+                    mods.Except(installing?.Select(m => m.identifier) ?? new string[] {}),
+                    installing
+                )).Memoize();
             IEnumerable<string> goners = revdep.Union(
                     registry_manager.registry.FindRemovableAutoInstalled(
                         registry_manager.registry.InstalledModules.Where(im => !revdep.Contains(im.identifier)))
@@ -794,12 +798,6 @@ namespace CKAN
             }
 
             User.RaiseMessage("Done!\r\n");
-        }
-
-        public void UninstallList(string mod, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager)
-        {
-            var list = new List<string> { mod };
-            UninstallList(list, ref possibleConfigOnlyDirs, registry_manager);
         }
 
         /// <summary>

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -74,7 +74,9 @@ namespace CKAN
         /// <summary>
         /// Finds and returns all modules that could not exist without the listed modules installed, including themselves.
         /// </summary>
-        IEnumerable<string> FindReverseDependencies(IEnumerable<string> modules);
+        IEnumerable<string> FindReverseDependencies(
+            IEnumerable<string> modulesToRemove, IEnumerable<CkanModule> modulesToInstall = null
+        );
 
         /// <summary>
         /// Find auto-installed modules that have no depending modules

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1073,10 +1073,10 @@ namespace CKAN
 
                     if (modulesToInstall != null)
                     {
-                        // We added modules to the hypothetical list which are not yet installed,
-                        // but not their dependencies (we don't know them yet).
-                        // Thus the SanityChecker wants to remove them again -> don't let him.
-                        broken = broken.Except(modulesToInstall.Select(m => m.identifier)).ToHashSet();
+                        // Make sure to only report modules as broken if they are actually currently installed.
+                        // This is mainly to remove the modulesToInstall again which we added
+                        // earlier to the hypothetical list.
+                        broken.IntersectWith(origInstalled.Select(m => m.identifier));
                     }
                     // Lazily return each newly found rev dep
                     foreach (string newFound in broken.Except(modulesToRemove))

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -311,7 +311,7 @@ namespace CKAN
             // is true.
             var sub_options = (RelationshipResolverOptions) options.Clone();
             sub_options.with_suggests = false;
-            
+
             old_stanza = old_stanza?.Memoize();
 
             log.DebugFormat("Resolving dependencies for {0}", module.identifier);
@@ -364,8 +364,7 @@ namespace CKAN
                 else if (descriptor.ContainsAny(modlist.Keys))
                 {
                     CkanModule module = modlist.Values
-                        .Where(m => descriptor.ContainsAny(new string[] { m.identifier }))
-                        .FirstOrDefault();
+                        .FirstOrDefault(m => descriptor.ContainsAny(new string[] { m.identifier }));
                     if (options.proceed_with_inconsistencies)
                     {
                         conflicts.Add(new KeyValuePair<CkanModule, CkanModule>(module, reason.Parent));
@@ -392,8 +391,7 @@ namespace CKAN
                 {
                     CkanModule module = registry.InstalledModules
                         .Select(im => im.Module)
-                        .Where(m => descriptor.ContainsAny(new string[] { m.identifier }))
-                        .FirstOrDefault();
+                        .FirstOrDefault(m => descriptor.ContainsAny(new string[] { m.identifier }));
                     if (options.proceed_with_inconsistencies)
                     {
                         conflicts.Add(new KeyValuePair<CkanModule, CkanModule>(module, reason.Parent));
@@ -688,7 +686,7 @@ namespace CKAN
                 get { return "  Requested by user.\r\n"; }
             }
         }
-        
+
         public class NoLongerUsed: SelectionReason
         {
             public override string Reason

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using CKAN.Extensions;

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -177,7 +177,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.UninstallList(toUninstall, ref possibleConfigOnlyDirs, registry_manager, false, toInstall.Select(m => m.identifier));
+                            installer.UninstallList(toUninstall, ref possibleConfigOnlyDirs, registry_manager, false, toInstall);
                             processSuccessful = true;
                         }
                     }

--- a/GUI/Main/MainModList.cs
+++ b/GUI/Main/MainModList.cs
@@ -848,19 +848,21 @@ namespace CKAN
 
             var installed_modules =
                 registry.InstalledModules.Select(imod => imod.Module).ToDictionary(mod => mod.identifier, mod => mod);
-            foreach (var dependency in registry.FindReverseDependencies(
+
+            foreach (var dependent in registry.FindReverseDependencies(
                 modules_to_remove
                     .Select(mod => mod.identifier)
-                    .Except(modules_to_install.Select(m => m.identifier))
+                    .Except(modules_to_install.Select(m => m.identifier)),
+                modules_to_install
             ))
             {
                 //TODO This would be a good place to have an event that alters the row's graphics to show it will be removed
                 CkanModule depMod;
-                if (installed_modules.TryGetValue(dependency, out depMod))
+                if (installed_modules.TryGetValue(dependent, out depMod))
                 {
                     CkanModule module_by_version = registry.GetModuleByVersion(depMod.identifier,
                     depMod.version)
-                        ?? registry.InstalledModule(dependency).Module;
+                        ?? registry.InstalledModule(dependent).Module;
                     changeSet.Add(new ModChange(module_by_version, GUIModChangeType.Remove, null));
                     modules_to_remove.Add(module_by_version);
                 }

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -440,7 +440,7 @@ namespace Tests.Core
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
                     // This should throw, as our tidy KSP has no mods installed.
-                    CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList("Foo", ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                    CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(new List<string> {"Foo"}, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
                 });
 
                 manager.CurrentInstance = null; // I weep even more.
@@ -520,10 +520,10 @@ namespace Tests.Core
                 {
                     $"{mod.identifier}={mod.version}"
                 };
-                
+
                 // Act
                 inst.InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
-                
+
                 // Assert
                 Assert.IsTrue(File.Exists(mod_file_path));
 

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -340,7 +340,7 @@ namespace Tests.Core.Relationships
             var dll_count = dlls.Count;
             var mods_count = mods.Count;
 
-            var results = CKAN.Registry.FindReverseDependencies(to_remove, mods, dlls, dlc);
+            var results = CKAN.Registry.FindReverseDependencies(to_remove, null, mods, dlls, dlc);
 
             // Make sure nothing changed.
             Assert.AreEqual(remove_count, to_remove.Count, message + " remove count");


### PR DESCRIPTION
## Problem
Found out thanks to [this comment](https://forum.kerbalspaceprogram.com/index.php?/topic/159443-12-181-spectra-v124-visual-compilation-10th-february-20/&do=findComment&comment=3739637) on the Spectra forum thread.

Currently when uninstalling dependencies of a mod and installing a new mod that also provides these dependencies, CKAN will remove the dependent mod, even though its dependencies will be satisfied after the process completed, thanks to the new mod.

## Example
Scatterer depends on Scatterer-config and Scatterer-sunflare.
Spectra provides both of these modules.

When you have Scatterer installed with its default config + sunflare and mark Spectra for installation, CKAN correctly reports conflicts.
Then you de-select the default config + sunflare so they get uninstalled.
Even though Spectra provides these modules too (which triggered the TooManyModsProvide conflict), CKAN (both GUI and ConsoleUI) wants to remove Scatterer.

## Cause
This is due to the mods that are about to be installed not being respected in `FindReverseDependencies()` > `FindUnsatisfiedDepends()` > `MatchesAny()`.
Only the currently installed mods are taken into account for the dependency resolution.

## Changes
This commit adds an optional argument to `FindReverseDependencies()`, `IEnumerable<CkanModule> modulesToInstall`.
This list will be added to the list of "currently installed" mods, so `FindUnsatisfiedDepends()` considers them and their provided modules.

`UninstallList` now takes a `IEnumerable<CkanModule> installing` instead of `IEnumerable<string> installing` which it passes on to `FindReverseDependencies()`.
`ConsoleUI/InstallScreen.Run()` and `GUI/Main/MainInstall.InstallMods()` are changed to pass the list of mods that are about to be installed to `UninstallList()`.
`GUI/MainModList.ComputeChangeSetFromModList()` also passes `modules_to_install`.

I've removed the `UninstallList()` override which takes a single string instead of a list of mods to uninstall, because it was only used in one single test.
This test now creates a new `List<string>` on the fly.

Closes #1909