### PR TITLE
Fix reinstall prompt crash

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -6,13 +6,13 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Autofac;
 using ChinhDo.Transactions.FileManager;
-using CKAN.GameVersionProviders;
-using CKAN.Versioning;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
 using Newtonsoft.Json;
+using CKAN.GameVersionProviders;
+using CKAN.Versioning;
 
 namespace CKAN
 {
@@ -181,6 +181,8 @@ namespace CKAN
         /// <param name="metadataChanges">List of modules that changed</param>
         /// <param name="user">Object for user interaction callbacks</param>
         /// <param name="ksp">Game instance</param>
+        /// <param name="cache">Cacne object for mod downloads</param>
+        /// <param name="registry_manager">Manager that holds our game instances</param>
         private static void HandleModuleChanges(List<CkanModule> metadataChanges, IUser user, KSP ksp, NetModuleCache cache, RegistryManager registry_manager)
         {
             StringBuilder sb = new StringBuilder();

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -198,7 +198,7 @@ namespace CKAN
                 CkanModule.FmtSize(m_cacheSize)
             );
 
-            if (deleteConfirmationDialog.ShowYesNoDialog(confirmationText) == DialogResult.Yes)
+            if (deleteConfirmationDialog.ShowYesNoDialog(this, confirmationText) == DialogResult.Yes)
             {
                 // tell the cache object to nuke itself
                 Main.Instance.Manager.Cache.RemoveAll();

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Windows.Forms;
+using System.Threading.Tasks;
 
 namespace CKAN
 {
@@ -8,25 +9,24 @@ namespace CKAN
         public YesNoDialog()
         {
             InitializeComponent();
+            defaultYes = YesButton.Text;
+            defaultNo  = NoButton.Text;
         }
 
-        public DialogResult ShowYesNoDialog(string text, string yesText = null, string noText = null)
+        public DialogResult ShowYesNoDialog(Form parentForm, string text, string yesText = null, string noText = null)
         {
-            Util.Invoke(DescriptionLabel, () =>
+            task = new TaskCompletionSource<DialogResult>();
+
+            Util.Invoke(parentForm, () =>
             {
                 DescriptionLabel.Text = text;
-                if (yesText != null)
-                {
-                    YesButton.Text = yesText;
-                }
-                if (noText != null)
-                {
-                    NoButton.Text = noText;
-                }
+                YesButton.Text = yesText ?? defaultYes;
+                NoButton.Text  = noText  ?? defaultNo;
                 ClientSize = new Size(ClientSize.Width, StringHeight(text, ClientSize.Width - 25) + 2 * 54);
+                task.SetResult(ShowDialog(parentForm));
             });
 
-            return ShowDialog();
+            return task.Task.Result;
         }
 
         /// <summary>
@@ -46,5 +46,9 @@ namespace CKAN
         {
             Util.Invoke(this, Close);
         }
+
+        private TaskCompletionSource<DialogResult> task;
+        private string defaultYes;
+        private string defaultNo;
     }
 }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -1269,7 +1269,7 @@ namespace CKAN
 
             YesNoDialog reinstallDialog = new YesNoDialog();
             string confirmationText = string.Format(Properties.Resources.MainReinstallConfirm, module.Name);
-            if (reinstallDialog.ShowYesNoDialog(confirmationText) == DialogResult.No)
+            if (reinstallDialog.ShowYesNoDialog(this, confirmationText) == DialogResult.No)
                 return;
 
             IRegistryQuerier registry = RegistryManager.Instance(CurrentInstance).registry;

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -35,7 +35,7 @@ namespace CKAN
 
         public bool YesNoDialog(string text, string yesText = null, string noText = null)
         {
-            return yesNoDialog.ShowYesNoDialog(text, yesText, noText) == DialogResult.Yes;
+            return yesNoDialog.ShowYesNoDialog(this, text, yesText, noText) == DialogResult.Yes;
         }
 
         public int SelectionDialog(string message, params object[] args)


### PR DESCRIPTION
## Problem

My Mono does a hard crash when CKAN tries to ask the user whether to reinstall a changed mod after a refresh:

```
	  at <unknown> <0xffffffff>
	  at System.Windows.Forms.X11Keyboard:XCreateFontSet <0x000ce>
	  at System.Windows.Forms.X11Keyboard:CreateOverTheSpotXic <0x000e7>
	  at System.Windows.Forms.X11Keyboard:CreateXic <0x00117>
	  at System.Windows.Forms.X11Keyboard:CreateXicForWindow <0x00053>
	  at System.Windows.Forms.X11Keyboard:FocusIn <0x000c3>
	  at System.Windows.Forms.XplatUIX11:SetFocus <0x000ef>
	  at System.Windows.Forms.XplatUI:SetFocus <0x0003c>
	  at System.Windows.Forms.ContainerControl:SendControlFocus <0x000bf>
	  at System.Windows.Forms.Form:SetVisibleCore <0x004f3>
	  at System.Windows.Forms.Control:set_Visible <0x0004b>
	  at System.Windows.Forms.Control:set_Visible <0x00083>
	  at System.Windows.Forms.Application:RunLoop <0x003df>
	  at System.Windows.Forms.Form:ShowDialog <0x008f7>
	  at System.Windows.Forms.Form:ShowDialog <0x0002b>
	  at CKAN.YesNoDialog:ShowYesNoDialog <0x001cf>
	  at CKAN.YesNoDialog:ShowYesNoDialog <0x000a3>
	  at CKAN.Main:YesNoDialog <0x00057>
	  at CKAN.Main:YesNoDialog <0x000a3>
	  at CKAN.GUIUser:RaiseYesNoDialog <0x0003f>
	  at CKAN.Repo:HandleModuleChanges <0x001bf>
	  at CKAN.Repo:UpdateAllRepositories <0x00573>
	  at CKAN.Main:UpdateRepo <0x005c3>
	  at System.ComponentModel.BackgroundWorker:OnDoWork <0x00046>
	  at System.ComponentModel.BackgroundWorker:WorkerThreadStart <0x000c2>
	  at System.ComponentModel.BackgroundWorker:<RunWorkerAsync>b__27_0 <0x00033>
	  at System.Threading.Tasks.Task:InnerInvoke <0x0008f>
	  at System.Threading.Tasks.Task:Execute <0x00037>
	  at System.Threading.Tasks.Task:ExecutionContextCallback <0x0005b>
	  at System.Threading.ExecutionContext:RunInternal <0x00191>
	  at System.Threading.ExecutionContext:Run <0x00042>
	  at System.Threading.Tasks.Task:ExecuteWithThreadLocal <0x000f6>
	  at System.Threading.Tasks.Task:ExecuteEntry <0x000dc>
	  at System.Threading.Tasks.Task:System.Threading.IThreadPoolWorkItem.ExecuteWorkItem <0x00026>
	  at System.Threading.ThreadPoolWorkQueue:Dispatch <0x00279>
	  at System.Threading._ThreadPoolWaitCallback:PerformWaitCallback <0x0001c>
	  at <Module>:runtime_invoke_bool <0x00086>
```

## Cause

The update runs on a background thread, and then it uses `IUser` to do GUI stuff.

## Changes

Now `YesNoDialog.ShowYesNoDialog` does all its GUI operations on the GUI thread and uses a `TaskCompetionSource` to propagate the result back to the background thread.

I made the parent form a parameter because `Util.Invoke` wasn't reliably switching to the right thread in my testing when the first parameter was from the YesNo form. I think that parameter needs to be a UI object that's properly connected to the rest of the app. As a bonus, this means we can pass the parent form to `ShowDialog`.

I also realized that the if you had a `ShowYesNoDialog` call with the custom button caption parameters followed by a call without them, the buttons would keep the custom captions from the first call, so they need to be reset each time.