### PR TITLE
Treat metapackage depends as not auto installed

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -215,7 +215,7 @@ namespace CKAN
                     User.RaiseProgress(String.Format("Installing mod \"{0}\"", modsToInstall[i]),
                                          percent_complete);
 
-                    Install(modsToInstall[i], resolver.ReasonFor(modsToInstall[i]) is SelectionReason.Depends, registry_manager.registry);
+                    Install(modsToInstall[i], resolver.IsAutoInstalled(modsToInstall[i]), registry_manager.registry);
                 }
 
                 User.RaiseProgress("Updating registry", 70);

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -639,6 +639,21 @@ namespace CKAN
 
             return reasons[mod];
         }
+
+        /// <summary>
+        /// Indicates whether a module should be considered auto-installed in this change set.
+        /// A mod is auto-installed if it is in the list because it's a dependency
+        /// and if its depending mod is not a metpaackage.
+        /// </summary>
+        /// <param name="mod">Module to check</param>
+        /// <returns>
+        /// true if auto-installed, false otherwise
+        /// </returns>
+        public bool IsAutoInstalled(CkanModule mod)
+        {
+            var reason = ReasonFor(mod);
+            return reason is SelectionReason.Depends && !reason.Parent.IsMetapackage;
+        }
     }
 
     /// <summary>

--- a/GUI/Controls/ThemedTabControl.cs
+++ b/GUI/Controls/ThemedTabControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -21,11 +22,19 @@ namespace CKAN
             bgRect.Inflate(-2, -1);
             bgRect.Offset(0, 1);
             e.Graphics.FillRectangle(new SolidBrush(BackColor), bgRect);
-            // Text
-            var tabPage = TabPages[e.Index];
-            Rectangle rect = e.Bounds;
-            TextRenderer.DrawText(e.Graphics, tabPage.Text, tabPage.Font,
-                rect, tabPage.ForeColor);
+            // e.Index can be invalid (!!), so we need try/catch
+            try
+            {
+                // Text
+                var tabPage = TabPages[e.Index];
+                Rectangle rect = e.Bounds;
+                TextRenderer.DrawText(e.Graphics, tabPage.Text, tabPage.Font,
+                    rect, tabPage.ForeColor);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // No such tab page, oh well
+            }
             // Alert event subscribers
             base.OnDrawItem(e);
         }


### PR DESCRIPTION
## Problem

If you install a `depends`-based modpack, its mods will be queued for removal automatically:

![changeset](https://user-images.githubusercontent.com/6690779/74649362-aa6a2180-517f-11ea-8072-b5026a9634b4.png)

This may also cause a crash:

```
System.ArgumentOutOfRangeException: InvalidArgument=Verdi 2 er en ugyldig for index.
Parameternavn: index
   ved System.Windows.Forms.TabControl.GetTabPage(Int32 index)
   ved System.Windows.Forms.TabControl.TabPageCollection.get_Item(Int32 index)
   ved CKAN.ThemedTabControl.OnDrawItem(DrawItemEventArgs e)
   ved System.Windows.Forms.TabControl.WmReflectDrawItem(Message& m)
   ved System.Windows.Forms.TabControl.WndProc(Message& m)
   ved System.Windows.Forms.Control.ControlNativeWindow.OnMessage(Message& m)
   ved System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m)
   ved System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Cause

After #2753, we track which mods are auto-installed to satisfy dependencies, so they can be uninstalled when the depending modules are uninstalled.

A modpack is represented as a `CkanModule` in which `IsMetapackage` is `true`, and it is not saved to the registry when it is installed. So its dependencies are all flagged as auto-installed, but their depending module is missing, and they are queued for removal.

The crash indicates that the GUI runtime is asking us to draw an item that doesn't exist. Maybe this is caused by a weird timing issue, because having auto-removable modules brings the change set back at the end of installation?

## Changes

Now we can ask the relationship resolver whether a module is auto-installed. To make this determination, in addition to checking whether it's being installed to satisfy a dependency (the previous logic) it *also* checks whether the depending module is a metapackage; if so, then the dependency is considered as not auto-installed. This will force modpack dependencies to be considered not auto-installed.

As well, the `ThemedTabControl` now protects itself from runtime malfeasance by ignoring `ArgumentOutOfRangeException`. This should prevent issues like this from causing crashes in the future.

Fixes #3007.