### PR TITLE
Don't auto-stage if version is "any"

### DIFF
--- a/Netkan/Transformers/StagingTransformer.cs
+++ b/Netkan/Transformers/StagingTransformer.cs
@@ -14,7 +14,11 @@ namespace CKAN.NetKAN.Transformers
         public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
         {
             JObject json = metadata.Json();
-            var matchingKeys = kspVersionKeys.Where(vk => json.ContainsKey(vk)).Memoize();
+            var matchingKeys = kspVersionKeys
+                .Where(vk => json.ContainsKey(vk)
+                          && !string.IsNullOrEmpty((string)json[vk])
+                          && (string)json[vk] != "any")
+                .Memoize();
             if (matchingKeys.Any())
             {
                 string msg = string.Join(", ", matchingKeys.Select(mk => $"{mk} = {json[mk]}"));


### PR DESCRIPTION
The auto-staging from #2970 has been triggering when the corresponding value is `"any"`:

- KSP-CKAN/CKAN-meta#1790
- KSP-CKAN/CKAN-meta#1797
- KSP-CKAN/CKAN-meta#1839

This isn't aligned with the intentions of this feature; a module compatible with all versions is much less likely to change compatibility than a module with specific compatible versions.

Now we only auto-stage if at least one of the present properties isn't `"any"` or `null`.