### PR TITLE
Update macOS wiki URL

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -39,7 +39,7 @@ MONO=$(which mono)
 if [ -z "$MONO" -o ! -x "$MONO" ]
 then
     # We could not find mono. The wiki explains how to install.
-    open 'https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-OSX'
+    open 'https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-macOS'
 else
     # Mono found, so we can run CKAN
     # The exe is called ckan.exe


### PR DESCRIPTION
## Problem

Before a few minutes ago, if you tried to run the CKAN.app bundle for Mac without Mono installed, your browser would open a missing page in the CKAN wiki.

## Cause

The page was renamed to reflect the name change from OSX to macOS, but the launch script still used the old URL.

- https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-macOS

Hooray for pointlessly renaming long established products to freshen up their brands.

## Changes

I just added back the old page with a link to the new.

- https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-OSX

And now the script is updated to use the new URL.

Fixes #3017.