### PR TITLE
Only stage auto-epoch if epoch changed

### DIFF
--- a/Core/Versioning/ModuleVersion.cs
+++ b/Core/Versioning/ModuleVersion.cs
@@ -60,6 +60,14 @@ namespace CKAN.Versioning
         }
 
         /// <returns>
+        /// true if versions have the same epoch, false if different
+        /// </returns>
+        public bool EpochEquals(ModuleVersion other)
+        {
+            return _epoch == other._epoch;
+        }
+
+        /// <returns>
         /// New module version with same version as 'this' but with one greater epoch
         /// </returns>
         public ModuleVersion IncrementEpoch()

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -60,7 +60,8 @@ namespace CKAN.NetKAN.Transformers
                     // Increment epoch if too small
                     currentV = currentV.IncrementEpoch();
                 }
-                if (startV < opts.HighestVersion && opts.HighestVersion < currentV)
+                if (!opts.HighestVersion.EpochEquals(currentV)
+                    && startV < opts.HighestVersion && opts.HighestVersion < currentV)
                 {
                     // New file, tell the Indexer to be careful
                     opts.Staged = true;


### PR DESCRIPTION
## Background

In #2824 we added the ability to automatically increment the epoch of a module during inflation, if needed to preserve in-order versioning; for example, if a module releases version `2` followed by version `1`, we would automatically change the latter to `1:1` to ensure that the later version is sorted later. To ensure that this did not go haywire, we turned on staging of such a module to allow for manual review before merge when it occurs.

Since this was working out reasonably well so far, in #2947 we made the staging more permissive by suppressing it when an auto-epoch'd version was equal to an existing version. This allowed previously created files to be updated without manual review, since our intention is to monitor the creation of new versions.

## Motivation

A significant fraction of auto-epoch pull requests are modules that are being epoch'd simply to keep up with a previously established auto-epoch for that module. In other words, if a module releases version `2` followed by version `1` followed by version `3`, we would establish an auto-epoch with version `1:1` via manual review as intended, but then the later version needs to become `1:3` as well even though it isn't out of order. Manual review is not needed in the `1:3` case, and creating a pull request just delays an update and takes up reviewers' time (a very small amount, but still).

Examples:

- KSP-CKAN/CKAN-meta#1846
- KSP-CKAN/CKAN-meta#1848
- KSP-CKAN/CKAN-meta#1853
- KSP-CKAN/CKAN-meta#1854
- KSP-CKAN/CKAN-meta#1866
- KSP-CKAN/CKAN-meta#1867

## Changes

Now we can check whether two `ModuleVersion`s have the same epoch. If this is so for an auto-epoch'd version and the previous highest version, we don't stage. This will allow such versions to be auto-epoch'd without unnecessary review, so pull requests will be limited to those where a significant change actually needs review.

(I created `ModuleVersion.EpochEquals` instead of exposing `_epoch` publicly to keep `ModuleVersion`'s public interface small. This way we can limit the things that other code does with this object and make clean extensions to it in the future rather than proliferating all sorts of operations on what is currently private data.)