### PR TITLE
Improve modpack identifier validation

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -440,7 +440,7 @@ namespace CKAN
             {
                 // v1.18 to allow Unlicense
                 spec_version = new ModuleVersion("v1.18"),
-                identifier   = name,
+                identifier   = Identifier.Sanitize(name),
                 name         = name,
                 @abstract    = $"A list of modules installed on the {kspInstanceName} KSP instance",
                 kind         = "metapackage",

--- a/Core/Types/Identifier.cs
+++ b/Core/Types/Identifier.cs
@@ -14,5 +14,31 @@ namespace CKAN
             @"^[A-Za-z0-9][A-Za-z0-9-]+$",
             RegexOptions.Compiled
         );
+
+        /// <summary>
+        /// Turn a possibly invalid identifier string into a valid identifier string
+        /// </summary>
+        /// <param name="ident">String that we want to turn into an identifier</param>
+        /// <returns>
+        /// ident with any non-alphanumeric characters removed from the start so it
+        /// begins with alphanumeric, and any remaining non-alphanumeric characters
+        /// replaced with dashes so the overall string format is preserved
+        /// </returns>
+        public static string Sanitize(string ident)
+        {
+            return InvalidIdentifierCharacterPattern.Replace(
+                InvalidPrefixPattern.Replace(ident, ""),
+                "-"
+            );
+        }
+
+        private static readonly Regex InvalidIdentifierCharacterPattern = new Regex(
+            @"[^A-Za-z0-9-]",
+            RegexOptions.Compiled
+        );
+        private static readonly Regex InvalidPrefixPattern = new Regex(
+            @"^[^A-Za-z0-9]+",
+            RegexOptions.Compiled
+        );
     }
 }

--- a/GUI/Controls/EditModpack.Designer.cs
+++ b/GUI/Controls/EditModpack.Designer.cs
@@ -250,6 +250,7 @@ namespace CKAN
             this.RelationshipsListView.Groups.Add(this.RecommendationsGroup);
             this.RelationshipsListView.Groups.Add(this.SuggestionsGroup);
             this.RelationshipsListView.Groups.Add(this.IgnoredGroup);
+            this.RelationshipsListView.KeyDown += new System.Windows.Forms.KeyEventHandler(RelationshipsListView_KeyDown);
             this.RelationshipsListView.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(RelationshipsListView_ItemSelectionChanged);
             // 
             // ModNameColumn

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -172,7 +172,32 @@ namespace CKAN
             return true;
         }
 
-        private void RelationshipsListView_ItemSelectionChanged(Object sender, ListViewItemSelectionChangedEventArgs e)
+        private void RelationshipsListView_KeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                // Select all on ctrl-A
+                case Keys.A:
+                    if (e.Control)
+                    {
+                        foreach (ListViewItem lvi in RelationshipsListView.Items)
+                        {
+                            lvi.Selected = true;
+                        }
+                    }
+                    break;
+
+                // Deselect all on Esc
+                case Keys.Escape:
+                    foreach (ListViewItem lvi in RelationshipsListView.Items)
+                    {
+                        lvi.Selected = false;
+                    }
+                    break;
+            }
+        }
+
+        private void RelationshipsListView_ItemSelectionChanged(object sender, ListViewItemSelectionChangedEventArgs e)
         {
             if (OnSelectedItemsChanged != null)
             {

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -364,7 +364,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
 {0}</value></data>
   <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Update Notifications</value></data>
   <data name="MainLabelsUntagged" xml:space="preserve"><value>Untagged ({0})</value></data>
-  <data name="EditModpackBadIdentifier" xml:space="preserve"><value>Identifier must contain one or more letters, numbers, and dashes, and must start with a letter or number</value></data>
+  <data name="EditModpackBadIdentifier" xml:space="preserve"><value>Identifier must contain ONLY letters, numbers, and dashes, and must start with a letter or number</value></data>
   <data name="EditModpackBadName" xml:space="preserve"><value>Name is required</value></data>
   <data name="EditModpackBadVersion" xml:space="preserve"><value>Version is required</value></data>
   <data name="EditModpackBadKspVersions" xml:space="preserve"><value>Min KSP version must be less than or equal to max KSP version</value></data>


### PR DESCRIPTION
## Problems

Discord user Silverlight pointed out some issues with Export Modpack:

- The default value for the identifier field can be invalid, since the KSP instance name is used and may contain characters that are not valid for identifiers
- The error message says `Identifier must contain one or more letters, numbers, and dashes, and must start with a letter or number`, which could be interpreted to mean that other characters are allowed as long as one or more of the indicated characters are present. ~~I don't know whether the German translation has this problem.~~ The German translation does not have this problem.

## Cause

The export function always generated invalid identifiers going way back, but only with #2971 did we start validating the string, since the user can now edit it. I think most of my testing was with instances with names that are valid identifiers.

## Changes

- The default identifier string is now generated by stripping any non-alphanumeric characters off the front, then replacing any other non-alphanumeric characters with dashes
- The error message is clarified to indicate that **only** the specified characters are allowed
- Ctrl-A while the modpack list has focus will select all
- Escape while the modpack list has focus will deselect all

Test build:

- [ckan.zip](https://github.com/KSP-CKAN/CKAN/files/4423183/ckan.zip)
  (I think the cmd window will remain open on Windows, just ignore that, it's for debugging)