### PR TITLE
Consider supports in recommendations screen descriptions

### DIFF
--- a/GUI/Controls/ChooseRecommendedMods.resx
+++ b/GUI/Controls/ChooseRecommendedMods.resx
@@ -119,12 +119,12 @@
   </resheader>
   <data name="RecommendedModsCancelButton.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="RecommendedModsContinueButton.Text" xml:space="preserve"><value>Continue</value></data>
-  <data name="RecommendedModsToggleCheckbox.Text" xml:space="preserve"><value>(De-)select all recommended or suggested mods</value></data>
-  <data name="RecommendedDialogLabel.Text" xml:space="preserve"><value>The following modules have been recommended or suggested by one or more of the chosen modules:</value></data>
+  <data name="RecommendedModsToggleCheckbox.Text" xml:space="preserve"><value>(De-)select all</value></data>
+  <data name="RecommendedDialogLabel.Text" xml:space="preserve"><value>The chosen modules recommend, suggest, or are supported by the following modules:</value></data>
   <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Recommendations</value></data>
   <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Suggestions</value></data>
-  <data name="SupportedByGroup.Header" xml:space="preserve"><value>Supported By</value></data>
+  <data name="SupportedByGroup.Header" xml:space="preserve"><value>Supported By (not endorsed by chosen mods)</value></data>
   <data name="ModNameHeader.Text" xml:space="preserve"><value>Mod</value></data>
-  <data name="SourceModulesHeader.Text" xml:space="preserve"><value>Recommended or suggested by:</value></data>
+  <data name="SourceModulesHeader.Text" xml:space="preserve"><value>Related mod</value></data>
   <data name="DescriptionHeader.Text" xml:space="preserve"><value>Mod description</value></data>
 </root>

--- a/GUI/Localization/de-DE/ChooseRecommendedMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ChooseRecommendedMods.de-DE.resx
@@ -119,11 +119,11 @@
   </resheader>
   <data name="RecommendedModsCancelButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
   <data name="RecommendedModsContinueButton.Text" xml:space="preserve"><value>Fortsetzen</value></data>
-  <data name="RecommendedModsToggleCheckbox.Text" xml:space="preserve"><value>Alle Empfehlungen und Vorschläge ab-/auswählen</value></data>
-  <data name="RecommendedDialogLabel.Text" xml:space="preserve"><value>Die folgenden Module wurden von mindestens einer ausgewählten Mod empfohlen oder vorgeschlagen</value></data>
+  <data name="RecommendedModsToggleCheckbox.Text" xml:space="preserve"><value>Alles ab-/auswählen</value></data>
+  <data name="RecommendedDialogLabel.Text" xml:space="preserve"><value>Die ausgewählten Module empfehlen oder schlagen folgende Module vor, oder eines der ausgewählten Module wird werden von einem der folgenden unterstützt.</value></data>
   <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Empfehlungen</value></data>
   <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Vorschläge</value></data>
-  <data name="SupportedByGroup.Header" xml:space="preserve"><value>Unterstützt durch</value></data>
-  <data name="SourceModulesHeader.Text" xml:space="preserve"><value>Empfohlen/vorgeschlagen von:</value></data>
+  <data name="SupportedByGroup.Header" xml:space="preserve"><value>Unterstützt durch (nicht befürwortet von den ausgewählten Mods)</value></data>
+  <data name="SourceModulesHeader.Text" xml:space="preserve"><value>Zugehörige Mod</value></data>
   <data name="DescriptionHeader.Text" xml:space="preserve"><value>Kurzbeschreibung</value></data>
 </root>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -225,7 +225,7 @@
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Änderungen</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Statuslog</value></data>
   <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Wähle Mods</value></data>
-  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Wähle Empfehlungen und Vorschläge aus</value></data>
+  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Auswahl von Empfehlungen, Vorschlägen und unterstützenden Mods</value></data>
   <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modpack bearbeiten</value></data>
   <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N verfügbare Updates</value></data>
   <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Aktualisieren</value></data>

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -231,7 +231,7 @@
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Changeset</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Status log</value></data>
   <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Choose mods</value></data>
-  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choose recommended or suggested mods</value></data>
+  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choose recommended, suggested, or supporting mods</value></data>
   <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Delete Directories</value></data>
   <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Edit Modpack</value></data>
   <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -274,8 +274,8 @@ Wenn du ein Fehler mit dem CKAN Client vermutest: https://github.com/KSP-CKAN/CK
   <data name="MainModListAll" xml:space="preserve"><value>Alle ({0})</value></data>
   <data name="MainModListUpdatingTray" xml:space="preserve"><value>Aktualisiere Taskleiste...</value></data>
   <data name="MainModListUnknownFilter" xml:space="preserve"><value>Unbekannter Filtertyp {0} in IsModInFilter</value></data>
-  <data name="MainRecommendationsTitle" xml:space="preserve"><value>Wähle empfohlene oder vorgeschlagene Mods aus.</value></data>
-  <data name="MainRecommendationsNoneFound" xml:space="preserve"><value>Keine Empfehlungen oder Vorschläge gefunden.</value></data>
+  <data name="MainRecommendationsTitle" xml:space="preserve"><value>Auswahl von Empfehlungen, Vorschlägen und unterstützenden Mods</value></data>
+  <data name="MainRecommendationsNoneFound" xml:space="preserve"><value>Keine Empfehlungen, Vorschläge oder unterstützende Mods gefunden.</value></data>
   <data name="MainRepoWaitTitle" xml:space="preserve"><value>Aktualisiere Repository</value></data>
   <data name="MainRepoScanning" xml:space="preserve"><value>Suche nach DLCs und manuell installierten Modulen...</value></data>
   <data name="MainRepoContacting" xml:space="preserve"><value>Kontaktiere das Repository...</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -296,8 +296,8 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="MainModListUpdatingTray" xml:space="preserve"><value>Updating tray...</value></data>
   <data name="MainModListAutoDetected" xml:space="preserve"><value>AD</value></data>
   <data name="MainModListUnknownFilter" xml:space="preserve"><value>Unknown filter type {0} in IsModInFilter</value></data>
-  <data name="MainRecommendationsTitle" xml:space="preserve"><value>Choose recommended or suggested mods</value></data>
-  <data name="MainRecommendationsNoneFound" xml:space="preserve"><value>No recommendations or suggestions found.</value></data>
+  <data name="MainRecommendationsTitle" xml:space="preserve"><value>Choose recommended, suggested, or supporting mods</value></data>
+  <data name="MainRecommendationsNoneFound" xml:space="preserve"><value>No recommended, suggested, or supporting mods found.</value></data>
   <data name="MainRepoWaitTitle" xml:space="preserve"><value>Updating repositories</value></data>
   <data name="MainRepoScanning" xml:space="preserve"><value>Scanning for DLCs and manually installed modules...</value></data>
   <data name="MainRepoContacting" xml:space="preserve"><value>Contacting repository...</value></data>


### PR DESCRIPTION
## Background

In #2960 we added a "Supported By" section to the GUI recommendations screen. Unlike the recommendation and suggestion sections, which show mods mentioned by the mods chosen for install, this section is based on relationships in which **other** mods mention the chosen mods. This provides better support for certain scenarios:

- If I install a tech tree, I would be able to see which mods integrate with that tech tree
- If I install RPM, I would be able to see mods that provide MFD pages
- If I install TweakScale, I would be able to see part mods that allow scaling

## Problem

The orange marks highlight places in the current UI that incorrectly state or imply that "supported by" mods are recommended or suggested by the chosen mods (because that was how the screen worked after #2744 and the text was not updated):

![image](https://user-images.githubusercontent.com/1559108/78462209-78753600-76bf-11ea-92bb-9898bf290463.png)

Only the blue highlighted part indicates the status of those mods, and it's pretty terse.

The German translation also has this problem.

## Changes

Now the English UI no longer says that supported-by modules are recommended or suggested by the chosen mods:

- The tab caption now mentions supporting mods explicitly
- The explanatory text mentions supported-by explicitly
- The column header now just says "Related mod" since there are several different relationships
- The checkbox just says "(De-)select all" instead of specifying a relationship
- The "Supported By" header now clarifies "(not endorsed by chosen mods)", to set the expectation that this section is not generated from or owned by the mods the user selected

![image](https://user-images.githubusercontent.com/1559108/78462210-7ad79000-76bf-11ea-99a8-68917b9163b3.png)

The German UI is updated as well.