### PR TITLE
Disable reinstall option for AD mods

### DIFF
--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -1257,7 +1257,7 @@ namespace CKAN
 
                 downloadContentsToolStripMenuItem.Enabled = !guiMod.IsCached;
                 purgeContentsToolStripMenuItem.Enabled = guiMod.IsCached;
-                reinstallToolStripMenuItem.Enabled = guiMod.IsInstalled;
+                reinstallToolStripMenuItem.Enabled = guiMod.IsInstalled && !guiMod.IsAutodetected;
             }
         }
 


### PR DESCRIPTION
## Problem

If you install a mod manually, the Reinstall right click option is enabled:

![image](https://user-images.githubusercontent.com/1559108/79029550-54649980-7b84-11ea-9669-0b0ba31b355e.png)

It doesn't work though:

```
CKAN.ModNotInstalledKraken: Module Astrogator is not installed!
   at CKAN.ModuleInstaller.UninstallList(IEnumerable`1 mods, HashSet`1& possibleConfigOnlyDirs, RegistryManager registry_manager, Boolean ConfirmPrompt, IEnumerable`1 installing)
   at CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

## Cause

The reinstall logic tries to uninstall the specified mod first, which we can't do for a manually installed mod.

## Changes

Now the Reinstall option is only enabled for mods installed by CKAN.

![image](https://user-images.githubusercontent.com/1559108/79029543-5169a900-7b84-11ea-9c77-12008fdb629c.png)


Fixes #3033.