### PR TITLE
Support multiple remote versions

### DIFF
--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -72,14 +72,34 @@ namespace CKAN.NetKAN.Transformers
                         {
                             var remoteJson = _github?.DownloadText(remoteUri)
                                 ?? _http.DownloadText(remoteUri);
-                            var remoteAvc = JsonConvert.DeserializeObject<AvcVersion>(remoteJson);
 
-                            if (avc.version.CompareTo(remoteAvc.version) == 0)
+                            var rootToken = JToken.Parse(remoteJson, new JsonLoadSettings { CommentHandling = CommentHandling.Ignore });
+
+                            if (rootToken.Type == JTokenType.Object)
                             {
-                                // Local AVC and Remote AVC describe the same version, prefer
-                                Log.Info("Remote AVC version file describes same version as local AVC version file, using it preferrentially.");
-                                avc = remoteAvc;
+                                var remoteAvc = rootToken.ToObject<AvcVersion>();
+                                if (avc.version.CompareTo(remoteAvc.version) == 0)
+                                {
+                                    // Local AVC and Remote AVC describe the same version, prefer
+                                    Log.Info("Remote AVC version file describes same version as local AVC version file, using it preferrentially.");
+                                    avc = remoteAvc;
+                                }
                             }
+                            else if (rootToken.Type == JTokenType.Array)
+                            {
+                                var remoteAvcs = rootToken.ToObject<AvcVersion[]>();
+                                AvcVersion matchedVersion = null;
+                                foreach (var remoteAvc in remoteAvcs)
+                                {
+                                    if (avc.version.CompareTo(remoteAvc.version) != 0) continue;
+                                    if (matchedVersion != null) throw new InvalidOperationException("More than one matching version found in remote AVC file");
+                                    matchedVersion = remoteAvc;
+                                }
+                                if (matchedVersion == null) throw new InvalidOperationException("No matching version found in remote AVC file");
+                                avc = matchedVersion;
+                            }
+                            else
+                                throw new InvalidOperationException("Invalid root token in remote AVC: " + rootToken.Type.ToString());
                         }
                         catch (Exception e)
                         {

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -291,5 +291,140 @@ namespace Tests.NetKAN.Transformers
             );
         }
 
+        [Test]
+        public void Transform_RemoteAvcOverrides_SameVersion()
+        {
+            // Arrange
+            var mHttp = new Mock<IHttpService>();
+            mHttp.Setup(i => i.DownloadText(It.Is<System.Uri>(u => u.OriginalString == "https://awesomemod.example/avc.version")))
+                .Returns("//leading comment\n\n{\"version\":\"1.0.0\",\"ksp_version_min\":\"1.2.1\",\"ksp_version_max\":\"1.2.99\"}");
+
+            var mModuleService = new Mock<IModuleService>();
+            mModuleService.Setup(i => i.GetInternalAvc(It.IsAny<CkanModule>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new AvcVersion()
+                {
+                    version = new ModuleVersion("1.0.0"),
+                    ksp_version = new KspVersion(1, 2, 3),
+                    Url = "https://awesomemod.example/avc.version",
+                }); ;
+
+            ITransformer sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
+
+            JObject json = new JObject();
+            json["spec_version"] = 1;
+            json["identifier"] = "AwesomeMod";
+            json["$vref"] = "#/ckan/ksp-avc";
+            json["download"] = "https://awesomemod.example/AwesomeMod.zip";
+            json["version"] = "1.0.0";
+            json["ksp_version"] = "1.2.3";
+
+            // Act
+            Metadata result = sut.Transform(new Metadata(json), opts).First();
+            JObject transformedJson = result.Json();
+
+            // Assert
+            Assert.That((string)transformedJson["ksp_version"], Is.Null,
+                "AvcTransformer should replace local AVC info with remote AVC info if the module versions match."
+            );
+
+            Assert.That((string)transformedJson["ksp_version_min"], Is.EqualTo("1.2.1"),
+                "AvcTransformer should replace local AVC info with remote AVC info if the module versions match."
+            );
+
+            Assert.That((string)transformedJson["ksp_version_max"], Is.EqualTo("1.2.99"),
+                "AvcTransformer should replace local AVC info with remote AVC info if the module versions match."
+            );
+        }
+
+        [Test]
+        public void Transform_RemoteAvcOverrides_DifferentVersion()
+        {
+            // Arrange
+            var mHttp = new Mock<IHttpService>();
+            mHttp.Setup(i => i.DownloadText(It.Is<System.Uri>(u => u.OriginalString == "https://awesomemod.example/avc.version")))
+                .Returns("//leading comment\n\n{\"version\":\"1.0.1\",\"ksp_version_min\":\"1.2.1\",\"ksp_version_max\":\"1.2.99\"}");
+
+            var mModuleService = new Mock<IModuleService>();
+            mModuleService.Setup(i => i.GetInternalAvc(It.IsAny<CkanModule>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new AvcVersion()
+                {
+                    version = new ModuleVersion("1.0.0"),
+                    ksp_version = new KspVersion(1, 2, 3),
+                    Url = "https://awesomemod.example/avc.version",
+                }); ;
+
+            ITransformer sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
+
+            JObject json = new JObject();
+            json["spec_version"] = 1;
+            json["identifier"] = "AwesomeMod";
+            json["$vref"] = "#/ckan/ksp-avc";
+            json["download"] = "https://awesomemod.example/AwesomeMod.zip";
+            json["version"] = "1.0.0";
+            json["ksp_version"] = "1.2.3";
+
+            // Act
+            Metadata result = sut.Transform(new Metadata(json), opts).First();
+            JObject transformedJson = result.Json();
+
+            // Assert
+            Assert.That((string)transformedJson["ksp_version"], Is.EqualTo("1.2.3"),
+                "AvcTransformer should not replace local AVC info with remote AVC info if the module versions don't match."
+            );
+
+            Assert.That((string)transformedJson["ksp_version_min"], Is.Null,
+                "AvcTransformer should not replace local AVC info with remote AVC info if the module versions don't match."
+            );
+
+            Assert.That((string)transformedJson["ksp_version_max"], Is.Null,
+                "AvcTransformer should not replace local AVC info with remote AVC info if the module versions don't match."
+            );
+        }
+
+        [Test]
+        public void Transform_RemoteAvcOverrides_FetchError()
+        {
+            // Arrange
+            var mHttp = new Mock<IHttpService>();
+            mHttp.Setup(i => i.DownloadText(It.Is<System.Uri>(u => u.OriginalString == "https://awesomemod.example/avc.version")))
+                .Throws<System.Exception>();
+
+            var mModuleService = new Mock<IModuleService>();
+            mModuleService.Setup(i => i.GetInternalAvc(It.IsAny<CkanModule>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new AvcVersion()
+                {
+                    version = new ModuleVersion("1.0.0"),
+                    ksp_version = new KspVersion(1, 2, 3),
+                    Url = "https://awesomemod.example/avc.version",
+                }); ;
+
+            ITransformer sut = new AvcTransformer(mHttp.Object, mModuleService.Object, null);
+
+            JObject json = new JObject();
+            json["spec_version"] = 1;
+            json["identifier"] = "AwesomeMod";
+            json["$vref"] = "#/ckan/ksp-avc";
+            json["download"] = "https://awesomemod.example/AwesomeMod.zip";
+            json["version"] = "1.0.0";
+            json["ksp_version"] = "1.2.3";
+
+            // Act
+            Metadata result = sut.Transform(new Metadata(json), opts).First();
+            JObject transformedJson = result.Json();
+
+            // Assert
+            Assert.That((string)transformedJson["ksp_version"], Is.EqualTo("1.2.3"),
+                "AvcTransformer should not replace local AVC info with remote AVC info if the module versions don't match."
+            );
+
+            Assert.That((string)transformedJson["ksp_version_min"], Is.Null,
+                "AvcTransformer should not replace local AVC info with remote AVC info if the module versions don't match."
+            );
+
+            Assert.That((string)transformedJson["ksp_version_max"], Is.Null,
+                "AvcTransformer should not replace local AVC info with remote AVC info if the module versions don't match."
+            );
+        }
+
     }
 }


### PR DESCRIPTION
This will be used by AVC to determine the newest version for your KSP version.  For NetKAN's purpose we just need the matching version.