### PR TITLE
Show DLC in recommendations list

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -30,7 +30,7 @@
         },
         "kind" : {
             "description" : "Package type, defaults to package.",
-            "enum"        : [ "package", "metapackage" ]
+            "enum"        : [ "package", "metapackage", "dlc" ]
         },
         "abstract" : {
             "description" : "Short description of the mod",
@@ -219,6 +219,16 @@
                     "description" : "Mod's remote hosted netkan",
                     "type"        : "string",
                     "format"      : "uri"
+                },
+                "store": {
+                    "description" : "Purchase DLC here",
+                    "type"        : "string",
+                    "format"      : "uri"
+                },
+                "steamstore": {
+                    "description" : "Purchase DLC on Steam here",
+                    "type"        : "string",
+                    "format"      : "uri"
                 }
             }
         },
@@ -316,7 +326,7 @@
         {
             "properties": {
                 "kind": {
-                    "enum": [ "metapackage" ]
+                    "enum": [ "metapackage", "dlc" ]
                 }
             },
             "not": {

--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Collections.Generic;
 
 namespace CKAN.CmdLine
@@ -15,7 +16,10 @@ namespace CKAN.CmdLine
         {
             AvailableOptions opts       = (AvailableOptions)raw_options;
             IRegistryQuerier registry   = RegistryManager.Instance(ksp).registry;
-            var              compatible = registry.CompatibleModules(ksp.VersionCriteria());
+            
+            var compatible = registry
+                .CompatibleModules(ksp.VersionCriteria())
+                .Where(m => !m.IsDLC);
 
             user.RaiseMessage("Modules compatible with KSP {0}", ksp.Version());
             user.RaiseMessage("");

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -288,6 +288,19 @@ namespace CKAN.CmdLine
                     user.RaiseMessage("\r\n{0}", kraken.Message);
                     return Exit.ERROR;
                 }
+                catch (ModuleIsDLCKraken kraken)
+                {
+                    user.RaiseMessage($"CKAN can't install expansion '{kraken.module.name}' for you.");
+                    var res = kraken?.module?.resources;
+                    var storePagesMsg = new Uri[] { res?.store, res?.steamstore }
+                        .Where(u => u != null)
+                        .Aggregate("", (a, b) => $"{a}\r\n- {b}");
+                    if (!string.IsNullOrEmpty(storePagesMsg))
+                    {
+                        user.RaiseMessage($"To install this expansion, purchase it from one of its store pages:\r\n{storePagesMsg}");
+                    }
+                    return Exit.ERROR;
+                }
             }
 
             return Exit.OK;

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -95,8 +95,16 @@ namespace CKAN.CmdLine
                 else
                 {
                     user.RaiseMessage("Marking {0} as {1}...", id, descrip);
-                    im.AutoInstalled = value;
-                    needSave = true;
+                    try
+                    {
+                        im.AutoInstalled = value;
+                        needSave = true;
+                    }
+                    catch (ModuleIsDLCKraken kraken)
+                    {
+                        user.RaiseMessage($"Can't mark expansion '{kraken.module.name}' as auto-installed.");
+                        return Exit.BADOPT;
+                    }
                 }
             }
             if (needSave)

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -107,10 +107,13 @@ namespace CKAN.CmdLine
             ICollection<string> files = module.Files as ICollection<string>;
             if (files == null) throw new InvalidCastException();
 
-            user.RaiseMessage("\r\nShowing {0} installed files:", files.Count);
-            foreach (string file in files)
+            if (!module.Module.IsDLC)
             {
-                user.RaiseMessage("- {0}", file);
+                user.RaiseMessage("\r\nShowing {0} installed files:", files.Count);
+                foreach (string file in files)
+                {
+                    user.RaiseMessage("- {0}", file);
+                }
             }
 
             return return_value;
@@ -192,22 +195,43 @@ namespace CKAN.CmdLine
             if (module.resources != null)
             {
                 if (module.resources.bugtracker != null)
+                {
                     user.RaiseMessage("- bugtracker: {0}", Uri.EscapeUriString(module.resources.bugtracker.ToString()));
+                }
                 if (module.resources.homepage != null)
+                {
                     user.RaiseMessage("- homepage: {0}", Uri.EscapeUriString(module.resources.homepage.ToString()));
+                }
                 if (module.resources.spacedock != null)
+                {
                     user.RaiseMessage("- spacedock: {0}", Uri.EscapeUriString(module.resources.spacedock.ToString()));
+                }
                 if (module.resources.repository != null)
+                {
                     user.RaiseMessage("- repository: {0}", Uri.EscapeUriString(module.resources.repository.ToString()));
+                }
                 if (module.resources.curse != null)
+                {
                     user.RaiseMessage("- curse: {0}", Uri.EscapeUriString(module.resources.curse.ToString()));
+                }
+                if (module.resources.store != null)
+                {
+                    user.RaiseMessage("- store: {0}", Uri.EscapeUriString(module.resources.store.ToString()));
+                }
+                if (module.resources.steamstore != null)
+                {
+                    user.RaiseMessage("- steamstore: {0}", Uri.EscapeUriString(module.resources.steamstore.ToString()));
+                }
             }
 
-            // Compute the CKAN filename.
-            string file_uri_hash = NetFileCache.CreateURLHash(module.download);
-            string file_name = CkanModule.StandardName(module.identifier, module.version);
-
-            user.RaiseMessage("\r\nFilename: {0}", file_uri_hash + "-" + file_name);
+            if (!module.IsDLC)
+            {
+                // Compute the CKAN filename.
+                string file_uri_hash = NetFileCache.CreateURLHash(module.download);
+                string file_name = CkanModule.StandardName(module.identifier, module.version);
+                
+                user.RaiseMessage("\r\nFilename: {0}", file_uri_hash + "-" + file_name);
+            }
 
             return Exit.OK;
         }

--- a/Core/DLC/IDlcDetector.cs
+++ b/Core/DLC/IDlcDetector.cs
@@ -37,19 +37,19 @@ namespace CKAN.DLC
         /// </item>
         /// </list>
         /// </returns>
-        bool IsInstalled (KSP ksp, out string identifier, out UnmanagedModuleVersion version);
+        bool IsInstalled(KSP ksp, out string identifier, out UnmanagedModuleVersion version);
 
         /// <summary>
         /// Path to the DLC directory relative to GameDir.
         /// E.g. GameData/SquadExpansion/Serenity
         /// </summary>
         /// <returns>The relative path as string.</returns>
-        string InstallPath ();
+        string InstallPath();
 
         /// <summary>
         /// Determines whether the DLC is allowed to be installed (or faked)
         /// on the specified base version (i.e. the game version of the KSP instance.)
         /// </summary>
-        bool AllowedOnBaseVersion (KspVersion baseVersion);
+        bool AllowedOnBaseVersion(KspVersion baseVersion);
     }
 }

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -25,7 +25,7 @@ namespace CKAN
             Dictionary<string, AvailableModule> available,
             Dictionary<string, HashSet<AvailableModule>> providers,
             HashSet<string> dlls,
-            Dictionary<string, UnmanagedModuleVersion> dlc
+            IDictionary<string, ModuleVersion> dlc
         )
         {
             CompatibleVersions = crit;
@@ -63,7 +63,7 @@ namespace CKAN
         private readonly Stack<string> Investigating = new Stack<string>();
 
         private readonly HashSet<string> dlls;
-        private readonly Dictionary<string, UnmanagedModuleVersion> dlc;
+        private readonly IDictionary<string, ModuleVersion> dlc;
 
         /// <summary>
         /// Filter the provides mapping by compatibility
@@ -78,9 +78,10 @@ namespace CKAN
             var compat = new Dictionary<string, HashSet<AvailableModule>>();
             foreach (var kvp in providers)
             {
-                // Find providing modules that are compatible with crit
+                // Find providing non-DLC modules that are compatible with crit
                 var compatAvail = kvp.Value.Where(avm =>
                     avm.AllAvailable().Any(ckm =>
+                        !ckm.IsDLC &&
                         ckm.ProvidesList.Contains(kvp.Key) && ckm.IsCompatibleKSP(crit))
                 ).ToHashSet();
                 // Add compatible providers to mapping, if any

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -11,7 +11,7 @@ namespace CKAN
     {
         IEnumerable<InstalledModule> InstalledModules { get; }
         IEnumerable<string>          InstalledDlls    { get; }
-        IDictionary<string, UnmanagedModuleVersion> InstalledDlc { get; }
+        IDictionary<string, ModuleVersion> InstalledDlc { get; }
 
         int? DownloadCount(string identifier);
 

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -116,7 +116,13 @@ namespace CKAN
         public bool AutoInstalled
         {
             get { return auto_installed;  }
-            set { auto_installed = value; }
+            set { 
+                if (Module.IsDLC)
+                {
+                    throw new ModuleIsDLCKraken(Module);
+                }
+                auto_installed = value;
+            }
         }
 
         #endregion

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -478,8 +478,8 @@ namespace CKAN
         /// </returns>
         public bool ScanDlc()
         {
-            var dlc = new Dictionary<string, UnmanagedModuleVersion>(registry.InstalledDlc);
-            UnmanagedModuleVersion foundVer;
+            var dlc = new Dictionary<string, ModuleVersion>(registry.InstalledDlc);
+            ModuleVersion foundVer;
             bool changed = false;
 
             registry.ClearDlc();

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -508,6 +508,10 @@ namespace CKAN
         {
             if (module.IsMetapackage)
                 return;
+            if (module.IsDLC)
+            {
+                throw new ModuleIsDLCKraken(module);
+            }
 
             log.DebugFormat("Adding {0} {1}", module.identifier, module.version);
 
@@ -552,7 +556,10 @@ namespace CKAN
         /// <returns>If it has dependencies compatible for the current version</returns>
         private bool MightBeInstallable(CkanModule module, List<string> compatible = null)
         {
-            if (module.depends == null) return true;
+            if (module.IsDLC)
+                return false;
+            if (module.depends == null)
+                return true;
             if (compatible == null)
             {
                 compatible = new List<string>();

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -20,7 +20,7 @@ namespace CKAN
         public static ICollection<string> ConsistencyErrors(
             IEnumerable<CkanModule> modules,
             IEnumerable<string> dlls,
-            IDictionary<string, UnmanagedModuleVersion> dlc
+            IDictionary<string, ModuleVersion> dlc
         )
         {
             List<KeyValuePair<CkanModule, RelationshipDescriptor>> unmetDepends;
@@ -48,7 +48,7 @@ namespace CKAN
         public static void EnforceConsistency(
             IEnumerable<CkanModule> modules,
             IEnumerable<string> dlls = null,
-            IDictionary<string, UnmanagedModuleVersion> dlc = null
+            IDictionary<string, ModuleVersion> dlc = null
         )
         {
             List<KeyValuePair<CkanModule, RelationshipDescriptor>> unmetDepends;
@@ -65,7 +65,7 @@ namespace CKAN
         public static bool IsConsistent(
             IEnumerable<CkanModule> modules,
             IEnumerable<string> dlls = null,
-            IDictionary<string, UnmanagedModuleVersion> dlc = null
+            IDictionary<string, ModuleVersion> dlc = null
         )
         {
             List<KeyValuePair<CkanModule, RelationshipDescriptor>> unmetDepends;
@@ -76,7 +76,7 @@ namespace CKAN
         private static bool CheckConsistency(
             IEnumerable<CkanModule> modules,
             IEnumerable<string> dlls,
-            IDictionary<string, UnmanagedModuleVersion> dlc,
+            IDictionary<string, ModuleVersion> dlc,
             out List<KeyValuePair<CkanModule, RelationshipDescriptor>> UnmetDepends,
             out List<KeyValuePair<CkanModule, RelationshipDescriptor>> Conflicts
         )
@@ -101,7 +101,7 @@ namespace CKAN
         public static List<KeyValuePair<CkanModule, RelationshipDescriptor>> FindUnsatisfiedDepends(
             IEnumerable<CkanModule> modules,
             HashSet<string> dlls,
-            IDictionary<string, UnmanagedModuleVersion> dlc
+            IDictionary<string, ModuleVersion> dlc
         )
         {
             var unsat = new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();
@@ -135,7 +135,7 @@ namespace CKAN
         public static List<KeyValuePair<CkanModule, RelationshipDescriptor>> FindConflicting(
             IEnumerable<CkanModule> modules,
             HashSet<string> dlls,
-            IDictionary<string, UnmanagedModuleVersion> dlc
+            IDictionary<string, ModuleVersion> dlc
         )
         {
             var confl = new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -567,4 +567,19 @@ namespace CKAN
             this.instName = name;
         }
     }
+    
+    public class ModuleIsDLCKraken : Kraken
+    {
+        /// <summary>
+        /// The DLC module that can't be operated upon
+        /// </summary>
+        public readonly CkanModule module;
+
+        public ModuleIsDLCKraken(CkanModule module, string reason = null)
+            : base(reason)
+        {
+            this.module = module;
+        }
+    }
+    
 }

--- a/GUI/Controls/AllModVersions.cs
+++ b/GUI/Controls/AllModVersions.cs
@@ -106,6 +106,8 @@ namespace CKAN
                     }
                 }
                 VersionsListView.Items.Clear();
+                // Only show checkboxes for non-DLC modules
+                VersionsListView.CheckBoxes = !value.ToModule().IsDLC;
 
                 KSP currentInstance = Main.Instance.Manager.CurrentInstance;
                 IRegistryQuerier registry = RegistryManager.Instance(currentInstance).registry;

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -45,8 +45,6 @@
             this.ReplacementTextBox = new TransparentTextBox();
             this.KSPCompatibilityLabel = new System.Windows.Forms.Label();
             this.ReleaseLabel = new System.Windows.Forms.Label();
-            this.GitHubLabel = new System.Windows.Forms.Label();
-            this.HomePageLabel = new System.Windows.Forms.Label();
             this.AuthorLabel = new System.Windows.Forms.Label();
             this.LicenseLabel = new System.Windows.Forms.Label();
             this.MetadataModuleVersionTextBox = new TransparentTextBox();
@@ -54,9 +52,7 @@
             this.MetadataModuleAuthorTextBox = new TransparentTextBox();
             this.VersionLabel = new System.Windows.Forms.Label();
             this.MetadataModuleReleaseStatusTextBox = new TransparentTextBox();
-            this.MetadataModuleHomePageLinkLabel = new System.Windows.Forms.LinkLabel();
             this.MetadataModuleKSPCompatibilityTextBox = new TransparentTextBox();
-            this.MetadataModuleGitHubLinkLabel = new System.Windows.Forms.LinkLabel();
             this.RelationshipTabPage = new System.Windows.Forms.TabPage();
             this.DependsGraphTree = new System.Windows.Forms.TreeView();
             this.LegendDependsImage = new System.Windows.Forms.PictureBox();
@@ -214,26 +210,22 @@
             this.MetaDataLowerLayoutPanel.Controls.Add(this.VersionLabel, 0, 0);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.LicenseLabel, 0, 1);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.AuthorLabel, 0, 2);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.HomePageLabel, 0, 3);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.GitHubLabel, 0, 4);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReleaseLabel, 0, 5);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.KSPCompatibilityLabel, 0, 6);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.IdentifierLabel, 0, 7);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReplacementLabel, 0, 8);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReleaseLabel, 0, 3);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.KSPCompatibilityLabel, 0, 4);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.IdentifierLabel, 0, 5);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReplacementLabel, 0, 6);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleVersionTextBox, 1, 0);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleLicenseTextBox, 1, 1);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleAuthorTextBox, 1, 2);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleHomePageLinkLabel, 1, 3);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleGitHubLinkLabel, 1, 4);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleReleaseStatusTextBox, 1, 5);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleKSPCompatibilityTextBox, 1, 6);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataIdentifierTextBox, 1, 7);
-            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReplacementTextBox, 1, 8);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleReleaseStatusTextBox, 1, 3);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataModuleKSPCompatibilityTextBox, 1, 4);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataIdentifierTextBox, 1, 5);
+            this.MetaDataLowerLayoutPanel.Controls.Add(this.ReplacementTextBox, 1, 6);
             this.MetaDataLowerLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataLowerLayoutPanel.Location = new System.Drawing.Point(0, 0);
             this.MetaDataLowerLayoutPanel.Name = "MetaDataLowerLayoutPanel";
             this.MetaDataLowerLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 8, 0, 0);
-            this.MetaDataLowerLayoutPanel.RowCount = 9;
+            this.MetaDataLowerLayoutPanel.RowCount = 7;
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
@@ -241,8 +233,6 @@
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 15F));
             this.MetaDataLowerLayoutPanel.Size = new System.Drawing.Size(346, 255);
             this.MetaDataLowerLayoutPanel.AutoSize = true;
             this.MetaDataLowerLayoutPanel.AutoScroll = true;
@@ -322,28 +312,6 @@
             this.ReleaseLabel.Size = new System.Drawing.Size(84, 30);
             this.ReleaseLabel.TabIndex = 12;
             resources.ApplyResources(this.ReleaseLabel, "ReleaseLabel");
-            //
-            // GitHubLabel
-            //
-            this.GitHubLabel.AutoSize = true;
-            this.GitHubLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GitHubLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.GitHubLabel.Location = new System.Drawing.Point(3, 120);
-            this.GitHubLabel.Name = "GitHubLabel";
-            this.GitHubLabel.Size = new System.Drawing.Size(84, 30);
-            this.GitHubLabel.TabIndex = 10;
-            resources.ApplyResources(this.GitHubLabel, "GitHubLabel");
-            //
-            // HomePageLabel
-            //
-            this.HomePageLabel.AutoSize = true;
-            this.HomePageLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.HomePageLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.HomePageLabel.Location = new System.Drawing.Point(3, 90);
-            this.HomePageLabel.Name = "HomePageLabel";
-            this.HomePageLabel.Size = new System.Drawing.Size(84, 30);
-            this.HomePageLabel.TabIndex = 7;
-            resources.ApplyResources(this.HomePageLabel, "HomePageLabel");
             //
             // AuthorLabel
             //
@@ -434,17 +402,6 @@
             this.MetadataModuleReleaseStatusTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             resources.ApplyResources(this.MetadataModuleReleaseStatusTextBox, "MetadataModuleReleaseStatusTextBox");
             //
-            // MetadataModuleHomePageLinkLabel
-            //
-            this.MetadataModuleHomePageLinkLabel.AutoSize = true;
-            this.MetadataModuleHomePageLinkLabel.Location = new System.Drawing.Point(93, 90);
-            this.MetadataModuleHomePageLinkLabel.Name = "MetadataModuleHomePageLinkLabel";
-            this.MetadataModuleHomePageLinkLabel.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleHomePageLinkLabel.TabIndex = 25;
-            this.MetadataModuleHomePageLinkLabel.TabStop = true;
-            this.MetadataModuleHomePageLinkLabel.Text = "linkLabel1";
-            this.MetadataModuleHomePageLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
-            //
             // MetadataModuleKSPCompatibilityTextBox
             //
             this.MetadataModuleKSPCompatibilityTextBox.AutoSize = true;
@@ -458,17 +415,6 @@
             this.MetadataModuleKSPCompatibilityTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.MetadataModuleKSPCompatibilityTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             resources.ApplyResources(this.MetadataModuleKSPCompatibilityTextBox, "MetadataModuleKSPCompatibilityTextBox");
-            //
-            // MetadataModuleGitHubLinkLabel
-            //
-            this.MetadataModuleGitHubLinkLabel.AutoSize = true;
-            this.MetadataModuleGitHubLinkLabel.Location = new System.Drawing.Point(93, 120);
-            this.MetadataModuleGitHubLinkLabel.Name = "MetadataModuleGitHubLinkLabel";
-            this.MetadataModuleGitHubLinkLabel.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleGitHubLinkLabel.TabIndex = 26;
-            this.MetadataModuleGitHubLinkLabel.TabStop = true;
-            this.MetadataModuleGitHubLinkLabel.Text = "linkLabel2";
-            this.MetadataModuleGitHubLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             //
             // RelationshipTabPage
             //
@@ -708,8 +654,6 @@
         private TransparentTextBox ReplacementTextBox;
         private System.Windows.Forms.Label KSPCompatibilityLabel;
         private System.Windows.Forms.Label ReleaseLabel;
-        private System.Windows.Forms.Label GitHubLabel;
-        private System.Windows.Forms.Label HomePageLabel;
         private System.Windows.Forms.Label AuthorLabel;
         private System.Windows.Forms.Label LicenseLabel;
         private TransparentTextBox MetadataModuleVersionTextBox;
@@ -717,9 +661,7 @@
         private TransparentTextBox MetadataModuleAuthorTextBox;
         private System.Windows.Forms.Label VersionLabel;
         private TransparentTextBox MetadataModuleReleaseStatusTextBox;
-        private System.Windows.Forms.LinkLabel MetadataModuleHomePageLinkLabel;
         private TransparentTextBox MetadataModuleKSPCompatibilityTextBox;
-        private System.Windows.Forms.LinkLabel MetadataModuleGitHubLinkLabel;
         private System.Windows.Forms.TabPage RelationshipTabPage;
         private System.Windows.Forms.TreeView DependsGraphTree;
         private System.Windows.Forms.PictureBox LegendDependsImage;

--- a/GUI/Controls/ModInfo.resx
+++ b/GUI/Controls/ModInfo.resx
@@ -125,8 +125,6 @@
   <data name="ReplacementTextBox.Text" xml:space="preserve"><value>-</value></data>
   <data name="KSPCompatibilityLabel.Text" xml:space="preserve"><value>Max KSP ver.:</value></data>
   <data name="ReleaseLabel.Text" xml:space="preserve"><value>Release status:</value></data>
-  <data name="GitHubLabel.Text" xml:space="preserve"><value>Source code:</value></data>
-  <data name="HomePageLabel.Text" xml:space="preserve"><value>Home page:</value></data>
   <data name="AuthorLabel.Text" xml:space="preserve"><value>Author:</value></data>
   <data name="LicenseLabel.Text" xml:space="preserve"><value>Licence:</value></data>
   <data name="MetadataModuleVersionTextBox.Text" xml:space="preserve"><value>0.0.0</value></data>

--- a/GUI/Localization/de-DE/ModInfo.de-DE.resx
+++ b/GUI/Localization/de-DE/ModInfo.de-DE.resx
@@ -123,8 +123,6 @@
   <data name="ReplacementLabel.Text" xml:space="preserve"><value>Ersetzt durch:</value></data>
   <data name="KSPCompatibilityLabel.Text" xml:space="preserve"><value>Max. KSP-Version:</value></data>
   <data name="ReleaseLabel.Text" xml:space="preserve"><value>Releasestatus:</value></data>
-  <data name="GitHubLabel.Text" xml:space="preserve"><value>Quellcode:</value></data>
-  <data name="HomePageLabel.Text" xml:space="preserve"><value>Homepage:</value></data>
   <data name="AuthorLabel.Text" xml:space="preserve"><value>Autor:</value></data>
   <data name="LicenseLabel.Text" xml:space="preserve"><value>Lizenz:</value></data>
   <data name="MetadataModuleLicenseTextBox.Text" xml:space="preserve"><value>N/A</value></data>

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -328,6 +328,13 @@ namespace CKAN
                     }
                     throw;
                 }
+                catch (ModuleIsDLCKraken kraken)
+                {
+                    string msg = string.Format(Properties.Resources.MainInstallCantInstallDLC, kraken.module.name);
+                    currentUser.RaiseMessage(msg);
+                    currentUser.RaiseError(msg);
+                    return;
+                }
             }
         }
 

--- a/GUI/Main/MainModList.cs
+++ b/GUI/Main/MainModList.cs
@@ -188,16 +188,19 @@ namespace CKAN
             var gui_mods = new HashSet<GUIMod>();
             gui_mods.UnionWith(
                 registry.InstalledModules
+                    .Where(instMod => !instMod.Module.IsDLC)
                     .Select(instMod => new GUIMod(instMod, registry, versionCriteria))
             );
             Wait.AddLogMessage(Properties.Resources.MainModListLoadingAvailable);
             gui_mods.UnionWith(
                 registry.CompatibleModules(versionCriteria)
+                    .Where(m => !m.IsDLC)
                     .Select(m => new GUIMod(m, registry, versionCriteria))
             );
             Wait.AddLogMessage(Properties.Resources.MainModListLoadingIncompatible);
             gui_mods.UnionWith(
                 registry.IncompatibleModules(versionCriteria)
+                    .Where(m => !m.IsDLC)
                     .Select(m => new GUIMod(m, registry, versionCriteria, true))
             );
 

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -84,7 +84,6 @@ namespace CKAN
 
         public string Abstract { get; private set; }
         public string Description { get; private set; }
-        public string Homepage { get; private set; }
         public string Identifier { get; private set; }
         public bool IsInstallChecked { get; set; }
         public bool IsUpgradeChecked { get; private set; }
@@ -168,15 +167,6 @@ namespace CKAN
             HasReplacement = registry.GetReplacement(mod, current_ksp_version) != null;
             DownloadSize   = mod.download_size == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.download_size);
 
-            if (mod.resources != null)
-            {
-                Homepage = mod.resources.homepage?.ToString()
-                        ?? mod.resources.spacedock?.ToString()
-                        ?? mod.resources.curse?.ToString()
-                        ?? mod.resources.repository?.ToString()
-                        ?? Properties.Resources.GUIModNSlashA;
-            }
-
             // Get the Searchables.
             SearchableName        = mod.SearchableName;
             SearchableAbstract    = mod.SearchableAbstract;
@@ -253,9 +243,6 @@ namespace CKAN
             {
                 LatestVersion = "-";
             }
-
-            // If we have a homepage provided, use that; otherwise use the spacedock page, curse page or the github repo so that users have somewhere to get more info than just the abstract.
-            Homepage = Properties.Resources.GUIModNSlashA;
 
             SearchableIdentifier = CkanModule.nonAlphaNums.Replace(Identifier, "");
         }

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -58,7 +58,7 @@ namespace CKAN
         {
             return $"{ChangeType} {Mod} ({Reason})";
         }
-        
+
         protected string modNameAndStatus(CkanModule m)
         {
             return m.IsMetapackage
@@ -68,7 +68,7 @@ namespace CKAN
                     : string.Format(Properties.Resources.MainChangesetHostSize,
                         m.name, m.version, m.download.Host ?? "", CkanModule.FmtSize(m.download_size));
         }
-        
+
         public virtual string NameAndStatus
         {
             get
@@ -104,7 +104,7 @@ namespace CKAN
         {
             this.targetMod = targetMod;
         }
-        
+
         public override string NameAndStatus
         {
             get
@@ -112,7 +112,7 @@ namespace CKAN
                 return modNameAndStatus(targetMod);
             }
         }
-        
+
         public override string Description
         {
             get
@@ -120,10 +120,10 @@ namespace CKAN
                 return string.Format(
                     Properties.Resources.MainChangesetUpdateSelected,
                     targetMod.version
-                );                
+                );
             }
         }
 
-        private readonly CkanModule targetMod;        
+        private readonly CkanModule targetMod;
     }
 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -430,6 +430,9 @@ namespace CKAN.Properties {
         internal static string MainReinstallConfirm {
             get { return (string)(ResourceManager.GetObject("MainReinstallConfirm", resourceCulture)); }
         }
+        internal static string MainCantInstallDLC {
+            get { return (string)(ResourceManager.GetObject("MainCantInstallDLC", resourceCulture)); }
+        }
 
         internal static string AllModVersionsInstallPrompt {
             get { return (string)(ResourceManager.GetObject("AllModVersionsInstallPrompt", resourceCulture)); }
@@ -539,6 +542,9 @@ namespace CKAN.Properties {
         internal static string MainInstallProvidedBy {
             get { return (string)(ResourceManager.GetObject("MainInstallProvidedBy", resourceCulture)); }
         }
+        internal static string MainInstallCantInstallDLC {
+            get { return (string)(ResourceManager.GetObject("MainInstallCantInstallDLC", resourceCulture)); }
+        }
 
         internal static string ModInfoNSlashA {
             get { return (string)(ResourceManager.GetObject("ModInfoNSlashA", resourceCulture)); }
@@ -554,6 +560,39 @@ namespace CKAN.Properties {
         }
         internal static string ModInfoCached {
             get { return (string)(ResourceManager.GetObject("ModInfoCached", resourceCulture)); }
+        }
+        internal static string ModInfoHomepageLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoHomepageLabel", resourceCulture)); }
+        }
+        internal static string ModInfoSpaceDockLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoSpaceDockLabel", resourceCulture)); }
+        }
+        internal static string ModInfoCurseLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoCurseLabel", resourceCulture)); }
+        }
+        internal static string ModInfoRepositoryLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoRepositoryLabel", resourceCulture)); }
+        }
+        internal static string ModInfoBugTrackerLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoBugTrackerLabel", resourceCulture)); }
+        }
+        internal static string ModInfoContinuousIntegrationLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoContinuousIntegrationLabel", resourceCulture)); }
+        }
+        internal static string ModInfoLicenseLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoLicenseLabel", resourceCulture)); }
+        }
+        internal static string ModInfoManualLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoManualLabel", resourceCulture)); }
+        }
+        internal static string ModInfoMetanetkanLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoMetanetkanLabel", resourceCulture)); }
+        }
+        internal static string ModInfoStoreLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoStoreLabel", resourceCulture)); }
+        }
+        internal static string ModInfoSteamStoreLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoSteamStoreLabel", resourceCulture)); }
         }
 
         internal static string MainModListWaitTitle {

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -249,11 +249,18 @@ Wenn du ein Fehler mit den Mod-Metadaten vermutest: https://github.com/KSP-CKAN/
 Wenn du ein Fehler mit dem CKAN Client vermutest: https://github.com/KSP-CKAN/CKAN/new/choose</value></data>
   <data name="MainInstallFailed" xml:space="preserve"><value>Installation fehlgeschlagen!</value></data>
   <data name="MainInstallProvidedBy" xml:space="preserve"><value>Modul {0} wird von mehr als einem verfügbaren Modul bereitgestellt, bitte wähle eine der folgenden Mods:</value></data>
+  <data name="MainInstallCantInstallDLC" xml:space="preserve"><value>CKAN kann die Erweiterung '{0}' nicht für dich installieren.</value></data>
   <data name="ModInfoVirtual" xml:space="preserve"><value>{0} (virtuell)</value></data>
   <data name="ModInfoNotIndexed" xml:space="preserve"><value>{0} (nicht indiziert)</value></data>
   <data name="ModInfoNotCached" xml:space="preserve"><value>Diese Mod ist nicht im Cache, klicke auf 'Download' um eine Inhaltsübersicht zu erhalten.</value></data>
   <data name="ModInfoCached" xml:space="preserve"><value>Modul ist im Cache, Vorschau verfügbar</value></data>
   <data name="ModInfoHomepageLabel" xml:space="preserve"><value>Homepage:</value></data>
+  <data name="ModInfoBugTrackerLabel" xml:space="preserve"><value>Bugtracker:</value></data>
+  <data name="ModInfoContinuousIntegrationLabel" xml:space="preserve"><value>Continuous Integration:</value></data>
+  <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Lizenz:</value></data>
+  <data name="ModInfoManualLabel" xml:space="preserve"><value>Anleitung:</value></data>
+  <data name="ModInfoStoreLabel" xml:space="preserve"><value>Shop:</value></data>
+  <data name="ModInfoSteamStoreLabel" xml:space="preserve"><value>Steam Shop:</value></data>
   <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Lizenz:</value></data>
   <data name="MainModListWaitTitle" xml:space="preserve"><value>Module laden</value></data>
   <data name="MainModListLoadingRegistry" xml:space="preserve"><value>Lade Registry...</value></data>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -253,6 +253,8 @@ Wenn du ein Fehler mit dem CKAN Client vermutest: https://github.com/KSP-CKAN/CK
   <data name="ModInfoNotIndexed" xml:space="preserve"><value>{0} (nicht indiziert)</value></data>
   <data name="ModInfoNotCached" xml:space="preserve"><value>Diese Mod ist nicht im Cache, klicke auf 'Download' um eine Inhaltsübersicht zu erhalten.</value></data>
   <data name="ModInfoCached" xml:space="preserve"><value>Modul ist im Cache, Vorschau verfügbar</value></data>
+  <data name="ModInfoHomepageLabel" xml:space="preserve"><value>Homepage:</value></data>
+  <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Lizenz:</value></data>
   <data name="MainModListWaitTitle" xml:space="preserve"><value>Module laden</value></data>
   <data name="MainModListLoadingRegistry" xml:space="preserve"><value>Lade Registry...</value></data>
   <data name="MainModListLoadingInstalled" xml:space="preserve"><value>Lade installierte Module...</value></data>

--- a/GUI/Properties/Resources.en-US.resx
+++ b/GUI/Properties/Resources.en-US.resx
@@ -120,4 +120,5 @@
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
   <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The license for this modpack</value></data>
+  <data name="ModInfoLicenseLabel" xml:space="preserve"><value>License:</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -202,6 +202,7 @@
   <data name="MainTSV" xml:space="preserve"><value>Tab-separated values (*.tsv)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Not found.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Do you want to reinstall {0}?</value></data>
+  <data name="MainCantInstallDLC" xml:space="preserve"><value>CKAN can't install expansion {0}!</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current game version and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
 
 Do you really want to install it?</value></data>
@@ -269,11 +270,23 @@ If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new
 If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose</value></data>
   <data name="MainInstallFailed" xml:space="preserve"><value>Installation failed!</value></data>
   <data name="MainInstallProvidedBy" xml:space="preserve"><value>Module {0} is provided by more than one available module, please choose one of the following mods:</value></data>
+  <data name="MainInstallCantInstallDLC" xml:space="preserve"><value>CKAN can't install expansion '{0}' for you.</value></data>
   <data name="ModInfoNSlashA" xml:space="preserve"><value>N/A</value></data>
   <data name="ModInfoVirtual" xml:space="preserve"><value>{0} (virtual)</value></data>
   <data name="ModInfoNotIndexed" xml:space="preserve"><value>{0} (not indexed)</value></data>
   <data name="ModInfoNotCached" xml:space="preserve"><value>This mod is not in the cache, click 'Download' to preview contents</value></data>
   <data name="ModInfoCached" xml:space="preserve"><value>Module is cached, preview available</value></data>
+  <data name="ModInfoHomepageLabel" xml:space="preserve"><value>Home page:</value></data>
+  <data name="ModInfoSpaceDockLabel" xml:space="preserve"><value>SpaceDock:</value></data>
+  <data name="ModInfoCurseLabel" xml:space="preserve"><value>Curse:</value></data>
+  <data name="ModInfoRepositoryLabel" xml:space="preserve"><value>Repository:</value></data>
+  <data name="ModInfoBugTrackerLabel" xml:space="preserve"><value>Bug tracker:</value></data>
+  <data name="ModInfoContinuousIntegrationLabel" xml:space="preserve"><value>Continuous integration:</value></data>
+  <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Licence:</value></data>
+  <data name="ModInfoManualLabel" xml:space="preserve"><value>Manual:</value></data>
+  <data name="ModInfoMetanetkanLabel" xml:space="preserve"><value>Metanetkan:</value></data>
+  <data name="ModInfoStoreLabel" xml:space="preserve"><value>Store:</value></data>
+  <data name="ModInfoSteamStoreLabel" xml:space="preserve"><value>Steam store:</value></data>
   <data name="MainModListWaitTitle" xml:space="preserve"><value>Loading modules</value></data>
   <data name="MainModListLoadingRegistry" xml:space="preserve"><value>Loading registry...</value></data>
   <data name="MainModListLoadingInstalled" xml:space="preserve"><value>Loading installed modules...</value></data>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Validators\AlphaNumericIdentifierValidator.cs" />
     <Compile Include="Validators\DownloadVersionValidator.cs" />
     <Compile Include="Validators\InstallValidator.cs" />
+    <Compile Include="Validators\KindValidator.cs" />
     <Compile Include="Validators\KrefDownloadMutexValidator.cs" />
     <Compile Include="Validators\LicensesValidator.cs" />
     <Compile Include="Validators\MatchesKnownGameVersionsValidator.cs" />

--- a/Netkan/Validators/CkanValidator.cs
+++ b/Netkan/Validators/CkanValidator.cs
@@ -15,7 +15,8 @@ namespace CKAN.NetKAN.Validators
                 new IsCkanModuleValidator(),
                 new InstallsFilesValidator(downloader, moduleService),
                 new MatchesKnownGameVersionsValidator(),
-                new ObeysCKANSchemaValidator()
+                new ObeysCKANSchemaValidator(),
+                new KindValidator(),
             };
         }
 

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -18,25 +18,28 @@ namespace CKAN.NetKAN.Validators
         public void Validate(Metadata metadata)
         {
             var mod = CkanModule.FromJson(metadata.Json().ToString());
-            var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+            if (!mod.IsDLC)
+            {
+                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
 
-            // Make sure this would actually generate an install.
-            if (!_moduleService.HasInstallableFiles(mod, file))
-            {
-                throw new Kraken(string.Format(
-                    "Module contains no files matching: {0}",
-                    mod.DescribeInstallStanzas()
-                ));
-            }
-            
-            // Make sure no paths include GameData other than at the start
-            var gamedatas = _moduleService.FileDestinations(mod, file)
-                .Where(p => p.StartsWith("GameData") && p.LastIndexOf("/GameData/") > 0)
-                .ToList();
-            if (gamedatas.Any())
-            {
-                var badPaths = string.Join("\r\n", gamedatas);
-                throw new Kraken($"GameData directory found within GameData:\r\n{badPaths}");
+                // Make sure this would actually generate an install.
+                if (!_moduleService.HasInstallableFiles(mod, file))
+                {
+                    throw new Kraken(string.Format(
+                        "Module contains no files matching: {0}",
+                        mod.DescribeInstallStanzas()
+                    ));
+                }
+                
+                // Make sure no paths include GameData other than at the start
+                var gamedatas = _moduleService.FileDestinations(mod, file)
+                    .Where(p => p.StartsWith("GameData") && p.LastIndexOf("/GameData/") > 0)
+                    .ToList();
+                if (gamedatas.Any())
+                {
+                    var badPaths = string.Join("\r\n", gamedatas);
+                    throw new Kraken($"GameData directory found within GameData:\r\n{badPaths}");
+                }
             }
         }
     }

--- a/Netkan/Validators/KindValidator.cs
+++ b/Netkan/Validators/KindValidator.cs
@@ -1,0 +1,25 @@
+﻿using CKAN.NetKAN.Model;
+using CKAN.Versioning;
+
+namespace CKAN.NetKAN.Validators
+{
+    internal sealed class KindValidator : IValidator
+    {
+        public void Validate(Metadata metadata)
+        {
+            var json = metadata.Json();
+            var kind = json["kind"];
+            if (metadata.SpecVersion < v1p6 && (string)kind == "metapackage")
+            {
+                throw new Kraken($"spec_version 1.6+ required for kind 'metpackage'");
+            }
+            if (metadata.SpecVersion < v1p28 && (string)kind == "dlc")
+            {
+                throw new Kraken($"spec_version 1.28+ required for kind 'dlc'");
+            }
+        }
+
+        private static readonly ModuleVersion v1p6  = new ModuleVersion("v1.6");
+        private static readonly ModuleVersion v1p28 = new ModuleVersion("v1.28");
+    }
+}

--- a/Netkan/Validators/KrefDownloadMutexValidator.cs
+++ b/Netkan/Validators/KrefDownloadMutexValidator.cs
@@ -11,7 +11,7 @@ namespace CKAN.NetKAN.Validators
             {
                 throw new Kraken($"{metadata.Identifier} has a $kref and a download field, this is likely incorrect");
             }
-            if (!json.ContainsKey("download") && !json.ContainsKey("$kref"))
+            if ((string)json["kind"] != "dlc" && !json.ContainsKey("download") && !json.ContainsKey("$kref"))
             {
                 throw new Kraken($"{metadata.Identifier} has no $kref field, this is required when no download url is specified");
             }

--- a/Spec.md
+++ b/Spec.md
@@ -71,6 +71,7 @@ and the
 
 ### Example CKAN file
 
+```json
     {
         "spec_version"   : 1,
         "name"           : "Advanced Jet Engine (AJE)",
@@ -108,6 +109,7 @@ and the
             { "name" : "HotRockets" }
         ]
     }
+```
 
 ### Metadata description
 
@@ -160,7 +162,8 @@ with any version and the `.dll` suffix removed.
 ##### download
 
 A fully formed URL, indicating where a machine may download the
-described version of the mod. Note: This field is not required if the `kind` is `metapackage`.
+described version of the mod. Note: This field is not required if the `kind` is `metapackage`
+or `dlc`.
 
 ##### license
 
@@ -187,9 +190,11 @@ A single license (**v1.0**) , or list of licenses (**v1.8**) may be provided. Th
 are both valid, the first describing a mod released under the BSD license,
 the second under the *user's choice* of BSD-2-clause or GPL-2.0 licenses.
 
+```json
     "license" : "BSD-2-clause"
 
     "license" : [ "BSD-2-clause", "GPL-2.0" ]
+```
 
 If different assets in the mod have different licenses, the *most restrictive*
 license should be specified, which may be `restricted`.
@@ -320,12 +325,14 @@ and install that with a target of `GameData`.
 
 A typical install directive only has `file` and `install_to` sections:
 
+```json
     "install" : [
         {
             "file"       : "GameData/ExampleMod",
             "install_to" : "GameData"
         }
     ]
+```
 
 ##### comment
 
@@ -443,11 +450,13 @@ are not installed at the same time.
 At its most basic, this is an array of objects, each being a name
 and identifier:
 
+```json
     "depends" : [
         { "name" : "ModuleManager" },
         { "name" : "RealFuels" },
         { "name" : "RealSolarSystem" }
     ]
+```
 
 Each relationship is an array of entries, each entry *must*
 have a `name`.
@@ -455,11 +464,13 @@ have a `name`.
 The optional fields `min_version`, `max_version`,
 and `version`, may more precisely describe which versions are needed:
 
+```json
     "depends" : [
         { "name" : "ModuleManager",   "min_version" : "2.1.5" },
         { "name" : "RealSolarSystem", "min_version" : "7.3"   },
         { "name" : "RealFuels" }
     ]
+```
 
 It is an error to mix `version` (which specifies an exact version) with
 either `min_version` or `max_version` in the same object.
@@ -477,6 +488,7 @@ satisfied if **any** of the specified modules are installed. It is intended for
 situations in which a module supports multiple ways of providing functionality,
 which are not in themselves mutually compatible enough to use the `"provides"` property.
 
+```json
     "depends": [
         {
             "any_of": [
@@ -487,6 +499,7 @@ which are not in themselves mutually compatible enough to use the `"provides"` p
             ]
         }
     ]
+```
 
 ##### depends
 
@@ -549,24 +562,30 @@ are described. Unless specified otherwise, these are URLs:
 - `curse` :  (**v1.20**) The mod on Curse.
 - `manual` : The mod's manual, if it exists.
 - `metanetkan` :  (**v1.27**) URL of the module's remote hosted netkan
+- `store`:  (**v1.28**) URL where you can purchase a DLC
+- `steamstore`:  (**v1.28**) URL where you can purchase a DLC on Steam
 
 Example resources:
 
+```json
     "resources" : {
         "homepage"     : "https://tinyurl.com/DogeCoinFlag",
         "bugtracker"   : "https://github.com/pjf/DogeCoinFlag/issues",
         "repository"   : "https://github.com/pjf/DogeCoinFlag",
-        "ci"           : "https://ksp.sarbian.com/jenkins/DogecoinFlag"
-        "spacedock"    : "https://spacedock.info/mod/269/Dogecoin%20Flag"
+        "ci"           : "https://ksp.sarbian.com/jenkins/DogecoinFlag",
+        "spacedock"    : "https://spacedock.info/mod/269/Dogecoin%20Flag",
         "curse"        : "https://kerbal.curseforge.com/projects/220221"
     }
+```
 
 While all currently defined resources are URLs, future revisions of the spec may provide for more complex types.
 
 It is permissible to have fields prefixed with an `x_`. These are considered
 custom use fields, and will be ignored. For example:
 
+```json
     "x_twitter" : "https://twitter.com/pjf"
+```
 
 #### Special use fields
 
@@ -575,7 +594,11 @@ Typical mods *should not* include these special use fields.
 
 ##### kind
 
-Specifies the type of package the .ckan file delivers. This field defaults to `package`, the other option (and presently the only time the field is explicitly declared) is `metapackage`. Metapackages allow for a distributable .ckan file that has relationships to other mods while having no `download` of its own. **v1.6**
+Specifies the type of package the .ckan file represents. Allowed values:
+
+- `package` or empty - the default, a normal installable module
+- `metapackage` - a distributable .ckan file that has relationships to other mods while having no `download` of its own. **v1.6**
+- `dlc` - A paid expansion from SQUAD, which CKAN can detect but not install. Also has no `download`. **v1.28**
 
 ##### provides
 
@@ -584,7 +607,9 @@ is intended for use in modules which require one of a selection of texture
 downloads, or one of a selection of mods which provide equivalent
 functionality.  For example:
 
+```json
     "provides"  : [ "RealSolarSystemTextures" ]
+```
 
 It is recommended that this field be used *sparingly*, as all mods with
 the same `provides` string are essentially declaring they can be used
@@ -615,10 +640,12 @@ SHA1 and SHA256 calculated hashes of the resulting file downloaded.
 It is recommended that this field is only generated by automated
 tools (where it is encouraged), and not filled in by hand.
 
+```json
     "download_hash": {
         "sha1": "1F4B3F21A77D4A302E3417A7C7A24A0B63740FC5",
         "sha256": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
     }
+```
 
 ##### download_content_type
 
@@ -627,7 +654,9 @@ downloaded from the `download` URL. It is recommended that this field is
 only generated by automated tools (where it is encouraged),
 and not filled in by hand.
 
+```json
     "download_content_type": "application/zip"
+```
 
 #### Extensions
 
@@ -753,6 +782,7 @@ an `object` with the following fields:
 If any options are not present their default values are used.
 
 An example `.netkan` excerpt:
+
 ```json
 {
     "$kref": "#/ckan/jenkins/https://jenkins.kspmods.example/job/AwesomeMod/",
@@ -811,6 +841,7 @@ The following conditions apply:
 - Any fields specified in the metanetkan will override any fields in the target netkan file.
 
 An example `.netkan` including all required fields for a valid metanetkan:
+
 ```json
 {
     "spec_version": 1,
@@ -863,6 +894,7 @@ Note that an epoch can be added without this property or incremented automatical
 release.
 
 An example `.netkan` excerpt:
+
 ```json
 {
     "x_netkan_epoch": 1
@@ -879,6 +911,7 @@ Typical mods should not use this property, to allow their version epochs to be a
 of order version.
 
 An example `.netkan` excerpt:
+
 ```json
 {
     "x_netkan_allow_out_of_order": true
@@ -894,6 +927,7 @@ A combination of `x_netkan_epoch` and `x_netkan_version_edit` should be used ins
 field *only* contains the actual version string.
 
 An example `.netkan` excerpt:
+
 ```json
 {
     "x_netkan_force_v": true
@@ -917,6 +951,7 @@ an `object` with the following fields:
 the default values for the `replace` and `strict` fields are used.
 
 An example `.netkan` excerpt:
+
 ```json
 {
     "$kref": "#/ckan/jenkins/https://jenkins.kspmods.example/job/AwesomeMod/",

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -98,7 +98,7 @@ namespace Tests.Core.Relationships
         {
             var mods = new List<CkanModule>();
             var dlls = CKAN.Extensions.EnumerableExtensions.ToHashSet(Enumerable.Empty<string>());
-            var dlc = new Dictionary<string, UnmanagedModuleVersion>();
+            var dlc = new Dictionary<string, ModuleVersion>();
 
             Assert.IsEmpty(CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc), "Empty list");
 
@@ -330,7 +330,7 @@ namespace Tests.Core.Relationships
             List<string> to_remove,
             List<CkanModule> mods,
             List<string> dlls,
-            Dictionary<string, UnmanagedModuleVersion> dlc,
+            Dictionary<string, ModuleVersion> dlc,
             List<string> expected,
             string message)
         {

--- a/Tests/NetKAN/Validators/KindValidatorTests.cs
+++ b/Tests/NetKAN/Validators/KindValidatorTests.cs
@@ -1,0 +1,47 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Validators;
+
+namespace Tests.NetKAN.Validators
+{
+    [TestFixture]
+    public sealed class KindValidatorTests
+    {
+        [Test,
+            TestCase("1",     @"""package"""),
+            TestCase("v1.2",  @"""package"""),
+            TestCase("v1.6",  @"""metapackage"""),
+            TestCase("v1.28", @"""dlc"""),
+        ]
+        public void Validate_GoodSpecVersionKind_DoesNotThrow(string spec_version, string kind)
+        {
+            Assert.DoesNotThrow(() => TryKind(spec_version, kind));
+        }
+
+        [Test,
+            TestCase("1",     @"""metapackage"""),
+            TestCase("v1.5",  @"""metapackage"""),
+            TestCase("1",     @"""dlc"""),
+            TestCase("v1.4",  @"""dlc"""),
+            TestCase("v1.17", @"""dlc"""),
+        ]
+        public void Validate_BadSpecVersionKind_Throws(string spec_version, string kind)
+        {
+            Assert.Throws<CKAN.Kraken>(() => TryKind(spec_version, kind));
+        }
+
+        private void TryKind(string spec_version, string kind)
+        {
+            // Arrange
+            var json = new JObject();
+            json["spec_version"] = spec_version;
+            json["identifier"]   = "AwesomeMod";
+            json["kind"]         = JToken.Parse(kind);
+
+            // Act
+            var val = new KindValidator();
+            val.Validate(new Metadata(json));
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

In KSP-CKAN/NetKAN#7205, we added our first module that `recommends` a DLC. Currently this is allowed and doesn't crash, and it appears in the relationships tab, but it doesn't appear during the install flow. It would be nice to notify users installing that module that they should consider purchasing the DLC.

## Changes

**NOTE: If this is merged, the next release must be v1.28.0 due to spec changes!**

The spec and schema are updated to allow:

```json
    "kind": "dlc",
```

When this is set, the module is treated as a DLC and the `"download"` property is not required. This allows us to represent a DLC with a `CkanModule`.

The `resources` property can now contain `store` and `steamstore` to hold links for DLC.

Installed DLCs are now represented in the registry as a module in `installed_modules` with `kind` set to `dlc`.

Fixes #2770.

### Setup

Testing this requires a bit more preparation than usual due to the schema changes:

1. Edit your `CHANGELOG.md` file and change the first version listed to `v1.28.0`, to allow modules with that `spec_version` to be added to your registry
2. `./build`
3. Switch to a repo that has DLC metadata (see KSP-CKAN/CKAN-meta#1901) (the install/remove steps are to force `ScanDlc` to run):
   ```bash
   ckan repo add add-dlc https://github.com/HebaruSan/CKAN-meta/archive/add-dlc.tar.gz
   ckan repo forget default
   ckan update
   ckan install astrogator
   ckan remove --all
   ```

I recommend creating an instance with all DLC and an instance with no DLC for ease of testing.

### GUI

Now if you install a module that recommends a DLC that you don't have installed, the DLC will appear in the recommendations list:

![image](https://user-images.githubusercontent.com/1559108/80295723-cfa87c80-873a-11ea-91cc-a59db251982b.png)

- The checkbox will always be unchecked regardless of whether it's a recommendation or a suggestion (since we can't install DLC for you, it's just informational)
- The checkbox cannot be checked (it just doesn't react when you click it)
- The checkboxes on the Version tab are hidden for DLC
- Mod info now shows **all** entries in the `resources` property, at the bottom of the table, so you can see the `store` and `steamstore` links

Apparently the install from .ckan option now allows multi-select as well.

### CmdLine

Now if you try to install, remove, or upgrade a DLC, we tell you you can't and provide links where you can purchase:

```
$ _build/ckan.exe install BreakingGround-DLC
CKAN can't install expansion 'Breaking Ground' for you.
To install this expansion, purchase it from one of its store pages:

- https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/
- https://store.steampowered.com/app/982970

$ _build/ckan.exe remove BreakingGround-DLC --ksp steam
CKAN can't remove expansion 'Breaking Ground' for you.
To remove this expansion, follow the instructions for the store page from which you purchased it:

- https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/
- https://store.steampowered.com/app/982970

$ _build/ckan.exe upgrade BreakingGround-DLC --ksp steam

Upgrading modules...

CKAN can't upgrade expansion 'Breaking Ground' for you.
To upgrade this expansion, download any updates from the store page from which you purchased it:

- https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/
- https://store.steampowered.com/app/982970
```

The `ckan mark` command blocks you from marking DLC as auto-installed (because it could cause us to attempt auto removal):

```
$ _build/ckan.exe mark auto BreakingGround-DLC --ksp steam
Marking BreakingGround-DLC as auto-installed...
Can't mark expansion 'Breaking Ground' as auto-installed.
```

The `ckan show` command is updated to print the `store` and `steamstore` resources and to hide fields that aren't used:

```
$ _build/ckan.exe show BreakingGround-DLC
Breaking Ground: The second expansion pack adds new science-collecting equipment to deploy on your missions, surface features to be investigated scattered across distant planets, and a wealth of new robotic parts for players to test their creativity with

Module info:
- version:	1.3.1
- authors:	SQUAD
- status:	
- license:	restricted

Provides:
- BreakingGround-DLC

Resources:
- store: https://www.kerbalspaceprogram.com/product/kerbal-space-program-breaking-ground/
- steamstore: https://store.steampowered.com/app/982970
```

### Netkan

When we validate .ckan files, we now enforce the `spec_version` requirements documented for the `"kind"` property in the spec, and tests are included to exercise this.