### PR TITLE
Restore cmdline update message

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -153,7 +153,7 @@ namespace CKAN.CmdLine
                 ? CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, manager.Cache, user) != CKAN.RepoUpdateResult.Failed
                 : CKAN.Repo.Update(registry_manager, ksp, user, repository);
 
-            user.RaiseMessage("Updated information on {0} compatible modules", updated);
+            user.RaiseMessage("Updated information on {0} compatible modules", registry_manager.registry.CompatibleModules(ksp.VersionCriteria()).Count());
         }
     }
 }


### PR DESCRIPTION
## Problems

```
$ mono ckan.exe update
Downloading updates...
Updated information on True compatible modules
```

"True"?...

## Cause

#2963 unintentionally reverted part of #2617 that updated the format of this line.

## Changes

Now it prints the number of compatible modules again.