### PR TITLE
Prompt user to overwrite manually installed files

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -100,6 +100,15 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Returns the file path of a DLL.
+        /// null if not found.
+        /// </summary>
+        public string DllPath(string identifier)
+        {
+            return installed_dlls.TryGetValue(identifier, out string path) ? path : null;
+        }
+
+        /// <summary>
         /// A map between module identifiers and versions for official DLC that are installed.
         /// </summary>
         [JsonIgnore] public IDictionary<string, ModuleVersion> InstalledDlc

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -567,7 +567,7 @@ namespace CKAN
             this.instName = name;
         }
     }
-    
+
     public class ModuleIsDLCKraken : Kraken
     {
         /// <summary>
@@ -581,5 +581,20 @@ namespace CKAN
             this.module = module;
         }
     }
-    
+
+    /// <summary>
+    /// A manually installed mod is installed somewhere other than
+    /// where CKAN would install it, so we can't safely overwrite it.
+    /// </summary>
+    public class DllLocationMismatchKraken : Kraken
+    {
+        public readonly string path;
+
+        public DllLocationMismatchKraken(string path, string reason = null)
+            : base(reason)
+        {
+            this.path = path;
+        }
+    }
+
 }

--- a/GUI/Dialogs/YesNoDialog.Designer.cs
+++ b/GUI/Dialogs/YesNoDialog.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(YesNoDialog));
             this.panel1 = new System.Windows.Forms.Panel();
-            this.DescriptionLabel = new System.Windows.Forms.Label();
+            this.DescriptionLabel = new TransparentTextBox();
             this.YesButton = new System.Windows.Forms.Button();
             this.NoButton = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
@@ -55,7 +55,12 @@
             this.DescriptionLabel.Name = "DescriptionLabel";
             this.DescriptionLabel.Size = new System.Drawing.Size(393, 73);
             this.DescriptionLabel.TabIndex = 0;
-            this.DescriptionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.DescriptionLabel.TabStop = false;
+            this.DescriptionLabel.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.DescriptionLabel.ReadOnly = true;
+            this.DescriptionLabel.BackColor = System.Drawing.SystemColors.Control;
+            this.DescriptionLabel.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.DescriptionLabel.BorderStyle = System.Windows.Forms.BorderStyle.None;
             resources.ApplyResources(this.DescriptionLabel, "DescriptionLabel");
             // 
             // YesButton
@@ -103,7 +108,7 @@
         #endregion
 
         private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Label DescriptionLabel;
+        private TransparentTextBox DescriptionLabel;
         private System.Windows.Forms.Button YesButton;
         private System.Windows.Forms.Button NoButton;
     }

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Threading.Tasks;
@@ -19,10 +20,20 @@ namespace CKAN
 
             Util.Invoke(parentForm, () =>
             {
+                var height = StringHeight(text, ClientSize.Width - 25) + 2 * 54;
                 DescriptionLabel.Text = text;
+                DescriptionLabel.TextAlign = text.Contains("\n")
+                    ? HorizontalAlignment.Left
+                    : HorizontalAlignment.Center;
+                DescriptionLabel.ScrollBars = height < maxHeight
+                    ? ScrollBars.None
+                    : ScrollBars.Vertical;
                 YesButton.Text = yesText ?? defaultYes;
                 NoButton.Text  = noText  ?? defaultNo;
-                ClientSize = new Size(ClientSize.Width, StringHeight(text, ClientSize.Width - 25) + 2 * 54);
+                ClientSize = new Size(
+                    ClientSize.Width,
+                    Math.Min(maxHeight, height)
+                );
                 task.SetResult(ShowDialog(parentForm));
             });
 
@@ -47,6 +58,7 @@ namespace CKAN
             Util.Invoke(this, Close);
         }
 
+        private const int maxHeight = 600;
         private TaskCompletionSource<DialogResult> task;
         private string defaultYes;
         private string defaultNo;

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -279,8 +279,10 @@ namespace CKAN
                     currentUser.RaiseMessage(ex.InconsistenciesPretty);
                     return;
                 }
-                catch (CancelledActionKraken)
+                catch (CancelledActionKraken kraken)
                 {
+                    currentUser.RaiseMessage(kraken.Message);
+                    installCanceled = true;
                     return;
                 }
                 catch (MissingCertificateKraken kraken)
@@ -333,6 +335,11 @@ namespace CKAN
                     string msg = string.Format(Properties.Resources.MainInstallCantInstallDLC, kraken.module.name);
                     currentUser.RaiseMessage(msg);
                     currentUser.RaiseError(msg);
+                    return;
+                }
+                catch (DllLocationMismatchKraken kraken)
+                {
+                    currentUser.RaiseMessage(kraken.Message);
                     return;
                 }
             }
@@ -410,8 +417,6 @@ namespace CKAN
             else if (installCanceled)
             {
                 // User cancelled the installation
-                // Rebuilds the list of GUIMods
-                UpdateModsList(ChangeSet);
                 if (result.Key) {
                     FailWaitDialog(
                         Properties.Resources.MainInstallCancelTooLate,


### PR DESCRIPTION
## Motivation

Most new KSP users start out by installing mods manually and find out about CKAN later, at which point they already have an install with some mods and would like to have CKAN take over.

Currently this user's only option is to manually clean out their game folders and start from scratch with CKAN. Some of the manually installed mods will show up in the GUI as "AD", but CKAN can't remove/install/upgrade them. Other manually installed mods will simply show up as not installed, but error out if you try to install them.

## Changes

Now you can:

1. Select an AD mod
2. Go to the Versions tab
3. Check the box for one of the versions (usually you'd want the most recent)
   (Or instead of steps 1-3, select a manually installed mod that doesn't show up as AD and add it to be installed normally)
   The apply button becomes enabled
4. Click the apply button and continue through the installation
5. Get a new prompt explaining that some files are already present and manually installed:
  ![image](https://user-images.githubusercontent.com/1559108/80666354-938a5a00-8a61-11ea-8d28-6ce6f1b4fd9a.png)
   Files that are different are highlighted at the top of the list.
6. Click No to cancel and abort the install; or
   Click Yes to replace the files
7. Finish the installation and enjoy your freshly CKAN-installed mod

Similarly, CmdLine's `install` command can overwrite AD mods' files with the same prompt.

The Versions tab is involved because I don't know how to turn the current "AD" text in the checkbox column into an installable checkbox in a clean and clear way. This is kind of a pilot program for some delicate functionality so I'd like to take a cautious approach. If this goes well we can try to build upon it and make the UI better.

Fixes #949.
Fixes #2186.
Fixes #3029.