### PR TITLE
NetKAN warnings

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Processors\Inflator.cs" />
     <Compile Include="Processors\QueueHandler.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="QueueAppender.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\CachingHttpService.cs" />
     <Compile Include="Services\FileService.cs" />
@@ -158,10 +159,13 @@
     <Compile Include="Validators\MatchesKnownGameVersionsValidator.cs" />
     <Compile Include="Validators\ObeysCKANSchemaValidator.cs" />
     <Compile Include="Validators\OverrideValidator.cs" />
+    <Compile Include="Validators\PluginCompatibilityValidator.cs" />
     <Compile Include="Validators\ReplacedByValidator.cs" />
     <Compile Include="Validators\RelationshipsValidator.cs" />
     <Compile Include="Validators\SpecVersionFormatValidator.cs" />
     <Compile Include="Validators\VersionStrictValidator.cs" />
+    <Compile Include="Validators\VrefValidator.cs" />
+    <Compile Include="Validators\ModuleManagerDependsValidator.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\CKAN.schema">

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -28,7 +28,7 @@ namespace CKAN.NetKAN.Processors
             IFileService   fileService   = new FileService(cache);
             http          = new CachingHttpService(cache, overwriteCache);
             ckanValidator = new CkanValidator(http, moduleService);
-            transformer   = new NetkanTransformer(http, fileService, moduleService, githubToken, prerelease);
+            transformer   = new NetkanTransformer(http, fileService, moduleService, githubToken, prerelease, netkanValidator);
         }
 
         internal IEnumerable<Metadata> Inflate(string filename, Metadata netkan, TransformOptions opts)
@@ -49,7 +49,6 @@ namespace CKAN.NetKAN.Processors
 
                 foreach (Metadata ckan in ckans)
                 {
-                    netkanValidator.Validate(ckan);
                     ckanValidator.ValidateCkan(ckan, netkan);
                 }
                 log.Info("Output successfully passed post-validation");

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -153,16 +153,11 @@ namespace CKAN.NetKAN
             Parser.Default.ParseArgumentsStrict(args, Options);
 
             Logging.Initialize();
-            LogManager.GetRepository().Threshold = Level.Warn;
 
-            if (Options.Verbose)
-            {
-                LogManager.GetRepository().Threshold = Level.Info;
-            }
-            else if (Options.Debug)
-            {
-                LogManager.GetRepository().Threshold = Level.Debug;
-            }
+            LogManager.GetRepository().Threshold =
+                  Options.Verbose ? Level.Info
+                : Options.Debug   ? Level.Debug
+                :                   Level.Warn;
 
             if (Options.NetUserAgent != null)
             {

--- a/Netkan/QueueAppender.cs
+++ b/Netkan/QueueAppender.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using log4net;
+using log4net.Core;
+using log4net.Appender;
+using log4net.Repository.Hierarchy;
+
+namespace CKAN.NetKAN
+{
+    public class QueueAppender : AppenderSkeleton
+    {
+        public QueueAppender() { }
+
+        protected override void Append(LoggingEvent evt)
+        {
+            Warnings.Add(evt.RenderedMessage);
+        }
+
+        public List<string> Warnings = new List<string>();
+
+        public void Close() { }
+    }
+}

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -12,6 +12,7 @@ namespace CKAN.NetKAN.Services
         bool HasInstallableFiles(CkanModule module, string filePath);
         
         IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip);
+        IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip);
         
         IEnumerable<string> FileDestinations(CkanModule module, string filePath);
     }

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -72,6 +72,18 @@ namespace CKAN.NetKAN.Services
                 .Where(instF => cfgRegex.IsMatch(instF.source.Name));
         }
 
+        private static readonly Regex dllRegex = new Regex(
+            @"\.dll$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled
+        );
+        
+        public IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip)
+        {
+            return ModuleInstaller
+                .FindInstallableFiles(module, zip, null)
+                .Where(instF => dllRegex.IsMatch(instF.source.Name));
+        }
+
         public IEnumerable<string> FileDestinations(CkanModule module, string filePath)
         {
             return ModuleInstaller

--- a/Netkan/Transformers/AvcKrefTransformer.cs
+++ b/Netkan/Transformers/AvcKrefTransformer.cs
@@ -44,6 +44,7 @@ namespace CKAN.NetKAN.Transformers
                 );
 
                 json.SafeAdd("name",     remoteAvc.Name);
+                json.Remove("$kref");
                 json.SafeAdd("download", remoteAvc.Download);
 
                 // Set .resources.repository based on GITHUB properties

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Validators;
 using CKAN.NetKAN.Sources.Avc;
 using CKAN.Versioning;
 using CKAN.NetKAN.Sources.Github;
@@ -24,6 +25,7 @@ namespace CKAN.NetKAN.Transformers
         private readonly IHttpService   _http;
         private readonly IModuleService _moduleService;
         private readonly IGithubApi     _github;
+        private readonly VrefValidator  _vrefValidator;
 
         public string Name { get { return "avc"; } }
 
@@ -32,10 +34,13 @@ namespace CKAN.NetKAN.Transformers
             _http          = http;
             _moduleService = moduleService;
             _github        = github;
+            _vrefValidator = new VrefValidator(_http, _moduleService);
         }
 
         public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
         {
+            _vrefValidator.Validate(metadata);
+            
             if (metadata.Vref != null && metadata.Vref.Source == "ksp-avc")
             {
                 var json = metadata.Json();

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -83,7 +83,7 @@ namespace CKAN.NetKAN.Transformers
                         }
                         catch (Exception e)
                         {
-                            Log.InfoFormat("An error occured fetching the remote AVC version file, ignoring: {0}", e.Message);
+                            Log.WarnFormat("An error occured fetching the remote AVC version file, ignoring: {0}", e.Message);
                             Log.Debug(e);
                         }
                     }
@@ -204,7 +204,13 @@ namespace CKAN.NetKAN.Transformers
         private static Uri GetRemoteAvcUri(AvcVersion avc)
         {
             if (!Uri.IsWellFormedUriString(avc.Url, UriKind.Absolute))
+            {
+                if (avc.Url != null)
+                {
+                    Log.WarnFormat("Version file URL property is invalid: {0}", avc.Url);
+                }
                 return null;
+            }
 
             var remoteUri = new Uri(avc.Url);
 

--- a/Netkan/Transformers/CurseTransformer.cs
+++ b/Netkan/Transformers/CurseTransformer.cs
@@ -127,6 +127,7 @@ namespace CKAN.NetKAN.Transformers
             else                         json.SafeAdd("version", latestVersion.GetFileVersion());
 
             json.SafeAdd("author",   () => JToken.FromObject(curseMod.authors));
+            json.Remove("$kref");
             json.SafeAdd("download", Regex.Replace(latestVersion.GetDownloadUrl(), " ", "%20"));
 
             // Curse provides users with the following default selection of licenses. Let's convert them to CKAN

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -108,6 +108,7 @@ namespace CKAN.NetKAN.Transformers
             {
                 json.SafeAdd("version",  ghRelease.Version.ToString());
                 json.SafeAdd("author",   () => getAuthors(ghRepo, ghRelease));
+                json.Remove("$kref");
                 json.SafeAdd("download", ghRelease.Download.ToString());
                 json.SafeAdd(Metadata.UpdatedPropertyName, ghRelease.AssetUpdated);
 

--- a/Netkan/Transformers/HttpTransformer.cs
+++ b/Netkan/Transformers/HttpTransformer.cs
@@ -31,6 +31,7 @@ namespace CKAN.NetKAN.Transformers
 
                     if (resolvedUri != null)
                     {
+                        json.Remove("$kref");
                         json["download"] = resolvedUri.ToString();
 
                         Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);

--- a/Netkan/Transformers/JenkinsTransformer.cs
+++ b/Netkan/Transformers/JenkinsTransformer.cs
@@ -76,6 +76,7 @@ namespace CKAN.NetKAN.Transformers
                         $"{build.Url}artifact/{artifact.RelativePath}"
                     );
                     Log.DebugFormat("Using download URL: {0}", download);
+                    json.Remove("$kref");
                     json.SafeAdd("download", download);
 
                     if (options.UseFilenameVersion)

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -78,6 +78,7 @@ namespace CKAN.NetKAN.Transformers
             json.SafeAdd("name", sdMod.name);
             json.SafeAdd("abstract", sdMod.short_description);
             json.SafeAdd("version", latestVersion.friendly_version.ToString());
+            json.Remove("$kref");
             json.SafeAdd("download", latestVersion.download_path.OriginalString);
             json.SafeAdd(Model.Metadata.UpdatedPropertyName, latestVersion.created);
 

--- a/Netkan/Validators/CkanValidator.cs
+++ b/Netkan/Validators/CkanValidator.cs
@@ -10,6 +10,8 @@ namespace CKAN.NetKAN.Validators
 
         public CkanValidator(IHttpService downloader, IModuleService moduleService)
         {
+            this.downloader    = downloader;
+            this.moduleService = moduleService;
             _validators = new List<IValidator>
             {
                 new IsCkanModuleValidator(),
@@ -17,6 +19,8 @@ namespace CKAN.NetKAN.Validators
                 new MatchesKnownGameVersionsValidator(),
                 new ObeysCKANSchemaValidator(),
                 new KindValidator(),
+                new ModuleManagerDependsValidator(downloader, moduleService),
+                new PluginCompatibilityValidator(downloader, moduleService),
             };
         }
 
@@ -32,6 +36,10 @@ namespace CKAN.NetKAN.Validators
         {
             Validate(metadata);
             new MatchingIdentifiersValidator(netkan.Identifier).Validate(metadata);
+            new VrefValidator(netkan, downloader, moduleService).Validate(metadata);
         }
+
+        private IHttpService   downloader;
+        private IModuleService moduleService;
     }
 }

--- a/Netkan/Validators/CkanValidator.cs
+++ b/Netkan/Validators/CkanValidator.cs
@@ -36,7 +36,6 @@ namespace CKAN.NetKAN.Validators
         {
             Validate(metadata);
             new MatchingIdentifiersValidator(netkan.Identifier).Validate(metadata);
-            new VrefValidator(netkan, downloader, moduleService).Validate(metadata);
         }
 
         private IHttpService   downloader;

--- a/Netkan/Validators/ModuleManagerDependsValidator.cs
+++ b/Netkan/Validators/ModuleManagerDependsValidator.cs
@@ -55,7 +55,7 @@ namespace CKAN.NetKAN.Validators
         private string[] identifiers = new string[] { "ModuleManager" };
 
         private static readonly Regex moduleManagerRegex = new Regex(
-            @"^\s+[@%]",
+            @"^\s*[@+$\-!%]",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
 

--- a/Netkan/Validators/ModuleManagerDependsValidator.cs
+++ b/Netkan/Validators/ModuleManagerDependsValidator.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using ICSharpCode.SharpZipLib.Zip;
+using log4net;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Validators
+{
+    internal sealed class ModuleManagerDependsValidator : IValidator
+    {
+        public ModuleManagerDependsValidator(IHttpService http, IModuleService moduleService)
+        {
+            _http          = http;
+            _moduleService = moduleService;
+        }
+
+        public void Validate(Metadata metadata)
+        {
+            Log.Info("Validating that metadata dependencies are consistent with cfg file syntax");
+
+            JObject    json = metadata.Json();
+            CkanModule mod  = CkanModule.FromJson(json.ToString());
+            ZipFile    zip  = new ZipFile(_http.DownloadPackage(
+                metadata.Download,
+                metadata.Identifier,
+                metadata.RemoteTimestamp
+            ));
+
+            bool hasMMsyntax = _moduleService.GetConfigFiles(mod, zip)
+                .Select(cfg => new StreamReader(zip.GetInputStream(cfg.source)).ReadToEnd())
+                .Any(contents => moduleManagerRegex.IsMatch(contents));
+
+            bool dependsOnMM = mod?.depends?.Any(r => r.ContainsAny(identifiers)) ?? false;
+
+            if (hasMMsyntax && !dependsOnMM)
+            {
+                Log.Warn("ModuleManager syntax used without ModuleManager dependency");
+            }
+            else if (!hasMMsyntax && dependsOnMM)
+            {
+                Log.Warn("ModuleManager dependency may not be needed, no ModuleManager syntax found");
+            }
+        }
+
+        private string[] identifiers = new string[] { "ModuleManager" };
+
+        private static readonly Regex moduleManagerRegex = new Regex(
+            @"^\s+[@%]",
+            RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
+        );
+
+        private readonly IHttpService   _http;
+        private readonly IModuleService _moduleService;
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(ModuleManagerDependsValidator));
+    }
+}

--- a/Netkan/Validators/NetkanValidator.cs
+++ b/Netkan/Validators/NetkanValidator.cs
@@ -39,7 +39,6 @@ namespace CKAN.NetKAN.Validators
         {
             Validate(metadata);
             new MatchingIdentifiersValidator(Path.GetFileNameWithoutExtension(filename)).Validate(metadata);
-
         }
     }
 }

--- a/Netkan/Validators/PluginCompatibilityValidator.cs
+++ b/Netkan/Validators/PluginCompatibilityValidator.cs
@@ -23,19 +23,26 @@ namespace CKAN.NetKAN.Validators
 
             JObject    json = metadata.Json();
             CkanModule mod  = CkanModule.FromJson(json.ToString());
-            ZipFile    zip  = new ZipFile(_http.DownloadPackage(
-                metadata.Download,
-                metadata.Identifier,
-                metadata.RemoteTimestamp
-            ));
-
-            bool hasPlugin = _moduleService.GetPlugins(mod, zip).Any();
-            
-            bool boundedCompatibility = json.ContainsKey("ksp_version") || json.ContainsKey("ksp_version_max");
-
-            if (hasPlugin && !boundedCompatibility)
+            if (!mod.IsDLC)
             {
-                Log.Warn("Unbounded future compatibility for module with a plugin, consider setting $vref or ksp_version or ksp_version_max");
+                var package = _http.DownloadPackage(
+                    metadata.Download,
+                    metadata.Identifier,
+                    metadata.RemoteTimestamp
+                );
+                if (!string.IsNullOrEmpty(package))
+                {
+                    ZipFile zip  = new ZipFile(package);
+        
+                    bool hasPlugin = _moduleService.GetPlugins(mod, zip).Any();
+                    
+                    bool boundedCompatibility = json.ContainsKey("ksp_version") || json.ContainsKey("ksp_version_max");
+        
+                    if (hasPlugin && !boundedCompatibility)
+                    {
+                        Log.Warn("Unbounded future compatibility for module with a plugin, consider setting $vref or ksp_version or ksp_version_max");
+                    }
+                }
             }
         }
 

--- a/Netkan/Validators/PluginCompatibilityValidator.cs
+++ b/Netkan/Validators/PluginCompatibilityValidator.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using ICSharpCode.SharpZipLib.Zip;
+using log4net;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Validators
+{
+    internal sealed class PluginCompatibilityValidator : IValidator
+    {
+        public PluginCompatibilityValidator(IHttpService http, IModuleService moduleService)
+        {
+            _http          = http;
+            _moduleService = moduleService;
+        }
+
+        public void Validate(Metadata metadata)
+        {
+            Log.Info("Validating that metadata compatibility is appropriate for DLLs");
+
+            JObject    json = metadata.Json();
+            CkanModule mod  = CkanModule.FromJson(json.ToString());
+            ZipFile    zip  = new ZipFile(_http.DownloadPackage(
+                metadata.Download,
+                metadata.Identifier,
+                metadata.RemoteTimestamp
+            ));
+
+            bool hasPlugin = _moduleService.GetPlugins(mod, zip).Any();
+            
+            bool boundedCompatibility = json.ContainsKey("ksp_version") || json.ContainsKey("ksp_version_max");
+
+            if (hasPlugin && !boundedCompatibility)
+            {
+                Log.Warn("Unbounded future compatibility for module with a plugin, consider setting $vref or ksp_version or ksp_version_max");
+            }
+        }
+
+        private readonly IHttpService   _http;
+        private readonly IModuleService _moduleService;
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(PluginCompatibilityValidator));
+    }
+}

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -1,0 +1,54 @@
+using log4net;
+using Newtonsoft.Json.Linq;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Validators
+{
+    internal sealed class VrefValidator : IValidator
+    {
+        public VrefValidator(Metadata netkan, IHttpService http, IModuleService moduleService)
+        {
+            _netkan        = netkan;
+            _http          = http;
+            _moduleService = moduleService;
+        }
+
+        public void Validate(Metadata metadata)
+        {
+            Log.Info("Validating that metadata vref is consistent with download contents");
+
+            JObject json = metadata.Json();
+            var noVersion = metadata.Version == null;
+            if (noVersion)
+            {
+                json["version"] = "0";
+            }
+            var mod = CkanModule.FromJson(json.ToString());
+            if (noVersion)
+            {
+                json.Remove("version");
+            }
+            var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+            var avc = _moduleService.GetInternalAvc(mod, file, null);
+
+            bool hasVref = (_netkan.Vref != null);
+            bool hasVersionFile = (avc != null);
+
+            if (hasVref && !hasVersionFile)
+            {
+                Log.Warn("$vref present, version file missing");
+            }
+            else if (!hasVref && hasVersionFile)
+            {
+                Log.Warn("$vref absent, version file present");
+            }
+        }
+
+        private readonly Metadata       _netkan;
+        private readonly IHttpService   _http;
+        private readonly IModuleService _moduleService;
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(VrefValidator));
+    }
+}

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -29,19 +29,27 @@ namespace CKAN.NetKAN.Validators
             {
                 json.Remove("version");
             }
-            var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
-            var avc = _moduleService.GetInternalAvc(mod, file, null);
 
-            bool hasVref = (_netkan.Vref != null);
-            bool hasVersionFile = (avc != null);
+            if (!mod.IsDLC)
+            {
+                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+                if (!string.IsNullOrEmpty(file))
+                {
+                    var avc = _moduleService.GetInternalAvc(mod, file, null);
 
-            if (hasVref && !hasVersionFile)
-            {
-                Log.Warn("$vref present, version file missing");
-            }
-            else if (!hasVref && hasVersionFile)
-            {
-                Log.Warn("$vref absent, version file present");
+                    bool hasVref = (_netkan.Vref != null);
+
+                    bool hasVersionFile = (avc != null);
+
+                    if (hasVref && !hasVersionFile)
+                    {
+                        Log.Warn("$vref present, version file missing");
+                    }
+                    else if (!hasVref && hasVersionFile)
+                    {
+                        Log.Warn("$vref absent, version file present");
+                    }
+                }
             }
         }
 

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -7,9 +7,8 @@ namespace CKAN.NetKAN.Validators
 {
     internal sealed class VrefValidator : IValidator
     {
-        public VrefValidator(Metadata netkan, IHttpService http, IModuleService moduleService)
+        public VrefValidator(IHttpService http, IModuleService moduleService)
         {
-            _netkan        = netkan;
             _http          = http;
             _moduleService = moduleService;
         }
@@ -37,7 +36,7 @@ namespace CKAN.NetKAN.Validators
                 {
                     var avc = _moduleService.GetInternalAvc(mod, file, null);
 
-                    bool hasVref = (_netkan.Vref != null);
+                    bool hasVref = (metadata.Vref != null);
 
                     bool hasVersionFile = (avc != null);
 
@@ -53,7 +52,6 @@ namespace CKAN.NetKAN.Validators
             }
         }
 
-        private readonly Metadata       _netkan;
         private readonly IHttpService   _http;
         private readonly IModuleService _moduleService;
 

--- a/Tests/NetKAN/Validators/CkanValidatorTests.cs
+++ b/Tests/NetKAN/Validators/CkanValidatorTests.cs
@@ -35,13 +35,6 @@ namespace Tests.NetKAN.Validators
             mModuleService.Setup(i => i.HasInstallableFiles(It.IsAny<CkanModule>(), It.IsAny<string>()))
                 .Returns(true);
 
-            var ckan = new JObject();
-            ckan["spec_version"] = 1;
-            ckan["identifier"] = "AwesomeMod";
-            ckan["name"] = "Awesome Mod";
-            ckan["abstract"] = "A great mod";
-            ckan["license"] = "GPL-3.0";
-
             var sut = new CkanValidator(mHttp.Object, mModuleService.Object);
             var json = (JObject)ValidCkan.DeepClone();
 


### PR DESCRIPTION
## Motivation

See KSP-CKAN/NetKAN-Infra#160, it would be nice to be able to capture non-fatal warnings in netkan.exe to discover opportunities to improve the metadata.

## Changes

- `AvcTransformer` now prints a warning via `Log.Warn` if a version file's `URL` property contains an invalid URL, or if the URL can't be downloaded
- A new `PluginCompatibilityValidator` prints a warning via `Log.Warn` if a module contains a DLL file and claims to be compatible with all future versions, since plugins always break eventually
- A new `VrefValidator` prints a warning via `Log.Warn` if a module contains a version file and has no vref, OR if a module has a vref and no version file
- A new `ModuleManagerDependsValidator` prints a warning via `Log.Warn` if a module's cfg files use ModuleManager syntax but the module doesn't depend on ModuleManager, OR if the module depends on ModuleManager and doesn't use ModuleManager syntax
- A new `QueueAppender` class intercepts `Log.Warn` calls when running in SQS queue mode and collects them for later inclusion in the new `WarningMessages` message attribute

Together, this will give users, the PR validation scripts, and the NetKAN-Infra Indexer access to these warnings to do with as they see fit. A future NetKAN-Infra PR will probably update the Indexer to add them to the status page somehow.

In addition, each intermediate stage of transforming a netkan is now checked by `NetkanValidator`, to catch invalid data in metanetkans or internal ckans.

Fixes #969. ("If a mod is indexed but looks weird we can flip things to a warning." Although note that we already addressed "(eg: the latest version compares to be older than an existing version)" with auto-epoching, see #2824.)