### PR TITLE
Don't try to install multiple versions of the same mod

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -410,7 +410,9 @@ namespace CKAN
                 var descriptor1 = descriptor;
                 List<CkanModule> candidates = descriptor
                     .LatestAvailableWithProvides(registry, kspversion, modlist.Values)
-                    .Where(mod => descriptor1.WithinBounds(mod) && MightBeInstallable(mod))
+                    .Where(mod => !modlist.ContainsKey(mod.identifier)
+                        && descriptor1.WithinBounds(mod)
+                        && MightBeInstallable(mod))
                     .ToList();
                 if (candidates.Count == 0)
                 {
@@ -418,7 +420,9 @@ namespace CKAN
                     // (conflicts will still be caught below)
                     candidates = descriptor
                         .LatestAvailableWithProvides(registry, kspversion)
-                        .Where(mod => descriptor1.WithinBounds(mod) && MightBeInstallable(mod))
+                        .Where(mod => !modlist.ContainsKey(mod.identifier)
+                            && descriptor1.WithinBounds(mod)
+                            && MightBeInstallable(mod))
                         .ToList();
                 }
 
@@ -519,7 +523,7 @@ namespace CKAN
             {
                 // We should never be adding something twice!
                 log.ErrorFormat("Assertion failed: Adding {0} twice in relationship resolution", module.identifier);
-                throw new ArgumentException("Already contains module:" + module.identifier);
+                throw new ArgumentException("Already contains module: " + module.identifier);
             }
             modlist.Add(module.identifier, module);
             if (!reasons.ContainsKey(module))


### PR DESCRIPTION
## Background

In KSP-CKAN/NetKAN#7891, Spectra removed `PlanetShine-Config` from its `provides` list because it no longer ships with a PlanetShine config. Versions v1.2.5 and earlier were released before that change, and v1.3 and later were released after.

## Problem

If you install Spectra v1.3.1 (after the above change):

![changeset](https://i.imgur.com/RBtF72t.png)

... and then install the PlanetShine suggestion, you will be prompted to choose between PlanetShine's default config and Spectra v1.2.5:

![prompt](https://i.imgur.com/GoedBGK.png)

If you choose Spectra v1.2.5, this fails because you're already installing Spectra v1.3.1, and you can't install two different versions of the same mod at the same time.

```
System.ArgumentException: Already contains module:Spectra
   at CKAN.RelationshipResolver.Add(CkanModule module, SelectionReason reason)
   at CKAN.RelationshipResolver.AddModulesToInstall(IEnumerable`1 modules)
   at CKAN.ModuleInstaller.InstallList(ICollection`1 modules, RelationshipResolverOptions options, RegistryManager registry_manager, IDownloader downloader, Boolean ConfirmPrompt)
   at CKAN.Main.InstallMods(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

## Cause

When the `RelationshipResolver` looks for modules to satisfy a `depends` relationship, `LatestAvailableWithProvides` can find other versions of a mod we're already installing, and it doesn't account for this possibility.

## Canges

Now we exclude modules if they have the same identifier as one we're already installing. This allows Spectra v1.3.1 to install with the default PlanetShine config without prompting, and Spectra v1.2.5 to install its own PlanetShine config without prompting.