### PR TITLE
Create a system menu entry for ConsoleUI

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -19,10 +19,12 @@ COPYRIGHTSRC:=copyright
 COPYRIGHTDEST:=$(DESTDIR)/usr/share/doc/ckan/copyright
 DESKTOPSRC:=ckan.desktop
 DESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan.desktop
+CONSOLEUIDESKTOPSRC:=ckan-consoleui.desktop
+CONSOLEUIDESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan-consoleui.desktop
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
 DEB:=../_build/deb/ckan_$(VERSION)_all.deb
 
-$(DEB): $(EXEDEST) $(SCRIPTDEST) $(CONTROLDEST) $(CHANGELOGDEST) $(DEBCHANGEDEST) $(MANDEST) $(ICONDEST) $(COPYRIGHTDEST) $(DESKTOPDEST)
+$(DEB): $(EXEDEST) $(SCRIPTDEST) $(CONTROLDEST) $(CHANGELOGDEST) $(DEBCHANGEDEST) $(MANDEST) $(ICONDEST) $(COPYRIGHTDEST) $(DESKTOPDEST) $(CONSOLEUIDESKTOPDEST)
 	umask 0022 && mkdir -p $(shell dirname $@)
 	fakeroot dpkg-deb --build $(DESTDIR)/ $@
 
@@ -62,6 +64,10 @@ $(COPYRIGHTDEST): $(COPYRIGHTSRC)
 	umask 0022 && cp $< $@
 
 $(DESKTOPDEST): $(DESKTOPSRC)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && cp $< $@
+
+$(CONSOLEUIDESKTOPDEST): $(CONSOLEUIDESKTOPSRC)
 	umask 0022 && mkdir -p $(shell dirname $@)
 	umask 0022 && cp $< $@
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ckan (1.28.0) unstable; urgency=low
+
+  * Added ConsoleUI desktop file.
+
+ -- The CKAN Authors <debian@ksp-ckan.space>  Wed, 15 May 2020 19:12:00 +0600
+
 ckan (1.24.0) unstable; urgency=low
 
   * Initial release.

--- a/debian/ckan-consoleui.desktop
+++ b/debian/ckan-consoleui.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=CKAN Console UI
+Comment=Comprehensive Kerbal Archive Network Console UI
+Icon=/usr/share/icons/ckan.ico
+Categories=Game;Utility
+Exec=/usr/bin/ckan consoleui
+StartupNotify=true
+Terminal=true
+Type=Application
+Version=1.0

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -7,6 +7,7 @@ TOPDIR:=$(shell pwd)/../_build/rpm
 SCRIPTSRC:=$(DEBDIR)/ckan
 MANSRC:=$(DEBDIR)/ckan.1
 DESKTOPSRC:=$(DEBDIR)/ckan.desktop
+CONSOLEUIDESKTOPSRC:=$(DEBDIR)/ckan-consoleui.desktop
 ICONSRC:=$(DEBDIR)/ckan.ico
 EXESRC:=$(shell pwd)/../_build/repack/Release/ckan.exe
 CHANGELOGSRC:=../CHANGELOG.md
@@ -17,7 +18,7 @@ RPM:=$(shell pwd)/../_build/rpm/RPMS/noarch/ckan-$(VERSION)-1.noarch.rpm
 # rpmbuild can't handle relative paths for its topdir
 # rpmbuild assumes we'll copy files into its SOURCES dir for it
 
-$(RPM): $(SCRIPTSRC) $(EXESRC) $(MANSRC) $(DESKTOPSRC) $(ICONSRC)
+$(RPM): $(SCRIPTSRC) $(EXESRC) $(MANSRC) $(DESKTOPSRC) $(ICONSRC) $(CONSOLEUIDESKTOPSRC)
 	mkdir -p "${TOPDIR}/SOURCES"
 	cp $^ "${TOPDIR}/SOURCES"
 	rpmbuild --define "_topdir ${TOPDIR}" --define "_version $(VERSION)" -bb ckan.spec

--- a/rpm/ckan.spec
+++ b/rpm/ckan.spec
@@ -14,6 +14,7 @@ Source1: ckan.exe
 Source2: ckan.1
 Source3: ckan.desktop
 Source4: ckan.ico
+Source5: ckan-consoleui.desktop
 
 %description
 KSP-CKAN official client.
@@ -34,6 +35,7 @@ mkdir -p %{buildroot}%{_mandir}/man1
 cp %{SOURCE2} %{buildroot}%{_mandir}/man1
 mkdir -p %{buildroot}%{_datadir}/applications
 cp %{SOURCE3} %{buildroot}%{_datadir}/applications
+cp %{SOURCE5} %{buildroot}%{_datadir}/applications
 mkdir -p %{buildroot}%{_datadir}/icons
 cp %{SOURCE4} %{buildroot}%{_datadir}/icons
 
@@ -45,5 +47,8 @@ cp %{SOURCE4} %{buildroot}%{_datadir}/icons
 %{_mandir}/man1/*
 
 %changelog
+* Fri May 15 2020 The CKAN authors <rpm@ksp-ckan.space> 1.28.0
+- Added ConsoleUI desktop file
+
 * Thu May 9 2019 The CKAN authors <rpm@ksp-ckan.space> 1.26.3-1
 - Initial RPM release


### PR DESCRIPTION
## Motivation

The current DEB and RPM packages install a `ckan.desktop` file that launches GUI, but some users may not always wish to run the GUI.

## Changes

Now the DEB and RPM packages install a `/usr/share/applications/ckan-consoleui.desktop` file that runs `ckan consoleui` in a terminal:

![image](https://user-images.githubusercontent.com/1559108/82105510-494fdc80-96e1-11ea-8ff0-06ac60980f52.png)