### PR TITLE
Non-parallel GitHub downloads, one progress bar per download

### DIFF
--- a/Core/Net/IDownloader.cs
+++ b/Core/Net/IDownloader.cs
@@ -1,3 +1,4 @@
+using System;
 ﻿using System.Collections.Generic;
 
 namespace CKAN
@@ -12,6 +13,16 @@ namespace CKAN
         /// Blocks until the downloads are complete, cancelled, or errored.
         /// </summary>
         void DownloadModules(IEnumerable<CkanModule> modules);
+
+        /// <summary>
+        /// Raised when data arrives for a module
+        /// </summary>
+        event Action<CkanModule, long, long> Progress;
+
+        /// <summary>
+        /// Raised when a batch of downloads is all done
+        /// </summary>
+        event Action AllComplete;
 
         /// <summary>
         /// Cancel any running downloads.

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using Timer = System.Windows.Forms.Timer;
 using log4net;
 using CKAN.Versioning;
 

--- a/GUI/Controls/Wait.Designer.cs
+++ b/GUI/Controls/Wait.Designer.cs
@@ -45,7 +45,7 @@
             this.TopPanel.Controls.Add(this.DialogProgressBar);
             this.TopPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.TopPanel.Name = "TopPanel";
-            this.TopPanel.Size = new System.Drawing.Size(500, 80);
+            this.TopPanel.Size = new System.Drawing.Size(500, 85);
             // 
             // MessageTextBox
             // 
@@ -66,7 +66,8 @@
             // DialogProgressBar
             // 
             this.DialogProgressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));            this.DialogProgressBar.Location = new System.Drawing.Point(5, 45);
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.DialogProgressBar.Location = new System.Drawing.Point(5, 45);
             this.DialogProgressBar.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.DialogProgressBar.Minimum = 0;
             this.DialogProgressBar.Maximum = 100;

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Drawing;
 using System.Windows.Forms;
+using Timer = System.Windows.Forms.Timer;
 
 namespace CKAN
 {
@@ -8,6 +12,7 @@ namespace CKAN
         public Wait()
         {
             InitializeComponent();
+            progressTimer.Tick += (sender, evt) => ReflowProgressBars();
         }
 
         public event Action OnRetry;
@@ -44,10 +49,146 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// React to data received for a module,
+        /// adds or updates a label and progress bar so user can see how each download is going
+        /// </summary>
+        /// <param name="module">The module that is being downloaded</param>
+        /// <param name="remaining">Number of bytes left to download</param>
+        /// <param name="total">Number of bytes in complete download</param>
+        public void SetModuleProgress(CkanModule module, long remaining, long total)
+        {
+            Util.Invoke(this, () =>
+            {
+                if (moduleBars.TryGetValue(module, out ProgressBar pb))
+                {
+                    pb.Value = (int) (100 * (total - remaining) / total);
+                }
+                else
+                {
+                    var rowTop = TopPanel.Height - padding;
+                    var newLb = new Label()
+                    {
+                        AutoSize = true,
+                        Location = new Point(2 * padding, rowTop),
+                        Size     = new Size(labelWidth, progressHeight),
+                        Text     = string.Format(
+                                Properties.Resources.MainChangesetHostSize,
+                                module.name,
+                                module.version,
+                                module.download.Host ?? "",
+                                CkanModule.FmtSize(module.download_size)),
+                    };
+                    moduleLabels.Add(module, newLb);
+                    var newPb = new ProgressBar()
+                    {
+                        Anchor   = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
+                        Location = new Point(labelWidth + 3 * padding, rowTop),
+                        Size     = new Size(TopPanel.Width - labelWidth - 5 * padding, progressHeight),
+                        Minimum  = 0,
+                        Maximum  = 100,
+                        Value    = (int) (100 * (total - remaining) / total),
+                        Style    = ProgressBarStyle.Continuous,
+                    };
+                    moduleBars.Add(module, newPb);
+                }
+                progressTimer.Start();
+            });
+        }
+
+        private const int padding        = 5;
+        private const int labelWidth     = 400;
+        private const int progressHeight = 20;
+        private const int emptyHeight    = 85;
+
+        private Dictionary<CkanModule, Label>       moduleLabels = new Dictionary<CkanModule, Label>();
+        private Dictionary<CkanModule, ProgressBar> moduleBars   = new Dictionary<CkanModule, ProgressBar>();
+        private Timer progressTimer = new Timer() { Interval = 3000 };
+
+        /// <summary>
+        /// Add new progress bars and remove completed ones (100%) in a single scheduled pass,
+        /// so they don't constantly flicker and jump around.
+        /// </summary>
+        private void ReflowProgressBars()
+        {
+            Util.Invoke(this, () =>
+            {
+                int rowTop = emptyHeight - padding;
+                var theBars = moduleBars.OrderBy(kvp => kvp.Value.Top).ToList();
+                foreach (var kvp in theBars)
+                {
+                    if (kvp.Value.Value == 100)
+                    {
+                        // Finished, remove in this pass
+                        TopPanel.Controls.Remove(moduleLabels[kvp.Key]);
+                        TopPanel.Controls.Remove(kvp.Value);
+                        // rowTop is unchanged, so next row will replace this one
+                    }
+                    else if (!TopPanel.Controls.Contains(kvp.Value))
+                    {
+                        // Just started, add it in this pass
+                        moduleLabels[kvp.Key].Top = rowTop;
+                        kvp.Value.Top = rowTop;
+                        TopPanel.Controls.Add(moduleLabels[kvp.Key]);
+                        TopPanel.Controls.Add(kvp.Value);
+                        rowTop += progressHeight + padding;
+                    }
+                    else
+                    {
+                        // Not finished, already displayed, just make sure it's in the right position
+                        moduleLabels[kvp.Key].Top = rowTop;
+                        kvp.Value.Top = rowTop;
+                        rowTop += progressHeight + padding;
+                    }
+                }
+                // Make room for everything that's still visible
+                TopPanel.Height = rowTop + padding;
+
+                var removedModules = moduleBars
+                    .Where(kvp => !TopPanel.Controls.Contains(kvp.Value))
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+                foreach (var module in removedModules)
+                {
+                    moduleLabels.Remove(module);
+                    moduleBars.Remove(module);
+                }
+            });
+        }
+
+        /// <summary>
+        /// React to completion of all downloads,
+        /// removes all the module progress bars since we don't need them anymore
+        /// </summary>
+        public void DownloadsComplete()
+        {
+            ClearModuleBars();
+            progressTimer.Stop();
+        }
+
+        private void ClearModuleBars()
+        {
+            Util.Invoke(this, () =>
+            {
+                foreach (var kvp in moduleLabels)
+                {
+                    TopPanel.Controls.Remove(kvp.Value);
+                }
+                foreach (var kvp in moduleBars)
+                {
+                    TopPanel.Controls.Remove(kvp.Value);
+                }
+                moduleLabels.Clear();
+                moduleBars.Clear();
+                TopPanel.Height = emptyHeight;
+            });
+        }
+
         public void Reset(bool cancelable)
         {
             Util.Invoke(this, () =>
             {
+                ClearModuleBars();
                 ProgressValue = DialogProgressBar.Minimum;
                 ProgressIndeterminate = true;
                 RetryCurrentActionButton.Enabled = false;

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -154,6 +154,8 @@ namespace CKAN
             tabController.SetTabLock(true);
 
             IDownloader downloader = new NetAsyncModulesDownloader(currentUser, Manager.Cache);
+            downloader.Progress    += Wait.SetModuleProgress;
+            downloader.AllComplete += Wait.DownloadsComplete;
             cancelCallback = () =>
             {
                 downloader.CancelDownload();


### PR DESCRIPTION
## Problem

If you try to install lots of mods that you haven't previously downloaded, you'll likely get errors like this (possibly in a different format since we've changed them a bunch recently):

> Failed to download "https://github.com/jrossignol/ContractPack-AnomalySurveyor/releases/download/1.6.0/ContractPack-AnomalySurveyor_1.6.0.zip" - error: The remote server returned an error: (403) Forbidden.

## Cause

GitHub doesn't like it when you try to download multiple things from it at the same time, which CKAN aggressively does. GitHub sometimes responds to such attempts with 403-Forbidden statuses (the precise rules are not publicly known).

The GitHub _API_ works similarly, except it has [defined](https://developer.github.com/v3/#abuse-rate-limits) (and [queryable](https://api.github.com/rate_limit)) throttling rules and explicitly [says not to download from it in parallel](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits):

> Make requests for a single user or client ID serially. Do not make requests for a single user or client ID concurrently.

## Motivation

Since we're planning a pre-release anyway, why not go nuts?

## Changes

Now if multiple GitHub downloads are requested, only one of them will be started, and the rest will wait. Non-GitHub downloads will still be performed in parallel as before. When the current GitHub download finishes, one of the others will be started, and so on until completion.

Now each active download has its own progress bar in GUI, so the user can tell what's happening:

![image](https://user-images.githubusercontent.com/1559108/82126391-0e49b980-9772-11ea-8b92-9ba740e5c0bf.png)

Fixes #1817.
Fixes #2210. (URLs haven't been migrated to API format, but that's probably not needed.)
Probably fixes #2400.
Fixes #1085. (The description and conversation went all over the place, so it may not be possible to even define what the issue is about, but the original complaint was about 403 statuses during downloads.)