### PR TITLE
Unbreak reinstall right click

### DIFF
--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -417,6 +417,7 @@
             this.ManageMods.OpenProgressTab += ManageMods_OpenProgressTab;
             this.ManageMods.CloseProgressTab += ManageMods_CloseProgressTab;
             this.ManageMods.LabelsAfterUpdate += ManageMods_LabelsAfterUpdate;
+            this.ManageMods.StartChangeSet += ManageMods_StartChangeSet;
             //
             // ChangesetTabPage
             //


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/82154207-e6ba2600-9831-11ea-83f8-1fda6e8a6dfd.png)

https://github.com/HebaruSan/CKAN/blob/d36da4ddabc016dc0b9de4f1615cb8913c1eeb63/GUI/Controls/ManageMods.cs#L908-L911

## Cause

The mod list control needs to ask the main app code to switch over to installer mode, and this was meant to be done via the `StartChangeSet` event. However, there was no event handler for this event in #3041.

## Changes

Now the event handler is set and it works again.