### PR TITLE
Fix errors caused by warnings changes

### DIFF
--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -63,6 +63,7 @@ namespace CKAN.NetKAN.Processors
                 LevelToMatch  = Level.Warn,
                 AcceptOnMatch = true,
             });
+            qap.AddFilter(new DenyAllFilter());
             return qap;
         }
 

--- a/Netkan/Validators/DownloadVersionValidator.cs
+++ b/Netkan/Validators/DownloadVersionValidator.cs
@@ -7,7 +7,9 @@ namespace CKAN.NetKAN.Validators
         public void Validate(Metadata metadata)
         {
             var json = metadata.Json();
-            if (json.ContainsKey("download") && !json.ContainsKey("version"))
+            if (json.ContainsKey("download")
+                && !json.ContainsKey("version")
+                && !json.ContainsKey("$vref"))
             {
                 throw new Kraken($"{metadata.Identifier} expects a version when a download url is provided");
             }

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -34,7 +34,8 @@ namespace CKAN.NetKAN.Validators
                 var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
                 if (!string.IsNullOrEmpty(file))
                 {
-                    var avc = _moduleService.GetInternalAvc(mod, file, null);
+                    // Pass a regex that matches anything so it returns the first if found
+                    var avc = _moduleService.GetInternalAvc(mod, file, ".");
 
                     bool hasVref = (metadata.Vref != null);
 


### PR DESCRIPTION
## Problems

![image](https://user-images.githubusercontent.com/1559108/82160482-542e7c80-985b-11ea-84a1-c59d711bd526.png)

![image](https://user-images.githubusercontent.com/1559108/82160631-5e04af80-985c-11ea-8e20-dbf27daf0ea9.png)

![image](https://user-images.githubusercontent.com/1559108/82161071-6ad6d280-985f-11ea-871e-cd0d9af485c3.png)

## Cause

When mods include multiple version files (often due to bundling other mods), we use the last part of the vref to determine which one to use. In #3045 we added a new call to `GetInternalAvc`, but with the vref Id left out because initially I thought we would not have it available by that point in the processing. Due to more recent changes this isn't an issue, but we do need the call to work for modules with _no_ vref, to see if we should add one, so it needs to work and not throw regardless of what the vref is or how many version files there are. Now we pass a vref matching string of `"."`, to force it to match any version file at all without throwing, since we only care if any exist.

Jenkins doesn't provide a version at all; it comes from the .version file via the `$vref`. But this is done by a later transformer, so we have to allow metadata with a download but with no version.

Every log message that netkan emits is going into `WarningMessages`; we have a `LevelMatchFilter` to select only warnings, but apparently in `log4net` world, that doesn't reject non-warnings, it just accepts the warnings, and the default for appender filters is to accept, so after the `LevelMatchFilter` fails for an `Info` message, it still accepts.

## Changes

Now we pass the vref Id so the correct version file can be selected.

Now when a download URL is present, `DownloadVersionValidator` requires either a `version` property or a `$vref` property.

Now non-warnings are rejected by a `DenyAllFilter` after the `LevelMatchFilter` accepts warnings.