### PR TITLE
Ignore internal krefs, don't error on unused version file syntax errors

### DIFF
--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -43,6 +43,12 @@ namespace CKAN.NetKAN.Transformers
 
                     foreach (var property in internalJson.Properties())
                     {
+                        // We've already got the file, too late to tell us where it lives
+                        if (property.Name == "$kref")
+                        {
+                            Log.DebugFormat("Skipping $kref property: {0}", property.Value);
+                            continue;
+                        }
                         json.SafeAdd(property.Name, property.Value);
                     }
 

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -34,12 +34,22 @@ namespace CKAN.NetKAN.Validators
                 var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
                 if (!string.IsNullOrEmpty(file))
                 {
-                    // Pass a regex that matches anything so it returns the first if found
-                    var avc = _moduleService.GetInternalAvc(mod, file, ".");
-
                     bool hasVref = (metadata.Vref != null);
 
-                    bool hasVersionFile = (avc != null);
+                    bool hasVersionFile = false;
+                    try
+                    {
+                        // Pass a regex that matches anything so it returns the first if found
+                        var avc = _moduleService.GetInternalAvc(mod, file, ".");
+                        hasVersionFile = (avc != null);
+                    }
+                    catch (Kraken k)
+                    {
+                        // If GetInternalAvc throws, then there's a version file with a syntax error.
+                        // This shouldn't cause the inflation to fail.
+                        hasVersionFile = true;
+                        Log.Warn(k.Message);
+                    }
 
                     if (hasVref && !hasVersionFile)
                     {


### PR DESCRIPTION
## Problems

A bunch of files that used to inflate fine before #3045 now fail:

![image](https://user-images.githubusercontent.com/1559108/82264499-a25e8100-992a-11ea-8605-04462339a439.png)

And there's this special one with its own unique error:

![retrofuture kref](https://cdn.discordapp.com/attachments/601455398553387008/712056586369106060/unknown.png)

## Causes

The `VrefValidator` uses `ModuleService.GetInternalAvc` to scan a ZIP for version files.

| Case | Outcome |
| --- | --- |
| No version files found | Returns `null` |
| At least one valid version file found | Returns an `AvcVersion` object |
| At least one version file, but with syntax errors | Throws a `Kraken` |

Prior to #3045 and #3056, we only called `GetInternalAvc` when the netkan had a `$vref`, and if we've specified to use the version file, it makes sense to fail on syntax errors. But now we want to call it for mods that don't have a `$vref` so we can find out if we should add one, so the inflation should not be interrupted.

I found the other one kind of amazing. `retrofuturespaceplaneparts` is using an internal ckan file! And it has a `$kref` property, pointing to KerbalStuff! So after we download it from SpaceDock and replace the original `$kref` with `download`, the internal ckan transformer puts the `$kref` back, and the `NetkanValidator` discovers it's invalid!

## Changes

- Now `VrefValidator` catches `Kraken`s thrown by `GetInternalAvc` and logs them as warnings (and treats them as indicative of a version file being present)
- Now `InternalCkanTransformer` no longer sets `$kref`, since we already have the file and won't be running any more `$kref` transformers. If found, a debug message will be logged.