### PR TITLE
Don't save registry when opening settings

### DIFF
--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -466,9 +466,11 @@ namespace CKAN
                 }
                 var newDlls = new HashSet<string>(manager.registry.InstalledDlls);
                 bool dllChanged = !oldDlls.SetEquals(newDlls);
-
                 bool dlcChanged = manager.ScanDlc();
-                manager.Save(false);
+
+                if (dllChanged || dlcChanged)
+                    manager.Save(false);
+
                 tx.Complete();
 
                 return dllChanged || dlcChanged;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -41,7 +41,7 @@ namespace CKAN
 
         public void UpdateDialog()
         {
-            RefreshReposListBox();
+            RefreshReposListBox(false);
             RefreshAuthTokensListBox();
             UpdateLanguageSelectionComboBox();
 
@@ -75,27 +75,35 @@ namespace CKAN
             Main.Instance.UpdateRefreshTimer();
         }
 
-        private void RefreshReposListBox()
+        private void RefreshReposListBox(bool saveChanges = true)
         {
-            // Give the Repository the priority it
-            // currently has in the gui
-            for (int i = 0; i < _sortedRepos.Count; i++)
-            {
-                _sortedRepos[i].priority = i;
-            }
-
             var manager = RegistryManager.Instance(Main.Instance.CurrentInstance);
             var registry = manager.registry;
-            _sortedRepos = new List<Repository>(registry.Repositories.Values);
 
-            _sortedRepos.Sort((repo1, repo2) => repo1.priority.CompareTo(repo2.priority));
-            ReposListBox.Items.Clear();
+            if (saveChanges)
+            {
+                // Give the Repository the priority it
+                // currently has in the gui
+                for (int i = 0; i < _sortedRepos.Count; i++)
+                {
+                    _sortedRepos[i].priority = i;
+                }
+
+                _sortedRepos = new List<Repository>(registry.Repositories.Values);
+
+                _sortedRepos.Sort((repo1, repo2) => repo1.priority.CompareTo(repo2.priority));
+                ReposListBox.Items.Clear();
+
+                manager.Save();
+            }
+            else
+            {
+                _sortedRepos = new List<Repository>(registry.Repositories.Values);
+            }
             foreach (var repo in _sortedRepos)
             {
                 ReposListBox.Items.Add(string.Format("{0} | {1}", repo.name, repo.uri));
             }
-
-            manager.Save();
         }
 
         private void UpdateLanguageSelectionComboBox()


### PR DESCRIPTION
## Motivation
I recently noticed that opening the settings window is pretty slow from time to time. When profiling it, I found out that we save the registry on settings startup, and it seems to be the culprit (the serialization, to be precise).

## Problem
In `RefreshReposListBox>()`, the registry is saved after the we sort the list of repositories in the registry to how they are sorted in the GUI.
This is also done when the settings are just opened. In this case there are no repositories listed in the GUI (and the user couldn't have changed the sorting yet), so the whole operation is not doing anything.
However we still save the registry afterwards, which takes a long time.

## Changes
THe costly operation is put behind an if-clause. When `_sortedRepos.Count == 0`, we just pull the  list of repositories from the registry (needed to build the list for the GUI later), but jump over all the sorting and saving stuff.
