### PR TITLE
Support fallback URLs for netkan validate-ckan

### DIFF
--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+﻿using System.Linq;
 using CKAN.Versioning;
 using Newtonsoft.Json.Linq;
 
@@ -116,12 +117,39 @@ namespace CKAN.NetKAN.Model
                 RemoteTimestamp = t;
             }
         }
+        
+        public string[] Licenses
+        {
+            get
+            {
+                var lic = _json["license"];
+                switch (lic.Type)
+                {
+                    case JTokenType.Array:
+                        return lic.Children()
+                            .Select(t => (string)t)
+                            .ToArray();
+                    
+                    case JTokenType.String:
+                        return new string[] { (string)lic };
+                }
+                return new string[] { };
+            }
+        }
+
+        public bool Redistributable
+        {
+            get
+            {
+                return Licenses.Any(lic => new License(lic).Redistributable);
+            }
+        }
 
         public Uri FallbackDownload
         {
             get
             {
-                if (Identifier == null || Version == null)
+                if (Identifier == null || Version == null || !Redistributable)
                 {
                     return null;
                 }

--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -101,7 +101,7 @@ namespace CKAN.NetKAN.Model
             {
                 Staged = (bool)stagedToken;
             }
-            
+
             JToken stagingReasonToken;
             if (json.TryGetValue(StagingReasonPropertyName, out stagingReasonToken))
             {
@@ -114,6 +114,31 @@ namespace CKAN.NetKAN.Model
                 && DateTime.TryParse(updatedToken.ToString(), out t))
             {
                 RemoteTimestamp = t;
+            }
+        }
+
+        public Uri FallbackDownload
+        {
+            get
+            {
+                if (Identifier == null || Version == null)
+                {
+                    return null;
+                }
+                string verStr = Version.ToString().Replace(':', '-');
+                var hashes = (JObject)_json["download_hash"];
+                if (hashes == null)
+                {
+                    return null;
+                }
+                var sha1 = (string)hashes["sha1"];
+                if (sha1 == null)
+                {
+                    return null;
+                }
+                return new Uri(
+                    $"https://archive.org/download/{Identifier}-{verStr}/{sha1.Substring(0, 8)}-{Identifier}-{verStr}.zip"
+                );
             }
         }
 

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -36,13 +36,17 @@ namespace CKAN.NetKAN.Services
                 }
                 else
                 {
-                    return DownloadPackage(fallback, metadata.Identifier, metadata.RemoteTimestamp);
+                    return DownloadPackage(fallback, metadata.Identifier, metadata.RemoteTimestamp, metadata.Download);
                 }
             }
         }
 
-        private string DownloadPackage(Uri url, string identifier, DateTime? updated)
+        private string DownloadPackage(Uri url, string identifier, DateTime? updated, Uri primaryUrl = null)
         {
+            if (primaryUrl == null)
+            {
+                primaryUrl = url;
+            }
             if (_overwriteCache && !_requestedURLs.Contains(url))
             {
                 // Discard cached file if command line says so,
@@ -52,7 +56,7 @@ namespace CKAN.NetKAN.Services
 
             _requestedURLs.Add(url);
 
-            var cachedFile = _cache.GetCachedFilename(url, updated);
+            var cachedFile = _cache.GetCachedFilename(primaryUrl, updated);
 
             if (!string.IsNullOrWhiteSpace(cachedFile))
             {
@@ -93,7 +97,7 @@ namespace CKAN.NetKAN.Services
                 }
 
                 return _cache.Store(
-                    url,
+                    primaryUrl,
                     downloadedFile,
                     string.Format("netkan-{0}.{1}", identifier, extension),
                     move: true

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using log4net;
+using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Services
 {
@@ -20,7 +21,27 @@ namespace CKAN.NetKAN.Services
             _overwriteCache = overwrite;
         }
 
-        public string DownloadPackage(Uri url, string identifier, DateTime? updated)
+        public string DownloadModule(Metadata metadata)
+        {
+            try
+            {
+                return DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+            }
+            catch (Exception exc)
+            {
+                var fallback = metadata.FallbackDownload;
+                if (fallback == null)
+                {
+                    throw;
+                }
+                else
+                {
+                    return DownloadPackage(fallback, metadata.Identifier, metadata.RemoteTimestamp);
+                }
+            }
+        }
+
+        private string DownloadPackage(Uri url, string identifier, DateTime? updated)
         {
             if (_overwriteCache && !_requestedURLs.Contains(url))
             {

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -36,6 +36,7 @@ namespace CKAN.NetKAN.Services
                 }
                 else
                 {
+                    log.InfoFormat("Trying fallback URL: {0}", fallback);
                     return DownloadPackage(fallback, metadata.Identifier, metadata.RemoteTimestamp, metadata.Download);
                 }
             }

--- a/Netkan/Services/IHttpService.cs
+++ b/Netkan/Services/IHttpService.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Services
 {
     internal interface IHttpService
     {
-        string DownloadPackage(Uri url, string identifier, DateTime? updated);
+        string DownloadModule(Metadata metadata);
         string DownloadText(Uri url);
         string DownloadText(Uri url, string authToken, string mimeType);
 

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -62,7 +62,7 @@ namespace CKAN.NetKAN.Transformers
                     json.Remove("version");
                 }
 
-                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+                var file = _http.DownloadModule(metadata);
                 var avc = _moduleService.GetInternalAvc(mod, file, metadata.Vref.Id);
 
                 if (avc != null)

--- a/Netkan/Transformers/DownloadAttributeTransformer.cs
+++ b/Netkan/Transformers/DownloadAttributeTransformer.cs
@@ -35,7 +35,7 @@ namespace CKAN.NetKAN.Transformers
                 Log.InfoFormat("Executing Download attribute transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 
-                string file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+                string file = _http.DownloadModule(metadata);
 
                 if (file != null)
                 {

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -32,7 +32,7 @@ namespace CKAN.NetKAN.Transformers
             {
                 var json = metadata.Json();
 
-                string file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+                string file = _http.DownloadModule(metadata);
 
                 var internalJson = _moduleService.GetInternalCkan(file);
 

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -50,11 +50,7 @@ namespace CKAN.NetKAN.Transformers
             else
             {
                 CkanModule mod  = CkanModule.FromJson(json.ToString());
-                ZipFile    zip  = new ZipFile(_http.DownloadPackage(
-                    metadata.Download,
-                    metadata.Identifier,
-                    metadata.RemoteTimestamp
-                ));
+                ZipFile    zip  = new ZipFile(_http.DownloadModule(metadata));
 
                 log.Debug("Extracting locales");
                 // Extract the locale names from the ZIP's cfg files

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -20,7 +20,7 @@ namespace CKAN.NetKAN.Validators
             var mod = CkanModule.FromJson(metadata.Json().ToString());
             if (!mod.IsDLC)
             {
-                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+                var file = _http.DownloadModule(metadata);
 
                 // Make sure this would actually generate an install.
                 if (!_moduleService.HasInstallableFiles(mod, file))

--- a/Netkan/Validators/ModuleManagerDependsValidator.cs
+++ b/Netkan/Validators/ModuleManagerDependsValidator.cs
@@ -25,11 +25,7 @@ namespace CKAN.NetKAN.Validators
             CkanModule mod  = CkanModule.FromJson(json.ToString());
             if (!mod.IsDLC)
             {
-                var package = _http.DownloadPackage(
-                    metadata.Download,
-                    metadata.Identifier,
-                    metadata.RemoteTimestamp
-                );
+                var package = _http.DownloadModule(metadata);
                 if (!string.IsNullOrEmpty(package))
                 {
                     ZipFile zip  = new ZipFile(package);

--- a/Netkan/Validators/PluginCompatibilityValidator.cs
+++ b/Netkan/Validators/PluginCompatibilityValidator.cs
@@ -25,11 +25,7 @@ namespace CKAN.NetKAN.Validators
             CkanModule mod  = CkanModule.FromJson(json.ToString());
             if (!mod.IsDLC)
             {
-                var package = _http.DownloadPackage(
-                    metadata.Download,
-                    metadata.Identifier,
-                    metadata.RemoteTimestamp
-                );
+                var package = _http.DownloadModule(metadata);
                 if (!string.IsNullOrEmpty(package))
                 {
                     ZipFile zip  = new ZipFile(package);

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -31,7 +31,7 @@ namespace CKAN.NetKAN.Validators
 
             if (!mod.IsDLC)
             {
-                var file = _http.DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
+                var file = _http.DownloadModule(metadata);
                 if (!string.IsNullOrEmpty(file))
                 {
                     bool hasVref = (metadata.Vref != null);

--- a/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
@@ -28,7 +28,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mFileService = new Mock<IFileService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
+            mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(downloadFilePath);
 
             mFileService.Setup(i => i.GetFileHashSha1(downloadFilePath))
@@ -75,7 +75,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mFileService = new Mock<IFileService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
+            mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns((string)null);
 
             var sut = new DownloadAttributeTransformer(mHttp.Object, mFileService.Object);

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -27,7 +27,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
+            mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
             mModuleService.Setup(i => i.GetInternalCkan(filePath))
@@ -62,7 +62,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
+            mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
             mModuleService.Setup(i => i.GetInternalCkan(filePath))
@@ -100,7 +100,7 @@ namespace Tests.NetKAN.Transformers
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
 
-            mHttp.Setup(i => i.DownloadPackage(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<DateTime?>()))
+            mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
             mModuleService.Setup(i => i.GetInternalCkan(filePath))


### PR DESCRIPTION
## Problem

If you submit a CKAN-meta pull request for a module that currently relies on its archive.org fallback URL for download, the pull request validation will fail, even though the module can be installed by the client.

## Cause

Netkan uses a downloading service separate from the client's, which does not know about fallback URLs.

## Changes

- Now `Metadata` provides a `FallbackDownload` property that returns an archive.org `Uri` if we have enough info to do so and `null` otherwise.
- Now `CachingHttpService` takes `Metadata` as input when downloading instead of a `Uri`, identifier, and timestamp separately.
- Now if a download fails, `CachingHttpService` attempts to get `FallbackDownload` if it is set, and propagates the exception otherwise.

This will allow `netkan.exe --validate-ckan` to access fallback URLs and pass validation for modules relying on them.

NOTE: I just realized I forgot to check for redistributable licenses. I'll start that and remove the "In Progress" label when done.
NOTE: Also, the cache entries should be stored according to the original URL, not the fallback. Consider this pending as well.

Fixes #2938.