### PR TITLE
Netkan warning for archived repos, set bugtracker for GitHub

### DIFF
--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -11,8 +11,8 @@ namespace CKAN.NetKAN.Services
         private          bool         _overwriteCache = false;
         private Dictionary<Uri, StringCacheEntry> _stringCache = new Dictionary<Uri, StringCacheEntry>();
 
-        // Re-use string value URLs within 2 minutes
-        private static readonly TimeSpan stringCacheLifetime = new TimeSpan(0, 2, 0);
+        // Re-use string value URLs within 15 minutes
+        private static readonly TimeSpan stringCacheLifetime = new TimeSpan(0, 15, 0);
 
         public CachingHttpService(NetFileCache cache, bool overwrite = false)
         {

--- a/Netkan/Sources/Github/GithubRepo.cs
+++ b/Netkan/Sources/Github/GithubRepo.cs
@@ -21,15 +21,21 @@ namespace CKAN.NetKAN.Sources.Github
 
         [JsonProperty("license")]
         public GithubLicense License { get; set; }
-        
+
         [JsonProperty("parent")]
         public GithubRepo ParentRepo { get; set; }
-        
+
         [JsonProperty("source")]
         public GithubRepo SourceRepo { get; set; }
-        
+
         [JsonProperty("owner")]
         public GithubUser Owner { get; set; }
+
+        [JsonProperty("has_issues")]
+        public bool HasIssues { get; set; }
+
+        [JsonProperty("archived")]
+        public bool Archived { get; set; }
     }
 
     public class GithubLicense
@@ -37,12 +43,12 @@ namespace CKAN.NetKAN.Sources.Github
         [JsonProperty("spdx_id")]
         public string Id;
     }
-    
+
     public class GithubUser
     {
         [JsonProperty("login")]
         public string Login { get; set; }
-        
+
         [JsonProperty("type")]
         public string Type { get; set; }
     }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -56,6 +56,10 @@ namespace CKAN.NetKAN.Transformers
 
                 // Get the GitHub repository
                 var ghRepo = _api.GetRepo(ghRef);
+                if (ghRepo.Archived)
+                {
+                    Log.Warn("Repo is archived, consider freezing");
+                }
                 var versions = _api.GetAllReleases(ghRef);
                 if (opts.SkipReleases.HasValue)
                 {
@@ -103,6 +107,10 @@ namespace CKAN.NetKAN.Transformers
                 resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
 
             resourcesJson.SafeAdd("repository", ghRepo.HtmlUrl);
+            if (ghRepo.HasIssues)
+            {
+                resourcesJson.SafeAdd("bugtracker", $"{ghRepo.HtmlUrl}/issues");
+            }
 
             if (ghRelease != null)
             {

--- a/Netkan/Validators/ModuleManagerDependsValidator.cs
+++ b/Netkan/Validators/ModuleManagerDependsValidator.cs
@@ -55,7 +55,7 @@ namespace CKAN.NetKAN.Validators
         private string[] identifiers = new string[] { "ModuleManager" };
 
         private static readonly Regex moduleManagerRegex = new Regex(
-            @"^\s*[@+$\-!%]",
+            @"^\s*[@+$\-!%]|^\s*\S+:",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
 

--- a/Netkan/Validators/ModuleManagerDependsValidator.cs
+++ b/Netkan/Validators/ModuleManagerDependsValidator.cs
@@ -60,7 +60,7 @@ namespace CKAN.NetKAN.Validators
         private string[] identifiers = new string[] { "ModuleManager" };
 
         private static readonly Regex moduleManagerRegex = new Regex(
-            @"^\s*[@+$\-!%]|^\s*\S+:",
+            @"^\s*[@+$\-!%]|^\s*[a-zA-Z0-9_]+:",
             RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline
         );
 


### PR DESCRIPTION
## Motivation

A GitHub repo can be "archived", meaning that it's effectively read-only and very unlikely to ever be updated. Currently some of the netkans that we crawl every 2 hours are probably archived, so it's not necessary to keep checking them, but we don't know about it.

There's a `resources.bugtracker` property in the spec, but it's only populated manually. Many mods are hosted on GitHub repos where issues can be submitted, but we don't check that.

## Changes

- Now if a GitHub repo is archived, Netkan will print a warning suggesting that we freeze that netkan, which will be visible on the status page
- Now if a GitHub repo has issues enabled (not all of them do), `resources.bugtracker` will automatically be set to that repo's issues list
- The duration of caching of strings from #2950 is extended from 2 to 15 minutes, since that's about what a typical bot pass takes
- The warning about ModuleManager syntax now prints the affected filenames to ease investigation
- The ModuleManager syntax regexp is updated to detect post-clauses without leading special operator characters:
  ```
  PART:NEEDS[NEBULA]
  {
  ```
  ```
  SCALETYPE:NEEDS[TweakScale]
  {
  ```
  ```
  MATERIAL:NEEDS[RealChute]
  {
  ```
  ```
  PART:NEEDS[Launchpad]
  {
  ```