### PR TITLE
Move WebException stack trace from User error to verbose log

### DIFF
--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -97,7 +97,7 @@ namespace CKAN
         {
             if (error != null)
             {
-                User.RaiseError(error.ToString());
+                log.Info(error.ToString());
             }
             else
             {


### PR DESCRIPTION
## Problem

Download errors look like this currently:

```
Continue? [Y/n] 

Downloading "https://spacedock.info/mod/1805/Whirligig%20World/download/0.10.0"
System.Net.WebException: The remote server returned an error: (404) NOT FOUND.
  at System.Net.HttpWebRequest.GetResponseFromData (System.Net.WebResponseStream stream, System.Threading.CancellationToken cancellationToken) [0x00146] in <88f564ea69dd4dc8ba9bf979e48d5996>:0 
  at System.Net.HttpWebRequest.RunWithTimeoutWorker[T] (System.Threading.Tasks.Task`1[TResult] workerTask, System.Int32 timeout, System.Action abort, System.Func`1[TResult] aborted, System.Threading.CancellationTokenSource cts) [0x000f8] in <88f564ea69dd4dc8ba9bf979e48d5996>:0 
  at System.Net.HttpWebRequest.EndGetResponse (System.IAsyncResult asyncResult) [0x00020] in <88f564ea69dd4dc8ba9bf979e48d5996>:0 
  at System.Net.WebClient.GetWebResponse (System.Net.WebRequest request, System.IAsyncResult result) [0x00000] in <88f564ea69dd4dc8ba9bf979e48d5996>:0 
  at System.Net.WebClient.GetWebResponseTaskAsync (System.Net.WebRequest request) [0x0008d] in <88f564ea69dd4dc8ba9bf979e48d5996>:0 
  at System.Net.WebClient.DownloadBitsAsync (System.Net.WebRequest request, System.IO.Stream writeStream, System.ComponentModel.AsyncOperation asyncOp, System.Action`3[T1,T2,T3] completionDelegate) [0x0008d] in <88f564ea69dd4dc8ba9bf979e48d5996>:0 
One or more downloads were unsuccessful:

Error downloading WhirligigWorld 0.10.0: The remote server returned an error: (404) NOT FOUND.
```

This is scary-looking and redundant; the `WebException` stack trace does not contain useful information, and we summarize all the errors at the end after that anyway.

All UIs are affected in the same way.

## Cause

When an error happens, this line tells `NetAsyncModulesDownloader`:

https://github.com/KSP-CKAN/CKAN/blob/5b08975e5430da21e5ad57e78ffbd4279b4d257c/Core/Net/NetAsyncDownloader.cs#L433

... which then prints the exception with `User.RaiseError`.

## Changes

Now we put that stack trace into `log.Info` instead, so it won't be visible by default but you can re-enable it with `--verbose`.

```
Continue? [Y/n] 

Downloading "https://spacedock.info/mod/1805/Whirligig%20World/download/0.10.0"
One or more downloads were unsuccessful:

Error downloading WhirligigWorld 0.10.0: The remote server returned an error: (404) NOT FOUND.
```