### PR TITLE
Multi-find fixes

### DIFF
--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -84,6 +84,7 @@ namespace CKAN.NetKAN.Services
         {
             return ModuleInstaller
                 .FindInstallableFiles(module, filePath, new KSP("/", "dummy", null, false))
+                .Where(f => !f.source.IsDirectory)
                 .Select(f => f.destination);
         }
 


### PR DESCRIPTION
## Background

[The spec](https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md) says:

```markdown
- `find`: (**v1.4**) Locate the top-most directory which exactly matches
  the name specified. This is particularly useful when distributions
  have structures which change based upon each release.
```

In #3064 we attempted to relax the "top-most" requirement and allow multiple folders matched by `find` to be installed.

## Problems

![image](https://user-images.githubusercontent.com/1559108/84447557-eda83e80-ac0d-11ea-8b06-7547086d6e6a.png)

![image](https://user-images.githubusercontent.com/1559108/84447582-fac52d80-ac0d-11ea-928b-cd7acb8e68bc.png)

![image](https://user-images.githubusercontent.com/1559108/84447602-087ab300-ac0e-11ea-8449-73b7c0d983e0.png)

![image](https://user-images.githubusercontent.com/1559108/84447677-4a0b5e00-ac0e-11ea-9a54-6fb809c90bd7.png)

![image](https://user-images.githubusercontent.com/1559108/84447693-54c5f300-ac0e-11ea-9202-6e2f53572cc7.png)

## Cause

For most of those, the conflict is only a directory, but it's fine to install a directory multiple times (they can even be shared between modules).

However, GPP's problem cannot be solved with #3064 as it is. Its ZIP includes multiple instances of "GameData/GPP", one that is the main install, and two more in paths under "Optional Mods":

![image](https://user-images.githubusercontent.com/1559108/84447910-ea618280-ac0e-11ea-8e1f-1adb520de584.png)

Even if we were hypothetically to create an automatic conflict resolution mechanism, that would not help here, because **neither of the conflicting folders is supposed to be installed**! They are both in the optional folder, outside of the intended path. If this wasn't a metanetkan, we could add `"filter": [ "Optional Mods" ],` and it would be fine. However, GPP's metadata lives here:

- https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPP.netkan

... and I can't really go to the GPP team and say, hey, we're making this breaking change in a future version, update your metanetkan. They'd respond, "Why are you changing this, it was fine as is?", and they'd be right.

## Changes

`ModuleService.FileDestinations` no longer returns directory paths.

Now we restore some of the previous hack-iness by only installing the "top-most" folder again when `find` is set. GPP indexes and installs correctly. We still don't convert `find` to `file`.