### PR TITLE
Cache hashes on disk

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -401,10 +401,12 @@ namespace CKAN
                 DirectoryInfo legDir = new DirectoryInfo(legacyDir);
                 files = files.Union(legDir.EnumerateFiles());
             }
-            return files
-                // Require 8 digit hex prefix followed by dash; any else was not put there by CKAN
-                .Where(fi => cacheFileRegex.IsMatch(fi.Name))
-                .ToList();
+            return files.Where(fi =>
+                    // Require 8 digit hex prefix followed by dash; any else was not put there by CKAN
+                    cacheFileRegex.IsMatch(fi.Name)
+                    // Treat the hash files as companions of the main files, not their own entries
+                    && !fi.Name.EndsWith(".sha1") && !fi.Name.EndsWith(".sha256")
+                ).ToList();
         }
 
         /// <summary>
@@ -662,7 +664,10 @@ namespace CKAN
                 {
                     hash = BitConverter.ToString(sha1.ComputeHash(bs)).Replace("-", "");
                     sha1Cache.Add(filePath, hash);
-                    File.WriteAllText(hashFile, hash);
+                    if (Path.GetDirectoryName(hashFile) == cachePath)
+                    {
+                        File.WriteAllText(hashFile, hash);
+                    }
                     return hash;
                 }
             }
@@ -695,7 +700,10 @@ namespace CKAN
                 {
                     hash = BitConverter.ToString(sha256.ComputeHash(bs)).Replace("-", "");
                     sha256Cache.Add(filePath, hash);
-                    File.WriteAllText(hashFile, hash);
+                    if (Path.GetDirectoryName(hashFile) == cachePath)
+                    {
+                        File.WriteAllText(hashFile, hash);
+                    }
                     return hash;
                 }
             }


### PR DESCRIPTION
## Motivation

#2940 sped up the Inflator by caching hashes to RAM, but this only helps on the second-and-later passes; the first pass after redeployment still takes a long time.

## Changes

Now when we store a ZIP to the cache, we store two additional files next to it, with the same name plus `.sha1` and `.sha256` appended:

- FFA1EF94-ContractsWindowPlus-9.4.zip
- FFA1EF94-ContractsWindowPlus-9.4.zip.sha1
- FFA1EF94-ContractsWindowPlus-9.4.zip.sha256

When we need to retrieve the hash, we check for these files in between checking our in-memory cache and computing the hashes based on the ZIPs.

This should speed up the first passes of the Inflator.