### PR TITLE
Don't fallback to Curl on 404, allow smaller GUI

### DIFF
--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -668,7 +668,7 @@
             this.KeyPreview = true;
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.MinimumSize = new System.Drawing.Size(1280, 700);
+            this.MinimumSize = new System.Drawing.Size(880, 400);
             this.Name = "Main";
             this.Resize += new System.EventHandler(this.Main_Resize);
             this.Icon = Properties.Resources.AppIcon;


### PR DESCRIPTION
## Problem

See #3083 for in-depth explanation.

In addition to issues noted there, the Curl fallback attempts **do not** use the bot's GitHub token, so they are prone to running out of rate limiting. They're bad news all around.

## Changes

Now we don't fall back to Curl if we get a response from the server, even if it's a failure. This will allow the first 404 to "stick", and the Discord spam will end. The Curl fallback will only happen if a problem occurs that prevents communication with the server.

Fixes #3083.

Now the GUI window is allowed to be smaller, because I had this change sitting in my working copy and it's so minor.