### PR TITLE
Use authToken for Curl

### DIFF
--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -124,7 +124,7 @@ namespace CKAN
                         {
                             string header  = string.Empty;
 
-                            var client = Curl.CreateEasy(url, stream, delegate(byte[] buf, int size, int nmemb, object extraData)
+                            var client = Curl.CreateEasy(url, null, stream, delegate(byte[] buf, int size, int nmemb, object extraData)
                             {
                                 header += Encoding.UTF8.GetString(buf);
                                 return size * nmemb;
@@ -288,7 +288,7 @@ namespace CKAN
                 string content = string.Empty;
                 string header  = string.Empty;
 
-                var client = Curl.CreateEasy(url.OriginalString,
+                var client = Curl.CreateEasy(url.OriginalString, authToken,
                     delegate (byte[] buf, int size, int nmemb, object extraData)
                     {
                         content += Encoding.UTF8.GetString(buf);

--- a/Tests/Core/Net/Net.cs
+++ b/Tests/Core/Net/Net.cs
@@ -67,7 +67,7 @@ namespace Tests.Core.Net
             // this test on that platform.
             if (Platform.IsWindows) return;
 
-            var curl = Curl.CreateEasy("https://example.com", (FileStream) null);
+            var curl = Curl.CreateEasy("https://example.com", null, (FileStream) null);
             Assert.IsTrue(curl.SslVerifyPeer, "We should enforce SSL");
         }
 


### PR DESCRIPTION
## Problem

During investigation of #3084, I noticed that the Curl fallback has no support for auth tokens. If Curl is to serve a useful role as a fallback, it should be able to handle the Inflator's network traffic without running into rate limiting issues, and that means auth tokens.

## Changes

Now Curl calls set the Authorization header just like the WebClient ones.