### PR TITLE
Change Bucket Upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,12 +51,12 @@ jobs:
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           ./build docker-inflator
       - name: Push to S3
-        # Send ckan.exe and netkan.exe to http://ckan-travis.s3-website-us-east-1.amazonaws.com/
+        # Send ckan.exe and netkan.exe to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --delete
+          args: --follow-symlinks --delete
         env:
-          AWS_S3_BUCKET: ckan-travis
+          AWS_S3_BUCKET: ksp-ckan
           AWS_ACCESS_KEY_ID: AKIAI5JWAEFPFK6GH3XA
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1


### PR DESCRIPTION
While we decide about the home for our build artifacts, we should move to using our own bucket.

 https://ksp-ckan.s3-us-west-2.amazonaws.com/

This will only contain the artifacts from this process, so the bucket policy has already been set accordingly.