### PR TITLE
Use Secrets for Usernames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
 
     - name: Install Mono
       run: |
-        sudo apt-get update
         sudo apt-get remove mono-complete --auto-remove --purge -y
-        sudo apt-get install -y gnupg ca-certificates
         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
         echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/${{ matrix.mono }} main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt-get update
+        sudo apt-get install -y gnupg ca-certificates
         sudo apt-get install -y mono-complete
     - name: Install runtime dependencies
       run: sudo apt-get install -y libcurl4-openssl-dev xvfb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,14 @@ jobs:
 
     - name: Install Mono
       run: |
-        sudo apt remove mono-complete --auto-remove --purge
-        sudo apt install --upgrade gnupg ca-certificates
+        sudo apt-get update
+        sudo apt-get remove mono-complete --auto-remove --purge -y
+        sudo apt-get install -y gnupg ca-certificates
         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
         echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/${{ matrix.mono }} main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt update
-        sudo apt install mono-complete
+        sudo apt-get install -y mono-complete
     - name: Install runtime dependencies
-      run: sudo apt install --upgrade libcurl4-openssl-dev xvfb
+      run: sudo apt-get install -y libcurl4-openssl-dev xvfb
     - name: Restore cache for _build/lib/nuget
       uses: actions/cache@v1
       with:
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Install runtime dependencies
-        run: sudo apt install --upgrade libcurl4-openssl-dev
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - uses: actions/checkout@v2
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Installing Mono
         run: |
           sudo apt-get remove -y mono-complete --auto-remove --purge
-          sudo apt-get update
-          sudo apt-get install -y gnupg ca-certificates
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/$RELEASE_MONO_VERSION main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          sudo apt-get update
+          sudo apt-get install -y gnupg ca-certificates
           sudo apt-get install -y mono-complete
       - name: Installing runtime dependencies
         run: sudo apt-get install -y libcurl4-openssl-dev xvfb

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,14 +16,14 @@ jobs:
 
       - name: Installing Mono
         run: |
-          sudo apt remove mono-complete --auto-remove --purge
-          sudo apt install --upgrade gnupg ca-certificates
+          sudo apt-get remove -y mono-complete --auto-remove --purge
+          sudo apt-get update
+          sudo apt-get install -y gnupg ca-certificates
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/$RELEASE_MONO_VERSION main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-          sudo apt update
-          sudo apt install mono-complete
+          sudo apt-get install -y mono-complete
       - name: Installing runtime dependencies
-        run: sudo apt install --upgrade libcurl4-openssl-dev xvfb
+        run: sudo apt-get install -y libcurl4-openssl-dev xvfb
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,9 +42,9 @@ jobs:
 
       - name: Generate Docker image and publish to Hub
         env:
-          DOCKERHUB_USERNAME: kspckanbuilder
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          AWS_ACCESS_KEY_ID: AKIAZA4K6RW77XSCAMI2
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-west-2
         run: |
@@ -57,7 +57,7 @@ jobs:
           args: --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: AKIAI5JWAEFPFK6GH3XA
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/repack/Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Installing Mono
         run: |
           sudo apt-get remove -y mono-complete --auto-remove --purge
-          sudo apt-get update
-          sudo apt-get install -y gnupg ca-certificates
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/$RELEASE_MONO_VERSION main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          sudo apt-get update
+          sudo apt-get install -y gnupg ca-certificates
           sudo apt-get install -y mono-complete
       - name: Installing build dependencies
         run: sudo apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,16 @@ jobs:
 
       - name: Installing Mono
         run: |
-          sudo apt remove mono-complete --auto-remove --purge
-          sudo apt install --upgrade gnupg ca-certificates
+          sudo apt-get remove -y mono-complete --auto-remove --purge
+          sudo apt-get update
+          sudo apt-get install -y gnupg ca-certificates
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/$RELEASE_MONO_VERSION main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-          sudo apt update
-          sudo apt install mono-complete
+          sudo apt-get install -y mono-complete
       - name: Installing build dependencies
-        run: sudo apt install --upgrade git make sed libplist-utils xorriso gzip fakeroot lintian rpm
+        run: sudo apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm
       - name: Installing runtime dependencies
-        run: sudo apt install --upgrade libcurl4-openssl-dev xvfb
+        run: sudo apt-get install -y libcurl4-openssl-dev xvfb
 
       - name: Build dmg
         run: ./build osx --configuration=Release


### PR DESCRIPTION
In the last PR I missed that the deploy username for S3 was still the old one, which caused the S3 deploy failure.

I also noticed NetCore failing, which is likely due to a stale apt cache. Converted to apt-get to remove this warning `WARNING: apt does not have a stable CLI interface. Use with caution in scripts.`