### PR TITLE
Don't run workflow steps that require secrets on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,12 @@ jobs:
       run: xvfb-run ./build test+only --configuration=${{ matrix.configuration }} --where="Category!=FlakyNetwork"
 
     - name: Send Discord Notification
-      if: failure()
       env:
         JOB_STATUS: ${{ job.status }}
         WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
         HOOK_OS_NAME: ${{ runner.os }}
         WORKFLOW_NAME: ${{ github.workflow }}
+      if: ${{ env.DISCORD_WEBHOOK && failure() }}
       run: |
         git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
         bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
@@ -92,12 +92,12 @@ jobs:
         run: ./build test+only --configuration=${{ matrix.configuration }}
 
       - name: Send Discord Notification
-        if: failure()
         env:
           JOB_STATUS: ${{ job.status }}
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
+        if: ${{ env.DISCORD_WEBHOOK && failure() }}
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-west-2
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD && env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           ./build docker-inflator
@@ -61,6 +62,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/repack/Release
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Send Discord Notification
         env:
@@ -68,6 +70,7 @@ jobs:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
+        if: ${{ env.DISCORD_WEBHOOK }}
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
+        if: ${{ env.DISCORD_WEBHOOK }}]
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
+++ b/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using CKAN;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Sources.Spacedock;
@@ -72,7 +73,7 @@ namespace Tests.NetKAN.Sources.Spacedock
             TestDelegate act = () => sut.GetMod(-1);
 
             // Assert
-            Assert.That(act, Throws.Exception.InstanceOf<Kraken>());
+            Assert.That(act, Throws.Exception.InstanceOf<WebException>());
         }
     }
 }


### PR DESCRIPTION
## Problem
Since #3085 we run CKAN's CI with GitHub Actions. An advantage of this is that they also run in forked repositories automatically, without the need to set up an external service.

However, this also leads the workflows trying to execute all the deployment steps and the Discord notification, which doesn't make sense in forked repos and will ultimately fail since the secrets needed to run these steps aren't available.

## Changes
This PR adds `if`s to all the steps that need secrets to work. These `if`s check whether the needed secrets are set, and if not, skip the step.

Also fixed one network test failing since #3084.