### PR TITLE
Be more specific in GUI config parse error

### DIFF
--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -149,7 +149,10 @@ namespace CKAN
                         throw;
                     }
 
-                    string message = string.Format(Properties.Resources.ConfigurationParseError, path, additionalErrorData);
+                    var fi = new FileInfo(path);
+                    string message = string.Format(
+                        Properties.Resources.ConfigurationParseError,
+                        path, additionalErrorData, fi.Name, fi.DirectoryName);
                     throw new Kraken(message);
                 }
             }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -129,7 +129,7 @@
   <data name="CompatibleKspVersionsDialogVersionDetails" xml:space="preserve"><value>{0} (vorherige Version: {1})</value></data>
   <data name="CompatibleKspVersionsDialogInvalidFormat" xml:space="preserve"><value>Ungültiges Versionsformat</value></data>
   <data name="CompatibleKspVersionsDialogErrorTitle" xml:space="preserve"><value>Fehler</value></data>
-  <data name="ConfigurationParseError" xml:space="preserve"><value>Fehler beim Versuch, "{0}"{1} zu parsen. Versuche es aus dem Ordner zu verschieben und CKAN neu zu starten.</value></data>
+  <data name="ConfigurationParseError" xml:space="preserve"><value>Fehler beim Versuch, "{0}"{1} zu parsen. Versuche {2} aus {3} zu verschieben und CKAN neu zu starten.</value></data>
   <data name="GUIModUnknown" xml:space="preserve"><value>Unbekannt</value></data>
   <data name="GUIModKSPCompatibilityLong" xml:space="preserve"><value>{0} (bei Mod-Version {1})</value></data>
   <data name="MainAutoUpdateFailed" xml:space="preserve">

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -129,7 +129,9 @@
   <data name="CompatibleKspVersionsDialogVersionDetails" xml:space="preserve"><value>{0} (vorherige Version: {1})</value></data>
   <data name="CompatibleKspVersionsDialogInvalidFormat" xml:space="preserve"><value>Ungültiges Versionsformat</value></data>
   <data name="CompatibleKspVersionsDialogErrorTitle" xml:space="preserve"><value>Fehler</value></data>
-  <data name="ConfigurationParseError" xml:space="preserve"><value>Fehler beim Versuch, "{0}"{1} zu parsen. Versuche {2} aus {3} zu verschieben und CKAN neu zu starten.</value></data>
+  <data name="ConfigurationParseError" xml:space="preserve"><value>Fehler beim Parsen von "{0}"{1}
+
+Versuche {2} aus {3} zu verschieben und CKAN neu zu starten.</value></data>
   <data name="GUIModUnknown" xml:space="preserve"><value>Unbekannt</value></data>
   <data name="GUIModKSPCompatibilityLong" xml:space="preserve"><value>{0} (bei Mod-Version {1})</value></data>
   <data name="MainAutoUpdateFailed" xml:space="preserve">

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -158,7 +158,7 @@
   <data name="CompatibleKspVersionsDialogVersionDetails" xml:space="preserve"><value>{0} (previous game version: {1})</value></data>
   <data name="CompatibleKspVersionsDialogInvalidFormat" xml:space="preserve"><value>Version has invalid format</value></data>
   <data name="CompatibleKspVersionsDialogErrorTitle" xml:space="preserve"><value>Error</value></data>
-  <data name="ConfigurationParseError" xml:space="preserve"><value>Error trying to parse "{0}"{1}. Try to move it out of the folder and restart CKAN.</value></data>
+  <data name="ConfigurationParseError" xml:space="preserve"><value>Error trying to parse "{0}"{1}. Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="GUIModNSlashA" xml:space="preserve"><value>N/A</value></data>
   <data name="GUIModUnknown" xml:space="preserve"><value>Unknown</value></data>
   <data name="GUIModMethodNotCKAN" xml:space="preserve"><value>Method can not be called unless IsCKAN</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -158,7 +158,8 @@
   <data name="CompatibleKspVersionsDialogVersionDetails" xml:space="preserve"><value>{0} (previous game version: {1})</value></data>
   <data name="CompatibleKspVersionsDialogInvalidFormat" xml:space="preserve"><value>Version has invalid format</value></data>
   <data name="CompatibleKspVersionsDialogErrorTitle" xml:space="preserve"><value>Error</value></data>
-  <data name="ConfigurationParseError" xml:space="preserve"><value>Error trying to parse "{0}"{1}. Try to move {2} out of {3} and restart CKAN.</value></data>
+  <data name="ConfigurationParseError" xml:space="preserve"><value>Error trying to parse "{0}"{1}
+Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="GUIModNSlashA" xml:space="preserve"><value>N/A</value></data>
   <data name="GUIModUnknown" xml:space="preserve"><value>Unknown</value></data>
   <data name="GUIModMethodNotCKAN" xml:space="preserve"><value>Method can not be called unless IsCKAN</value></data>


### PR DESCRIPTION
## Problem

Apparently this message is confusing:

![image](https://user-images.githubusercontent.com/1559108/85953943-927a8980-b939-11ea-8325-3070ea1d0a4b.png)

![image](https://user-images.githubusercontent.com/1559108/85953953-a0c8a580-b939-11ea-9b0c-e3ba4ac49e4d.png)

## Changes

Now 'it' is replaced with the file name and 'the folder' is replaced with the folder path. Hopefully this gives folks a clearer idea of what to do. I _think_ I got the change right for German, but maybe a "zum" needs to become a "zur" or something.

> CKAN.Kraken: Error trying to parse "/home/user/.local/share/Steam/steamapps/common/Kerbal Space Program/CKAN/GUIConfig.xml": Data at the root level is invalid. Line 2, position 1.. Try to move GUIConfig.xml out of /home/user/.local/share/Steam/steamapps/common/Kerbal Space Program/CKAN and restart CKAN.