### PR TITLE
Run workflows in Mono Docker containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,14 @@ jobs:
         mono: ['5.20', '6.4', '6.6', '6.8']
         configuration: [Debug, Release]
 
+    container:
+      image: mono:${{ matrix.mono }}
+
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Mono
-      run: |
-        sudo apt-get remove mono-complete --auto-remove --purge -y
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/${{ matrix.mono }} main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt-get update
-        sudo apt-get install -y gnupg ca-certificates
-        sudo apt-get install -y mono-complete
     - name: Install runtime dependencies
-      run: sudo apt-get install -y libcurl4-openssl-dev xvfb
+      run: apt-get update && apt-get install -y libcurl4-openssl-dev xvfb
     - name: Restore cache for _build/lib/nuget
       uses: actions/cache@v1
       with:
@@ -52,7 +47,7 @@ jobs:
         WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
         HOOK_OS_NAME: ${{ runner.os }}
         WORKFLOW_NAME: ${{ github.workflow }}
-      if: ${{ env.DISCORD_WEBHOOK && failure() }}
+      if: ${{ env.WEBHOOK_URL && failure() }}
       run: |
         git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
         bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
@@ -97,7 +92,7 @@ jobs:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
-        if: ${{ env.DISCORD_WEBHOOK && failure() }}
+        if: ${{ env.WEBHOOK_URL && failure() }}
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,19 +11,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    container:
+      image: mono:${{ env.RELEASE_MONO_VERSION }}
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Installing Mono
-        run: |
-          sudo apt-get remove -y mono-complete --auto-remove --purge
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-          echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/$RELEASE_MONO_VERSION main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-          sudo apt-get update
-          sudo apt-get install -y gnupg ca-certificates
-          sudo apt-get install -y mono-complete
       - name: Installing runtime dependencies
-        run: sudo apt-get install -y libcurl4-openssl-dev xvfb
+        run: apt-get update && apt-get install -y libcurl4-openssl-dev xvfb
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:
@@ -70,7 +65,7 @@ jobs:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
-        if: ${{ env.DISCORD_WEBHOOK }}
+        if: ${{ env.WEBHOOK_URL }}
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,21 +11,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    container:
+      image: mono:${{ env.RELEASE_MONO_VERSION }}
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Installing Mono
-        run: |
-          sudo apt-get remove -y mono-complete --auto-remove --purge
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-          echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic/snapshots/$RELEASE_MONO_VERSION main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-          sudo apt-get update
-          sudo apt-get install -y gnupg ca-certificates
-          sudo apt-get install -y mono-complete
       - name: Installing build dependencies
-        run: sudo apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm
+        run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm
       - name: Installing runtime dependencies
-        run: sudo apt-get install -y libcurl4-openssl-dev xvfb
+        run: apt-get install -y libcurl4-openssl-dev xvfb
 
       - name: Build dmg
         run: ./build osx --configuration=Release
@@ -93,7 +88,7 @@ jobs:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
-        if: ${{ env.DISCORD_WEBHOOK }}]
+        if: ${{ env.WEBHOOK_URL }}]
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL


### PR DESCRIPTION
## Motivation
The CI builds still take quite a long time to finish, since installing Mono takes around 10 minutes.
@techman83 had the excellent idea of running the builds in Docker containers from the images published [here](https://hub.docker.com/_/mono/?tab=tags&page=1).
Downloading the images should be way faster than installing and pre-compiling it.

## Changes
There exists a `container` keyword for workflow jobs: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer
If I understood the documentation correctly, it makes all steps of this job run in the specified container after pulling it from the Docker hub.
Let's see if it works.

Also realized that I messed up the Discord notifications in #3089 since the env var is named differently.