### PR TITLE
Deploy already built netkan.exe in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD && env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          ./build docker-inflator
+          ./build docker-inflator --exclusive
       - name: Push to S3
         # Send ckan.exe and netkan.exe to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
## Problem

Currently the Cake task to redeploy the Inflator rebuilds netkan.exe, after it has already been built in previous tasks.

## Cause

In a Makefile, filesystem timestamps are used to determine whether dependencies need to be rebuilt. For example, if we have this:

```Makefile
a: b
	cat b | sed -e s/b/a/g > a
```

And then we run `make a`, the `cat`/`sed` pipeline will only run if `b` is newer on disk than `a`. This is a really powerful feature for optimizing build times, since you can build up the tree of all of your project's dependencies and then a simple `make` command will only rebuild what needs to be rebuilt after your latest changes.

Cake instead seems to see each dependency as always needing to be executed, so when we do this:

https://github.com/KSP-CKAN/CKAN/blob/82587f5d61d4a6a7c75447abf83bed1b50008a89/build.cake#L48-L51

... it's _always_ going to rebuild netkan.exe regardless of how recently that was just done.

## Background

We aren't the first team to encounter this, naturally:

- cake-build/cake#2094

In response, the Cake team added an `--exclusive` parameter that skips a task's dependencies:

- cake-build/cake#2098

This isn't quite Makefile-level power, but it's useful for our problem.

## Changes

Now the deploy step uses `--exclusive` to skip its dependencies, which are already performed earlier in the build process. This means it will use the already-built netkan.exe file to rebuild the docker image.