### PR TITLE
Release date column

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -63,6 +63,7 @@
             this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.KSPCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SizeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ReleaseDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.InstallDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.DownloadCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -295,6 +296,7 @@
             this.LatestVersion,
             this.KSPCompatibility,
             this.SizeCol,
+            this.ReleaseDate,
             this.InstallDate,
             this.DownloadCount,
             this.Description});
@@ -398,6 +400,14 @@
             this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.SizeCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             resources.ApplyResources(this.SizeCol, "SizeCol");
+            //
+            // ReleaseDate
+            //
+            this.ReleaseDate.Name = "ReleaseDate";
+            this.ReleaseDate.ReadOnly = true;
+            this.ReleaseDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.ReleaseDate.Width = 140;
+            resources.ApplyResources(this.ReleaseDate, "ReleaseDate");
             //
             // InstallDate
             //
@@ -549,6 +559,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn LatestVersion;
         private System.Windows.Forms.DataGridViewTextBoxColumn KSPCompatibility;
         private System.Windows.Forms.DataGridViewTextBoxColumn SizeCol;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ReleaseDate;
         private System.Windows.Forms.DataGridViewTextBoxColumn InstallDate;
         private System.Windows.Forms.DataGridViewTextBoxColumn DownloadCount;
         private System.Windows.Forms.DataGridViewTextBoxColumn Description;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1161,8 +1161,9 @@ namespace CKAN
                 case 0: case 1:
                 case 2: case 3: return Sort(rows, CheckboxSorter);
                 case 9:         return Sort(rows, DownloadSizeSorter);
-                case 10:        return Sort(rows, InstallDateSorter);
-                case 11:        return Sort(rows, r => (r.Tag as GUIMod)?.DownloadCount ?? 0);
+                case 10:        return Sort(rows, ReleaseDateSorter);
+                case 11:        return Sort(rows, InstallDateSorter);
+                case 12:        return Sort(rows, r => (r.Tag as GUIMod)?.DownloadCount ?? 0);
             }
             return Sort(rows, DefaultSorter);
         }
@@ -1223,6 +1224,11 @@ namespace CKAN
         private long DownloadSizeSorter(DataGridViewRow row)
         {
             return (row.Tag as GUIMod)?.ToCkanModule()?.download_size ?? 0;
+        }
+
+        private long ReleaseDateSorter(DataGridViewRow row)
+        {
+            return -(row.Tag as GUIMod)?.ToModule().release_date?.Ticks ?? 0;
         }
 
         /// <summary>

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -179,6 +179,7 @@
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Latest version</value></data>
   <data name="KSPCompatibility.HeaderText" xml:space="preserve"><value>Max KSP version</value></data>
   <data name="SizeCol.HeaderText" xml:space="preserve"><value>Download</value></data>
+  <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Release date</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Install date</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloads</value></data>
   <data name="Description.HeaderText" xml:space="preserve"><value>Description</value></data>

--- a/GUI/Localization/de-DE/ManageMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ManageMods.de-DE.resx
@@ -175,6 +175,7 @@
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Neueste Version</value></data>
   <data name="KSPCompatibility.HeaderText" xml:space="preserve"><value>Max. KSP Version</value></data>
   <data name="SizeCol.HeaderText" xml:space="preserve"><value>Downloadgröße</value></data>
+  <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Veröffentlichungsdatum</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Installationsdatum</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloadanzahl</value></data>
   <data name="Description.HeaderText" xml:space="preserve"><value>Kurzbeschreibung</value></data>

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -339,10 +339,11 @@ namespace CKAN
             var downloadCount = new DataGridViewTextBoxCell() { Value = String.Format("{0:N0}", mod.DownloadCount) };
             var compat        = new DataGridViewTextBoxCell() { Value = mod.KSPCompatibility                       };
             var size          = new DataGridViewTextBoxCell() { Value = mod.DownloadSize                           };
+            var releaseDate   = new DataGridViewTextBoxCell() { Value = mod.ToModule().release_date                };
             var installDate   = new DataGridViewTextBoxCell() { Value = mod.InstallDate                            };
             var desc          = new DataGridViewTextBoxCell() { Value = mod.Abstract                               };
 
-            item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, size, installDate, downloadCount, desc);
+            item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, size, releaseDate, installDate, downloadCount, desc);
 
             selecting.ReadOnly     = selecting     is DataGridViewTextBoxCell;
             autoInstalled.ReadOnly = autoInstalled is DataGridViewTextBoxCell;

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -87,7 +87,7 @@ namespace Tests.GUI
             _listGui.Columns.Add(new DataGridViewCheckBoxColumn());
             _listGui.Columns.Add(new DataGridViewCheckBoxColumn());
             _listGui.Columns.Add(new DataGridViewCheckBoxColumn());
-            for (int i = 0; i < 9; i++)
+            for (int i = 0; i < 10; i++)
             {
                 _listGui.Columns.Add(i.ToString(), "Column" + i);
             }


### PR DESCRIPTION
## Motivation

One of my earliest memories of chatting on the CKAN thread is suggesting that a release date column shouldn't be that hard to add:

- https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1272-chandrasekhar/page/14/&tab=comments#comment-3076850

This is a pretty popular request and would allow users to see which mods have been updated recently. Here's another time it came up:

- https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1272-chandrasekhar/page/72/&tab=comments#comment-3624808

## Background

After #3059 the Netkan Inflator has collected a full round of release date metadata from GitHub and Jenkins, and SpaceDock is in progress pending the next run of the webhooks only pass. The only thing left is the UI.

## Changes

Now a new sortable "Release date" column appears in GUI, so users can tell how recently mods were updated.
I attempted a German translation with Google Translate.

Fixes #1155.
Fixes #1766.
Closes #2916.