### PR TITLE
Mark conflicts in initial recommendations

### DIFF
--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -31,6 +31,7 @@ namespace CKAN
                 RecommendedModsListView.Items.Clear();
                 RecommendedModsListView.Items.AddRange(
                     getRecSugRows(cache, recommendations, suggestions, supporters).ToArray());
+                MarkConflicts();
             });
         }
 
@@ -77,23 +78,28 @@ namespace CKAN
             }
             else
             {
-                var conflicts = FindConflicts();
-                foreach (var item in RecommendedModsListView.Items.Cast<ListViewItem>()
-                    // Apparently ListView handes AddRange by:
-                    //   1. Expanding the Items list to the new size by filling it with nulls
-                    //   2. One by one, replace each null with a real item and call _ItemChecked
-                    // ... so the Items list can contain null!!
-                    .Where(it => it != null))
-                {
-                    item.BackColor = conflicts.ContainsKey(item.Tag as CkanModule)
-                        ? Color.LightCoral
-                        : Color.Empty;
-                }
-                RecommendedModsContinueButton.Enabled = !conflicts.Any();
-                if (OnConflictFound != null)
-                {
-                    OnConflictFound(conflicts.Any() ? conflicts.First().Value : "");
-                }
+                MarkConflicts();
+            }
+        }
+        
+        private void MarkConflicts()
+        {
+            var conflicts = FindConflicts();
+            foreach (var item in RecommendedModsListView.Items.Cast<ListViewItem>()
+                // Apparently ListView handes AddRange by:
+                //   1. Expanding the Items list to the new size by filling it with nulls
+                //   2. One by one, replace each null with a real item and call _ItemChecked
+                // ... so the Items list can contain null!!
+                .Where(it => it != null))
+            {
+                item.BackColor = conflicts.ContainsKey(item.Tag as CkanModule)
+                    ? Color.LightCoral
+                    : Color.Empty;
+            }
+            RecommendedModsContinueButton.Enabled = !conflicts.Any();
+            if (OnConflictFound != null)
+            {
+                OnConflictFound(conflicts.Any() ? conflicts.First().Value : "");
             }
         }
 


### PR DESCRIPTION
## Problem

If you try to install RP-0 from before KSP-RO/RP-0#1303 and KSP-CKAN/CKAN-meta#2099, the install will fail on the conflict between RealAntennas and RemoteTech. But this happens in the install flow; the recommendations screen seems to think everything is fine, when it should be catching this conflict.

## Cause

The recommendations view was only checking for conflicts after the user clicked, presumably on the assumption that mods won't recommend conflicting modules. But they have!

## Changes

Now we check for conflicts right after we finish loading the recommendations. For those old RP-0 revisions, the rows are red right at the start.