### PR TITLE
Stop release Action if build of dmg, deb, or rpm fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,17 @@ jobs:
       - name: Installing runtime dependencies
         run: apt-get install -y libcurl4-openssl-dev xvfb
 
+      - name: Build ckan.exe
+        run: ./build --configuration=Release
+      - name: Run tests
+        run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
+
       - name: Build dmg
-        run: ./build osx --configuration=Release
+        run: ./build osx --configuration=Release --exclusive
       - name: Build deb
-        run: ./build deb --configuration=Release
+        run: ./build deb --configuration=Release --exclusive
       - name: Build rpm
-        run: ./build rpm --configuration=Release
+        run: ./build rpm --configuration=Release --exclusive
 
       - name: Get release data
         id: release_data

--- a/build.cake
+++ b/build.cake
@@ -94,47 +94,51 @@ Task("docker-inflator")
 Task("osx")
     .Description("Build the macOS(OSX) dmg package.")
     .IsDependentOn("Ckan")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { WorkingDirectory = "macosx" }));
+    .Does(() => MakeIn("macosx"));
 
 Task("osx-clean")
     .Description("Clean the output directory of the macOS(OSX) package.")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { Arguments = "clean", WorkingDirectory = "macosx" }));
+    .Does(() => MakeIn("macosx", "clean"));
 
 Task("deb")
     .Description("Build the deb package for Debian-based distros.")
     .IsDependentOn("Ckan")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { WorkingDirectory = "debian" }));
+    .Does(() => MakeIn("debian"));
 
 Task("deb-test")
     .Description("Test the deb packaging.")
     .IsDependentOn("deb")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { Arguments = "test", WorkingDirectory = "debian" }));
+    .Does(() => MakeIn("debian", "test"));
 
 Task("deb-clean")
     .Description("Clean the deb output directory.")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { Arguments = "clean", WorkingDirectory = "debian" }));
+    .Does(() => MakeIn("debian", "clean"));
 
 Task("rpm")
     .Description("Build the rpm package for RPM-based distros.")
     .IsDependentOn("Ckan")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { WorkingDirectory = "rpm" }));
+    .Does(() => MakeIn("rpm"));
 
 Task("rpm-test")
     .Description("Test the rpm packaging.")
     .IsDependentOn("Ckan")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { Arguments = "test", WorkingDirectory = "rpm" }));
+    .Does(() => MakeIn("rpm", "test"));
 
 Task("rpm-clean")
     .Description("Clean the rpm package output directory.")
-    .Does(() => StartProcess("make",
-        new ProcessSettings { Arguments = "clean", WorkingDirectory = "rpm" }));
+    .Does(() => MakeIn("rpm", "clean"));
+
+private void MakeIn(string dir, string args = null)
+{
+    int exitCode = StartProcess("make", new ProcessSettings {
+        WorkingDirectory = dir,
+        Arguments = args,
+    });
+    if (exitCode != 0)
+    {
+        throw new Exception("Make failed with exit code: " + exitCode);
+    }
+}
 
 Task("Restore-Nuget")
     .Description("Intermediate - Download dependencies with NuGet when building for .NET Framework.")


### PR DESCRIPTION
## Problem

Initial builds of v1.28.0-PRE1 failed in the step that deploys the RPM file, because RPM doesn't allow dashes in version names.

However, the RPM build step itself succeeded when it should have failed. The deploy only failed because the RPM file didn't exist.

## Cause

`StartProcess` returns the failed exit code, but `.Does(() => ...)` simply ignores it. Cake expects us to throw exceptions when builds fail.

```cake
    .Does(() => StartProcess("make",
        new ProcessSettings { WorkingDirectory = "rpm" }));
```

## Changes

- Now we throw an exception if our `make` commands return an exit status other than 0, which will stop everything
- For a small performance gain, we no longer re-build ckan.exe every time for the dmg, deb, and rpm tasks; instead we build once and then use the same artifact for all three, using the `--exclusive` flag from #3093.