### PR TITLE
Fix reinstallation of updated incompatible modules

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -970,10 +970,16 @@ namespace CKAN
         /// Will *re-install* or *downgrade* (with a warning) as well as upgrade.
         /// Throws ModuleNotFoundKraken if a module is not installed.
         /// </summary>
-        public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool enforceConsistency = true)
+        public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool enforceConsistency = true, bool resolveRelationships = false)
         {
             modules = modules.Memoize();
             User.RaiseMessage("About to upgrade...\r\n");
+            
+            if (resolveRelationships)
+            {
+                var resolver = new RelationshipResolver(modules, null, RelationshipResolver.DependsOnlyOpts(), registry_manager.registry, ksp.VersionCriteria());
+                modules = resolver.ModList();
+            }
 
             // Start by making sure we've downloaded everything.
             DownloadModules(modules, netAsyncDownloader);

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -205,32 +205,32 @@ Do you wish to reinstall now?", sb)))
                 // This is perfectly normal and shouldn't produce an error, therefore we skip enforcing
                 // consistency. However, we will show the user any inconsistencies later on.
 
-                // Use the identifiers so we use the overload that actually resolves relationships
                 // Do each changed module one at a time so a failure of one doesn't cause all the others to fail
-                foreach (string changedIdentifier in metadataChanges.Select(i => i.identifier))
+                foreach (CkanModule mod in metadataChanges)
                 {
                     try
                     {
                         HashSet<string> possibleConfigOnlyDirs = null;
                         installer.Upgrade(
-                            new[] { changedIdentifier },
+                            new CkanModule[] { mod },
                             new NetAsyncModulesDownloader(new NullUser(), cache),
                             ref possibleConfigOnlyDirs,
                             registry_manager,
-                            enforceConsistency: false
+                            enforceConsistency: false,
+                            resolveRelationships: true
                         );
                     }
                     // Thrown when a dependency couldn't be satisfied
                     catch (ModuleNotFoundKraken)
                     {
-                        log.WarnFormat("Skipping installation of {0} due to relationship error.", changedIdentifier);
-                        user.RaiseMessage("Skipping installation of {0} due to relationship error.", changedIdentifier);
+                        log.WarnFormat("Skipping installation of {0} due to relationship error.", mod.identifier);
+                        user.RaiseMessage("Skipping installation of {0} due to relationship error.", mod.identifier);
                     }
                     // Thrown when a conflicts relationship is violated
                     catch (InconsistentKraken)
                     {
-                        log.WarnFormat("Skipping installation of {0} due to relationship error.", changedIdentifier);
-                        user.RaiseMessage("Skipping installation of {0} due to relationship error.", changedIdentifier);
+                        log.WarnFormat("Skipping installation of {0} due to relationship error.", mod.identifier);
+                        user.RaiseMessage("Skipping installation of {0} due to relationship error.", mod.identifier);
                     }
                 }
             }

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -75,12 +75,7 @@ namespace CKAN
     {
         #region Fields and Properties
 
-        // This rather awful looking code is because while we write to install_time,
-        // we never read from it. That's cool, C#, because it *does* get serialised,
-        // and in the future we will read from it.
-        #pragma warning disable 0414
         [JsonProperty] private DateTime install_time;
-        #pragma warning restore 0414
 
         [JsonProperty] private CkanModule source_module;
 

--- a/Netkan/QueueAppender.cs
+++ b/Netkan/QueueAppender.cs
@@ -16,7 +16,5 @@ namespace CKAN.NetKAN
         }
 
         public List<string> Warnings = new List<string>();
-
-        public void Close() { }
     }
 }

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -27,7 +27,7 @@ namespace CKAN.NetKAN.Services
             {
                 return DownloadPackage(metadata.Download, metadata.Identifier, metadata.RemoteTimestamp);
             }
-            catch (Exception exc)
+            catch (Exception)
             {
                 var fallback = metadata.FallbackDownload;
                 if (fallback == null)

--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -82,7 +82,6 @@ namespace CKAN.NetKAN.Sources.Github
 
                         Uri       download = null;
                         DateTime? updated  = null;
-                        DateTime  parsed;
 
                         if (reference.UseSourceArchive)
                         {


### PR DESCRIPTION
## Problem

1. Install an incompatible module
2. Wait for it to be changed in CKAN-meta
3. Get this popup:
   ![screenshot](https://user-images.githubusercontent.com/1630166/84268861-5f8d6480-aaf6-11ea-8461-0c3d73036533.png)
4. Click Yes
5. It seems to reinstall
6. However, the next time there's a change to the metadata, it'll give you the same prompt for the same mod again, and again, and again...

## Cause

The repo update code has a specific `CkanModule` that it wants to re-install, but it only passes the identifier to force the relationships to be resolved, crossing its fingers that the same `CkanModule` will be found. But if the module is incompatible, then the attempt to find it via the identifier fails, and the relationship resolver falls back to the installed version:

https://github.com/KSP-CKAN/CKAN/blob/d0902a9c9c5cae5b1657161912528afe154ac39a/Core/ModuleInstaller.cs#L964-L965

⇒

https://github.com/KSP-CKAN/CKAN/blob/d0902a9c9c5cae5b1657161912528afe154ac39a/Core/Relationships/RelationshipResolver.cs#L137

⇒

https://github.com/KSP-CKAN/CKAN/blob/d0902a9c9c5cae5b1657161912528afe154ac39a/Core/Relationships/RelationshipResolver.cs#L161

⇒

https://github.com/KSP-CKAN/CKAN/blob/d0902a9c9c5cae5b1657161912528afe154ac39a/Core/Types/CkanModule.cs#L411-L412

This causes the already installed `CkanModule` to be installed again.

## Changes

Now `ModuleInstaller.Update` has a new `resolveRelationships` parameter that allows it to accept a `CkanModule` parameter _and_ resolve its relationships. The repo updater is updated to use this instead of retreating to identifiers with their attendant compatibility checks. This should force the reinstall to use the newly updated `CkanModule`.

Fixes #3073.