### PR TITLE
Don't prompt to delete SCANsat's settings at upgrade

### DIFF
--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -49,12 +49,14 @@ namespace CKAN.CmdLine
                     RegistryManager regMgr = RegistryManager.Instance(ksp);
                     ModuleInstaller inst      = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                     inst.ImportFiles(toImport, user, mod => toInstall.Add(mod.identifier), regMgr.registry, !opts.Headless);
+                    HashSet<string> possibleConfigOnlyDirs = null;
                     if (toInstall.Count > 0)
                     {
                         inst.InstallList(
                             toInstall,
                             new RelationshipResolverOptions(),
-                            regMgr
+                            regMgr,
+                            ref possibleConfigOnlyDirs
                         );
                     }
                     return Exit.OK;

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -135,8 +135,9 @@ namespace CKAN.CmdLine
                 // Install everything requested. :)
                 try
                 {
+                    HashSet<string> possibleConfigOnlyDirs = null;
                     var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
-                    installer.InstallList(modules, install_ops, regMgr);
+                    installer.InstallList(modules, install_ops, regMgr, ref possibleConfigOnlyDirs);
                     user.RaiseMessage("\r\n");
                     done = true;
                 }

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -71,7 +71,7 @@ namespace CKAN.ConsoleUI {
                         }
                         if (plan.Install.Count > 0) {
                             List<CkanModule> iList = new List<CkanModule>(plan.Install);
-                            inst.InstallList(iList, resolvOpts, regMgr, dl);
+                            inst.InstallList(iList, resolvOpts, regMgr, ref possibleConfigOnlyDirs, dl);
                             plan.Install.Clear();
                         }
                         if (plan.Replace.Count > 0) {

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -197,7 +197,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.InstallList(toInstall, opts.Value, registry_manager, downloader, false);
+                            installer.InstallList(toInstall, opts.Value, registry_manager, ref possibleConfigOnlyDirs, downloader, false);
                             processSuccessful = true;
                         }
                     }

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -443,7 +443,8 @@ namespace Tests.Core
                 // Attempt to install it.
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                HashSet<string> possibleConfigOnlyDirs = null;
+                CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
@@ -478,7 +479,8 @@ namespace Tests.Core
                 };
 
                 // Act
-                inst.InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                HashSet<string> possibleConfigOnlyDirs = null;
+                inst.InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 // Assert
                 Assert.IsTrue(File.Exists(mod_file_path));
@@ -511,13 +513,13 @@ namespace Tests.Core
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                HashSet<string> possibleConfigOnlyDirs = null;
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
 
                 // Attempt to uninstall it.
-                HashSet<string> possibleConfigOnlyDirs = null;
                 CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the module is not installed.
@@ -552,7 +554,8 @@ namespace Tests.Core
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                HashSet<string> possibleConfigOnlyDirs = null;
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 modules.Clear();
 
@@ -562,7 +565,7 @@ namespace Tests.Core
 
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 modules.Clear();
 
@@ -574,7 +577,6 @@ namespace Tests.Core
                 modules.Add(TestData.DogeCoinFlag_101_module().identifier);
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
-                HashSet<string> possibleConfigOnlyDirs = null;
                 CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the directory has been deleted.
@@ -613,7 +615,8 @@ namespace Tests.Core
                         // Attempt to install it.
                         List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
-                        CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                        HashSet<string> possibleConfigOnlyDirs = null;
+                        CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                         // Check that the module is installed.
                         string mod_file_path = Path.Combine(ksp.KSP.GameData(), mod_file_name);

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -47,10 +47,12 @@ namespace Tests.Core
             _registry.AddAvailable(_testModule);
             var testModFile = TestData.DogeCoinFlagZip();
             _manager.Cache.Store(_testModule, testModFile);
+            HashSet<string> possibleConfigOnlyDirs = null;
             _installer.InstallList(
                 new List<string>() { _testModule.identifier },
                 new RelationshipResolverOptions(),
-                _registryManager
+                _registryManager,
+                ref possibleConfigOnlyDirs
             );
         }
 

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -68,10 +68,12 @@ namespace Tests.GUI
             _registry.RegisterModule(_anyVersionModule, new string[] { }, _instance.KSP, false);
             _registry.AddAvailable(_anyVersionModule);
 
+            HashSet<string> possibleConfigOnlyDirs = null;
             ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                 new List<CkanModule> { { _anyVersionModule } },
                 new RelationshipResolverOptions(),
                 _registryManager,
+                ref possibleConfigOnlyDirs,
                 new NetAsyncModulesDownloader(_manager.User, _manager.Cache)
             );
 
@@ -137,11 +139,13 @@ namespace Tests.GUI
 
             Assert.DoesNotThrow(() =>
             {
+                HashSet<string> possibleConfigOnlyDirs = null;
                 // perform the install of the "other" module - now we need to sort
                 ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                     _modList.ComputeUserChangeSet(null).Select(change => change.Mod).ToList(),
                     new RelationshipResolverOptions(),
                     _registryManager,
+                    ref possibleConfigOnlyDirs,
                     new NetAsyncModulesDownloader(_manager.User, _manager.Cache)
                 );
 


### PR DESCRIPTION
## Problem

1. Install SCANsat v20.1
2. Use it; it will create `GameData/SCANsat/PluginData/Settings.cfg`
3. Upgrade to v20.2
4. You'll be asked whether to remove the PluginData folder, even though the mod is still installed
   ![image](https://user-images.githubusercontent.com/1559108/86942700-0facb800-c10b-11ea-857c-93a873c15d13.png)

## Cause

SCANsat creates PluginData as an empty folder and only uses it for saving its Settings.cfg, so it naturally meets the criteria for a removable config-only dir at uninstall. When we upgrade, we:

1. Remove the older version, which flags PluginData as potentially removable
2. Install the newer version, which creates the PluginData folder if it doesn't already exist but leaves it in the list of possibly removable dirs

## Changes

Now when we install a directory, we remove it from the list of empty directories to ask the user about. This removes the prompt from the upgrade flow but still presents it at uninstall.