### PR TITLE
Dependency/compatibility fixes

### DIFF
--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -24,11 +24,13 @@ namespace CKAN
             KspVersionCriteria crit,
             Dictionary<string, AvailableModule> available,
             Dictionary<string, HashSet<AvailableModule>> providers,
+            Dictionary<string, InstalledModule> installed,
             HashSet<string> dlls,
             IDictionary<string, ModuleVersion> dlc
         )
         {
             CompatibleVersions = crit;
+            this.installed = installed;
             this.dlls = dlls;
             this.dlc  = dlc;
             PartitionModules(available, CompatibleProviders(crit, providers));
@@ -62,6 +64,7 @@ namespace CKAN
         /// </summary>
         private readonly Stack<string> Investigating = new Stack<string>();
 
+        private readonly Dictionary<string, InstalledModule> installed;
         private readonly HashSet<string> dlls;
         private readonly IDictionary<string, ModuleVersion> dlc;
 
@@ -151,7 +154,7 @@ namespace CKAN
                     foreach (RelationshipDescriptor rel in m.depends)
                     {
                         bool foundCompat = false;
-                        if (rel.MatchesAny(null, dlls, dlc))
+                        if (rel.MatchesAny(installed.Select(kvp => kvp.Value.Module), dlls, dlc))
                         {
                             // Matches a DLL or DLC, cool
                             foundCompat = true;

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -710,6 +710,8 @@ namespace CKAN
         {
             SealionTransaction();
 
+            sorter = null;
+
             // But we also want to keep track of all its files.
             // We start by checking to see if any files are owned by another mod,
             // if so, we abort with a list of errors.
@@ -769,6 +771,8 @@ namespace CKAN
         public void DeregisterModule(KSP ksp, string module)
         {
             SealionTransaction();
+
+            sorter = null;
 
             var inconsistencies = new List<string>();
 
@@ -1265,6 +1269,7 @@ namespace CKAN
             {
                 sorter = new CompatibilitySorter(
                     versCrit, available_modules, providers,
+                    installed_modules,
                     InstalledDlls.ToHashSet(), InstalledDlc
                 );
             }


### PR DESCRIPTION
## Problems

- Modules with upgrades (Spectra) with incompatible dependencies (EVE) are shown as upgradeable, then display an error if you try to upgrade them
- Versions with incompatible dependencies (Spectra) are shown as installable in the Versions tab
- Force-installing an incompatible dependency (GPPTextures) doesn't make dependent modules (GPP) installable

## Causes

- `IRegistryQuerier.HasUpdate` doesn't check dependencies
- The Versions tab doesn't check dependencies
- `CompatibilitySorter` doesn't consider installed modules

## Changes

- Now `IRegistryQuerier.HasUpdate` and the Versions tab run `RelationshipResolver` if all of their other checks pass
- Now `CompatibilitySorter` takes the installed modules as a parameter and treats dependencies on them as satisfied
  - And the `CompatibilitySorter` is reset when a module is installed or uninstalled

Fixes #3101.

### Known limitations

Ideally, `Registry.LatestAvailable` would use `RelationshipResolver` as well. At this point I don't see a way to do that:

- `RelationshipResolver` itself uses `Registry.LatestAvailable` internally to find compatible modules, so we would have a sort of layering violation and a risk (likelihood?) of infinite recursion
- This would potentially be super slow, as logic that is currently simple and fast would be replaced with in-depth inspection of relationships (e.g., for every row of the GUI mod list)

Among other things this means that:

- The default install checkbox does **not** check relationships
- The above `HasUpdate` fix doesn't help with intermediate upates; if you install _two_ versions back, and the very latest version has incompatible dependencies but the one in between is fine, it won't be shown as upgradeable

Really we need an overhaul of how relationships and compatibility are handled. I think the `CompatibilitySorter` is a step towards this, and one possible path forward is to make it track version-specific compatibility rather than just `AvailableModule`-level. I have not attempted to do this here.