### PR TITLE
Sort GUI KSP version column correctly

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1273,8 +1273,16 @@ namespace CKAN
         /// </returns>
         private int KSPCompatComparison(DataGridViewRow a, DataGridViewRow b)
         {
-            KspVersion verA = ((GUIMod)a.Tag).KSPCompatibilityVersion;
-            KspVersion verB = ((GUIMod)b.Tag).KSPCompatibilityVersion;
+            KspVersion verA = ((GUIMod)a.Tag)?.KSPCompatibilityVersion;
+            KspVersion verB = ((GUIMod)b.Tag)?.KSPCompatibilityVersion;
+            if (verA == null)
+            {
+                return verB == null ? 0 : -1;
+            }
+            else if (verB == null)
+            {
+                return 1;
+            }
             var majorCompare = VersionPieceCompare(verA.IsMajorDefined, verA.Major, verB.IsMajorDefined, verB.Major);
             if (majorCompare != 0)
             {

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1160,6 +1160,7 @@ namespace CKAN
                 // XXX: There should be a better way to identify checkbox columns than hardcoding their indices here
                 case 0: case 1:
                 case 2: case 3: return Sort(rows, CheckboxSorter);
+                case 8:         return Sort(rows, KSPCompatComparison);
                 case 9:         return Sort(rows, DownloadSizeSorter);
                 case 10:        return Sort(rows, ReleaseDateSorter);
                 case 11:        return Sort(rows, InstallDateSorter);
@@ -1172,7 +1173,7 @@ namespace CKAN
         {
             var get_row_mod_name = new Func<DataGridViewRow, string>(row => ((GUIMod)row.Tag).Name);
             DataGridViewColumnHeaderCell header =
-                this.ModGrid.Columns[Main.Instance.configuration.SortByColumnIndex].HeaderCell;
+                ModGrid.Columns[Main.Instance.configuration.SortByColumnIndex].HeaderCell;
 
             // The columns will be sorted by mod name in addition to whatever the current sorting column is
             if (Main.Instance.configuration.SortDescending)
@@ -1183,6 +1184,48 @@ namespace CKAN
 
             header.SortGlyphDirection = SortOrder.Ascending;
             return rows.OrderBy(sortFunction).ThenBy(get_row_mod_name);
+        }
+
+        private IEnumerable<DataGridViewRow> Sort(IEnumerable<DataGridViewRow> rows, Comparison<DataGridViewRow> comparison)
+        {
+            DataGridViewColumnHeaderCell header =
+                ModGrid.Columns[Main.Instance.configuration.SortByColumnIndex].HeaderCell;
+
+            var descending = Main.Instance.configuration.SortDescending;
+            var newRows = rows.ToList();
+            header.SortGlyphDirection = descending
+                ? SortOrder.Descending
+                : SortOrder.Ascending;
+            // The columns will be sorted by mod name in addition to whatever the current sorting column is
+            newRows.Sort(CompareThenByName(comparison, descending));
+            return newRows;
+        }
+        
+        /// <summary>
+        /// Compare two rows, first by an arbitrary comparison, then by name
+        /// </summary>
+        /// <param name="comparison">First comparison to check</param>
+        /// <param name="descending">true to reverse the comparison, false to leave as-is</param>
+        /// <returns>
+        /// Wrapper around comparison parameter that falls back to checking name if equal
+        /// </returns>
+        private Comparison<DataGridViewRow> CompareThenByName(Comparison<DataGridViewRow> comparison, bool descending = false)
+        {
+            // If we check descending inside the lambda, it has to be checked for every row,
+            // which would be slightly slower. This way we build just the logic we need.
+            return descending
+                ? (Comparison<DataGridViewRow>)((DataGridViewRow a, DataGridViewRow b) =>
+                    {
+                        int result = comparison(a, b);
+                        return result != 0 ? -result
+                            : ((GUIMod)a.Tag).Name.CompareTo(((GUIMod)b.Tag).Name);
+                    })
+                : (DataGridViewRow a, DataGridViewRow b) =>
+                    {
+                        int result = comparison(a, b);
+                        return result != 0 ? result
+                            : ((GUIMod)a.Tag).Name.CompareTo(((GUIMod)b.Tag).Name);
+                    };
         }
 
         /// <summary>
@@ -1217,6 +1260,61 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// Compare two rows' KspVersions as max versions.
+        /// KspVersion.CompareTo sorts IsAny to the beginning instead
+        /// of the end, and we can't change that without breaking many things.
+        /// Similarly, 1.8 should sort after 1.8.0.
+        /// </summary>
+        /// <param name="a">First row to compare</param>
+        /// <param name="b">Second row to compare</param>
+        /// <returns>
+        /// Positive to sort as a lessthan b, negative to sort as b lessthan a
+        /// </returns>
+        private int KSPCompatComparison(DataGridViewRow a, DataGridViewRow b)
+        {
+            KspVersion verA = ((GUIMod)a.Tag).KSPCompatibilityVersion;
+            KspVersion verB = ((GUIMod)b.Tag).KSPCompatibilityVersion;
+            var majorCompare = VersionPieceCompare(verA.IsMajorDefined, verA.Major, verB.IsMajorDefined, verB.Major);
+            if (majorCompare != 0)
+            {
+                return majorCompare;
+            }
+            else
+            {
+                var minorCompare = VersionPieceCompare(verA.IsMinorDefined, verA.Minor, verB.IsMinorDefined, verB.Minor);
+                if (minorCompare != 0)
+                {
+                    return minorCompare;
+                }
+                else
+                {
+                    var patchCompare = VersionPieceCompare(verA.IsPatchDefined, verA.Patch, verB.IsPatchDefined, verB.Patch);
+                    return patchCompare != 0
+                        ? patchCompare
+                        : VersionPieceCompare(verA.IsBuildDefined, verA.Build, verB.IsBuildDefined, verB.Build);
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Compare pieces of two versions, each of which may be undefined,
+        /// sorting undefined toward the end.
+        /// </summary>
+        /// <param name="definedA">true if the first version piece is defined, false if undefined</param>
+        /// <param name="valA">Value of the first version piece</param>
+        /// <param name="definedB">true if the second version piece is defined, false if undefined</param>
+        /// <param name="valB">Value of the second version piece</param>
+        /// <returns>
+        /// Positive to sort a lessthan b, negative to sort b lessthan a
+        /// </returns>
+        private int VersionPieceCompare(bool definedA, int valA, bool definedB, int valB)
+        {
+            return definedA
+                ? (definedB ? valA.CompareTo(valB) : -1)
+                : (definedB ? 1                    :  0);
+        }
+        
         /// <summary>
         /// Transforms a DataGridViewRow into a long representing the download size,
         /// suitable for sorting.

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -174,8 +174,8 @@ namespace CKAN
             SearchableDescription = mod.SearchableDescription;
             SearchableAuthors     = mod.SearchableAuthors;
 
-            // If they hasn't been set in GUIMod(identifier, ...) (because the mod is not known to the registry,
-            // set them based on the the data we have from the CkanModule.
+            // If not set in GUIMod(identifier, ...) (because the mod is not known to the registry),
+            // set based on the the data we have from the CkanModule.
             if (KSPCompatibilityVersion == null)
             {
                 KSPCompatibilityVersion = mod.LatestCompatibleKSP();

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -79,6 +79,7 @@ namespace CKAN
         // These indicate the maximum KSP version that the maximum available
         // version of this mod can handle. The "Long" version also indicates
         // to the user if a mod upgrade would be required. (#1270)
+        public KspVersion KSPCompatibilityVersion { get; private set; }
         public string KSPCompatibility { get; private set; }
         public string KSPCompatibilityLong { get; private set; }
 
@@ -221,7 +222,8 @@ namespace CKAN
             // KSP.
             if (latest_available_for_any_ksp != null)
             {
-                KSPCompatibility = registry.LatestCompatibleKSP(identifier)?.ToYalovString()
+                KSPCompatibilityVersion = registry.LatestCompatibleKSP(identifier);
+                KSPCompatibility = KSPCompatibilityVersion?.ToYalovString()
                     ?? Properties.Resources.GUIModUnknown;
                 KSPCompatibilityLong = string.Format(Properties.Resources.GUIModKSPCompatibilityLong, KSPCompatibility, latest_available_for_any_ksp.version);
             }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -174,6 +174,19 @@ namespace CKAN
             SearchableDescription = mod.SearchableDescription;
             SearchableAuthors     = mod.SearchableAuthors;
 
+            // If they hasn't been set in GUIMod(identifier, ...) (because the mod is not known to the registry,
+            // set them based on the the data we have from the CkanModule.
+            if (KSPCompatibilityVersion == null)
+            {
+                KSPCompatibilityVersion = mod.LatestCompatibleKSP();
+                KSPCompatibility = KSPCompatibilityVersion?.ToYalovString() ?? Properties.Resources.GUIModUnknown;
+                KSPCompatibilityLong = string.Format(
+                    Properties.Resources.GUIModKSPCompatibilityLong,
+                    KSPCompatibility,
+                    mod.version
+                );
+            }
+
             UpdateIsCached();
         }
 
@@ -226,11 +239,6 @@ namespace CKAN
                 KSPCompatibility = KSPCompatibilityVersion?.ToYalovString()
                     ?? Properties.Resources.GUIModUnknown;
                 KSPCompatibilityLong = string.Format(Properties.Resources.GUIModKSPCompatibilityLong, KSPCompatibility, latest_available_for_any_ksp.version);
-            }
-            else
-            {
-                // No idea what this mod is, sorry!
-                KSPCompatibility = KSPCompatibilityLong = Properties.Resources.GUIModUnknown;
             }
 
             if (latest_version != null)


### PR DESCRIPTION
## Problem

If you sort by Max KSP version, 1.10 comes between 1.1 and 1.2, which is wrong.

![image](https://user-images.githubusercontent.com/1559108/87082517-c5056b80-c1f0-11ea-964b-fb001c85281c.png)

![image](https://user-images.githubusercontent.com/1559108/87082558-d3538780-c1f0-11ea-9a72-0ff61ad55552.png)

## Cause

Currently this column sorts as a string, which only works if the lexicographical sort order of the strings corresponds to the true sorting of the versions, which it doesn't.

## Changes

This gets a bit tricky. We need to expose the `GUIMod`'s `KspVersion` object, but we can't just sort _by_ that object naïvely, because `KspVersion.CompareTo` sorts undefined values inappropriately for upper bounds; it considers 1.8 < 1.8.0, and `any` < everything. We want the opposite, so we can't use `.OrderBy` or `.OrderByDescending` for this.

Instead, `ManageMods` now has an alternate `Sort` overload that takes a `Comparison<DataGridViewRow>`, which can handle comparisons _between two objects_ rather than just returning a sort key for one object. The KSP version column uses this `Sort` with a new function that treats undefined components of `KspVersion` as maximum rather than minimum. This causes the column to sort according to actual compatibility.

Fixes #3105.

### Quirks

Note that this logic makes finer distinctions in mod compatibility than the `.ToYalovString()` display function does. This means that the alphabetical fallback sorting may sometimes appear to reset unexpectedly. For example, consider this block of mods that all display as "1.10.9":

![image](https://user-images.githubusercontent.com/1559108/87082046-fe89a700-c1ef-11ea-8199-2e6a692d4e27.png)

The Versions tab reveals:

- SmokeScreen is compatible up to 1.10.90
- AblativeAirbrake through Tundra Technologies are compatible up to 1.10.99
- Astrogator is compatible up to 1.10

So while the column's strings are superficially the same, the introduction of a KSP 1.10.95 or KSP 1.10.100 would draw out real distinctions in their compatibility, which this sort order reflects.