### PR TITLE
Init Curl at netkan.exe and ckan.exe startup

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -55,6 +55,9 @@ namespace CKAN.CmdLine
             // This is on by default in .NET 4.6, but not in 4.5.
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
+            // Make sure Curl is all set up
+            Curl.Init();
+
             try
             {
                 return Execute(null, null, args);

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -5,10 +5,12 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using CommandLine;
+
 using log4net;
 using log4net.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Processors;
@@ -43,6 +45,9 @@ namespace CKAN.NetKAN
                     Console.WriteLine(Meta.GetVersion(VersionFormat.Full));
                     return ExitOk;
                 }
+
+                // Make sure Curl is all set up
+                Curl.Init();
 
                 if (!string.IsNullOrEmpty(Options.ValidateCkan))
                 {


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/87002947-512b7a80-c180-11ea-99c8-db65a98b5b90.png)

## Cause

`Curl.CreateEasy` requires that `Curl.Init()` be called; if it hasn't been, it will be at that point. Supposedly `Curl.Init()` isn't thread-safe, so `CreateEasy` will print a warning about this since it can't guarantee that it's not being executed in some complicated threading scenario.

Netkan falls afoul of this by not calling `Curl.Init()` till it's needed.

## Changes

Now we init Curl at netkan and ckan startup, which isn't in a complicated threading scenario, so the message won't appear anymore.

Fixes #1441.