### PR TITLE
Ignore missing DLL for libcurl

### DIFF
--- a/Core/Net/Curl.cs
+++ b/Core/Net/Curl.cs
@@ -32,7 +32,7 @@ namespace CKAN
                 CurlSharp.Curl.GlobalInit(CurlInitFlag.All);
                 _initComplete = true;
             }
-            catch (DllNotFoundException exc)
+            catch (DllNotFoundException)
             {
                 Log.Info("Curl initialization failed. Maybe you should install the DLL?\r\n\r\nhttps://github.com/KSP-CKAN/CKAN/wiki/libcurl");
             }

--- a/Core/Net/Curl.cs
+++ b/Core/Net/Curl.cs
@@ -27,8 +27,15 @@ namespace CKAN
                 Log.Info("Curl init already performed, not running twice");
                 return;
             }
-            CurlSharp.Curl.GlobalInit(CurlInitFlag.All);
-            _initComplete = true;
+            try
+            {
+                CurlSharp.Curl.GlobalInit(CurlInitFlag.All);
+                _initComplete = true;
+            }
+            catch (DllNotFoundException exc)
+            {
+                Log.Info("Curl initialization failed. Maybe you should install the DLL?\r\n\r\nhttps://github.com/KSP-CKAN/CKAN/wiki/libcurl");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

https://ci.ksp-ckan.space/job/NetKAN/9883/console

```
Fetching latest ckan.exe

Unhandled Exception:
System.DllNotFoundException: libcurl assembly:<unknown assembly> type:<unknown type> member:(null)
  at (wrapper managed-to-native) CurlSharp.NativeMethods.curl_global_init(int)
  at CurlSharp.Curl.GlobalInit (CurlSharp.CurlInitFlag flags) [0x00001] in <5257a4b91e0a46648a337ec8fa636dea>:0 
  at CKAN.Curl.Init () [0x00017] in <5257a4b91e0a46648a337ec8fa636dea>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x00091] in <5257a4b91e0a46648a337ec8fa636dea>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.DllNotFoundException: libcurl assembly:<unknown assembly> type:<unknown type> member:(null)
  at (wrapper managed-to-native) CurlSharp.NativeMethods.curl_global_init(int)
  at CurlSharp.Curl.GlobalInit (CurlSharp.CurlInitFlag flags) [0x00001] in <5257a4b91e0a46648a337ec8fa636dea>:0 
  at CKAN.Curl.Init () [0x00017] in <5257a4b91e0a46648a337ec8fa636dea>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x00091] in <5257a4b91e0a46648a337ec8fa636dea>:0 
Build step 'Execute shell' marked build as failure
```

The command that's failing is `mono ckan.exe version`.

## Cause

In #3107 we started calling `Curl.Init()` unconditionally at the start of ckan.exe and netkan.exe to suppress the "non-threadsafe init" message.

`Curl.Init()` throws that exception if libcurl isn't installed.

## Background

https://github.com/KSP-CKAN/CKAN/wiki/libcurl

> `libcurl` is a third party package that CKAN uses. It was required as of CKAN 1.6.6 and made optional in CKAN 1.22.2. Currently it is only used as a fallback if the main downloader fails. In normal use you should be able to get by without `libcurl`.

We just made it required again. That's no good.

## Changes

Now `Curl.Init()` doesn't care if the DLL isn't found.