### PR TITLE
Add author to list of required properties in CKAN.schema

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -319,6 +319,7 @@
     "required" : [
         "spec_version",
         "name",
+        "author",
         "abstract",
         "identifier",
         "license",

--- a/Spec.md
+++ b/Spec.md
@@ -133,16 +133,6 @@ are marked with **v1.2** through to **v1.26** respectively. For maximum
 compatibility, using older spec versions is preferred when newer features are
 not required.
 
-##### name
-
-This is the human readable name of the mod, and may contain any
-printable characters. Eg: "Ferram Aërospace Research (FAR)",
-"Real Solar System".
-
-##### abstract
-
-A short, one line description of the mod and what it does.
-
 ##### identifier
 
 This is the globally unique identifier for the mod, and is how the mod
@@ -158,6 +148,21 @@ identifier *should* be same as the ModuleManager name. For most mods,
 this means the identifier *should* be the name of the directory in
 `GameData` in which the mod would be installed, or the name of the `.dll`
 with any version and the `.dll` suffix removed.
+
+##### name
+
+This is the human readable name of the mod, and may contain any
+printable characters. Eg: "Ferram Aërospace Research (FAR)",
+"Real Solar System".
+
+##### abstract
+
+A short, one line description of the mod and what it does.
+
+##### author
+
+The author, or list of authors, for this mod. No restrictions are
+placed upon this field.
 
 ##### download
 
@@ -339,11 +344,6 @@ A typical install directive only has `file` and `install_to` sections:
 A comment field, if included, is ignored. It is not displayed to users,
 nor used by programs. Its primary use is to convey information to humans
 examining the CKAN file manually
-
-##### author
-
-The author, or list of authors, for this mod. No restrictions are
-placed upon this field.
 
 ##### description
 

--- a/Tests/NetKAN/Validators/CkanValidatorTests.cs
+++ b/Tests/NetKAN/Validators/CkanValidatorTests.cs
@@ -20,6 +20,7 @@ namespace Tests.NetKAN.Validators
             ValidCkan["identifier"] = "AwesomeMod";
             ValidCkan["name"] = "Awesome Mod";
             ValidCkan["abstract"] = "A great mod";
+            ValidCkan["author"] = "Phenomenal Author";
             ValidCkan["license"] = "GPL-3.0";
             ValidCkan["version"] = "1.0.0";
             ValidCkan["download"] = "https://www.awesome-mod.example/AwesomeMod.zip";

--- a/Tests/NetKAN/Validators/ObeysCKANSchemaValidatorTests.cs
+++ b/Tests/NetKAN/Validators/ObeysCKANSchemaValidatorTests.cs
@@ -20,6 +20,7 @@ namespace Tests.NetKAN.Validators
             TestCase(boringModule, "spec_version"),
             TestCase(boringModule, "identifier"),
             TestCase(boringModule, "name"),
+            TestCase(boringModule, "author"),
             TestCase(boringModule, "version"),
             TestCase(boringModule, "license"),
             TestCase(boringModule, "download"),
@@ -74,6 +75,7 @@ namespace Tests.NetKAN.Validators
             ""identifier"":   ""BoringModule"",
             ""name"":         ""Boring Module"",
             ""abstract"":     ""A minimal module that obeys CKAN.schema"",
+            ""author"":       ""Boring Author"",
             ""version"":      ""1.0.0"",
             ""license"":      ""MIT"",
             ""download"":     ""https://mysite.org/mymod.zip""


### PR DESCRIPTION
## Problem
Currrently the `author` property isn't required by the metadata schema. This doesn't make sense, a mod should _always_ have an author listed with it, for several reasons:
1) Users have a starting point finding a place for help if there's no forum thread or repo or anything in the resources.
2) It's without question that we should always give attribution to whoever made a mod. It's a thing of fairness and respect to list the mod author. And if we mirror the mod to archive.org, we are redistributing the mod, and almost all licenses require attribution to the author of some sort.
3) Authors might understandably get very upset if they see that their own mods don't list themselves as authors.

## Changes
Add `"author"` to the list of required properties for .ckan files.
This makes sure our indexer and the pull request validation scripts fail if it is missing.

## Notes
This came up as a result of the mirrorer failing to upload EarlyBird-0.2.1.0 since it was missing the author property(https://github.com/KSP-CKAN/NetKAN/pull/8037):
```
Uncaught exception:
Traceback (most recent call last):
  File ".local/bin/netkan", line 8, in <module>
    sys.exit(netkan())
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/cli/services.py", line 76, in mirrorer
    ).process_queue(common.queue, common.timeout)
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 331, in process_queue
    if self.try_mirror(CkanMirror(self.ia_collection, path)):
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/mirrorer.py", line 353, in try_mirror
    ckan.item_metadata,
  File "/home/netkan/.local/lib/python3.7/site-packages/netkan/metadata.py", line 284, in __getattr__
    raise AttributeError
AttributeError
```

There were some more ckans without an author in CKAN-meta, I've fixed them or frozen them.
```
$ grep -L "author" **/*.ckan
AdvancedJetEngine/AdvancedJetEngine-1.6.4.ckan
AdvancedJetEngine/AdvancedJetEngine-1.6.8.ckan
AdvancedJetEngine/AdvancedJetEngine-1.6.ckan
AdvancedJetEngine/AdvancedJetEngine-1.7a.ckan
CustomBiomes/CustomBiomes-1.6.8.ckan
DynamicBatteryStorage/DynamicBatteryStorage-1.0.0.ckan
EarlyBird/EarlyBird-0.1.5.0.ckan
EarlyBird/EarlyBird-0.1.6.0.ckan
EarlyBird/EarlyBird-0.1.7.0.ckan
EarlyBird/EarlyBird-0.2.0.0.ckan
kOS/kOS-0.14.ckan
PunishTheLazy/PunishTheLazy-0.01.ckan
ResetSAS/ResetSAS-0.01.ckan
RSSTextures2048/RealSolarSystemTextures_2048-1.0.ckan
RSSTextures4096/RealSolarSystemTextures_4096-1.0.ckan
RSSTextures8192/RealSolarSystemTextures_8192-1.0.ckan
RSSTexturesDDS2048/RSSTexturesDDS2048-1.0.ckan
RSSTexturesDDS4096/RSSTexturesDDS4096-1.0.ckan
RSSTexturesDDS8192/RSSTexturesDDS8192-1.0.ckan
SciFiVisualEnhancements/SciFiVisualEnhancements-v1.4.ckan
SciFiVisualEnhancements/SciFiVisualEnhancements-v1.5.ckan
```
