### PR TITLE
Delete authtoken when setting to null

### DIFF
--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -306,7 +306,14 @@ namespace CKAN.Configuration
         {
             lock (_lock)
             {
-                config.AuthTokens[host] = token;
+                if (string.IsNullOrEmpty(token))
+                {
+                    config.AuthTokens.Remove(host);
+                }
+                else
+                {
+                    config.AuthTokens[host] = token;
+                }
 
                 SaveConfig();
             }


### PR DESCRIPTION
## Problem
When deleting an auth token it sets the token itself to `null` but keeps it in our config which keeps it showing in the list.
**config.json :**
```
  "AuthTokens": {
    "GitHub": null
  },
```
**Settings dialog :**
![image](https://user-images.githubusercontent.com/8020752/87862919-8e98c080-c955-11ea-8ad2-239bb7b9b785.png)

## Changes
Now when pressing "Delete" or setting the token to `null` properly deletes the auth token.