### PR TITLE
Fix build from scratch on Windows 7

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -37,7 +37,7 @@ if (!(Test-Path "$NugetDir")) {
 
 if (!(Test-Path "$NugetExe")) {
     # Enable TLS1.2 for WebClient
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12 -bor [System.Net.SecurityProtocolType]::Tls13
     (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v${NugetVersion}/nuget.exe", $NugetExe)
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -36,6 +36,8 @@ if (!(Test-Path "$NugetDir")) {
 }
 
 if (!(Test-Path "$NugetExe")) {
+    # Enable TLS1.2 for WebClient
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
     (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v${NugetVersion}/nuget.exe", $NugetExe)
 }
 


### PR DESCRIPTION
## Problem

On Windows 7, delete the `_build` folder and try to build:

![image](https://user-images.githubusercontent.com/1559108/87880838-73c15d00-c9e4-11ea-9da0-00f16acf374c.png)

## Cause

Same as #2293, the script uses `WebClient` to download an HTTPS URL, but it doesn't support TLS1.2 by default, and nuget.org requires TLS1.2 as of April.

- https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe
- https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/

## Changes

Now we perform the PowerShell equivalent of #2297's change in the build script. This allows `WebClient` to download a modern HTTPS URL.