### PR TITLE
Cache build tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           path: _build/tools
           key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+      - name: Restore cache for _build/cake
+        uses: actions/cache@v1
+        with:
+          path: _build/cake
+          key: build-cake-${{ hashfiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/tools
-          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
       - name: Restore cache for _build/cake
         uses: actions/cache@v1
         with:
           path: _build/cake
-          key: build-cake-${{ hashfiles('build.cake') }}
+          key: build-cake-${{ hashFiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:
@@ -84,12 +84,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/tools
-          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
       - name: Restore cache for _build/cake
         uses: actions/cache@v1
         with:
           path: _build/cake
-          key: build-cake-${{ hashfiles('build.cake') }}
+          key: build-cake-${{ hashFiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,16 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.301'
+      - name: Restore cache for _build/tools
+        uses: actions/cache@v1
+        with:
+          path: _build/tools
+          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+      - name: Restore cache for _build/cake
+        uses: actions/cache@v1
+        with:
+          path: _build/cake
+          key: build-cake-${{ hashfiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,39 +21,44 @@ jobs:
       image: mono:${{ matrix.mono }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Installing build dependencies
-      run: apt-get update && apt-get install -y git
-    - name: Install runtime dependencies
-      run: apt-get install -y xvfb
-    - name: Restore cache for _build/lib/nuget
-      uses: actions/cache@v1
-      with:
-        path: _build/lib/nuget
-        key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
-    - name: Restore cache for ~/.nuget/packages
-      uses: actions/cache@v1
-      with:
-        path: ~/.nuget/packages
-        key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
+      - name: Installing build dependencies
+        run: apt-get update && apt-get install -y git
+      - name: Install runtime dependencies
+        run: apt-get install -y xvfb
+      - name: Restore cache for _build/tools
+        uses: actions/cache@v1
+        with:
+          path: _build/tools
+          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+      - name: Restore cache for _build/lib/nuget
+        uses: actions/cache@v1
+        with:
+          path: _build/lib/nuget
+          key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
+      - name: Restore cache for ~/.nuget/packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.nuget/packages
+          key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
 
-    - name: Build ckan.exe and netkan.exe
-      run: ./build --configuration=${{ matrix.configuration}}
-    - name: Run tests
-      run: xvfb-run ./build test+only --configuration=${{ matrix.configuration }} --where="Category!=FlakyNetwork"
+      - name: Build ckan.exe and netkan.exe
+        run: ./build --configuration=${{ matrix.configuration}}
+      - name: Run tests
+        run: xvfb-run ./build test+only --configuration=${{ matrix.configuration }} --where="Category!=FlakyNetwork"
 
-    - name: Send Discord Notification
-      env:
-        JOB_STATUS: ${{ job.status }}
-        WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-        HOOK_OS_NAME: ${{ runner.os }}
-        WORKFLOW_NAME: ${{ github.workflow }}
-      if: ${{ failure() && env.WEBHOOK_URL }}
-      run: |
-        git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
-        bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
-      shell: bash
+      - name: Send Discord Notification
+        env:
+          JOB_STATUS: ${{ job.status }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        if: ${{ failure() && env.WEBHOOK_URL }}
+        run: |
+          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+        shell: bash
 
 
   build_NetCore:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           path: _build/tools
           key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+      - name: Restore cache for _build/cake
+        uses: actions/cache@v1
+        with:
+          path: _build/cake
+          key: build-cake-${{ hashfiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,12 +26,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/tools
-          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
       - name: Restore cache for _build/cake
         uses: actions/cache@v1
         with:
           path: _build/cake
-          key: build-cake-${{ hashfiles('build.cake') }}
+          key: build-cake-${{ hashFiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,11 @@ jobs:
         run: |
           curl -fsSL https://get.docker.com -o get-docker.sh
           sh get-docker.sh
+      - name: Restore cache for _build/tools
+        uses: actions/cache@v1
+        with:
+          path: _build/tools
+          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,21 @@ jobs:
         run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq
       - name: Installing runtime dependencies
         run: apt-get install -y xvfb
+      - name: Restore cache for _build/tools
+        uses: actions/cache@v1
+        with:
+          path: _build/tools
+          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+      - name: Restore cache for _build/lib/nuget
+        uses: actions/cache@v1
+        with:
+          path: _build/lib/nuget
+          key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
+      - name: Restore cache for ~/.nuget/packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.nuget/packages
+          key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           path: _build/tools
           key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+      - name: Restore cache for _build/cake
+        uses: actions/cache@v1
+        with:
+          path: _build/cake
+          key: build-cake-${{ hashfiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/tools
-          key: build-tools-${{ hashfiles('build', 'build.ps1', 'build.cake') }}
+          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
       - name: Restore cache for _build/cake
         uses: actions/cache@v1
         with:
           path: _build/cake
-          key: build-cake-${{ hashfiles('build.cake') }}
+          key: build-cake-${{ hashFiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
- Now all build actions cache `_build/tools`
  - NuGet
  - NUnit
  - ILRepack
- Now all build actions cache `_build/cake`
  - Cake.SemVer
  - semver
  - Cake.Docker
- Now the release build step caches `_build/tools`, `_build/cake`, `_build/lib/nuget`, and `~/.nuget/packages`
- Indenting in the yml files is more consistent

This should allow quicker builds with fewer downloads.