### PR TITLE
Better message when ZipFile throws NotSupportedException

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -467,6 +467,12 @@ namespace CKAN
                 invalidReason = ex.Message;
                 return false;
             }
+            catch (NotSupportedException nse) when (Platform.IsMono)
+            {
+                // SharpZipLib throws this if your locale isn't installed on Mono
+                invalidReason = $"{nse.Message}\r\n\r\nInstall the `mono-complete` package or equivalent for your operating system.";
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

See #3066 and #3123; if Mono users in a non-en_US locale don't install `mono-complete`, this exception can be thrown:

```
System.NotSupportedException: Encoding 852 data could not be found. Make sure you have correct international codeset assembly installed and enabled.
  at System.Text.Encoding.GetEncoding (System.Int32 codepage) [0x0024d] in <12b418a7818c4ca0893feeaaf67f1e7f>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipConstants.ConvertToString (System.Byte[] data, System.Int32 count) [0x00017] in <29fa7683355b471a9cc202367184a830>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipConstants.ConvertToStringExt (System.Int32 flags, System.Byte[] data, System.Int32 count) [0x00032] in <29fa7683355b471a9cc202367184a830>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipFile.ReadEntries () [0x00312] in <29fa7683355b471a9cc202367184a830>:0 
  at ICSharpCode.SharpZipLib.Zip.ZipFile..ctor (System.String name) [0x0006b] in <29fa7683355b471a9cc202367184a830>:0 
  at CKAN.NetFileCache.ZipValid (System.String filename, System.String& invalidReason) [0x00003] in <29fa7683355b471a9cc202367184a830>:0 
```

## Cause

SharpZipLib apparently uses some kind of locale-specific code in its ZIP validation logic, which does not like being called without the locale data installed.

## Changes

Now we catch that exception on Mono and tell the user to install `mono-complete`. The mod installation will still fail, because we need to confirm the file is valid, and we can't do that if this is thrown.