### PR TITLE
Fix missing DLC registration gap

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -864,40 +864,30 @@ namespace CKAN
 
         public void RegisterDlc(string identifier, UnmanagedModuleVersion version)
         {
+            CkanModule dlcModule = null;
             if (available_modules.TryGetValue(identifier, out AvailableModule avail))
             {
-                CkanModule dlcModule = avail.ByVersion(version);
-                if (dlcModule != null)
-                {
-                    installed_modules.Add(
-                        dlcModule.identifier,
-                        new InstalledModule(null, dlcModule, new string[] { }, false)
-                    );
-                }
+                dlcModule = avail.ByVersion(version);
             }
-            else
+            if (dlcModule == null)
             {
                 // Don't have the real thing, make a fake one
-                installed_modules.Add(
-                    identifier,
-                    new InstalledModule(
-                        null,
-                        new CkanModule()
-                        {
-                            spec_version = new ModuleVersion("v1.28"),
-                            identifier   = identifier,
-                            name         = identifier,
-                            @abstract    = "An official expansion pack for KSP",
-                            author       = new List<string>() { "SQUAD" },
-                            version      = version,
-                            kind         = "dlc",
-                            license      = new List<License>() { new License("restricted") },
-                        },
-                        new string[] { },
-                        false
-                    )
-                );
+                dlcModule = new CkanModule()
+                {
+                    spec_version = new ModuleVersion("v1.28"),
+                    identifier   = identifier,
+                    name         = identifier,
+                    @abstract    = "An official expansion pack for KSP",
+                    author       = new List<string>() { "SQUAD" },
+                    version      = version,
+                    kind         = "dlc",
+                    license      = new List<License>() { new License("restricted") },
+                };
             }
+            installed_modules.Add(
+                identifier,
+                new InstalledModule(null, dlcModule, new string[] { }, false)
+            );
         }
 
         public void ClearDlc()


### PR DESCRIPTION
## Problem

Up until a few minutes ago, the v1.28.0 client thought nobody on KSP 1.10.x had any DLCs installed.
KSP-CKAN/CKAN-meta#2130 added the new DLC metadata to fix this, but in the meantime the client should have fallen back on mocked-up CkanModules to represent the DLC.

## Cause

The fallback code only runs in case the DLC **identifier** isn't found. If the identifier exists but the DLC version found on disk isn't available (99.99% of real world usages), then `RegisterDlc` does nothing.

## Changes

Now `RegisterDlc` **always** adds _something_ to the installed modules list. First it looks for the identifier and version in the available modules list, and if _either_ isn't found, then it makes the fake module, as intended.

Fixes #3135.