### PR TITLE
Satisfy dependencies with installed incompatible modules

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -576,7 +576,16 @@ namespace CKAN
             // in case a dependent depends on it
             compatible.Add(module.identifier);
 
-            var needed = module.depends.Select(depend => depend.LatestAvailableWithProvides(registry, kspversion));
+            // Get list of lists of dependency choices
+            var needed = module.depends
+                // Skip dependencies satisfied by installed modules
+                .Where(depend => !depend.MatchesAny(installed_modules, null, null))
+                .Select(depend => depend.LatestAvailableWithProvides(registry, kspversion));
+
+            log.DebugFormat("Trying to satisfy: {0}",
+                string.Join("; ", needed.Select(need =>
+                    string.Join(", ", need.Select(mod => mod.identifier)))));
+
             //We need every dependency to have at least one possible module
             var installable = needed.All(need => need.Any(mod => MightBeInstallable(mod, compatible)));
             compatible.Remove(module.identifier);

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -60,7 +60,7 @@ namespace CKAN
 
         // TODO: Is there a way to set the stringify version of this?
         public ModuleNotFoundKraken(string module, string version, string reason, Exception innerException = null)
-            : base(reason, innerException)
+            : base(reason ?? $"Dependency on {module} version {version} not satisfied", innerException)
         {
             this.module  = module;
             this.version = version;
@@ -91,7 +91,9 @@ namespace CKAN
         /// <param name="innerException">Originating exception parameter for base class</param>
         public DependencyNotSatisfiedKraken(CkanModule parentModule,
             string module, string version = null, string reason = null, Exception innerException = null)
-            : base(module, version, reason, innerException)
+            : base(module, version,
+                reason ?? $"{parentModule.identifier} dependency on {module} version {version ?? "(any)"} not satisfied",
+                innerException)
         {
             parent = parentModule;
         }


### PR DESCRIPTION
## Problem

If you force-install an incompatible module (with no compatible versions), then try to install a mod with a recommendation that depends on it, you get this in the recommendations screen:

```
CKAN.DependencyNotSatisfiedKraken: Exception of type 'CKAN.DependencyNotSatisfiedKraken' was thrown.
  at CKAN.RelationshipResolver.ResolveStanza (System.Collections.Generic.IEnumerable`1[T] stanza, CKAN.SelectionReason reason, CKAN.RelationshipResolverOptions options, System.Boolean soft_resolve, System.Collections.Generic.IEnumerable`1[T] old_stanza) [0x0038f] in /home/DasSkelett/git/CKAN/Core/Relationships/RelationshipResolver.cs:434 
  at CKAN.RelationshipResolver.Resolve (CKAN.CkanModule module, CKAN.RelationshipResolverOptions options, System.Collections.Generic.IEnumerable`1[T] old_stanza) [0x00038] in /home/DasSkelett/git/CKAN/Core/Relationships/RelationshipResolver.cs:318 
  at CKAN.RelationshipResolver.AddModulesToInstall (System.Collections.Generic.IEnumerable`1[T] modules) [0x00189] in /home/DasSkelett/git/CKAN/Core/Relationships/RelationshipResolver.cs:260 
  at CKAN.RelationshipResolver..ctor (System.Collections.Generic.IEnumerable`1[T] modulesToInstall, System.Collections.Generic.IEnumerable`1[T] modulesToRemove, CKAN.RelationshipResolverOptions options, CKAN.IRegistryQuerier registry, CKAN.Versioning.KspVersionCriteria kspversion) [0x00028] in /home/DasSkelett/git/CKAN/Core/Relationships/RelationshipResolver.cs:183 
  at CKAN.ChooseRecommendedMods.FindConflicts () [0x00001] in /home/DasSkelett/git/CKAN/GUI/Controls/ChooseRecommendedMods.cs:116 
  at CKAN.ChooseRecommendedMods.MarkConflicts () [0x00001] in /home/DasSkelett/git/CKAN/GUI/Controls/ChooseRecommendedMods.cs:87 
  at CKAN.ChooseRecommendedMods.RecommendedModsListView_ItemChecked (System.Object sender, System.Windows.Forms.ItemCheckedEventArgs e) [0x00045] in /home/DasSkelett/git/CKAN/GUI/Controls/ChooseRecommendedMods.cs:81 
  at System.Windows.Forms.ListView.OnItemChecked (System.Windows.Forms.ItemCheckedEventArgs e) [0x00019] in <f8d3988c81fd41129e6b0d880060d203>:0 
  at System.Windows.Forms.ListViewItem.set_Checked (System.Boolean value) [0x0006c] in <f8d3988c81fd41129e6b0d880060d203>:0 
```

If you try to install a mod that depends on the depending mod, without the recommendations step:

![image](https://user-images.githubusercontent.com/1559108/89598880-80034200-d84d-11ea-880b-b9380e33627a.png)

Somehow if you simply install a mod that depends on the manually installed mod, that works fine. No idea why, `RelationshipResolver` is magic. :stars: 

## Cause

`RelationshipResolver.MightBeInstallable`, which is used as the first-pass basic installability checker, only looks at compatible available modules to satisfy dependencies. It doesn't check installed modules at all.

## Changes

Now dependencies that are satisfied by an installed module will be treated as satisfied.

The `DependencyNotSatisfiedKraken` also has some more informative default reason messages.

Fixes #3134.