### PR TITLE
Don't fail modpack export when having unindexed mods installed

### DIFF
--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -116,7 +116,7 @@ namespace CKAN
         /// This includes DLLs, which will have a version type of `DllVersion`.
         /// This includes Provides if set, which will have a version of `ProvidesVersion`.
         /// </summary>
-        Dictionary<string, ModuleVersion> Installed(bool include_provides = true);
+        Dictionary<string, ModuleVersion> Installed(bool withProvides = true, bool withDLLs = true);
 
         /// <summary>
         /// Returns the InstalledModule, or null if it is not installed.

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -904,20 +904,23 @@ namespace CKAN
         /// <summary>
         /// <see cref = "IRegistryQuerier.Installed" />
         /// </summary>
-        public Dictionary<string, ModuleVersion> Installed(bool withProvides = true)
+        public Dictionary<string, ModuleVersion> Installed(bool withProvides = true, bool withDLLs = true)
         {
             var installed = new Dictionary<string, ModuleVersion>();
 
-            // Index our DLLs, as much as we dislike them.
-            foreach (var dllinfo in installed_dlls)
+            if (withDLLs)
             {
-                installed[dllinfo.Key] = new UnmanagedModuleVersion(null);
+                // Index our DLLs, as much as we dislike them.
+                foreach (var dllinfo in installed_dlls)
+                {
+                    installed[dllinfo.Key] = new UnmanagedModuleVersion(null);
+                }
             }
 
             // Index our provides list, so users can see virtual packages
             if (withProvides)
             {
-                foreach (var provided in Provided())
+                foreach (var provided in ProvidedByInstalled())
                 {
                     installed[provided.Key] = provided.Value;
                 }
@@ -948,14 +951,16 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Returns a dictionary of provided (virtual) modules, and a
-        /// ProvidesVersion indicating what provides them.
+        /// Find modules provided by currently installed modules
         /// </summary>
-
-        // TODO: In the future it would be nice to cache this list, and mark it for rebuild
-        // if our installed modules change.
-        internal Dictionary<string, ProvidesModuleVersion> Provided()
+        /// <returns>
+        /// Dictionary of provided (virtual) modules and a
+        /// ProvidesVersion indicating what provides them
+        /// </returns>
+        internal Dictionary<string, ProvidesModuleVersion> ProvidedByInstalled()
         {
+            // TODO: In the future it would be nice to cache this list, and mark it for rebuild
+            // if our installed modules change.
             var installed = new Dictionary<string, ProvidesModuleVersion>();
 
             foreach (var modinfo in installed_modules)
@@ -1001,7 +1006,7 @@ namespace CKAN
             // withProvides is false.
             if (!with_provides) return null;
 
-            var provided = Provided();
+            var provided = ProvidedByInstalled();
 
             ProvidesModuleVersion version;
             return provided.TryGetValue(modIdentifier, out version) ? version : null;

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -449,8 +449,19 @@ namespace CKAN
                 download_content_type = "application/zip",
             };
 
-            List<RelationshipDescriptor> mods = registry.Installed()
-                .Where(mod => !(mod.Value is ProvidesModuleVersion || mod.Value is UnmanagedModuleVersion))
+            List<RelationshipDescriptor> mods = registry.Installed(false, false)
+                .Where(kvp => {
+                    // Skip unavailable modules (custom .ckan files)
+                    try
+                    {
+                        var avail = registry.LatestAvailable(kvp.Key, null, null);
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                })
                 .Select(kvp => (RelationshipDescriptor) new ModuleRelationshipDescriptor()
                     {
                         name    = kvp.Key,

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -90,6 +90,20 @@ namespace CKAN
             }
 
             ignored.Clear();
+            // Find installed modules that aren't in the module's relationships
+            ignored.AddRange(registry.Installed(false, false)
+                .Where(kvp => {
+                    var ids = new string[] { kvp.Key };
+                    return !module.depends.Any(rel => rel.ContainsAny(ids))
+                        && !module.recommends.Any(rel => rel.ContainsAny(ids))
+                        && !module.suggests.Any(rel => rel.ContainsAny(ids));
+                })
+                .Select(kvp => (RelationshipDescriptor) new ModuleRelationshipDescriptor()
+                    {
+                        name    = kvp.Key,
+                        version = kvp.Value,
+                    })
+            );
             RelationshipsListView.Items.Clear();
             AddGroup(module.depends,    DependsGroup,         registry);
             AddGroup(module.recommends, RecommendationsGroup, registry);

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -1,10 +1,8 @@
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Text.RegularExpressions;
 using Autofac;
 using CKAN.Versioning;
 using CKAN.GameVersionProviders;
@@ -118,7 +116,9 @@ namespace CKAN
                         {
                             (r as ModuleRelationshipDescriptor)?.name,
                             (r as ModuleRelationshipDescriptor)?.version?.ToString(),
-                            registry.LatestAvailable((r as ModuleRelationshipDescriptor)?.name, null, null)?.@abstract
+                            registry.InstalledModules.First(
+                                im => im.identifier == (r as ModuleRelationshipDescriptor)?.name
+                            )?.Module.@abstract
                         })
                         {
                             Tag   = r,

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -521,16 +521,6 @@ namespace CKAN
                         continue;
                     }
 
-                    // Don't add metapacakges to the registry
-                    if (!module.IsMetapackage)
-                    {
-                        // Remove this version of the module in the registry, if it exists.
-                        registry_manager.registry.RemoveAvailable(module);
-
-                        // Sneakily add our version in...
-                        registry_manager.registry.AddAvailable(module);
-                    }
-
                     if (module.IsDLC)
                     {
                         currentUser.RaiseError(Properties.Resources.MainCantInstallDLC, module);


### PR DESCRIPTION
## Problem
When you have mods or mod versions installed that are not in the list of available modules ("DarkKAN modules"), the modpack export tab freezes.
This is caused by `registry.LatestAvailable()` in `AddGroup()` throwing an `ModuleNotFoundKraken` for unknown mods when trying to fetch the abstract for each installed mod.

## Changes
Now we search the registry for an `InstalledModule` with the given identifier, and use its abstract property. We should always have an `InstalledModule` for each module we're handling in the export logic, and if for some reason we haven't, it shouldn't break anything.

Fixes #3138 
...maybe, hard to say without the registry or any information about installed mods, but it solved it for me.
@mgalyean if you can still reproduce the problem and want to try a debug build of ckan.exe with this fix implemented, let me know and I can upload one. That way we could confirm that it does indeed solve your problem too.