### PR TITLE
Escape '&' in mod list, consistent path separators in exception

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -232,16 +232,16 @@
             this.FilterAllButton.Size = new System.Drawing.Size(307, 30);
             this.FilterAllButton.Click += new System.EventHandler(this.FilterAllButton_Click);
             resources.ApplyResources(this.FilterAllButton, "FilterAllButton");
-            // 
+            //
             // FilterTagsToolButton
-            // 
+            //
             this.FilterTagsToolButton.Name = "FilterTagsToolButton";
             this.FilterTagsToolButton.Size = new System.Drawing.Size(179, 22);
             resources.ApplyResources(this.FilterTagsToolButton, "FilterTagsToolButton");
             this.FilterTagsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterTagsToolButton_DropDown_Opening);
-            // 
+            //
             // FilterLabelsToolButton
-            // 
+            //
             this.FilterLabelsToolButton.Name = "FilterLabelsToolButton";
             this.FilterLabelsToolButton.Size = new System.Drawing.Size(179, 22);
             resources.ApplyResources(this.FilterLabelsToolButton, "FilterLabelsToolButton");
@@ -264,9 +264,9 @@
             this.NavForwardToolButton.Size = new System.Drawing.Size(44, 56);
             this.NavForwardToolButton.Click += new System.EventHandler(this.NavForwardToolButton_Click);
             resources.ApplyResources(this.NavForwardToolButton, "NavForwardToolButton");
-            // 
+            //
             // EditModSearch
-            // 
+            //
             this.EditModSearch.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.EditModSearch.ApplySearch += EditModSearch_ApplySearch;
             this.EditModSearch.SurrenderFocus += EditModSearch_SurrenderFocus;

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -152,7 +152,7 @@ namespace CKAN
                     var fi = new FileInfo(path);
                     string message = string.Format(
                         Properties.Resources.ConfigurationParseError,
-                        path, additionalErrorData, fi.Name, fi.DirectoryName);
+                        fi.FullName, additionalErrorData, fi.Name, fi.DirectoryName);
                     throw new Kraken(message);
                 }
             }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -312,8 +312,8 @@ namespace CKAN
                     Value = "-"
                 };
 
-            var name   = new DataGridViewTextBoxCell() {Value = mod.Name};
-            var author = new DataGridViewTextBoxCell() {Value = mod.Authors};
+            var name   = new DataGridViewTextBoxCell { Value = mod.Name   .Replace("&", "&&") };
+            var author = new DataGridViewTextBoxCell { Value = mod.Authors.Replace("&", "&&") };
 
             var installVersion = new DataGridViewTextBoxCell()
             {
@@ -336,12 +336,12 @@ namespace CKAN
                         : mod.LatestVersion)
             };
 
-            var downloadCount = new DataGridViewTextBoxCell() { Value = String.Format("{0:N0}", mod.DownloadCount) };
-            var compat        = new DataGridViewTextBoxCell() { Value = mod.KSPCompatibility                       };
-            var size          = new DataGridViewTextBoxCell() { Value = mod.DownloadSize                           };
-            var releaseDate   = new DataGridViewTextBoxCell() { Value = mod.ToModule().release_date                };
-            var installDate   = new DataGridViewTextBoxCell() { Value = mod.InstallDate                            };
-            var desc          = new DataGridViewTextBoxCell() { Value = mod.Abstract                               };
+            var downloadCount = new DataGridViewTextBoxCell { Value = $"{mod.DownloadCount:N0}"       };
+            var compat        = new DataGridViewTextBoxCell { Value = mod.KSPCompatibility            };
+            var size          = new DataGridViewTextBoxCell { Value = mod.DownloadSize                };
+            var releaseDate   = new DataGridViewTextBoxCell { Value = mod.ToModule().release_date     };
+            var installDate   = new DataGridViewTextBoxCell { Value = mod.InstallDate                 };
+            var desc          = new DataGridViewTextBoxCell { Value = mod.Abstract.Replace("&", "&&") };
 
             item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, size, releaseDate, installDate, downloadCount, desc);
 


### PR DESCRIPTION
## Problems
Ampersands (`&`) in mod names or abstracts in the mod list are currently interpreted as hint to create automatic keyboard shortcuts (visualized through underscores), instead of printing them as literal.
See for example the mod `DumpAndBurn`, with the name `Dump&Burn!`:
![unescaped-ampersand](https://user-images.githubusercontent.com/28812678/92311936-172df780-efbc-11ea-9bcf-0ada28ee4e59.png)

Error messages of krakens thrown while trying to load the `GUIConfig.xml` have a mix of `/` and `\` as path seperators on Windows, like:
```
Unhandled Exception:
CKAN.Kraken: Error trying to parse "c:/program files(x86)/steam/SteamApps/common/Kerbal Space Program/CKAN\GUIConfig.xml": Root element missing.
```

## Changes
The texts in the name, author and abstract are now escaped using `&&` in `ModList.MakeRow()`. I didn't spot another location where they would need escaping (tested recommendation tab and modpack export tab).

The exception about broken `GUIConfig.xml` files now gets the path string from a `FileInfo` object, which should always be formatted consistently and correctly for the user's OS.