### PR TITLE
Extend -single-instance fix to 1.10

### DIFF
--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -541,7 +541,7 @@ namespace CKAN
 
                     InstallModuleDriver(registry_manager.registry, module);
                 }
-                registry_manager.Save(true);                        
+                registry_manager.Save(true);
             }
         }
 
@@ -704,7 +704,7 @@ namespace CKAN
             {
                 var brokenVersionRange = new KspVersionRange(
                     new KspVersion(1, 8),
-                    new KspVersion(1, 9)
+                    new KspVersion(1, 10)
                 );
                 split = filterCmdLineArgs(split, brokenVersionRange, "-single-instance");
             }


### PR DESCRIPTION
Continuation of #3001 

Forum user steve_v reported that this is still needed for KSP 1.10, and testing confirmed that.
The user also complained about CKAN eating stderr, and for some reason the line about the directory change and the line about the segfault we saw previously is now longer printed, but I don't think this due to a change on our side, is it?

```
Found path: /NAS/games/KubuntuGames/steamapps/common/Kerbal Space Program/./KSP.x86_64
```

Anyways, we now filter `-single-instance` for KSP 1.10 too.