### PR TITLE
Remove invalid zip files in NetKAN

### DIFF
--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using log4net;
 using CKAN.NetKAN.Model;
 
@@ -88,7 +89,8 @@ namespace CKAN.NetKAN.Services
                         string invalidReason;
                         if (!NetFileCache.ZipValid(downloadedFile, out invalidReason))
                         {
-                            log.Debug($"{downloadedFile} is not a valid ZIP file: {invalidReason}");
+                            log.Debug($"{url} is not a valid ZIP file: {invalidReason}");
+                            File.Delete(downloadedFile);
                             throw new Kraken($"{url} is not a valid ZIP file: {invalidReason}");
                         }
                         break;
@@ -114,7 +116,7 @@ namespace CKAN.NetKAN.Services
         {
             return TryGetCached(url, () => Net.DownloadText(url, authToken, mimeType));
         }
-        
+
         private string TryGetCached(Uri url, Func<string> uncached)
         {
             if (_stringCache.TryGetValue(url, out StringCacheEntry entry))
@@ -153,5 +155,5 @@ namespace CKAN.NetKAN.Services
         public string   Value;
         public DateTime Timestamp;
     }
-    
+
 }

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -47,7 +47,7 @@ namespace CKAN.NetKAN.Transformers
                 new VersionEditTransformer(),
                 new ForcedVTransformer(),
                 new EpochTransformer(),
-                // This is the "default" VersionedOverrideTransformer for compatability with overrides that don't
+                // This is the "default" VersionedOverrideTransformer for compatibility with overrides that don't
                 // specify a before or after property.
                 new VersionedOverrideTransformer(before: new string[] { null }, after: new string[] { null }),
                 new DownloadAttributeTransformer(http, fileService),


### PR DESCRIPTION
## Problem
Invalid zip files that fail the `ZipValid` check fill up the bot's disk over time. The tempfiles but never get removed or moved into the cache, thus filling the disk with every indexer run.
In contrast, files failing to download at all get removed immediately, and files failing inflation later on are still stay in the cache and don't get redownloaded for the next try.

## Changes
Simply remove the file if it fails the `ZipValid` check.

This has a downside when using netkan manually, if one would want to investigate the zip file after netkan fails (I remember [my comment](https://github.com/KSP-CKAN/CKAN/pull/2903#issuecomment-546433290)...). Now you have to download the file manually again to check it out.
I tried to think of an easy solution, like keeping the file if `--debug` is set, but as of right now we don't save that anywhere globally accessible in netkan.
I think it's worth it though, and not every mod is as big as HumanStuff, so redownloading the file manually isn't much of a deal usually.