### PR TITLE
Convert remote timestamp to UTC in NetKAN to fix comparisons

### DIFF
--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -114,7 +114,7 @@ namespace CKAN.NetKAN.Model
             if (json.TryGetValue(UpdatedPropertyName, out updatedToken)
                 && DateTime.TryParse(updatedToken.ToString(), out t))
             {
-                RemoteTimestamp = t;
+                RemoteTimestamp = t.ToUniversalTime();
             }
         }
 


### PR DESCRIPTION
## Problem
Trying to inflate HumanStuff locally shortly after a new version got uploaded, I noticed netkan.exe being stuck in a download loop. Running it with debug logging showed, that the freshly downloaded file got repeatedly purged from the cache again because it was "stale".
The check happens here:
https://github.com/KSP-CKAN/CKAN/blob/0195a054c6dec35ea01d59da0aad28d1d5fccf65/Core/Net/NetFileCache.cs#L208-L211
However the `release_date` property contained the correct time with the correct timezone, and the file modification time C# got was also correct with the correct timezone.

## Cause
Turns out: Microsoft went once again completely insane, and decided comparisons of timezone-aware DateTime objects should ignore the timezones.
>To determine the relationship of t1 to t2, the Compare method compares the Ticks property of t1 and t2 but ignores their Kind property. Before comparing DateTime objects, ensure that the objects represent times in the same time zone.

https://docs.microsoft.com/en-us/dotnet/api/system.datetime.compare?view=netframework-4.7.2#remarks

## Changes
To compensate for that ridiculousness, the `DateTime` object parsed from the JSON data is now converted to UTC before being assigned to `RemoteTimestamp`, which already happens with the file modification time.

I also thought about converting the timestamps returned by the APIs before writing them into the JSON, ~~but IMHO it would be nice to keep them, and it would also require changes in more codepaths.


I couldn't spot another place where we are comparing timestamps that would need an update.