### PR TITLE
Print message for unknown install exception

### DIFF
--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -370,6 +370,10 @@ namespace CKAN
                         currentUser.RaiseMessage(dlcMsg);
                         currentUser.RaiseError(dlcMsg);
                         break;
+
+                    default:
+                        currentUser.RaiseMessage(e.Error.Message);
+                        break;
                 }
 
                 FailWaitDialog(


### PR DESCRIPTION
## Problem

We have had a few reports of installation failing without any info about the reason for the failure (see #3143, #3144, #3150):

![image](https://user-images.githubusercontent.com/1559108/94956261-7eeb3b80-04b1-11eb-958b-5b06537e3943.png)

That should never happen. Either the install should succeed, or we should see an indication of the reason it failed.

## Cause

An exception is thrown during install, but `PostInstall` only prints messages for certain specific exception types. If the exception is something else, it won't be logged.

Unfortunately when we've sent a test build, the error went away, so the actual error is probably already fixed in master HEAD. We just don't know when or what it was, due to the lack of an error message.

Probably caused by the refactor of the install flow in #3041, when error printing was moved from `InstallMods` to `PostInstall` and `PostInstall` was simplified. I tried to keep the code functionally equivalent, but it was kind of spaghetti-ish so it's possible I missed a use case.

## Changes

Now if `PostInstall` encounters an exception it doesn't recognize, we print the exception's `Message` property. This means that even if a really weird error happens, we'll have at least a basic clue of what it was.

Fixes #3143. Fixes #3144. Fixes #3150.
(The exception thrown in these seems to have been fixed already, but now we're fixing the part where you can't see it.)