### PR TITLE
ConsoleUI fixes for DLC

### DIFF
--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -104,10 +104,13 @@ namespace CKAN.ConsoleUI {
             AddBinding(Keys.Escape, (object sender) => false);
 
             AddTip("Ctrl+D", "Download",
-                () => !manager.Cache.IsMaybeCachedZip(mod)
+                () => !manager.Cache.IsMaybeCachedZip(mod) && !mod.IsDLC
             );
             AddBinding(Keys.CtrlD, (object sender) => {
-                Download();
+                if (!mod.IsDLC)
+                {
+                    Download();
+                }
                 return true;
             });
 

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -149,6 +149,20 @@ namespace CKAN.ConsoleUI {
                         () => LaunchURL(mod.resources.curse)
                     ));
                 }
+                if (mod.resources.store != null) {
+                    opts.Add(new ConsoleMenuOption(
+                        "Store",      "", "Open the Store URL in a browser",
+                        true,
+                        () => LaunchURL(mod.resources.store)
+                    ));
+                }
+                if (mod.resources.steamstore != null) {
+                    opts.Add(new ConsoleMenuOption(
+                        "Steam Store", "", "Open the Steam Store URL in a browser",
+                        true,
+                        () => LaunchURL(mod.resources.steamstore)
+                    ));
+                }
                 if (debug) {
                     opts.Add(null);
                     opts.Add(new ConsoleMenuOption(
@@ -472,7 +486,7 @@ namespace CKAN.ConsoleUI {
 
         private string HostedOn()
         {
-            string dl = mod.download.ToString();
+            string dl = mod.download?.ToString() ?? "";
             foreach (var kvp in hostDomains) {
                 if (dl.IndexOf(kvp.Key, StringComparison.CurrentCultureIgnoreCase) >= 0) {
                     return $"Hosted on {kvp.Value}";
@@ -503,8 +517,19 @@ namespace CKAN.ConsoleUI {
                         }
                     }
                 }
+
+                if (mod.resources.store != null || mod.resources.steamstore != null) {
+                    List<string> stores = new List<string>();
+                    if (mod.resources.store != null) {
+                        stores.Add("KSP store");
+                    }
+                    if (mod.resources.steamstore != null) {
+                        stores.Add("Steam store");
+                    }
+                    return $"Buy from {string.Join(" or ", stores)}";
+                }
             }
-            return mod.download.Host;
+            return mod.download?.Host ?? "";
         }
 
         private void Download()

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -167,11 +167,11 @@ namespace CKAN.ConsoleUI {
             // Conditionally show only one of these based on selected mod status
 
             moduleList.AddTip("+", "Install",
-                () => moduleList.Selection != null
+                () => moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && !registry.IsInstalled(moduleList.Selection.identifier, false)
             );
             moduleList.AddTip("+", "Upgrade",
-                () => moduleList.Selection != null
+                () => moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && registry.HasUpdate(moduleList.Selection.identifier, manager.CurrentInstance.VersionCriteria())
             );
             moduleList.AddTip("+", "Replace",
@@ -179,7 +179,7 @@ namespace CKAN.ConsoleUI {
                     && registry.GetReplacement(moduleList.Selection.identifier, manager.CurrentInstance.VersionCriteria()) != null
             );
             moduleList.AddBinding(Keys.Plus, (object sender) => {
-                if (moduleList.Selection != null) {
+                if (moduleList.Selection != null && !moduleList.Selection.IsDLC) {
                     if (!registry.IsInstalled(moduleList.Selection.identifier, false)) {
                         plan.ToggleInstall(moduleList.Selection);
                     } else if (registry.IsInstalled(moduleList.Selection.identifier, false)
@@ -193,12 +193,12 @@ namespace CKAN.ConsoleUI {
             });
 
             moduleList.AddTip("-", "Remove",
-                () => moduleList.Selection != null
+                () => moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && registry.IsInstalled(moduleList.Selection.identifier, false)
                     && !registry.IsAutodetected(moduleList.Selection.identifier)
             );
             moduleList.AddBinding(Keys.Minus, (object sender) => {
-                if (moduleList.Selection != null
+                if (moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && registry.IsInstalled(moduleList.Selection.identifier, false)
                     && !registry.IsAutodetected(moduleList.Selection.identifier)) {
                     plan.ToggleRemove(moduleList.Selection);

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -207,16 +207,16 @@ namespace CKAN.ConsoleUI {
             });
             
             moduleList.AddTip("F8", "Mark auto-installed",
-                () => moduleList.Selection != null
+                () => moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && (!registry.InstalledModule(moduleList.Selection.identifier)?.AutoInstalled ?? false)
             );
             moduleList.AddTip("F8", "Mark user-selected",
-                () => moduleList.Selection != null
+                () => moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && (registry.InstalledModule(moduleList.Selection.identifier)?.AutoInstalled ?? false)
             );
             moduleList.AddBinding(Keys.F8, (object sender) => {
                 InstalledModule im = registry.InstalledModule(moduleList.Selection.identifier);
-                if (im != null) {
+                if (im != null && !moduleList.Selection.IsDLC) {
                     im.AutoInstalled = !im.AutoInstalled;
                     RegistryManager.Instance(manager.CurrentInstance).Save(false);
                 }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -883,6 +883,7 @@ namespace CKAN
                     kind         = "dlc",
                     license      = new List<License>() { new License("restricted") },
                 };
+                dlcModule.CalculateSearchables();
             }
             installed_modules.Add(
                 identifier,


### PR DESCRIPTION
## Problems

- If you have a DLC installed, and there is no `"kind": "dlc"` module for it, ConsoleUI throws an exception when searching
- ConsoleUI thinks it can install and uninstall DLC (you can add them to the change set), but if you try it, an exception is thrown
- The mod info page for a DLC shows an exception where it would normally say where the mod is hosted
- The `store` and `steamstore` resources aren't shown anywhere in ConsoleUI

## Causes

- The `CkanModule.Searchable*` properties are null because we create a fake DLC CkanModule without calling `CalculateSearchables`
- The "+"/"-" key binds and screen tips were not DLC-aware
- `CkanModule.download` is null for DLC, but `ModInfoScreen.HostedOn` did not allow for this

## Changes

- Now we call `CalculateSearchables` when we make a fake DLC CkanModule
- Now ConsoleUI won't let you try to install or uninstall DLC
- Now the hosted on area will tell you where you can buy the DLC
- Now the mod info screen's hamburger menu contains the store and steamstore links for DLC

Fixes #3140.