### PR TITLE
Retry failed web requests, fix install stanza error

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -646,9 +646,16 @@ namespace CKAN
         public string DescribeInstallStanzas()
         {
             List<string> descriptions = new List<string>();
-            foreach (ModuleInstallDescriptor mid in install)
+            if (install != null)
             {
-                descriptions.Add(mid.DescribeMatch());
+                foreach (ModuleInstallDescriptor mid in install)
+                {
+                    descriptions.Add(mid.DescribeMatch());
+                }
+            }
+            else
+            {
+                descriptions.Add(ModuleInstallDescriptor.DefaultInstallStanza(identifier).DescribeMatch());
             }
             return string.Join(", ", descriptions);
         }

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -418,7 +418,8 @@ namespace CKAN
                 : zipfile.Cast<ZipEntry>()
                     .Select(entry => inst_pattern.Match(entry.Name.Replace('\\', '/')))
                     .Where(match => match.Success)
-                    .Min(match => match.Index);
+                    .DefaultIfEmpty()
+                    .Min(match => match?.Index);
 
             // O(N^2) solution, as we're walking the zipfile for each stanza.
             // Surely there's a better way, although this is fast enough we may not care.

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -94,7 +94,7 @@ namespace CKAN.NetKAN.Transformers
                         }
                         catch (Exception e)
                         {
-                            Log.WarnFormat("Error fetching remote version file: {0}", e.Message);
+                            Log.WarnFormat("Error fetching remote version file {0}: {1}", remoteUri, e.Message);
                             Log.Debug(e);
                         }
                     }


### PR DESCRIPTION
## Problems

- Since #3074, a mod with a bad install stanza says, "Sequence contains no elements" instead of explaining that the stanza didn't match any files
- Even if the previous point is fixed, a mod using the default install stanza will throw a null reference error if it doesn't match any files
- Warnings about fetching remote version files don't print the remote URL (which would have been convenient for the following point)
- Prior to the recent flood of SpaceDock "The request was canceled" spam, after #3118, the netkan-bot channel was plagued with these errors:
  ![image](https://user-images.githubusercontent.com/1559108/94983037-dd8dd500-0504-11eb-85f6-b4a322e17b26.png)
  This is mostly harmless, _unless_ a mod author is actually using the remote version file to update compatibility after release, in which case it can cause CKAN's metadata to temporarily revert to the at-release state.

## Causes

- The code to find `shortestMatch` threw an exception if there were no matches, when it should have defaulted to null
- `CkanModule.DescribeInstallStanzas` assumed `install` would not be null
- ksp-avc.cybutek.net and ksp.spacetux.net are flaky servers, probably because they're run by individuals rather than big companies with cloud resources. They seem to fail in about 0.1% of requests; prior to #3118, we fell back to CurlSharp in these cases, but after that PR the fallback is removed.

## Changes

- Now errors like `Module contains no files matching: find="Cosmogator"` are back
- Now `CkanModule.DescribeInstallStanzas` knows how default install stanzas work
- Now remote version file fetch errors print the URL
- Now if a URL fails for non-protocol reasons (i.e., if it's a network failure rather than a HTTP 404), we try again immediately, then after waiting 0.1s, then 0.2s, then 0.3s. If it still doesn't work, we finally give up and fail as before.