### PR TITLE
Search timer for Linux

### DIFF
--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -189,6 +189,13 @@ namespace CKAN
             switch (e.KeyCode)
             {
                 case Keys.Enter:
+                    // Bypass the timer for immediate update
+                    e.Handled = true;
+                    e.SuppressKeyPress = true;
+                    filterTimer?.Stop();
+                    TriggerSearch();
+                    break;
+
                 case Keys.Up:
                 case Keys.Down:
                 case Keys.PageUp:
@@ -204,9 +211,9 @@ namespace CKAN
 
         private void TriggerSearchOrTimer()
         {
-            if (Platform.IsMac)
+            if (Platform.IsMono && !string.IsNullOrEmpty(FilterCombinedTextBox.Text))
             {
-                // Delay updating to improve typing performance on OS X.
+                // Delay updating to improve typing performance on OS X and Linux
                 RunFilterUpdateTimer();
             }
             else
@@ -227,7 +234,7 @@ namespace CKAN
             {
                 filterTimer = new Timer();
                 filterTimer.Tick += OnFilterUpdateTimer;
-                filterTimer.Interval = 700;
+                filterTimer.Interval = 500;
                 filterTimer.Start();
             }
             else


### PR DESCRIPTION
## Background

GUI search currently works slightly differently per platform: On Mac, it waits 700 milliseconds after you stop typing to update the filters, but on Windows and Linux it updates immediately after each keystroke.

## Problems

On Linux:

- Sometimes (exact conditions unclear) if you type a search quickly, the characters appear out-of-order in the search box, which obviously searches for something other than what you intended
- Even if you don't suffer from the above problem (I had seen it happen previously but was not able to reproduce it while working on this fix), the UI updates are kind of slow and unreliable; there's an impression of repeated flickering and the cursor moves before the characters appear.

## Cause

The `DataGridView` updates more slowly on Mono than on Windows, and it happens on the GUI thread, so updating it immediately after each keystroke inhibits the text box from responding. (I tried performing all of CKAN's own search logic in a background thread and then only applying the changes in the GUI thread, but it made no noticeable difference.)

## Changes

- Now the search timer is enabled for all Mono clients (Linux **and** Mac) rather than just Mac
- The timer is changed from 700 milliseconds to 500 milliseconds to make it seem somewhat more responsive
- Pressing Enter triggers the search immediately without delay
- Clearing the search box (e.g. with Escape) triggers the search immediately without delay

Fixes #3120.