### PR TITLE
Delete netkan tmp files if cache fills up

### DIFF
--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -99,12 +99,22 @@ namespace CKAN.NetKAN.Services
                         break;
                 }
 
-                return _cache.Store(
-                    primaryUrl,
-                    downloadedFile,
-                    string.Format("netkan-{0}.{1}", identifier, extension),
-                    move: true
-                );
+                try
+                {
+                    return _cache.Store(
+                        primaryUrl,
+                        downloadedFile,
+                        $"netkan-{identifier}.{extension}",
+                        move: true
+                    );                    
+                }
+                catch (IOException exc)
+                {
+                    // If cache is full, don't also fill /tmp
+                    log.Debug($"Failed to store to cache: {exc.Message}");
+                    File.Delete(downloadedFile);
+                    throw;
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

The Inflator's `/tmp` partition filled up:

```
netkan@945a9d40d33e:/tmp/CdFileMgr$ du -hs *
1.6G    136049aa-d02d-4a.tmp
1.6G    190528d6-ffe7-44.tmp
1.6G    197cb16c-7bd8-49.tmp
91M    241da6c0-ee1f-45.tmp
91M    283785f4-c7a7-4e.tmp
91M    28df1ab1-cafd-4b.tmp
1.6G    2fabe926-dd25-46.tmp
91M    322b5b76-38b6-46.tmp
91M    3892e70d-d10d-41.tmp
1.6G    3d4376f1-748f-4f.tmp
1.6G    45782341-d73b-4c.tmp
91M    4c1f0f27-b592-4c.tmp
1.6G    5803da08-e7fb-4b.tmp
91M    610da03d-dba6-49.tmp
91M    67901f4e-6360-4a.tmp
91M    9e59cf92-ea96-48.tmp
91M    b8ec7a18-6db6-4e.tmp
1.6G    bcd5650b-fc6c-47.tmp
1.6G    c3fceeff-78d4-48.tmp
91M    c44a1bbb-b313-42.tmp
1.6G    c68dc340-e109-4b.tmp
1.6G    cc9752a0-ce66-4d.tmp
91M    d34b2f4a-ab1b-49.tmp
91M    e115d711-0f3f-44.tmp
1.6G    e529f468-8441-4c.tmp
1.6G    f0b979c7-b3b7-48.tmp
91M    f5d8bc81-dd90-45.tmp
```

## Cause

The cache filled up first because HumanStuff (see KSP-CKAN/NetKAN#8142) released many enormous versions in rapid sequence (about 12GB in under 30 days). When the Inflator attempted to move a downloaded file into the cache, the attempt failed, and the temp file was not cleaned up. Over time the temp files accumulated until `/tmp` was full.

## Changes

Now if `NetFileCache.Store` fails, the Inflator deletes the temp file.

(Note that some of HumanStuff's bloat has since been pruned, with the latest download only 366 MB, so with luck we should not have the cache fill up again.)

Fixes #3168.