### PR TITLE
Search dropdown

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -205,6 +205,12 @@
     <Compile Include="Controls\EditModSearch.Designer.cs">
       <DependentUpon>EditModSearch.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\EditModSearchDetails.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\EditModSearchDetails.Designer.cs">
+      <DependentUpon>EditModSearchDetails.cs</DependentUpon>
+    </Compile>
     <Compile Include="Controls\ManageMods.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -481,6 +487,15 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Localization\zh-CN\EditModSearch.zh-CN.resx">
       <DependentUpon>..\..\Controls\EditModSearch.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Controls\EditModSearchDetails.resx">
+      <DependentUpon>EditModSearchDetails.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Localization\de-DE\EditModSearchDetails.de-DE.resx">
+      <DependentUpon>..\..\Controls\EditModSearchDetails.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Localization\zh-CN\EditModSearchDetails.zh-CN.resx">
+      <DependentUpon>..\..\Controls\EditModSearchDetails.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Localization\de-DE\ModInfo.de-DE.resx">
       <DependentUpon>..\..\Controls\ModInfo.cs</DependentUpon>

--- a/GUI/Controls/EditModSearch.Designer.cs
+++ b/GUI/Controls/EditModSearch.Designer.cs
@@ -16,6 +16,7 @@
             if (disposing && (components != null))
             {
                 components.Dispose();
+                SearchDetails.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -31,231 +32,24 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(EditModSearch));
             this.ToolTip = new System.Windows.Forms.ToolTip();
-            this.FilterByNameLabel = new System.Windows.Forms.Label();
-            this.FilterByNameTextBox = new CKAN.HintTextBox();
-            this.FilterByAuthorLabel = new System.Windows.Forms.Label();
-            this.FilterByAuthorTextBox = new CKAN.HintTextBox();
-            this.FilterByDescriptionLabel = new System.Windows.Forms.Label();
-            this.FilterByDescriptionTextBox = new CKAN.HintTextBox();
-            this.FilterByLanguageLabel = new System.Windows.Forms.Label();
-            this.FilterByLanguageTextBox = new CKAN.HintTextBox();
-            this.FilterByDependsLabel = new System.Windows.Forms.Label();
-            this.FilterByDependsTextBox = new CKAN.HintTextBox();
-            this.FilterByRecommendsLabel = new System.Windows.Forms.Label();
-            this.FilterByRecommendsTextBox = new CKAN.HintTextBox();
-            this.FilterBySuggestsLabel = new System.Windows.Forms.Label();
-            this.FilterBySuggestsTextBox = new CKAN.HintTextBox();
-            this.FilterByConflictsLabel = new System.Windows.Forms.Label();
-            this.FilterByConflictsTextBox = new CKAN.HintTextBox();
             this.FilterCombinedLabel = new System.Windows.Forms.Label();
             this.FilterCombinedTextBox = new CKAN.HintTextBox();
             this.ExpandButton = new System.Windows.Forms.CheckBox();
+            this.SearchDetails = new CKAN.EditModSearchDetails();
             this.SuspendLayout();
-            // 
+            //
             // ToolTip
-            // 
+            //
             this.ToolTip.AutoPopDelay = 10000;
             this.ToolTip.InitialDelay = 250;
             this.ToolTip.ReshowDelay = 250;
             this.ToolTip.ShowAlways = true;
             //
-            // FilterByNameLabel
-            //
-            this.FilterByNameLabel.AutoSize = true;
-            this.FilterByNameLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByNameLabel.Location = new System.Drawing.Point(6, 9);
-            this.FilterByNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterByNameLabel.Name = "FilterByNameLabel";
-            this.FilterByNameLabel.Size = new System.Drawing.Size(147, 20);
-            this.FilterByNameLabel.TabIndex = 0;
-            this.FilterByNameLabel.Visible = false;
-            resources.ApplyResources(this.FilterByNameLabel, "FilterByNameLabel");
-            //
-            // FilterByNameTextBox
-            //
-            this.FilterByNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByNameTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterByNameTextBox.Name = "FilterByNameTextBox";
-            this.FilterByNameTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterByNameTextBox.TabIndex = 1;
-            this.FilterByNameTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterByNameTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            this.FilterByNameTextBox.Visible = false;
-            resources.ApplyResources(this.FilterByNameTextBox, "FilterByNameTextBox");
-            //
-            // FilterByAuthorLabel
-            //
-            this.FilterByAuthorLabel.AutoSize = true;
-            this.FilterByAuthorLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByAuthorLabel.Location = new System.Drawing.Point(372, 9);
-            this.FilterByAuthorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterByAuthorLabel.Name = "FilterByAuthorLabel";
-            this.FilterByAuthorLabel.Size = new System.Drawing.Size(162, 20);
-            this.FilterByAuthorLabel.TabIndex = 2;
-            this.FilterByAuthorLabel.Visible = false;
-            resources.ApplyResources(this.FilterByAuthorLabel, "FilterByAuthorLabel");
-            //
-            // FilterByAuthorTextBox
-            //
-            this.FilterByAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByAuthorTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterByAuthorTextBox.Name = "FilterByAuthorTextBox";
-            this.FilterByAuthorTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterByAuthorTextBox.TabIndex = 3;
-            this.FilterByAuthorTextBox.Visible = false;
-            this.FilterByAuthorTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterByAuthorTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            resources.ApplyResources(this.FilterByAuthorTextBox, "FilterByAuthorTextBox");
-            //
-            // FilterByDescriptionLabel
-            //
-            this.FilterByDescriptionLabel.AutoSize = true;
-            this.FilterByDescriptionLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByDescriptionLabel.Location = new System.Drawing.Point(754, 9);
-            this.FilterByDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterByDescriptionLabel.Name = "FilterByDescriptionLabel";
-            this.FilterByDescriptionLabel.Size = new System.Drawing.Size(149, 20);
-            this.FilterByDescriptionLabel.TabIndex = 4;
-            this.FilterByDescriptionLabel.Visible = false;
-            resources.ApplyResources(this.FilterByDescriptionLabel, "FilterByDescriptionLabel");
-            //
-            // FilterByDescriptionTextBox
-            //
-            this.FilterByDescriptionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByDescriptionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterByDescriptionTextBox.Name = "FilterByDescriptionTextBox";
-            this.FilterByDescriptionTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterByDescriptionTextBox.TabIndex = 5;
-            this.FilterByDescriptionTextBox.Visible = false;
-            this.FilterByDescriptionTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterByDescriptionTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            resources.ApplyResources(this.FilterByDescriptionTextBox, "FilterByDescriptionTextBox");
-            //
-            // FilterByLanguageLabel
-            //
-            this.FilterByLanguageLabel.AutoSize = true;
-            this.FilterByLanguageLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByLanguageLabel.Location = new System.Drawing.Point(754, 9);
-            this.FilterByLanguageLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterByLanguageLabel.Name = "FilterByLanguageLabel";
-            this.FilterByLanguageLabel.Size = new System.Drawing.Size(149, 20);
-            this.FilterByLanguageLabel.TabIndex = 6;
-            this.FilterByLanguageLabel.Visible = false;
-            resources.ApplyResources(this.FilterByLanguageLabel, "FilterByLanguageLabel");
-            //
-            // FilterByLanguageTextBox
-            //
-            this.FilterByLanguageTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByLanguageTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterByLanguageTextBox.Name = "FilterByLanguageTextBox";
-            this.FilterByLanguageTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterByLanguageTextBox.TabIndex = 7;
-            this.FilterByLanguageTextBox.Visible = false;
-            this.FilterByLanguageTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterByLanguageTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            resources.ApplyResources(this.FilterByLanguageTextBox, "FilterByLanguageTextBox");
-            //
-            // FilterByDependsLabel
-            //
-            this.FilterByDependsLabel.AutoSize = true;
-            this.FilterByDependsLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByDependsLabel.Location = new System.Drawing.Point(754, 9);
-            this.FilterByDependsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterByDependsLabel.Name = "FilterByDependsLabel";
-            this.FilterByDependsLabel.Size = new System.Drawing.Size(149, 20);
-            this.FilterByDependsLabel.TabIndex = 8;
-            this.FilterByDependsLabel.Visible = false;
-            resources.ApplyResources(this.FilterByDependsLabel, "FilterByDependsLabel");
-            //
-            // FilterByDependsTextBox
-            //
-            this.FilterByDependsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByDependsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterByDependsTextBox.Name = "FilterByDependsTextBox";
-            this.FilterByDependsTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterByDependsTextBox.TabIndex = 9;
-            this.FilterByDependsTextBox.Visible = false;
-            this.FilterByDependsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterByDependsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            resources.ApplyResources(this.FilterByDependsTextBox, "FilterByDependsTextBox");
-            //
-            // FilterByRecommendsLabel
-            //
-            this.FilterByRecommendsLabel.AutoSize = true;
-            this.FilterByRecommendsLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByRecommendsLabel.Location = new System.Drawing.Point(754, 9);
-            this.FilterByRecommendsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterByRecommendsLabel.Name = "FilterByRecommendsLabel";
-            this.FilterByRecommendsLabel.Size = new System.Drawing.Size(149, 20);
-            this.FilterByRecommendsLabel.TabIndex = 10;
-            this.FilterByRecommendsLabel.Visible = false;
-            resources.ApplyResources(this.FilterByRecommendsLabel, "FilterByRecommendsLabel");
-            //
-            // FilterByRecommendsTextBox
-            //
-            this.FilterByRecommendsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByRecommendsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterByRecommendsTextBox.Name = "FilterByRecommendsTextBox";
-            this.FilterByRecommendsTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterByRecommendsTextBox.TabIndex = 11;
-            this.FilterByRecommendsTextBox.Visible = false;
-            this.FilterByRecommendsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterByRecommendsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            resources.ApplyResources(this.FilterByRecommendsTextBox, "FilterByRecommendsTextBox");
-            //
-            // FilterBySuggestsLabel
-            //
-            this.FilterBySuggestsLabel.AutoSize = true;
-            this.FilterBySuggestsLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterBySuggestsLabel.Location = new System.Drawing.Point(754, 9);
-            this.FilterBySuggestsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterBySuggestsLabel.Name = "FilterBySuggestsLabel";
-            this.FilterBySuggestsLabel.Size = new System.Drawing.Size(149, 20);
-            this.FilterBySuggestsLabel.TabIndex = 12;
-            this.FilterBySuggestsLabel.Visible = false;
-            resources.ApplyResources(this.FilterBySuggestsLabel, "FilterBySuggestsLabel");
-            //
-            // FilterBySuggestsTextBox
-            //
-            this.FilterBySuggestsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterBySuggestsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterBySuggestsTextBox.Name = "FilterBySuggestsTextBox";
-            this.FilterBySuggestsTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterBySuggestsTextBox.TabIndex = 13;
-            this.FilterBySuggestsTextBox.Visible = false;
-            this.FilterBySuggestsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterBySuggestsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            resources.ApplyResources(this.FilterBySuggestsTextBox, "FilterBySuggestsTextBox");
-            //
-            // FilterByConflictsLabel
-            //
-            this.FilterByConflictsLabel.AutoSize = true;
-            this.FilterByConflictsLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByConflictsLabel.Location = new System.Drawing.Point(754, 9);
-            this.FilterByConflictsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.FilterByConflictsLabel.Name = "FilterByConflictsLabel";
-            this.FilterByConflictsLabel.Size = new System.Drawing.Size(149, 20);
-            this.FilterByConflictsLabel.TabIndex = 14;
-            this.FilterByConflictsLabel.Visible = false;
-            resources.ApplyResources(this.FilterByConflictsLabel, "FilterByConflictsLabel");
-            //
-            // FilterByConflictsTextBox
-            //
-            this.FilterByConflictsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByConflictsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.FilterByConflictsTextBox.Name = "FilterByConflictsTextBox";
-            this.FilterByConflictsTextBox.Size = new System.Drawing.Size(170, 26);
-            this.FilterByConflictsTextBox.TabIndex = 15;
-            this.FilterByConflictsTextBox.Visible = false;
-            this.FilterByConflictsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
-            this.FilterByConflictsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
-            resources.ApplyResources(this.FilterByConflictsTextBox, "FilterByConflictsTextBox");
-            //
             // FilterCombinedLabel
             //
             this.FilterCombinedLabel.AutoSize = true;
             this.FilterCombinedLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterCombinedLabel.Location = new System.Drawing.Point(6, 9);
+            this.FilterCombinedLabel.Location = new System.Drawing.Point(80, 9);
             this.FilterCombinedLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.FilterCombinedLabel.Name = "FilterCombinedLabel";
             this.FilterCombinedLabel.Size = new System.Drawing.Size(147, 20);
@@ -264,53 +58,49 @@
             //
             // FilterCombinedTextBox
             //
+            this.FilterCombinedTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterCombinedTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.FilterCombinedTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterCombinedTextBox.Name = "FilterCombinedTextBox";
-            this.FilterCombinedTextBox.Size = new System.Drawing.Size(340, 26);
+            this.FilterCombinedTextBox.Location = new System.Drawing.Point(154, 7);
+            this.FilterCombinedTextBox.MinimumSize = new System.Drawing.Size(60, 20);
+            this.FilterCombinedTextBox.Size = new System.Drawing.Size(247, 26);
             this.FilterCombinedTextBox.TabIndex = 17;
             this.FilterCombinedTextBox.TextChanged += new System.EventHandler(this.FilterCombinedTextBox_TextChanged);
             this.FilterCombinedTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
             resources.ApplyResources(this.FilterCombinedTextBox, "FilterCombinedTextBox");
-            // 
+            //
             // ExpandButton
-            // 
+            //
+            this.ExpandButton.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Right);
             this.ExpandButton.Appearance = System.Windows.Forms.Appearance.Button;
+            this.ExpandButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ExpandButton.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.ExpandButton.Location = new System.Drawing.Point(330, 5);
+            this.ExpandButton.Location = new System.Drawing.Point(400, 5);
             this.ExpandButton.Name = "ExpandButton";
             this.ExpandButton.Size = new System.Drawing.Size(20, 26);
             this.ExpandButton.TabIndex = 18;
-            this.ExpandButton.Text = "▴";
+            this.ExpandButton.Text = "▾";
             this.ExpandButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.ExpandButton.UseVisualStyleBackColor = true;
             this.ExpandButton.CheckedChanged += new System.EventHandler(this.ExpandButton_CheckedChanged);
             resources.ApplyResources(this.ExpandButton, "ExpandButton");
             //
+            // SearchDetails
+            //
+            this.SearchDetails.Name = "SearchDetails";
+            this.SearchDetails.Visible = false;
+            this.SearchDetails.ApplySearch += this.SearchDetails_ApplySearch;
+            this.SearchDetails.SurrenderFocus += this.SearchDetails_SurrenderFocus;
+            //
             // EditModSearch
             //
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.Controls.Add(this.FilterCombinedLabel);
-            this.Controls.Add(this.FilterCombinedTextBox);
             this.Controls.Add(this.ExpandButton);
-            this.Controls.Add(this.FilterByAuthorTextBox);
-            this.Controls.Add(this.FilterByAuthorLabel);
-            this.Controls.Add(this.FilterByNameLabel);
-            this.Controls.Add(this.FilterByNameTextBox);
-            this.Controls.Add(this.FilterByDescriptionLabel);
-            this.Controls.Add(this.FilterByDescriptionTextBox);
-            this.Controls.Add(this.FilterByLanguageLabel);
-            this.Controls.Add(this.FilterByLanguageTextBox);
-            this.Controls.Add(this.FilterByDependsLabel);
-            this.Controls.Add(this.FilterByDependsTextBox);
-            this.Controls.Add(this.FilterByRecommendsLabel);
-            this.Controls.Add(this.FilterByRecommendsTextBox);
-            this.Controls.Add(this.FilterBySuggestsLabel);
-            this.Controls.Add(this.FilterBySuggestsTextBox);
-            this.Controls.Add(this.FilterByConflictsLabel);
-            this.Controls.Add(this.FilterByConflictsTextBox);
+            this.Controls.Add(this.FilterCombinedTextBox);
             this.Name = "EditModSearch";
-            this.Size = new System.Drawing.Size(500, 26);
+            this.Size = new System.Drawing.Size(500, 34);
             resources.ApplyResources(this, "$this");
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -320,24 +110,9 @@
         #endregion
 
         private System.Windows.Forms.ToolTip ToolTip;
-        private System.Windows.Forms.Label FilterByNameLabel;
-        private CKAN.HintTextBox FilterByNameTextBox;
-        private System.Windows.Forms.Label FilterByAuthorLabel;
-        private CKAN.HintTextBox FilterByAuthorTextBox;
-        private System.Windows.Forms.Label FilterByDescriptionLabel;
-        private CKAN.HintTextBox FilterByDescriptionTextBox;
-        private System.Windows.Forms.Label FilterByLanguageLabel;
-        private CKAN.HintTextBox FilterByLanguageTextBox;
-        private System.Windows.Forms.Label FilterByDependsLabel;
-        private CKAN.HintTextBox FilterByDependsTextBox;
-        private System.Windows.Forms.Label FilterByRecommendsLabel;
-        private CKAN.HintTextBox FilterByRecommendsTextBox;
-        private System.Windows.Forms.Label FilterBySuggestsLabel;
-        private CKAN.HintTextBox FilterBySuggestsTextBox;
-        private System.Windows.Forms.Label FilterByConflictsLabel;
-        private CKAN.HintTextBox FilterByConflictsTextBox;
         private System.Windows.Forms.Label FilterCombinedLabel;
         private CKAN.HintTextBox FilterCombinedTextBox;
         private System.Windows.Forms.CheckBox ExpandButton;
+        private CKAN.EditModSearchDetails SearchDetails;
     }
 }

--- a/GUI/Controls/EditModSearchDetails.Designer.cs
+++ b/GUI/Controls/EditModSearchDetails.Designer.cs
@@ -1,0 +1,291 @@
+﻿namespace CKAN
+{
+    partial class EditModSearchDetails
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(EditModSearchDetails));
+            this.FilterByNameLabel = new System.Windows.Forms.Label();
+            this.FilterByNameTextBox = new CKAN.HintTextBox();
+            this.FilterByAuthorLabel = new System.Windows.Forms.Label();
+            this.FilterByAuthorTextBox = new CKAN.HintTextBox();
+            this.FilterByDescriptionLabel = new System.Windows.Forms.Label();
+            this.FilterByDescriptionTextBox = new CKAN.HintTextBox();
+            this.FilterByLanguageLabel = new System.Windows.Forms.Label();
+            this.FilterByLanguageTextBox = new CKAN.HintTextBox();
+            this.FilterByDependsLabel = new System.Windows.Forms.Label();
+            this.FilterByDependsTextBox = new CKAN.HintTextBox();
+            this.FilterByRecommendsLabel = new System.Windows.Forms.Label();
+            this.FilterByRecommendsTextBox = new CKAN.HintTextBox();
+            this.FilterBySuggestsLabel = new System.Windows.Forms.Label();
+            this.FilterBySuggestsTextBox = new CKAN.HintTextBox();
+            this.FilterByConflictsLabel = new System.Windows.Forms.Label();
+            this.FilterByConflictsTextBox = new CKAN.HintTextBox();
+            this.SuspendLayout();
+            //
+            // FilterByNameLabel
+            //
+            this.FilterByNameLabel.AutoSize = true;
+            this.FilterByNameLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterByNameLabel.Location = new System.Drawing.Point(6, 9);
+            this.FilterByNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterByNameLabel.Name = "FilterByNameLabel";
+            this.FilterByNameLabel.Size = new System.Drawing.Size(147, 20);
+            this.FilterByNameLabel.TabIndex = 0;
+            resources.ApplyResources(this.FilterByNameLabel, "FilterByNameLabel");
+            //
+            // FilterByNameTextBox
+            //
+            this.FilterByNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterByNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterByNameTextBox.Location = new System.Drawing.Point(110, 7);
+            this.FilterByNameTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterByNameTextBox.Name = "FilterByNameTextBox";
+            this.FilterByNameTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterByNameTextBox.TabIndex = 1;
+            this.FilterByNameTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterByNameTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterByNameTextBox, "FilterByNameTextBox");
+            //
+            // FilterByAuthorLabel
+            //
+            this.FilterByAuthorLabel.AutoSize = true;
+            this.FilterByAuthorLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterByAuthorLabel.Location = new System.Drawing.Point(6, 35);
+            this.FilterByAuthorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterByAuthorLabel.Name = "FilterByAuthorLabel";
+            this.FilterByAuthorLabel.Size = new System.Drawing.Size(162, 20);
+            this.FilterByAuthorLabel.TabIndex = 2;
+            resources.ApplyResources(this.FilterByAuthorLabel, "FilterByAuthorLabel");
+            //
+            // FilterByAuthorTextBox
+            //
+            this.FilterByAuthorTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterByAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterByAuthorTextBox.Location = new System.Drawing.Point(110, 33);
+            this.FilterByAuthorTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterByAuthorTextBox.Name = "FilterByAuthorTextBox";
+            this.FilterByAuthorTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterByAuthorTextBox.TabIndex = 3;
+            this.FilterByAuthorTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterByAuthorTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterByAuthorTextBox, "FilterByAuthorTextBox");
+            //
+            // FilterByDescriptionLabel
+            //
+            this.FilterByDescriptionLabel.AutoSize = true;
+            this.FilterByDescriptionLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterByDescriptionLabel.Location = new System.Drawing.Point(6, 61);
+            this.FilterByDescriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterByDescriptionLabel.Name = "FilterByDescriptionLabel";
+            this.FilterByDescriptionLabel.Size = new System.Drawing.Size(149, 20);
+            this.FilterByDescriptionLabel.TabIndex = 4;
+            resources.ApplyResources(this.FilterByDescriptionLabel, "FilterByDescriptionLabel");
+            //
+            // FilterByDescriptionTextBox
+            //
+            this.FilterByDescriptionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterByDescriptionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterByDescriptionTextBox.Location = new System.Drawing.Point(110, 59);
+            this.FilterByDescriptionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterByDescriptionTextBox.Name = "FilterByDescriptionTextBox";
+            this.FilterByDescriptionTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterByDescriptionTextBox.TabIndex = 5;
+            this.FilterByDescriptionTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterByDescriptionTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterByDescriptionTextBox, "FilterByDescriptionTextBox");
+            //
+            // FilterByLanguageLabel
+            //
+            this.FilterByLanguageLabel.AutoSize = true;
+            this.FilterByLanguageLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterByLanguageLabel.Location = new System.Drawing.Point(6, 87);
+            this.FilterByLanguageLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterByLanguageLabel.Name = "FilterByLanguageLabel";
+            this.FilterByLanguageLabel.Size = new System.Drawing.Size(149, 20);
+            this.FilterByLanguageLabel.TabIndex = 6;
+            resources.ApplyResources(this.FilterByLanguageLabel, "FilterByLanguageLabel");
+            //
+            // FilterByLanguageTextBox
+            //
+            this.FilterByLanguageTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterByLanguageTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterByLanguageTextBox.Location = new System.Drawing.Point(110, 85);
+            this.FilterByLanguageTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterByLanguageTextBox.Name = "FilterByLanguageTextBox";
+            this.FilterByLanguageTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterByLanguageTextBox.TabIndex = 7;
+            this.FilterByLanguageTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterByLanguageTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterByLanguageTextBox, "FilterByLanguageTextBox");
+            //
+            // FilterByDependsLabel
+            //
+            this.FilterByDependsLabel.AutoSize = true;
+            this.FilterByDependsLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterByDependsLabel.Location = new System.Drawing.Point(6, 113);
+            this.FilterByDependsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterByDependsLabel.Name = "FilterByDependsLabel";
+            this.FilterByDependsLabel.Size = new System.Drawing.Size(149, 20);
+            this.FilterByDependsLabel.TabIndex = 8;
+            resources.ApplyResources(this.FilterByDependsLabel, "FilterByDependsLabel");
+            //
+            // FilterByDependsTextBox
+            //
+            this.FilterByDependsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterByDependsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterByDependsTextBox.Location = new System.Drawing.Point(110, 111);
+            this.FilterByDependsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterByDependsTextBox.Name = "FilterByDependsTextBox";
+            this.FilterByDependsTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterByDependsTextBox.TabIndex = 9;
+            this.FilterByDependsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterByDependsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterByDependsTextBox, "FilterByDependsTextBox");
+            //
+            // FilterByRecommendsLabel
+            //
+            this.FilterByRecommendsLabel.AutoSize = true;
+            this.FilterByRecommendsLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterByRecommendsLabel.Location = new System.Drawing.Point(6, 139);
+            this.FilterByRecommendsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterByRecommendsLabel.Name = "FilterByRecommendsLabel";
+            this.FilterByRecommendsLabel.Size = new System.Drawing.Size(149, 20);
+            this.FilterByRecommendsLabel.TabIndex = 10;
+            resources.ApplyResources(this.FilterByRecommendsLabel, "FilterByRecommendsLabel");
+            //
+            // FilterByRecommendsTextBox
+            //
+            this.FilterByRecommendsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterByRecommendsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterByRecommendsTextBox.Location = new System.Drawing.Point(110, 137);
+            this.FilterByRecommendsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterByRecommendsTextBox.Name = "FilterByRecommendsTextBox";
+            this.FilterByRecommendsTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterByRecommendsTextBox.TabIndex = 11;
+            this.FilterByRecommendsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterByRecommendsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterByRecommendsTextBox, "FilterByRecommendsTextBox");
+            //
+            // FilterBySuggestsLabel
+            //
+            this.FilterBySuggestsLabel.AutoSize = true;
+            this.FilterBySuggestsLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterBySuggestsLabel.Location = new System.Drawing.Point(6, 165);
+            this.FilterBySuggestsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterBySuggestsLabel.Name = "FilterBySuggestsLabel";
+            this.FilterBySuggestsLabel.Size = new System.Drawing.Size(149, 20);
+            this.FilterBySuggestsLabel.TabIndex = 12;
+            resources.ApplyResources(this.FilterBySuggestsLabel, "FilterBySuggestsLabel");
+            //
+            // FilterBySuggestsTextBox
+            //
+            this.FilterBySuggestsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterBySuggestsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterBySuggestsTextBox.Location = new System.Drawing.Point(110, 163);
+            this.FilterBySuggestsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterBySuggestsTextBox.Name = "FilterBySuggestsTextBox";
+            this.FilterBySuggestsTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterBySuggestsTextBox.TabIndex = 13;
+            this.FilterBySuggestsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterBySuggestsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterBySuggestsTextBox, "FilterBySuggestsTextBox");
+            //
+            // FilterByConflictsLabel
+            //
+            this.FilterByConflictsLabel.AutoSize = true;
+            this.FilterByConflictsLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterByConflictsLabel.Location = new System.Drawing.Point(6, 191);
+            this.FilterByConflictsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterByConflictsLabel.Name = "FilterByConflictsLabel";
+            this.FilterByConflictsLabel.Size = new System.Drawing.Size(149, 20);
+            this.FilterByConflictsLabel.TabIndex = 14;
+            resources.ApplyResources(this.FilterByConflictsLabel, "FilterByConflictsLabel");
+            //
+            // FilterByConflictsTextBox
+            //
+            this.FilterByConflictsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterByConflictsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterByConflictsTextBox.Location = new System.Drawing.Point(110, 189);
+            this.FilterByConflictsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterByConflictsTextBox.Name = "FilterByConflictsTextBox";
+            this.FilterByConflictsTextBox.Size = new System.Drawing.Size(180, 26);
+            this.FilterByConflictsTextBox.TabIndex = 15;
+            this.FilterByConflictsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterByConflictsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterByConflictsTextBox, "FilterByConflictsTextBox");
+            //
+            // EditModSearchDetails
+            //
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.Controls.Add(this.FilterByAuthorTextBox);
+            this.Controls.Add(this.FilterByAuthorLabel);
+            this.Controls.Add(this.FilterByNameLabel);
+            this.Controls.Add(this.FilterByNameTextBox);
+            this.Controls.Add(this.FilterByDescriptionLabel);
+            this.Controls.Add(this.FilterByDescriptionTextBox);
+            this.Controls.Add(this.FilterByLanguageLabel);
+            this.Controls.Add(this.FilterByLanguageTextBox);
+            this.Controls.Add(this.FilterByDependsLabel);
+            this.Controls.Add(this.FilterByDependsTextBox);
+            this.Controls.Add(this.FilterByRecommendsLabel);
+            this.Controls.Add(this.FilterByRecommendsTextBox);
+            this.Controls.Add(this.FilterBySuggestsLabel);
+            this.Controls.Add(this.FilterBySuggestsTextBox);
+            this.Controls.Add(this.FilterByConflictsLabel);
+            this.Controls.Add(this.FilterByConflictsTextBox);
+            this.Name = "EditModSearchDetails";
+            this.Size = new System.Drawing.Size(300, 218);
+            resources.ApplyResources(this, "$this");
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label FilterByNameLabel;
+        internal CKAN.HintTextBox FilterByNameTextBox;
+        private System.Windows.Forms.Label FilterByAuthorLabel;
+        internal CKAN.HintTextBox FilterByAuthorTextBox;
+        private System.Windows.Forms.Label FilterByDescriptionLabel;
+        internal CKAN.HintTextBox FilterByDescriptionTextBox;
+        private System.Windows.Forms.Label FilterByLanguageLabel;
+        internal CKAN.HintTextBox FilterByLanguageTextBox;
+        private System.Windows.Forms.Label FilterByDependsLabel;
+        internal CKAN.HintTextBox FilterByDependsTextBox;
+        private System.Windows.Forms.Label FilterByRecommendsLabel;
+        internal CKAN.HintTextBox FilterByRecommendsTextBox;
+        private System.Windows.Forms.Label FilterBySuggestsLabel;
+        internal CKAN.HintTextBox FilterBySuggestsTextBox;
+        private System.Windows.Forms.Label FilterByConflictsLabel;
+        internal CKAN.HintTextBox FilterByConflictsTextBox;
+    }
+}

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using log4net;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A control for displaying and editing a search of mods.
+    /// Contains several separate fields for searching different properties,
+    /// plus a combined field that represents them all in a special syntax.
+    /// </summary>
+    public partial class EditModSearchDetails : UserControl
+    {
+        /// <summary>
+        /// Initialize a mod search editing control
+        /// </summary>
+        public EditModSearchDetails()
+        {
+            InitializeComponent();
+            // Float over other controls
+            SetTopLevel(true);
+        }
+
+        /// <summary>
+        /// Event fired when a search needs to be executed.
+        /// The parameter is true if the search should be executed immediately,
+        /// or false if the keystroke timer should be used.
+        /// </summary>
+        public event Action<bool> ApplySearch;
+
+        /// <summary>
+        /// Event fired when user wants to switch focus away from this control.
+        /// </summary>
+        public event Action SurrenderFocus;
+
+        /// <summary>
+        /// Override special settings to make this control behave like a dropdown.
+        /// The "|=" lines are turning ON those flags.
+        /// The "&amp;= ~" lines are turning OFF those flags.
+        /// https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles
+        /// https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
+        /// </summary>
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                CreateParams cp = base.CreateParams;
+                //  The window is a child window. A window with this style cannot have a menu bar. This style cannot be used with the WS_POPUP style.
+                cp.Style   &= ~(int)WindowStyles.WS_CHILD;
+                // The window is initially visible. This style can be turned on and off by using the ShowWindow or SetWindowPos function.
+                cp.Style   &= ~(int)WindowStyles.WS_VISIBLE;
+                // The window is a pop-up window. This style cannot be used with the WS_CHILD style.
+                cp.Style   |= unchecked((int)WindowStyles.WS_POPUP);
+                // The window is intended to be used as a floating toolbar. A tool window has a title bar that is shorter than a normal title bar, and the window title is drawn using a smaller font. A tool window does not appear in the taskbar or in the dialog that appears when the user presses ALT+TAB. If a tool window has a system menu, its icon is not displayed on the title bar. However, you can display the system menu by right-clicking or by typing ALT+SPACE.
+                cp.ExStyle |= (int)WindowExStyles.WS_EX_TOOLWINDOW;
+                // The window itself contains child windows that should take part in dialog box navigation. If this style is specified, the dialog manager recurses into children of this window when performing navigation operations such as handling the TAB key, an arrow key, or a keyboard mnemonic.
+                cp.ExStyle |= (int)WindowExStyles.WS_EX_CONTROLPARENT;
+                // A top-level window created with this style does not become the foreground window when the user clicks it. The system does not bring this window to the foreground when the user minimizes or closes the foreground window. The window should not be activated through programmatic access or via keyboard navigation by accessible technology, such as Narrator. To activate the window, use the SetActiveWindow or SetForegroundWindow function. The window does not appear on the taskbar by default. To force the window to appear on the taskbar, use the WS_EX_APPWINDOW style.
+                cp.ExStyle |= (int)WindowExStyles.WS_EX_NOACTIVATE;
+                return cp;
+            }
+        }
+
+        protected override void OnLeave(EventArgs e)
+        {
+            if (SurrenderFocus != null)
+            {
+                SurrenderFocus();
+            }
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(EditModSearchDetails));
+
+        private void FilterTextBox_TextChanged(object sender, EventArgs e)
+        {
+            if (ApplySearch != null)
+            {
+                ApplySearch(string.IsNullOrEmpty((sender as TextBox)?.Text));
+            }
+        }
+
+        private void FilterTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            // Switch focus from filters to mod list on enter, down, or pgdn
+            switch (e.KeyCode)
+            {
+                case Keys.Enter:
+                    if (ApplySearch != null)
+                    {
+                        ApplySearch(true);
+                        e.Handled = true;
+                        e.SuppressKeyPress = true;
+                    }
+                    break;
+
+                case Keys.Escape:
+                    if (SurrenderFocus != null
+                        && string.IsNullOrEmpty((sender as HintTextBox)?.Text ?? null))
+                    {
+                        SurrenderFocus();
+                        e.Handled = true;
+                        e.SuppressKeyPress = true;
+                    }
+                    break;
+
+                case Keys.Up:
+                case Keys.Down:
+                case Keys.PageUp:
+                case Keys.PageDown:
+                    if (SurrenderFocus != null)
+                    {
+                        SurrenderFocus();
+                        e.Handled = true;
+                    }
+                    break;
+            }
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            switch (keyData)
+            {
+                case Keys.Control | Keys.Shift | Keys.F:
+                    SurrenderFocus();
+                    return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        // https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles
+        private enum WindowStyles : uint
+        {
+            WS_VISIBLE = 0x10000000,
+            WS_CHILD   = 0x40000000,
+            WS_POPUP   = 0x80000000,
+        }
+
+        // https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
+        private enum WindowExStyles : uint
+        {
+            WS_EX_TOOLWINDOW    =       0x80,
+            WS_EX_CONTROLPARENT =    0x10000,
+            WS_EX_NOACTIVATE    = 0x08000000,
+        }
+
+    }
+}

--- a/GUI/Controls/EditModSearchDetails.resx
+++ b/GUI/Controls/EditModSearchDetails.resx
@@ -117,5 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>Search:</value></data>
+  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Author:</value></data>
+  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>Description:</value></data>
+  <data name="FilterByLanguageLabel.Text" xml:space="preserve"><value>Language:</value></data>
+  <data name="FilterByDependsLabel.Text" xml:space="preserve"><value>Depends on:</value></data>
+  <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>Recommends:</value></data>
+  <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>Suggests:</value></data>
+  <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>Conflicts with:</value></data>
 </root>

--- a/GUI/Controls/HintTextBox.cs
+++ b/GUI/Controls/HintTextBox.cs
@@ -37,11 +37,7 @@ namespace CKAN
         /// <param name="e">The event arguments</param>
         private void HintTextBox_TextChanged(object sender, EventArgs e)
         {
-            // sanity checks
-            if (Visible && !ReadOnly)
-            {
-                ClearIcon.Visible = (TextLength > 0);
-            }
+            ClearIcon.Visible = (TextLength > 0) && !ReadOnly;
         }
 
         /// <summary>
@@ -71,13 +67,22 @@ namespace CKAN
         /// <returns></returns>
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
-            if (keyData == Keys.Escape)
+            if (keyData == Keys.Escape && !string.IsNullOrEmpty(Text))
             {
                 Text = "";
                 return true;
             }
 
-            return base.ProcessCmdKey(ref msg, keyData);
+            try
+            {
+                return base.ProcessCmdKey(ref msg, keyData);
+            }
+            catch
+            {
+                // The above throws on Mono for a top-level Control
+                // (as opposed to a Form)
+                return false;
+            }
         }
     }
 }

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -267,7 +267,7 @@
             //
             // EditModSearch
             //
-            this.EditModSearch.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.EditModSearch.Dock = System.Windows.Forms.DockStyle.Top;
             this.EditModSearch.ApplySearch += EditModSearch_ApplySearch;
             this.EditModSearch.SurrenderFocus += EditModSearch_SurrenderFocus;
             //
@@ -497,7 +497,7 @@
             //
             // InstallAllCheckbox
             //
-            this.InstallAllCheckbox.Location = new System.Drawing.Point(2, 50);
+            this.InstallAllCheckbox.Location = new System.Drawing.Point(2, 86);
             this.InstallAllCheckbox.Size = new System.Drawing.Size(20, 20);
             this.InstallAllCheckbox.Checked = true;
             this.InstallAllCheckbox.CheckedChanged += new System.EventHandler(this.InstallAllCheckbox_CheckChanged);
@@ -509,8 +509,8 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.Controls.Add(this.InstallAllCheckbox);
             this.Controls.Add(this.ModGrid);
-            this.Controls.Add(this.menuStrip2);
             this.Controls.Add(this.EditModSearch);
+            this.Controls.Add(this.menuStrip2);
             this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "ManageMods";
             this.Size = new System.Drawing.Size(1544, 948);

--- a/GUI/Localization/de-DE/EditModSearch.de-DE.resx
+++ b/GUI/Localization/de-DE/EditModSearch.de-DE.resx
@@ -118,12 +118,4 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>Suche:</value></data>
-  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>Name:</value></data>
-  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Autor:</value></data>
-  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>Beschreibung:</value></data>
-  <data name="FilterByLanguageLabel.Text" xml:space="preserve"><value>Sprache:</value></data>
-  <data name="FilterByDependsLabel.Text" xml:space="preserve"><value>Hängt ab von:</value></data>
-  <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>Empfiehlt:</value></data>
-  <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>Schlägt vor:</value></data>
-  <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>Hat einen Konflikt mit:</value></data>
 </root>

--- a/GUI/Localization/de-DE/EditModSearchDetails.de-DE.resx
+++ b/GUI/Localization/de-DE/EditModSearchDetails.de-DE.resx
@@ -117,5 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>Search:</value></data>
+  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Autor:</value></data>
+  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>Beschreibung:</value></data>
+  <data name="FilterByLanguageLabel.Text" xml:space="preserve"><value>Sprache:</value></data>
+  <data name="FilterByDependsLabel.Text" xml:space="preserve"><value>Hängt ab von:</value></data>
+  <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>Empfiehlt:</value></data>
+  <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>Schlägt vor:</value></data>
+  <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>Hat einen Konflikt mit:</value></data>
 </root>

--- a/GUI/Localization/zh-CN/EditModSearch.zh-CN.resx
+++ b/GUI/Localization/zh-CN/EditModSearch.zh-CN.resx
@@ -150,13 +150,5 @@
   <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
     <value>(Default)</value>
   </data>
-  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>按作者名筛选:</value></data>
-  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>按Mod名称筛选:</value></data>
-  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>按描述筛选:</value></data>
   <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>搜索:</value></data>
-  <data name="FilterByLanguageLabel.Text" xml:space="preserve"><value>按语言筛选:</value></data>
-  <data name="FilterByDependsLabel.Text" xml:space="preserve"><value>按依赖Mod筛选:</value></data>
-  <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>按推荐Mod筛选:</value></data>
-  <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>按建议Mod筛选:</value></data>
-  <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>按冲突Mod筛选:</value></data>
 </root>

--- a/GUI/Localization/zh-CN/EditModSearchDetails.zh-CN.resx
+++ b/GUI/Localization/zh-CN/EditModSearchDetails.zh-CN.resx
@@ -117,5 +117,45 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>Search:</value></data>
+  <metadata name="menuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>236, 17</value>
+  </metadata>
+  <metadata name="Installed.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ModName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Author.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="InstalledVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ModListContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>351, 17</value>
+  </metadata>
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
+    <value>(Default)</value>
+  </data>
+  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>按作者名筛选:</value></data>
+  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>按Mod名称筛选:</value></data>
+  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>按描述筛选:</value></data>
+  <data name="FilterByLanguageLabel.Text" xml:space="preserve"><value>按语言筛选:</value></data>
+  <data name="FilterByDependsLabel.Text" xml:space="preserve"><value>按依赖Mod筛选:</value></data>
+  <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>按推荐Mod筛选:</value></data>
+  <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>按建议Mod筛选:</value></data>
+  <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>按冲突Mod筛选:</value></data>
 </root>


### PR DESCRIPTION
## Background / motivation

In #3041, we replaced the 3 old search fields at the top with 1 at the bottom, which can be expanded to to reveal 8 detail-level fields:

<img src="https://user-images.githubusercontent.com/1559108/80555820-05e23800-8997-11ea-98a8-6f7903cfa742.png" width="320"/> <img src="https://user-images.githubusercontent.com/1559108/80555873-36c26d00-8997-11ea-9ea1-5182317ed713.png" width="320"/>

Initially during development I tried to keep the search field at the top, but I had trouble figuring out how to create a dropdown in WinForms that floats over the grid with editable controls in it, and it wasn't clear whether that was important. An expand/collapse (in the style of the above screenshots) on the top was jarring because it caused the top of the grid to jump up and down. Moving it to the bottom allowed those changes to be finished up and released with less risk of bugs, and I found examples of other applications that do just that:

<img src="https://user-images.githubusercontent.com/1559108/94623537-f0ee3580-02a3-11eb-99b5-e790e17d8df6.png" width="320"/> <img src="https://user-images.githubusercontent.com/1559108/94623639-2eeb5980-02a4-11eb-989d-158634f08cb5.png" width="320"/>

We included this change in [the v1.28.0-PRE1 pre-release](https://github.com/KSP-CKAN/CKAN/releases/tag/v1.28.0-PRE1) and didn't hear a peep, but after it was fully released, multiple users expressed a preference for having the search at the top (see #3163).

## Changes

Now the search is moved back to the top:

![image](https://user-images.githubusercontent.com/1559108/95798624-21789b00-0cb8-11eb-928f-2960bd2518ef.png)

If you expand it, the other fields appear in a dropdown:

![image](https://user-images.githubusercontent.com/1559108/95799236-aadc9d00-0cb9-11eb-8376-d319b1c1f6ec.png)

This is not easy to do in WinForms (there's not one simple switch to flip to turn it on; rather you have to tweak many poorly-documented settings in concert in just the right way), so careful testing is needed and quirks are likely to be found. In effect, the dropdown is a new top-level/standalone window with special flags set, with which the main window communicates from the outside.

Fixes #3163.