### PR TITLE
Allow installation into Ships/Script

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -411,7 +411,7 @@
                 {
                     "description" : "Spec v1.12 Ships subfolder paths",
                     "type"        : "string",
-                    "pattern"     : "^Ships/(SPH|VAB)$"
+                    "pattern"     : "^Ships/(SPH|VAB|Script)$"
                 },
                 {
                     "description" : "Spec v1.16 thumbs paths",

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -388,6 +388,13 @@ namespace CKAN
                 Path.Combine(ShipsThumbs(), "VAB")
             );
         }
+        
+        public string ShipsScript()
+        {
+            return KSPPathUtils.NormalizePath(
+                Path.Combine(Ships(), "Script")
+            );
+        }
 
         public string Tutorial()
         {

--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -168,13 +168,15 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Normalizes the path by replace any \ with / and removing any trailing slash.
+        /// Normalizes the path by replacing all \ with / and removing any trailing slash.
         /// </summary>
-        /// <returns>The normalized path.</returns>
-        /// <param name="path">The path to normalize.</param>
+        /// <param name="path">The path to normalize</param>
+        /// <returns>The normalized path</returns>
         public static string NormalizePath(string path)
         {
-            return path?.Replace('\\', '/').TrimEnd('/');
+            return path == null    ? null
+                 : path.Length < 2 ? path.Replace('\\', '/')
+                 : path.Replace('\\', '/').TrimEnd('/');
         }
 
         /// <summary>

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -511,7 +511,8 @@ namespace CKAN
                     || path == ksp.Scenarios() || path == ksp.GameData()
                     || path == ksp.GameDir() || path == ksp.CkanDir()
                     || path == ksp.ShipsThumbs() || path == ksp.ShipsThumbsVAB()
-                    || path == ksp.ShipsThumbsSPH() || path == ksp.Missions();
+                    || path == ksp.ShipsThumbsSPH() || path == ksp.ShipsScript()
+                    || path == ksp.Missions();
         }
 
         /// <summary>
@@ -881,7 +882,8 @@ namespace CKAN
                     var results = new HashSet<string>();
                     // adding in the DirectorySeparatorChar fixes attempts on Windows
                     // to parse "X:" which resolves to Environment.CurrentDirectory
-                    var dirInfo = new DirectoryInfo(dir + Path.DirectorySeparatorChar);
+                    var dirInfo = new DirectoryInfo(
+                        dir.EndsWith("/") ? dir : dir + Path.DirectorySeparatorChar);
 
                     // if this is a parentless directory (Windows)
                     // or if the Root equals the current directory (Mono)

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -82,10 +82,11 @@ namespace CKAN.NetKAN.Services
 
         public IEnumerable<string> FileDestinations(CkanModule module, string filePath)
         {
+            var ksp = new KSP("/", "dummy", null, false);
             return ModuleInstaller
-                .FindInstallableFiles(module, filePath, new KSP("/", "dummy", null, false))
+                .FindInstallableFiles(module, filePath, ksp)
                 .Where(f => !f.source.IsDirectory)
-                .Select(f => f.destination);
+                .Select(f => ksp.ToRelativeGameDir(f.destination));
         }
 
         /// <summary>

--- a/Netkan/Validators/InstallValidator.cs
+++ b/Netkan/Validators/InstallValidator.cs
@@ -18,6 +18,10 @@ namespace CKAN.NetKAN.Validators
                     {
                         throw new Kraken("spec_version v1.2+ required for GameData with path");
                     }
+                    if (metadata.SpecVersion < v1p29 && install_to.StartsWith("Ships/Script"))
+                    {
+                        throw new Kraken("spec_version v1.29+ required to install to Ships/Script");
+                    }
                     if (metadata.SpecVersion < v1p12 && install_to.StartsWith("Ships/"))
                     {
                         throw new Kraken("spec_version v1.12+ required to install to Ships/ with path");
@@ -65,6 +69,7 @@ namespace CKAN.NetKAN.Validators
         private static readonly ModuleVersion v1p12 = new ModuleVersion("v1.12");
         private static readonly ModuleVersion v1p16 = new ModuleVersion("v1.16");
         private static readonly ModuleVersion v1p18 = new ModuleVersion("v1.18");
+        private static readonly ModuleVersion v1p29 = new ModuleVersion("v1.29");
         private static readonly string[] pathProperties = {"find", "file", "install_to"};
     }
 }

--- a/Spec.md
+++ b/Spec.md
@@ -293,7 +293,7 @@ three source directives:
 In addition a destination directive *must* be provided:
 
 - `install_to`: The target location where the matched file or directory should be installed.
-  -  Valid values for this entry are `GameData`, `Missions`(**v1.25**), `Ships`, `Ships/SPH`(**v1.12**), `Ships/VAB`(**v1.12**), `Ships/@thumbs/VAB`(**v1.16**), `Ships/@thumbs/SPH`(**v1.16**), `Tutorial`, `Scenarios` (**v1.14**)
+  -  Valid values for this entry are `GameData`, `Missions`(**v1.25**), `Ships`, `Ships/SPH`(**v1.12**), `Ships/VAB`(**v1.12**), `Ships/@thumbs/VAB`(**v1.16**), `Ships/@thumbs/SPH`(**v1.16**), `Ships/Script`(**v1.29**), `Tutorial`, `Scenarios` (**v1.14**)
   and `GameRoot` (which should be used sparingly, if at all).
   -  A path to a given subfolder location can be specified *only* under `GameData` (**v1.2**);
   for example: `GameData/MyMod/Plugins`. The client *must* check this path and abort the install


### PR DESCRIPTION
## Problems

- kOS stores scripts in the `Ships/Script` folder under the game root. Currently CKAN doesn't allow this, and KSP-CKAN/NetKAN#7967 is in stasis because it needs to install kOS scripts to that folder.
- `ShipSaveSplicer` is being installed into `GameData/veSplicer` because it starts with `Ships`

## Changes

- Now we allow installation into `Ships/Script`, including creation of new directories.
  **Since this requires an update of the schema, the next release of CKAN will need to be v1.29.0 if this is merged.**
- Now we require a path to start with `Ships/` with a slash to trigger that truncation, so `ShipSaveSplicer` will be installed correctly.
  Fixes #3187.