### PR TITLE
Allow upgrading manually installed modules

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -41,7 +41,7 @@ namespace CKAN.CmdLine
                 return true;
             }
 
-            Console.Write("{0} [Y/n] ", question);
+            Console.Write("\r\n{0} [Y/n] ", question);
             while (true)
             {
                 var input = Console.In.ReadLine();

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -476,7 +476,9 @@ namespace CKAN
                 bool dlcChanged = manager.ScanDlc();
 
                 if (dllChanged || dlcChanged)
+                {
                     manager.Save(false);
+                }
 
                 tx.Complete();
 

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1004,12 +1004,6 @@ namespace CKAN
 
                 if (installed_mod == null)
                 {
-                    //Maybe ModuleNotInstalled ?
-                    if (registry_manager.registry.IsAutodetected(ident))
-                    {
-                        throw new ModuleNotFoundKraken(ident, module.version.ToString(), String.Format("Can't upgrade {0} as it was not installed by CKAN. \r\n Please remove manually before trying to install it.", ident));
-                    }
-
                     User.RaiseMessage("Installing previously uninstalled mod {0}", ident);
                 }
                 else

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -184,7 +184,6 @@ namespace CKAN
             }
             if (newest_version == null
                 || !querier.IsInstalled(identifier, false)
-                || querier.InstalledDlls.Contains(identifier)
                 || !newest_version.version.IsGreaterThan(querier.InstalledVersion(identifier)))
             {
                 return false;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -372,6 +372,7 @@ namespace CKAN
         /// <param name="allowRepoUpdate">true if a repo update is allowed if needed (e.g. on initial load), false otherwise</param>
         private void CurrentInstanceUpdated(bool allowRepoUpdate)
         {
+            CurrentInstance.ScanGameData();
             Util.Invoke(this, () =>
             {
                 Text = $"CKAN {Meta.GetVersion()} - KSP {CurrentInstance.Version()}    --    {CurrentInstance.GameDir().Replace('/', Path.DirectorySeparatorChar)}";

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -111,9 +111,6 @@ namespace CKAN
         /// </returns>
         public bool IsInstallable()
         {
-            // Auto detected mods are never installable
-            if (IsAutodetected)
-                return false;
             // Compatible mods are installable, but so are mods that are already installed
             return !IsIncompatible || IsInstalled;
         }
@@ -203,7 +200,7 @@ namespace CKAN
             Identifier     = identifier;
             IsAutodetected = registry.IsAutodetected(identifier);
             DownloadCount  = registry.DownloadCount(identifier);
-            if (registry.IsAutodetected(identifier))
+            if (IsAutodetected)
             {
                 IsInstalled = true;
             }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -265,7 +265,12 @@ namespace CKAN
 
             ModChange myChange = changes?.FindLast((ModChange ch) => ch.Mod.Equals(mod));
 
-            var selecting = mod.IsInstallable()
+            var selecting = mod.IsAutodetected
+                ? new DataGridViewTextBoxCell()
+                {
+                    Value = Properties.Resources.MainModListAutoDetected
+                }
+                : mod.IsInstallable()
                 ? (DataGridViewCell) new DataGridViewCheckBoxCell()
                 {
                     Value = myChange == null ? mod.IsInstalled
@@ -275,7 +280,7 @@ namespace CKAN
                 }
                 : new DataGridViewTextBoxCell()
                 {
-                    Value = mod.IsAutodetected ? Properties.Resources.MainModListAutoDetected : "-"
+                    Value = "-"
                 };
 
             var autoInstalled = mod.IsInstalled && !mod.IsAutodetected


### PR DESCRIPTION
## Motivation

A very longstanding enhancement request is the ability to have CKAN take over management of mods that were manually installed. We took a first step towards this in #3043 by prompting the user if we need to overwrite manually installed files to install a module, which meant the user could use the Versions tab to have CKAN install a mod on top of a manual install. Now it's time to take this further.

Benefits:

- New users can more easily migrate their pre-CKAN installs to CKAN-managed
- Recovery from a corrupted registry will be easier

## Related problem

If you install a mod and then upgrade to a newer version of it that has new dependencies, the `ckan upgrade modname` command doesn't install them. (`ckan upgrade --all` _does_ install them.)

### Cause

The `ckan upgrade modname` command doesn't resolve relationships. We have a parameter for this, which is left at its default value of `false`.

## Changes

Now it is possible to upgrade a manually installed module using the familiar upgrade tools of each UI. The user will be prompted to overwrite the files via the normal yes/no prompt for each UI. If the user chooses to overwrite, the installation will complete and the module becomes CKAN-managed. If the user chooses not to overwrite, the installation will abort.

Core:

- Now `ModuleInstaller.Upgrade` doesn't skip manually installed mods, and instead tries to install them
- Now `IRegistryQuerier.HasUpdate` returns `true` for manually installed mods with compatible versions

CmdLine:

- `ckan upgrade --all` now includes manually installed modules in the list of mods to upgrade
- Now a yes/no prompt in CmdLine will print a newline first, so we can prompt for overwrite when the latest message is from `RaiseProgress` which doesn't print a newline at the end
- Now if a `CancelledActionKraken` is thrown during a `ckan upgrade` command (which can happen if the user chooses not to overwrite manually installed files), we catch it and print a message
- Now `ckan upgrade modname` installs dependencies (fixes #1124)

ConsoleUI:

- Now the "Scan KSP dir" command is removed and instead occurs automatically whenever we generate or refresh the mod list, to ensure that manually installed mods are always shown or not shown based on the current status of the game dir
- Now a manually installed module with an installable version is treated as upgradeable for purposes of the status icon column and the upgrade-all command

GUI:

- Now we scan for manually installed mods when we load a game instance rather than when updating repositories, to make sure they're up to date at startup
- Now `GUIMod.IsInstallable` is true for manually installed mods with compatible versions
- Now the upgrade checkbox is available for manually installed mods with compatible versions

### Known limitations

This functionality depends on CKAN's existing method for detecting manually installed mods, which is not changed (essentially we look for files of the form `<identifier>.dll`, with some allowances for variations in the format of the name). Manually installed mods that CKAN can't detect (i.e, ones that don't show up as "AD" in GUI) will _not_ be upgradeable (but they are already _installable_). Users sometimes request an automated process for migrating whole installs to CKAN control, with the implication that any random `.cfg` file they download from the forum and toss into their GameData would be detected and managed; it's important to note that we're not attempting to do that, just improve handling of mods CKAN already detects.