### PR TITLE
Upgrade DLL build to .NET 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.301'
+          dotnet-version: '5.0.x'
       - name: Restore cache for _build/tools
         uses: actions/cache@v1
         with:

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -19,7 +19,7 @@
   <Choose>
     <When Condition="$(Configuration.EndsWith('NetCore'))">
       <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -48,7 +48,7 @@
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="System.Security.Permissions" Version="4.7.0" />

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -370,7 +370,7 @@ namespace CKAN.Configuration
                     // Ensure the directory exists
                     new FileInfo(configFile).Directory.Create();
 
-#if !NETSTANDARD
+#if !NETCOREAPP
                     // If we are not running on .NET Standard, try to migrate from the real registry
                     if (Win32RegistryConfiguration.DoesRegistryConfigurationExist())
                     {

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -371,7 +371,7 @@ namespace CKAN.Configuration
                     new FileInfo(configFile).Directory.Create();
 
 #if !NETCOREAPP
-                    // If we are not running on .NET Standard, try to migrate from the real registry
+                    // If we are not running on .NET Core, try to migrate from the real registry
                     if (Win32RegistryConfiguration.DoesRegistryConfigurationExist())
                     {
                         Migrate();

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -15,6 +15,7 @@ namespace CKAN.Extensions
             return source is ICollection<T> collection ? collection : source.ToArray();
         }
 
+#if NET45
         public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
         {
             if (source == null)
@@ -22,6 +23,7 @@ namespace CKAN.Extensions
 
             return new HashSet<T>(source);
         }
+#endif
 
         public static IEnumerable<T> Memoize<T>(this IEnumerable<T> source)
         {

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -980,7 +980,7 @@ namespace CKAN
         {
             modules = modules.Memoize();
             User.RaiseMessage("About to upgrade...\r\n");
-            
+
             if (resolveRelationships)
             {
                 var resolver = new RelationshipResolver(modules, null, RelationshipResolver.DependsOnlyOpts(), registry_manager.registry, ksp.VersionCriteria());
@@ -1040,8 +1040,9 @@ namespace CKAN
         /// <summary>
         /// Enacts listed Module Replacements to the specified versions for the user's KSP.
         /// Will *re-install* or *downgrade* (with a warning) as well as upgrade.
-        /// Throws ModuleNotFoundKraken if a module is not installed.
         /// </summary>
+        /// <exception cref="DependencyNotSatisfiedKraken">Thrown if a dependency for a replacing module couldn't be satisfied.</exception>
+        /// <exception cref="ModuleNotFoundKraken">Thrown if a module that should be replaced is not installed.</exception>
         public void Replace(IEnumerable<ModuleReplacement> replacements, RelationshipResolverOptions options, IDownloader netAsyncDownloader, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool enforceConsistency = true)
         {
             replacements = replacements.Memoize();
@@ -1115,22 +1116,14 @@ namespace CKAN
                 }
             }
             var resolver = new RelationshipResolver(modsToInstall, null, options, registry_manager.registry, ksp.VersionCriteria());
-            try
-            {
-                var resolvedModsToInstall = resolver.ModList().ToList();
-                AddRemove(
-                    ref possibleConfigOnlyDirs,
-                    registry_manager,
-                    resolvedModsToInstall,
-                    modsToRemove,
-                    enforceConsistency
-                );
-            }
-            catch (DependencyNotSatisfiedKraken kraken)
-            {
-                throw kraken;
-            }
-
+            var resolvedModsToInstall = resolver.ModList().ToList();
+            AddRemove(
+                ref possibleConfigOnlyDirs,
+                registry_manager,
+                resolvedModsToInstall,
+                modsToRemove,
+                enforceConsistency
+            );
         }
 
         #endregion

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using Autofac;
 using log4net;
 using Newtonsoft.Json;
-using CKAN.Extensions;
 using CKAN.Versioning;
 
 namespace CKAN

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -104,7 +104,7 @@ namespace Tests.Core.Relationships
         public void FindUnsatisfiedDepends()
         {
             var mods = new List<CkanModule>();
-            var dlls = CKAN.Extensions.EnumerableExtensions.ToHashSet(Enumerable.Empty<string>());
+            var dlls = Enumerable.Empty<string>().ToHashSet();
             var dlc = new Dictionary<string, ModuleVersion>();
 
             Assert.IsEmpty(CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc), "Empty list");

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -20,7 +20,7 @@
   <Choose>
     <When Condition="$(Configuration.EndsWith('NetCore'))">
       <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -29,7 +29,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <DefaultItemExcludes>$(DefaultItemExcludes);NetKAN\**;GUI\**</DefaultItemExcludes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug_NetCore' ">
@@ -56,7 +56,7 @@
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
   <ItemGroup>

--- a/build.cake
+++ b/build.cake
@@ -7,7 +7,7 @@
 using System.Text.RegularExpressions;
 using Semver;
 
-var buildNetCore = "netcoreapp3.1";
+var buildNetCore = "net5.0";
 var buildNetFramework = "net45";
 
 var target = Argument<string>("target", "Default");

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.38.4" />
+  <package id="Cake" version="0.38.5" />
 </packages>


### PR DESCRIPTION
## Motivation
Mostly because I already have the changes and because @HebaruSan said I should do a PR :D
Also [.NET 5 has been released yesterday](https://devblogs.microsoft.com/dotnet/announcing-net-5-0/) as "the first release in [Microsoft's] .NET unification journey."

The Core DLL isn't really used anywhere on its own, especially in its .NET (Core) form, so this shouldn't break anything either.

One day we want to create a new GUI based on MAUI, so it's not a bad idea to keep the Core up to date.


## Changes
* Changed the `netstandard2.0` `TargetFramework` to `net5.0` in `CKAN-core.csproj`. The `net45` one is untouched.
* Changed the `netcoreapp3.1` `TargetFramework` to `net5.0` in `Tests.csproj`. The `net45` one is untouched.
* Put our own `IEnumerable.TohashSet()` implementation between `#if NET45 ... #endif`, since .NET 5 (and even .NET Framework 4.7.2) comes with a native implementation. We'll have to update this if/when we ever change our Framework build away from 4.5.
* Related, changed a line in the test that called `TohashSet()` via the full namespace path as static funtion, passing the object, to calling it on the object.
* Upgraded Cake to v0.38.5 which has improved .NET 5 support. I've also just seen that there is [Cake v1.0.0-rc1 available now](https://cakebuild.net/blog/#cake-v1-0-0-rc1-released), but I haven't tested it yet.
* Upgraded the cake build script to target `net5.0` for .NET (Core) builds.
* And changed our GitHub workflow to install .NET 5 prior to running our netcore build script.
