### PR TITLE
Fix error when removing file from GameRoot

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -775,7 +775,7 @@ namespace CKAN
                         }
                         else
                         {
-                            // Add this files' directory to the list for deletion if it isn't already there.
+                            // Add this file's directory to the list for deletion if it isn't already there.
                             // Helps clean up directories when modules are uninstalled out of dependency order
                             // Since we check for directory contents when deleting, this should purge empty
                             // dirs, making less ModuleManager headaches for people.
@@ -873,19 +873,19 @@ namespace CKAN
             var gameDir = KSPPathUtils.NormalizePath(ksp.GameDir());
             return directories
                 .Where(dir => !string.IsNullOrWhiteSpace(dir))
-                // normalize all paths before deduplicate
+                // Normalize all paths before deduplicate
                 .Select(KSPPathUtils.NormalizePath)
-                // remove any duplicate paths
+                // Remove any duplicate paths
                 .Distinct()
                 .SelectMany(dir =>
                 {
                     var results = new HashSet<string>();
-                    // adding in the DirectorySeparatorChar fixes attempts on Windows
+                    // Adding in the DirectorySeparatorChar fixes attempts on Windows
                     // to parse "X:" which resolves to Environment.CurrentDirectory
                     var dirInfo = new DirectoryInfo(
                         dir.EndsWith("/") ? dir : dir + Path.DirectorySeparatorChar);
 
-                    // if this is a parentless directory (Windows)
+                    // If this is a parentless directory (Windows)
                     // or if the Root equals the current directory (Mono)
                     if (dirInfo.Parent == null || dirInfo.Root == dirInfo)
                     {
@@ -897,14 +897,18 @@ namespace CKAN
                         dir = KSPPathUtils.ToAbsolute(dir, gameDir);
                     }
 
-                    // remove the system paths, leaving the path under the instance directory
+                    // Remove the system paths, leaving the path under the instance directory
                     var relativeHead = KSPPathUtils.ToRelative(dir, gameDir);
-                    var pathArray = relativeHead.Split('/');
-                    var builtPath = string.Empty;
-                    foreach (var path in pathArray)
+                    // Don't try to remove GameRoot
+                    if (!string.IsNullOrEmpty(relativeHead))
                     {
-                        builtPath += path + '/';
-                        results.Add(KSPPathUtils.ToAbsolute(builtPath, gameDir));
+                        var pathArray = relativeHead.Split('/');
+                        var builtPath = "";
+                        foreach (var path in pathArray)
+                        {
+                            builtPath += path + '/';
+                            results.Add(KSPPathUtils.ToAbsolute(builtPath, gameDir));
+                        }
                     }
 
                     return results;

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -653,6 +653,7 @@ namespace Tests.Core
         [TestCase("Ships/@thumbs")]
         [TestCase("Ships/@thumbs/VAB")]
         [TestCase("Ships/@thumbs/SPH")]
+        [TestCase("Ships/Script")]
         public void AllowsInstallsToShipsDirectories(string directory)
         {
             // Arrange

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -25,6 +25,7 @@ namespace Tests.Core
         private CKAN.Registry        _registry;
         private CKAN.ModuleInstaller _installer;
         private CkanModule           _testModule;
+        private string               _gameDir;
         private string               _gameDataDir;
         private IUser                _nullUser;
 
@@ -45,6 +46,7 @@ namespace Tests.Core
             _registry  = _registryManager.registry;
             _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _nullUser);
 
+            _gameDir = _instance.KSP.GameDir();
             _gameDataDir = _instance.KSP.GameData();
             _registry.AddAvailable(_testModule);
             var testModFile = TestData.DogeCoinFlagZip();
@@ -64,6 +66,19 @@ namespace Tests.Core
             _manager.Dispose();
             _config.Dispose();
             _instance.Dispose();
+        }
+
+        /// <summary>
+        /// Make sure that the GameRoot directory is not included and doesn't throw an exception.
+        /// </summary>
+        [Test]
+        public void TestGameRoot()
+        {
+            var result = _installer
+                .AddParentDirectories(new HashSet<string>() { _gameDir })
+                .ToList();
+
+            Assert.IsEmpty(result);
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

If you install a mod that installs a file to GameRoot (e.g. [AdvancedFlyByWire](https://github.com/KSP-CKAN/CKAN-meta/blob/master/AdvancedFlyByWire/AdvancedFlyByWire-1.8.3.2.ckan)), and then remove it, the removal fails:

```
About to remove:

 * Advanced Fly-By-Wire (Windows) 1.8.3.2
 * Toolbar Controller 1:0.1.9.4
 * ClickThrough Blocker 1:0.1.10.14
 * Zero MiniAVC 1:1.1.0.1
Removing AdvancedFlyByWire...
/ is already absolute
Error during installation!
If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
```

## Cause

In #3180 we fixed `KSPPathUtils.NormalizePath` to no longer incorrectly convert `"/"` to `""`, because those are two different directories, and normalization is supposed to generate a standardized format of the **same** directory.

That change indirectly confused this loop:

https://github.com/KSP-CKAN/CKAN/blob/a494e1dafb5ed2f19307bdc6180a163c6f5ef9ed/Core/ModuleInstaller.cs#L900-L908

For a file in GameRoot, the absolute path to the game folder is included in the `directories` parameter of `ModuleInstaller.AddParentDirectories`, which results in `relativeHead` containing the empty string. Then in the first iteration of the loop, `buildPath` is set to `/`, and `ToAbsolute` calls `NormalizePath` on it, after which it is still `/`, so `ToAbsolute` throws because that path is already absolute.

## Considered and not done

We _could_ change `ToAbsolute` to use some method other than `NormalizePath` to massage its inputs. I think it would be better to continue to uncover places in Core where paths are treated sloppily and fix them. `ToAbsolute("/", "/myroot/")` _should_ throw an exception if `ToAbsolute("/afile", "/myroot/")` would.

## Changes

Now if `relativeHead` is empty, that means there are no parent folders to check, so we skip that loop.

Fixes #3195.