### PR TITLE
Generate APT repo for releases and under dev builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Installing build dependencies
-        run: apt-get update && apt-get install -y git
+        run: apt-get update && apt-get install -y git make sed gzip fakeroot lintian dpkg-dev
       - name: Installing runtime dependencies
         run: apt-get install -y xvfb
       - name: Install Docker
@@ -45,6 +45,8 @@ jobs:
 
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=Release
+      - name: Build deb
+        run: ./build deb --configuration=Release --exclusive
       - name: Run tests
         run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
 
@@ -59,7 +61,7 @@ jobs:
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           ./build docker-inflator --exclusive
-      - name: Push to S3
+      - name: Push ckan.exe and netkan.exe to S3
         # Send ckan.exe and netkan.exe to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master
         with:
@@ -70,6 +72,19 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/repack/Release
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+      - name: Push deb to S3
+        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/deb/apt-repo
+          DEST_DIR: deb/dists/nightly/main/binary-all
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Send Discord Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Installing build dependencies
-        run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq
+        run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq dpkg-dev
       - name: Installing runtime dependencies
         run: apt-get install -y xvfb
       - name: Restore cache for _build/tools
@@ -105,6 +105,19 @@ jobs:
           asset_path: _build/out/AutoUpdater/Release/bin/AutoUpdater.exe
           asset_name: AutoUpdater.exe
           asset_content_type: application/vnd.microsoft.portable-executable
+      - name: Push deb to S3
+        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/deb/apt-repo
+          DEST_DIR: deb/dists/stable/main/binary-all
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Send Discord Notification
         env:

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean test
+.PHONY: clean test repo
 
 DESTDIR:=../_build/deb/fakeroot
 EXESRC:=../_build/repack/Release/ckan.exe
@@ -23,6 +23,25 @@ CONSOLEUIDESKTOPSRC:=ckan-consoleui.desktop
 CONSOLEUIDESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan-consoleui.desktop
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
 DEB:=../_build/deb/ckan_$(VERSION)_all.deb
+APTREPO:=../_build/deb/apt-repo
+REPODEB:=$(APTREPO)/ckan_$(VERSION)_all.deb
+PACKAGES:=$(APTREPO)/Packages.gz
+RELEASESRC:=Release.in
+RELEASEDEST:=$(APTREPO)/Release
+
+repo: $(REPODEB) $(PACKAGES) $(RELEASEDEST)
+
+$(REPODEB): $(DEB)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && cp $< $@
+
+$(PACKAGES): $(REPODEB)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && (cd $(shell dirname $<) && dpkg-scanpackages -m .) | gzip -c > $@
+
+$(RELEASEDEST): $(RELEASESRC)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && sed -e 's/@VERSION@/$(VERSION)/' $< > $@
 
 $(DEB): $(EXEDEST) $(SCRIPTDEST) $(CONTROLDEST) $(CHANGELOGDEST) $(DEBCHANGEDEST) $(MANDEST) $(ICONDEST) $(COPYRIGHTDEST) $(DESKTOPDEST) $(CONSOLEUIDESKTOPDEST)
 	umask 0022 && mkdir -p $(shell dirname $@)

--- a/debian/Release.in
+++ b/debian/Release.in
@@ -1,0 +1,4 @@
+Components: main
+Architectures: all
+Description: Packages of the latest releases of the KSP-CKAN official client
+Version: @VERSION@


### PR DESCRIPTION
## Motivation

Currently we provide `.deb` packages, but somewhat ironically (given what CKAN is for), the user must download a new `.deb` file and install it manually when a new version is released.

## Changes

Now when we build the `.deb` file, we also create a `_build/deb/apt-repo` folder containing the `.deb` file, a `Release` file, and a `Packages.gz` file, modeled on Mono's:

- https://download.mono-project.com/repo/ubuntu/dists/stable-bionic/main/binary-amd64/

For releases, these are uploaded to: `https://ksp-ckan.s3-us-west-2.amazonaws.com/deb/dists/stable/main/binary-all`
For other builds, these are uploaded to: `https://ksp-ckan.s3-us-west-2.amazonaws.com/deb/dists/nightly/main/binary-all`

This should allow users to add one of the following lines to their `sources.list` and get ckan releases automatically:

```
deb https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable main
```
```
deb https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly main
```

**NOTE: This is all based on documentation of how to build an APT repo. It still needs to be tested to confirm that it will actually work with APT clients.**

### Open questions

- Is the level of traffic associated with a deb repo acceptable for S3?
  - Previous CKAN release (v1.28.0) has 111977 downloads total, and 3285 downloads for its .deb (https://api.github.com/repos/KSP-CKAN/CKAN/releases)
  - The Packages.gz file is 483 bytes
  - Supposing that every one of those 3285 users would sign up for the APT repo, that's 1.5 MB of traffic every however-often-they-check-for-updates (in aggregate)
  - The deb file is 748 KB, so about 2.5 GB for all of those users to download it
- Do we need the `--delete` flag for `deploy.yml`, or would it erase the release builds as well?
- Should we modify our versioning for nightly builds, and if so, how?