### PR TITLE
Search UI fixes

### DIFF
--- a/GUI/Controls/EditModSearch.Designer.cs
+++ b/GUI/Controls/EditModSearch.Designer.cs
@@ -74,6 +74,7 @@
             //
             this.ExpandButton.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Right);
             this.ExpandButton.Appearance = System.Windows.Forms.Appearance.Button;
+            this.ExpandButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ExpandButton.Cursor = System.Windows.Forms.Cursors.Hand;
             this.ExpandButton.Location = new System.Drawing.Point(400, 5);
             this.ExpandButton.Name = "ExpandButton";
@@ -95,7 +96,6 @@
             // EditModSearch
             //
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.Leave += new System.EventHandler(this.OnLeave);
             this.Controls.Add(this.FilterCombinedLabel);
             this.Controls.Add(this.ExpandButton);
             this.Controls.Add(this.FilterCombinedTextBox);

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -160,7 +160,7 @@ namespace CKAN
             }
         }
 
-        private void OnLeave(object sender, EventArgs e)
+        protected override void OnLeave(EventArgs e)
         {
             ExpandButton.Checked = false;
         }

--- a/GUI/Controls/EditModSearchDetails.Designer.cs
+++ b/GUI/Controls/EditModSearchDetails.Designer.cs
@@ -63,10 +63,10 @@
             //
             this.FilterByNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByNameTextBox.Location = new System.Drawing.Point(100, 7);
+            this.FilterByNameTextBox.Location = new System.Drawing.Point(110, 7);
             this.FilterByNameTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByNameTextBox.Name = "FilterByNameTextBox";
-            this.FilterByNameTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterByNameTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterByNameTextBox.TabIndex = 1;
             this.FilterByNameTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterByNameTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
@@ -87,10 +87,10 @@
             //
             this.FilterByAuthorTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByAuthorTextBox.Location = new System.Drawing.Point(100, 33);
+            this.FilterByAuthorTextBox.Location = new System.Drawing.Point(110, 33);
             this.FilterByAuthorTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByAuthorTextBox.Name = "FilterByAuthorTextBox";
-            this.FilterByAuthorTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterByAuthorTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterByAuthorTextBox.TabIndex = 3;
             this.FilterByAuthorTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterByAuthorTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
@@ -111,10 +111,10 @@
             //
             this.FilterByDescriptionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByDescriptionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByDescriptionTextBox.Location = new System.Drawing.Point(100, 59);
+            this.FilterByDescriptionTextBox.Location = new System.Drawing.Point(110, 59);
             this.FilterByDescriptionTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByDescriptionTextBox.Name = "FilterByDescriptionTextBox";
-            this.FilterByDescriptionTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterByDescriptionTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterByDescriptionTextBox.TabIndex = 5;
             this.FilterByDescriptionTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterByDescriptionTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
@@ -135,10 +135,10 @@
             //
             this.FilterByLanguageTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByLanguageTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByLanguageTextBox.Location = new System.Drawing.Point(100, 85);
+            this.FilterByLanguageTextBox.Location = new System.Drawing.Point(110, 85);
             this.FilterByLanguageTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByLanguageTextBox.Name = "FilterByLanguageTextBox";
-            this.FilterByLanguageTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterByLanguageTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterByLanguageTextBox.TabIndex = 7;
             this.FilterByLanguageTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterByLanguageTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
@@ -159,10 +159,10 @@
             //
             this.FilterByDependsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByDependsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByDependsTextBox.Location = new System.Drawing.Point(100, 111);
+            this.FilterByDependsTextBox.Location = new System.Drawing.Point(110, 111);
             this.FilterByDependsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByDependsTextBox.Name = "FilterByDependsTextBox";
-            this.FilterByDependsTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterByDependsTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterByDependsTextBox.TabIndex = 9;
             this.FilterByDependsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterByDependsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
@@ -183,10 +183,10 @@
             //
             this.FilterByRecommendsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByRecommendsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByRecommendsTextBox.Location = new System.Drawing.Point(100, 137);
+            this.FilterByRecommendsTextBox.Location = new System.Drawing.Point(110, 137);
             this.FilterByRecommendsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByRecommendsTextBox.Name = "FilterByRecommendsTextBox";
-            this.FilterByRecommendsTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterByRecommendsTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterByRecommendsTextBox.TabIndex = 11;
             this.FilterByRecommendsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterByRecommendsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
@@ -207,10 +207,10 @@
             //
             this.FilterBySuggestsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterBySuggestsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterBySuggestsTextBox.Location = new System.Drawing.Point(100, 163);
+            this.FilterBySuggestsTextBox.Location = new System.Drawing.Point(110, 163);
             this.FilterBySuggestsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterBySuggestsTextBox.Name = "FilterBySuggestsTextBox";
-            this.FilterBySuggestsTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterBySuggestsTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterBySuggestsTextBox.TabIndex = 13;
             this.FilterBySuggestsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterBySuggestsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
@@ -231,10 +231,10 @@
             //
             this.FilterByConflictsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByConflictsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByConflictsTextBox.Location = new System.Drawing.Point(100, 189);
+            this.FilterByConflictsTextBox.Location = new System.Drawing.Point(110, 189);
             this.FilterByConflictsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByConflictsTextBox.Name = "FilterByConflictsTextBox";
-            this.FilterByConflictsTextBox.Size = new System.Drawing.Size(190, 26);
+            this.FilterByConflictsTextBox.Size = new System.Drawing.Size(180, 26);
             this.FilterByConflictsTextBox.TabIndex = 15;
             this.FilterByConflictsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             this.FilterByConflictsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);

--- a/GUI/Controls/HintTextBox.cs
+++ b/GUI/Controls/HintTextBox.cs
@@ -37,11 +37,7 @@ namespace CKAN
         /// <param name="e">The event arguments</param>
         private void HintTextBox_TextChanged(object sender, EventArgs e)
         {
-            // sanity checks
-            if (Visible && !ReadOnly)
-            {
-                ClearIcon.Visible = (TextLength > 0);
-            }
+            ClearIcon.Visible = (TextLength > 0) && !ReadOnly;
         }
 
         /// <summary>
@@ -71,7 +67,7 @@ namespace CKAN
         /// <returns></returns>
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
-            if (keyData == Keys.Escape)
+            if (keyData == Keys.Escape && !string.IsNullOrEmpty(Text))
             {
                 Text = "";
                 return true;


### PR DESCRIPTION
## Problem

I force-pushed some Windows UI fixes for #3175, but when code review was finished, I mistakenly merged the original Linux branch instead, resulting in the release of some annoyances that users might eventually complain about.

This was why GitHub did not automatically close that PR or the issue it fixed upon merge. I thought it was due to something else. Lesson learned, listen to GitHub!

## Changes

Luckily I still had the Windows branch sitting around.

- The search dropdown button is flat style instead of 3D to better fit in to the other UI elements
- The dropdown window is no longer always-on-top
- Pressing Esc in the dropdown will first clear the focused text box, if not empty, otherwise close the dropdown
- The labels in the search dropdown are 10 pixels wider to give enough space for all the text