### PR TITLE
Streamline Mac onboarding

### DIFF
--- a/ConsoleUI/ConsoleCKAN.cs
+++ b/ConsoleUI/ConsoleCKAN.cs
@@ -26,7 +26,15 @@ namespace CKAN.ConsoleUI {
             if (new SplashScreen(manager).Run()) {
 
                 if (manager.CurrentInstance == null) {
-                    new KSPListScreen(manager, true).Run();
+                    if (manager.Instances.Count == 0) {
+                        // No instances, add one
+                        new KSPAddScreen(manager).Run();
+                        // Set instance to current if they added one
+                        manager.GetPreferredInstance();
+                    } else {
+                        // Multiple instances, no default, pick one
+                        new KSPListScreen(manager).Run();
+                    }
                 }
                 if (manager.CurrentInstance != null) {
                     new ModListScreen(manager, debug).Run();

--- a/ConsoleUI/KSPAddScreen.cs
+++ b/ConsoleUI/KSPAddScreen.cs
@@ -1,3 +1,7 @@
+using System;
+using System.IO;
+using CKAN.ConsoleUI.Toolkit;
+
 namespace CKAN.ConsoleUI {
 
     /// <summary>
@@ -9,7 +13,14 @@ namespace CKAN.ConsoleUI {
         /// Initialize the Screen
         /// </summary>
         /// <param name="mgr">KSP manager containing the instances</param>
-        public KSPAddScreen(KSPManager mgr) : base(mgr) { }
+        public KSPAddScreen(KSPManager mgr) : base(mgr)
+        {
+            AddObject(new ConsoleLabel(
+                labelWidth, pathRow + 1, -1,
+                () => $"Example: {examplePath}",
+                null, () => ConsoleTheme.Current.DimLabelFg
+            ));
+        }
 
         /// <summary>
         /// Return whether the fields are valid.
@@ -24,12 +35,27 @@ namespace CKAN.ConsoleUI {
         }
 
         /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Add KSP Instance";
+        }
+
+        /// <summary>
         /// Add the instance
         /// </summary>
         protected override void Save()
         {
             manager.AddInstance(new KSP(path.Value, name.Value, new NullUser()));
         }
+
+        private static readonly string examplePath = Path.Combine(
+            !string.IsNullOrEmpty(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles))
+                ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+                : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Kerbal Space Program"
+        );
     }
 
 }

--- a/ConsoleUI/KSPEditScreen.cs
+++ b/ConsoleUI/KSPEditScreen.cs
@@ -175,6 +175,14 @@ namespace CKAN.ConsoleUI {
         }
 
         /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Edit KSP Instance";
+        }
+
+        /// <summary>
         /// Return whether the fields are valid.
         /// Similar to adding, except leaving the fields unchanged is allowed.
         /// </summary>

--- a/ConsoleUI/KSPListScreen.cs
+++ b/ConsoleUI/KSPListScreen.cs
@@ -23,7 +23,7 @@ namespace CKAN.ConsoleUI {
 
             AddObject(new ConsoleLabel(
                 1, 2, -1,
-                () => "Select a game instance:"
+                () => "Select or add a game instance:"
             ));
 
             kspList = new ConsoleListBox<KSP>(

--- a/ConsoleUI/KSPScreen.cs
+++ b/ConsoleUI/KSPScreen.cs
@@ -36,8 +36,12 @@ namespace CKAN.ConsoleUI {
                 return false;
             });
 
-            name = new ConsoleField(labelWidth, nameRow, -1, initName);
-            path = new ConsoleField(labelWidth, pathRow, -1, initPath);
+            name = new ConsoleField(labelWidth, nameRow, -1, initName) {
+                GhostText = () => "<Enter the name to use for this copy of KSP>"
+            };
+            path = new ConsoleField(labelWidth, pathRow, -1, initPath) {
+                GhostText = () => "<Enter the location of this copy of KSP on disk>"
+            };
 
             AddObject(new ConsoleLabel(1, nameRow, labelWidth, () => "Name:"));
             AddObject(name);
@@ -51,14 +55,6 @@ namespace CKAN.ConsoleUI {
         protected override string LeftHeader()
         {
             return $"CKAN {Meta.GetVersion()}";
-        }
-
-        /// <summary>
-        /// Put description in top center
-        /// </summary>
-        protected override string CenterHeader()
-        {
-            return "Edit KSP Instance";
         }
 
         /// <summary>
@@ -98,7 +94,11 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected bool pathValid()
         {
-            if (!IsKspDir(path.Value)) {
+            if (Platform.IsMac) {
+                // Handle default path dragged-and-dropped onto Mac's Terminal
+                path.Value = path.Value.Replace("Kerbal\\ Space\\ Program", "Kerbal Space Program");
+            }
+            if (!KSP.IsKspDir(path.Value)) {
                 // Complain about non-KSP path
                 RaiseError("Path does not correspond to a KSP folder!");
                 SetFocus(path);
@@ -122,14 +122,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected KSPManager manager;
 
-        // Copied from KSP class because it's inaccessible.
-        // (Calling a constructor just for validation is gross.)
-        private static bool IsKspDir(string directory)
-        {
-            return Directory.Exists(Path.Combine(directory, "GameData"));
-        }
-
-        private   const int labelWidth = 16;
+        protected const int labelWidth = 16;
         private   const int nameRow    = 2;
         /// <summary>
         /// Y coordinate of path field

--- a/ConsoleUI/RepoScreen.cs
+++ b/ConsoleUI/RepoScreen.cs
@@ -19,8 +19,12 @@ namespace CKAN.ConsoleUI {
         {
             editList = reps;
 
-            name = new ConsoleField(labelWidth, nameRow, -1, initName);
-            url  = new ConsoleField(labelWidth, urlRow,  -1, initUrl);
+            name = new ConsoleField(labelWidth, nameRow, -1, initName) {
+                GhostText = () => "<Enter the name to use for this repository>"
+            };
+            url  = new ConsoleField(labelWidth, urlRow,  -1, initUrl) {
+                GhostText = () => "<Enter the URL of this repository>"
+            };
 
             AddObject(new ConsoleLabel(1, nameRow, labelWidth, () => "Name:"));
             AddObject(name);

--- a/Core/KSP.cs
+++ b/Core/KSP.cs
@@ -219,7 +219,6 @@ namespace CKAN
         {
             // See if we can find KSP as part of a Steam install.
             string kspSteamPath = KSPPathUtils.KSPSteamPath();
-
             if (kspSteamPath != null)
             {
                 if (IsKspDir(kspSteamPath))
@@ -228,6 +227,18 @@ namespace CKAN
                 }
 
                 log.DebugFormat("Have Steam, but KSP is not at \"{0}\".", kspSteamPath);
+            }
+
+            // See if we can find a non-Steam Mac KSP install
+            string kspMacPath = KSPPathUtils.KSPMacPath();
+            if (kspMacPath != null)
+            {
+                if (IsKspDir(kspMacPath))
+                {
+                    log.InfoFormat("Found a KSP install at {0}", kspMacPath);
+                    return kspMacPath;
+                }
+                log.DebugFormat("Default Mac KSP folder exists at \"{0}\", but KSP is not installed there.", kspMacPath);
             }
 
             // Oh noes! We can't find KSP!
@@ -240,7 +251,7 @@ namespace CKAN
         /// Checking for a GameData directory probably isn't the best way to
         /// detect KSP, but it works. More robust implementations welcome.
         /// </summary>
-        internal static bool IsKspDir(string directory)
+        public static bool IsKspDir(string directory)
         {
             return Directory.Exists(Path.Combine(directory, "GameData"));
         }
@@ -388,7 +399,7 @@ namespace CKAN
                 Path.Combine(ShipsThumbs(), "VAB")
             );
         }
-        
+
         public string ShipsScript()
         {
             return KSPPathUtils.NormalizePath(

--- a/Core/KSPManager.cs
+++ b/Core/KSPManager.cs
@@ -515,23 +515,4 @@ namespace CKAN
         }
 
     }
-
-    public class KSPManagerKraken : Kraken
-    {
-        public KSPManagerKraken(string reason = null, Exception innerException = null)
-            : base(reason, innerException)
-        {
-        }
-    }
-
-    public class InvalidKSPInstanceKraken : Exception
-    {
-        public string instance;
-
-        public InvalidKSPInstanceKraken(string instance, string reason = null, Exception innerException = null)
-            : base(reason, innerException)
-        {
-            this.instance = instance;
-        }
-    }
 }

--- a/Core/KSPPathUtils.cs
+++ b/Core/KSPPathUtils.cs
@@ -166,6 +166,26 @@ namespace CKAN
             // Could not locate the folder.
             return null;
         }
+        
+        /// <summary>
+        /// Get the default non-Steam path to KSP on macOS
+        /// </summary>
+        /// <returns>
+        /// "/Applications/Kerbal Space Program" if it exists and we're on a Mac, else null
+        /// </returns>
+        public static string KSPMacPath()
+        {
+            if (Platform.IsMac)
+            {
+                string installPath = Path.Combine(
+                    // This is "/Applications" in Mono on Mac
+                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                    "Kerbal Space Program"
+                );
+                return Directory.Exists(installPath) ? installPath : null;
+            }
+            return null;
+        }
 
         /// <summary>
         /// Normalizes the path by replacing all \ with / and removing any trailing slash.

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -564,4 +564,22 @@ namespace CKAN
         }
     }
 
+    public class KSPManagerKraken : Kraken
+    {
+        public KSPManagerKraken(string reason = null, Exception innerException = null)
+            : base(reason, innerException)
+        {
+        }
+    }
+
+    public class InvalidKSPInstanceKraken : Kraken
+    {
+        public string instance;
+
+        public InvalidKSPInstanceKraken(string instance, string reason = null, Exception innerException = null)
+            : base(reason, innerException)
+        {
+            this.instance = instance;
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

Mac users have been struggling with how to start using Console UI, see #3047, #3185, and recent discussions in the macos support channel in Discord. On close inspection, not all the on-screen prompts are as clear or helpful as they could be.

## Problems

If you start ConsoleUI with no instances and you don't have KSP installed in Steam, you get the KSP instance list screen:

![select a game instance](https://cdn.discordapp.com/attachments/601459431980400699/777943109636063292/Screenshot_2020-11-16_at_17.07.56.png)

- There's not much of a hint of what to do (the right answer is to press <kbd>a</kbd> to add an instance.)
- "Select a game instance" is incomplete on a screen where you can also add instances

When adding an instance:

![enter a value](https://cdn.discordapp.com/attachments/601459431980400699/777943354292830238/Screenshot_2020-11-16_at_17.09.00.png)

- The fields have the default `<Enter a value>` ghost text, which could be more helpful
- Not all users may necessarily know what a path is, and if they do, they might not be sure about what format to use (macOS uses `:` as a path separator in some contexts and `/` in others)

Multiple users have asked for help with this exact screenshot:

![does not correspond](https://user-images.githubusercontent.com/73739262/97776167-35504800-1b66-11eb-81f4-b504566bc44e.png)

- The header says "Edit KSP Instance", but we're adding
- I think they got here by dragging and dropping their KSP folder into Terminal, which "helpfully" adds backslashes on the incorrect assumption that the string will be used by `bash`
- I think `/Applications/Kerbal Space Program` is where the KSP Store installer installs KSP

## Changes

- Now if you're on Mac, you don't have any instances, and your game is located in `/Applications/Kerbal Space Program`, we detect it automatically like we can with Steam
- New more inclusive help label on the instance list screen:
  ![image](https://user-images.githubusercontent.com/1559108/99304423-41b4f000-284a-11eb-909f-4b98a8deb39f.png)
- Now if you don't have any instances and we can't detect the game automatically, Console UI will jump to the add instance screen instead of the empty list

When adding an instance:

![image](https://user-images.githubusercontent.com/1559108/99304660-8e98c680-284a-11eb-8dcc-3137c75c07bd.png)

- Add instance title changed from "Edit KSP Instance" to "Add KSP Instance"
- Field ghost text now gives more info about what the fields are for
  - Also done for the add repo screen, which was the only other spot where we weren't customizing the ghost text
- A help label under the path field shows `<Program Files>\Kerbal Space Program` or `/Applications/Kerbal Space Program` in your OS's path format, so you can figure out what to enter even if it's different from the default
- If you drag and drop `/Applications/Kerbal\ Space\ Program` onto the path field, we remove the backslashes when you try to save. Note that backslashes _in general_ are not removed; **only** the ones in the specific string `Kerbal\ Space\ Program` because this is common and guaranteed wrong