### PR TITLE
Fix dependency resolution in mod upgrades

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -967,7 +967,16 @@ namespace CKAN
         /// </summary>
         public void Upgrade(IEnumerable<string> identifiers, IDownloader netAsyncDownloader, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool enforceConsistency = true)
         {
-            var resolver = new RelationshipResolver(identifiers.ToList(), null, RelationshipResolver.DependsOnlyOpts(), registry_manager.registry, ksp.VersionCriteria());
+            // When upgrading, we are removing these mods first and install them again afterwards (but in different versions).
+            // So the list of identifiers of modulesToRemove and modulesToInstall is the same,
+            // RelationshipResolver take care of finding the right CkanModule for each identifier.
+            List<string> identifierList = identifiers.ToList();
+            var resolver = new RelationshipResolver(
+                identifierList,
+                identifierList,
+                RelationshipResolver.DependsOnlyOpts(),
+                registry_manager.registry, ksp.VersionCriteria()
+            );
             Upgrade(resolver.ModList(), netAsyncDownloader, ref possibleConfigOnlyDirs, registry_manager, enforceConsistency);
         }
 
@@ -980,7 +989,7 @@ namespace CKAN
         {
             modules = modules.Memoize();
             User.RaiseMessage("About to upgrade...\r\n");
-            
+
             if (resolveRelationships)
             {
                 var resolver = new RelationshipResolver(modules, null, RelationshipResolver.DependsOnlyOpts(), registry_manager.registry, ksp.VersionCriteria());

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -385,9 +385,14 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Tries to parse an identifier in the format Modname=version
-        /// If the module cannot be found in the registry, throws a ModuleNotFoundKraken.
+        /// Tries to parse an identifier in the format identifier=version and returns a matching CkanModule from the registry.
+        /// Returns the latest compatible or installed module if no version has been given.
         /// </summary>
+        /// <param name="registry">CKAN registry object for current game instance</param>
+        /// <param name="name">The identifier or identifier=version of the module</param>
+        /// <param name="ksp_version">The current KSP version criteria to consider</param>
+        /// <returns>A CkanModule</returns>
+        /// <exception cref="ModuleNotFoundKraken">Thrown if no matching module could be found</exception>
         public static CkanModule FromIDandVersion(IRegistryQuerier registry, string mod, KspVersionCriteria ksp_version)
         {
             CkanModule module;


### PR DESCRIPTION
# Problem
Upgrading mods that previously provided a module and depend on it in the next version currently fails:
```
About to upgrade...

Downloading "https://github.com/R-T-B/Kopernicus/releases/download/UBE-release-46/KopernicusBE_1101_Release46.zip"
Module "Kopernicus Bleeding Edge Beta - DEV RELEASE" successfully installed
The following inconsistencies were found:
* Kopernicus-BE UBEE_1101_46 missing dependency ModularFlightIntegrator 1.2.7.0 or later
Error during installation!
If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
ModularFlightIntegrator 1.2.7.0 conflicts with Kopernicus-BE UBEE_1101_45
```
In this case, Kopernicus-BE v1.10.1-45 provided ModularFlightIntegrator, but Kopernicus-BE v1.10.1-46 no longer does so and has it as dependency instead (see #3193). CKAN should automatically pull in MFI to satisfy the new dependency.


## Causes
1) `ModuleInstaller.Upgrade(IEnumerable<string> identifiers, ...)` doesn't tell the newly created `RelationshipResolver` that it also removes the old modules before adding the new ones. So the dependency is wrongly satisfied by the old module.
2) `RelationshipResolver(IEnumerable<string> modulesToInstall, IEnumerable<string> modulesToRemove, ...)` tries to find matching `CkanModule`s for all the identifiers in `modulesToInstall` and `modulesToRemove`. It does so by calling `TranslateModule()` -> `FromIDandVersion()`, that ultimately returns the latest compatible module.
This is fine for `modulesToInstall`, however for `modulesToRemove` we only want search through the currently installed modules (we can only remove modules that are actually installed after all).
3) `RelationshipResolver.ResolveStanza()` checks whether dependencies of the new modules are already satisfied by the installed modules, however it does so by querying the registry, which might have outdated information. Thus it incorrectly assumes the dependencies are satisfied (by the old mod versions). Only the resolvers own `installed_modules` knows about the modules that are going to be removed.


## Changes

1) `ModuleInstaller.Upgrade()` now tells the relationship resolver which modules it's about remove by passing the same identifier list for `modulesToRemove` as it passes for `modulesToInstall`.
2) `RelationshipResolver()` now uses `registry.InstalledModule()` to convert identifiers to `CkanModule`s for `modulesToRemove`. We can use the registry here since we're just in the process of creating the resolver and `installed_modules` is only declared and populated a few steps later.
3) `RelationshipResolver.ResolveStanza()` now looks into the resolvers own `installed_modules` instead of querying the potentially outdated registry. `installed_modules` is already reduced by the modules that are about to be removed, thus the resolver has to find other mods that can satisfy the .dependencies