### PR TITLE
Put Release file in stable/nightly folders of APT repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,19 @@ jobs:
           SOURCE_DIR: _build/deb/apt-repo
           DEST_DIR: deb/dists/nightly/main/binary-all
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+      - name: Push Release file to S3
+        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/deb/apt-repo-rel
+          DEST_DIR: deb/dists/nightly
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Send Discord Notification
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,19 @@ jobs:
           SOURCE_DIR: _build/deb/apt-repo
           DEST_DIR: deb/dists/stable/main/binary-all
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+      - name: Push Release file to S3
+        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/deb/apt-repo-rel
+          DEST_DIR: deb/dists/stable
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Send Discord Notification
         env:

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -23,13 +23,17 @@ CONSOLEUIDESKTOPSRC:=ckan-consoleui.desktop
 CONSOLEUIDESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan-consoleui.desktop
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
 DEB:=../_build/deb/ckan_$(VERSION)_all.deb
+
 APTREPO:=../_build/deb/apt-repo
 REPODEB:=$(APTREPO)/ckan_$(VERSION)_all.deb
 PACKAGES:=$(APTREPO)/Packages.gz
 RELEASESRC:=Release.in
 RELEASEDEST:=$(APTREPO)/Release
 
-repo: $(REPODEB) $(PACKAGES) $(RELEASEDEST)
+APTREPOREL:=../_build/deb/apt-repo-rel
+RELRELEASEDEST:=$(APTREPOREL)/Release
+
+repo: $(REPODEB) $(PACKAGES) $(RELEASEDEST) $(RELRELEASEDEST)
 
 $(REPODEB): $(DEB)
 	umask 0022 && mkdir -p $(shell dirname $@)
@@ -40,6 +44,10 @@ $(PACKAGES): $(REPODEB)
 	umask 0022 && (cd $(shell dirname $<) && dpkg-scanpackages -m .) | gzip -c > $@
 
 $(RELEASEDEST): $(RELEASESRC)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && sed -e 's/@VERSION@/$(VERSION)/' $< > $@
+
+$(RELRELEASEDEST): $(RELEASESRC)
 	umask 0022 && mkdir -p $(shell dirname $@)
 	umask 0022 && sed -e 's/@VERSION@/$(VERSION)/' $< > $@
 


### PR DESCRIPTION
## Problem

The APT repo doesn't work yet.

```
Fehl:22 https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly Release
404  Not Found [IP: 52.218.233.33 443]
Paketlisten werden gelesen... Fertig
E: Das Depot »https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly Release« enthält keine Release-Datei
```

## Cause

We're supposed to have a file at `/deb/dists/nightly/Release`:

```
s3-us-west-2-r-w.amazonaws.com	http	HTTP		250		GET /deb/dists/nightly/InRelease HTTP/1.1 
s3-us-west-2-r-w.amazonaws.com	http	HTTP		248		GET /deb/dists/nightly/Release HTTP/1.1 
```

Mono has this.

- https://download.mono-project.com/repo/ubuntu/dists/stable-bionic/

## Changes

Now we copy the Release file into an additional folder at `_build/deb/apt-repo-rel`, and sync that folder to `deb/dists/nightly` and/or `deb/dists/stable`.