### PR TITLE
Put .deb file in root of APT repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,11 +83,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo
-          DEST_DIR: deb/dists/nightly/main/binary-all
+          SOURCE_DIR: _build/deb/apt-repo-root
+          DEST_DIR: deb
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
       - name: Push Release file to S3
-        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --follow-symlinks
@@ -96,7 +95,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-rel
+          SOURCE_DIR: _build/deb/apt-repo-dist
           DEST_DIR: deb/dists/nightly
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo
-          DEST_DIR: deb/dists/stable/main/binary-all
+          SOURCE_DIR: _build/deb/apt-repo-root
+          DEST_DIR: deb
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
       - name: Push Release file to S3
-        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --follow-symlinks
@@ -128,7 +127,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-rel
+          SOURCE_DIR: _build/deb/apt-repo-dist
           DEST_DIR: deb/dists/stable
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -24,32 +24,36 @@ CONSOLEUIDESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan-consoleui.desktop
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
 DEB:=../_build/deb/ckan_$(VERSION)_all.deb
 
-APTREPO:=../_build/deb/apt-repo
-REPODEB:=$(APTREPO)/ckan_$(VERSION)_all.deb
-PACKAGES:=$(APTREPO)/Packages.gz
+# Files for /deb/ (the .deb file)
+APT_REPO_ROOT:=../_build/deb/apt-repo-root
+REPODEB:=$(APT_REPO_ROOT)/ckan_$(VERSION)_all.deb
+
+# Files for /deb/dists/{stable,nightly}/
+# (Release, main/binary-all/Release, main/binary-all/Packages.gz,
+#  actual path to be determined by yml files)
+APT_REPO_DIST:=../_build/deb/apt-repo-dist
 RELEASESRC:=Release.in
-RELEASEDEST:=$(APTREPO)/Release
+DISTRELEASEDEST:=$(APT_REPO_DIST)/Release
+ARCHRELEASEDEST:=$(APT_REPO_DIST)/main/binary-all/Release
+PACKAGES:=$(APT_REPO_DIST)/main/binary-all/Packages.gz
 
-APTREPOREL:=../_build/deb/apt-repo-rel
-RELRELEASEDEST:=$(APTREPOREL)/Release
-
-repo: $(REPODEB) $(PACKAGES) $(RELEASEDEST) $(RELRELEASEDEST)
+repo: $(REPODEB) $(DISTRELEASEDEST) $(ARCHRELEASEDEST) $(PACKAGES)
 
 $(REPODEB): $(DEB)
 	umask 0022 && mkdir -p $(shell dirname $@)
 	umask 0022 && cp $< $@
 
+$(DISTRELEASEDEST): $(RELEASESRC)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && sed -e 's/@VERSION@/$(VERSION)/' $< > $@
+
+$(ARCHRELEASEDEST): $(RELEASESRC)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && sed -e 's/@VERSION@/$(VERSION)/' $< > $@
+
 $(PACKAGES): $(REPODEB)
 	umask 0022 && mkdir -p $(shell dirname $@)
 	umask 0022 && (cd $(shell dirname $<) && dpkg-scanpackages -m .) | gzip -c > $@
-
-$(RELEASEDEST): $(RELEASESRC)
-	umask 0022 && mkdir -p $(shell dirname $@)
-	umask 0022 && sed -e 's/@VERSION@/$(VERSION)/' $< > $@
-
-$(RELRELEASEDEST): $(RELEASESRC)
-	umask 0022 && mkdir -p $(shell dirname $@)
-	umask 0022 && sed -e 's/@VERSION@/$(VERSION)/' $< > $@
 
 $(DEB): $(EXEDEST) $(SCRIPTDEST) $(CONTROLDEST) $(CHANGELOGDEST) $(DEBCHANGEDEST) $(MANDEST) $(ICONDEST) $(COPYRIGHTDEST) $(DESKTOPDEST) $(CONSOLEUIDESKTOPDEST)
 	umask 0022 && mkdir -p $(shell dirname $@)


### PR DESCRIPTION
## Problem

The repo from #3197 is closer to working after #3201, but still has some issues, including this when attempting to install ckan:

```
Fehl:3 http://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly/main all ckan all 1.29.1                                  
404  Not Found [IP: 52.218.240.57 80]                           
E: Fehlschlag beim Holen von http://ksp-ckan.s3-us-west-2.amazonaws.com/deb/./ckan_1.29.1_all.deb 404  Not Found [IP: 52.218.240.57 80]
---
Err:3 http://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly/main all ckan all 1.29.1                                  
404  Not Found [IP: 52.218.240.57 80]                           
E: Error while fetching http://ksp-ckan.s3-us-west-2.amazonaws.com/deb/./ckan_1.29.1_all.deb 404  Not Found [IP: 52.218.240.57 80]
```

## Cause

The `deb/dists/nightly/main/binary-all/Packages.gz` file contains:

```
Filename: ./ckan_1.29.1_all.deb
```

... which I thought from the documentation would be interpreted relative to that file's location to produce `deb/dists/nightly/main/binary-all/./ckan_1.29.1_all.deb`, similar to how web relative URLs normally work. Rather it looks like that path is appended to the root path of the repo, which is not where our .deb file currently is.

## Changes

Now we put the .deb file in `/deb/`. To make this work, the two S3 sync commands are now:

- Put `_build/deb/apt-repo-root` into `/deb/`, which will contain just the .deb file
- Put `_build/deb/apt-repo-dist` into `/deb/dists/stable/` or `/deb/dists/nightly/`, which will contain everything else

The Makefile is adjusted to generate those folders accordingly.

Note, there are still other issues relating to signatures and architectures. Those will be addressed in future changes and are not attempted to be solved here.