### PR TITLE
Confirmation prompt for Cmdline upgrades

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -138,7 +138,7 @@ namespace CKAN.CmdLine
                     HashSet<string> possibleConfigOnlyDirs = null;
                     var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                     installer.InstallList(modules, install_ops, regMgr, ref possibleConfigOnlyDirs);
-                    user.RaiseMessage("\r\n");
+                    user.RaiseMessage("");
                     done = true;
                 }
                 catch (DependencyNotSatisfiedKraken ex)
@@ -257,9 +257,9 @@ namespace CKAN.CmdLine
                     user.RaiseMessage("Install canceled. Your files have been returned to their initial state.");
                     return Exit.ERROR;
                 }
-                catch (CancelledActionKraken)
+                catch (CancelledActionKraken k)
                 {
-                    user.RaiseMessage("Installation canceled at user request.");
+                    user.RaiseMessage("Installation aborted: {0}", k.Message);
                     return Exit.ERROR;
                 }
                 catch (MissingCertificateKraken kraken)

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -80,6 +80,7 @@ namespace CKAN.CmdLine
                     var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
                     Search.AdjustModulesCase(ksp, options.modules);
                     installer.UninstallList(options.modules, ref possibleConfigOnlyDirs, regMgr);
+                    user.RaiseMessage("");
                 }
                 catch (ModNotInstalledKraken kraken)
                 {
@@ -99,6 +100,11 @@ namespace CKAN.CmdLine
                         user.RaiseMessage($"To remove this expansion, follow the instructions for the store page from which you purchased it:\r\n{storePagesMsg}");
                     }
                     return Exit.BADOPT;
+                }
+                catch (CancelledActionKraken k)
+                {
+                    user.RaiseMessage("Remove aborted: {0}", k.Message);
+                    return Exit.ERROR;
                 }
             }
             else

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -145,7 +145,7 @@ namespace CKAN.CmdLine
                         r.ToReplace.identifier, r.ToReplace.version);
                 }
 
-                bool ok = User.RaiseYesNoDialog("\r\nContinue?");
+                bool ok = User.RaiseYesNoDialog("Continue?");
 
                 if (!ok)
                 {
@@ -158,7 +158,7 @@ namespace CKAN.CmdLine
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
                     ModuleInstaller.GetInstance(ksp, manager.Cache, User).Replace(to_replace, replace_ops, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
-                    User.RaiseMessage("\r\nDone!\r\n");
+                    User.RaiseMessage("");
                 }
                 catch (DependencyNotSatisfiedKraken ex)
                 {

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -81,8 +81,6 @@ namespace CKAN.CmdLine
                 return Exit.OK;
             }
 
-            User.RaiseMessage("\r\nUpgrading modules...\r\n");
-
             try
             {
                 HashSet<string> possibleConfigOnlyDirs = null;
@@ -129,6 +127,7 @@ namespace CKAN.CmdLine
                     Search.AdjustModulesCase(ksp, options.modules);
                     ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
                 }
+                User.RaiseMessage("");
             }
             catch (CancelledActionKraken k)
             {
@@ -158,7 +157,6 @@ namespace CKAN.CmdLine
                 }
                 return Exit.ERROR;
             }
-            User.RaiseMessage("\r\nDone!\r\n");
 
             return Exit.OK;
         }


### PR DESCRIPTION
## Problems

CmdLine's `upgrade` command is pretty inconsistent with `install` and `remove`:

- It doesn't describe the changes and present a yes/no prompt to confirm the user wants to proceed
- It prints double messages "Upgrading modules..." and "About to upgrade..." at the start
- It prints double messages "Done!" and "Done!" at the end
  ```
  Upgrading modules...
  
  About to upgrade...
  
  Installing previously uninstalled mod Kopernicus-BE
  
  Installing "Kopernicus-BE UBEE_1101_44"
  Updating registry
  Committing filesystem changes
  Done!
  Done!
  ```
- It says `Removing "CKAN.InstalledModule"` for each installed module being upgraded

Other problems:

- #3200 doesn't work for `ckan upgrade --all`
- `ModuleInstaller.InstallList` prints "Rescanning GameData" even if it's not doing that

## Cause

- The fix from #3200 only affects calls to the version of `Upgrade` based on strings, not `CkanModule`s
- We attempted to print an `InstalledModule` object

## Changes

- Now `ckan upgrade` prints the changes to be made and asks the user whether to continue
- Now `ckan upgrade` no longer prints double messages at start and end
- Now the "Removing" message prints the module's name instead
- Now `ckan upgrade --all` passes the installed modules to be removed to the `RelationshipResolver`, as per #3200
- Now all three commands use a colon instead of an ellipsis for the header before the list of changes
- Now all three commands throw `CancelledActionKraken` if the user opts to abort (`remove` previously just printed and returned)
