### PR TITLE
Allow sort by multiple columns

### DIFF
--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -39,9 +39,8 @@ namespace CKAN
         /// </summary>
         public string CustomLabelFilter = null;
 
-        // Sort by the mod name (index = 2) column by default
-        public int SortByColumnIndex = 2;
-        public bool SortDescending = false;
+        public List<string> SortColumns = new List<string>();
+        public List<bool> MultiSortDescending = new List<bool>();
 
         [XmlArray, XmlArrayItem(ElementName = "ColumnName")]
         public List<string> HiddenColumnNames = new List<string>();


### PR DESCRIPTION
## Motivation

Request from Discord:

![image](https://user-images.githubusercontent.com/1559108/99869783-a31bec80-2bc5-11eb-8853-87f80483df99.png)

## Changes

Now the main mod list in GUI supports multi-column sorting. If you shift-click a column header, instead of replacing the previous sort, it is added as a secondary sort.

Note that the previous saved sort setting is replaced with a new, multi-column one, without a migration. This means the value of the old setting will be lost on upgrade, and users will be presented with the default view of the grid sorted by mod name. Users can restore their old setting by clicking the column header.