### PR TITLE
Suppress confirmation prompt for GUI upgrades

### DIFF
--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -80,7 +80,7 @@ namespace CKAN
             // this will be the final list of mods we want to install
             HashSet<CkanModule> toInstall = new HashSet<CkanModule>();
             var toUninstall = new HashSet<string>();
-            var toUpgrade   = new HashSet<string>();
+            var toUpgrade   = new HashSet<CkanModule>();
 
             // First compose sets of what the user wants installed, upgraded, and removed.
             foreach (ModChange change in opts.Key)
@@ -91,7 +91,9 @@ namespace CKAN
                         toUninstall.Add(change.Mod.identifier);
                         break;
                     case GUIModChangeType.Update:
-                        toUpgrade.Add(change.Mod.identifier);
+                        toUpgrade.Add(change is ModUpgrade mu
+                            ? mu.targetMod
+                            : change.Mod);
                         break;
                     case GUIModChangeType.Install:
                         toInstall.Add(change.Mod);
@@ -188,7 +190,7 @@ namespace CKAN
                         processSuccessful = false;
                         if (!installCanceled)
                         {
-                            installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager);
+                            installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager, true, true, false);
                             processSuccessful = true;
                         }
                     }

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -124,6 +124,6 @@ namespace CKAN
             }
         }
 
-        private readonly CkanModule targetMod;
+        public readonly CkanModule targetMod;
     }
 }


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/99908582-1e0a0380-2ca9-11eb-8e1d-f53b8a1e4240.png)

## Cause

#3204 added a yes/no prompt in `ModuleInstaller.Upgrade`, but I thought GUI only used `UninstallList` and `InstallList`. No, it does call `Upgrade`.

## Changes

Now the confirmation prompt is suppressed.

- Now GUI passes `ConfirmPrompt=False`
  - This is only available on the `CkanModule`-based version of `Upgrade`, and GUI previously used the `string`-based version, so now we've switched to the other