### PR TITLE
Netkan warning for craft files installed outside Ships folder

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Transformers\VersionedOverrideTransformer.cs" />
     <Compile Include="Validators\AlphaNumericIdentifierValidator.cs" />
     <Compile Include="Validators\CkanValidator.cs" />
+    <Compile Include="Validators\CraftsInShipsValidator.cs" />
     <Compile Include="Validators\DownloadVersionValidator.cs" />
     <Compile Include="Validators\HasIdentifierValidator.cs" />
     <Compile Include="Validators\InstallsFilesValidator.cs" />

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -10,10 +10,11 @@ namespace CKAN.NetKAN.Services
         AvcVersion GetInternalAvc(CkanModule module, string filePath, string internalFilePath = null);
         JObject GetInternalCkan(string filePath);
         bool HasInstallableFiles(CkanModule module, string filePath);
-        
+
         IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip);
         IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip);
-        
+        IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, KSP ksp);
+
         IEnumerable<string> FileDestinations(CkanModule module, string filePath);
     }
 }

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -66,17 +66,24 @@ namespace CKAN.NetKAN.Services
 
         public IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip)
         {
-            return ModuleInstaller
-                .FindInstallableFiles(module, zip, null)
-                .Where(instF => instF.source.Name.EndsWith(".cfg",
-                    StringComparison.InvariantCultureIgnoreCase));
+            return GetFilesBySuffix(module, zip, ".cfg");
         }
 
         public IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip)
         {
+            return GetFilesBySuffix(module, zip, ".dll");
+        }
+
+        public IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, KSP ksp)
+        {
+            return GetFilesBySuffix(module, zip, ".craft", ksp);
+        }
+
+        private IEnumerable<InstallableFile> GetFilesBySuffix(CkanModule module, ZipFile zip, string suffix, KSP ksp = null)
+        {
             return ModuleInstaller
-                .FindInstallableFiles(module, zip, null)
-                .Where(instF => instF.source.Name.EndsWith(".dll",
+                .FindInstallableFiles(module, zip, ksp)
+                .Where(instF => instF.source.Name.EndsWith(suffix,
                     StringComparison.InvariantCultureIgnoreCase));
         }
 

--- a/Netkan/Validators/CkanValidator.cs
+++ b/Netkan/Validators/CkanValidator.cs
@@ -22,6 +22,7 @@ namespace CKAN.NetKAN.Validators
                 new KindValidator(),
                 new ModuleManagerDependsValidator(downloader, moduleService),
                 new PluginCompatibilityValidator(downloader, moduleService),
+                new CraftsInShipsValidator(downloader, moduleService),
             };
         }
 

--- a/Netkan/Validators/CraftsInShipsValidator.cs
+++ b/Netkan/Validators/CraftsInShipsValidator.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using ICSharpCode.SharpZipLib.Zip;
+using log4net;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Validators
+{
+    internal sealed class CraftsInShipsValidator : IValidator
+    {
+        public CraftsInShipsValidator(IHttpService http, IModuleService moduleService)
+        {
+            _http          = http;
+            _moduleService = moduleService;
+        }
+
+        public void Validate(Metadata metadata)
+        {
+            Log.Info("Validating that craft files are installed into Ships");
+
+            JObject    json = metadata.Json();
+            CkanModule mod  = CkanModule.FromJson(json.ToString());
+            if (!mod.IsDLC)
+            {
+                var package = _http.DownloadModule(metadata);
+                if (!string.IsNullOrEmpty(package))
+                {
+                    var zip       = new ZipFile(package);
+                    var ksp       = new KSP("/", "dummy", null, false);
+                    var badCrafts = _moduleService.GetCrafts(mod, zip, ksp)
+                        .Where(f => !ksp.ToRelativeGameDir(f.destination).StartsWith("Ships/"))
+                        .ToList();
+
+                    if (badCrafts.Any())
+                    {
+                        Log.WarnFormat(
+                            "Craft files installed outside Ships folder: {0}",
+                            string.Join(", ", badCrafts.Select(f =>
+                                ksp.ToRelativeGameDir(f.destination)
+                            ))
+                        );
+                    }
+                }
+            }
+        }
+
+        private readonly IHttpService   _http;
+        private readonly IModuleService _moduleService;
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(CraftsInShipsValidator));
+    }
+}

--- a/Netkan/Validators/PluginCompatibilityValidator.cs
+++ b/Netkan/Validators/PluginCompatibilityValidator.cs
@@ -29,11 +29,11 @@ namespace CKAN.NetKAN.Validators
                 if (!string.IsNullOrEmpty(package))
                 {
                     ZipFile zip  = new ZipFile(package);
-        
+
                     bool hasPlugin = _moduleService.GetPlugins(mod, zip).Any();
-                    
+
                     bool boundedCompatibility = json.ContainsKey("ksp_version") || json.ContainsKey("ksp_version_max");
-        
+
                     if (hasPlugin && !boundedCompatibility)
                     {
                         Log.Warn("Unbounded future compatibility for module with a plugin, consider setting $vref or ksp_version or ksp_version_max");


### PR DESCRIPTION
## Motivation

Mods commonly distribute craft files, sometimes in a separate Ships folder, but sometimes in GameData. They are available to the user in-game if and only if they're installed into `Ships/VAB` or `Ships/SPH`. We can create custom install stanzas to handle this, but currently we lack guardrails in case we miss a chance.

## Changes

Now a new Netkan validator prints a warning if any craft files are installed outside the Ships folder. These warnings will appear in Discord and the status page so we can update the affected mods.