### PR TITLE
Skip warnings for craft files in missions and contract packs

### DIFF
--- a/Netkan/Validators/CraftsInShipsValidator.cs
+++ b/Netkan/Validators/CraftsInShipsValidator.cs
@@ -31,7 +31,7 @@ namespace CKAN.NetKAN.Validators
                     var zip       = new ZipFile(package);
                     var ksp       = new KSP("/", "dummy", null, false);
                     var badCrafts = _moduleService.GetCrafts(mod, zip, ksp)
-                        .Where(f => !ksp.ToRelativeGameDir(f.destination).StartsWith("Ships/"))
+                        .Where(f => !AllowedCraftPath(ksp.ToRelativeGameDir(f.destination)))
                         .ToList();
 
                     if (badCrafts.Any())
@@ -45,6 +45,13 @@ namespace CKAN.NetKAN.Validators
                     }
                 }
             }
+        }
+
+        private bool AllowedCraftPath(string path)
+        {
+            return path.StartsWith("Ships/")
+                || path.StartsWith("Missions/")
+                || path.StartsWith("GameData/ContractPacks/");
         }
 
         private readonly IHttpService   _http;


### PR DESCRIPTION
## Problem

These are all programmatically detectable false positives:

![image](https://user-images.githubusercontent.com/1559108/100475474-cc96b580-30a8-11eb-9d4c-1ce2f2c466c0.png)

ContractConfigurator and the stock (DLC) Missions framework both incorporate craft files into their folder structures, so these files should be installed where they are.

## Changes

Now we don't print the warning if the path starts with `Missions/` or `GameData/ContractPacks/`.