### PR TITLE
Manage repos with separate name and URL fields

### DIFF
--- a/GUI/Dialogs/NewRepoDialog.Designer.cs
+++ b/GUI/Dialogs/NewRepoDialog.Designer.cs
@@ -31,74 +31,138 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(NewRepoDialog));
             this.RepositoryGroupBox = new System.Windows.Forms.GroupBox();
+            this.RepoNameLabel = new System.Windows.Forms.Label();
+            this.RepoNameTextBox = new System.Windows.Forms.TextBox();
+            this.RepoUrlLabel = new System.Windows.Forms.Label();
             this.RepoUrlTextBox = new System.Windows.Forms.TextBox();
+            this.BottomButtonPanel = new System.Windows.Forms.Panel();
             this.RepoCancel = new System.Windows.Forms.Button();
             this.RepoOK = new System.Windows.Forms.Button();
-            this.ReposListBox = new System.Windows.Forms.ListBox();
+            this.ReposListBox = new System.Windows.Forms.ListView();
+            this.RepoNameHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.RepoURLHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.RepositoryGroupBox.SuspendLayout();
             this.SuspendLayout();
             //
             // RepositoryGroupBox
             //
-            this.RepositoryGroupBox.Controls.Add(this.RepoUrlTextBox);
-            this.RepositoryGroupBox.Controls.Add(this.RepoCancel);
-            this.RepositoryGroupBox.Controls.Add(this.RepoOK);
+            this.RepositoryGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.RepositoryGroupBox.Controls.Add(this.ReposListBox);
             this.RepositoryGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.RepositoryGroupBox.Location = new System.Drawing.Point(12, 12);
             this.RepositoryGroupBox.Name = "RepositoryGroupBox";
-            this.RepositoryGroupBox.Size = new System.Drawing.Size(476, 410);
+            this.RepositoryGroupBox.Size = new System.Drawing.Size(476, 380);
             this.RepositoryGroupBox.TabIndex = 8;
             this.RepositoryGroupBox.TabStop = false;
             resources.ApplyResources(this.RepositoryGroupBox, "RepositoryGroupBox");
             //
+            // ReposListBox
+            //
+            this.ReposListBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.ReposListBox.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.RepoNameHeader,
+            this.RepoURLHeader});
+            this.ReposListBox.Location = new System.Drawing.Point(6, 19);
+            this.ReposListBox.FullRowSelect = true;
+            this.ReposListBox.MultiSelect = false;
+            this.ReposListBox.View = System.Windows.Forms.View.Details;
+            this.ReposListBox.Name = "ReposListBox";
+            this.ReposListBox.Size = new System.Drawing.Size(464, 355);
+            this.ReposListBox.TabIndex = 8;
+            this.ReposListBox.SelectedIndexChanged += new System.EventHandler(this.ReposListBox_SelectedIndexChanged);
+            //
+            // RepoNameHeader
+            //
+            this.RepoNameHeader.Width = 110;
+            resources.ApplyResources(this.RepoNameHeader, "RepoNameHeader");
+            //
+            // RepoURLHeader
+            //
+            this.RepoURLHeader.Width = 370;
+            resources.ApplyResources(this.RepoURLHeader, "RepoURLHeader");
+            // 
+            // BottomButtonPanel
+            // 
+            this.BottomButtonPanel.Controls.Add(this.RepoNameLabel);
+            this.BottomButtonPanel.Controls.Add(this.RepoNameTextBox);
+            this.BottomButtonPanel.Controls.Add(this.RepoUrlLabel);
+            this.BottomButtonPanel.Controls.Add(this.RepoUrlTextBox);
+            this.BottomButtonPanel.Controls.Add(this.RepoOK);
+            this.BottomButtonPanel.Controls.Add(this.RepoCancel);
+            this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.BottomButtonPanel.Name = "BottomButtonPanel";
+            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 94);
+            //
+            // RepoNameLabel
+            //
+            this.RepoNameLabel.AutoSize = true;
+            this.RepoNameLabel.Location = new System.Drawing.Point(6, 6);
+            this.RepoNameLabel.Name = "RepoNameLabel";
+            this.RepoNameLabel.Size = new System.Drawing.Size(70, 13);
+            this.RepoNameLabel.TabIndex = 1;
+            resources.ApplyResources(this.RepoNameLabel, "RepoNameLabel");
+            //
+            // RepoNameTextBox
+            //
+            this.RepoNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            this.RepoNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.RepoNameTextBox.Location = new System.Drawing.Point(6, 22);
+            this.RepoNameTextBox.Name = "RepoNameTextBox";
+            this.RepoNameTextBox.Size = new System.Drawing.Size(110, 30);
+            this.RepoNameTextBox.TabIndex = 11;
+            this.RepoNameTextBox.TextChanged += new System.EventHandler(this.RepoUrlTextBox_TextChanged);
+            //
+            // RepoUrlLabel
+            //
+            this.RepoUrlLabel.AutoSize = true;
+            this.RepoUrlLabel.Location = new System.Drawing.Point(122, 6);
+            this.RepoUrlLabel.Name = "RepoUrlLabel";
+            this.RepoUrlLabel.Size = new System.Drawing.Size(70, 13);
+            this.RepoUrlLabel.TabIndex = 1;
+            resources.ApplyResources(this.RepoUrlLabel, "RepoUrlLabel");
+            //
             // RepoUrlTextBox
             //
-            this.RepoUrlTextBox.Location = new System.Drawing.Point(6, 384);
+            this.RepoUrlTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.RepoUrlTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.RepoUrlTextBox.Location = new System.Drawing.Point(122, 22);
             this.RepoUrlTextBox.Name = "RepoUrlTextBox";
-            this.RepoUrlTextBox.Size = new System.Drawing.Size(332, 20);
+            this.RepoUrlTextBox.Size = new System.Drawing.Size(372, 30);
             this.RepoUrlTextBox.TabIndex = 11;
             this.RepoUrlTextBox.TextChanged += new System.EventHandler(this.RepoUrlTextBox_TextChanged);
             //
             // RepoCancel
             //
+            this.RepoCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RepoCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.RepoCancel.Location = new System.Drawing.Point(348, 56);
             this.RepoCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RepoCancel.Location = new System.Drawing.Point(344, 380);
             this.RepoCancel.Name = "RepoCancel";
-            this.RepoCancel.Size = new System.Drawing.Size(70, 26);
+            this.RepoCancel.Size = new System.Drawing.Size(70, 30);
             this.RepoCancel.TabIndex = 10;
             this.RepoCancel.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.RepoCancel, "RepoCancel");
             //
             // RepoOK
             //
+            this.RepoOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RepoOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.RepoOK.Enabled = false;
             this.RepoOK.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RepoOK.Location = new System.Drawing.Point(420, 380);
+            this.RepoOK.Location = new System.Drawing.Point(424, 56);
             this.RepoOK.Name = "RepoOK";
-            this.RepoOK.Size = new System.Drawing.Size(50, 26);
+            this.RepoOK.Size = new System.Drawing.Size(70, 30);
             this.RepoOK.TabIndex = 9;
             this.RepoOK.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.RepoOK, "RepoOK");
             //
-            // ReposListBox
-            //
-            this.ReposListBox.FormattingEnabled = true;
-            this.ReposListBox.Location = new System.Drawing.Point(6, 19);
-            this.ReposListBox.Name = "ReposListBox";
-            this.ReposListBox.Size = new System.Drawing.Size(464, 355);
-            this.ReposListBox.TabIndex = 8;
-            this.ReposListBox.SelectedIndexChanged += new System.EventHandler(this.ReposListBox_SelectedIndexChanged);
-            //
             // NewRepoDialog
             //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(495, 434);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.ClientSize = new System.Drawing.Size(500, 220);
             this.Controls.Add(this.RepositoryGroupBox);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Controls.Add(this.BottomButtonPanel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.Icon = Properties.Resources.AppIcon;
             this.Name = "NewRepoDialog";
             this.Load += new System.EventHandler(this.NewRepoDialog_Load);
@@ -106,15 +170,20 @@
             this.RepositoryGroupBox.ResumeLayout(false);
             this.RepositoryGroupBox.PerformLayout();
             this.ResumeLayout(false);
-
         }
 
         #endregion
 
         private System.Windows.Forms.GroupBox RepositoryGroupBox;
+        private System.Windows.Forms.ListView ReposListBox;
+        private System.Windows.Forms.ColumnHeader RepoNameHeader;
+        private System.Windows.Forms.ColumnHeader RepoURLHeader;
+        private System.Windows.Forms.Label RepoNameLabel;
+        private System.Windows.Forms.TextBox RepoNameTextBox;
+        private System.Windows.Forms.Label RepoUrlLabel;
+        private System.Windows.Forms.TextBox RepoUrlTextBox;
+        private System.Windows.Forms.Panel BottomButtonPanel;
         private System.Windows.Forms.Button RepoOK;
-        private System.Windows.Forms.ListBox ReposListBox;
         private System.Windows.Forms.Button RepoCancel;
-        public System.Windows.Forms.TextBox RepoUrlTextBox;
     }
 }

--- a/GUI/Dialogs/NewRepoDialog.cs
+++ b/GUI/Dialogs/NewRepoDialog.cs
@@ -1,16 +1,23 @@
 ﻿using System;
+﻿using System.Linq;
 using System.Windows.Forms;
 
 namespace CKAN
 {
-
-
     public partial class NewRepoDialog : Form
     {
         public NewRepoDialog()
         {
             InitializeComponent();
             StartPosition = FormStartPosition.CenterScreen;
+        }
+
+        public Repository Selection
+        {
+            get
+            {
+                return new Repository(RepoNameTextBox.Text, RepoUrlTextBox.Text);
+            }
         }
 
         private void NewRepoDialog_Load(object sender, EventArgs e)
@@ -35,26 +42,30 @@ namespace CKAN
                 return;
             }
 
-            foreach (Repository repository in repositories.repositories)
-            {
-                ReposListBox.Items.Add(String.Format("{0} | {1}", repository.name, repository.uri));
-            }
+            ReposListBox.Items.AddRange(repositories.repositories.Select(r =>
+                new ListViewItem(new string[] { r.name, r.uri.ToString() })
+                {
+                    Tag = r
+                }
+            ).ToArray());
         }
 
         private void ReposListBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (ReposListBox.SelectedItem == null)
+            if (ReposListBox.SelectedItems.Count == 0)
             {
                 return;
             }
 
-            RepoUrlTextBox.Text = (string) ReposListBox.SelectedItem;
+            Repository r = ReposListBox.SelectedItems[0].Tag as Repository;
+            RepoNameTextBox.Text = r.name;
+            RepoUrlTextBox.Text = r.uri.ToString();
         }
 
         private void RepoUrlTextBox_TextChanged(object sender, EventArgs e)
         {
-            RepoOK.Enabled = RepoUrlTextBox.Text.Length != 0;
+            RepoOK.Enabled = RepoNameTextBox.Text.Length > 0
+                && RepoUrlTextBox.Text.Length > 0;
         }
-
     }
 }

--- a/GUI/Dialogs/NewRepoDialog.resx
+++ b/GUI/Dialogs/NewRepoDialog.resx
@@ -119,7 +119,11 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="RepositoryGroupBox.Text" xml:space="preserve"><value>Official repositories</value></data>
-  <data name="RepoCancel.Text" xml:space="preserve"><value>Cancel</value></data>
-  <data name="RepoOK.Text" xml:space="preserve"><value>OK</value></data>
-  <data name="$this.Text" xml:space="preserve"><value>Settings</value></data>
+  <data name="RepoCancel.Text" xml:space="preserve"><value>&amp;Cancel</value></data>
+  <data name="RepoOK.Text" xml:space="preserve"><value>&amp;Add</value></data>
+  <data name="RepoNameHeader.Text" xml:space="preserve"><value>Name</value></data>
+  <data name="RepoURLHeader.Text" xml:space="preserve"><value>URL</value></data>
+  <data name="RepoNameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="RepoUrlLabel.Text" xml:space="preserve"><value>URL:</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Add Repository</value></data>
 </root>

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -31,13 +31,17 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(SettingsDialog));
             this.RepositoryGroupBox = new System.Windows.Forms.GroupBox();
-            this.ReposListBox = new System.Windows.Forms.ListBox();
+            this.ReposListBox = new System.Windows.Forms.ListView();
+            this.RepoNameHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.RepoURLHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.NewRepoButton = new System.Windows.Forms.Button();
             this.UpRepoButton = new System.Windows.Forms.Button();
             this.DownRepoButton = new System.Windows.Forms.Button();
             this.DeleteRepoButton = new System.Windows.Forms.Button();
             this.AuthTokensGroupBox = new System.Windows.Forms.GroupBox();
-            this.AuthTokensListBox = new System.Windows.Forms.ListBox();
+            this.AuthTokensListBox = new System.Windows.Forms.ListView();
+            this.AuthHostHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.AuthTokenHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.NewAuthTokenButton = new System.Windows.Forms.Button();
             this.DeleteAuthTokenButton = new System.Windows.Forms.Button();
             this.CacheGroupBox = new System.Windows.Forms.GroupBox();
@@ -103,12 +107,27 @@
             // ReposListBox
             //
             this.ReposListBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.ReposListBox.FormattingEnabled = true;
+            this.ReposListBox.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.RepoNameHeader,
+            this.RepoURLHeader});
             this.ReposListBox.Location = new System.Drawing.Point(12, 18);
+            this.ReposListBox.FullRowSelect = true;
+            this.ReposListBox.MultiSelect = false;
             this.ReposListBox.Name = "ReposListBox";
             this.ReposListBox.Size = new System.Drawing.Size(452, 67);
             this.ReposListBox.TabIndex = 0;
+            this.ReposListBox.View = System.Windows.Forms.View.Details;
             this.ReposListBox.SelectedIndexChanged += new System.EventHandler(this.ReposListBox_SelectedIndexChanged);
+            //
+            // RepoNameHeader
+            //
+            this.RepoNameHeader.Width = 120;
+            resources.ApplyResources(this.RepoNameHeader, "RepoNameHeader");
+            //
+            // RepoURLHeader
+            //
+            this.RepoURLHeader.Width = 380;
+            resources.ApplyResources(this.RepoURLHeader, "RepoURLHeader");
             //
             // NewRepoButton
             //
@@ -169,12 +188,27 @@
             // AuthTokensListBox
             //
             this.AuthTokensListBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.AuthTokensListBox.FormattingEnabled = true;
+            this.AuthTokensListBox.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.AuthHostHeader,
+            this.AuthTokenHeader});
+            this.AuthTokensListBox.FullRowSelect = true;
+            this.AuthTokensListBox.MultiSelect = false;
+            this.AuthTokensListBox.View = System.Windows.Forms.View.Details;
             this.AuthTokensListBox.Location = new System.Drawing.Point(12, 18);
             this.AuthTokensListBox.Name = "AuthTokensListBox";
             this.AuthTokensListBox.Size = new System.Drawing.Size(452, 67);
             this.AuthTokensListBox.TabIndex = 0;
             this.AuthTokensListBox.SelectedIndexChanged += new System.EventHandler(this.AuthTokensListBox_SelectedIndexChanged);
+            //
+            // AuthHostHeader
+            //
+            this.AuthHostHeader.Width = 120;
+            resources.ApplyResources(this.AuthHostHeader, "AuthHostHeader");
+            //
+            // AuthTokenHeader
+            //
+            this.AuthTokenHeader.Width = 380;
+            resources.ApplyResources(this.AuthTokenHeader, "AuthTokenHeader");
             //
             // NewAuthTokenButton
             //
@@ -598,13 +632,17 @@
         #endregion
 
         private System.Windows.Forms.GroupBox RepositoryGroupBox;
-        private System.Windows.Forms.ListBox ReposListBox;
+        private System.Windows.Forms.ListView ReposListBox;
+        private System.Windows.Forms.ColumnHeader RepoNameHeader;
+        private System.Windows.Forms.ColumnHeader RepoURLHeader;
         private System.Windows.Forms.Button NewRepoButton;
         private System.Windows.Forms.Button UpRepoButton;
         private System.Windows.Forms.Button DownRepoButton;
         private System.Windows.Forms.Button DeleteRepoButton;
         private System.Windows.Forms.GroupBox AuthTokensGroupBox;
-        private System.Windows.Forms.ListBox AuthTokensListBox;
+        private System.Windows.Forms.ListView AuthTokensListBox;
+        private System.Windows.Forms.ColumnHeader AuthHostHeader;
+        private System.Windows.Forms.ColumnHeader AuthTokenHeader;
         private System.Windows.Forms.Button NewAuthTokenButton;
         private System.Windows.Forms.Button DeleteAuthTokenButton;
         private System.Windows.Forms.GroupBox CacheGroupBox;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -320,7 +320,7 @@ namespace CKAN
 
         private void DownRepoButton_Click(object sender, EventArgs e)
         {
-            if (ReposListBox.SelectedIndices.Count == 0 
+            if (ReposListBox.SelectedIndices.Count == 0
                 || ReposListBox.SelectedIndices[0] == ReposListBox.Items.Count - 1)
             {
                 return;
@@ -475,7 +475,7 @@ namespace CKAN
 
                 config.SetAuthToken(host, null);
                 RefreshAuthTokensListBox();
-                DeleteRepoButton.Enabled = false;
+                DeleteAuthTokenButton.Enabled = false;
             }
         }
 

--- a/GUI/Dialogs/SettingsDialog.resx
+++ b/GUI/Dialogs/SettingsDialog.resx
@@ -165,5 +165,9 @@
   <data name="HideEpochsCheckbox.Text" xml:space="preserve"><value>Hide epoch numbers in mod list (requires restart)</value></data>
   <data name="HideVCheckbox.Text" xml:space="preserve"><value>Hide "v" in mod list (requires restart)</value></data>
   <data name="AutoSortUpdateCheckBox.Text" xml:space="preserve"><value>Automatically sort by "Update"-column when clicking "Add available updates"</value></data>
+  <data name="RepoNameHeader.Text" xml:space="preserve"><value>Name</value></data>
+  <data name="RepoURLHeader.Text" xml:space="preserve"><value>URL</value></data>
+  <data name="AuthHostHeader.Text" xml:space="preserve"><value>Host</value></data>
+  <data name="AuthTokenHeader.Text" xml:space="preserve"><value>Token</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Settings</value></data>
 </root>


### PR DESCRIPTION
## Problems

The repo and auth token sections of the GUI Settings use pipe characters to fake multiple columns:

![image](https://user-images.githubusercontent.com/1559108/100481006-86e1e900-30b8-11eb-9a4f-9d66279cd852.png)

The popup to add a repo:

![image](https://user-images.githubusercontent.com/1559108/100481076-ba247800-30b8-11eb-834e-fa4ba9a35abd.png)

- has title "Settings"
- is enormous compared to how much space its content requires
- isn't resizable
- also uses pipe characters to fake multiple columns in the list
- requires the user to type pipe characters in a special format to enter a custom repo
- has no label for its text field
- has the text field, cancel, and OK buttons inside the "Official repositories" frame even though these controls are not related to official repositories

## Changes

![image](https://user-images.githubusercontent.com/1559108/100481292-42a31880-30b9-11eb-9bf4-aae13cb90702.png)

- The repo table in Settings is a ListView with two columns
- The auth token table in Settings is a ListView with two columns

![image](https://user-images.githubusercontent.com/1559108/100481309-4f277100-30b9-11eb-9f2a-2f6f9dde718d.png)

- Title is now "Add Repository"
- The blank space in the repo list is reduced
- The form is resiable
- The list is now a ListView with two columns
- The text box is split into one for name, one for URL, each with a label, so the user doesn't have to type pipes
- The text box and buttons are moved outside the "Official repositories" frame
- The "OK" button is now relabeled to the more descriptive "Add" and is the same width as the other button, and they have keyboard shortcuts