### PR TITLE
Distinguish deb packages with build numbers

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -21,7 +21,7 @@ DESKTOPSRC:=ckan.desktop
 DESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan.desktop
 CONSOLEUIDESKTOPSRC:=ckan-consoleui.desktop
 CONSOLEUIDESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan-consoleui.desktop
-VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
+VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' ).$(shell date +'%g%j')
 DEB:=../_build/deb/ckan_$(VERSION)_all.deb
 
 # Files for /deb/ (the .deb file)


### PR DESCRIPTION
## Background

In #3197 (and subsequent fixes), we added a deb repo with `stable` and `nightly` builds.

## Problem

If you install a `nightly` build, and then we merge new changes the next day, the resulting build will have the same version number as what you have installed (currently v1.29.1), and so APT packaging tools won't prompt you to update.
(`sudo apt-get update && sudo apt-get reinstall ckan` does work, though.)

## Changes

Now the versions for the .deb files have the 2-digit year and the day-of-year appended as the build number, as in:

- v1.29.1.20333

This way you will be prompted to update if your installed version is a day or more older than the latest version in the dist you chose. Note that both `nightly` and `stable` releases are affected by this change, but only `nightly` is updated with each merge to `master`; `stable` only updates when we create a new release, so users of that dist won't be prompted to update as often.