### PR TITLE
Make Mono 6 builds work on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mono: ['5.20', '6.4', '6.6', '6.8']
+        mono: ['5.20', '6.4', '6.6', '6.8', 'latest']
         configuration: [Debug, Release]
 
     container:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: mono:5.20
+      image: mono:latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: mono:5.20
+      image: mono:latest
 
     steps:
       - uses: actions/checkout@v2

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -147,9 +147,6 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
   <data name="launchKSPToolStripMenuItem.Text" xml:space="preserve"><value>Launch KSP</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>Refresh</value></data>
   <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>Add available updates</value></data>

--- a/GUI/Localization/de-DE/ManageMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ManageMods.de-DE.resx
@@ -147,9 +147,6 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
   <data name="launchKSPToolStripMenuItem.Text" xml:space="preserve"><value>KSP starten</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>Aktualisieren</value></data>
   <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>Verfügbare Updates auswählen</value></data>

--- a/GUI/Localization/zh-CN/EditModSearch.zh-CN.resx
+++ b/GUI/Localization/zh-CN/EditModSearch.zh-CN.resx
@@ -147,8 +147,5 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
   <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>搜索:</value></data>
 </root>

--- a/GUI/Localization/zh-CN/EditModSearchDetails.zh-CN.resx
+++ b/GUI/Localization/zh-CN/EditModSearchDetails.zh-CN.resx
@@ -147,9 +147,6 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
   <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>按作者名筛选:</value></data>
   <data name="FilterByNameLabel.Text" xml:space="preserve"><value>按Mod名称筛选:</value></data>
   <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>按描述筛选:</value></data>

--- a/GUI/Localization/zh-CN/Main.zh-CN.resx
+++ b/GUI/Localization/zh-CN/Main.zh-CN.resx
@@ -162,9 +162,6 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
   <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>文件</value></data>
   <data name="manageKspInstancesMenuItem.Text" xml:space="preserve"><value>管理KSP实例</value></data>
   <data name="openKspDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>打开KSP目录</value></data>

--- a/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
+++ b/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
@@ -147,9 +147,6 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
   <data name="launchKSPToolStripMenuItem.Text" xml:space="preserve"><value>启动KSP</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>刷新</value></data>
   <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>添加可用更新</value></data>

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -135,9 +135,6 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
   <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>File</value></data>
   <data name="manageKspInstancesMenuItem.Text" xml:space="preserve"><value>Manage KSP Instances</value></data>
   <data name="openKspDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Open KSP Directory</value></data>


### PR DESCRIPTION
## Background

Before #2964, we built releases on Mono 5.16, then that PR changed it to Mono 6.6. This broke things (see below), so as 
a workaround, #2976 changed it back to Mono 5.20 in a panic. Here we attempt to address the root cause.

## Problem

When we build on Mono 6, running the GUI on Windows throws an exception at startup:

```
Unhandled Exception: System.ArgumentException: Object of type 'System.Globalization.CalendarId[]' cannot be converted to type 'System.Int32[]'.
   at System.RuntimeType.TryChangeType(Object value, Binder binder, CultureInfo culture, Boolean needsSpecialCast)
   at System.RuntimeType.CheckValue(Object value, Binder binder, CultureInfo culture, BindingFlags invokeAttr)
   at System.Reflection.RtFieldInfo.UnsafeSetValue(Object obj, Object value, BindingFlags invokeAttr, Binder binder, CultureInfo culture)
   at System.Runtime.Serialization.FormatterServices.SerializationSetValue(MemberInfo fi, Object target, Object value)
   at System.Runtime.Serialization.ObjectManager.CompleteObject(ObjectHolder holder, Boolean bObjectFullyComplete)
   at System.Runtime.Serialization.ObjectManager.DoNewlyRegisteredObjectFixups(ObjectHolder holder)
   at System.Runtime.Serialization.ObjectManager.RegisterObject(Object obj, Int64 objectID, SerializationInfo info, Int64 idOfContainingObj, MemberInfo member, Int32[] arrayIndex)
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.RegisterObject(Object obj, ParseRecord pr, ParseRecord objectPr, Boolean bIsString)
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.ParseObjectEnd(ParseRecord pr)
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Parse(ParseRecord pr)
   at System.Runtime.Serialization.Formatters.Binary.__BinaryParser.Run()
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Deserialize(HeaderHandler handler, __BinaryParser serParser, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(Stream serializationStream, HeaderHandler handler, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Resources.ResourceReader.DeserializeObject(Int32 typeIndex)
   at System.Resources.ResourceReader._LoadObjectV2(Int32 pos, ResourceTypeCode& typeCode)
   at System.Resources.ResourceReader.LoadObjectV2(Int32 pos, ResourceTypeCode& typeCode)
   at System.Resources.ResourceReader.LoadObject(Int32 pos)
   at System.Resources.ResourceReader.ResourceEnumerator.get_Entry()
   at System.Resources.ResourceReader.ResourceEnumerator.get_Current()
   at System.ComponentModel.ComponentResourceManager.FillResources(CultureInfo culture, ResourceSet& resourceSet)
   at System.ComponentModel.ComponentResourceManager.FillResources(CultureInfo culture, ResourceSet& resourceSet)
   at System.ComponentModel.ComponentResourceManager.FillResources(CultureInfo culture, ResourceSet& resourceSet)
   at System.ComponentModel.ComponentResourceManager.ApplyResources(Object value, String objectName, CultureInfo culture)
   at System.ComponentModel.ComponentResourceManager.ApplyResources(Object value, String objectName)
   at CKAN.Main.InitializeComponent()
   at CKAN.Main..ctor(String[] cmdlineArgs, KSPManager mgr, Boolean showConsole)
   at CKAN.GUI.Main_(String[] args, KSPManager manager, Boolean showConsole)
   at CKAN.CmdLine.MainClass.RunSimpleAction(Options cmdline, CommonOptions options, String[] args, IUser user, KSPManager manager)
   at CKAN.CmdLine.MainClass.Execute(KSPManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

Mono 5 also freaks out, in a similar but slightly different way. It seems the same problem causes a null reference exception instead of the above.

## Cause

Clearly there's something involving `CalendarId` that Windows doesn't like. The `.resx` files are compiled to `.resources` files in `_build/out/CKAN-GUI/Debug`, and if we inspect one of these files in a Mono 6 build, we indeed see instances of `CalendarId`:

![image](https://user-images.githubusercontent.com/1559108/100716092-d73d9d00-337d-11eb-874f-e309ea9aa051.png)

Looking above, these seem to be within an instance of a `System.Globalization.CultureInfo` object, and our `.resx` file contains exactly one of those, in the `$this.Language` property. The same file built on Windows shows no references to `CalendarId` at all; so Mono and .NET disagree on precisely how `CultureInfo` should be (de)serialized, which causes problems trying to use data from one platform on the other.

`$this.Language` sets the `Control.Language` or `Form.Language` property, which is used by Visual Studio to control what locale is being edited in its form designer. This property has no role at run-time :facepalm:.

## Changes

Now our `.resx` files no longer contain `$this.Language`, which makes our Mono 6 builds run on Windows and Mono 5.
To celebrate, we now build releases on `mono:latest`.