### PR TITLE
Add test for Control.Language property resource

### DIFF
--- a/GUI/Properties/AssemblyInfo.cs
+++ b/GUI/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Resources;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("CKAN-GUI")]
 [assembly: AssemblyDescription("CKAN GUI Client")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 
+[assembly: InternalsVisibleTo("CKAN.Tests")]

--- a/GUI/SingleAssemblyComponentResourceManager.cs
+++ b/GUI/SingleAssemblyComponentResourceManager.cs
@@ -9,7 +9,7 @@ namespace CKAN
 {
     // Thanks and credit to this guy: https://stackoverflow.com/q/1952638/2422988
 
-    class SingleAssemblyComponentResourceManager : ComponentResourceManager
+    internal class SingleAssemblyComponentResourceManager : ComponentResourceManager
     {
         public SingleAssemblyComponentResourceManager(Type t) : base(t)
         {

--- a/Tests/GUI/ResourcesTests.cs
+++ b/Tests/GUI/ResourcesTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.ComponentModel;
+using System.Globalization;
+using NUnit.Framework;
+
+namespace Tests.GUI
+{
+    [TestFixture]
+    public class ResourcesTests
+    {
+        /// <summary>
+        /// .resx files should never have a $this.Language property because it
+        /// does not deserialize properly in Windows when serialized on Mono 6+
+        /// </summary>
+        [Test,
+            // Controls
+            TestCase(typeof(CKAN.AllModVersions)),
+            TestCase(typeof(CKAN.Changeset)),
+            TestCase(typeof(CKAN.ChooseProvidedMods)),
+            TestCase(typeof(CKAN.ChooseRecommendedMods)),
+            TestCase(typeof(CKAN.DeleteDirectories)),
+            TestCase(typeof(CKAN.EditModpack)),
+            TestCase(typeof(CKAN.EditModSearch)),
+            TestCase(typeof(CKAN.HintTextBox)),
+            TestCase(typeof(CKAN.ManageMods)),
+            TestCase(typeof(CKAN.ModInfo)),
+            TestCase(typeof(CKAN.Wait)),
+
+            // Dialogs
+            TestCase(typeof(CKAN.Main)),
+            TestCase(typeof(CKAN.AboutDialog)),
+            TestCase(typeof(CKAN.AskUserForAutoUpdatesDialog)),
+            TestCase(typeof(CKAN.CloneFakeKspDialog)),
+            TestCase(typeof(CKAN.CompatibleKspVersionsDialog)),
+            TestCase(typeof(CKAN.EditLabelsDialog)),
+            TestCase(typeof(CKAN.ErrorDialog)),
+            TestCase(typeof(CKAN.KSPCommandLineOptionsDialog)),
+            TestCase(typeof(CKAN.ManageKspInstancesDialog)),
+            TestCase(typeof(CKAN.NewRepoDialog)),
+            TestCase(typeof(CKAN.NewUpdateDialog)),
+            TestCase(typeof(CKAN.PluginsDialog)),
+            TestCase(typeof(CKAN.RenameInstanceDialog)),
+            TestCase(typeof(CKAN.SelectionDialog)),
+            TestCase(typeof(CKAN.YesNoDialog)),
+        ]
+        public void ControlOrDialog_LanguageResource_NotSet(Type t)
+        {
+            // Arrange
+            ComponentResourceManager resources = new CKAN.SingleAssemblyComponentResourceManager(t);
+
+            // Act/Assert
+            foreach (CultureInfo resourceCulture in cultures)
+            {
+                Assert.IsNull(resources.GetObject("$this.Language", resourceCulture));
+            }
+        }
+
+        // The cultures to test
+        private static CultureInfo[] cultures = CKAN.Utilities.AvailableLanguages
+            .Select(l => new CultureInfo(l))
+            .ToArray();
+    }
+}


### PR DESCRIPTION
## Background

#3218 fixed a problem with Mono 6 generating builds that don't work on Windows, but there's a risk that Visual Studio will create the problem again by setting the `$this.Language` property of a `.resx` file. If this happens, the current maintainers may not remember or may never have known that this is a problem, and a broken release could happen.

## Changes

Now a new Test checks that `$this.Language` is not set in any known resource file, which will prevent this problem from recurring in the future. To achieve this, `SingleAssemblyComponentResourceManager` is marked as `internal` and the Tests project is given internals-visibility into the GUI project.