### PR TITLE
Allow label to pin installed mod version

### DIFF
--- a/GUI/Dialogs/EditLabelsDialog.Designer.cs
+++ b/GUI/Dialogs/EditLabelsDialog.Designer.cs
@@ -45,6 +45,7 @@ namespace CKAN
             this.RemoveOnChangesCheckBox = new System.Windows.Forms.CheckBox();
             this.AlertOnInstallCheckBox = new System.Windows.Forms.CheckBox();
             this.RemoveOnInstallCheckBox = new System.Windows.Forms.CheckBox();
+            this.HoldVersionCheckBox = new System.Windows.Forms.CheckBox();
             this.CreateButton = new System.Windows.Forms.Button();
             this.CloseButton = new System.Windows.Forms.Button();
             this.SaveButton = new System.Windows.Forms.Button();
@@ -81,9 +82,10 @@ namespace CKAN
             this.LabelSelectionTree.HideSelection = false;
             this.LabelSelectionTree.Indent = 16;
             this.LabelSelectionTree.ItemHeight = 24;
+            this.LabelSelectionTree.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
             this.LabelSelectionTree.Location = new System.Drawing.Point(10, 43);
             this.LabelSelectionTree.Name = "LabelSelectionTree";
-            this.LabelSelectionTree.Size = new System.Drawing.Size(125, 320);
+            this.LabelSelectionTree.Size = new System.Drawing.Size(125, 350);
             this.LabelSelectionTree.ShowPlusMinus = false;
             this.LabelSelectionTree.ShowRootLines = false;
             this.LabelSelectionTree.ShowLines = false;
@@ -115,12 +117,13 @@ namespace CKAN
             this.EditDetailsPanel.Controls.Add(this.RemoveOnChangesCheckBox);
             this.EditDetailsPanel.Controls.Add(this.AlertOnInstallCheckBox);
             this.EditDetailsPanel.Controls.Add(this.RemoveOnInstallCheckBox);
+            this.EditDetailsPanel.Controls.Add(this.HoldVersionCheckBox);
             this.EditDetailsPanel.Controls.Add(this.SaveButton);
             this.EditDetailsPanel.Controls.Add(this.CancelEditButton);
             this.EditDetailsPanel.Controls.Add(this.DeleteButton);
             this.EditDetailsPanel.Location = new System.Drawing.Point(135, 43);
             this.EditDetailsPanel.Name = "EditDetailsPanel";
-            this.EditDetailsPanel.Size = new System.Drawing.Size(350, 320);
+            this.EditDetailsPanel.Size = new System.Drawing.Size(350, 350);
             this.EditDetailsPanel.TabIndex = 1;
             this.EditDetailsPanel.Visible = false;
             // 
@@ -220,11 +223,19 @@ namespace CKAN
             this.RemoveOnInstallCheckBox.Size = new System.Drawing.Size(200, 23);
             resources.ApplyResources(this.RemoveOnInstallCheckBox, "RemoveOnInstallCheckBox");
             // 
+            // HoldVersionCheckBox
+            // 
+            this.HoldVersionCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.HoldVersionCheckBox.Location = new System.Drawing.Point(90, 250);
+            this.HoldVersionCheckBox.Name = "HoldVersionCheckBox";
+            this.HoldVersionCheckBox.Size = new System.Drawing.Size(200, 23);
+            resources.ApplyResources(this.HoldVersionCheckBox, "HoldVersionCheckBox");
+            // 
             // SaveButton
             // 
             this.SaveButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
-            this.SaveButton.Location = new System.Drawing.Point(10, 290);
+            this.SaveButton.Location = new System.Drawing.Point(10, 320);
             this.SaveButton.Name = "SaveButton";
             this.SaveButton.Size = new System.Drawing.Size(75, 23);
             this.SaveButton.TabIndex = 0;
@@ -236,7 +247,7 @@ namespace CKAN
             // 
             this.CancelEditButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
-            this.CancelEditButton.Location = new System.Drawing.Point(90, 290);
+            this.CancelEditButton.Location = new System.Drawing.Point(90, 320);
             this.CancelEditButton.Name = "CancelEditButton";
             this.CancelEditButton.Size = new System.Drawing.Size(75, 23);
             this.CancelEditButton.TabIndex = 0;
@@ -248,7 +259,7 @@ namespace CKAN
             // 
             this.DeleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
-            this.DeleteButton.Location = new System.Drawing.Point(170, 290);
+            this.DeleteButton.Location = new System.Drawing.Point(170, 320);
             this.DeleteButton.Name = "DeleteButton";
             this.DeleteButton.Size = new System.Drawing.Size(75, 23);
             this.DeleteButton.TabIndex = 0;
@@ -260,7 +271,7 @@ namespace CKAN
             // 
             this.CloseButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
-            this.CloseButton.Location = new System.Drawing.Point(10, 367);
+            this.CloseButton.Location = new System.Drawing.Point(10, 397);
             this.CloseButton.Name = "CloseButton";
             this.CloseButton.Size = new System.Drawing.Size(75, 23);
             this.CloseButton.TabIndex = 2;
@@ -272,7 +283,7 @@ namespace CKAN
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(500, 400);
+            this.ClientSize = new System.Drawing.Size(500, 430);
             this.Controls.Add(this.CreateButton);
             this.Controls.Add(this.LabelSelectionTree);
             this.Controls.Add(this.SelectOrCreateLabel);
@@ -304,6 +315,7 @@ namespace CKAN
         private System.Windows.Forms.CheckBox RemoveOnChangesCheckBox;
         private System.Windows.Forms.CheckBox AlertOnInstallCheckBox;
         private System.Windows.Forms.CheckBox RemoveOnInstallCheckBox;
+        private System.Windows.Forms.CheckBox HoldVersionCheckBox;
         private System.Windows.Forms.Label ColorLabel;
         private System.Windows.Forms.Button ColorButton;
         private System.Windows.Forms.Button CreateButton;

--- a/GUI/Dialogs/EditLabelsDialog.cs
+++ b/GUI/Dialogs/EditLabelsDialog.cs
@@ -25,6 +25,7 @@ namespace CKAN
             this.ToolTip.SetToolTip(RemoveOnChangesCheckBox, Properties.Resources.EditLabelsToolTipRemoveOnChanges);
             this.ToolTip.SetToolTip(AlertOnInstallCheckBox, Properties.Resources.EditLabelsToolTipAlertOnInstall);
             this.ToolTip.SetToolTip(RemoveOnInstallCheckBox, Properties.Resources.EditLabelsToolTipRemoveOnInstall);
+            this.ToolTip.SetToolTip(HoldVersionCheckBox, Properties.Resources.EditLabelsToolTipHoldVersion);
         }
 
         private void LoadTree()
@@ -39,13 +40,21 @@ namespace CKAN
                 string groupName = string.IsNullOrEmpty(group.Key)
                     ? Properties.Resources.ModuleLabelListGlobal
                     : group.Key;
-                var gnd = LabelSelectionTree.Nodes.Add(groupName);
-                gnd.NodeFont = new Font(LabelSelectionTree.Font, FontStyle.Bold);
-                foreach (ModuleLabel mlbl in group.OrderBy(l => l.Name))
-                {
-                    var lblnd = gnd.Nodes.Add(mlbl.Name);
-                    lblnd.Tag = mlbl;
-                }
+                LabelSelectionTree.Nodes.Add(new TreeNode(
+                    groupName,
+                    group.OrderBy(mlbl => mlbl.Name)
+                        .Select(mlbl => new TreeNode(mlbl.Name)
+                        {
+                            // Windows's TreeView has a bug where the node's visual
+                            // width is based on the owning TreeView.Font rather
+                            // than TreeNode.Font, so to ensure there's enough space,
+                            // we have to make the default bold and then override it
+                            // for non-bold nodes.
+                            NodeFont = new Font(LabelSelectionTree.Font, FontStyle.Regular),
+                            Tag      = mlbl
+                        })
+                        .ToArray()
+                ));
             }
             LabelSelectionTree.ExpandAll();
             LabelSelectionTree.EndUpdate();
@@ -159,6 +168,7 @@ namespace CKAN
             RemoveOnChangesCheckBox.Checked      = lbl.RemoveOnChange;
             AlertOnInstallCheckBox.Checked       = lbl.AlertOnInstall;
             RemoveOnInstallCheckBox.Checked      = lbl.RemoveOnInstall;
+            HoldVersionCheckBox.Checked          = lbl.HoldVersion;
 
             DeleteButton.Enabled = labels.Labels.Contains(lbl);
 
@@ -209,6 +219,7 @@ namespace CKAN
                 currentlyEditing.RemoveOnChange  = RemoveOnChangesCheckBox.Checked;
                 currentlyEditing.AlertOnInstall  = AlertOnInstallCheckBox.Checked;
                 currentlyEditing.RemoveOnInstall = RemoveOnInstallCheckBox.Checked;
+                currentlyEditing.HoldVersion     = HoldVersionCheckBox.Checked;
 
                 EditDetailsPanel.Visible = false;
                 currentlyEditing = null;
@@ -267,6 +278,7 @@ namespace CKAN
                     || currentlyEditing.RemoveOnChange  != RemoveOnChangesCheckBox.Checked
                     || currentlyEditing.AlertOnInstall  != AlertOnInstallCheckBox.Checked
                     || currentlyEditing.RemoveOnInstall != RemoveOnInstallCheckBox.Checked
+                    || currentlyEditing.HoldVersion     != HoldVersionCheckBox.Checked
                 );
         }
 

--- a/GUI/Dialogs/EditLabelsDialog.resx
+++ b/GUI/Dialogs/EditLabelsDialog.resx
@@ -130,6 +130,7 @@
   <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Remove on updates</value></data>
   <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Alert on install</value></data>
   <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Remove on install</value></data>
+  <data name="HoldVersionCheckBox.Text" xml:space="preserve"><value>Don't upgrade</value></data>
   <data name="CloseButton.Text" xml:space="preserve"><value>Close</value></data>
   <data name="SaveButton.Text" xml:space="preserve"><value>Save</value></data>
   <data name="CancelEditButton.Text" xml:space="preserve"><value>Cancel</value></data>

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -37,6 +37,10 @@ namespace CKAN
         [DefaultValue(false)]
         public bool    RemoveOnInstall;
 
+        [JsonProperty("hold_version", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        public bool    HoldVersion;
+
         [JsonProperty("module_identifiers", NullValueHandling = NullValueHandling.Ignore)]
         public HashSet<string> ModuleIdentifiers = new HashSet<string>();
 

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -41,6 +41,12 @@ namespace CKAN
                         Hide  = true,
                         Color = Color.PaleVioletRed,
                     },
+                    new ModuleLabel()
+                    {
+                        Name        = Properties.Resources.ModuleLabelListHeld,
+                        HoldVersion = true,
+                        Color       = Color.FromArgb(255, 255, 176),
+                    }
                 }
             };
         }

--- a/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
@@ -130,6 +130,7 @@
   <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Label nach Updates entfernen</value></data>
   <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Vor Installation warnen</value></data>
   <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Label nach der Installation entfernen</value></data>
+  <data name="HoldVersionCheckBox.Text" xml:space="preserve"><value>Aktualisierungen zurückhalten</value></data>
   <data name="CloseButton.Text" xml:space="preserve"><value>Schließen</value></data>
   <data name="SaveButton.Text" xml:space="preserve"><value>Speichern</value></data>
   <data name="CancelEditButton.Text" xml:space="preserve"><value>Abbrechen</value></data>

--- a/GUI/Main/MainLabels.cs
+++ b/GUI/Main/MainLabels.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Windows.Forms;
 using System.Collections.Generic;
@@ -55,6 +54,12 @@ namespace CKAN
             {
                 l.Remove(mod.identifier);
             }
+        }
+
+        public bool LabelsHeld(string identifier)
+        {
+            return ManageMods.mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
+                .Any(l => l.HoldVersion && l.ModuleIdentifiers.Contains(identifier));
         }
 
         #endregion

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -799,6 +799,9 @@ namespace CKAN.Properties {
         internal static string ModuleLabelListHidden {
             get { return (string)(ResourceManager.GetObject("ModuleLabelListHidden", resourceCulture)); }
         }
+        internal static string ModuleLabelListHeld {
+            get { return (string)(ResourceManager.GetObject("ModuleLabelListHeld", resourceCulture)); }
+        }
         internal static string ModuleLabelListGlobal {
             get { return (string)(ResourceManager.GetObject("ModuleLabelListGlobal", resourceCulture)); }
         }
@@ -855,6 +858,9 @@ namespace CKAN.Properties {
         }
         internal static string EditLabelsToolTipRemoveOnInstall {
             get { return (string)(ResourceManager.GetObject("EditLabelsToolTipRemoveOnInstall", resourceCulture)); }
+        }
+        internal static string EditLabelsToolTipHoldVersion {
+            get { return (string)(ResourceManager.GetObject("EditLabelsToolTipHoldVersion", resourceCulture)); }
         }
         internal static string MainLabelsUpdateMessage {
             get { return (string)(ResourceManager.GetObject("MainLabelsUpdateMessage", resourceCulture)); }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -332,6 +332,7 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Spielinstanz: {0} ({1} {2})</value></data>
   <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoriten</value></data>
   <data name="ModuleLabelListHidden" xml:space="preserve"><value>Versteckt</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Zurückgehalten</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Möchtest du {0} wirklich löschen? Das kann nicht mehr rückgängig gemacht werden!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Änderungen speichern?</value></data>
@@ -351,6 +352,7 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird das Label von Modulen entfernt, sobald sie kompatibel werden</value></data>
   <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Warnung angezeigt, wenn das Modul installiert werden soll</value></data>
   <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird das Label von dem Modul entfernt, wenn es installiert wurde</value></data>
+  <data name="EditLabelsToolTipHoldVersion" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird das Modul nicht automatisch aktualisiert</value></data>
   <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Mods die du beobachtest wurden aktualisiert:
 
 {0}</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -354,6 +354,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Game instance: {0} ({1} {2})</value></data>
   <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favourites</value></data>
   <data name="ModuleLabelListHidden" xml:space="preserve"><value>Hidden</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Held</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Are you sure you want to delete {0}? This can't be undone!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Save changes?</value></data>
@@ -373,6 +374,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>If checked, a module that changes from incompatible to compatible will be removed from this label</value></data>
   <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>If checked, the change set screen will alert you if this mod is about to be installed</value></data>
   <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>If checked, modules will be removed from this label if they are installed</value></data>
+  <data name="EditLabelsToolTipHoldVersion" xml:space="preserve"><value>If checked, modules will not be upgraded</value></data>
   <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Some of your watched mods have updated:
 
 {0}</value></data>


### PR DESCRIPTION
## Motivation

Sometimes a user doesn't want to upgrade an upgradeable mod for the foreseeable future:

![image](https://user-images.githubusercontent.com/1559108/100894510-79f83780-34b4-11eb-8989-78dce3b5a4c6.png)

![image](https://user-images.githubusercontent.com/1559108/100894597-91372500-34b4-11eb-8241-29459a6d6823.png)

![image](https://user-images.githubusercontent.com/1559108/100894649-a14f0480-34b4-11eb-88c4-6a4e5ffc486c.png)

## Changes

Now a new "Don't upgrade" checkbox is added to the Edit Labels form:

![image](https://user-images.githubusercontent.com/1559108/100894904-e5420980-34b4-11eb-94c9-f1b7bc430be8.png)

 If checked, mods with this label will not be upgraded by the "Add available updates" button (though the Update column will still appear to let users know an update exists and isn't being installed, and the user can still choose to upgrade manually):

![image](https://user-images.githubusercontent.com/1559108/100895549-99439480-34b5-11eb-97f3-d33d6a7bb4f6.png)

A user installing CKAN for the first time will have a default label "Held" created with this feature enabled; existing users will have to create their own labels.