### PR TITLE
April Fools' Day prank for macOS

### DIFF
--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -13,6 +13,19 @@ namespace CKAN.CmdLine
         public int RunCommand(KSPManager manager, object raw_options)
         {
             CommonOptions opts = raw_options as CommonOptions;
+            // Print an intro if not in headless mode
+            if (!(opts?.Headless ?? false))
+            {
+                Console.WriteLine("Welcome to CKAN!");
+                Console.WriteLine("");
+                if (DateTime.Now.Month == 4 && DateTime.Now.Day == 1)
+                {
+                    Console.WriteLine("Happy April Fools' Day! You may want to try the consoleui command.");
+                    Console.WriteLine("");
+                }
+                Console.WriteLine("To get help, type help and press enter.");
+                Console.WriteLine("");
+            }
             bool done = false;
             while (!done)
             {

--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -67,9 +67,15 @@ else
     # Default to consoleui on Catalina and later if they double click
     if ! supports_32_bit && [[ "$@" == "" ]]
     then
+        COMMAND=consoleui
+        if [[ $(date +'%m%d') == 0401 ]]
+        then
+            # Prank Mac users on April 1
+            COMMAND=prompt
+        fi
         osascript <<END
 tell application "Terminal"
-    do script "cd \"`pwd`\"; \"$MONO\" \"$ASSEMBLY\" consoleui"
+    do script "cd \"`pwd`\"; \"$MONO\" \"$ASSEMBLY\" $COMMAND"
 end tell
 END
     else


### PR DESCRIPTION
## Background

On macOS 10.15 and later, the GUI doesn't work anymore (see #2272), so we fall back to ConsoleUI, which is based on DOS user interfaces circa 1990 (see #2177), the high point of PC-vs-Mac rivalry. It amuses me to no end to see Mac users using the style of program most emblematic of their vendor's big enemy (and some of them have even said they like it!).

However, we also have a fully functional `ckan prompt` command emulating command line user interfaces circa 1980 (see #2273), which almost nobody knows about. It might be fun to have a little Easter egg that shows it off. Or this might not be a good idea :shrug:.

## Changes

Now if you double click the CKAN.app bundle while your system clock indicates a date of April 1st of any year, your Terminal will run `ckan prompt` instead of `ckan consoleui`, dropping you into a simple command line environment with commands for all of CKAN's functionality.

To avoid being overly cruel, `ckan prompt` now prints an April Fools' Day message on that day (as a clue to why it's different) and recommends the `consoleui` command (to get Mac users back into their familiar DOS-like environment easily). At worst it should be a minor annoyance for 24 hours per year, and at best some users might discover they like the command line environment.