### PR TITLE
Metadata GitHub Actions Container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run tests
         run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
 
-      - name: Generate Docker image and publish to Hub
+      - name: Generate inflator Docker image and publish to Hub
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -72,6 +72,14 @@ jobs:
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           ./build docker-inflator --exclusive
+      - name: Generate metadata tester Docker image and publish to Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
+        run: |
+          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          ./build docker-metadata --exclusive
       - name: Push ckan.exe and netkan.exe to S3
         # Send ckan.exe and netkan.exe to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,0 +1,8 @@
+FROM mono:6.8
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    apt-get clean
+
+ADD netkan.exe /usr/local/bin/.
+ADD ckan.exe /usr/local/bin/.


### PR DESCRIPTION
Deprecating or Jenkin's CI infrastructure has been on the road map for some time. To support this path we can build a container with the ckan/netkan tools for use during GitHub Actions.