### PR TITLE
Build Inflator on latest Mono

### DIFF
--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -1,4 +1,4 @@
-FROM mono:5.20.1
+FROM mono:latest
 RUN useradd -ms /bin/bash netkan
 USER netkan
 WORKDIR /home/netkan


### PR DESCRIPTION
As of #3218 we know what the problem was with our Mono 6 builds: a serialization problem that only affected GUI and is now fixed.

Now we build the Inflator on `mono:latest` since it is safe to do so.