### PR TITLE
Format installation errors for GitHub Actions in headless mode

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -143,14 +143,7 @@ namespace CKAN.CmdLine
                 }
                 catch (DependencyNotSatisfiedKraken ex)
                 {
-                    if (ex.version == null)
-                    {
-                        user.RaiseMessage("{0} requires {1} but it is not listed in the index, or not available for your version of KSP.", ex.parent, ex.module);
-                    }
-                    else
-                    {
-                        user.RaiseMessage("{0} requires {1} {2} but it is not listed in the index, or not available for your version of KSP.", ex.parent, ex.module, ex.version);
-                    }
+                    user.RaiseError(ex.Message);
                     user.RaiseMessage("If you're lucky, you can do a `ckan update` and try again.");
                     user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules.");
                     user.RaiseMessage("Or `ckan install --allow-incompatible` to ignore module compatibility.");
@@ -160,11 +153,13 @@ namespace CKAN.CmdLine
                 {
                     if (ex.version == null)
                     {
-                        user.RaiseMessage("Module {0} required but it is not listed in the index, or not available for your version of KSP.", ex.module);
+                        user.RaiseError("Module {0} required but it is not listed in the index, or not available for your version of KSP.",
+                            ex.module);
                     }
                     else
                     {
-                        user.RaiseMessage("Module {0} {1} required but it is not listed in the index, or not available for your version of KSP.", ex.module, ex.version);
+                        user.RaiseError("Module {0} {1} required but it is not listed in the index, or not available for your version of KSP.",
+                            ex.module, ex.version);
                     }
                     user.RaiseMessage("If you're lucky, you can do a `ckan update` and try again.");
                     user.RaiseMessage("Try `ckan install --no-recommends` to skip installation of recommended modules.");
@@ -173,8 +168,8 @@ namespace CKAN.CmdLine
                 }
                 catch (BadMetadataKraken ex)
                 {
-                    user.RaiseMessage("Bad metadata detected for module {0}.", ex.module);
-                    user.RaiseMessage(ex.Message);
+                    user.RaiseError("Bad metadata detected for module {0}: {1}",
+                        ex.module, ex.Message);
                     return Exit.ERROR;
                 }
                 catch (TooManyModsProvideKraken ex)
@@ -217,8 +212,8 @@ namespace CKAN.CmdLine
                 {
                     if (ex.owningModule != null)
                     {
-                        user.RaiseMessage(
-                            "\r\nOh no! We tried to overwrite a file owned by another mod!\r\n"+
+                        user.RaiseError(
+                            "Oh no! We tried to overwrite a file owned by another mod!\r\n"+
                             "Please try a `ckan update` and try again.\r\n\r\n"+
                             "If this problem re-occurs, then it maybe a packaging bug.\r\n"+
                             "Please report it at:\r\n\r\n" +
@@ -234,64 +229,66 @@ namespace CKAN.CmdLine
                     }
                     else
                     {
-                        user.RaiseMessage(
-                            "\r\n\r\nOh no!\r\n\r\n"+
+                        user.RaiseError(
+                            "Oh no!\r\n\r\n"+
                             "It looks like you're trying to install a mod which is already installed,\r\n"+
                             "or which conflicts with another mod which is already installed.\r\n\r\n"+
-                            "As a safety feature, the CKAN will *never* overwrite or alter a file\r\n"+
+                            "As a safety feature, CKAN will *never* overwrite or alter a file\r\n"+
                             "that it did not install itself.\r\n\r\n"+
-                            "If you wish to install {0} via the CKAN,\r\n"+
+                            "If you wish to install {0} via CKAN,\r\n"+
                             "then please manually uninstall the mod which owns:\r\n\r\n"+
                             "{1}\r\n\r\n"+"and try again.\r\n",
                             ex.installingModule, ex.filename
                         );
                     }
 
-                    user.RaiseMessage("Your GameData has been returned to its original state.\r\n");
+                    user.RaiseMessage("Your GameData has been returned to its original state.");
                     return Exit.ERROR;
                 }
                 catch (InconsistentKraken ex)
                 {
                     // The prettiest Kraken formats itself for us.
-                    user.RaiseMessage(ex.InconsistenciesPretty);
+                    user.RaiseError(ex.InconsistenciesPretty);
                     user.RaiseMessage("Install canceled. Your files have been returned to their initial state.");
                     return Exit.ERROR;
                 }
                 catch (CancelledActionKraken k)
                 {
-                    user.RaiseMessage("Installation aborted: {0}", k.Message);
+                    user.RaiseError("Installation aborted: {0}", k.Message);
                     return Exit.ERROR;
                 }
                 catch (MissingCertificateKraken kraken)
                 {
                     // Another very pretty kraken.
-                    user.RaiseMessage(kraken.ToString());
+                    user.RaiseError(kraken.ToString());
                     return Exit.ERROR;
                 }
                 catch (DownloadThrottledKraken kraken)
                 {
-                    user.RaiseMessage(kraken.ToString());
-                    user.RaiseMessage($"Try the authtoken command. See {kraken.infoUrl} for details.");
+                    user.RaiseError(kraken.ToString());
+                    user.RaiseMessage("Try the authtoken command. See {0} for details.",
+                        kraken.infoUrl);
                     return Exit.ERROR;
                 }
                 catch (DownloadErrorsKraken)
                 {
-                    user.RaiseMessage("One or more files failed to download, stopped.");
+                    user.RaiseError("One or more files failed to download, stopped.");
                     return Exit.ERROR;
                 }
                 catch (ModuleDownloadErrorsKraken kraken)
                 {
-                    user.RaiseMessage(kraken.ToString());
+                    user.RaiseError(kraken.ToString());
                     return Exit.ERROR;
                 }
                 catch (DirectoryNotFoundKraken kraken)
                 {
-                    user.RaiseMessage("\r\n{0}", kraken.Message);
+                    user.RaiseError(kraken.Message);
                     return Exit.ERROR;
                 }
                 catch (ModuleIsDLCKraken kraken)
                 {
-                    user.RaiseMessage($"CKAN can't install expansion '{kraken.module.name}' for you.");
+                    user.RaiseError("CKAN can't install expansion '{0}' for you.",
+                        kraken.module.name);
                     var res = kraken?.module?.resources;
                     var storePagesMsg = new Uri[] { res?.store, res?.steamstore }
                         .Where(u => u != null)

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+﻿using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
 
@@ -18,22 +19,22 @@ namespace CKAN.CmdLine
         /// <summary>
         /// Initializes a new instance of the <see cref="T:CKAN.CmdLine.ConsoleUser"/> class.
         /// </summary>
-        /// <param name="headless">If set to <c>true</c>, supress interactive dialogs like Yes/No-Dialog or SelectionDialog.</param>
+        /// <param name="headless">If set to <c>true</c>, supress interactive dialogs like Yes/No-Dialog or SelectionDialog</param>
         public ConsoleUser (bool headless)
         {
             Headless = headless;
         }
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/> is headless.
+        /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/> is headless
         /// </summary>
-        /// <value><c>true</c> if headless; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if headless; otherwise, <c>false</c></value>
         public bool Headless { get; }
 
         /// <summary>
-        /// Ask the user for a yes or no input.
+        /// Ask the user for a yes or no input
         /// </summary>
-        /// <param name="question">Question.</param>
+        /// <param name="question">Question</param>
         public bool RaiseYesNoDialog(string question)
         {
             if (Headless)
@@ -77,9 +78,9 @@ namespace CKAN.CmdLine
         /// The output is index 0 based.
         /// To supply a default option, make the first option an integer indicating the index of it.
         /// </summary>
-        /// <returns>The selection dialog.</returns>
-        /// <param name="message">Message.</param>
-        /// <param name="args">Array of available options.</param>
+        /// <returns>The selection dialog</returns>
+        /// <param name="message">Message</param>
+        /// <param name="args">Array of available options</param>
         public int RaiseSelectionDialog(string message, params object[] args)
         {
             const int return_cancel = -1;
@@ -241,21 +242,32 @@ namespace CKAN.CmdLine
         }
 
         /// <summary>
-        /// Write an error to the console.
+        /// Write an error to the console
         /// </summary>
-        /// <param name="message">Message.</param>
-        /// <param name="args">Possible arguments to format the message.</param>
+        /// <param name="message">Message</param>
+        /// <param name="args">Possible arguments to format the message</param>
         public void RaiseError(string message, params object[] args)
         {
-            Console.Error.WriteLine(message, args);
+            if (Headless)
+            {
+                // Special GitHub Action formatting for mutli-line errors
+                log.ErrorFormat(
+                    message.Replace("\r\n", "%0A"),
+                    args.Select(a => a.ToString().Replace("\r\n", "%0A")).ToArray()
+                );
+            }
+            else
+            {
+                Console.Error.WriteLine(message, args);
+            }
         }
 
         /// <summary>
         /// Write a progress message including the percentage to the console.
         /// Rewrites the line, so the console is not cluttered by progress messages.
         /// </summary>
-        /// <param name="message">Message.</param>
-        /// <param name="percent">Progress in percent.</param>
+        /// <param name="message">Message</param>
+        /// <param name="percent">Progress in percent</param>
         public void RaiseProgress(string message, int percent)
         {
             if (Regex.IsMatch(message, "download", RegexOptions.IgnoreCase))
@@ -285,10 +297,10 @@ namespace CKAN.CmdLine
         private int previousPercent = -1;
 
         /// <summary>
-        /// Writes a message to the console.
+        /// Writes a message to the console
         /// </summary>
-        /// <param name="message">Message.</param>
-        /// <param name="args">Arguments to format the message.</param>
+        /// <param name="message">Message</param>
+        /// <param name="args">Arguments to format the message</param>
         public void RaiseMessage(string message, params object[] args)
         {
             Console.WriteLine(message, args);

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+﻿using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
 
@@ -18,10 +19,10 @@ namespace CKAN
         private static readonly ILog log = LogManager.GetLogger(typeof(ConsoleUser));
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:CKAN.CmdLine.ConsoleUser"/> class.
+        /// Initializes a new instance of the <see cref="T:CKAN.CmdLine.ConsoleUser"/> class
         /// </summary>
-        /// <param name="headless">If set to <c>true</c>, suppress interactive dialogs like Yes/No-Dialog or SelectionDialog.</param>
-        public ConsoleUser (bool headless)
+        /// <param name="headless">If set to <c>true</c>, suppress interactive dialogs like Yes/No-Dialog or SelectionDialog</param>
+        public ConsoleUser(bool headless)
         {
             Headless = headless;
         }
@@ -29,14 +30,14 @@ namespace CKAN
         /// <summary>
         /// Gets a value indicating whether this <see cref="T:CKAN.CmdLine.ConsoleUser"/> is headless.
         /// </summary>
-        /// <value><c>true</c> if headless; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if headless; otherwise, <c>false</c></value>
         public bool Headless { get; }
 
         /// <summary>
-        /// Ask the user for a yes or no input.
+        /// Ask the user for a yes or no input
         /// </summary>
-        /// <param name="question">Question.</param>
-        public bool RaiseYesNoDialog (string question)
+        /// <param name="question">Question</param>
+        public bool RaiseYesNoDialog(string question)
         {
             if (Headless)
             {
@@ -79,10 +80,10 @@ namespace CKAN
         /// The output is index 0 based.
         /// To supply a default option, make the first option an integer indicating the index of it.
         /// </summary>
-        /// <returns>The selection dialog.</returns>
-        /// <param name="message">Message.</param>
-        /// <param name="args">Array of available options.</param>
-        public int RaiseSelectionDialog (string message, params object[] args)
+        /// <returns>The selection dialog</returns>
+        /// <param name="message">Message</param>
+        /// <param name="args">Array of available options</param>
+        public int RaiseSelectionDialog(string message, params object[] args)
         {
             const int return_cancel = -1;
 
@@ -240,21 +241,31 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Write an error to the console.
+        /// Write an error to the console
         /// </summary>
-        /// <param name="message">Message.</param>
-        /// <param name="args">Possible arguments to format the message.</param>
-        public void RaiseError (string message, params object[] args)
+        /// <param name="message">Message</param>
+        /// <param name="args">Possible arguments to format the message</param>
+        public void RaiseError(string message, params object[] args)
         {
-            Console.Error.WriteLine(message, args);
+            if (Headless)
+            {
+                log.ErrorFormat(
+                    message.Replace("\r\n", "%0A"),
+                    args.Select(a => a.ToString().Replace("\r\n", "%0A")).ToArray()
+                );
+            }
+            else
+            {
+                Console.Error.WriteLine(message, args);
+            }
         }
 
         /// <summary>
         /// Write a progress message including the percentage to the console.
         /// Rewrites the line, so the console is not cluttered by progress messages.
         /// </summary>
-        /// <param name="message">Message.</param>
-        /// <param name="percent">Progress in percent.</param>
+        /// <param name="message">Message</param>
+        /// <param name="percent">Progress in percent</param>
         public void RaiseProgress (string message, int percent)
         {
             if (Regex.IsMatch(message, "download", RegexOptions.IgnoreCase))
@@ -284,11 +295,11 @@ namespace CKAN
         private int previousPercent = -1;
 
         /// <summary>
-        /// Writes a message to the console.
+        /// Writes a message to the console
         /// </summary>
-        /// <param name="message">Message.</param>
-        /// <param name="args">Arguments to format the message.</param>
-        public void RaiseMessage (string message, params object[] args)
+        /// <param name="message">Message</param>
+        /// <param name="args">Arguments to format the message</param>
+        public void RaiseMessage(string message, params object[] args)
         {
             Console.WriteLine(message, args);
         }


### PR DESCRIPTION
## Problem

If metadata pull request validation (see KSP-CKAN/xKAN-meta_testing#61) fails at the installation stage, errors are printed but aren't recognized as errors by the GitHub workflow framework, so they're not highlighted or pinned to the affected file:

- https://github.com/KSP-CKAN/CKAN-meta/runs/1572305201

![image](https://user-images.githubusercontent.com/1559108/102536102-bc9e4000-406e-11eb-912b-4bb9a5ffe55e.png)

## Cause

Error messages are just passed to `IUser.RaiseMessage`, despite reporting error conditions, which in turn just outputs via `System.Console.WriteLine`. GitHub actions require special formatting to recognize error messages.

## Changes

- Now one call per error is made to `RaiseError`, the one that's most likely to be helpful if pinned to a file
- Now if we're in `Headless` mode, `RaiseError` prints via `log.ErrorFormat`, and also replaces all line break sequences with `%0A` so multi-line messages can be handled properly
- Some other minor cleanup like using `DependencyNotSatisfiedKraken.Message` since it's nicer than the message we had previously

As far as I could tell we do not have a warning-level message in this code currently, which is good because `IUser` doesn't have a designated way to handle them.