### PR TITLE
Modpack usability fixes

### DIFF
--- a/Core/DLC/StandardDlcDetectorBase.cs
+++ b/Core/DLC/StandardDlcDetectorBase.cs
@@ -26,7 +26,7 @@ namespace CKAN.DLC
         private IGame game;
 
         private static readonly Regex VersionPattern = new Regex(
-            @"^Version\s+(?<version>\S+)$",
+            @"^Version\s+(?<version>\S+)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase
         );
 

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1315,17 +1315,16 @@ namespace CKAN
         /// Determine whether there is any way to install the given set of mods.
         /// Handles virtual dependencies, including recursively.
         /// </summary>
-        /// <param name="registry">Registry of instance into which we want to install</param>
-        /// <param name="versionCriteria">Compatible versions of instance</param>
         /// <param name="opts">Installer options</param>
         /// <param name="toInstall">Mods we want to install</param>
+        /// <param name="registry">Registry of instance into which we want to install</param>
         /// <returns>
         /// True if it's possible to install these mods, false otherwise
         /// </returns>
-        private bool CanInstall(
+        public bool CanInstall(
             RelationshipResolverOptions opts,
             List<CkanModule>            toInstall,
-            Registry                    registry
+            IRegistryQuerier            registry
         )
         {
             string request = toInstall.Select(m => m.identifier).Aggregate((a, b) => $"{a}, {b}");

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -441,11 +441,13 @@ namespace CKAN
                 spec_version = new ModuleVersion("v1.18"),
                 identifier   = Identifier.Sanitize(name),
                 name         = name,
+                author       = new List<string>() { System.Environment.UserName },
                 @abstract    = $"A list of modules installed on the {kspInstanceName} KSP instance",
                 kind         = "metapackage",
                 version      = new ModuleVersion(DateTime.UtcNow.ToString("yyyy.MM.dd.hh.mm.ss")),
                 license      = new List<License>() { new License("unknown") },
                 download_content_type = "application/zip",
+                release_date = DateTime.Now,
             };
 
             List<RelationshipDescriptor> mods = registry.Installed(false, false)

--- a/GUI/Controls/Changeset.Designer.cs
+++ b/GUI/Controls/Changeset.Designer.cs
@@ -36,6 +36,7 @@
             this.Reason = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.BottomButtonPanel = new System.Windows.Forms.Panel();
             this.ConfirmChangesButton = new System.Windows.Forms.Button();
+            this.BackButton = new System.Windows.Forms.Button();
             this.CancelChangesButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             //
@@ -75,10 +76,23 @@
             // BottomButtonPanel
             // 
             this.BottomButtonPanel.Controls.Add(this.ConfirmChangesButton);
+            this.BottomButtonPanel.Controls.Add(this.BackButton);
             this.BottomButtonPanel.Controls.Add(this.CancelChangesButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
             this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
+            //
+            // BackButton
+            //
+            this.BackButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.BackButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.BackButton.Location = new System.Drawing.Point(149, 5);
+            this.BackButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.BackButton.Name = "BackButton";
+            this.BackButton.Size = new System.Drawing.Size(112, 30);
+            this.BackButton.TabIndex = 1;
+            this.BackButton.Click += new System.EventHandler(this.BackButton_Click);
+            resources.ApplyResources(this.BackButton, "BackButton");
             //
             // CancelChangesButton
             //
@@ -125,6 +139,7 @@
         private System.Windows.Forms.ColumnHeader ChangeType;
         private System.Windows.Forms.ColumnHeader Reason;
         private System.Windows.Forms.Panel BottomButtonPanel;
+        private System.Windows.Forms.Button BackButton;
         private System.Windows.Forms.Button CancelChangesButton;
         private System.Windows.Forms.Button ConfirmChangesButton;
     }

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -42,6 +42,16 @@ namespace CKAN
             }
         }
 
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+            if (Visible && Platform.IsMono)
+            {
+                // Workaround: make sure the ListView headers are drawn
+                Util.Invoke(ChangesListView, () => ChangesListView.EndUpdate());
+            }
+        }
+
         public ListView.SelectedListViewItemCollection SelectedItems
         {
             get
@@ -53,7 +63,7 @@ namespace CKAN
         public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
 
         public event Action OnConfirmChanges;
-        public event Action OnCancelChanges;
+        public event Action<bool> OnCancelChanges;
 
         private void ChangesListView_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -75,7 +85,15 @@ namespace CKAN
         {
             if (OnCancelChanges != null)
             {
-                OnCancelChanges();
+                OnCancelChanges(true);
+            }
+        }
+
+        private void BackButton_Click(object sender, EventArgs e)
+        {
+            if (OnCancelChanges != null)
+            {
+                OnCancelChanges(false);
             }
         }
 

--- a/GUI/Controls/Changeset.resx
+++ b/GUI/Controls/Changeset.resx
@@ -120,6 +120,7 @@
   <data name="Mod.Text" xml:space="preserve"><value>Mod</value></data>
   <data name="ChangeType.Text" xml:space="preserve"><value>Change</value></data>
   <data name="Reason.Text" xml:space="preserve"><value>Reason for action</value></data>
+  <data name="BackButton.Text" xml:space="preserve"><value>Back</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>Clear</value></data>
   <data name="ConfirmChangesButton.Text" xml:space="preserve"><value>Apply</value></data>
 </root>

--- a/GUI/Controls/EditModpack.Designer.cs
+++ b/GUI/Controls/EditModpack.Designer.cs
@@ -38,6 +38,8 @@ namespace CKAN
             this.NameTextBox = new System.Windows.Forms.TextBox();
             this.AbstractLabel = new System.Windows.Forms.Label();
             this.AbstractTextBox = new System.Windows.Forms.TextBox();
+            this.AuthorLabel = new System.Windows.Forms.Label();
+            this.AuthorTextBox = new System.Windows.Forms.TextBox();
             this.VersionLabel = new System.Windows.Forms.Label();
             this.VersionTextBox = new System.Windows.Forms.TextBox();
             this.GameVersionLabel = new System.Windows.Forms.Label();
@@ -78,6 +80,8 @@ namespace CKAN
             this.TopEditPanel.Controls.Add(this.NameTextBox);
             this.TopEditPanel.Controls.Add(this.AbstractLabel);
             this.TopEditPanel.Controls.Add(this.AbstractTextBox);
+            this.TopEditPanel.Controls.Add(this.AuthorLabel);
+            this.TopEditPanel.Controls.Add(this.AuthorTextBox);
             this.TopEditPanel.Controls.Add(this.VersionLabel);
             this.TopEditPanel.Controls.Add(this.VersionTextBox);
             this.TopEditPanel.Controls.Add(this.GameVersionLabel);
@@ -88,7 +92,7 @@ namespace CKAN
             this.TopEditPanel.Controls.Add(this.IncludeVersionsCheckbox);
             this.TopEditPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.TopEditPanel.Name = "TopEditPanel";
-            this.TopEditPanel.Size = new System.Drawing.Size(500, 130);
+            this.TopEditPanel.Size = new System.Drawing.Size(500, 160);
             // 
             // IdentifierLabel
             // 
@@ -147,6 +151,25 @@ namespace CKAN
             this.AbstractTextBox.Size = new System.Drawing.Size(250, 50);
             this.AbstractTextBox.TabIndex = 5;
             resources.ApplyResources(this.AbstractTextBox, "AbstractTextBox");
+            // 
+            // AuthorLabel
+            // 
+            this.AuthorLabel.AutoSize = true;
+            this.AuthorLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.AuthorLabel.Location = new System.Drawing.Point(10, 130);
+            this.AuthorLabel.Name = "AuthorLabel";
+            this.AuthorLabel.Size = new System.Drawing.Size(75, 23);
+            this.AuthorLabel.TabIndex = 4;
+            resources.ApplyResources(this.AuthorLabel, "AuthorLabel");
+            // 
+            // AuthorTextBox
+            // 
+            this.AuthorTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.AuthorTextBox.Location = new System.Drawing.Point(125, 130);
+            this.AuthorTextBox.Name = "AbstractTextBox";
+            this.AuthorTextBox.Size = new System.Drawing.Size(250, 23);
+            this.AuthorTextBox.TabIndex = 5;
+            resources.ApplyResources(this.AuthorTextBox, "AuthorTextBox");
             // 
             // VersionLabel
             // 
@@ -411,6 +434,8 @@ namespace CKAN
         private System.Windows.Forms.TextBox NameTextBox;
         private System.Windows.Forms.Label AbstractLabel;
         private System.Windows.Forms.TextBox AbstractTextBox;
+        private System.Windows.Forms.Label AuthorLabel;
+        private System.Windows.Forms.TextBox AuthorTextBox;
         private System.Windows.Forms.Label VersionLabel;
         private System.Windows.Forms.TextBox VersionTextBox;
         private System.Windows.Forms.Label GameVersionLabel;

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -40,6 +40,7 @@ namespace CKAN
                 IdentifierTextBox.Text = module.identifier;
                 NameTextBox.Text       = module.name;
                 AbstractTextBox.Text   = module.@abstract;
+                AuthorTextBox.Text     = string.Join(", ", module.author);
                 VersionTextBox.Text    = module.version.ToString();
                 var options = new string[] { "" }.Concat(Main.Instance.CurrentInstance.game.KnownVersions
                     .SelectMany(v => new GameVersion[] {
@@ -175,6 +176,8 @@ namespace CKAN
             module.identifier = IdentifierTextBox.Text;
             module.name       = NameTextBox.Text;
             module.@abstract  = AbstractTextBox.Text;
+            module.author     = AuthorTextBox.Text
+                .Split(',').Select(a => a.Trim()).ToList();
             module.version    = new ModuleVersion(VersionTextBox.Text);
             module.license    = new List<License>() { new License(LicenseComboBox.Text) };
             module.ksp_version_min = string.IsNullOrEmpty(GameVersionMinComboBox.Text)

--- a/GUI/Controls/EditModpack.resx
+++ b/GUI/Controls/EditModpack.resx
@@ -120,6 +120,7 @@
   <data name="IdentifierLabel.Text" xml:space="preserve"><value>Identifier:</value></data>
   <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
   <data name="AbstractLabel.Text" xml:space="preserve"><value>Abstract:</value></data>
+  <data name="AuthorLabel.Text" xml:space="preserve"><value>Author:</value></data>
   <data name="VersionLabel.Text" xml:space="preserve"><value>Version:</value></data>
   <data name="GameVersionLabel.Text" xml:space="preserve"><value>Game versions:</value></data>
   <data name="LicenseLabel.Text" xml:space="preserve"><value>Licence:</value></data>

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -312,7 +312,7 @@
             this.ModGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModList_CellContentClick);
             this.ModGrid.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModList_CellMouseDoubleClick);
             this.ModGrid.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModList_HeaderMouseClick);
-            this.ModGrid.SelectionChanged += new System.EventHandler(this.ModList_SelectedIndexChanged);
+            this.ModGrid.SelectionChanged += new System.EventHandler(this.ModList_SelectionChanged);
             this.ModGrid.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ModList_KeyDown);
             this.ModGrid.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ModList_KeyPress);
             this.ModGrid.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ModList_MouseDown);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -412,7 +412,8 @@ namespace CKAN
             // only sort by Update column if checkbox in settings checked
             if (Main.Instance.configuration.AutoSortByUpdate)
             {
-                SetSort(UpdateCol);
+                // Retain their current sort as secondaries
+                AddSort(UpdateCol, true);
                 UpdateFilters();
                 // Select the top row and scroll the list to it.
                 if (ModGrid.Rows.Count > 0)
@@ -460,7 +461,7 @@ namespace CKAN
             NavGoForward();
         }
 
-        private void ModList_SelectedIndexChanged(object sender, EventArgs e)
+        private void ModList_SelectionChanged(object sender, EventArgs e)
         {
             // Skip if already disposed (i.e. after the form has been closed).
             // Needed for TransparentTextBoxes
@@ -470,12 +471,12 @@ namespace CKAN
             }
 
             var module = SelectedModule;
-            if (OnSelectedModuleChanged != null)
-            {
-                OnSelectedModuleChanged(module);
-            }
             if (module != null)
             {
+                if (OnSelectedModuleChanged != null)
+                {
+                    OnSelectedModuleChanged(module);
+                }
                 NavSelectMod(module);
             }
         }
@@ -881,8 +882,8 @@ namespace CKAN
                 // Set the menu options.
                 var guiMod = (GUIMod)ModGrid.Rows[rowIndex].Tag;
 
-                downloadContentsToolStripMenuItem.Enabled = !guiMod.IsCached;
-                purgeContentsToolStripMenuItem.Enabled = guiMod.IsCached;
+                downloadContentsToolStripMenuItem.Enabled = !guiMod.ToModule().IsMetapackage &&  !guiMod.IsCached;
+                purgeContentsToolStripMenuItem.Enabled = !guiMod.ToModule().IsMetapackage && guiMod.IsCached;
                 reinstallToolStripMenuItem.Enabled = guiMod.IsInstalled && !guiMod.IsAutodetected;
             }
         }
@@ -1185,7 +1186,7 @@ namespace CKAN
             }
         }
 
-        private void AddSort(DataGridViewColumn col)
+        private void AddSort(DataGridViewColumn col, bool atStart = false)
         {
             if (sortColumns.Count > 0 && sortColumns[sortColumns.Count - 1] == col.Name)
             {
@@ -1199,8 +1200,16 @@ namespace CKAN
                     sortColumns.RemoveAt(middlePosition);
                     descending.RemoveAt(middlePosition);
                 }
-                sortColumns.Add(col.Name);
-                descending.Add(false);
+                if (atStart)
+                {
+                    sortColumns.Insert(0, col.Name);
+                    descending.Insert(0, false);
+                }
+                else
+                {
+                    sortColumns.Add(col.Name);
+                    descending.Add(false);
+                }
             }
         }
 

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -62,7 +62,10 @@ namespace CKAN
             {
                 if (moduleBars.TryGetValue(module, out ProgressBar pb))
                 {
-                    pb.Value = (int) (100 * (total - remaining) / total);
+                    // download_size is allowed to be 0
+                    pb.Value = Math.Max(pb.Minimum, Math.Min(pb.Maximum,
+                        (int) (100 * (total - remaining) / total)
+                    ));
                 }
                 else
                 {
@@ -87,7 +90,10 @@ namespace CKAN
                         Size     = new Size(TopPanel.Width - labelWidth - 5 * padding, progressHeight),
                         Minimum  = 0,
                         Maximum  = 100,
-                        Value    = (int) (100 * (total - remaining) / total),
+                        // download_size is allowed to be 0
+                        Value    = Math.Max(0, Math.Min(100,
+                                       (int) (100 * (total - remaining) / total)
+                                   )),
                         Style    = ProgressBarStyle.Continuous,
                     };
                     moduleBars.Add(module, newPb);

--- a/GUI/Localization/de-DE/Changeset.de-DE.resx
+++ b/GUI/Localization/de-DE/Changeset.de-DE.resx
@@ -119,6 +119,7 @@
   </resheader>
   <data name="ChangeType.Text" xml:space="preserve"><value>Änderung</value></data>
   <data name="Reason.Text" xml:space="preserve"><value>Grund</value></data>
+  <data name="BackButton.Text" xml:space="preserve"><value>Zurück</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>Löschen</value></data>
   <data name="ConfirmChangesButton.Text" xml:space="preserve"><value>Annehmen</value></data>
 </root>

--- a/GUI/Localization/de-DE/EditModpack.de-DE.resx
+++ b/GUI/Localization/de-DE/EditModpack.de-DE.resx
@@ -120,6 +120,7 @@
   <data name="IdentifierLabel.Text" xml:space="preserve"><value>Kennung:</value></data>
   <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
   <data name="AbstractLabel.Text" xml:space="preserve"><value>Abstrakt:</value></data>
+  <data name="AuthorLabel.Text" xml:space="preserve"><value>Autor:</value></data>
   <data name="VersionLabel.Text" xml:space="preserve"><value>Modpack-Version:</value></data>
   <data name="GameVersionLabel.Text" xml:space="preserve"><value>Spielversionen:</value></data>
   <data name="LicenseLabel.Text" xml:space="preserve"><value>Lizenz:</value></data>

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -533,7 +533,7 @@ namespace CKAN
         private GUIMod ActiveModInfo
         {
             set {
-                if (value == null)
+                if (value?.ToModule() == null)
                 {
                     splitContainer1.Panel2Collapsed = true;
                 }

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -20,10 +20,13 @@ namespace CKAN
             ShowSelectionModInfo(items);
         }
 
-        private void Changeset_OnCancelChanges()
+        private void Changeset_OnCancelChanges(bool reset)
         {
-            ManageMods.ClearChangeSet();
-            UpdateChangesDialog(null);
+            if (reset)
+            {
+                ManageMods.ClearChangeSet();
+                UpdateChangesDialog(null);
+            }
             tabController.ShowTab("ManageModsTabPage");
         }
 

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -186,7 +186,7 @@ namespace CKAN
                 resolver.ModList()
                     .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonFor(m))));
 
-            return changeSet;
+            return changeSet.Where(m => !m.Mod.IsMetapackage);
         }
 
         public bool IsVisible(GUIMod mod, string instanceName)

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -558,6 +558,9 @@ namespace CKAN.Properties {
         internal static string ModInfoCached {
             get { return (string)(ResourceManager.GetObject("ModInfoCached", resourceCulture)); }
         }
+        internal static string ModInfoNoDownload {
+            get { return (string)(ResourceManager.GetObject("ModInfoNoDownload", resourceCulture)); }
+        }
         internal static string ModInfoHomepageLabel {
             get { return (string)(ResourceManager.GetObject("ModInfoHomepageLabel", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -255,6 +255,7 @@ Wenn du ein Fehler mit dem CKAN Client vermutest: https://github.com/KSP-CKAN/CK
   <data name="ModInfoNotIndexed" xml:space="preserve"><value>{0} (nicht indiziert)</value></data>
   <data name="ModInfoNotCached" xml:space="preserve"><value>Diese Mod ist nicht im Cache, klicke auf 'Download' um eine Inhaltsübersicht zu erhalten.</value></data>
   <data name="ModInfoCached" xml:space="preserve"><value>Modul ist im Cache, Vorschau verfügbar</value></data>
+  <data name="ModInfoNoDownload" xml:space="preserve"><value>Modul kann nicht heruntergeladen werden</value></data>
   <data name="ModInfoHomepageLabel" xml:space="preserve"><value>Homepage:</value></data>
   <data name="ModInfoBugTrackerLabel" xml:space="preserve"><value>Bugtracker:</value></data>
   <data name="ModInfoContinuousIntegrationLabel" xml:space="preserve"><value>Continuous Integration:</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -276,6 +276,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ModInfoNotIndexed" xml:space="preserve"><value>{0} (not indexed)</value></data>
   <data name="ModInfoNotCached" xml:space="preserve"><value>This mod is not in the cache, click 'Download' to preview contents</value></data>
   <data name="ModInfoCached" xml:space="preserve"><value>Module is cached, preview available</value></data>
+  <data name="ModInfoNoDownload" xml:space="preserve"><value>Module has no download</value></data>
   <data name="ModInfoHomepageLabel" xml:space="preserve"><value>Home page:</value></data>
   <data name="ModInfoSpaceDockLabel" xml:space="preserve"><value>SpaceDock:</value></data>
   <data name="ModInfoCurseLabel" xml:space="preserve"><value>Curse:</value></data>


### PR DESCRIPTION
## Background

@kerbal-propulsion-laboratory (ezee on Discord) presented us with the idea of a metapackage in a custom repo. It works, with quirks.

## Problems

- The Download button in mod info is enabled for metapackages
- The right click menu download option is enabled for metapackages
- Exporting a modpack doesn't populate the author and release date
- The changeset tab has only two options, Clear and Apply, neither of which lets you go back to the modlist with the same changeset intact
- The column headers on the changeset tab sometimes disappear on Mono
- The "release status" and "replaced by" fields in mod info are always shown even when they're not set, cluttering the display
- The version of the current Breaking Ground expansion is not detected, so its other metadata (such as the store links) isn't available
- In Mono, the mod info panel flickers noticeably when you select a mod row
- The versions tab of mod info is slow to refresh when clicking Scatterer and frequently says that compatible modules are incompatible
- If you install a large module hosted on a server that doesn't send the download size:
  ```
  41176 [1] ERROR CKAN.ErrorDialog (null) - Unhandled exception:
  System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.ArgumentOutOfRangeException: '-61800' is not a valid value for 'Value'. 'Value' should be between 'Minimum' and 'Maximum'
  Parameter name: Value
    at System.Windows.Forms.ProgressBar.set_Value (System.Int32 value) [0x00027] in <47c199caaa3c4c6c9c48a7c6ebb3fd29>:0 
    at (wrapper remoting-invoke-with-check) System.Windows.Forms.ProgressBar.set_Value(int)
    at CKAN.Wait+<>c__DisplayClass13_0.<SetModuleProgress>b__0 () [0x00161] in <3cb683943e2a481fbd7ca14981128ab6>:0 
    at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <9f0df102fe6e4cfea29d2e46f585d8a5>:0 
  ```
- The "Automatically sort by 'Update'-column when clicking 'Add available updates'" setting overwrites your current sort, so if you chose a complex multi-column sort, it's gone after you update

## Causes

- `<KSP>/GameData/SquadExpansion/Serenity/readme.txt` now has whitespace after the version string, but the standard DLC detector doesn't allow this
- Mono's `DataGridView` has some quirks in how it fires its `SelectionChanged` event:
  - Usually it fires twice—once to deselect the previously selected row (with an empty selection) and once to select the newly selected row (with it as the selection)—which caused mod info to be collapsed and expanded rapidly every time the selection changes
  - Occasionally it fires multiple times in a row with the same selection
    - If Mod info was told to show the same mod twice in a row, it would perform all the same visual updates all over again, ending up in the same state but with extra flickering
- The tag list in mod info uses a `FlowLayoutPanel`, which was updated without turning off its layout, exacerbating flickering caused by repeated rapid updates
- The versions tab of mod info has its own logic for relationships which is slow and inaccurate when virtual modules are involved
- The per-module progress bars from #3054 don't clamp the calculated percentage to a minimum or maximum value, in effect assuming that the server will always send the file size, but it's a big negative value if that isn't the case
- We treat the update-sort as if it was the same as clicking a column header

## Changes

- Now the Download button in mod info is disabled for metapackages and the label explains there's no download
- Now the right click menu download option is disabled for metapackages
- Now the export modpack screen has an author field, defaulting to your system username (use commas to separate multiple authors)
- Now exporting a modpack sets the release date to the current time
- Now the changeset tab has a Back button which returns to the modlist without clearing the changeset
- Now the workaround from #2685 is applied to the changeset tab, preserving the column headers
- Now the "release status" and "replaced by" fields in mod info are hidden when they're not set
- Now the standard DLC detector allows whitespace after the version string
- Now we only fire `ManageMods_OnSelectedModuleChanged` if the selected module is not `null`, which will suppress the superfluous collapse/expand events
- Now mod info doesn't update itself if it's already showing the info for the given mod, which will reduce flickering
- Now we call tag list's `FlowLayoutPanel.SuspendLayout` before we update the tags and `TableLayoutPanel.ResumeLayout` after, which will also reduce flickering
- Now the versions tab of mod info uses `ModuleInstaller.CanInstall`, which is now `public`, and which is faster and more accurate, so the compatibility shown is correct
- Now the per-module progress bars handle missing server download size info without crashing
- Now the update-sort feature adds the Update column to the beginning of the sorted columns list, with the previous setting retained as secondary sorts. Once updates are installed, everything in the column will be `-`, and the previous sort restores itself by default.
