### PR TITLE
Repo update usability fixes

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -33,8 +33,6 @@ namespace CKAN.CmdLine
 
             List<CkanModule> compatible_prior = null;
 
-            user.RaiseMessage("Downloading updates...");
-
             if (options.list_changes)
             {
                 // Get a list of compatible modules prior to the update.

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -248,6 +248,7 @@ namespace CKAN.CmdLine
         /// <param name="args">Possible arguments to format the message</param>
         public void RaiseError(string message, params object[] args)
         {
+            GoToStartOfLine();
             if (Headless)
             {
                 // Special GitHub Action formatting for mutli-line errors
@@ -260,6 +261,7 @@ namespace CKAN.CmdLine
             {
                 Console.Error.WriteLine(message, args);
             }
+            atStartOfLine = true;
         }
 
         /// <summary>
@@ -287,8 +289,11 @@ namespace CKAN.CmdLine
                 // The percent looks weird on non-download messages.
                 // The leading newline makes sure we don't end up with a mess from previous
                 // download messages.
-                Console.Write("\r\n{0}", message);
+                GoToStartOfLine();
+                Console.Write("{0}", message);
             }
+            // These messages leave the cursor at the end of a line of text
+            atStartOfLine = false;
         }
 
         /// <summary>
@@ -303,7 +308,21 @@ namespace CKAN.CmdLine
         /// <param name="args">Arguments to format the message</param>
         public void RaiseMessage(string message, params object[] args)
         {
+            GoToStartOfLine();
             Console.WriteLine(message, args);
+            atStartOfLine = true;
         }
+
+        private void GoToStartOfLine()
+        {
+            if (!atStartOfLine)
+            {
+                // Carriage return
+                Console.WriteLine("");
+                atStartOfLine = true;
+            }
+        }
+
+        private bool atStartOfLine = true;
     }
 }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -416,11 +416,8 @@ namespace CKAN.ConsoleUI {
 
         private bool UpdateRegistry()
         {
-            ConsoleMessageDialog d = new ConsoleMessageDialog(
-                "Updating registry...",
-                new List<string>()
-            );
-            d.Run(() => {
+            ProgressScreen ps = new ProgressScreen("Updating Registry", "Checking for updates");
+            LaunchSubScreen(ps, () => {
                 HashSet<string> availBefore = new HashSet<string>(
                     Array.ConvertAll<CkanModule, string>(
                         registry.CompatibleModules(
@@ -435,11 +432,11 @@ namespace CKAN.ConsoleUI {
                         RegistryManager.Instance(manager.CurrentInstance),
                         manager.CurrentInstance,
                         manager.Cache,
-                        this
+                        ps
                     );
                 } catch (Exception ex) {
                     // There can be errors while you re-install mods with changed metadata
-                    RaiseError(ex.Message + ex.StackTrace);
+                    ps.RaiseError(ex.Message + ex.StackTrace);
                 }
                 // Update recent with mods that were updated in this pass
                 foreach (CkanModule mod in registry.CompatibleModules(

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -359,8 +359,12 @@ namespace CKAN
 
             if (needRegistrySave)
             {
-                // Save registry
-                RegistryManager.Instance(CurrentInstance).Save(false);
+                using (var transaction = CkanTransaction.CreateTransactionScope())
+                {
+                    // Save registry
+                    RegistryManager.Instance(CurrentInstance).Save(false);
+                    transaction.Complete();
+                }
             }
 
             base.OnFormClosing(e);

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -373,6 +373,12 @@ namespace CKAN
                         currentUser.RaiseError(dlcMsg);
                         break;
 
+                    case TransactionalKraken exc:
+                        // Want to see the stack trace for this one
+                        currentUser.RaiseMessage(exc.ToString());
+                        currentUser.RaiseError(exc.ToString());
+                        break;
+
                     default:
                         currentUser.RaiseMessage(e.Error.Message);
                         break;

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -123,6 +123,7 @@ namespace CKAN
 
                 case RepoUpdateResult.Failed:
                     AddStatusMessage(Properties.Resources.MainRepoFailed);
+                    HideWaitDialog(false);
                     break;
 
                 case RepoUpdateResult.Updated:
@@ -135,6 +136,7 @@ namespace CKAN
                     break;
             }
 
+            tabController.HideTab("WaitTabPage");
             Util.Invoke(this, SwitchEnabledState);
             Util.Invoke(this, RecreateDialogs);
             Util.Invoke(this, ManageMods.ModGrid.Select);


### PR DESCRIPTION
## Background / motivation

After KSP-CKAN/CKAN-meta#2159, many users opted in to the Kopernicus Bleeding Edge repo to use Kopernicus on recent game versions.

This PR attempts to modernize repo updates somewhat.

## Problems

- In the last few days, @R-T-B's server went down and those users saw errors:
  ![screenshot](https://media.discordapp.net/attachments/771551196942958629/791005724313649192/unknown.png)
  - The stack trace is big and scary and doesn't help users
  - There's no obvious way back to the normal app screens. Cancel is available but does nothing; if you're extremely clever, clicking the Manage mods tab works.
  - There's not a lot of info shown about what's going on during a repo update
- CmdLine's `IUser` implementation always prints `\r\n` before `RaiseProgress` and after `RaiseMessage` (implicitly via `WriteLine`). This means that if you alternate them, you end up with separate messages combined onto one line or extra blank lines. The existing code has a number of workarounds in place due to this.
- For the last few releases, we've been getting reports of registry corruption at upgrade, where `CKAN/registry.json` is truncated and can no longer be loaded. I had this happen once myself far too long ago to be able to investigate it (and probably not related to updating CKAN).

## Changes

Core:

- Now the repo update code uses `IUser.RaiseProgress` to announce the start of each step it performs and `IUser.RaiseMessage` to announce the completion of each step it performs. This way, you can look at the progress bar to see what CKAN is doing right now and the text box to see what has already been finished.
  - 0%–10% - Querying the ETags to see if we need to update at all
  - 10%–90% - Updating each repo, with the percentages split up evenly across this range
  - 90%–100% - Saving the registry
- Now the repo update code calls `IUser.RaiseError` instead of `IUser.RaiseMessage` when there's a download error, and it uses `Exception.Message` instead of `Exception.ToString()` to omit the stack trace
- Now registry saves are done in a transaction, so truncated files should be a thing of the past, as if anything goes wrong the old file will be preserved

CmdLine:

- Now `ConsoleUser` internally tracks whether its last output left the cursor at the start of the line or not. This allows it to alternate `RaiseProgress` and `RaiseMessage` calls with no missing or extra line breaks. This makes the above Core changes look right for `ckan update`.
- Now `ckan update` no longer prints a message at the start, because the Core code will take care of that

ConsoleUI:

- Now updating the repo jumps the user to a progress bar screen that displays the above messages and errors and progress bar updates from Core. Previously it was just a non-interactive dialog box that went away when the update finished.
  (I'm kind of proud how easy it was to do this, just a few lines to add a whole new screen flow.)

GUI:

- Now if a repo update fails, the changes to Core will announce them with an error popup that doesn't have a stack trace. Once the user closes the error, GUI switches back to the mod list and hides the progress bar tab.