### PR TITLE
Report AutoUpdater errors to user, fix rare failure

### DIFF
--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">

--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -168,12 +168,14 @@ namespace CKAN
             {
                 Verb      = "runas",
                 FileName  = updaterFilename,
-                Arguments = String.Format(@"{0} ""{1}"" ""{2}"" {3}", pid, exePath, ckanFilename, launchCKANAfterUpdate ? "launch" : "nolaunch"),
-                UseShellExecute = false
+                Arguments = String.Format(@"{0} ""{1}"" ""{2}"" {3}", -pid, exePath, ckanFilename, launchCKANAfterUpdate ? "launch" : "nolaunch"),
+                UseShellExecute = false,
+                // Make child's stdin a pipe so it can tell when we exit
+                RedirectStandardInput = true,
+                CreateNoWindow = true,
             });
 
-            // exit this ckan instance
-            Environment.Exit(0);
+            // Caller should now exit. Let them do it safely.
         }
 
         public static void SetExecutable(string fileName)

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -242,6 +242,9 @@
     <Compile Include="Main\Main.Designer.cs">
       <DependentUpon>Main.cs</DependentUpon>
     </Compile>
+    <Compile Include="Main\MainAutoUpdate.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Main\MainChangeset.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/Dialogs/NewUpdateDialog.Designer.cs
+++ b/GUI/Dialogs/NewUpdateDialog.Designer.cs
@@ -1,5 +1,3 @@
-﻿using System.Windows.Forms;
-
 namespace CKAN
 {
     partial class NewUpdateDialog
@@ -64,6 +62,8 @@ namespace CKAN
             this.ReleaseNotesTextbox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.ReleaseNotesTextbox.BackColor = System.Drawing.SystemColors.Control;
+            this.ReleaseNotesTextbox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.ReleaseNotesTextbox.Location = new System.Drawing.Point(12, 25);
             this.ReleaseNotesTextbox.Name = "ReleaseNotesTextbox";
             this.ReleaseNotesTextbox.ReadOnly = true;
@@ -99,6 +99,7 @@ namespace CKAN
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.ClientSize = new System.Drawing.Size(426, 310);
             this.Controls.Add(this.CancelUpdateButton);
             this.Controls.Add(this.InstallUpdateButton);
@@ -118,7 +119,7 @@ namespace CKAN
 
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label VersionLabel;
-        private RichTextBox ReleaseNotesTextbox;
+        private System.Windows.Forms.RichTextBox ReleaseNotesTextbox;
         private System.Windows.Forms.Button InstallUpdateButton;
         private System.Windows.Forms.Button CancelUpdateButton;
     }

--- a/GUI/Dialogs/NewUpdateDialog.cs
+++ b/GUI/Dialogs/NewUpdateDialog.cs
@@ -4,12 +4,16 @@ namespace CKAN
 {
     public partial class NewUpdateDialog : Form
     {
+        /// <summary>
+        /// Iniitialize the update info form with version and release notes
+        /// </summary>
+        /// <param name="version">Version number of new release</param>
+        /// <param name="releaseNotes">Markdown formatted description of the new release</param>
         public NewUpdateDialog(string version, string releaseNotes)
         {
             InitializeComponent();
-
             VersionLabel.Text = version;
-            ReleaseNotesTextbox.Text = releaseNotes;
+            ReleaseNotesTextbox.Text = releaseNotes.Trim();
         }
     }
 }

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -1,0 +1,77 @@
+using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+using CKAN.Versioning;
+
+namespace CKAN
+{
+    public partial class Main
+    {
+        /// <summary>
+        /// Look for a CKAN update and start installing it if found.
+        /// Note that this will happen on a background thread!
+        /// </summary>
+        /// <returns>
+        /// true if update found, false otherwise.
+        /// </returns>
+        private bool CheckForCKANUpdate()
+        {
+            if (configuration.CheckForUpdatesOnLaunch && AutoUpdate.CanUpdate)
+            {
+                try
+                {
+                    log.Info("Making auto-update call");
+                    AutoUpdate.Instance.FetchLatestReleaseInfo();
+                    var latest_version = AutoUpdate.Instance.latestUpdate.Version;
+                    var current_version = new ModuleVersion(Meta.GetVersion());
+
+                    if (AutoUpdate.Instance.IsFetched() && latest_version.IsGreaterThan(current_version))
+                    {
+                        log.Debug("Found higher ckan version");
+                        var release_notes = AutoUpdate.Instance.latestUpdate.ReleaseNotes;
+                        var dialog = new NewUpdateDialog(latest_version.ToString(), release_notes);
+                        if (dialog.ShowDialog() == DialogResult.OK)
+                        {
+                            UpdateCKAN();
+                            return true;
+                        }
+                    }
+                }
+                catch (Exception exception)
+                {
+                    currentUser.RaiseError(Properties.Resources.MainAutoUpdateFailed, exception.Message);
+                    log.Error("Error in auto-update", exception);
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Download a CKAN update and start AutoUpdater.exe, then exit.
+        /// Note it will return control and then interrupt whatever is happening to exit!
+        /// </summary>
+        public void UpdateCKAN()
+        {
+            ResetProgress();
+            ShowWaitDialog(false);
+            SwitchEnabledState();
+            Wait.ClearLog();
+            tabController.RenameTab("WaitTabPage", Properties.Resources.MainUpgradingWaitTitle);
+            Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo, AutoUpdate.Instance.latestUpdate.Version));
+
+            log.Info("Start ckan update");
+            BackgroundWorker updateWorker = new BackgroundWorker();
+            updateWorker.DoWork += (sender, args) => AutoUpdate.Instance.StartUpdateProcess(true, currentUser);
+            updateWorker.RunWorkerCompleted += UpdateReady;
+            updateWorker.RunWorkerAsync();
+        }
+
+        private void UpdateReady(object sender, RunWorkerCompletedEventArgs e)
+        {
+            // Close will be cancelled if the window is still disabled
+            SwitchEnabledState();
+            Close();
+        }
+
+    }
+}


### PR DESCRIPTION
## Problems

- If anything goes wrong with the AutoUpdater, it doesn't tell the user anything about what happened.
- One of the things that can go wrong is that it's possible (though _very_ unlikely) for the old ckan.exe to be deleted without the new one being renamed or launched, see #3245.
- Users have reported truncated registries and other issues when an auto-update happens
- The auto-update window uses black text on a dark background if you're using a dark theme
- The auto-update window positions itself at the absolute upper-left of your overall screen space, which may be quite far away from where you're working or where CKAN will appear

## Cause

- AutoUpdater just exited and never printed anything on errors, presumably because it was intended as a very simple small tool that would never have any problems (ha ha).
- The code to delete the old ckan.exe file has a retry mechanism, which has an unlikely but possible loophole: If the first 7 tries fail but the 8th try succeeds, then the old ckan.exe is deleted _but the new one is not copied or launched_.
- The auto-update code in `Core` calls `Exit(0)` which exits immediately, and in GUI this is done from a background task, interrupting anything else that might be going on, including saving the registry

## Changes

- Now the AutoUpdater returns standard Unix exit codes (0=success, 1=mild failure, 2=serious failure)—but just for completeness, we don't check them anywhere yet
- Now if the AutoUpdater encounters a problem, it prints a message to stderr
  - This includes any checks that explicitly exited before _and_ any unhandled exceptions
- Now if the AutoUpdater is launched by the GUI (determined by the 4th argument being `launch`, only passed by GUI and not by `ckan upgrade ckan`), then any errors are also reported in a popup window, so average GUI users will be able to see it:
  ![image](https://user-images.githubusercontent.com/1559108/103258520-e69f0e80-495a-11eb-83a3-8a86f93efc47.png)
- Now the retry mechanism uses exponential back-off instead of a static 1-second delay: 100ms, 200ms, 400ms, ..., 25.6 sec, to allow more time for whatever is blocking deletion to go away
- Now the retry loop is rewritten to eliminate the possibility of treating a success on the 8th try as a failure, so on success we will replace and launch the new EXE, and on failure the old EXE will still be there
- Now if we fail to delete the EXE, we re-launch it so the user isn't just sitting there wondering what the heck happened
- Now `AutoUpdate.StartUpdateProcess` no longer exits, and instead the calling code from each UI is expected to exit safely according to its own practices, which GUI now does via `Close()`
- Now the auto-update window uses light text on a dark background if you have a dark theme
- Now the auto-update window positions itself in the center of your current screen
- Now the auto-update window's release note listing won't start with a blank line
- All of the GUI auto-update code is split into `GUI/Main/MainAutoUpdate.cs` so we don't have to go hunting for it

Since we identiifed and fixed a way it could have happened, I think we can say this fixes #3245, but if it doesn't, at least we'll be able to gather enough info to figure out the true fix next time.