### PR TITLE
Validate renamed files by their new names in Netkan

### DIFF
--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -11,8 +11,8 @@ namespace CKAN.NetKAN.Services
         JObject GetInternalCkan(string filePath);
         bool HasInstallableFiles(CkanModule module, string filePath);
 
-        IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip);
-        IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip);
+        IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip, KSP ksp);
+        IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip, KSP ksp);
         IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, KSP ksp);
 
         IEnumerable<string> FileDestinations(CkanModule module, string filePath);

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -64,14 +64,14 @@ namespace CKAN.NetKAN.Services
             return true;
         }
 
-        public IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip)
+        public IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip, KSP ksp)
         {
-            return GetFilesBySuffix(module, zip, ".cfg");
+            return GetFilesBySuffix(module, zip, ".cfg", ksp);
         }
 
-        public IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip)
+        public IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip, KSP ksp)
         {
-            return GetFilesBySuffix(module, zip, ".dll");
+            return GetFilesBySuffix(module, zip, ".dll", ksp);
         }
 
         public IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, KSP ksp)
@@ -79,11 +79,11 @@ namespace CKAN.NetKAN.Services
             return GetFilesBySuffix(module, zip, ".craft", ksp);
         }
 
-        private IEnumerable<InstallableFile> GetFilesBySuffix(CkanModule module, ZipFile zip, string suffix, KSP ksp = null)
+        private IEnumerable<InstallableFile> GetFilesBySuffix(CkanModule module, ZipFile zip, string suffix, KSP ksp)
         {
             return ModuleInstaller
                 .FindInstallableFiles(module, zip, ksp)
-                .Where(instF => instF.source.Name.EndsWith(suffix,
+                .Where(instF => instF.destination.EndsWith(suffix,
                     StringComparison.InvariantCultureIgnoreCase));
         }
 

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -49,12 +49,13 @@ namespace CKAN.NetKAN.Transformers
             }
             else
             {
-                CkanModule mod  = CkanModule.FromJson(json.ToString());
-                ZipFile    zip  = new ZipFile(_http.DownloadModule(metadata));
+                CkanModule mod = CkanModule.FromJson(json.ToString());
+                ZipFile    zip = new ZipFile(_http.DownloadModule(metadata));
+                var        ksp = new KSP("/", "dummy", null, false);
 
                 log.Debug("Extracting locales");
                 // Extract the locale names from the ZIP's cfg files
-                var locales = _moduleService.GetConfigFiles(mod, zip)
+                var locales = _moduleService.GetConfigFiles(mod, zip, ksp)
                     .Select(cfg => new StreamReader(zip.GetInputStream(cfg.source)).ReadToEnd())
                     .SelectMany(contents => localizationRegex.Matches(contents).Cast<Match>()
                         .Select(m => m.Groups["contents"].Value))

--- a/Netkan/Validators/ModuleManagerDependsValidator.cs
+++ b/Netkan/Validators/ModuleManagerDependsValidator.cs
@@ -29,9 +29,10 @@ namespace CKAN.NetKAN.Validators
                 var package = _http.DownloadModule(metadata);
                 if (!string.IsNullOrEmpty(package))
                 {
-                    ZipFile zip  = new ZipFile(package);
+                    ZipFile zip = new ZipFile(package);
+                    var     ksp = new KSP("/", "dummy", null, false);
 
-                    var mmConfigs = _moduleService.GetConfigFiles(mod, zip)
+                    var mmConfigs = _moduleService.GetConfigFiles(mod, zip, ksp)
                         .Where(cfg => moduleManagerRegex.IsMatch(
                             new StreamReader(zip.GetInputStream(cfg.source)).ReadToEnd()))
                         .Memoize();

--- a/Netkan/Validators/PluginCompatibilityValidator.cs
+++ b/Netkan/Validators/PluginCompatibilityValidator.cs
@@ -28,9 +28,10 @@ namespace CKAN.NetKAN.Validators
                 var package = _http.DownloadModule(metadata);
                 if (!string.IsNullOrEmpty(package))
                 {
-                    ZipFile zip  = new ZipFile(package);
+                    ZipFile zip = new ZipFile(package);
+                    var     ksp = new KSP("/", "dummy", null, false);
 
-                    bool hasPlugin = _moduleService.GetPlugins(mod, zip).Any();
+                    bool hasPlugin = _moduleService.GetPlugins(mod, zip, ksp).Any();
 
                     bool boundedCompatibility = json.ContainsKey("ksp_version") || json.ContainsKey("ksp_version_max");
 


### PR DESCRIPTION
## Problem

This from KSP-CKAN/NetKAN#8275 is a false positive:

![image](https://user-images.githubusercontent.com/1559108/103317939-590efd80-49f2-11eb-9e94-6f6f2a9fcbc2.png)

And there are probably several related false negatives (i.e. missing errors that should be there).

## Cause

When Netkan looks for files with a particular suffix in a ZIP, it looks at the source filename in the ZIP, not the destination filename that will be installed. But what matters at run time is the destination file name, and the above PR renames many .txt files to .cfg. Currently they're not checked for MM syntax.

## Changes

Now Netkan looks at the destination file name when listing files from a ZIP by suffix, so files that are renamed from .txt to .cfg will be checked for MM syntax.

This will probably have some fun conflicts with #3223. Will rebase that one later.

I'm planning to merge quickly this so I can try revalidating that PR.