### PR TITLE
Fix screen clamping logic

### DIFF
--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Drawing;
+using log4net;
 
 namespace CKAN
 {
@@ -174,19 +175,22 @@ namespace CKAN
         {
             if (screen == null)
             {
+                log.DebugFormat("Looking for screen of {0}, {1}", location, size);
                 screen = FindScreen(location, size);
             }
             if (screen != null)
             {
+                log.DebugFormat("Found screen: {0}", screen.WorkingArea);
                 // Slide the whole rectangle fully onto the screen
-                if (location.X < screen.WorkingArea.Top)
-                    location.X = screen.WorkingArea.Top;
-                if (location.Y < screen.WorkingArea.Left)
-                    location.Y = screen.WorkingArea.Left;
+                if (location.X < screen.WorkingArea.Left)
+                    location.X = screen.WorkingArea.Left;
+                if (location.Y < screen.WorkingArea.Top)
+                    location.Y = screen.WorkingArea.Top;
                 if (location.X + size.Width > screen.WorkingArea.Right)
                     location.X = screen.WorkingArea.Right - size.Width;
                 if (location.Y + size.Height > screen.WorkingArea.Bottom)
                     location.Y = screen.WorkingArea.Bottom - size.Height;
+                log.DebugFormat("Clamped location: {0}", location);
             }
             return location;
         }
@@ -209,5 +213,7 @@ namespace CKAN
             // then place our window at an offset within the box
             return ClampedLocation(location - topLeftMargin, size + topLeftMargin + bottomRightMargin, screen) + topLeftMargin;
         }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(Util));
     }
 }


### PR DESCRIPTION
## Problem

On certain multi-monitor configurations (mine looks like  ![image](https://user-images.githubusercontent.com/1559108/103468141-c5a03a00-4d1b-11eb-87fb-994e0c292070.png)), the tray icon menu appears offscreen (this is monitor 1, the one on the lower right):

![image](https://user-images.githubusercontent.com/1559108/103468088-28dd9c80-4d1b-11eb-8b07-ccb2c92f036c.png)

There may also be some related problems with the entire window appearing offscreen, but I haven't observed that directly.

## Cause

We have logic to "clamp" the menu's area to be on-screen (see #2587, shared with the window position restoration code, see #2677), but currently the `Top` and `Left` properties are switched, so the position won't get adjusted if the `Y` value is greater than the `Left` position of the screen.

## Changes

Now we compare `X` to `Left` and `Y` to `Top`, and the menu appears onscreen:

![image](https://user-images.githubusercontent.com/1559108/103468181-334c6600-4d1c-11eb-931e-86fe673fc120.png)
