### PR TITLE
A bad install stanza is not a version file

### DIFF
--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -48,7 +48,7 @@ namespace CKAN.Configuration
             "downloads"
         );
 
-        // The actual config file state, and it's location on the disk (we allow
+        // The actual config file state, and its location on the disk (we allow
         // the location to be changed for unit tests). Note that these are static
         // because we only want to have one copy of the config file in memory. This
         // version is considered authoritative, and we save it to the disk every time

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -43,9 +43,14 @@ namespace CKAN.NetKAN.Validators
                         var avc = _moduleService.GetInternalAvc(mod, file, ".");
                         hasVersionFile = (avc != null);
                     }
+                    catch (BadMetadataKraken k)
+                    {
+                        // This means the install stanzas don't match any files.
+                        // That's not our problem; someone else will report it.
+                    }
                     catch (Kraken k)
                     {
-                        // If GetInternalAvc throws, then there's a version file with a syntax error.
+                        // If GetInternalAvc throws anything else, then there's a version file with a syntax error.
                         // This shouldn't cause the inflation to fail.
                         hasVersionFile = true;
                         Log.Warn(k.Message);


### PR DESCRIPTION
## Problem

If your install stanzas don't match any files, netkan will falsely report that you have a version file:

- https://github.com/KSP-CKAN/NetKAN/runs/1654148422

![image](https://user-images.githubusercontent.com/1559108/103801355-3cd31800-5013-11eb-863a-5404039432b3.png)

A bad install stanza is most likely to be submitted by an inexperienced netkan user, to whom it's not good to send misleading messages, since they might take the advice and get frustrated.

## Cause

`VrefValidator` is catching the `BadMetadataKraken` thrown by Core as a `Kraken` generated by `GetInternalAvc` and interpreting it as a problem with a found version file.

Exceptions are a blunt instrument reliant on guessing and interpretation and prone to surprises.

## Changes

Now `VrefValidator` catches `BadMetadataKraken` separately and ignores it. Install stnazas are checked more rigorously in other validators, which will print the error (that's why one of the messages is duplicated in the screenshot; the red one isn't going away).

I'm planning to merge this quickly to try it out on the above PR.