### PR TITLE
Store remote version file URL in metadata resources

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -220,6 +220,11 @@
                     "type"        : "string",
                     "format"      : "uri"
                 },
+                "remote-avc" : {
+                    "description" : "Mod's remote hosted version file",
+                    "type"        : "string",
+                    "format"      : "uri"
+                },
                 "store": {
                     "description" : "Purchase DLC here",
                     "type"        : "string",

--- a/Core/Types/ResourcesDescriptor.cs
+++ b/Core/Types/ResourcesDescriptor.cs
@@ -41,11 +41,15 @@ namespace CKAN
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri metanetkan;
         
-        [JsonProperty("store", Order = 10, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("remote-avc", Order = 10, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonOldResourceUrlConverter))]
+        public Uri remoteAvc;
+        
+        [JsonProperty("store", Order = 11, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri store;
 
-        [JsonProperty("steamstore", Order = 11, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("steamstore", Order = 12, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri steamstore;
     }

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -157,6 +157,7 @@ namespace CKAN
                     AddResourceLink(Properties.Resources.ModInfoLicenseLabel,               res.license);
                     AddResourceLink(Properties.Resources.ModInfoManualLabel,                res.manual);
                     AddResourceLink(Properties.Resources.ModInfoMetanetkanLabel,            res.metanetkan);
+                    AddResourceLink(Properties.Resources.ModInfoRemoteAvcLabel,             res.remoteAvc);
                     AddResourceLink(Properties.Resources.ModInfoStoreLabel,                 res.store);
                     AddResourceLink(Properties.Resources.ModInfoSteamStoreLabel,            res.steamstore);
                 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -585,6 +585,9 @@ namespace CKAN.Properties {
         internal static string ModInfoMetanetkanLabel {
             get { return (string)(ResourceManager.GetObject("ModInfoMetanetkanLabel", resourceCulture)); }
         }
+        internal static string ModInfoRemoteAvcLabel {
+            get { return (string)(ResourceManager.GetObject("ModInfoRemoteAvcLabel", resourceCulture)); }
+        }
         internal static string ModInfoStoreLabel {
             get { return (string)(ResourceManager.GetObject("ModInfoStoreLabel", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -260,6 +260,7 @@ Wenn du ein Fehler mit dem CKAN Client vermutest: https://github.com/KSP-CKAN/CK
   <data name="ModInfoContinuousIntegrationLabel" xml:space="preserve"><value>Continuous Integration:</value></data>
   <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Lizenz:</value></data>
   <data name="ModInfoManualLabel" xml:space="preserve"><value>Anleitung:</value></data>
+  <data name="ModInfoRemoteAvcLabel" xml:space="preserve"><value>Online Versionsdatei:</value></data>
   <data name="ModInfoStoreLabel" xml:space="preserve"><value>Shop:</value></data>
   <data name="ModInfoSteamStoreLabel" xml:space="preserve"><value>Steam Shop:</value></data>
   <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Lizenz:</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -285,6 +285,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Licence:</value></data>
   <data name="ModInfoManualLabel" xml:space="preserve"><value>Manual:</value></data>
   <data name="ModInfoMetanetkanLabel" xml:space="preserve"><value>Metanetkan:</value></data>
+  <data name="ModInfoRemoteAvcLabel" xml:space="preserve"><value>Remote version file:</value></data>
   <data name="ModInfoStoreLabel" xml:space="preserve"><value>Store:</value></data>
   <data name="ModInfoSteamStoreLabel" xml:space="preserve"><value>Steam store:</value></data>
   <data name="MainModListWaitTitle" xml:space="preserve"><value>Loading modules</value></data>

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -73,6 +73,11 @@ namespace CKAN.NetKAN.Transformers
 
                     if (remoteUri != null)
                     {
+                        if (json["resources"] == null)
+                            json["resources"] = new JObject();
+                        var resourcesJson = (JObject)json["resources"];
+                        resourcesJson.SafeAdd("remote-avc", remoteUri.OriginalString);
+
                         try
                         {
                             var remoteJson = _github?.DownloadText(remoteUri)

--- a/Spec.md
+++ b/Spec.md
@@ -603,6 +603,7 @@ are described. Unless specified otherwise, these are URLs:
 - `curse` :  (**v1.20**) The mod on Curse.
 - `manual` : The mod's manual, if it exists.
 - `metanetkan` :  (**v1.27**) URL of the module's remote hosted netkan
+- `remote-avc` : URL of remote version file
 - `store`:  (**v1.28**) URL where you can purchase a DLC
 - `steamstore`:  (**v1.28**) URL where you can purchase a DLC on Steam
 


### PR DESCRIPTION
## Motivation

When investigating issues with mods' compatiiblity, the one piece of info that isn't readily available on http://status.ksp-ckan.space/ is the remote version file URL, which is important because it contains the latest compatibility data that is used for inflation. To get this, we have to download the ZIP and read the internal version file.

## Changes

Now `resources.remote-avc` is populated with the remote version file URL when available and displayed in GUI. I believe this will also flow through to the status page with no further changes, see KSP-CKAN/NetKAN-status#9.

The spec and schema are updated to support this new property, but I don't think we need to bump the minor version of the next CKAN release for this.

```json
    "resources": {
        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/155998-*",
        "repository": "https://github.com/HebaruSan/Astrogator",
        "bugtracker": "https://github.com/HebaruSan/Astrogator/issues",
        "remote-avc": "https://raw.githubusercontent.com/HebaruSan/Astrogator/master/Astrogator.version"
    },
```