### PR TITLE
Better version overrides in Netkan

### DIFF
--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -8,6 +8,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+using CKAN.Versioning;
 using CKAN.Extensions;
 using CKAN.NetKAN.Sources.Avc;
 using CKAN.Games;
@@ -99,10 +100,102 @@ namespace CKAN.NetKAN.Services
         }
 
         /// <summary>
-        /// Return a parsed JObject from a stream.
+        /// Update the game versions of a module.
+        /// Final range will be the union of the previous and new ranges.
+        /// Note that this means we always increase, never decrease, compatibility.
         /// </summary>
+        /// <param name="json">The module being inflated</param>
+        /// <param name="ver">The single game version</param>
+        /// <param name="minVer">The minimum game version</param>
+        /// <param name="maxVer">The maximum game version</param>
+        public static void ApplyVersions(JObject json, GameVersion ver, GameVersion minVer, GameVersion maxVer)
+        {
+            // Get the minimum and maximum game versions that already exist in the metadata.
+            // Use specific game version if min/max don't exist.
+            var existingMinStr = (string)json["ksp_version_min"] ?? (string)json["ksp_version"];
+            var existingMaxStr = (string)json["ksp_version_max"] ?? (string)json["ksp_version"];
 
-        // Courtesy https://stackoverflow.com/questions/8157636/can-json-net-serialize-deserialize-to-from-a-stream/17788118#17788118
+            var existingMin = existingMinStr == null ? null : GameVersion.Parse(existingMinStr);
+            var existingMax = existingMaxStr == null ? null : GameVersion.Parse(existingMaxStr);
+
+            GameVersion avcMin, avcMax;
+            if (minVer == null && maxVer == null)
+            {
+                // Use specific game version if min/max don't exist
+                avcMin = avcMax = ver;
+            }
+            else
+            {
+                avcMin = minVer;
+                avcMax = maxVer;
+            }
+
+            // Now calculate the minimum and maximum KSP versions between both the existing metadata and the
+            // AVC file.
+            var gameVerMins  = new List<GameVersion>();
+            var gameVerMaxes = new List<GameVersion>();
+
+            if (!GameVersion.IsNullOrAny(existingMin))
+                gameVerMins.Add(existingMin);
+
+            if (!GameVersion.IsNullOrAny(avcMin))
+                gameVerMins.Add(avcMin);
+
+            if (!GameVersion.IsNullOrAny(existingMax))
+                gameVerMaxes.Add(existingMax);
+
+            if (!GameVersion.IsNullOrAny(avcMax))
+                gameVerMaxes.Add(avcMax);
+
+            var gameVerMin = gameVerMins.DefaultIfEmpty(null).Min();
+            var gameVerMax = gameVerMaxes.DefaultIfEmpty(null).Max();
+
+            if (gameVerMin != null || gameVerMax != null)
+            {
+                // If we have either a minimum or maximum game version, remove all existing game version
+                // information from the metadata.
+                json.Remove("ksp_version");
+                json.Remove("ksp_version_min");
+                json.Remove("ksp_version_max");
+
+                if (gameVerMin != null && gameVerMax != null)
+                {
+                    // If we have both a minimum and maximum game version...
+                    if (gameVerMin.Equals(gameVerMax))
+                    {
+                        // ...and they are equal, then just set ksp_version
+                        Log.DebugFormat("Min and max game versions are same, setting ksp_version");
+                        json["ksp_version"] = gameVerMin.ToString();
+                    }
+                    else
+                    {
+                        // ...otherwise set both ksp_version_min and ksp_version_max
+                        Log.DebugFormat("Min and max game versions are different, setting both");
+                        json["ksp_version_min"] = gameVerMin.ToString();
+                        json["ksp_version_max"] = gameVerMax.ToString();
+                    }
+                }
+                else
+                {
+                    // If we have only one or the other then set which ever is applicable
+                    if (gameVerMin != null)
+                    {
+                        Log.DebugFormat("Only min game version is set");
+                        json["ksp_version_min"] = gameVerMin.ToString();
+                    }
+                    if (gameVerMax != null)
+                    {
+                        Log.DebugFormat("Only max game version is set");
+                        json["ksp_version_max"] = gameVerMax.ToString();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Return a parsed JObject from a stream.
+        /// Courtesy https://stackoverflow.com/questions/8157636/can-json-net-serialize-deserialize-to-from-a-stream/17788118#17788118
+        /// </summary>
         private static JObject DeserializeFromStream(Stream stream)
         {
             using (var sr = new StreamReader(stream))

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -40,7 +40,7 @@ namespace CKAN.NetKAN.Transformers
         public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
         {
             _vrefValidator.Validate(metadata);
-            
+
             if (metadata.Vref != null && metadata.Vref.Source == "ksp-avc")
             {
                 var json = metadata.Json();
@@ -121,87 +121,7 @@ namespace CKAN.NetKAN.Transformers
 
         public static void ApplyVersions(JObject json, AvcVersion avc)
         {
-            // Get the minimum and maximum KSP versions that already exist in the metadata.
-            // Use specific KSP version if min/max don't exist.
-            var existingKspMinStr = (string)json["ksp_version_min"] ?? (string)json["ksp_version"];
-            var existingKspMaxStr = (string)json["ksp_version_max"] ?? (string)json["ksp_version"];
-
-            var existingKspMin = existingKspMinStr == null ? null : GameVersion.Parse(existingKspMinStr);
-            var existingKspMax = existingKspMaxStr == null ? null : GameVersion.Parse(existingKspMaxStr);
-
-            // Get the minimum and maximum KSP versions that are in the AVC file.
-            // https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/master/KSP-AVC.schema.json
-            // KSP-AVC allows KSP_VERSION to be set
-            // when KSP_VERSION_MIN/_MAX are set, but CKAN treats
-            // its equivalent properties as mutually exclusive.
-            // Only fallback if neither min nor max are defined,
-            // for open ranges.
-            GameVersion avcKspMin, avcKspMax;
-            if (avc.ksp_version_min == null && avc.ksp_version_max == null)
-            {
-                // Use specific KSP version if min/max don't exist
-                avcKspMin = avcKspMax = avc.ksp_version;
-            }
-            else
-            {
-                avcKspMin = avc.ksp_version_min;
-                avcKspMax = avc.ksp_version_max;
-            }
-
-            // Now calculate the minimum and maximum KSP versions between both the existing metadata and the
-            // AVC file.
-            var kspMins  = new List<GameVersion>();
-            var kspMaxes = new List<GameVersion>();
-
-            if (!GameVersion.IsNullOrAny(existingKspMin))
-                kspMins.Add(existingKspMin);
-
-            if (!GameVersion.IsNullOrAny(avcKspMin))
-                kspMins.Add(avcKspMin);
-
-            if (!GameVersion.IsNullOrAny(existingKspMax))
-                kspMaxes.Add(existingKspMax);
-
-            if (!GameVersion.IsNullOrAny(avcKspMax))
-                kspMaxes.Add(avcKspMax);
-
-            var kspMin = kspMins.Any()  ? kspMins.Min()  : null;
-            var kspMax = kspMaxes.Any() ? kspMaxes.Max() : null;
-
-            if (kspMin != null || kspMax != null)
-            {
-                // If we have either a minimum or maximum KSP version, remove all existing KSP version
-                // information from the metadata.
-                json.Remove("ksp_version");
-                json.Remove("ksp_version_min");
-                json.Remove("ksp_version_max");
-
-                if (kspMin != null && kspMax != null)
-                {
-                    // If we have both a minimum and maximum KSP version...
-                    if (kspMin.Equals(kspMax))
-                    {
-                        // ...and they are equal, then just set ksp_version
-                        json["ksp_version"] = kspMin.ToString();
-                    }
-                    else
-                    {
-                        // ...otherwise set both ksp_version_min and ksp_version_max
-                        json["ksp_version_min"] = kspMin.ToString();
-                        json["ksp_version_max"] = kspMax.ToString();
-                    }
-                }
-                else
-                {
-                    // If we have only one or the other then set which ever is applicable
-
-                    if (kspMin != null)
-                        json["ksp_version_min"] = kspMin.ToString();
-
-                    if (kspMax != null)
-                        json["ksp_version_max"] = kspMax.ToString();
-                }
-            }
+            ModuleService.ApplyVersions(json, avc.ksp_version, avc.ksp_version_min, avc.ksp_version_max);
 
             if (avc.version != null)
             {

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -49,7 +49,7 @@ namespace Tests.NetKAN.Transformers
                 "AvcTransformer should add the version specified in the AVC version file."
             );
             Assert.That((string)transformedJson["ksp_version"], Is.EqualTo("1.0.4"),
-                "AvcTransformer should add the KSP version specified in the AVC version file."
+                "AvcTransformer should add the game version specified in the AVC version file."
             );
         }
 


### PR DESCRIPTION
## Problems

See KSP-CKAN/NetKAN#8291; if mod authors only track compatibility on SpaceDock (i.e. don't use a KSP-AVC version file), then the handy prompt to update compatibility when a new version is released just ends up changing the single compatible game version, so that for example compatibility with 1.11 is gained while compatibility with 1.10 is lost, when they may be expecting the total compatibility with prior versions to be remembered over the long term. All of @KSPSnark's mods have been subject to this forever, see KSP-CKAN/NetKAN#6629 and KSP-CKAN/NetKAN#6639 for the last time we tried wrestling with it.

The most natural thing is to add this:

```json
    "x_netkan_override": [ {
        "version": "1.10",
        "override": {
            "ksp_version_min": "1.8"
        }
    } ],
```

But that currently errors out:

```
2194 [1] FATAL CKAN.NetKAN.Program (null) - ksp_version mixed with ksp_version_(min|max)
```

## Cause

SpaceDock's compatibility goes into `ksp_version` and nowhere else. The override would need to delete that property, because it's not valid to mix `ksp_version_min` with `ksp_version`, but then the useful info it contained would be lost, and we would be back to 100% manual maintenance for compatibility of such mods rather than pulling author-generated data from SpaceDock.

## Background

Our AVC processing code has some pretty good logic for combining and overriding version ranges (which is part of why version files are so useful). Essentially it calculates an overall minimum and overall maximum from two input ranges, and then figures out the right metadata to represent the resulting range. This logic has usefulness for more than just AVC handling.

## Changes

- Now `AvcTransformer.ApplyVersions` is moved to `ModuleService` (except for the handling of `x_netkan_trust_version_file` which only makes sense for AVC), and calling code is updated to use the new location
- Now `VersionedOverrideTransformer` uses special logic to handle overrides of the compatibility properties; instead of just setting them blindly (and often generating invalid metadata), it passes them to `ModuleService.ApplyVersions`

After these changes, the above override works as intended:

```json
    "ksp_version_min": "1.8",
    "ksp_version_max": "1.11.0",
```

This will allow us to fix the compatibility of @KSPSnark's mods with just some slight additional manual maintenance, while still taking advantage of the author-generated data from SpaceDock.

This is the first part of fixing KSP-CKAN/NetKAN#8291 (the next part will be updating the netkans for the affected mods).