### PR TITLE
Visual cues for incompatibility reasons

### DIFF
--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Drawing;
+using System.ComponentModel;
 using System.Windows.Forms;
 using System.IO;
 using CKAN.Versioning;
@@ -140,7 +141,27 @@ namespace CKAN
 
             Util.Invoke(MetadataModuleReleaseStatusTextBox, () => MetadataModuleReleaseStatusTextBox.Text = module.release_status?.ToString() ?? Properties.Resources.ModInfoNSlashA);
             Util.Invoke(MetadataModuleGameCompatibilityTextBox, () => MetadataModuleGameCompatibilityTextBox.Text = gui_module.GameCompatibilityLong);
-            Util.Invoke(ReplacementTextBox, () => ReplacementTextBox.Text = gui_module.ToModule()?.replaced_by?.ToString() ?? Properties.Resources.ModInfoNSlashA);
+            Util.Invoke(ReplacementTextBox, () => ReplacementTextBox.Text = module?.replaced_by?.ToString() ?? Properties.Resources.ModInfoNSlashA);
+
+            Util.Invoke(ModInfoTabControl, () =>
+            {
+                // Mono doesn't draw TabPage.ImageIndex, so fake it
+                const string fakeStopSign = "<!> ";
+                ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(ModInfo));
+                resources.ApplyResources(RelationshipTabPage,   "RelationshipTabPage");
+                resources.ApplyResources(AllModVersionsTabPage, "AllModVersionsTabPage");
+                if (gui_module.IsIncompatible)
+                {
+                    if (!module.IsCompatibleKSP(manager.CurrentInstance.VersionCriteria()))
+                    {
+                        AllModVersionsTabPage.Text = fakeStopSign + AllModVersionsTabPage.Text;
+                    }
+                    else
+                    {
+                        RelationshipTabPage.Text = fakeStopSign + RelationshipTabPage.Text;
+                    }
+                }
+            });
 
             Util.Invoke(MetaDataLowerLayoutPanel, () =>
             {

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -325,7 +325,7 @@
             // splitContainer1.Panel2
             //
             this.splitContainer1.Panel2.Controls.Add(this.ModInfo);
-            this.splitContainer1.Panel2MinSize = 300;
+            this.splitContainer1.Panel2MinSize = 320;
             this.splitContainer1.Size = new System.Drawing.Size(1544, 981);
             this.splitContainer1.SplitterDistance = 1156;
             this.splitContainer1.SplitterWidth = 10;


### PR DESCRIPTION
## Motivation

We continue to get questions about why a mod is shown as incompatible when the user expects it to be compatible. The answer is that there is a conflict or an unsatisfied dependency, but this is generally not obvious.

## Changes

Now if a mod is incompatible because of the KSP versions, `<!>` is added to its Versions tab, which shows the range of compatible versions:

![image](https://user-images.githubusercontent.com/1559108/104863795-b5cc4c80-58fc-11eb-8f69-2f0bcc4fc1a6.png)

And if a mod is incompatible because of a conflict or an unsatisfied dependency, `<!>` is added to its Relationships tab, which shows those relationships:

![image](https://user-images.githubusercontent.com/1559108/104863830-cb417680-58fc-11eb-832b-ee58a8b76751.png)

Ideally these would have been big red stop sign icons instead, but Mono's `TabControl` does not display icons (it _makes room_ for them if you set `TabPage.ImageIndex` or `TabPage.ImageKey`, but they're never _drawn_ :roll_eyes:).

Priorities in choosing these characters:

- They should be wide enough to get attention but not _too_ wide (I found parentheses and square brackets too narrow)
- They should imply an alert or attention condition (hence exclamation mark)
- They should have a slight visual resemblance to a stop sign (angle brackets almost form a hexagon, which is almost an octagon)
- They should not crash Mono (as 🛑 does)
