### PR TITLE
Upload ckan.exe artifact on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,14 @@ jobs:
       - name: Run tests
         run: xvfb-run ./build test+only --configuration=${{ matrix.configuration }} --where="Category!=FlakyNetwork"
 
+      - name: Upload ckan.exe artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ckan.exe
+          path: _build/repack/Release/ckan.exe
+          retention-days: 7
+        if: matrix.configuration == 'release' && matrix.mono == 'latest' && github.event_name == 'pull_request'
+
       - name: Send Discord Notification
         env:
           JOB_STATUS: ${{ job.status }}


### PR DESCRIPTION
## Motivation
From time to time there are PRs that need a ckan.exe to be provided to users who don't have a dev environment for CKAN set up yet, and can't or don't want to run `./build`.
Some examples:
* #3272, which adds a new translation to CKAN. Someone adding or improving CKAN's localizations doesn't necessarily want to bother with setting up everything that's needed to compile CKAN, but still needs to check a client compiled with the changes to check whether everything works and makes sense.
* #3025 where a user reported a bug on Discord, and we wanted the user to test the changes

In the second case it's quite simple for us to provide a build, but it would still be nice to have a build provided by the isolated build system, in its release configuration. 
In the first case it's possible that all team members are currently asleep or otherwise busy, and it could take several hours until someone provides a new build for testing.

## Changes
`build.yml` has a new step, which uploads the newly compiled `ckan.exe` as artifact.
Since we're running the build multiple time with a matrix, I restricted it to only upload on the `configuration == release` and `mono == latest` run, and only when the workflow is triggered by a pull request (not pushes to master).

It can be downloaded either at the bottom of the action run's overview page (see the [docs](https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts)):
https://github.com/KSP-CKAN/CKAN/actions/runs/494575907
![grafik](https://user-images.githubusercontent.com/28812678/104964704-3cf0f180-59dd-11eb-9416-7d0df614ebdf.png)


...or on any of the details/log views of a run:
https://github.com/KSP-CKAN/CKAN/pull/3273/checks?check_run_id=1724131133
![grafik](https://user-images.githubusercontent.com/28812678/104964779-6c076300-59dd-11eb-9b5b-6581c1c074e4.png)
