### PR TITLE
 Support indexing mulitple release assets on GitHub 

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Sources\Github\GithubApi.cs" />
     <Compile Include="Sources\Github\GithubRef.cs" />
     <Compile Include="Sources\Github\GithubRelease.cs" />
+    <Compile Include="Sources\Github\GithubReleaseAsset.cs" />
     <Compile Include="Sources\Github\GithubRepo.cs" />
     <Compile Include="Sources\Github\IGithubApi.cs" />
     <Compile Include="Sources\Jenkins\IJenkinsApi.cs" />

--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-﻿using System.Linq;
+using System.Linq;
 using CKAN.Versioning;
 using Newtonsoft.Json.Linq;
 

--- a/Netkan/Sources/Github/GithubRef.cs
+++ b/Netkan/Sources/Github/GithubRef.cs
@@ -6,7 +6,7 @@ namespace CKAN.NetKAN.Sources.Github
     internal sealed class GithubRef : RemoteRef
     {
         private static readonly Regex Pattern = new Regex(
-            @"^(?<account>[^/]+)/(?<project>[^/]+)(?:/asset_match/(?<filter>.+))?$",
+            @"^(?<account>[^/]+)/(?<project>[^/]+)(?:(/asset_match/(?<filter>.+))|(/version_from_asset/(?<versionFromAsset>.+)))?$",
             RegexOptions.Compiled
         );
 
@@ -14,6 +14,7 @@ namespace CKAN.NetKAN.Sources.Github
         public string Project { get; private set; }
         public string Repository { get; private set; }
         public Regex Filter { get; private set; }
+        public Regex VersionFromAsset { get; private set; }
         public bool UseSourceArchive { get; private set; }
         public bool UsePrerelease { get; private set; }
 
@@ -34,6 +35,10 @@ namespace CKAN.NetKAN.Sources.Github
                 Filter = match.Groups["filter"].Success ?
                     new Regex(match.Groups["filter"].Value, RegexOptions.Compiled) :
                     Constants.DefaultAssetMatchPattern;
+
+                VersionFromAsset = match.Groups["versionFromAsset"].Success ?
+                    new Regex(match.Groups["versionFromAsset"].Value, RegexOptions.Compiled) :
+                    null;
 
                 UseSourceArchive = useSourceArchive;
                 UsePrerelease = usePrerelease;

--- a/Netkan/Sources/Github/GithubRelease.cs
+++ b/Netkan/Sources/Github/GithubRelease.cs
@@ -1,21 +1,20 @@
 using System;
+using System.Collections.Generic;
 using CKAN.Versioning;
 
 namespace CKAN.NetKAN.Sources.Github
 {
     public sealed class GithubRelease
     {
-        public string           Author       { get; }
-        public ModuleVersion    Version      { get; }
-        public Uri              Download     { get; }
-        public DateTime?        AssetUpdated { get; }
+        public string        Author { get; }
+        public ModuleVersion Tag    { get; }
+        public List<GithubReleaseAsset> Assets { get; }
 
-        public GithubRelease(string author, ModuleVersion version, Uri download, DateTime? updated)
+        public GithubRelease(string author, ModuleVersion tag, List<GithubReleaseAsset> assets)
         {
             Author       = author;
-            Version      = version;
-            Download     = download;
-            AssetUpdated = updated;
+            Tag          = tag;
+            Assets       = assets;
         }
     }
 }

--- a/Netkan/Sources/Github/GithubReleaseAsset.cs
+++ b/Netkan/Sources/Github/GithubReleaseAsset.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using CKAN.Versioning;
+
+namespace CKAN.NetKAN.Sources.Github
+{
+    public sealed class GithubReleaseAsset
+    {
+        public String        Name     { get; }
+        public Uri           Download { get; }
+        public DateTime?     Updated  { get; }
+
+        public GithubReleaseAsset(string name, Uri download, DateTime? updated)
+        {
+            Name     = name;
+            Download = download;
+            Updated  = updated;
+        }
+    }
+}

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -182,6 +182,11 @@ namespace CKAN.NetKAN.Transformers
                     json.SafeAdd("name", repoName);
                 }
 
+                json.SafeMerge(
+                    "x_netkan_version_pieces",
+                    JObject.FromObject(new Dictionary<string, string>{ {"tag", ghRelease.Tag.ToString()} })
+                );
+
                 Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
                 return new Metadata(json);

--- a/Spec.md
+++ b/Spec.md
@@ -965,6 +965,8 @@ an `object` with the following fields:
 - `replace` (type: `string`, regex substitution) (default: `"${version}"`)<br/>
   Specifies a [regex substitution string](https://msdn.microsoft.com/en-us/library/ewy2t5e0%28v=vs.110%29.aspx) which
   will be used as the value of the new `version` field.
+  The following special variables are supported and will be filled in by various metadata aggregated during inflation:
+  - `${tag}` (`$kref #/ckan/github` only): Replaced with the release tag from GitHub.
 - `strict` (type: `boolean`, default: `true`)<br/>
   Specifies if NetKAN should produce an error if `find` fails to produce a match against the `version` field.
 

--- a/Spec.md
+++ b/Spec.md
@@ -731,7 +731,7 @@ When used, the following fields will be auto-filled if not already present:
 - `resources.curse`
 - `ksp_version`
 
-###### `#/ckan/github/:user/:repo[/asset_match/:filter_regexp]`
+###### `#/ckan/github/:user/:repo[(/asset_match/:filter_regexp)|(/version_from_asset/:version_regexp)]`
 
 Indicates that data should be fetched from GitHub, using the `:user` and `:repo` provided.
 For example: `#/ckan/github/pjf/DogeCoinFlag`.
@@ -749,10 +749,21 @@ When used, the following fields will be auto-filled if not already present:
 - `download_content_type`
 - `resources.repository`
 
-Optionally, one asset `:filter_regexp` directive *may* be provided:
+Optionally, one of `asset_match` with `:filter_regexp` *or* `version_from_asset` with `:version_regexp` *may* be provided:
 
-- `filter_regexp`: A string which is treated as  case-sensitive C# regular expressions which are matched against the
+- `asset_match` with `filter_regexp`: A string which is treated as case-sensitive C# regular expressions which are matched against the
   name of the released artifact.
+- `version_from_asset` with `:version_regexp`: A string which is treated as case-sensitive C# regular expressions which are matched
+  against the names of all release artifacts. Every matching artifact will result in a separate metadata output. The `:version_regexp`
+  must have a named capturing group `version`, which is used as the `version` of each asset's module.
+
+An example `.netkan` excerpt:
+
+```json
+{
+    "$kref": "#/ckan/github/pjf/DogeCoinFlag/version_from_asset/^DogeCoinFlag-(?<version>.+).zip$"
+}
+```
 
 An `x_netkan_github` field may be provided to customize how the metadata is fetched from GitHub. It is an `object` with the following fields:
 

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 using CKAN;
 using CKAN.NetKAN.Services;
@@ -48,8 +49,9 @@ namespace Tests.NetKAN.Sources.Github
 
             // Assert
             Assert.IsNotNull(githubRelease.Author);
-            Assert.IsNotNull(githubRelease.Download);
-            Assert.IsNotNull(githubRelease.Version);
+            Assert.IsNotNull(githubRelease.Tag);
+            Assert.IsNotNull(githubRelease.Assets.FirstOrDefault());
+            Assert.IsNotNull(githubRelease.Assets.FirstOrDefault()?.Download);
         }
     }
 }

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -190,6 +190,15 @@ namespace Tests.NetKAN.Transformers
                 "http://github.example/download/1.1",
                 (string)transformedJsons[1]["download"]
             );
+
+            Assert.AreEqual(
+                "1.0",
+                (string)transformedJsons[0]["x_netkan_version_pieces"]["tag"]
+            );
+            Assert.AreEqual(
+                "1.1",
+                (string)transformedJsons[1]["x_netkan_version_pieces"]["tag"]
+            );
         }
 
         [Test]


### PR DESCRIPTION
## Motivation
Kopernicus is a complex mod usually breaking between KSP releases. It used to only support one "primary" KSP version and some older ones in a separate [backports repository](https://github.com/Kopernicus/Kopernicus-Backport/releases).

Now that @R-T-B has taken over development, he introduced a new build system which allows him to easily support multiple KSP versions at the same time in the same repo.
Preferably he would want to release all assets/zips for every supported KSP version in a single release tag, like he does for his [bleeding edge repo](https://github.com/R-T-B/Kopernicus/releases), where the metadata is currently [maintained by hand](https://github.com/R-T-B/CKAN-meta-dev-Kopernicus_BE).

However, NetKAN currently doesn't support this. With `/ckan/github` $krefs, it always takes the module version from the release tag. Even multiple .netkan files with different `asset_match` wouldn't work, since they'd all end up with the same version.

## Concept
Now there is a new optional `version_from_asset` extension to the GitHub $kref.
It is in the format `/version_from_asset/:version_regexp`, where the `version_regexp` is matched against all release assets. All matching release assets will be inflated individually and result in a new metadata module.
The `version_regexp` must provide a named capturing group called `version`, which will be used to retrieve the module version for each asset.

`asset_match` and `version_from_asset` are mutually exclusive. `version_from_asset` also provides the filtering aspect of `asset_match` if needed, because it just skips unmatched assets.

To allow filling in the release tag into the final version string, `x_netkan_version_edit` now supports a special `${tag}` placeholder, which will be replaced by the release tag.

## Changes
There is a new `GithubReleaseAsset` class which holds a few asset-specific properties. `GithubRelease` has a new field, `IEnumerable<GithubReleaseAsset> Assets`, and lost asset-specific ones.
`GithubApi` creates the `GithubRelease` with the list of all `GithubReleaseAsset` now.

`GithubRef`'s regex is extended to allow the `version_from_asset` directive.

`GithubTransformer.Transform()` decides based on whether a `version_from_asset` regex is given or not how to inflate the metadata. If we have a regex, we try to get the version out of it, and pass it to `TransformOne()` together with the asset.

`GithubTransformer.TransformOne()` also takes a `GithubReleaseAsset` and `String version` as argument, from which it takes parts of the needed metadata.
Furthermore it adds a entry for the release tag to the metadata under `x_netkan_version_pieces`.

`VersionEditTransformer` reads the dict from `x_netkan_version_pieces` to replace any special vars.

The spec is also updated. Suggestions welcome if you can put it in better words.

I'm also not really found fond of calling it `version_from_asset`. It misses the fact that it can result in multiple .ckans.
`multi_asset_match` misses the fact that it gets the version from the file name.
`multi_asset_match_with_version_from_asset` is a bit long...

## Testing
Take [Kopernicus.netkan](https://github.com/KSP-CKAN/NetKAN/blob/master/NetKAN/Kopernicus.netkan), switch the kref to
```json
"$kref"         : "#/ckan/github/R-T-B/Kopernicus/version_from_asset/^KopernicusBE_(?<version>.+)\\.zip",
```
optionally add 
```json
"x_netkan_version_edit": {
        "find": "(?<ksp_version>.+)_Release(?<build>[0-9]+)",
        "replace": "release-${ksp_version}-${build}",
        "strict": true
    },
```json
or a different `replace` to test the tag replacement
```
        "replace": "${tag}-${ksp_version}",
```
to make the version format match the old ones.

Inflating `Kopernicus.netkan` should result in 4 .ckan files.