### PR TITLE
Netkan warning for multiple assets

### DIFF
--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -62,17 +62,17 @@ namespace CKAN.NetKAN.Transformers
                 {
                     Log.Warn("Repo is archived, consider freezing");
                 }
-                var versions = _api.GetAllReleases(ghRef);
+                var releases = _api.GetAllReleases(ghRef);
                 if (opts.SkipReleases.HasValue)
                 {
-                    versions = versions.Skip(opts.SkipReleases.Value);
+                    releases = releases.Skip(opts.SkipReleases.Value);
                 }
                 if (opts.Releases.HasValue)
                 {
-                    versions = versions.Take(opts.Releases.Value);
+                    releases = releases.Take(opts.Releases.Value);
                 }
                 bool returnedAny = false;
-                foreach (GithubRelease rel in versions)
+                foreach (GithubRelease rel in releases)
                 {
                     if (ghRef.VersionFromAsset != null)
                     {
@@ -93,6 +93,11 @@ namespace CKAN.NetKAN.Transformers
                     }
                     else
                     {
+                        if (rel.Assets.Count > 1)
+                        {
+                            Log.WarnFormat("Multiple assets found for {0} {1} without `version_from_asset`",
+                                metadata.Identifier, rel.Tag);
+                        }
                         returnedAny = true;
                         yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel, rel.Assets.FirstOrDefault(), rel.Tag.ToString());
                     }


### PR DESCRIPTION
## Background

#3279 made it possible to inflate multiple assets per GitHub release, which KSP-CKAN/NetKAN#8338 then enabled for Kopernicus.

## Motivations

- There might be other mods out there that could benefit from this, either now or in the future
- Mods that upload mulitple assets may be generating bad metadata if their authors expected #3279 to exist before it existed

## Changes

Now if Netkan notices a multi-asset release and isn't configured for it, it prints a warning.