### PR TITLE
Upgrade AD mods with mismatched version in filename

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -341,7 +341,7 @@ namespace CKAN
                 // The least evil is to walk it once, and filter it ourselves.
                 IEnumerable<string> files = Directory
                     .EnumerateFiles(game.PrimaryModDirectory(this), "*", SearchOption.AllDirectories)
-                    .Where(file => dllRegex.IsMatch(file))
+                    .Where(file => file.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase))
                     .Select(CKANPathUtils.NormalizePath)
                     .Where(absPath => !game.StockFolders.Any(f =>
                         ToRelativeGameDir(absPath).StartsWith($"{f}/")));
@@ -364,8 +364,6 @@ namespace CKAN
                 return dllChanged || dlcChanged;
             }
         }
-
-        private static readonly Regex dllRegex = new Regex(@"\.dll$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         #endregion
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -836,9 +836,9 @@ namespace CKAN
 
             // http://xkcd.com/208/
             // This regex works great for things like GameData/Foo/Foo-1.2.dll
-            Match match = Regex.Match(
-                relative_path, @"
-                    ^GameData/            # DLLs only live in GameData
+            Match match = Regex.Match(relative_path,
+                // DLLs only live in the primary mod directory
+                $"^{ksp.game.PrimaryModDirectoryRelative}/" + @"
                     (?:.*/)?              # Intermediate paths (ending with /)
                     (?<modname>[^.]+)     # Our DLL name, up until the first dot.
                     .*\.dll$              # Everything else, ending in dll


### PR DESCRIPTION
## Problem

If you manually install a version of ModuleManager different from the one CKAN would install for you (e.g., I install MM 4.1.0 but CKAN knows that 4.1.4 is current), trying to convert it to CKAN control by upgrading as per #3043 fails with this error:

> Module Manager 4.1.4 (cached)
> DLL for module ModuleManager found at GameData/ModuleManager.4.1.0.dll, but it's not where CKAN would install it. Aborting to prevent multiple copies of the same mod being installed. To install this module, uninstall it manually and try again.
Error during installation!"

## Cause

We created that warning to catch cases where the manual install is incorrect, as it says. But the logic of the check is too strict; for a smooth automatic upgrade, we require that the old and new file names match _exactly_. That won't be the case for some **valid** manual installs for a mod like ModuleManager, because it puts its version in the file name, and there are multiple different ModuleManager versions compatible with a given KSP version.

## Changes

- Now we still try to catch bad manual installs, but we no longer require an exact file name match; instead, we just require:
  - A file starting with the mod identifier
  - Ending with `.dll` (case insensitive)
  - Installed to the same folder where the manually installed DLL is

  This will still complain if the folders don't match, but will now allow different ModuleManager DLLs to replace one another
- Now we delete a manually installed DLL we're replacing as part of the install/upgrade transaction (previously would have happened in `DeleteConflictingFiles` before, but only because the file names had to match exactly, which we no longer require)

Side changes:

- A too-simple regular expression is replaced with a call to `string.EndsWith` because that's probably simpler and faster
- `Registry.RegisterDll` now no longer uses a hard coded "GameData" prefix but instead checks the game's primary mod directory for multi-game support
- I think it was wrong to create a `CreateTransactionScope` for deleting overwritten files in #3043, because one is already created in calling code, so that's gone now

Fixes #3221.