### PR TITLE
Fix crashes in audit recommendations

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -534,11 +534,19 @@ namespace CKAN
 
             log.DebugFormat("Adding {0} {1}", module.identifier, module.version);
 
-            if (modlist.ContainsKey(module.identifier))
+            if (modlist.TryGetValue(module.identifier, out CkanModule possibleDup))
             {
-                // We should never be adding something twice!
-                log.ErrorFormat("Assertion failed: Adding {0} twice in relationship resolution", module.identifier);
-                throw new ArgumentException("Already contains module: " + module.identifier);
+                if (possibleDup.identifier == module.identifier)
+                {
+                    // We should never add the same module twice!
+                    log.ErrorFormat("Assertion failed: Adding {0} twice in relationship resolution", module.identifier);
+                    throw new ArgumentException("Already contains module: " + module.identifier);
+                }
+                else
+                {
+                    // Duplicates via "provides" are OK though, we'll just replace it
+                    modlist.Remove(module.identifier);
+                }
             }
             modlist.Add(module.identifier, module);
             if (!reasons.ContainsKey(module))

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -23,12 +23,11 @@ namespace CKAN
             Dictionary<CkanModule, HashSet<string>> supporters
         )
         {
-            this.registry   = registry;
+            this.registry    = registry;
             this.GameVersion = GameVersion;
             Util.Invoke(this, () =>
             {
                 RecommendedModsToggleCheckbox.Checked = true;
-                RecommendedModsListView.Items.Clear();
                 RecommendedModsListView.Items.AddRange(
                     getRecSugRows(cache, recommendations, suggestions, supporters).ToArray());
                 MarkConflicts();
@@ -184,6 +183,7 @@ namespace CKAN
         private void RecommendedModsCancelButton_Click(object sender, EventArgs e)
         {
             task?.SetResult(null);
+            RecommendedModsListView.Items.Clear();
         }
 
         private void RecommendedModsContinueButton_Click(object sender, EventArgs e)
@@ -193,9 +193,10 @@ namespace CKAN
                     .Select(item => item.Tag as CkanModule)
                     .ToHashSet()
             );
+            RecommendedModsListView.Items.Clear();
         }
 
-        private IRegistryQuerier   registry;
+        private IRegistryQuerier    registry;
         private GameVersionCriteria GameVersion;
 
         private TaskCompletionSource<HashSet<CkanModule>> task;

--- a/GUI/Controls/EditModSearch.Designer.cs
+++ b/GUI/Controls/EditModSearch.Designer.cs
@@ -66,6 +66,7 @@
             this.FilterCombinedTextBox.MinimumSize = new System.Drawing.Size(60, 20);
             this.FilterCombinedTextBox.Size = new System.Drawing.Size(247, 26);
             this.FilterCombinedTextBox.TabIndex = 17;
+            this.FilterCombinedTextBox.Enter += new System.EventHandler(this.FilterTextBox_Enter);
             this.FilterCombinedTextBox.TextChanged += new System.EventHandler(this.FilterCombinedTextBox_TextChanged);
             this.FilterCombinedTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
             resources.ApplyResources(this.FilterCombinedTextBox, "FilterCombinedTextBox");

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -165,6 +165,11 @@ namespace CKAN
             ExpandButton.Checked = false;
         }
 
+        private void FilterTextBox_Enter(object sender, EventArgs e)
+        {
+            (sender as TextBox)?.SelectAll();
+        }
+
         private void FilterTextBox_KeyDown(object sender, KeyEventArgs e)
         {
             // Switch focus from filters to mod list on enter, down, or pgdn


### PR DESCRIPTION
## Problem

Two ways to observe these bugs:

1. Open GUI
2. Install these mods: [Jesscah03.zip](https://github.com/KSP-CKAN/CKAN/files/5940449/Jesscah03.zip)
3. File → Audit recommendations
4. Scroll down to the two nearly identical rows for Not So Simple Construction
5. Check both of them
6. Get an exception:

```
28701 [1] ERROR CKAN.RelationshipResolver (null) - Assertion failed: Adding NSSC twice in relationship resolution
System.ArgumentException: Already contains module: NSSC
  at CKAN.RelationshipResolver.Add (CKAN.CkanModule module, CKAN.SelectionReason reason) [0x0007b] in <6a47e5b996604b7ea227275020b13b34>:0 
  at CKAN.RelationshipResolver.AddModulesToInstall (System.Collections.Generic.IEnumerable`1[T] modules) [0x00144] in <6a47e5b996604b7ea227275020b13b34>:0 
  at CKAN.RelationshipResolver..ctor (System.Collections.Generic.IEnumerable`1[T] modulesToInstall, System.Collections.Generic.IEnumerable`1[T] modulesToRemove, CKAN.RelationshipResolverOptions options, CKAN.IRegistryQuerier registry, CKAN.Versioning.GameVersionCriteria GameVersion) [0x00028] in <6a47e5b996604b7ea227275020b13b34>:0 
  at CKAN.ChooseRecommendedMods.FindConflicts () [0x0003a] in <6a47e5b996604b7ea227275020b13b34>:0 
  at CKAN.ChooseRecommendedMods.MarkConflicts () [0x00001] in <6a47e5b996604b7ea227275020b13b34>:0 
  at CKAN.ChooseRecommendedMods.RecommendedModsListView_ItemChecked (System.Object sender, System.Windows.Forms.ItemCheckedEventArgs e) [0x00045] in <6a47e5b996604b7ea227275020b13b34>:0 
  at System.Windows.Forms.ListView.OnItemChecked (System.Windows.Forms.ItemCheckedEventArgs e) [0x00019] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.ListViewItem.set_Checked (System.Boolean value) [0x0006c] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.ListView+ItemControl.ItemsMouseDown (System.Object sender, System.Windows.Forms.MouseEventArgs me) [0x000dd] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.Control.OnMouseDown (System.Windows.Forms.MouseEventArgs e) [0x00019] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.Control.WmLButtonDown (System.Windows.Forms.Message& m) [0x0008b] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.Control.WndProc (System.Windows.Forms.Message& m) [0x001bc] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.ListView+ItemControl.WndProc (System.Windows.Forms.Message& m) [0x00071] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.Control+ControlWindowTarget.OnMessage (System.Windows.Forms.Message& m) [0x00000] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.Control+ControlNativeWindow.WndProc (System.Windows.Forms.Message& m) [0x0000b] in <a0f8b82443494dec9b517126f4032efe>:0 
  at System.Windows.Forms.NativeWindow.WndProc (System.IntPtr hWnd, System.Windows.Forms.Msg msg, System.IntPtr wParam, System.IntPtr lParam) [0x00085] in <a0f8b82443494dec9b517126f4032efe>:0 
```

OR:

1. Open GUI
2. Install these mods: [Jesscah03.zip](https://github.com/KSP-CKAN/CKAN/files/5940449/Jesscah03.zip)
3. File → Audit recommendations
4. Uncheck the (De-)select all box in the lower left
  ![image](https://user-images.githubusercontent.com/1559108/107163638-56e47b00-6970-11eb-9667-3b32d4db611a.png)
5. Cancel
6. File → Audit recommendations again
7. Note that all the boxes are checked
8. Try to do anything and get an error:
   ![image](https://user-images.githubusercontent.com/78704479/107159502-1d067b00-6956-11eb-9cbe-66a7bd6a74eb.png)

Other possible manifestations:

- ![image](https://user-images.githubusercontent.com/78704479/107160608-e54f0180-695c-11eb-8568-055887bf67b3.png)
- ![image](https://user-images.githubusercontent.com/78704479/107163512-7a5af600-696f-11eb-9f37-db069ecddbef.png)

## Causes

Two different components are misbehaving.

### `RelationshipResolver`

As of KSP-CKAN/NetKAN#6202, we have duplicate modules NSSC and NotSoSimpleConstruction (see KSP-CKAN/NetKAN#7688). As of KSP-CKAN/NetKAN#7696, NotSoSimpleConstruction `provides` NSSC.

If you pass both of these modules to `RelationshipResolver`, the outcome depends on the ordering:

#### NSSC, then NotSoSimpleConstruction

1. NSSC is added to `modlist`
2. NotSoSimpleConstruction is added to `modlist`
3. NotSoSimpleConstruction's `provides` list is added to `modlist`, but since it contains only NSSC, it's just ignored
4. Everything else works fine

#### NotSoSimpleConstruction, then NSSC

1. NotSoSimpleConstruction is added to `modlist`
2. NotSoSimpleConstruction's `provides` list is added to `modlist`; since it contains NSSC, `modlist` now contains NSSC pointing to NotSoSimpleConstruction
3. NSSC is added to `modlist`, but since its identifier is already there, the exception is thrown

### `ChooseRecommendedMods`

But why should that happen at all in the case where the user _hasn't_ selected those two mods in GUI? I'm glad you asked!

The recommendations tab currently has three possible general states:

- Initially inactive and empty - At startup
- Active and populated - When it's visible
- Inactive and populated - After it's been visible at least once

In the third state, the tab isn't visible, _but its grid still has a list of rows populated from the last time it was open_. When you open it again, these lines end up trying to check the checkboxes in all of those old rows right before they're cleared out:

https://github.com/KSP-CKAN/CKAN/blob/ae3dd4443cf6d693896565aa3bc0aa1ad3e71b41/GUI/Controls/ChooseRecommendedMods.cs#L30-L34

If the bug from the previous section happens while that is going on, the exception that is thrown stops the loading of the tab and you see it in its all-selected state. From there everything pretty much goes haywire.

## Changes

Now `RelationshipResolver` only throws the exception if the duplicate in `modlist` has a matching identifier; if it was added as a result of its `provides` property, we remove and replace it instead.

Now the recommendations tab has only two possible states:

- Inactive and empty
- Active and populated

The formerly third inactive and populated state is eliminated by clearing the data when the tab is closed. This way when we re-check the checkbox, the grid will be empty and no weird stuff will happen.

Fixes #3291.

### Side change

While setting this up for testing, I noticed that it's annoying to search for a mod, click to add it to the change set, and then search for another mod, because when you press ctrl-F the second time, you have to clear the box before typing the new search.
Now ctrl-F selects the text in the search box when it sets the focus.