### PR TITLE
Fix checkbox sorting

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1246,6 +1246,15 @@ namespace CKAN
             return CompareColumn(a, b, ModName);
         }
 
+        /// <summary>
+        /// Compare two rows based on one of their columns
+        /// </summary>
+        /// <param name="a">First row</param>
+        /// <param name="b">Second row</param>
+        /// <param name="col">The column to compare</param>
+        /// <returns>
+        /// -1 if a&lt;b, 1 if a&gt;b, 0 if a==b
+        /// </returns>
         private int CompareColumn(DataGridViewRow a, DataGridViewRow b, DataGridViewColumn col)
         {
             GUIMod gmodA = a.Tag as GUIMod;
@@ -1256,15 +1265,21 @@ namespace CKAN
             var cellB = b.Cells[col.Index];
             if (col is DataGridViewCheckBoxColumn cbcol)
             {
+                // Checked < non-"-" text < unchecked < "-" text
                 if (cellA is DataGridViewCheckBoxCell checkboxA)
                 {
                     return cellB is DataGridViewCheckBoxCell checkboxB
-                        ? -((bool)checkboxA.Value).CompareTo((bool)checkboxB.Value)
-                        : -1;
+                            ? -((bool)checkboxA.Value).CompareTo((bool)checkboxB.Value)
+                        : (bool)checkboxA.Value || ((string)cellB.Value == "-") ? -1
+                        : 1;
                 }
                 else
                 {
-                    return cellB is DataGridViewCheckBoxCell ? 1: 0;
+                    return cellB is DataGridViewCheckBoxCell ? -CompareColumn(b, a, col)
+                        : (string)cellA.Value == (string)cellB.Value ? 0
+                        : (string)cellA.Value == "-" ? 1
+                        : (string)cellB.Value == "-" ? -1
+                        : ((string)cellA.Value).CompareTo((string)cellB.Value);
                 }
             }
             else


### PR DESCRIPTION
## Problem

If you have an AD mod and sort by the Installed column, the AD mod will be shown after all the non-installed compatible mods. This is bad because the installed mods should be listed together at the top.

Originally the sort order of a checkbox column was:

- Checked checkboxes
- Text not containing "-"
- Unchecked checkboxes
- Text containing "-"

## Cause

In #3205 the checkbox column sort logic was rewritten and the original logic was lost; it is now:

- Checked checkboxes
- Unchecked checkboxes
- Text of any kind, regardless of content

## Changes

Now the sort order for a checkbox column is restored to what it was.