### PR TITLE
Greeting for ckan prompt

### DIFF
--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -13,6 +13,14 @@ namespace CKAN.CmdLine
         public int RunCommand(GameInstanceManager manager, object raw_options)
         {
             CommonOptions opts = raw_options as CommonOptions;
+            // Print an intro if not in headless mode
+            if (!(opts?.Headless ?? false))
+            {
+                Console.WriteLine("Welcome to CKAN!");
+                Console.WriteLine("");
+                Console.WriteLine("To get help, type help and press enter.");
+                Console.WriteLine("");
+            }
             bool done = false;
             while (!done)
             {


### PR DESCRIPTION
## Background

This is the remnant of #3224 that survived a sanity check. (I debated whether to submit a PR or just push it to master, since it's so short and only what we saw earlier, but the work flow really isn't that onerous.)

## Motivation

Currently `ckan prompt` just drops you to a prompt, which you may or may not expect. There's a `help` command, but you might not think to try that if you don't already know about it.

## Change

Now `ckan prompt` prints a little greeting message at startup. It suggests trying the `help` command to get help.