### PR TITLE
Don't warn about incompatible DLCs, fix conflict highlighting with DLC installed

### DIFF
--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -157,7 +157,8 @@ namespace CKAN
         /// <summary>
         /// Ensures all files for this module have relative paths.
         /// Called when upgrading registry versions. Should be a no-op
-        /// if called on newer registries.</summary>
+        /// if called on newer registries.
+        /// </summary>
         public void Renormalise(GameInstance ksp)
         {
             var normalised_installed_files = new Dictionary<string, InstalledModuleFile>();

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -128,7 +128,9 @@ namespace CKAN
         public IEnumerable<InstalledModule> IncompatibleInstalled(GameVersionCriteria crit)
         {
             return installed_modules.Values
-                .Where(im => !im.Module.IsCompatibleKSP(crit));
+                .Where(im => !im.Module.IsCompatibleKSP(crit)
+                    && !(GetModuleByVersion(im.identifier, im.Module.version)?.IsCompatibleKSP(crit)
+                        ?? false));
         }
 
         #region Registry Upgrades

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -639,7 +639,8 @@ namespace CKAN
                 return;
 
             var registry = RegistryManager.Instance(CurrentInstance).registry;
-            var incomp   = registry.IncompatibleInstalled(CurrentInstance.VersionCriteria());
+            var incomp   = registry.IncompatibleInstalled(CurrentInstance.VersionCriteria())
+                .Where(m => !m.Module.IsDLC).ToList();
             if (incomp.Any())
             {
                 // Warn that it might not be safe to run Game with incompatible modules installed


### PR DESCRIPTION
## Problems

![popup](https://user-images.githubusercontent.com/25392186/108900815-b339d280-75df-11eb-84a9-912ec97afa3e.png)

Similarly, this can appear for a mod that was incompatible when you installed it but has since become compatible (because it's on SpaceDock and someone put in a `ksp_version_min` override).

Also if you have any DLC installed and you click to install two conflicting mods, they aren't highlighted red.

## Cause

SQUAD didn't update the MH version number correctly (flashbacks to the extra whitespace for the other DLC in #3243). Current `GameData/SquadExpansion/MakingHistory/readme.txt`:

```
*****************************************************************************************************
      __ _______ ____     __  ___      __   _               __  ___      __ 
     / //_/ ___// __ \   /  |/  /___ _/ /__(_)___  ___  _  / / / (_)____/ / ____ 
    / ,<  \__ \/ /_/ /  / /|_/ / __ `/ //_/ / __ \/ __ `/ / /_/ / / ___/ __/ __ \/ ___/ / / /
   / /| |___/ / ____/  / /  / / /_/ / ,< / / / / / /_/ / / __  / (__ ) /_/  /_/ / /  / /_/ /
  /_/ |_/____/_/      /_/  /_/\__,_/_/|_/_/_/ /_/\__, / /_/ /_/_/____/\__/\____/_/   \__, /  
                                                /____/                              /____/ 
 
*****************************************************************************************************

Thank you for downloading the Making History Expansion for Kerbal Space Program!

Version 1.11.0
```
...
```
ChangeLog:
=================================== v1.11.1 - Requires KSP v1.11.1 ================================
+++ Bugfixes
* Fix the servicemodules shielding antennae on launch when the shrouds are turned off.
* Fix KAL being unselectable in action pane in the mission builder.
* Fix the missing Robotics icon category in the action pane.
* Fix surface attachment issues with the LV-Tx87 Bobcat.

```

Since the `Version 1.11.0` line is what CKAN uses to detect DLC versions, CKAN thinks everyone using MH on 1.11.1 has an incompatible DLC.

When selecting conflicting rows, `ModuleIsDLCKraken` is thrown here, because the resolver is being told to install DLC:

https://github.com/KSP-CKAN/CKAN/blob/b748670c20db29ea366af3095837e2ffe0cbd7b7/GUI/Model/ModList.cs#L483-L488

## Changes

- Now the incompatible modules warning excludes DLCs.
- Now the incompatible modules warning excludes mods with compatible metadata in the available modules list but incompatible metadata in the installed modules list.
- Now the main mod list grid conflict detector doesn't pass installed modules to the resolver, since it gets them from the registry itself anyway. This means that DLC will never be in its to-install list.

Fixes #3302. Fixes #3269.