### PR TITLE
Handle incompatible force-installed dependencies of recommendations

### DIFF
--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -45,8 +45,9 @@ namespace CKAN
             {
                 tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
                 ChooseRecommendedMods.LoadRecommendations(
-                    registry, versionCriteria,
-                    Manager.Cache, recommendations, suggestions, supporters);
+                    registry, new HashSet<CkanModule>(), new HashSet<CkanModule>(),
+                    versionCriteria, Manager.Cache,
+                    recommendations, suggestions, supporters);
                 var result = ChooseRecommendedMods.Wait();
                 tabController.HideTab("ChooseRecommendedModsTabPage");
                 if (result != null && result.Any())


### PR DESCRIPTION
## Problem

1. Find an incompatible mod that has a compatible recommendation or suggestion that depends back on the original mod.
   (One example is RasterPropMonitor and RasterPropMonitor-Core, which are not compatible with KSP 1.11, and recommend ASETProps, which depends on RasterPropMonitor-Core.)
2. Use the Versions tab checkboxes to add the incompatible mod(s) to the change set.
3. Click Apply to go to the recommendations/suggestions screen
4. Check the checkbox for the mod that depends on the incompatible mods you're force-installing.
   (In our example, this is ASETProps)
5. On Windows:
   ![screenshot](https://user-images.githubusercontent.com/20694721/108915821-d1192e80-7603-11eb-9c7c-f7ae3e81ab78.png)
   On Linux, the same exception is printed to stdout.
   ```
   CKAN.DependencyNotSatisfiedKraken: ASETProps dependency on RasterPropMonitor-Core 1:v0.30.2 or later version (any) not satisfied
      at CKAN.RelationshipResolver.ResolveStanza(IEnumerable`1 stanza, SelectionReason reason, RelationshipResolverOptions options, Boolean soft_resolve, IEnumerable`1 old_stanza)
      at CKAN.RelationshipResolver.Resolve(CkanModule module, RelationshipResolverOptions options, IEnumerable`1 old_stanza)
      at CKAN.RelationshipResolver.AddModulesToInstall(IEnumerable`1 modules)
      at CKAN.ChooseRecommendedMods.FindConflicts()
      at CKAN.ChooseRecommendedMods.MarkConflicts()
      at CKAN.ChooseRecommendedMods.RecommendedModsListView_ItemChecked(Object sender, ItemCheckedEventArgs e)
      at System.Windows.Forms.ListView.OnItemChecked(ItemCheckedEventArgs e)
      at System.Windows.Forms.ListView.WmReflectNotify(Message& m)
      at System.Windows.Forms.ListView.WndProc(Message& m)
      at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
   ```

## Cause

The conflict checker in the recommendations/suggestions screen doesn't know about the mods we're force-installing, so when it asks the `RelationshipResolver` to look for conflicts, it finds out that the dependencies aren't satisfied.

## Changes

- Now `LoadRecommendations` has parameters for the mods that are planned to install and remove, and it includes them in the mods it passes to the `RelationshipResolver` for checking conflicts
- If we somehow get this exception again anyway, we now catch it and display it instead of letting it go to the unhandled exception handler:
  ![image](https://user-images.githubusercontent.com/1559108/109048782-18073280-769d-11eb-8a05-9951c14b14be.png)

Fixes #3303.