### PR TITLE
Fixes for GUI and .ckan-installed modules

### DIFF
--- a/ConsoleUI/ConsoleCKAN.cs
+++ b/ConsoleUI/ConsoleCKAN.cs
@@ -16,7 +16,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         public ConsoleCKAN(GameInstanceManager mgr, string themeName, bool debug)
         {
-            if (ConsoleTheme.Themes.TryGetValue(themeName, out ConsoleTheme theme))
+            if (ConsoleTheme.Themes.TryGetValue(themeName ?? "default", out ConsoleTheme theme))
             {
                 // GameInstanceManager only uses its IUser object to construct game instance objects,
                 // which only use it to inform the user about the creation of the CKAN/ folder.
@@ -40,7 +40,7 @@ namespace CKAN.ConsoleUI {
                         }
                     }
                     if (manager.CurrentInstance != null) {
-                        new ModListScreen(manager, debug).Run(theme);
+                        new ModListScreen(manager, debug, theme).Run(theme);
                     }
 
                     new ExitScreen().Run(theme);

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1347,7 +1347,7 @@ namespace CKAN
             {
                 RelationshipResolver resolver = new RelationshipResolver(
                     toInstall,
-                    null,
+                    toInstall.Select(m => registry.InstalledModule(m.identifier)?.Module).Where(m => m != null),
                     opts, registry, ksp.VersionCriteria()
                 );
 

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -356,6 +356,8 @@ namespace CKAN
 
             foreach (NetAsyncDownloaderDownloadPart t in downloads.ToList())
             {
+                if (t == null)
+                    continue;
                 if (t.bytesLeft > 0)
                 {
                     totalBytesPerSecond += t.bytesPerSecond;
@@ -366,6 +368,9 @@ namespace CKAN
             }
             foreach (Net.DownloadTarget t in queuedDownloads.ToList())
             {
+                // Somehow managed to get a NullRef for t here
+                if (t == null)
+                    continue;
                 totalBytesLeft += t.size;
                 totalSize += t.size;
             }

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -194,7 +194,7 @@ namespace CKAN
             {
                 RelationshipResolver resolver = new RelationshipResolver(
                     new CkanModule[] { newest_version },
-                    null,
+                    new CkanModule[] { querier.InstalledModule(identifier).Module },
                     new RelationshipResolverOptions()
                     {
                         with_recommends = false,

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -247,9 +247,9 @@ namespace CKAN
             {
                 log.DebugFormat("Preparing to resolve relationships for {0} {1}", module.identifier, module.version);
 
-                //Need to check against installed mods and those to install.
-                var mods = modlist.Values.Concat(installed_modules).Where(listed_mod => listed_mod.ConflictsWith(module));
-                foreach (CkanModule listed_mod in mods)
+                // Need to check against installed mods and those to install.
+                var conflictingModules = modlist.Values.Concat(installed_modules).Where(listed_mod => listed_mod.ConflictsWith(module));
+                foreach (CkanModule listed_mod in conflictingModules)
                 {
                     if (options.proceed_with_inconsistencies)
                     {

--- a/GUI/Controls/AllModVersions.cs
+++ b/GUI/Controls/AllModVersions.cs
@@ -122,6 +122,11 @@ namespace CKAN
                         visibleGuiModule.PropertyChanged += visibleGuiModule_PropertyChanged;
                     }
                 }
+                VersionsListView.Items.Clear();
+                if (value == null)
+                {
+                    return;
+                }
 
                 // Get all the data; can put this in bg if slow
                 GameInstance currentInstance = Main.Instance.Manager.CurrentInstance;
@@ -139,16 +144,28 @@ namespace CKAN
                 }
                 catch (ModuleNotFoundKraken)
                 {
-                    // No versions to be shown, abort and hope an auto refresh happens
+                    // Identifier unknown to registry, maybe installed from local .ckan
+                    allAvailableVersions = new Dictionary<CkanModule, bool>();
+                }
+
+                // Take the module associated with GUIMod, if any, and append it to the list if it's not already there.
+                var installedModule = value.InstalledMod?.Module;
+                if (installedModule != null && !allAvailableVersions.ContainsKey(installedModule))
+                {
+                    allAvailableVersions.Add(installedModule, installable(installer, installedModule, registry));
+                }
+
+                if (!allAvailableVersions.Any())
+                {
                     return;
                 }
+
                 ModuleVersion installedVersion = registry.InstalledVersion(value.Identifier);
 
                 // Update UI; must be in fg
                 ignoreItemCheck = true;
                 bool latestCompatibleVersionAlreadyFound = false;
 
-                VersionsListView.Items.Clear();
                 // Only show checkboxes for non-DLC modules
                 VersionsListView.CheckBoxes = !value.ToModule().IsDLC;
 

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace CKAN
+﻿using System.Windows.Forms;
+
+namespace CKAN
 {
     partial class ManageMods
     {
@@ -98,6 +100,7 @@
             this.FilterToolButton,
             this.NavBackwardToolButton,
             this.NavForwardToolButton});
+            this.menuStrip2.CanOverflow = true;
             this.menuStrip2.Location = new System.Drawing.Point(0, 0);
             this.menuStrip2.Name = "menuStrip2";
             this.menuStrip2.Size = new System.Drawing.Size(5876, 48);
@@ -110,6 +113,7 @@
             this.launchGameToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.launchGameToolStripMenuItem.Name = "launchGameToolStripMenuItem";
             this.launchGameToolStripMenuItem.Size = new System.Drawing.Size(146, 56);
+            this.launchGameToolStripMenuItem.Overflow = ToolStripItemOverflow.AsNeeded;
             this.launchGameToolStripMenuItem.Click += new System.EventHandler(this.launchGameToolStripMenuItem_Click);
             resources.ApplyResources(this.launchGameToolStripMenuItem, "launchGameToolStripMenuItem");
             //
@@ -119,6 +123,7 @@
             this.RefreshToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.RefreshToolButton.Name = "RefreshToolButton";
             this.RefreshToolButton.Size = new System.Drawing.Size(114, 56);
+            this.RefreshToolButton.Overflow = ToolStripItemOverflow.AsNeeded;
             this.RefreshToolButton.Click += new System.EventHandler(this.RefreshToolButton_Click);
             resources.ApplyResources(this.RefreshToolButton, "RefreshToolButton");
             //
@@ -128,6 +133,7 @@
             this.UpdateAllToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.UpdateAllToolButton.Name = "UpdateAllToolButton";
             this.UpdateAllToolButton.Size = new System.Drawing.Size(232, 56);
+            this.UpdateAllToolButton.Overflow = ToolStripItemOverflow.AsNeeded;
             this.UpdateAllToolButton.Click += new System.EventHandler(this.MarkAllUpdatesToolButton_Click);
             resources.ApplyResources(this.UpdateAllToolButton, "UpdateAllToolButton");
             //
@@ -137,6 +143,7 @@
             this.ApplyToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.ApplyToolButton.Name = "ApplyToolButton";
             this.ApplyToolButton.Size = new System.Drawing.Size(173, 56);
+            this.ApplyToolButton.Overflow = ToolStripItemOverflow.AsNeeded;
             this.ApplyToolButton.Click += new System.EventHandler(this.ApplyToolButton_Click);
             resources.ApplyResources(this.ApplyToolButton, "ApplyToolButton");
             //
@@ -161,6 +168,7 @@
             this.FilterToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.FilterToolButton.Name = "FilterToolButton";
             this.FilterToolButton.Size = new System.Drawing.Size(201, 56);
+            this.FilterToolButton.Overflow = ToolStripItemOverflow.AsNeeded;
             resources.ApplyResources(this.FilterToolButton, "FilterToolButton");
             //
             // FilterCompatibleButton
@@ -253,6 +261,7 @@
             this.NavBackwardToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.NavBackwardToolButton.Name = "NavBackwardToolButton";
             this.NavBackwardToolButton.Size = new System.Drawing.Size(44, 56);
+            this.NavBackwardToolButton.Overflow = ToolStripItemOverflow.AsNeeded;
             this.NavBackwardToolButton.Click += new System.EventHandler(this.NavBackwardToolButton_Click);
             resources.ApplyResources(this.NavBackwardToolButton, "NavBackwardToolButton");
             //
@@ -262,6 +271,7 @@
             this.NavForwardToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.NavForwardToolButton.Name = "NavForwardToolButton";
             this.NavForwardToolButton.Size = new System.Drawing.Size(44, 56);
+            this.NavForwardToolButton.Overflow = ToolStripItemOverflow.AsNeeded;
             this.NavForwardToolButton.Click += new System.EventHandler(this.NavForwardToolButton_Click);
             resources.ApplyResources(this.NavForwardToolButton, "NavForwardToolButton");
             //

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -786,8 +786,21 @@ namespace CKAN
                 {
                     mod.SetInstallChecked(row, Installed, mod.IsInstalled);
                 }
+                else if (mod.SelectedMod != mod.InstalledMod?.Module)
+                {
+                    mod.SelectedMod = mod.InstalledMod?.Module;
+                }
                 mod.SetUpgradeChecked(row, UpdateCol, false);
                 mod.SetReplaceChecked(row, ReplaceCol, false);
+                // Marking a mod as AutoInstalled can immediately queue it for removal if there is no dependent mod.
+                // Reset the state of the AutoInstalled checkbox for these by deducing it from the changeset.
+                if (mod.InstalledMod != null &&
+                    ChangeSet.Contains(new ModChange(mod.InstalledMod?.Module, GUIModChangeType.Remove,
+                        new SelectionReason.NoLongerUsed()))
+                )
+                {
+                    mod.SetAutoInstallChecked(row, AutoInstalled, false);
+                }
             }
         }
 

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -140,7 +140,7 @@ namespace CKAN
             Util.Invoke(MetadataModuleAuthorTextBox, () => MetadataModuleAuthorTextBox.Text = gui_module.Authors);
             Util.Invoke(MetadataIdentifierTextBox, () => MetadataIdentifierTextBox.Text = module.identifier);
 
-            Util.Invoke(MetadataModuleReleaseStatusTextBox, () => 
+            Util.Invoke(MetadataModuleReleaseStatusTextBox, () =>
             {
                 if (module.release_status == null)
                 {

--- a/GUI/Controls/Wait.Designer.cs
+++ b/GUI/Controls/Wait.Designer.cs
@@ -37,18 +37,19 @@
             this.BottomButtonPanel = new System.Windows.Forms.Panel();
             this.CancelCurrentActionButton = new System.Windows.Forms.Button();
             this.RetryCurrentActionButton = new System.Windows.Forms.Button();
+            this.OkButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
-            // 
+            //
             // TopPanel
-            // 
+            //
             this.TopPanel.Controls.Add(this.MessageTextBox);
             this.TopPanel.Controls.Add(this.DialogProgressBar);
             this.TopPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.TopPanel.Name = "TopPanel";
             this.TopPanel.Size = new System.Drawing.Size(500, 85);
-            // 
+            //
             // MessageTextBox
-            // 
+            //
             this.MessageTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));            this.MessageTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.MessageTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
@@ -62,9 +63,9 @@
             this.MessageTextBox.TabIndex = 0;
             this.MessageTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             resources.ApplyResources(this.MessageTextBox, "MessageTextBox");
-            // 
+            //
             // DialogProgressBar
-            // 
+            //
             this.DialogProgressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.DialogProgressBar.Location = new System.Drawing.Point(5, 45);
@@ -75,9 +76,9 @@
             this.DialogProgressBar.Size = new System.Drawing.Size(490, 25);
             this.DialogProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
             this.DialogProgressBar.TabIndex = 1;
-            // 
+            //
             // LogTextBox
-            // 
+            //
             this.LogTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.LogTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.LogTextBox.Location = new System.Drawing.Point(14, 89);
@@ -89,41 +90,54 @@
             this.LogTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.LogTextBox.Size = new System.Drawing.Size(500, 400);
             this.LogTextBox.TabIndex = 2;
-            // 
+            //
             // BottomButtonPanel
-            // 
-            this.BottomButtonPanel.Controls.Add(this.CancelCurrentActionButton);
+            //
             this.BottomButtonPanel.Controls.Add(this.RetryCurrentActionButton);
+            this.BottomButtonPanel.Controls.Add(this.CancelCurrentActionButton);
+            this.BottomButtonPanel.Controls.Add(this.OkButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
             this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
-            // 
+            //
             // RetryCurrentActionButton
-            // 
+            //
             this.RetryCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.RetryCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RetryCurrentActionButton.Location = new System.Drawing.Point(266, 5);
+            this.RetryCurrentActionButton.Location = new System.Drawing.Point(149, 5);
             this.RetryCurrentActionButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RetryCurrentActionButton.Name = "RetryCurrentActionButton";
             this.RetryCurrentActionButton.Size = new System.Drawing.Size(112, 30);
             this.RetryCurrentActionButton.TabIndex = 3;
             this.RetryCurrentActionButton.Click += new System.EventHandler(this.RetryCurrentActionButton_Click);
             resources.ApplyResources(this.RetryCurrentActionButton, "RetryCurrentActionButton");
-            // 
+            //
             // CancelCurrentActionButton
-            // 
+            //
             this.CancelCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelCurrentActionButton.Location = new System.Drawing.Point(383, 5);
+            this.CancelCurrentActionButton.Location = new System.Drawing.Point(266, 5);
             this.CancelCurrentActionButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.CancelCurrentActionButton.Name = "CancelCurrentActionButton";
             this.CancelCurrentActionButton.Size = new System.Drawing.Size(112, 30);
             this.CancelCurrentActionButton.TabIndex = 4;
             this.CancelCurrentActionButton.Click += new System.EventHandler(this.CancelCurrentActionButton_Click);
             resources.ApplyResources(this.CancelCurrentActionButton, "CancelCurrentActionButton");
-            // 
+            //
+            // OkButton
+            //
+            this.OkButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.OkButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.OkButton.Location = new System.Drawing.Point(383, 5);
+            this.OkButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.OkButton.Name = "OkButton";
+            this.OkButton.Size = new System.Drawing.Size(112, 30);
+            this.OkButton.TabIndex = 5;
+            this.OkButton.Click += new System.EventHandler(this.OkButton_Click);
+            resources.ApplyResources(this.OkButton, "OkButton");
+            //
             // Wait
-            // 
+            //
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.Controls.Add(this.LogTextBox);
             this.Controls.Add(this.TopPanel);
@@ -146,5 +160,6 @@
         private System.Windows.Forms.Panel BottomButtonPanel;
         private System.Windows.Forms.Button RetryCurrentActionButton;
         private System.Windows.Forms.Button CancelCurrentActionButton;
+        private System.Windows.Forms.Button OkButton;
     }
 }

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -17,6 +17,7 @@ namespace CKAN
 
         public event Action OnRetry;
         public event Action OnCancel;
+        public event Action OnOk;
 
         public bool RetryEnabled
         {
@@ -199,6 +200,7 @@ namespace CKAN
                 ProgressIndeterminate = true;
                 RetryCurrentActionButton.Enabled = false;
                 CancelCurrentActionButton.Enabled = cancelable;
+                OkButton.Enabled = false;
                 MessageTextBox.Text = Properties.Resources.MainWaitPleaseWait;
             });
         }
@@ -212,6 +214,7 @@ namespace CKAN
                 ProgressIndeterminate = false;
                 RetryCurrentActionButton.Enabled = !success;
                 CancelCurrentActionButton.Enabled = false;
+                OkButton.Enabled = true;
             });
         }
 
@@ -249,6 +252,14 @@ namespace CKAN
             }
             Util.Invoke(this, () =>
                 CancelCurrentActionButton.Enabled = false);
+        }
+
+        private void OkButton_Click(object sender, EventArgs e)
+        {
+            if (OnOk != null)
+            {
+                OnOk();
+            }
         }
     }
 }

--- a/GUI/Controls/Wait.resx
+++ b/GUI/Controls/Wait.resx
@@ -119,5 +119,6 @@
   </resheader>
   <data name="CancelCurrentActionButton.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="RetryCurrentActionButton.Text" xml:space="preserve"><value>Retry</value></data>
+  <data name="OkButton.Text" xml:space="preserve"><value>OK</value></data>
   <data name="MessageTextBox.Text" xml:space="preserve"><value>Waiting for operation to complete</value></data>
 </root>

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -19,7 +19,7 @@ namespace CKAN
             Filter           = GameFolderFilter(Main.Instance.Manager),
             Multiselect      = false
         };
-        
+
         /// <summary>
         /// Generate filter string for OpenFileDialog
         /// </summary>
@@ -213,7 +213,7 @@ namespace CKAN
 
         private void OpenDirectoryMenuItem_Click(object sender, EventArgs e)
         {
-            string path = GameInstancesListView.SelectedItems[0].SubItems[2].Text;
+            string path = _manager.Instances[(string) GameInstancesListView.SelectedItems[0].Tag].GameDir();
 
             if (!Directory.Exists(path))
             {

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -401,9 +401,9 @@
             this.ManageModsTabPage.Size = new System.Drawing.Size(1536, 948);
             this.ManageModsTabPage.TabIndex = 3;
             resources.ApplyResources(this.ManageModsTabPage, "ManageModsTabPage");
-            // 
+            //
             // ManageMods
-            // 
+            //
             this.ManageMods.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ManageMods.Location = new System.Drawing.Point(0, 0);
             this.ManageMods.Margin = new System.Windows.Forms.Padding(0,0,0,0);
@@ -467,6 +467,7 @@
             this.Wait.TabIndex = 32;
             this.Wait.OnRetry += Wait_OnRetry;
             this.Wait.OnCancel += Wait_OnCancel;
+            this.Wait.OnOk += Wait_OnOk;
             //
             // ChooseRecommendedModsTabPage
             //

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Windows.Forms;
@@ -37,13 +38,22 @@ namespace CKAN
             // Using the changeset passed in can cause issues with versions.
             // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.
             // TODO Work out why this is.
-            installWorker.RunWorkerAsync(
-                new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                    ManageMods.mainModList.ComputeUserChangeSet(RegistryManager.Instance(Main.Instance.CurrentInstance).registry).ToList(),
-                    RelationshipResolver.DependsOnlyOpts()
-                )
-            );
+            try
+            {
+                installWorker.RunWorkerAsync(
+                    new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
+                        ManageMods.mainModList
+                            .ComputeUserChangeSet(RegistryManager.Instance(Main.Instance.CurrentInstance).registry)
+                            .ToList(),
+                        RelationshipResolver.DependsOnlyOpts()
+                    )
+                );
+            }
+            catch (InvalidOperationException)
+            {
+                // Thrown if it's already busy, can happen if the user fouble-clicks the button. Ignore it.
+                // More thread-safe than checking installWorker.IsBusy beforehand.
+            }
         }
-
     }
 }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -142,6 +142,8 @@ namespace CKAN
 
             if (installCanceled)
             {
+                Util.Invoke(this, () => Enabled = true);
+                Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
                 tabController.ShowTab("ManageModsTabPage");
                 e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
                 return;
@@ -236,6 +238,8 @@ namespace CKAN
                     {
                         // User cancelled, get out
                         tabController.ShowTab("ManageModsTabPage");
+                        Util.Invoke(this, () => Enabled = true);
+                        Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
                         e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
                         return;
                     }
@@ -291,7 +295,11 @@ namespace CKAN
 
         private void PostInstallMods(object sender, RunWorkerCompletedEventArgs e)
         {
-            tabController.SetTabLock(false);
+            okCallback = () =>
+            {
+                ManageMods.UpdateModsList(null);
+                okCallback = null;
+            };
 
             if (e.Error != null)
             {
@@ -410,7 +418,10 @@ namespace CKAN
                         }
                     }
 
-                    // install successful
+                    Util.Invoke(this, () => Enabled = true);
+                    Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
+                    tabController.SetTabLock(false);
+
                     AddStatusMessage(Properties.Resources.MainInstallSuccess);
                     HideWaitDialog(true);
                 }
@@ -434,9 +445,6 @@ namespace CKAN
                     }
                 }
             }
-
-            Util.Invoke(this, () => Enabled = true);
-            Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
         }
     }
 }

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -6,6 +6,7 @@ namespace CKAN
     public partial class Main
     {
         private Action cancelCallback;
+        private Action okCallback;
 
         public void ShowWaitDialog(bool cancelable = true)
         {
@@ -86,6 +87,17 @@ namespace CKAN
             {
                 cancelCallback();
             }
+        }
+
+        public void Wait_OnOk()
+        {
+            if (okCallback != null)
+            {
+                okCallback();
+            }
+            Util.Invoke(this, () => Enabled = true);
+            Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
+            tabController.SetTabLock(false);
         }
     }
 }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -12,7 +12,7 @@ namespace CKAN
     {
         private CkanModule      Mod                 { get; set; }
         private CkanModule      LatestCompatibleMod { get; set; }
-        private InstalledModule InstalledMod        { get; set; }
+        public  InstalledModule InstalledMod        { get; private set; }
 
         /// <summary>
         /// The module of the checkbox that is checked in the MainAllModVersions list if any,
@@ -141,6 +141,8 @@ namespace CKAN
             {
                 LatestVersion = InstalledVersion;
             }
+            // For mods not known to the registry LatestCompatibleMod is null, however the installed module might be compatible
+            IsIncompatible   = incompatible ?? LatestCompatibleMod == null && !instMod.Module.IsCompatibleKSP(current_game_version);
         }
 
         /// <summary>
@@ -268,6 +270,12 @@ namespace CKAN
             IsCached = Main.Instance.Manager.Cache.IsMaybeCachedZip(Mod);
         }
 
+        /// <summary>
+        /// Get the CkanModule associated with this GUIMod.
+        /// See <see cref="ToModule"/> for a method that doesn't throw.
+        /// </summary>
+        /// <returns>The CkanModule associated with this GUIMod</returns>
+        /// <exception cref="InvalidCastException">Thrown if no CkanModule is associated</exception>
         public CkanModule ToCkanModule()
         {
             if (!IsCKAN)
@@ -276,6 +284,10 @@ namespace CKAN
             return mod;
         }
 
+        /// <summary>
+        /// Get the CkanModule associated with this GUIMod.
+        /// </summary>
+        /// <returns>The CkanModule associated with this GUIMod or null if there is none</returns>
         public CkanModule ToModule()
         {
             return Mod;


### PR DESCRIPTION
## Problems:
### GUI
* If you cancel an installation too late and can't be stopped anymore and finishes successfully, the changeset doesn't get cleared.
* Clearing the changeset on the changeset tab doesn't remove incompatible mods checked using the `AllModVersiions` tab. Neither does it remove mods queued for removal because they've been checked as auto-installed without any dependent mods.
* A Discord user from the r/KerbalSpaceProgram server who tends to find every bug and glitch in CKAN, likes to double-click the "Accept" button in the changeset tab. This throws an exception:
```
System.InvalidOperationException: This BackgroundWorker is currently busy and cannot run multiple tasks concurrently.
   at System.ComponentModel.BackgroundWorker.RunWorkerAsync(Object argument)
   at CKAN.Changeset.ConfirmChangesButton_Click(Object sender, EventArgs e)
   at System.Windows.Forms.Control.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ButtonBase.WndProc(Message& m)
   at System.Windows.Forms.Button.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
   ```
* If you install a mod from a .ckan file which isn't known to the registry (identifier-wise), the "Versions" tab doesn't update when you select it
* Furthermore, for those mods the dependencies tab always has the new STOP sign from #3271
* If you downsize the GUI, some buttons of the menu strip disappear if they don't fit in the window.

### ConsoleUI
* When loading a new instance the modlist is empty at first (or only contains the DLCs). This tends to confuse users. The GUI does automatically refresh the registry in this case.
* If you launch the un-repacked `CKAN-ConsoleUI.exe` directly (e.g. via IDE), you get an exception because the `themename` passed to `ConsoleCKAN()` is `null`.

### Core
* CKAN offers to upgrade modules even if it would violate another module's relationships (but the installation fortunately fails); related it shows all versions in the `VersionsListView` as installable.
* While downloading a huge set of mods I got a NullReferenceException in `NetAsyncDownloader.FileProgressReport()`, for the `t` variable in the `queuedDownloads` foreach-loop. Unfortunately KDE crashed some time later and I didn't save the stacktrace to disk yet.


## Causes:
### GUI
* We don't run `UpdateModsList` after the install process has been cancelled, thus the changeset doesn't get cleared. We can't run it immediately, because it would close the WaitTabPage and remove the useful log messages.
* `ClearChangeSet()` doesn't detect changes for incompatible mods since `IsInstallChecked` is `false` for them. `GetModChanges()` find it by comparing `GUIMod.SelectedMod` with `GUIMod.InstalledMod.Module`.
* And it doesn't know about the auto-installed modules because toggling the chexkbox isn't an action itself that gets added to the changeset – it's applied instantly by setting `InstalledMod.AutoInstalled`.
* If you manage to hit the "Accept" button again before the GUI switches to the WaitTabPage, it tries to call `installWorker.RunWorkerAsync()` a second time, throwing the exception.
* `AllModVersions` uses `registry.AvailableByIdentifier(value.Identifier)` to populate the `VersionListView`. If the registry can't find anything, we just return, even without clearing the existing version items from the previous mod.
* `GUIMod.IsIncompatible` is always `true` for unknown modules because `registry.LatestAvailable()` can't find anything.
* >  By default, menu items are not displayed if they cannot fit within the available space.

  https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.menustrip.canoverflow?view=net-5.0#System_Windows_Forms_MenuStrip_CanOverflow

### Core
* We don't tell the RelationshipResolver the module version that gets removed, only the new one to be installed. Thus it considers dependencies still satisfied by the old version.
* I guess if a new download gets picked out of the queue while we're in the loop adding all the sizes together, the `DownloadTarget` can become `null`.

## Changes
### GUI
* Add OK button to wait tab page; it is enabled if the install process failed or the user cancelled too late. It gives time to read the log messages, but ensures `UpdateModsList()` runs at some point. The tabController stays locked and the top menu deactivated until the user hits "OK". This means we also need to unlock the tabController when cancelling earlier in the installation process like when selecting the recommendations/suggestions or provides, because we never show the FailWaitDialog in this case.
* `ClearChangeSet()` also compares `SelectedMod` and `InstalledMod` now, and does the reverse of `GetModChanges()`, i.e. setting `SelectedMod` back to `InstalledMod` if they differ.
* Additionally, it deduces the previous state of now-marked-as-auto-installed modules by checking if they're in the changeset with `SelectionReason.NoLongerUsed`, and if so, sets it to false again. Doesn't catch all mods whose checkbox got changed, but it should suffice for most cases, to clear the changeset.
* If `installWorker` is already running, don't run it a second time. This was easier than trying to disable the button and finding all the right places where we'd need to enable it aǵain.
* If the registry doesn't know a mod, we still add the `CkanModule` associated with the `GUIModule`  to the list, if it exists.
* The `GUIMod` constructor that takes an `InstalledModule` as arg now overwrites `IsIncompatible` based on the compatibility of the installed module.
* Make `menuStrip2` overflowable. Instead of just not drawing the buttons, there's now a small dropdown to list those that didn't fit anymore. Doesn't work on Mono (it behaves just like before), but on Windows:
  ![](https://media.discordapp.net/attachments/601455398553387008/815355199878856714/unknown.png?width=956&height=667)

### ConsoleUI
* Update the registry if the loaded instance doesn't contain any modules, just like the GUI does. Should make initial setup easier for new users.
* If the `themeName` passed to `ConsoleCKAN` is `null` it falls pack to `default`.

### Core
* The two `RelationshipResolver` instantiations in `ModuleInstaller.CanInstall()` and `IRegistryQuerierHelper.HasUpdate()` now pass the currently installed module (if any) as `moduleToRemove`, just like the resolver for the actual install process does.
* Do a quick `null` check in the two foreach-loops in `NetAsyncDownloader.FileProgressReport()` and skip if `t` is `null`.