### PR TITLE
Update dialog was too small for French localization

### DIFF
--- a/GUI/Dialogs/AskUserForAutoUpdatesDialog.Designer.cs
+++ b/GUI/Dialogs/AskUserForAutoUpdatesDialog.Designer.cs
@@ -29,19 +29,18 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(AskUserForAutoUpdatesDialog));
-            this.label1 = new System.Windows.Forms.Label();
+            this.autoCheckLabel = new System.Windows.Forms.Label();
             this.YesButton = new System.Windows.Forms.Button();
-            this.button1 = new System.Windows.Forms.Button();
+            this.NoButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             //
-            // label1
+            // autoCheckLabel
             //
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 9);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(511, 13);
-            this.label1.TabIndex = 0;
-            resources.ApplyResources(this.label1, "label1");
+            this.autoCheckLabel.Location = new System.Drawing.Point(12, 9);
+            this.autoCheckLabel.Name = "autoCheckLabel";
+            this.autoCheckLabel.Size = new System.Drawing.Size(538, 50);
+            this.autoCheckLabel.TabIndex = 0;
+            resources.ApplyResources(this.autoCheckLabel, "autoCheckLabel");
             //
             // YesButton
             //
@@ -53,24 +52,24 @@
             this.YesButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.YesButton, "YesButton");
             //
-            // button1
+            // NoButton
             //
-            this.button1.DialogResult = System.Windows.Forms.DialogResult.No;
-            this.button1.Location = new System.Drawing.Point(323, 44);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(72, 23);
-            this.button1.TabIndex = 2;
-            this.button1.UseVisualStyleBackColor = true;
-            resources.ApplyResources(this.button1, "button1");
+            this.NoButton.Location = new System.Drawing.Point(323, 44);
+            this.NoButton.Size = new System.Drawing.Size(72, 23);
+            this.NoButton.DialogResult = System.Windows.Forms.DialogResult.No;
+            this.NoButton.Name = "NoButton";
+            this.NoButton.TabIndex = 2;
+            this.NoButton.UseVisualStyleBackColor = true;
+            resources.ApplyResources(this.NoButton, "NoButton");
             //
             // AskUserForAutoUpdatesDialog
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(562, 79);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.NoButton);
             this.Controls.Add(this.YesButton);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.autoCheckLabel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Icon = Properties.Resources.AppIcon;
             this.Name = "AskUserForAutoUpdatesDialog";
@@ -83,8 +82,8 @@
 
         #endregion
 
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label autoCheckLabel;
         private System.Windows.Forms.Button YesButton;
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button NoButton;
     }
 }

--- a/GUI/Dialogs/AskUserForAutoUpdatesDialog.resx
+++ b/GUI/Dialogs/AskUserForAutoUpdatesDialog.resx
@@ -118,8 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label1.Text" xml:space="preserve"><value>Do you wish for CKAN to automatically check for updates on start-up? (Can be changed later from Settings)</value></data>
+  <data name="autoCheckLabel.Text" xml:space="preserve"><value>Do you wish for CKAN to automatically check for updates on start-up? (Can be changed later from Settings)</value></data>
   <data name="YesButton.Text" xml:space="preserve"><value>Yes, check for updates</value></data>
-  <data name="button1.Text" xml:space="preserve"><value>No</value></data>
+  <data name="NoButton.Text" xml:space="preserve"><value>No</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Check for updates</value></data>
 </root>

--- a/GUI/Dialogs/NewUpdateDialog.Designer.cs
+++ b/GUI/Dialogs/NewUpdateDialog.Designer.cs
@@ -75,10 +75,9 @@ namespace CKAN
             //
             this.InstallUpdateButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.InstallUpdateButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.InstallUpdateButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.InstallUpdateButton.Location = new System.Drawing.Point(339, 277);
+            this.InstallUpdateButton.Location = new System.Drawing.Point(314, 277);
             this.InstallUpdateButton.Name = "InstallUpdateButton";
-            this.InstallUpdateButton.Size = new System.Drawing.Size(75, 23);
+            this.InstallUpdateButton.Size = new System.Drawing.Size(100, 23);
             this.InstallUpdateButton.TabIndex = 4;
             this.InstallUpdateButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.InstallUpdateButton, "InstallUpdateButton");
@@ -87,10 +86,9 @@ namespace CKAN
             //
             this.CancelUpdateButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelUpdateButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelUpdateButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelUpdateButton.Location = new System.Drawing.Point(258, 277);
+            this.CancelUpdateButton.Location = new System.Drawing.Point(208, 277);
             this.CancelUpdateButton.Name = "CancelUpdateButton";
-            this.CancelUpdateButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelUpdateButton.Size = new System.Drawing.Size(100, 23);
             this.CancelUpdateButton.TabIndex = 5;
             this.CancelUpdateButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.CancelUpdateButton, "CancelUpdateButton");

--- a/GUI/Localization/de-DE/AskUserForAutoUpdatesDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/AskUserForAutoUpdatesDialog.de-DE.resx
@@ -117,14 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="autoCheckLabel.Text" xml:space="preserve">
     <value>Möchtest du, dass CKAN beim Start automatisch nach Updates sucht?
 (Kann jederzeit in den Einstellungen geändert werden)</value>
   </data>
   <data name="YesButton.Text" xml:space="preserve">
     <value>Ja, suche nach Updates</value>
   </data>
-  <data name="button1.Text" xml:space="preserve">
+  <data name="NoButton.Text" xml:space="preserve">
     <value>Nein</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/fr-FR/AskUserForAutoUpdatesDialog.fr-FR.resx
+++ b/GUI/Localization/fr-FR/AskUserForAutoUpdatesDialog.fr-FR.resx
@@ -118,8 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label1.Text" xml:space="preserve"><value>Souhaitez-vous que CKAN vérifie automatiquement les mises à jour disponibles au démarrage? (Peut être modifié plus tard depuis les options)</value></data>
+  <data name="autoCheckLabel.Text" xml:space="preserve"><value>Souhaitez-vous que CKAN vérifie automatiquement les mises à jour disponibles au démarrage? (Peut être modifié plus tard depuis les options)</value></data>
   <data name="YesButton.Text" xml:space="preserve"><value>Oui, vérifier les mises à jour</value></data>
-  <data name="button1.Text" xml:space="preserve"><value>Non</value></data>
+  <data name="NoButton.Text" xml:space="preserve"><value>Non</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Vérifier les mises à jour</value></data>
 </root>

--- a/GUI/Localization/fr-FR/Main.fr-FR.resx
+++ b/GUI/Localization/fr-FR/Main.fr-FR.resx
@@ -142,7 +142,7 @@
   <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Sauvegarder la liste des mods installés...</value></data>
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Exporter modpack...</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Importer des &amp;mods téléchargés...</value></data>
-  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Auditionner les recommendations</value></data>
+  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Auditionner les recommandations</value></data>
   <data name="ExitToolButton.Text" xml:space="preserve"><value>&amp;Quitter</value></data>
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>Options</value></data>
   <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>Options CKAN</value></data>

--- a/GUI/Localization/fr-FR/NewUpdateDialog.fr-FR.resx
+++ b/GUI/Localization/fr-FR/NewUpdateDialog.fr-FR.resx
@@ -121,6 +121,6 @@
   <data name="label1.Text" xml:space="preserve"><value>Version:</value></data>
   <data name="VersionLabel.Text" xml:space="preserve"><value>v0.0.0</value></data>
   <data name="InstallUpdateButton.Text" xml:space="preserve"><value>Installer</value></data>
-  <data name="CancelUpdateButton.Text" xml:space="preserve"><value>Pas maintenant</value></data>
+  <data name="CancelUpdateButton.Text" xml:space="preserve"><value>Plus tard</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Une nouvelle version de CKAN est disponible</value></data>
 </root>

--- a/GUI/Localization/zh-CN/AskUserForAutoUpdatesDialog.zh-CN.resx
+++ b/GUI/Localization/zh-CN/AskUserForAutoUpdatesDialog.zh-CN.resx
@@ -118,8 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label1.Text" xml:space="preserve"><value>您希望CKAN在启动时自动检查更新吗？（可稍后在设置中修改）</value></data>
+  <data name="autoCheckLabel.Text" xml:space="preserve"><value>您希望CKAN在启动时自动检查更新吗？（可稍后在设置中修改）</value></data>
   <data name="YesButton.Text" xml:space="preserve"><value>是，检查更新</value></data>
-  <data name="button1.Text" xml:space="preserve"><value>否</value></data>
+  <data name="NoButton.Text" xml:space="preserve"><value>否</value></data>
   <data name="$this.Text" xml:space="preserve"><value>检查更新</value></data>
 </root>


### PR DESCRIPTION
Since this dialog only shows up on updating, I had no way to check if it worked.
When updating to 1.30, I noticed that the "not now" button wasn't big enough.
I made it bigger, and I shortened the text, but I don't know how to test my changes.