### PR TITLE
Suppress nightly debs with even builds, push release debs to s3 first

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Deploy CKAN + NetKAN
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   deploy:
@@ -14,6 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check version
+        id: check_version
+        run: |
+          VERSION=$(egrep '^\s*\#\#\s+v.*$' CHANGELOG.md | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-.*$//')
+          if [[ $VERSION =~ [13579]$ ]]
+          then
+            echo '::set-output name=odd_build::true'
+          else
+            echo '::set-output name=odd_build::false'
+          fi
+
       - name: Installing build dependencies
         run: apt-get update && apt-get install -y git make sed gzip fakeroot lintian dpkg-dev
       - name: Installing runtime dependencies
@@ -22,6 +34,7 @@ jobs:
         run: |
           curl -fsSL https://get.docker.com -o get-docker.sh
           sh get-docker.sh
+
       - name: Restore cache for _build/tools
         uses: actions/cache@v1
         with:
@@ -45,10 +58,12 @@ jobs:
 
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=Release
+
       - name: Build deb
         env:
           CODENAME: nightly
         run: ./build deb --configuration=Release --exclusive
+        if: ${{ steps.check_version.outputs.odd_build }}
       - name: Sign deb release
         env:
           CODENAME: nightly
@@ -57,7 +72,8 @@ jobs:
           echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
           ./build deb-sign --configuration=Release --exclusive
-        if: ${{ env.DEBIAN_PRIVATE_KEY }}
+        if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
+
       - name: Run tests
         run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
 
@@ -80,6 +96,7 @@ jobs:
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           ./build docker-metadata --exclusive
+
       - name: Push ckan.exe and netkan.exe to S3
         # Send ckan.exe and netkan.exe to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master
@@ -92,6 +109,7 @@ jobs:
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/repack/Release
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+
       - name: Push deb to S3
         # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master
@@ -104,7 +122,7 @@ jobs:
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/deb/apt-repo-root
           DEST_DIR: deb
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
       - name: Push Release file to S3
         uses: jakejarvis/s3-sync-action@master
         with:
@@ -116,7 +134,7 @@ jobs:
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/deb/apt-repo-dist
           DEST_DIR: deb/dists/nightly
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
 
       - name: Send Discord Notification
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Create Release Assets
 
 on:
   release:
-    types: [created]
+    types:
+      - created
 
 jobs:
   release:
@@ -18,26 +19,6 @@ jobs:
         run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq dpkg-dev
       - name: Installing runtime dependencies
         run: apt-get install -y xvfb
-      - name: Restore cache for _build/tools
-        uses: actions/cache@v1
-        with:
-          path: _build/tools
-          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
-      - name: Restore cache for _build/cake
-        uses: actions/cache@v1
-        with:
-          path: _build/cake
-          key: build-cake-${{ hashFiles('build.cake') }}
-      - name: Restore cache for _build/lib/nuget
-        uses: actions/cache@v1
-        with:
-          path: _build/lib/nuget
-          key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
-      - name: Restore cache for ~/.nuget/packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.nuget/packages
-          key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=Release
@@ -73,6 +54,32 @@ jobs:
           echo "::set-output name=rpm_version::$RPM_VERSION"
           DEB_VERSION=${VERSION}.$(date +'%g%j')
           echo "::set-output name=deb_version::$DEB_VERSION"
+      - name: Push deb to S3
+        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/deb/apt-repo-root
+          DEST_DIR: deb
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+      - name: Push Release file to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/deb/apt-repo-dist
+          DEST_DIR: deb/dists/stable
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+
       - name: Upload ckan.exe
         uses: actions/upload-release-asset@v1.0.1
         env:
@@ -118,31 +125,6 @@ jobs:
           asset_path: _build/out/AutoUpdater/Release/bin/AutoUpdater.exe
           asset_name: AutoUpdater.exe
           asset_content_type: application/vnd.microsoft.portable-executable
-      - name: Push deb to S3
-        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-root
-          DEST_DIR: deb
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
-      - name: Push Release file to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-dist
-          DEST_DIR: deb/dists/stable
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Send Discord Notification
         env:


### PR DESCRIPTION
## Problem

Upgrading the stable .deb to v1.30.0 isn't working:

```
The following packages will be upgraded:
  ckan
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 775 kB of archives.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable/main amd64 ckan all 1.30.0.21065 [775 kB]
Err:1 https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable/main amd64 ckan all 1.30.0.21065
  File has unexpected size (774308 != 774780). Mirror sync in progress? [IP: 52.218.184.25 443]
  Hashes of expected file:
   - SHA256:20bd6bbfe1132e3656e696f4e77bce8a5e0ae7e605563814b2f149ace96dbd0b
   - SHA1:24241c129cf0b4478706b430362568df35d55cd5 [weak]
   - MD5Sum:3bd7a5896c00e81b1bcd1ebe19c34909 [weak]
   - Filesize:774780 [weak]
E: Failed to fetch https://ksp-ckan.s3-us-west-2.amazonaws.com/deb/pool/ckan_1.30.0.21065_all.deb  File has unexpected size (774308 != 774780). Mirror sync in progress? [IP: 52.218.184.25 443]
   Hashes of expected file:
    - SHA256:20bd6bbfe1132e3656e696f4e77bce8a5e0ae7e605563814b2f149ace96dbd0b
    - SHA1:24241c129cf0b4478706b430362568df35d55cd5 [weak]
    - MD5Sum:3bd7a5896c00e81b1bcd1ebe19c34909 [weak]
    - Filesize:774780 [weak]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Unrelated, the caching steps in our cache work flow have decided that they don't want to run in release work flows:

![screenshot](https://cdn.discordapp.com/attachments/601455398553387008/817802611155271700/unknown.png)

## Cause

https://ksp-ckan.s3-us-west-2.amazonaws.com/deb/pool/ckan_1.30.0.21065_all.deb has 774308 bytes, but 
https://ksp-ckan.s3-us-west-2.amazonaws.com/deb/dists/stable/main/binary-amd64/Packages.gz says it should be 774780.

This happened because the deploy work flow to update the nightly build ran for v1.30.0 when 0376e0332f3815a0fc0e23329204bdab00b5dff5 was pushed, 2 minutes before the release work flow to update the stable build, so we ended up with the Packages.gz file from the stable build (of course) but the deb file from the nightly build.

(Something similar happened when #3304 and #3300 were merged, but we're not trying to fix that here.)

Trying to fix it after the fact by re-running the work flow didn't work, because it tried to upload assets to the release first, which GitHub rightfully didn't like.

## Changes

- Now the release work flow updates S3 before GitHub, so we can try re-doing the .deb if this happens again
- Now the deploy work flow only uploads deb files to S3 if the version ends in an odd digit, because even build numbers are for stable releases
- Now the caching steps are removed from the release work flow

Fixes the architectural side of #3309, since now only the release step would have updated S3 for a release. The current files for v1.30.0 won't be fixed by this, though, so we'll have to figure out a way to do that to close that issue.