### PR TITLE
Handle renamed modlist columns in sort list  gracefully

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -55,7 +55,16 @@ namespace CKAN
         {
             get
             {
-                return Main.Instance.configuration.SortColumns;
+                var configuration = Main.Instance.configuration;
+                // Make sure we don't return any column the GUI doesn't know about.
+                var unknownCols = configuration.SortColumns.Where(col => !ModGrid.Columns.Contains(col)).ToList();
+                foreach (var unknownCol in unknownCols)
+                {
+                    int index = configuration.SortColumns.IndexOf(unknownCol);
+                    configuration.SortColumns.RemoveAt(index);
+                    configuration.MultiSortDescending.RemoveAt(index);
+                }
+                return configuration.SortColumns;
             }
         }
 
@@ -1241,6 +1250,11 @@ namespace CKAN
             }
             for (int i = 0; i < sortColumns.Count; ++i)
             {
+                if (!ModGrid.Columns.Contains(sortColumns[i]))
+                {
+                    // Shouldn't be possible, but better safe than sorry.
+                    continue;
+                }
                 ModGrid.Columns[sortColumns[i]].HeaderCell.SortGlyphDirection = descending[i]
                     ? SortOrder.Descending : SortOrder.Ascending;
             }

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -155,7 +155,37 @@ namespace CKAN
             }
 
             configuration.path = path;
+            if (DeserializationFixes(configuration))
+            {
+                SaveConfiguration(configuration);
+            }
             return configuration;
+        }
+
+        /// <summary>
+        /// Apply fixes and migrations after deserialization.
+        /// </summary>
+        /// <param name="configuration">The current configuration to apply the fixes on</param>
+        /// <returns>A bool indicating whether something changed and the configuration should be saved to disk</returns>
+        private static bool DeserializationFixes(GUIConfiguration configuration)
+        {
+            bool needsSave = false;
+
+            // KSPCompatibility column got renamed to GameCompatibility
+            int kspCompatibilitySortIndex = configuration.SortColumns.IndexOf("KSPCompatibility");
+            if (kspCompatibilitySortIndex > -1)
+            {
+                configuration.SortColumns[kspCompatibilitySortIndex] = "GameCompatibility";
+                needsSave = true;
+            }
+            int kspCompatibilityHiddenIndex = configuration.HiddenColumnNames.IndexOf("KSPCompatibility");
+            if (kspCompatibilityHiddenIndex > -1)
+            {
+                configuration.HiddenColumnNames[kspCompatibilityHiddenIndex] = "GameCompatibility";
+                needsSave = true;
+            }
+
+            return needsSave;
         }
 
         private static void SaveConfiguration(GUIConfiguration configuration)


### PR DESCRIPTION
## Problem
#3223 renamed the `KSPCompatibility` column to `GameCompatibility`.
If you had the mod list sorted by this column (be it the only one or one of many) while upgrading from v1.29.2 to v1.30.0, the GUI crashes due to a NullReferenceException with a rather useless stacktrace:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Windows.Forms.Control.MarshaledInvoke(Control caller, Delegate method, Object[] args, Boolean synchronous)
   at System.Windows.Forms.Control.Invoke(Delegate method, Object[] args)
   at CKAN.ManageMods._UpdateModsList(Dictionary`2 old_modules)
   at System.Threading.Tasks.Task.Execute()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at CKAN.ManageMods.<UpdateModsList>d__91.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() 
```
Thankfully some users reported that the exception did no longer show up when removing the CKAN folder. This pointed to a problem with either the `GUIConfig.xml` or `registry.json`.

Trying out the `GUIConfig.xml` @Arkerthan subsequently posted, I could reproduce the issue (although on Linux it manifests itself in an endless loading screen, no exception shown anywhere). Some IDE magic revealed another stack trace:
```
System.NullReferenceException: Object reference not set to an instance of an object
  at CKAN.ManageMods.ApplyHeaderGlyphs () [0x00051] in CKAN/GUI/Controls/ManageMods.cs:1244 
  at CKAN.ManageMods._UpdateFilters () [0x0010b] in CKAN/GUI/Controls/ManageMods.cs:1007 
```
So the code path that throws is `_UpdateModsList()` -> `UpdateFilters()` -> the `Invoke` we see in the first stack trace -> `_UpdateFilters()` -> `ApplyHeaderGlyphs()`.

## Cause
In `ApplyHeaderGlyphs()` we try to set the sort direction glyph symbol. For this we get the actual column for each column name string in `sortColumns` (which comes from `Main.Instance.configuration.SortColumns`).
https://github.com/KSP-CKAN/CKAN/blob/76f656b99ef8120511053e3bd099a8ec86a7f29f/GUI/Controls/ManageMods.cs#L1244-L1245
However `ModGrid.Columns[sortColumns[i]]` is `null` if the column name is not known, which isn't for `KSPCompatibility` since it's now named `GameCompatibility`. Trying to access properties of it throws the `NullReferenceException`.

## Solution
Now we're triple safeguarding against this.
1) We apply migrations in `LoadConfiguration()`. If `KSPCompatibility` is in `SortColumns` or `HiddenColumnNames`, we rename it to `"GameCompatibility"`. This has the advantage that users don't loose their sorting setup (which we learned might be relatively complex after #3205).
2) Additionally, `ManageMods.sortColumns` now removes any unknown column names from `configuration.SortColumns`, and also removes them from `configuration.MultiSortDescending`. If we forget to write a migration for another rename, this should catch it. It's a bit more disruptive than  1) since you might loose one of the sort columns, but better than an exception.
3) This should never be possible with 2), but why not: `ApplyHeaderGlyphs()` just skips the columns if `ModGrid.Columns[sortColumns[i]] == null`. 

Fixes #3312 
**For a workaround until this gets released, see https://github.com/KSP-CKAN/CKAN/issues/3312#issuecomment-792339047**