### PR TITLE
Netkan errors and warnings for Harmony bundlers

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Validators\CraftsInShipsValidator.cs" />
     <Compile Include="Validators\DownloadVersionValidator.cs" />
     <Compile Include="Validators\HasIdentifierValidator.cs" />
+    <Compile Include="Validators\HarmonyValidator.cs" />
     <Compile Include="Validators\InstallsFilesValidator.cs" />
     <Compile Include="Validators\InstallValidator.cs" />
     <Compile Include="Validators\IsCkanModuleValidator.cs" />

--- a/Netkan/Validators/CkanValidator.cs
+++ b/Netkan/Validators/CkanValidator.cs
@@ -20,6 +20,7 @@ namespace CKAN.NetKAN.Validators
                 new MatchesKnownGameVersionsValidator(),
                 new ObeysCKANSchemaValidator(),
                 new KindValidator(),
+                new HarmonyValidator(downloader, moduleService),
                 new ModuleManagerDependsValidator(downloader, moduleService),
                 new PluginCompatibilityValidator(downloader, moduleService),
                 new CraftsInShipsValidator(downloader, moduleService),

--- a/Netkan/Validators/HarmonyValidator.cs
+++ b/Netkan/Validators/HarmonyValidator.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+using ICSharpCode.SharpZipLib.Zip;
+using log4net;
+
+using CKAN.Games;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Services;
+
+namespace CKAN.NetKAN.Validators
+{
+    internal sealed class HarmonyValidator : IValidator
+    {
+        public HarmonyValidator(IHttpService http, IModuleService moduleService)
+        {
+            _http          = http;
+            _moduleService = moduleService;
+        }
+
+        public void Validate(Metadata metadata)
+        {
+            JObject    json = metadata.Json();
+            CkanModule mod  = CkanModule.FromJson(json.ToString());
+            // The Harmony2 module is allowed to install a Harmony DLL;
+            // anybody else must have "provides":["Harmony1"] to do so
+            if (!mod.IsDLC && mod.identifier != "Harmony2")
+            {
+                // Need to peek at the mod's files
+                var package = _http.DownloadModule(metadata);
+                if (!string.IsNullOrEmpty(package))
+                {
+                    ZipFile zip = new ZipFile(package);
+                    GameInstance inst = new GameInstance(new KerbalSpaceProgram(), "/", "dummy", new NullUser());
+
+                    var harmonyDLLs = _moduleService.GetPlugins(mod, zip, inst)
+                        .Select(instF => instF.source.Name)
+                        .Where(f => f.IndexOf("Harmony", StringComparison.InvariantCultureIgnoreCase) != -1)
+                        .ToList();
+                    bool bundlesHarmony   = harmonyDLLs.Any();
+                    bool providesHarmony1 = mod.ProvidesList.Contains("Harmony1");
+                    if (bundlesHarmony && !providesHarmony1)
+                    {
+                        throw new Kraken($"Harmony DLL found at {string.Join(", ", harmonyDLLs)}, but Harmony1 is not in the provides list");
+                    }
+                    else if (providesHarmony1 && !bundlesHarmony)
+                    {
+                        Log.Warn("Harmony1 provided by module that doesn't install a Harmony DLL, consider removing from provides list");
+                    }
+                }
+            }
+        }
+
+        private readonly IHttpService   _http;
+        private readonly IModuleService _moduleService;
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(HarmonyValidator));
+    }
+}


### PR DESCRIPTION
## Background

See KSP-CKAN/NetKAN#8288, we are attempting to prevent mods that bundle conflicting versions of Harmony from clashing with each other.

### Harmony 1

Before that PR, all Harmony-based mods in CKAN bundled Harmony 1, and CKAN installed them as-is. They may continue to do so, but only if they are appropriately flagged in the metadata:

```json
    "provides": [ "Harmony1" ],
    "x_netkan_staging": true,
    "x_netkan_staging_reason": "Bundles Harmony. Please check the DLL's version, and if it's 2 or later, remove the provides and add a depends on Harmony2.",
```

A mod with this metadata will be treated as incompatible with `Harmony2`, and each time it releases a new version, it will be staged for manual review so we can check whether the author has upgraded to Harmony 2.

### Harmony 2

Mods that use Harmony 2 will share a common dependency on the new `Harmony2` module, and any bundled copies they may include will be filtered out:

```json
    "depends": [
        { "name": "Harmony2" }
    ],
    "install": [ {
        "filter_regexp": [ "0Harmony.*\\.dll" ]
    } ]
```

## Problem

The remaining gap in this strategy is that any mod author might decide to add Harmony to an existing mod at any time, and we would be none the wiser. There may even be some existing ones that we didn't catch in the first round of updates.

## Changes

Now if a mod installs a DLL with "Harmony" in its name and it _doesn't_ provide Harmony1, the inflator emits an error, to prevent any newly bundled files from causing conflicts in user installs. These must then be inspected manually to determine which version of Harmony is bundled, and then the appropriate solution will be applied.

Now if a mod _does_ provide Harmony1 but doesn't seem to bundle it, the inflator emits a warning.

The `Harmony2` module is exempted from these checks.