### PR TITLE
Print path of unused version file

### DIFF
--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CKAN.NetKAN.Sources.Avc;
 using ICSharpCode.SharpZipLib.Zip;
@@ -7,6 +8,7 @@ namespace CKAN.NetKAN.Services
 {
     internal interface IModuleService
     {
+        Tuple<ZipEntry, bool> FindInternalAvc(CkanModule module, ZipFile zipfile, string internalFilePath);
         AvcVersion GetInternalAvc(CkanModule module, string filePath, string internalFilePath = null);
         JObject GetInternalCkan(string filePath);
         bool HasInstallableFiles(CkanModule module, string filePath);


### PR DESCRIPTION
## Motivation

The "$vref absent, version file present" errors are hard to monitor because many of them are false positives:

http://status.ksp-ckan.space/

![image](https://user-images.githubusercontent.com/1559108/111886710-b0a48000-89c7-11eb-9c04-7eb9de170dac.png)

(x44 lines)

## Causes

Many of these are caused when a mod with no version file of its own bundles a mod with a version file. In such cases it would be incorrect to add a `$vref` to the bundling mod's metadata. Unfortunately the only way we can determine that at present is to inspect the ZIP manually.

The only public interface for finding version files is `IModuleService.GetInternalAvc`, which just returns either null or the fully parsed AVC object (or throws an exception). It doesn't tell us where it found the file or whether it would even be installed by this module (non-installable version files are checked as a fallback for cases where multiple modules share the same download).

## Changes

- Now version files that wouldn't be installed do not trigger this warning. This will remove many false positives from the list as bundling a mod will no longer cause it. Modules sharing downloads may be wrongly excluded from the warning now, but hopefully the maintainers setting up such modules will be smart enough to think of it at creation.
- Now the warning includes the path of the version file.

  ```
  $ ../CKAN/_build/netkan.exe NetKAN/UnKerballedStart.netkan
  4863 [1] WARN CKAN.NetKAN.Validators.VrefValidator (null) - $vref absent, version file present: UnKerballedStart-1.2.0/GameData/UnKerballedStart/UnKerballedStart.version
  
  $ ../CKAN/_build/netkan.exe NetKAN/RadioFreeKerbin.netkan
  1612 [1] WARN CKAN.NetKAN.Validators.VrefValidator (null) - $vref absent, version file present: GameData/RadioFreeKerbin/RadioFreeKerbin.version
  ```

To make this happen, the version file selection logic from `GetInternalAvc` is split into a separate `FindInternalAvc` function that returns the matching `ZipEntry` and a `bool` that's true if the file would be installed, wrapped in a `Tuple`. The `VrefValidator` now calls this function instead of `GetInternalAvc`, and adds `ZipEntry.Name` to the warning, which is only printed if the file would be installed by this module.

This will prune many of the false positives out of the list of warnings, and the remaining ones will be easier to manage because we will be able to guess much more easily whether it's a real version file by looking at the path.