### PR TITLE
Exclude version files with syntax errors from warnings

### DIFF
--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -284,7 +284,7 @@ namespace CKAN.NetKAN.Services
         /// <summary>
         /// Returns an AVC object for the given file in the archive, if any.
         /// </summary>
-        private static AvcVersion GetInternalAvc(ZipFile zipfile, ZipEntry avcEntry)
+        public static AvcVersion GetInternalAvc(ZipFile zipfile, ZipEntry avcEntry)
         {
             if (avcEntry == null)
             {

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -41,12 +41,17 @@ namespace CKAN.NetKAN.Validators
                     bool   installable = false;
                     try
                     {
-                        // Pass a regex that matches anything so it returns the first if found
                         using (var zipfile = new ZipFile(zipFilePath))
                         {
+                            // Pass a regex that matches anything so it returns the first if found
                             var verFileAndInstallable = _moduleService.FindInternalAvc(mod, zipfile, ".");
-                            path        = verFileAndInstallable?.Item1.Name;
-                            installable = verFileAndInstallable?.Item2 ?? false;
+                            if (verFileAndInstallable != null)
+                            {
+                                // This will throw if there's a syntax error
+                                var avc = ModuleService.GetInternalAvc(zipfile, verFileAndInstallable.Item1);
+                                path        = verFileAndInstallable.Item1.Name;
+                                installable = verFileAndInstallable.Item2;
+                            }
                         }
                     }
                     catch (BadMetadataKraken)
@@ -60,7 +65,6 @@ namespace CKAN.NetKAN.Validators
                         // This shouldn't cause the inflation to fail, but it does deprive us of the path.
                         path = "";
                         installable = false;
-                        Log.Warn(k.Message);
                     }
 
                     bool hasVersionFile = (path != null);


### PR DESCRIPTION
## Background

In #3327 we eliminated some false positives for the "vref absent" warnings.

KSP-CKAN/NetKAN#8429 attempted to address the remaining warnings, which revealed that they were mostly version files with syntax errors.

## Motivation

We can't use a version file with a syntax error, so those are still false positives in a sense, but in case one of those mods releases a new version with a fixed syntax error, it would be nice to know about it.

## Changes

Now we try to parse the version file, and if there's a syntax error, we don't print the warning. This will cut down on non-actionable warnings on the status page.

If the syntax error ever gets fixed, the warning will come back, which will trigger the usual Discord notification.