### PR TITLE
Switch from outdated SharpZipLib.Patched to newer SharpZipLib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ StyleCop.Cache
 *.ncrunchsolution
 *.pyc
 node_modules/
+venv/
 
 # Build results
 [Dd]ebug/

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="ICSharpCode.SharpZipLib.Patched" Version="0.86.5.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.3.103.64" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.102.31" />
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="ICSharpCode.SharpZipLib.Patched" Version="0.86.5.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Namotion.Reflection" Version="1.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="ICSharpCode.SharpZipLib.Patched" Version="0.86.5.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,4 +1,5 @@
 click
+exitstatus
 gitpython
 jsonschema
 pygithub


### PR DESCRIPTION
## Motivation
https://github.com/KSP-CKAN/NetKAN/issues/8425 and https://github.com/KSP-CKAN/NetKAN/issues/8315 show some weird errors when trying to extract certain zips with special characters on Windows systems with CJK locales.
_Maybe_ this is a bug of `SharpZipLib`, and _maybe_ it is already fixed in a newer versions. It's a total stab in the dark, but worth a try. I've asked affected users to try a debug build with an updated version of the package, we should know when we get an answer.

In any case, there have been some improvements to that library in the releases since, the usual performance enhancements, and support for BZip2 compression.

We have been using a "Patched" version of this library, which has been deprecated now. Its [NuGet page](https://www.nuget.org/packages/ICSharpCode.SharpZipLib.Patched) doesn't give any details on what it's patching, but it seems to be related to:
* https://github.com/KSP-CKAN/CKAN/issues/221
* https://github.com/KSP-CKAN/CKAN/pull/222
* https://github.com/pjf/SharpZipLib/commit/8ec3e47283b2c201474f731a52b8c752c5127e2e
The fix is applied upstream since v1.0.0-rc1:
* https://github.com/icsharpcode/SharpZipLib/pull/53


## Changes
Switch to the upstream SharpZipLib, v1.3.1. I haven't seen any breaking changes, and mod installation and inflation still works perfectly fine in my testing.

Add `venv/` folders to `.gitignore` - I have one inside `bin/` for the Python scripts there.

Add `exitstatus` to `bin/requirements.txt`. For some reason I didn't catch the missing dependency during the PRs for the `ckan-merge-pr.py`.

(Gonna give this the "Enhancement" flair for the time being and not say it closes the issue https://github.com/KSP-CKAN/NetKAN/issues/8425, since we don't know for sure yet)