### PR TITLE
Tell user if instance addition fails

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -381,7 +381,7 @@ Do you wish to reinstall now?", sb)))
                 using (GZipInputStream gzipStream = new GZipInputStream(inputStream))
                 {
                     // Create a handle for the tar stream.
-                    using (TarInputStream tarStream = new TarInputStream(gzipStream))
+                    using (TarInputStream tarStream = new TarInputStream(gzipStream, Encoding.UTF8))
                     {
                         TarEntry entry;
                         while ((entry = tarStream.GetNextEntry()) != null)

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -108,7 +108,10 @@ namespace CKAN
             {
                 _user.RaiseError(Properties.Resources.ManageGameInstancesNotValid,
                     new object[] { k.path });
-                return;
+            }
+            catch (Exception exc)
+            {
+                _user.RaiseError(exc.Message);
             }
         }
 

--- a/Netkan/Validators/VrefValidator.cs
+++ b/Netkan/Validators/VrefValidator.cs
@@ -59,7 +59,7 @@ namespace CKAN.NetKAN.Validators
                         // This means the install stanzas don't match any files.
                         // That's not our problem; someone else will report it.
                     }
-                    catch (Kraken k)
+                    catch (Kraken)
                     {
                         // If FindInternalAvc throws anything else, then there's a version file with a syntax error.
                         // This shouldn't cause the inflation to fail, but it does deprive us of the path.


### PR DESCRIPTION
## Problem

If a user tries to add a game instance for which they lack filesystem write privileges, it fails silently, and an exception appears in the terminal:

```
System.UnauthorizedAccessException: Access to the path '/ram/Fake-1.11.1/CKAN' is denied. ---> System.IO.IOException: Keine Berechtigung
--- End of inner exception stack trace ---
at System.IO.FileSystem.CreateDirectory (System.String fullPath) [0x00191] in <673b2a9c49de4736b9b01249f8d6d6b1>:0
at System.IO.Directory.CreateDirectory (System.String path) [0x0002c] in <673b2a9c49de4736b9b01249f8d6d6b1>:0
at ChinhDo.Transactions.FileManager.TxFileManager.CreateDirectory (System.String path) [0x0001b] in <bd256a5f4bd9434c90d5e776dca9de7b>:0
at CKAN.GameInstance.SetupCkanDirectories (System.Boolean scan) [0x0006e] in <bd256a5f4bd9434c90d5e776dca9de7b>:0
at CKAN.GameInstance..ctor (CKAN.Games.IGame game, System.String gameDir, System.String name, CKAN.IUser user, System.Boolean scan) [0x0007e] in <bd256a5f4bd9434c90d5e776dca9de7b>:0
at CKAN.GameInstanceManager.AddInstance (System.String path, System.String name, CKAN.IUser user) [0x00053] in <bd256a5f4bd9434c90d5e776dca9de7b>:0
at CKAN.ManageGameInstancesDialog.AddToCKANMenuItem_Click (System.Object sender, System.EventArgs e) [0x0005f] in <bd256a5f4bd9434c90d5e776dca9de7b>:0
```

Most users don't look at the terminal, so this is confusing.

## Cause

We try to create the `<KSP>/CKAN` folder, which fails, and we don't catch the exception.

## Changes

Now if an exception is thrown when we try to add an instance, we display the exception's `Message` in an error popup. This way the user should have some clue why it failed.

Also fixed two minor compiler warnings to do with `TarInputStream` wanting an encoding parameter and a `catch` block not using a parameter.

Fixes #3330.