### PR TITLE
Reset cache dir to default if creation fails

### DIFF
--- a/Tests/Core/CKANPathUtils.cs
+++ b/Tests/Core/CKANPathUtils.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace Tests.Core
 {
     [TestFixture]
-    public class CKANPathUtils
+    public class CKANPathUtilsTests
     {
         [Test]
         public void NormalizePath()

--- a/Tests/Core/GameInstance.cs
+++ b/Tests/Core/GameInstance.cs
@@ -9,7 +9,7 @@ using CKAN.Games;
 namespace Tests.Core
 {
     [TestFixture]
-    public class KSP
+    public class GameInstanceTests
     {
         private CKAN.GameInstance ksp;
         private string ksp_dir;

--- a/Tests/Core/GameInstanceManager.cs
+++ b/Tests/Core/GameInstanceManager.cs
@@ -10,7 +10,7 @@ using CKAN.Games;
 
 namespace Tests.Core
 {
-    [TestFixture] public class KSPManagerTests
+    [TestFixture] public class GameInstanceManagerTests
     {
         private DisposableKSP tidy;
         private const string nameInReg = "testing";
@@ -265,12 +265,13 @@ namespace Tests.Core
         {
             using (var tidy2 = new DisposableKSP())
             {
-                cfg.Instances.Add(new Tuple<string, string, string>("tidy2",tidy2.KSP.GameDir(), "KSP"));
-                manager.LoadInstancesFromRegistry();
-                manager.ClearAutoStart();
-                Assert.That(manager.GetPreferredInstance(), Is.Null);
+                cfg.Instances.Add(new Tuple<string, string, string>("tidy2", tidy2.KSP.GameDir(), "KSP"));
+                // Make a new manager with the updated config
+                var multiMgr = new GameInstanceManager(new NullUser(), cfg);
+                multiMgr.ClearAutoStart();
+                Assert.That(multiMgr.GetPreferredInstance(), Is.Null);
+                multiMgr.Dispose();
             }
-
         }
 
         [Test]


### PR DESCRIPTION
## Problem

If the download cache folder disappears, and the user can't write to its previous location anymore, CKAN refuses to start:

![image](https://user-images.githubusercontent.com/1559108/112766167-0c8e8a80-9000-11eb-84aa-873ca9d29a96.png)

## Cause

We try to create the cache path at startup to handle onboarding for new users and users upgrading to the version of CKAN after the cache was unified. `Directory.CreateDirectory` throws if this fails, which mostly makes sense because we can't really operate without a valid download cache.

Note that this happens in the CmdLine startup code before we attempt to load GUI, so improving the error message UI isn't a viable option.

## Changes

Now if the configured cache path doesn't exist and we can't create it, we revert it to the default setting and try again. This will work seamlessly if the only thing that's happened is that the user's name has changed, because the default setting will always contain the current user name and should always be creatable. If some other problem blocks the second `CreateDirectory` attempt, we will still print the exception as before so that problem can be diagnosed.

Also a bunch of references to the Windows registry in function names and comments have been removed to reduce confusion. And some test files and code have been multi-gamed (KSP → GameInstance). And a few public functions are refactored as private.

Fixes #3333.