### PR TITLE
Replace repo-reinst with kraken, handle in UIs

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -57,6 +57,10 @@ namespace CKAN.CmdLine
                     UpdateRepository(ksp, options.repo);
                 }
             }
+            catch (ReinstallModuleKraken rmk)
+            {
+                Upgrade.UpgradeModules(manager, user, ksp, false, rmk.Modules);
+            }
             catch (MissingCertificateKraken kraken)
             {
                 // Handling the kraken means we have prettier output.

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -178,7 +178,7 @@ namespace CKAN.CmdLine
         }
 
         /// <summary>
-        /// Upgrade some modules by their CkanModules
+        /// Upgrade some modules by their identifier and (optional) version
         /// </summary>
         /// <param name="manager">Game instance manager to use</param>
         /// <param name="user">IUser object for output</param>

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 ﻿using System.Collections.Generic;
+using System.Transactions;
 using log4net;
 using CKAN.Versioning;
 
@@ -83,7 +84,6 @@ namespace CKAN.CmdLine
 
             try
             {
-                HashSet<string> possibleConfigOnlyDirs = null;
                 var regMgr = RegistryManager.Instance(ksp);
                 var registry = regMgr.registry;
                 if (options.upgrade_all)
@@ -119,13 +119,12 @@ namespace CKAN.CmdLine
                                 mod.Key);
                         }
                     }
-
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(to_upgrade, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr, true, true);
+                    UpgradeModules(manager, User, ksp, true, to_upgrade);
                 }
                 else
                 {
                     Search.AdjustModulesCase(ksp, options.modules);
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Upgrade(options.modules, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
+                    UpgradeModules(manager, User, ksp, options.modules);
                 }
                 User.RaiseMessage("");
             }
@@ -160,5 +159,80 @@ namespace CKAN.CmdLine
 
             return Exit.OK;
         }
+
+        /// <summary>
+        /// Upgrade some modules by their CkanModules
+        /// </summary>
+        /// <param name="manager">Game instance manager to use</param>
+        /// <param name="user">IUser object for output</param>
+        /// <param name="ksp">Game instance to use</param>
+        /// <param name="modules">List of modules to upgrade</param>
+        public static void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance ksp, bool ConfirmPrompt, List<CkanModule> modules)
+        {
+            UpgradeModules(manager, user, ksp,
+                (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs) =>
+                    installer.Upgrade(modules, downloader,
+                        ref possibleConfigOnlyDirs, regMgr, true, true, ConfirmPrompt),
+                m => modules.Add(m)
+            );
+        }
+
+        /// <summary>
+        /// Upgrade some modules by their CkanModules
+        /// </summary>
+        /// <param name="manager">Game instance manager to use</param>
+        /// <param name="user">IUser object for output</param>
+        /// <param name="ksp">Game instance to use</param>
+        /// <param name="identsAndVersions">List of identifier[=version] to upgrade</param>
+        public static void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance ksp, List<string> identsAndVersions)
+        {
+            UpgradeModules(manager, user, ksp,
+                (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs) =>
+                    installer.Upgrade(identsAndVersions, downloader,
+                        ref possibleConfigOnlyDirs, regMgr, true),
+                m => identsAndVersions.Add(m.identifier)
+            );
+        }
+
+        // System.Action<ref T> isn't allowed
+        private delegate void AttemptUpgradeAction(ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs);
+
+        private static void UpgradeModules(
+            GameInstanceManager manager, IUser user, CKAN.GameInstance ksp,
+            AttemptUpgradeAction attemptUpgradeCallback,
+            System.Action<CkanModule> addUserChoiceCallback)
+        {
+            using (TransactionScope transact = CkanTransaction.CreateTransactionScope()) {
+                var installer  = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
+                var downloader = new NetAsyncModulesDownloader(user, manager.Cache);
+                var regMgr     = RegistryManager.Instance(ksp);
+                HashSet<string> possibleConfigOnlyDirs = null;
+                bool done = false;
+                while (!done)
+                {
+                    try
+                    {
+                        attemptUpgradeCallback?.Invoke(installer, downloader, regMgr, ref possibleConfigOnlyDirs);
+                        transact.Complete();
+                        done = true;
+                    }
+                    catch (TooManyModsProvideKraken k)
+                    {
+                        int choice = user.RaiseSelectionDialog(
+                            $"Choose a module to provide {k.requested}:",
+                            k.modules.Select(m => $"{m.identifier} ({m.name})").ToArray());
+                        if (choice < 0)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            addUserChoiceCallback?.Invoke(k.modules[choice]);
+                        }
+                    }
+                }
+            }
+        }
+
     }
 }

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -197,6 +197,17 @@ namespace CKAN.CmdLine
         // System.Action<ref T> isn't allowed
         private delegate void AttemptUpgradeAction(ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs);
 
+        /// <summary>
+        /// The core of the module upgrading logic, with callbacks to
+        /// support different input formats managed by the calling code.
+        /// Handles transactions, creating commonly required objects,
+        /// looping logic, prompting for TooManyModsProvideKraken resolution.
+        /// </summary>
+        /// <param name="manager">Game instance manager to use</param>
+        /// <param name="user">IUser object for output</param>
+        /// <param name="ksp">Game instance to use</param>
+        /// <param name="attemptUpgradeCallback">Function to call to try to perform the actual upgrade, may throw TooManyModsProvideKraken</param>
+        /// <param name="addUserChoiceCallback">Function to call when the user has requested a new module added to the change set in response to TooManyModsProvideKraken</param>
         private static void UpgradeModules(
             GameInstanceManager manager, IUser user, CKAN.GameInstance ksp,
             AttemptUpgradeAction attemptUpgradeCallback,

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -66,14 +66,14 @@ namespace CKAN.ConsoleUI {
                             plan.Remove.Clear();
                         }
                         NetAsyncModulesDownloader dl = new NetAsyncModulesDownloader(this, manager.Cache);
-                        if (plan.Upgrade.Count > 0) {
-                            inst.Upgrade(plan.Upgrade, dl, ref possibleConfigOnlyDirs, regMgr);
-                            plan.Upgrade.Clear();
-                        }
                         if (plan.Install.Count > 0) {
                             List<CkanModule> iList = new List<CkanModule>(plan.Install);
                             inst.InstallList(iList, resolvOpts, regMgr, ref possibleConfigOnlyDirs, dl);
                             plan.Install.Clear();
+                        }
+                        if (plan.Upgrade.Count > 0) {
+                            inst.Upgrade(plan.Upgrade, dl, ref possibleConfigOnlyDirs, regMgr);
+                            plan.Upgrade.Clear();
                         }
                         if (plan.Replace.Count > 0) {
                             inst.Replace(AllReplacements(plan.Replace), resolvOpts, dl, ref possibleConfigOnlyDirs, regMgr, true);

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -435,6 +435,12 @@ namespace CKAN.ConsoleUI {
                         manager.Cache,
                         ps
                     );
+                } catch (ReinstallModuleKraken rmk) {
+                    ChangePlan reinstPlan = new ChangePlan();
+                    foreach (CkanModule m in rmk.Modules) {
+                        reinstPlan.ToggleUpgrade(m);
+                    }
+                    LaunchSubScreen(theme, new InstallScreen(manager, reinstPlan, debug));
                 } catch (Exception ex) {
                     // There can be errors while you re-install mods with changed metadata
                     ps.RaiseError(ex.Message + ex.StackTrace);

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -968,7 +968,6 @@ namespace CKAN
         public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool enforceConsistency = true, bool resolveRelationships = false, bool ConfirmPrompt = true)
         {
             modules = modules.Memoize();
-            User.RaiseMessage("About to upgrade:\r\n");
 
             if (resolveRelationships)
             {
@@ -981,6 +980,8 @@ namespace CKAN
                 );
                 modules = resolver.ModList();
             }
+
+            User.RaiseMessage("About to upgrade:\r\n");
 
             // Our upgrade involves removing everything that's currently installed, then
             // adding everything that needs installing (which may involve new mods to

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -210,40 +210,7 @@ You should reinstall them in order to preserve consistency with the repository.
 
 Do you wish to reinstall now?", sb)))
             {
-                ModuleInstaller installer = ModuleInstaller.GetInstance(ksp, cache, new NullUser());
-                // New upstream metadata may break the consistency of already installed modules
-                // e.g. if user installs modules A and B and then later up A is made to conflict with B
-                // This is perfectly normal and shouldn't produce an error, therefore we skip enforcing
-                // consistency. However, we will show the user any inconsistencies later on.
-
-                // Do each changed module one at a time so a failure of one doesn't cause all the others to fail
-                foreach (CkanModule mod in metadataChanges)
-                {
-                    try
-                    {
-                        HashSet<string> possibleConfigOnlyDirs = null;
-                        installer.Upgrade(
-                            new CkanModule[] { mod },
-                            new NetAsyncModulesDownloader(new NullUser(), cache),
-                            ref possibleConfigOnlyDirs,
-                            registry_manager,
-                            enforceConsistency: false,
-                            resolveRelationships: true
-                        );
-                    }
-                    // Thrown when a dependency couldn't be satisfied
-                    catch (ModuleNotFoundKraken)
-                    {
-                        log.WarnFormat("Skipping installation of {0} due to relationship error.", mod.identifier);
-                        user.RaiseMessage("Skipping installation of {0} due to relationship error.", mod.identifier);
-                    }
-                    // Thrown when a conflicts relationship is violated
-                    catch (InconsistentKraken)
-                    {
-                        log.WarnFormat("Skipping installation of {0} due to relationship error.", mod.identifier);
-                        user.RaiseMessage("Skipping installation of {0} due to relationship error.", mod.identifier);
-                    }
-                }
+                throw new ReinstallModuleKraken(metadataChanges);
             }
         }
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -582,4 +582,17 @@ namespace CKAN
             this.instance = instance;
         }
     }
+
+    public class ReinstallModuleKraken : Kraken
+    {
+        public readonly List<CkanModule> Modules;
+
+        public ReinstallModuleKraken(List<CkanModule> modules)
+            : base(string.Format("Metadata changed, reinstallation recommended: {0}",
+                string.Join(", ", modules)))
+        {
+            Modules = modules;
+        }
+    }
+
 }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -189,21 +189,21 @@ namespace CKAN
                             processSuccessful = true;
                         }
                     }
-                    if (toUpgrade.Count > 0)
-                    {
-                        processSuccessful = false;
-                        if (!installCanceled)
-                        {
-                            installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager, true, true, false);
-                            processSuccessful = true;
-                        }
-                    }
                     if (toInstall.Count > 0)
                     {
                         processSuccessful = false;
                         if (!installCanceled)
                         {
                             installer.InstallList(toInstall, opts.Value, registry_manager, ref possibleConfigOnlyDirs, downloader, false);
+                            processSuccessful = true;
+                        }
+                    }
+                    if (toUpgrade.Count > 0)
+                    {
+                        processSuccessful = false;
+                        if (!installCanceled)
+                        {
+                            installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager, true, true, false);
                             processSuccessful = true;
                         }
                     }


### PR DESCRIPTION
## Background

When you refresh the registry, if the metadata for one of your installed modules has been changed upstream, CKAN will ask whether you want to reinstall those modules, and if you say Yes, it will reinstall them.

```
The following mods have had their metadata changed since last update:

- Buffalo v2.9.0
- WildBlueTools v1.81.5
- ExtraPlanetaryLaunchpads 6.8.3.0
- ClassicStockResources v1.1.4

You should reinstall them in order to preserve consistency with the repository.

Do you wish to reinstall now?
```

## Problems

If one of your installed modules has been updated to have a new dependency on a virtual module, the reinstall fails:

```
Failed to connect to repository. Exception: Too many mods provide Buffalo-PlayMode:
* Buffalo-PlayMode-CRP v2.10.2
* Buffalo-PlayMode-ClassicStock v2.10.2
* WildBlue-PlayMode-Pristine v1.82.1
* WildBlue-PlayMode-Simplified v1.82.1
* WildBlue-PlayMode-USI v1.0.0.2
```

## Causes

`Repo.HandleModuleChanges` creates its own `ModuleInstaller` to try to do the reinstall.

When a dependency on a virtual module is found, `ModuleInstaller` (via other classes) throws `TooManyModsProvideKraken`. The UI is supposed to catch this, prompt the user, add the module they chose to the change set, and try again. However, this is impossible in the case of a repo-reinstall, because the UI does not know what changes `Repo.HandleModuleChanges` was attempting to make and cannot retry the repo update to fix it.

## Changes

Now instead of initiating a half-hearted attempt at doing a reinstall itself, `Repo.HandleModuleChanges` throws a new `ReinstallModulesKraken` to instruct the UI-specific calling code to reinstall the given modules. Cmdline, ConsoleUI, and GUI are updated to catch this exception and launch into their upgrade flows for the given modules.

Now ConsoleUI and GUI perform upgrades after installs, so the installs (which contain the user's choice of virtual module providers) can satisfy dependencies needed by the upgrades.

As a side fix, Cmdline's `ckan upgrade` command is updated to handle prompting for virtual module providers (in a shared function also now called by the repo update code as needed).

Fixes #1889.
Fixes #3335.