### PR TITLE
Fix crash when overwriting manually installed files

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -485,8 +485,6 @@ namespace CKAN
                 }
                 bytesChecked += bytesFrom1;
             }
-            // Same bytes, they're equal.
-            return true;
         }
 
         /// <summary>

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -458,10 +458,16 @@ namespace CKAN
             const int bufLen = 1024;
             byte[] bytes1 = new byte[bufLen];
             byte[] bytes2 = new byte[bufLen];
-            for (int bytesChecked = 0; bytesChecked < s1.Length; )
+            int bytesChecked = 0;
+            while (true)
             {
                 int bytesFrom1 = s1.Read(bytes1, 0, bufLen);
                 int bytesFrom2 = s2.Read(bytes2, 0, bufLen);
+                if (bytesFrom1 == 0 && bytesFrom2 == 0)
+                {
+                    // Boths streams finished, all bytes are equal
+                    return true;
+                }
                 if (bytesFrom1 != bytesFrom2)
                 {
                     // One ended early, not equal.


### PR DESCRIPTION
## Problem

If you try to overwrite a manually installed file with the current dev build, an unhandled exception is thrown:

```
Unhandled Exception: System.NotSupportedException: InflaterInputStream Length is not supported
   at ICSharpCode.SharpZipLib.Zip.Compression.Streams.InflaterInputStream.get_Length()
   at CKAN.ModuleInstaller.StreamsEqual(Stream s1, Stream s2)
```

## Cause

icsharpcode/SharpZipLib#84 changed the zip lib to throw an exception if you ask it for the length of a file in a ZIP. Before that I think it would have returned the correct length, because `ModuleInstaller.StreamsEqual` correctly reported whether files were the same.

We upgraded to that version of the lib in #3329, so users are not yet affected by this.

## Changes

Now `ModuleInstaller.StreamsEqual` compares its input streams without checking their lengths.

Fixes #3348.