### PR TITLE
Use git cmd to add CHANGELOG.md in merge script

### DIFF
--- a/bin/ckan-merge-pr.py
+++ b/bin/ckan-merge-pr.py
@@ -101,7 +101,8 @@ class CkanPullRequest:
         repo.git.merge(branch, no_commit=True, no_ff=True)
         repo.prepend_line(repo.changelog_path(), self.changelog_entry())
         repo.user_edit_file(repo.changelog_path())
-        repo.index.add([repo.changelog_path().as_posix()])
+        # repo.index.add() doesn't respect core.autocrlf
+        repo.git.add(str(repo.changelog_path()))
         # repo.index.commit doesn't properly resolve a merge started via repo.git.merge
         repo.git.commit(m=self.merge_commit_message())
         return True


### PR DESCRIPTION
## Problems
Initially I only wanted to fix this one:
```
$ python bin/ckan-merge-pr.py 3340
Fetching origin...
Fetching https://github.com/gsantos9489/CKAN.git PTBR_Translation...
Traceback (most recent call last):
  File "C:\git-reps\CKAN\bin\ckan-merge-pr.py", line 122, in <module>
    merge_pr()
  File "C:\git-reps\CKAN\bin\venv\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "C:\git-reps\CKAN\bin\venv\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "C:\git-reps\CKAN\bin\venv\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\git-reps\CKAN\bin\venv\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "C:\git-reps\CKAN\bin\ckan-merge-pr.py", line 118, in merge_pr
    if ckpr.merge_into(ckr)
  File "C:\git-reps\CKAN\bin\ckan-merge-pr.py", line 104, in merge_into
    repo.index.add([repo.changelog_path().as_posix()])
  File "C:\git-reps\CKAN\bin\venv\lib\site-packages\git\index\base.py", line 734, in add
    paths, entries = self._preprocess_add_items(items)
  File "C:\git-reps\CKAN\bin\venv\lib\site-packages\git\index\base.py", line 574, in _preprocess_add_items
    paths.append(self._to_relative_path(item))
  File "C:\git-reps\CKAN\bin\venv\lib\site-packages\git\index\base.py", line 561, in _to_relative_path
    raise ValueError("Absolute path %r is not in git repository at %r" % (path, self.repo.working_tree_dir))
ValueError: Absolute path 'C:/git-reps/CKAN/CHANGELOG.md' is not in git repository at 'C:\\git-reps\\CKAN'
```

But during merge of #3349 I accidentally committed a CHANGELOG.md with all file endings replaced with CRLF, due to the following problem:

https://github.com/gitpython-developers/GitPython/issues/1189
GitPython's `repo.index.add()` doesn't respect `core.autocrlf`. Thus on Windows any files added to the index using this function will have their line endings messed up in the repository.

## Changes
Now we use `repo.git.add()`, which makes GitPython run the `git add` command using the binary.
Here's where this happens, because I was curious:
https://github.com/gitpython-developers/GitPython/blob/651a81ded00eb993977bcdc6d65f157c751edb02/git/cmd.py#L540-L546

This also seems to solve the above exception, since the git binary understands POSIX paths on Windows.
Regardless I still replaced the `.as_posix()`with `str()`(which always returns the path formatted according to the current OS' standards, so double backslash on Windows), because it feels cleaner and more future proof.

Slowly but surely we replace all actual GItPython usages with a call-through to the git binary...