### PR TITLE
Better recovery when registry.json is corrupted

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -30,6 +30,10 @@ namespace CKAN
         private List<GameVersion> _compatibleVersions = new List<GameVersion>();
 
         public string Name { get; set; }
+        /// <summary>
+        /// Returns a file system safe version of the instance name that can be used within file names.
+        /// </summary>
+        public string SanitizedName => string.Join("", Name.Split(Path.GetInvalidFileNameChars()));
         public GameVersion GameVersionWhenCompatibleVersionsWereStored { get; private set; }
         public bool CompatibleVersionsAreFromDifferentGameVersion { get { return _compatibleVersions.Count > 0 && GameVersionWhenCompatibleVersionsWereStored != Version(); } }
 

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -400,10 +400,8 @@ namespace CKAN
 
             file_transaction.WriteAllText(path, Serialize());
 
-            string sanitizedName = string.Join("", ksp.Name.Split(Path.GetInvalidFileNameChars()));
-
             ExportInstalled(
-                Path.Combine(directoryPath, $"installed-{sanitizedName}.ckan"),
+                Path.Combine(directoryPath, LatestInstalledExportFilename()),
                 false, true
             );
             if (!Directory.Exists(ksp.InstallHistoryDir()))
@@ -411,13 +409,13 @@ namespace CKAN
                 Directory.CreateDirectory(ksp.InstallHistoryDir());
             }
             ExportInstalled(
-                Path.Combine(
-                    ksp.InstallHistoryDir(),
-                    $"installed-{sanitizedName}-{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.ckan"
-                ),
+                Path.Combine(ksp.InstallHistoryDir(), HistoricInstalledExportFilename()),
                 false, true
             );
         }
+
+        public string LatestInstalledExportFilename() => $"installed-{ksp.SanitizedName}.ckan";
+        public string HistoricInstalledExportFilename() => $"installed-{ksp.SanitizedName}-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.ckan";
 
         /// <summary>
         /// Save a custom .ckan file that contains all the currently

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1548,7 +1548,7 @@ namespace CKAN
                     .Select(grp => $"{grp.Key}: "
                         + grp.Aggregate((a, b) => $"{a}, {b}"))
                     .Aggregate((a, b) => $"{a}\r\n{b}");
-                if (!Main.Instance.YesNoDialog(string.Format(Properties.Resources.MainQuitWIthUnappliedChanges, changeDescrip),
+                if (!Main.Instance.YesNoDialog(string.Format(Properties.Resources.MainQuitWithUnappliedChanges, changeDescrip),
                     Properties.Resources.MainQuit,
                     Properties.Resources.MainGoBack))
                 {

--- a/GUI/Dialogs/CloneFakeGameDialog.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.cs
@@ -57,7 +57,7 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Open an file dialog to search for a KSP instance, like in <code>ManageKspInstances</code>.
+        /// Open an file dialog to search for a game instance, like in <code>ManageGameInstancesDialog</code>.
         /// </summary>
         private void buttonInstancePathSelection_Click(object sender, EventArgs e)
         {
@@ -72,7 +72,7 @@ namespace CKAN
                 Multiselect      = false
             };
 
-            // Show the FileDialog and let the user search for the KSP directory.
+            // Show the FileDialog and let the user search for the game directory.
 		    if (instanceDialog.ShowDialog() != DialogResult.OK || !File.Exists(instanceDialog.FileName))
 			    return;
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -127,7 +127,15 @@ namespace CKAN
             try
             {
 #pragma warning disable 219
-                var lockedReg = RegistryManager.Instance(CurrentInstance).registry;
+                var regMgr = RegistryManager.Instance(CurrentInstance);
+                var lockedReg = regMgr.registry;
+                // Tell the user their registry was reset if it was corrupted
+                if (!string.IsNullOrEmpty(regMgr.previousCorruptedMessage)
+                    && !string.IsNullOrEmpty(regMgr.previousCorruptedPath))
+                {
+                    errorDialog.ShowErrorDialog(Properties.Resources.MainCorruptedRegistry,
+                        regMgr.previousCorruptedPath, regMgr.previousCorruptedMessage);
+                }
 #pragma warning restore 219
             }
             catch (RegistryInUseKraken kraken)

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -7,12 +7,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using CKAN.Versioning;
 using CKAN.Extensions;
-using CKAN.Properties;
-using CKAN.Types;
 using log4net;
 using Timer = System.Windows.Forms.Timer;
 using Autofac;
@@ -134,7 +130,10 @@ namespace CKAN
                     && !string.IsNullOrEmpty(regMgr.previousCorruptedPath))
                 {
                     errorDialog.ShowErrorDialog(Properties.Resources.MainCorruptedRegistry,
-                        regMgr.previousCorruptedPath, regMgr.previousCorruptedMessage);
+                        regMgr.previousCorruptedPath, regMgr.previousCorruptedMessage,
+                        Path.Combine(Path.GetDirectoryName(regMgr.previousCorruptedPath) ?? "", regMgr.LatestInstalledExportFilename()));
+                    regMgr.previousCorruptedMessage = null;
+                    regMgr.previousCorruptedPath = null;
                 }
 #pragma warning restore 219
             }
@@ -378,8 +377,18 @@ namespace CKAN
                     .ShowDialog();
             }
 
-            (RegistryManager.Instance(CurrentInstance).registry as Registry)
-                ?.BuildTagIndex(ManageMods.mainModList.ModuleTags);
+            var regMgr = RegistryManager.Instance(CurrentInstance);
+            var registry = regMgr.registry;
+            if (!string.IsNullOrEmpty(regMgr.previousCorruptedMessage)
+                                                && !string.IsNullOrEmpty(regMgr.previousCorruptedPath))
+            {
+                errorDialog.ShowErrorDialog(Properties.Resources.MainCorruptedRegistry,
+                    regMgr.previousCorruptedPath, regMgr.previousCorruptedMessage,
+                    Path.Combine(Path.GetDirectoryName(regMgr.previousCorruptedPath) ?? "", regMgr.LatestInstalledExportFilename()));
+                regMgr.previousCorruptedMessage = null;
+                regMgr.previousCorruptedPath = null;
+            }
+            registry?.BuildTagIndex(ManageMods.mainModList.ModuleTags);
 
             bool repoUpdateNeeded = configuration.RefreshOnStartup
                 || !RegistryManager.Instance(CurrentInstance).registry.HasAnyAvailable();
@@ -465,7 +474,7 @@ namespace CKAN
         {
             OpenFileDialog open_file_dialog = new OpenFileDialog()
             {
-                Filter      = Resources.CKANFileFilter,
+                Filter      = Properties.Resources.CKANFileFilter,
                 Multiselect = true,
             };
 

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -346,8 +346,8 @@ namespace CKAN.Properties {
         internal static string MainQuitWithUnmetDeps {
             get { return (string)(ResourceManager.GetObject("MainQuitWithUnmetDeps", resourceCulture)); }
         }
-        internal static string MainQuitWIthUnappliedChanges {
-            get { return (string)(ResourceManager.GetObject("MainQuitWIthUnappliedChanges", resourceCulture)); }
+        internal static string MainQuitWithUnappliedChanges {
+            get { return (string)(ResourceManager.GetObject("MainQuitWithUnappliedChanges", resourceCulture)); }
         }
         internal static string MainUpgradingWaitTitle {
             get { return (string)(ResourceManager.GetObject("MainUpgradingWaitTitle", resourceCulture)); }
@@ -432,6 +432,9 @@ namespace CKAN.Properties {
         }
         internal static string MainCantInstallDLC {
             get { return (string)(ResourceManager.GetObject("MainCantInstallDLC", resourceCulture)); }
+        }
+        internal static string MainCorruptedRegistry {
+            get { return (string)(ResourceManager.GetObject("MainCorruptedRegistry", resourceCulture)); }
         }
 
         internal static string AllModVersionsInstallPrompt {

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -182,6 +182,10 @@ Versuche {2} aus {3} zu verschieben und CKAN neu zu starten.</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Klartext (*.txt)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Nicht gefunden.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Möchtest du {0} neu installieren?</value></data>
+  <data name="MainCantInstallDLC" xml:space="preserve"><value>CKAN kann die Erweiterung {0} nicht installieren!</value></data>
+  <data name="MainCorruptedRegistry" xml:space="preserve"><value>Beschädigte Registry wurde nach {0} archiviert: {1}
+
+Das bedeuted, dass CKAN alle installierten Mods vergessen hat, sie befinden sich aber immer noch in GameData. Du kannst sie durch Importieren folgender Datei erneut installieren: {2}</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} wird von Ihrer aktuellen Spielversion nicht unterstützt und funktioniert möglicherweise überhaupt nicht. Wenn Sie Probleme damit haben, sollten Sie die Betreuer NICHT um Hilfe bitten.
 
 Möchten Sie es wirklich installieren?</value></data>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -146,7 +146,7 @@ Versuche {2} aus {3} zu verschieben und CKAN neu zu starten.</value></data>
   <data name="MainQuit" xml:space="preserve"><value>Beenden</value></data>
   <data name="MainGoBack" xml:space="preserve"><value>Zurück</value></data>
   <data name="MainQuitWithUnmetDeps" xml:space="preserve"><value>Es gibt unerfüllte Abhängigkeiten. Trotzdem beenden?</value></data>
-  <data name="MainQuitWIthUnappliedChanges" xml:space="preserve">
+  <data name="MainQuitWithUnappliedChanges" xml:space="preserve">
     <value>Du hast noch nicht übernommene Änderungen. Trotzdem beenden?
 
 {0}</value>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -149,7 +149,7 @@ Essayez de déplacer {2} en dehors de {3} et redémarrez CKAN.</value></data>
   <data name="MainQuit" xml:space="preserve"><value>Quitter</value></data>
   <data name="MainGoBack" xml:space="preserve"><value>Revenir</value></data>
   <data name="MainQuitWithUnmetDeps" xml:space="preserve"><value>Il y a des dépendances non-satisfaites. Voulez-vous vraiment quitter?</value></data>
-  <data name="MainQuitWIthUnappliedChanges" xml:space="preserve"><value>Il y a des changements non pris en compte. Voulez-vous vraiment quitter?
+  <data name="MainQuitWithUnappliedChanges" xml:space="preserve"><value>Il y a des changements non pris en compte. Voulez-vous vraiment quitter?
 
 {0}</value></data>
   <data name="MainUpgradingWaitTitle" xml:space="preserve"><value>Mis à jour de CKAN</value></data>

--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -149,7 +149,7 @@ Tentando mover {2} de {3} e reiniciar o CKAN.</value></data>
   <data name="MainQuit" xml:space="preserve"><value>Sair</value></data>
   <data name="MainGoBack" xml:space="preserve"><value>Voltar</value></data>
   <data name="MainQuitWithUnmetDeps" xml:space="preserve"><value>Existem dependências não atendidas. Deseja realmente sair?</value></data>
-  <data name="MainQuitWIthUnappliedChanges" xml:space="preserve"><value>Você tem alterações não aplicadas. Deseja realmente sair?
+  <data name="MainQuitWithUnappliedChanges" xml:space="preserve"><value>Você tem alterações não aplicadas. Deseja realmente sair?
 
 {0}</value></data>
   <data name="MainUpgradingWaitTitle" xml:space="preserve"><value>Atualizando o  CKAN</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -169,7 +169,7 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="MainQuit" xml:space="preserve"><value>Quit</value></data>
   <data name="MainGoBack" xml:space="preserve"><value>Go Back</value></data>
   <data name="MainQuitWithUnmetDeps" xml:space="preserve"><value>There are unmet dependencies. Really quit?</value></data>
-  <data name="MainQuitWIthUnappliedChanges" xml:space="preserve"><value>You have unapplied changes. Really quit?
+  <data name="MainQuitWithUnappliedChanges" xml:space="preserve"><value>You have unapplied changes. Really quit?
 
 {0}</value></data>
   <data name="MainUpgradingWaitTitle" xml:space="preserve"><value>Updating CKAN</value></data>
@@ -204,6 +204,7 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Not found.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Do you want to reinstall {0}?</value></data>
   <data name="MainCantInstallDLC" xml:space="preserve"><value>CKAN can't install expansion {0}!</value></data>
+  <data name="MainCorruptedRegistry" xml:space="preserve"><value>Corrupted registry archived to {0}: {1}</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current game version and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
 
 Do you really want to install it?</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -204,7 +204,9 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Not found.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Do you want to reinstall {0}?</value></data>
   <data name="MainCantInstallDLC" xml:space="preserve"><value>CKAN can't install expansion {0}!</value></data>
-  <data name="MainCorruptedRegistry" xml:space="preserve"><value>Corrupted registry archived to {0}: {1}</value></data>
+  <data name="MainCorruptedRegistry" xml:space="preserve"><value>Corrupted registry archived to {0}: {1}
+
+This means that CKAN forgot about all your installed mods, but they are still in GameData. You can reinstall them by importing the {2} file.</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current game version and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
 
 Do you really want to install it?</value></data>

--- a/GUI/Properties/Resources.zh-CN.resx
+++ b/GUI/Properties/Resources.zh-CN.resx
@@ -149,7 +149,7 @@
   <data name="MainQuit" xml:space="preserve"><value>退出</value></data>
   <data name="MainGoBack" xml:space="preserve"><value>返回</value></data>
   <data name="MainQuitWithUnmetDeps" xml:space="preserve"><value>有未满足的依赖. 真的要退出吗？</value></data>
-  <data name="MainQuitWIthUnappliedChanges" xml:space="preserve"><value>您有未应用的更改. 真的要退出吗？
+  <data name="MainQuitWithUnappliedChanges" xml:space="preserve"><value>您有未应用的更改. 真的要退出吗？
 
 {0}</value></data>
   <data name="MainUpgradingWaitTitle" xml:space="preserve"><value>正在更新CKAN</value></data>


### PR DESCRIPTION
## Problem

If your `CKAN/registry.json` file gets truncated somehow, CKAN won't start.

```
Unhandled exception:
Newtonsoft.Json.JsonSerializationException: Unexpected end when deserializing object. Path 'available_modules.WindowShineTR.module_version['1:2.0'].download_hash.sha256', line 979045, position 0.
```

```
Unhandled exception:
Newtonsoft.Json.JsonReaderException: Unexpected end of content while loading JArray. Path 'available_modules.RP-0.module_version['v1.6'].recommends[21]', line 648536, position 8403726.
   in Newtonsoft.Json.Linq.JContainer.ReadTokenFrom(JsonReader reader, JsonLoadSettings options)
   in Newtonsoft.Json.Linq.JArray.Load(JsonReader reader, JsonLoadSettings settings)
   in Newtonsoft.Json.Linq.JToken.ReadFrom(JsonReader reader, JsonLoadSettings settings)
```

```
Newtonsoft.Json.JsonReaderException: Unterminated string. Expected delimiter: ". Path 'available_modules.WarpShip.module_version['0.3.2'].resources.repository', line 878236, position 44.
```

Examples of this happening in the wild:

#1386, #1540, #1904, #1779, #2123, #2448, #2566, #2588, #2871, #3188, #3229, #3233

(Inspired by #3347.)

## Cause

The deserialization call can throw `JsonSerializationException` or `JsonReaderException` (both inherit from `JsonException`), and we don't handle it.

We currently don't have any clues as to how or why the corruption happens, because the exception can be thrown long after the file is corrupted. By the time the user knows it happened, it's too late to investigate.

## Changes

Now if our attempt to load `registry.json` throws a `JsonException`, `RegistryManager.LoadOrCreate` will catch it and move the file to a new location, `CKAN/registry.json_CORRUPTED_20210417020300`, where that last part is the current date. Then a new registry will be created in its place, to be filled in as usual for a new registry. This way even though the user's data is lost, they will still have a working CKAN, and they may be able to recover some data from the corrupted file.

Ideally we would notify the user that this happened. Unfortunately the UI isn't accessible inside of `RegistryManager` so this is currently not done, but we will log an error in the log system.