### PR TITLE
Update or refresh ConsoleUI mod list after repo or compat changes

### DIFF
--- a/Core/Types/Repository.cs
+++ b/Core/Types/Repository.cs
@@ -5,7 +5,7 @@ using CKAN.Games;
 
 namespace CKAN
 {
-    public class Repository
+    public class Repository : IEquatable<Repository>
     {
         [JsonIgnore] public static readonly string default_ckan_repo_name = "default";
 
@@ -13,7 +13,6 @@ namespace CKAN
         public Uri     uri;
         public string  last_server_etag;
         public int     priority = 0;
-        public Boolean ckan_mirror = false;
 
         public Repository()
         {
@@ -36,6 +35,24 @@ namespace CKAN
         {
             this.name = name;
             this.uri = uri;
+        }
+
+        public override bool Equals(Object other)
+        {
+            return Equals(other as Repository);
+        }
+
+        public bool Equals(Repository other)
+        {
+            return other    != null
+                && name     == other.name
+                && uri      == other.uri
+                && priority == other.priority;
+        }
+
+        public override int GetHashCode()
+        {
+            return name.GetHashCode();
         }
 
         public override string ToString()


### PR DESCRIPTION
## Problem

If you edit your current instance's repositories in ConsoleUI, the new module list is not fetched.

If you edit your current instance's compatible versions in ConsoleUI, the mod list is not updated to reflect the new compatibility.

## Cause

We refresh the mod list if you switch instances, but not otherwise.

## Changes

Now if you add or remove a repo, we update the registry upon returning to the mod list.

Now if you change the compatible versions, we refresh the mod list upon returning to it.

Fixes #3352.