### PR TITLE
Merge script fix for Windows

### DIFF
--- a/bin/ckan-merge-pr.py
+++ b/bin/ckan-merge-pr.py
@@ -39,7 +39,7 @@ class CkanRepo(Repo):
 
     def user_edit_file(self, path: Path) -> None:
         editor=self.config_reader().get('core', 'editor')
-        run([editor, path])
+        run([editor, str(path)])
 
 class CkanPullRequest:
 


### PR DESCRIPTION
## Problem

I was getting this when trying to run the PR merge script on Windows:

```
$ python bin/ckan-merge-pr.py 3353
Fetching upstream...
Fetching https://github.com/HebaruSan/CKAN.git fix/consoleui-refresh...
Traceback (most recent call last):
  File "bin/ckan-merge-pr.py", line 123, in <module>
    merge_pr()
  File "C:\Users\User\AppData\Roaming\Python\Python37\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\User\AppData\Roaming\Python\Python37\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "C:\Users\User\AppData\Roaming\Python\Python37\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\User\AppData\Roaming\Python\Python37\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "bin/ckan-merge-pr.py", line 119, in merge_pr
    if ckpr.merge_into(ckr)
  File "bin/ckan-merge-pr.py", line 103, in merge_into
    repo.user_edit_file(repo.changelog_path())
  File "bin/ckan-merge-pr.py", line 42, in user_edit_file
    run([editor, path])
  File "C:\Program Files (x86)\Python37-32\lib\subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "C:\Program Files (x86)\Python37-32\lib\subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "C:\Program Files (x86)\Python37-32\lib\subprocess.py", line 1119, in _execute_child
    args = list2cmdline(args)
  File "C:\Program Files (x86)\Python37-32\lib\subprocess.py", line 530, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: argument of type 'WindowsPath' is not iterable
```

## Cause

The `path` variable here is a `pathlib.WindowsPath`:

https://github.com/KSP-CKAN/CKAN/blob/921fe648ca3bc4ce1459d6be472f1f005f5061bf/bin/ckan-merge-pr.py#L42

The `subprocess.run` call uses the `in` operator to check whether it contains some strings, but apparently it's not set up for that in the library versions that I have, so a `TypeError` is thrown.

## Changes

Now we convert the path to a string before running it. This fixes the problem for me. Does it still work on Linux?