### PR TITLE
Make ModuleInstaller a non-singleton

### DIFF
--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -47,7 +47,7 @@ namespace CKAN.CmdLine
                     log.InfoFormat("Importing {0} files", toImport.Count);
                     List<string>    toInstall = new List<string>();
                     RegistryManager regMgr = RegistryManager.Instance(ksp);
-                    ModuleInstaller inst      = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
+                    ModuleInstaller inst      = new ModuleInstaller(ksp, manager.Cache, user);
                     inst.ImportFiles(toImport, user, mod => toInstall.Add(mod.identifier), regMgr.registry, !opts.Headless);
                     HashSet<string> possibleConfigOnlyDirs = null;
                     if (toInstall.Count > 0)

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -136,7 +136,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
-                    var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
+                    var installer = new ModuleInstaller(ksp, manager.Cache, user);
                     installer.InstallList(modules, install_ops, regMgr, ref possibleConfigOnlyDirs);
                     user.RaiseMessage("");
                     done = true;

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -77,7 +77,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
-                    var installer = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
+                    var installer = new ModuleInstaller(ksp, manager.Cache, user);
                     Search.AdjustModulesCase(ksp, options.modules);
                     installer.UninstallList(options.modules, ref possibleConfigOnlyDirs, regMgr);
                     user.RaiseMessage("");

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -157,7 +157,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
-                    ModuleInstaller.GetInstance(ksp, manager.Cache, User).Replace(to_replace, replace_ops, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
+                    new ModuleInstaller(ksp, manager.Cache, User).Replace(to_replace, replace_ops, new NetAsyncModulesDownloader(User, manager.Cache), ref possibleConfigOnlyDirs, regMgr);
                     User.RaiseMessage("");
                 }
                 catch (DependencyNotSatisfiedKraken ex)

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -214,7 +214,7 @@ namespace CKAN.CmdLine
             System.Action<CkanModule> addUserChoiceCallback)
         {
             using (TransactionScope transact = CkanTransaction.CreateTransactionScope()) {
-                var installer  = ModuleInstaller.GetInstance(ksp, manager.Cache, user);
+                var installer  = new ModuleInstaller(ksp, manager.Cache, user);
                 var downloader = new NetAsyncModulesDownloader(user, manager.Cache);
                 var regMgr     = RegistryManager.Instance(ksp);
                 HashSet<string> possibleConfigOnlyDirs = null;

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -25,7 +25,7 @@ namespace CKAN.ConsoleUI {
             manager   = mgr;
             plan      = cp;
             registry  = RegistryManager.Instance(manager.CurrentInstance).registry;
-            installer = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, this);
+            installer = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this);
             rejected  = rej;
 
             AddObject(new ConsoleLabel(

--- a/ConsoleUI/DownloadImportDialog.cs
+++ b/ConsoleUI/DownloadImportDialog.cs
@@ -30,7 +30,7 @@ namespace CKAN.ConsoleUI {
 
             if (files.Count > 0) {
                 ProgressScreen  ps   = new ProgressScreen("Importing Downloads", "Calculating...");
-                ModuleInstaller inst = ModuleInstaller.GetInstance(gameInst, cache, ps);
+                ModuleInstaller inst = new ModuleInstaller(gameInst, cache, ps);
                 ps.Run(theme, (ConsoleTheme th) => inst.ImportFiles(files, ps,
                     (CkanModule mod) => cp.Install.Add(mod), RegistryManager.Instance(gameInst).registry));
                 // Don't let the installer re-use old screen references

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -59,7 +59,7 @@ namespace CKAN.ConsoleUI {
                         HashSet<string> possibleConfigOnlyDirs = null;
 
                         RegistryManager regMgr = RegistryManager.Instance(manager.CurrentInstance);
-                        ModuleInstaller inst = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, this);
+                        ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this);
                         inst.onReportModInstalled = OnModInstalled;
                         if (plan.Remove.Count > 0) {
                             inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr, true, plan.Install);

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -540,7 +540,7 @@ namespace CKAN.ConsoleUI {
         {
             ProgressScreen            ps   = new ProgressScreen($"Downloading {mod.identifier}");
             NetAsyncModulesDownloader dl   = new NetAsyncModulesDownloader(ps, manager.Cache);
-            ModuleInstaller           inst = ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, ps);
+            ModuleInstaller           inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, ps);
             LaunchSubScreen(
                 theme,
                 ps,

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -40,39 +40,12 @@ namespace CKAN
         public ModuleInstallerReportModInstalled onReportModInstalled = null;
 
         // Constructor
-        private ModuleInstaller(GameInstance ksp, NetModuleCache cache, IUser user)
+        public ModuleInstaller(GameInstance ksp, NetModuleCache cache, IUser user)
         {
             User = user;
             Cache = cache;
             this.ksp = ksp;
             log.DebugFormat("Creating ModuleInstaller for {0}", ksp.GameDir());
-        }
-
-        /// <summary>
-        /// Gets the ModuleInstaller instance associated with the passed KSP instance. Creates a new ModuleInstaller instance if none exists.
-        /// </summary>
-        /// <returns>The ModuleInstaller instance.</returns>
-        /// <param name="ksp_instance">Current KSP instance.</param>
-        /// <param name="user">IUser implementation.</param>
-        public static ModuleInstaller GetInstance(GameInstance ksp_instance, NetModuleCache cache, IUser user)
-        {
-            ModuleInstaller instance;
-
-            // Check in the list of instances if we have already created a ModuleInstaller instance for this KSP instance.
-            if (!instances.TryGetValue(ksp_instance.GameDir(), out instance))
-            {
-                // Create a new instance and insert it in the static list.
-                instance = new ModuleInstaller(ksp_instance, cache, user);
-
-                instances.Add(ksp_instance.GameDir(), instance);
-            }
-            else if (user != null)
-            {
-                // Caller passed in a valid IUser. Let's use it.
-                instance.User = user;
-            }
-
-            return instance;
         }
 
         /// <summary>

--- a/GUI/Controls/AllModVersions.cs
+++ b/GUI/Controls/AllModVersions.cs
@@ -62,7 +62,7 @@ namespace CKAN
         {
             GameInstance currentInstance = Main.Instance.Manager.CurrentInstance;
             IRegistryQuerier registry = RegistryManager.Instance(currentInstance).registry;
-            var installer = ModuleInstaller.GetInstance(
+            var installer = new ModuleInstaller(
                 currentInstance,
                 Main.Instance.Manager.Cache,
                 Main.Instance.currentUser);
@@ -131,7 +131,7 @@ namespace CKAN
                 // Get all the data; can put this in bg if slow
                 GameInstance currentInstance = Main.Instance.Manager.CurrentInstance;
                 IRegistryQuerier registry = RegistryManager.Instance(currentInstance).registry;
-                var installer = ModuleInstaller.GetInstance(
+                var installer = new ModuleInstaller(
                     currentInstance,
                     Main.Instance.Manager.Cache,
                     Main.Instance.currentUser);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1591,7 +1591,7 @@ namespace CKAN
             var user_change_set = mainModList.ComputeUserChangeSet(registry);
             try
             {
-                var module_installer = ModuleInstaller.GetInstance(inst, Main.Instance.Manager.Cache, Main.Instance.currentUser);
+                var module_installer = new ModuleInstaller(inst, Main.Instance.Manager.Cache, Main.Instance.currentUser);
                 full_change_set = mainModList.ComputeChangeSetFromModList(registry, user_change_set, module_installer, inst.VersionCriteria());
             }
             catch (InconsistentKraken k)

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -631,7 +631,7 @@ namespace CKAN
                     ContentsPreviewTree.Enabled = true;
 
                     // Get all the data; can put this in bg if slow
-                    var contents = ModuleInstaller.GetInstance(
+                    var contents = new ModuleInstaller(
                             manager.CurrentInstance,
                             Main.Instance.Manager.Cache,
                             Main.Instance.currentUser)

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -36,7 +36,7 @@ namespace CKAN
 
                 try
                 {
-                    ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, currentUser).ImportFiles(
+                    new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser).ImportFiles(
                         GetFiles(dlg.FileNames),
                         currentUser,
                         (CkanModule mod) => ManageMods.MarkModForInstall(mod.identifier, false),

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -71,7 +71,7 @@ namespace CKAN
 
             RegistryManager registry_manager = RegistryManager.Instance(manager.CurrentInstance);
             Registry registry = registry_manager.registry;
-            ModuleInstaller installer = ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, currentUser);
+            ModuleInstaller installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser);
             // Avoid accumulating multiple event handlers
             installer.onReportModInstalled -= OnModInstalled;
             installer.onReportModInstalled += OnModInstalled;

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -33,7 +33,7 @@ namespace CKAN
 
         private void AuditRecommendations(IRegistryQuerier registry, GameVersionCriteria versionCriteria)
         {
-            var installer = ModuleInstaller.GetInstance(CurrentInstance, Manager.Cache, currentUser);
+            var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser);
             if (installer.FindRecommendations(
                 registry.InstalledModules.Select(im => im.Module).ToHashSet(),
                 new HashSet<CkanModule>(),

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -403,7 +403,7 @@ namespace Tests.Core
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
                     // This should throw, as our tidy KSP has no mods installed.
-                    CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(new List<string> {"Foo"}, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                    new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(new List<string> {"Foo"}, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
                 });
 
                 manager.CurrentInstance = null; // I weep even more.
@@ -454,7 +454,7 @@ namespace Tests.Core
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
                 HashSet<string> possibleConfigOnlyDirs = null;
-                CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
+                new CKAN.ModuleInstaller(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
@@ -479,7 +479,7 @@ namespace Tests.Core
                     CurrentInstance = ksp.KSP
                 };
                 var registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
-                var inst = CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser);
+                var inst = new CKAN.ModuleInstaller(ksp.KSP, manager.Cache, nullUser);
 
                 const string mod_file_name = "DogeCoinFlag/Flags/dogecoin.png";
                 string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);
@@ -530,13 +530,13 @@ namespace Tests.Core
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
                 HashSet<string> possibleConfigOnlyDirs = null;
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
+                new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
 
                 // Attempt to uninstall it.
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the module is not installed.
                 Assert.IsFalse(File.Exists(mod_file_path));
@@ -574,7 +574,7 @@ namespace Tests.Core
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
                 HashSet<string> possibleConfigOnlyDirs = null;
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
+                new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 modules.Clear();
 
@@ -584,7 +584,7 @@ namespace Tests.Core
 
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
+                new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                 modules.Clear();
 
@@ -596,7 +596,7 @@ namespace Tests.Core
                 modules.Add(TestData.DogeCoinFlag_101_module().identifier);
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
 
-                CKAN.ModuleInstaller.GetInstance(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
+                new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser).UninstallList(modules, ref possibleConfigOnlyDirs, CKAN.RegistryManager.Instance(manager.CurrentInstance));
 
                 // Check that the directory has been deleted.
                 Assert.IsFalse(Directory.Exists(directoryPath));
@@ -638,7 +638,7 @@ namespace Tests.Core
                         List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
 
                         HashSet<string> possibleConfigOnlyDirs = null;
-                        CKAN.ModuleInstaller.GetInstance(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
+                        new CKAN.ModuleInstaller(ksp.KSP, manager.Cache, nullUser).InstallList(modules, new RelationshipResolverOptions(), CKAN.RegistryManager.Instance(manager.CurrentInstance), ref possibleConfigOnlyDirs);
 
                         // Check that the module is installed.
                         string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -44,7 +44,7 @@ namespace Tests.Core
             _manager   = new GameInstanceManager(_nullUser, _config);
             _registryManager = CKAN.RegistryManager.Instance(_instance.KSP);
             _registry  = _registryManager.registry;
-            _installer = CKAN.ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _nullUser);
+            _installer = new CKAN.ModuleInstaller(_instance.KSP, _manager.Cache, _nullUser);
 
             _gameDir = _instance.KSP.GameDir();
             _gameDataDir = _instance.KSP.game.PrimaryModDirectory(_instance.KSP);

--- a/Tests/GUI/GH1866.cs
+++ b/Tests/GUI/GH1866.cs
@@ -44,7 +44,7 @@ namespace Tests.GUI
                 .Select((change) => change.Mod.ToCkanModule()).ToList();
 
             // do the install
-            ModuleInstaller.GetInstance(_instance.KSP, main.currentUser).InstallList(
+            new ModuleInstaller(_instance.KSP, main.currentUser).InstallList(
                 changeList,
                 new RelationshipResolverOptions(),
                 new NetAsyncModulesDownloader(main.currentUser)
@@ -72,7 +72,7 @@ namespace Tests.GUI
             _registry.AddAvailable(_anyVersionModule);
 
             HashSet<string> possibleConfigOnlyDirs = null;
-            ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
+            new ModuleInstaller(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                 new List<CkanModule> { { _anyVersionModule } },
                 new RelationshipResolverOptions(),
                 _registryManager,
@@ -145,7 +145,7 @@ namespace Tests.GUI
             {
                 HashSet<string> possibleConfigOnlyDirs = null;
                 // perform the install of the "other" module - now we need to sort
-                ModuleInstaller.GetInstance(_instance.KSP, _manager.Cache, _manager.User).InstallList(
+                new ModuleInstaller(_instance.KSP, _manager.Cache, _manager.User).InstallList(
                     _modList.ComputeUserChangeSet(null).Select(change => change.Mod).ToList(),
                     new RelationshipResolverOptions(),
                     _registryManager,


### PR DESCRIPTION
## Problems

1. Install something
2. Change the cache path
3. Install something else; the download will succeed but the install will fail:
   ```
   Downloading "https://spacedock.info/mod/1466/FuelEfficientPilots/download/0.2"
   Trying to install FuelEfficientPilots 0.2, but it's not downloaded or download is corrupted
   Error during installation!
   If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
   If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
   If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
   ```

## Cause

`ModuleInstaller` is a singleton (per game instance). It stores a reference to the cache object that it is given when created; if the user changes the cache path, that cache object becomes stale, but the installer doesn't know that.

1. Install something; this will create a persistent `ModuleInstaller` instance for your game instance, using the currently configured cache path
2. Change the cache path; this _replaces_ `Manager.Cache` with a new cache object, _but the persistent `ModuleInstaller` instance doesn't know that happened and still has the old object_
3. Install something else; the old `ModuleInstaller` and cache object will be used

## Changes

Now `ModuleInstaller` is a regular class; we create an instance of it when we need one, and when we're done with it, it fades out forever. This way it will always use the current cache object.

Fixes #333.
Fixes #3355.