### PR TITLE
Fix installation of AVP while removing EVE default configs

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -645,7 +645,9 @@ namespace CKAN
                 )).Memoize();
             var goners = revdep.Union(
                     registry_manager.registry.FindRemovableAutoInstalled(
-                        registry_manager.registry.InstalledModules.Where(im => !revdep.Contains(im.identifier)))
+                        registry_manager.registry.InstalledModules
+                            .Where(im => !revdep.Contains(im.identifier))
+                            .Concat(installing?.Select(m => new InstalledModule(null, m, new string[0], false)) ?? new InstalledModule[0]))
                     .Select(im => im.identifier))
                 .ToList();
 

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -61,10 +61,11 @@ namespace CKAN
         /// If no KSP version is provided, the latest module for *any* KSP version is given.
         /// </summary>
         List<CkanModule> LatestAvailableWithProvides(
-            string                  identifier,
-            GameVersionCriteria      ksp_version,
-            RelationshipDescriptor  relationship_descriptor = null,
-            IEnumerable<CkanModule> toInstall               = null
+            string identifier,
+            GameVersionCriteria ksp_version,
+            RelationshipDescriptor relationship_descriptor = null,
+            IEnumerable<CkanModule> installed = null,
+            IEnumerable<CkanModule> toInstall = null
         );
 
         /// <summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -669,10 +669,12 @@ namespace CKAN
         /// <see cref="IRegistryQuerier.LatestAvailableWithProvides" />
         /// </summary>
         public List<CkanModule> LatestAvailableWithProvides(
-            string                  identifier,
-            GameVersionCriteria      ksp_version,
-            RelationshipDescriptor  relationship_descriptor = null,
-            IEnumerable<CkanModule> toInstall               = null)
+            string identifier,
+            GameVersionCriteria ksp_version,
+            RelationshipDescriptor relationship_descriptor = null,
+            IEnumerable<CkanModule> installed = null,
+            IEnumerable<CkanModule> toInstall = null
+        )
         {
             if (providers.TryGetValue(identifier, out HashSet<AvailableModule> provs))
             {
@@ -681,7 +683,7 @@ namespace CKAN
                     .Select(am => am.Latest(
                         ksp_version,
                         relationship_descriptor,
-                        InstalledModules.Select(im => im.Module),
+                        installed ?? InstalledModules.Select(im => im.Module),
                         toInstall
                     ))
                     .Where(m => m?.ProvidesList?.Contains(identifier) ?? false)

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -17,7 +17,10 @@ namespace CKAN
 
         public abstract bool WithinBounds(CkanModule otherModule);
 
-        public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, GameVersionCriteria crit, IEnumerable<CkanModule> toInstall = null);
+        public abstract List<CkanModule> LatestAvailableWithProvides(
+            IRegistryQuerier registry, GameVersionCriteria crit, IEnumerable<CkanModule> installed = null,
+            IEnumerable<CkanModule> toInstall = null
+        );
 
         public abstract bool Equals(RelationshipDescriptor other);
 
@@ -138,9 +141,12 @@ namespace CKAN
             return false;
         }
 
-        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, GameVersionCriteria crit, IEnumerable<CkanModule> toInstall = null)
+        public override List<CkanModule> LatestAvailableWithProvides(
+            IRegistryQuerier registry, GameVersionCriteria crit, IEnumerable<CkanModule> installed = null,
+            IEnumerable<CkanModule> toInstall = null
+        )
         {
-            return registry.LatestAvailableWithProvides(name, crit, this, toInstall);
+            return registry.LatestAvailableWithProvides(name, crit, this, installed, toInstall);
         }
 
         public override bool Equals(RelationshipDescriptor other)
@@ -225,9 +231,12 @@ namespace CKAN
                 ?? false;
         }
 
-        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier registry, GameVersionCriteria crit, IEnumerable<CkanModule> toInstall = null)
+        public override List<CkanModule> LatestAvailableWithProvides(
+            IRegistryQuerier registry, GameVersionCriteria crit, IEnumerable<CkanModule> installed = null,
+            IEnumerable<CkanModule> toInstall = null
+        )
         {
-            return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit, toInstall)).ToList();
+            return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit, installed, toInstall)).ToList();
         }
 
         public override bool Equals(RelationshipDescriptor other)

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -186,6 +186,7 @@ namespace CKAN
                         {
                             installer.UninstallList(toUninstall.Select(m => m.identifier),
                                 ref possibleConfigOnlyDirs, registry_manager, false, toInstall);
+                            toUninstall.Clear();
                             processSuccessful = true;
                         }
                     }
@@ -195,6 +196,7 @@ namespace CKAN
                         if (!installCanceled)
                         {
                             installer.InstallList(toInstall, opts.Value, registry_manager, ref possibleConfigOnlyDirs, downloader, false);
+                            toInstall.Clear();
                             processSuccessful = true;
                         }
                     }
@@ -204,6 +206,7 @@ namespace CKAN
                         if (!installCanceled)
                         {
                             installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager, true, true, false);
+                            toUpgrade.Clear();
                             processSuccessful = true;
                         }
                     }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -161,9 +161,11 @@ namespace CKAN
                 }
             }
             foreach (var im in registry.FindRemovableAutoInstalled(
-                registry.InstalledModules.Where(im => !modules_to_remove.Any(m => m.identifier == im.identifier) || modules_to_install.Any(m => m.identifier == im.identifier))
+                registry.InstalledModules
+                    .Where(im => modules_to_remove.All(m => m.identifier != im.identifier) || modules_to_install.Any(m => m.identifier == im.identifier))
             ))
             {
+                // TODO this removes modules that a newly installed mod will depend on, and gets readded as module to install in the RelationshipResolver
                 changeSet.Add(new ModChange(im.Module, GUIModChangeType.Remove, new SelectionReason.NoLongerUsed()));
                 modules_to_remove.Add(im.Module);
             }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -163,6 +163,7 @@ namespace CKAN
             foreach (var im in registry.FindRemovableAutoInstalled(
                 registry.InstalledModules
                     .Where(im => modules_to_remove.All(m => m.identifier != im.identifier) || modules_to_install.Any(m => m.identifier == im.identifier))
+                    .Concat(modules_to_install.Select(m => new InstalledModule(null, m, new string[0], false)))
             ))
             {
                 // TODO this removes modules that a newly installed mod will depend on, and gets readded as module to install in the RelationshipResolver


### PR DESCRIPTION
Or: Fix resolution of circular dependencies when conflicts are involved.
Or: Another open heart surgery of the relationship resolver.

## Problem
Have EnvironmentalVisualEnhancements with its default configs EnvironmentalVisualEnhancements-HR installed.
Now deselect EnvironmentalVisualEnhancements-HR and select AVP.

See this double error message:
```
AVP-8kTextures v1.12 depends on AstronomersVisualPack, which is not compatible with the currently installed game version
```

The issue goes down to `MightBeInstallable()`  returning false for any AstronomersVisualPack,
because `LatestAvailableWithProvides()` can't find any provider for `AVP-Textures`,
because they all depend on AstronomersVisualPack again,
which `LatestAvailableWithProvides()` / `AvailableModule.Latest()`  sees as incompatible 
due to the conflict with `EnvironmentalVisualEnhancements-HR`,
which `AvailableModule.Latest()` doesn't know we're uninstalling.

In short: We pass the list of actually installed modules to  `AvailableModule.Latest()` instead of the theoretical one of the `RelationshipResolver`.

Another bug: our invocations of `FindRemovableAutoInstalled()` also try to remove mods that will be re-required by new mods we're about to install, so those mods get scheduled once for removal and once for reinstallation. Not a big problem, but preferably it shouldn't remove them in the first hand.

And: If the install step in `MainInstall.InstallMods()` throws a `TooManyModsProvide` kraken and it gets resolved by the user, it tries to start again from the beginning, re-trying to remove mods that have already been removed in the first round.

## Changes
The whole chain of `LatestAvailableWithProvides()` methods gets a new optional `installed` parameter, next to `toInstall`. If given, it passes that one along to `AvailableModule.Latest()` instead of `Registry.InstalledModules`.
Additionally, `MightBeInstallable()` passes the current source/parent of the stanza we're investigating as `toInstall`  `LatestAvailableWithProvides()`, since it's not yet in the list of installed modules. Basically we assume that the stanza source is compatible when checking its dependencies. I don't think this was needed to fix the above bug, but it should help when force-installing outdated mods.

I've written a unit test that models this relationship constellation. I'm actually quite proud of this one, it works really well. You can cherry-pick / checkout that commit on itself to see the test fail.

To fix `FindRemovableAutoInstalled()` staging removals of dependencies we need for new modules again, we concatenate the list of installed modules with the list of modules we're about to install, wrapped in pseudo-`InstalledModule`s.

And to fix the installation failure when `TooManyModsProvide` is thrown after the removal step, we clear the change lists after finishing them.