### PR TITLE
Handle searches for labels with spaces

### DIFF
--- a/GUI/Model/ModSearch.cs
+++ b/GUI/Model/ModSearch.cs
@@ -195,7 +195,7 @@ namespace CKAN
             }
             foreach (var label in Labels)
             {
-                pieces.Add($"{Properties.Resources.ModSearchLabelPrefix}{label.Name}");
+                pieces.Add($"{Properties.Resources.ModSearchLabelPrefix}{label.Name.Replace(" ", "")}");
             }
             if (Compatible.HasValue)
             {
@@ -306,7 +306,13 @@ namespace CKAN
                 }
                 else if (TryPrefix(s, Properties.Resources.ModSearchLabelPrefix, out string labelName))
                 {
-                    labels.AddRange(knownLabels.Where(lb => lb.Name == labelName));
+                    labels.AddRange(
+                        // Label searches exclude spaces, but label names can include them
+                        knownLabels.Where(lb => lb.Name.Replace(" ", "") == labelName)
+                            // If label doesn't exist, maybe it will be created later or the user is still typing.
+                            // Make an unofficial label object to accurately reflect the search.
+                            .DefaultIfEmpty(new ModuleLabel() { Name = labelName })
+                    );
                 }
                 else if (TryPrefix(s, Properties.Resources.ModSearchYesPrefix, out string yesSuffix))
                 {


### PR DESCRIPTION
## Problem

You can't search for a label with a space in its name.

## Cause

We use spaces to split up search terms.

## Changes

- When we generate a search string, we combine the words in a label with the spaces removed, so `label:Label with a space` becomes `label:Labelwithaspace`
- When we parse a search string, we remove spaces from the labels' names when we check whether they match.
