### PR TITLE
Create APT repo documentation

### DIFF
--- a/doc/apt-repo.md
+++ b/doc/apt-repo.md
@@ -1,0 +1,27 @@
+# CKAN's APT repository
+
+We have created an APT repository that you can add to your Debian-based OS to install CKAN. This will allow you to run CKAN from the system app menus or via `ckan` from your command line. Your system's package manager will pull in dependencies and update CKAN automatically. There's even a man page.
+
+(These instructions are here instead of a wiki because the `curl` command adds our trusted key to your APT configuration, and we do not want that line to be editable by the entire world, in case it might be altered maliciously.)
+
+## Stable builds
+
+These are [the main releases](https://github.com/KSP-CKAN/CKAN/releases), recommended for most users. You will have the same features at the same time as everyone else, but you will have the added conveniences of APT managing the updates for you.
+
+```
+sudo curl -sS -o /etc/apt/trusted.gpg.d/ksp-ckan.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
+sudo apt-add-repository -u -y 'deb https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable main'
+sudo apt install ckan
+```
+
+## Nightly builds
+
+If you like to live dangerously, these are the bleeding edge builds that are generated every time we merge changes to the main branch. On the plus side, you'll get fixes and enhancements faster than everyone else. On the minus side, these builds are essentially untested; we don't know whether they're reliable until we take a close look at them and make sure they're complete and won't break things, at which point they turn into a stable build (if that sounds more like what you want, scroll up to the previous section).
+
+Things may break! But if they do and you report it to us, you'll be a hero to CKAN users everywhere, whether they know it or not.
+
+```
+sudo curl -sS -o /etc/apt/trusted.gpg.d/ksp-ckan.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
+sudo apt-add-repository -u -y 'deb https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly main'
+sudo apt install ckan
+```


### PR DESCRIPTION
## Problem

Our release notes template needs to be revised, and one of the things that should go somewhere else is the APT repo instructions. However, the instructions involve several `sudo` commands, including one that adds CKAN's key to the system's trusted APT keys, so if we put this on a wiki page, there is a small risk that a random GitHub user would make an edit that would change the instructions to install a malicious key. We would revert that as soon as we noticed it, but there would be a risk to user systems as long as the edit was live.

## Considered and not done

We could lock down the wiki:

![image](https://user-images.githubusercontent.com/1559108/119231692-cb8a9200-bae7-11eb-8e09-724660d3cb66.png)

... but then it's not really a wiki anymore, and we would lose the benefits of user interaction and general editability.

As far as we have been able to determine, GitHub wikis cannot lock down individual pages, nor can they hold changes in a queue for review before they go live to the world.

## Changes

Now a new `doc/apt-repo.md` document holds the instructions behind the impenetrable barrier of push access and pull request code review. For the first time, the stable and nightly builds are documented in the same place, with hopefully enough text to help users determine which is right for them.

This will be linked from relevant wikis and possibly release notes (the plans there are not finalized, but this is part of it).