### PR TITLE
Invoke GUI update calls in SetupDefaultSearch() descendants

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -361,38 +361,45 @@ namespace CKAN
             var searches = search.Values.Select(s => ModSearch.Parse(s,
                 Main.Instance.ManageMods.mainModList.ModuleLabels.LabelsFor(Main.Instance.CurrentInstance.Name).ToList()
             )).ToList();
-            EditModSearches.SetSearches(searches);
 
-            // Ask the configuration which columns to show.
-            foreach (DataGridViewColumn col in ModGrid.Columns)
+            Util.Invoke(ModGrid, () =>
             {
-                // Some columns are always shown, and others are handled by UpdateModsList()
-                if (col.Name != "Installed" && col.Name != "UpdateCol" && col.Name != "ReplaceCol")
-                {
-                    col.Visible = !Main.Instance.configuration.HiddenColumnNames.Contains(col.Name);
-                }
-            }
+                EditModSearches.SetSearches(searches);
 
-            // If these columns aren't hidden by the user, show them if the search includes installed modules
-            setInstalledColumnsVisible(!SearchesExcludeInstalled(searches));
+                // Ask the configuration which columns to show.
+                foreach (DataGridViewColumn col in ModGrid.Columns)
+                {
+                    // Some columns are always shown, and others are handled by UpdateModsList()
+                    if (col.Name != "Installed" && col.Name != "UpdateCol" && col.Name != "ReplaceCol")
+                    {
+                        col.Visible = !Main.Instance.configuration.HiddenColumnNames.Contains(col.Name);
+                    }
+                }
+
+                // If these columns aren't hidden by the user, show them if the search includes installed modules
+                setInstalledColumnsVisible(!SearchesExcludeInstalled(searches));
+            });
         }
 
         public void SetSearches(List<ModSearch> searches)
         {
-            mainModList.SetSearches(searches);
-            EditModSearches.SetSearches(searches);
-
-            // Ask the configuration which columns to show.
-            foreach (DataGridViewColumn col in ModGrid.Columns)
+            Util.Invoke(ModGrid, () =>
             {
-                // Some columns are always shown, and others are handled by UpdateModsList()
-                if (col.Name != "Installed" && col.Name != "UpdateCol" && col.Name != "ReplaceCol")
-                {
-                    col.Visible = !Main.Instance.configuration.HiddenColumnNames.Contains(col.Name);
-                }
-            }
+                mainModList.SetSearches(searches);
+                EditModSearches.SetSearches(searches);
 
-            setInstalledColumnsVisible(!SearchesExcludeInstalled(searches));
+                // Ask the configuration which columns to show.
+                foreach (DataGridViewColumn col in ModGrid.Columns)
+                {
+                    // Some columns are always shown, and others are handled by UpdateModsList()
+                    if (col.Name != "Installed" && col.Name != "UpdateCol" && col.Name != "ReplaceCol")
+                    {
+                        col.Visible = !Main.Instance.configuration.HiddenColumnNames.Contains(col.Name);
+                    }
+                }
+
+                setInstalledColumnsVisible(!SearchesExcludeInstalled(searches));
+            });
         }
 
         private static readonly string[] installedColumnNames = new string[]


### PR DESCRIPTION
## Problem
With the restructuring to the search done in #3323 we added a call to `SetupDefaultSearch()`, which indirectly modifies GUI controls through other functions it calls.
As we all know, updating GUI components from another thread basically doesn't work.

In this case it manifests itself through freezes at the end of the repository update for some users.

## Changes
Now `ManageMods.Filter()` and `ManageMods.SetSearches()`, both called in `SetupDefaultSearch()`, wrap every GUI-related work and call in a `Util.Invoke()`.

The diff looks worse than the actual change :smile: 

I wonder if there's some static code analysis tool that can catch this? At least my IDE doesn't :/

I can't confirm the effectiveness of this patch, as my low core count tablet/laptop/convertible doesn't reproduce the hang/freeze (the runtime decides to run it all in a single thread there, I guess) and this only seems to affect Windows. I might dust off my Windows installation on my PC  tomorrow to see if it experiences the bug.

Fixes #3379 

@linuxgurugamer and @daantimmer, do you want to give this fix a try, after re-enabling the repo update on startup so it hits the critical code path?
If you click on the "Checks" tab in between the pull request header and body, there should be an "Artifacts" button on the right side, where you can download a ckan.exe built from this PR code.