### PR TITLE
Choose game instance if default is locked

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -72,14 +72,20 @@ namespace CKAN
             }
         }
 
-        public bool Valid
-        {
-            get
-            {
-                return game.GameInFolder(new DirectoryInfo(gameDir))
-                    && Version() != null;
-            }
-        }
+        /// <returns>
+        /// true if the game seems to be here and a version is found,
+        /// false otherwise
+        /// </returns>
+        public bool Valid => game.GameInFolder(new DirectoryInfo(gameDir)) && Version() != null;
+
+        /// <returns>
+        /// true if the instance may be locked, false otherwise.
+        /// Note that this is a tentative value; if it's true,
+        /// we still need to try to acquire the lock to confirm it isn't stale.
+        /// NOTE: Will throw NotKSPDirKraken if the instance isn't valid!
+        ///       Either be prepared to catch that exception, or check Valid first to avoid it.
+        /// </returns>
+        public bool IsMaybeLocked => RegistryManager.IsInstanceMaybeLocked(CkanDir());
 
         /// <summary>
         /// Create the CKAN directory and any supporting files.

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -40,6 +40,16 @@ namespace CKAN
         /// </summary>
         public string previousCorruptedPath;
 
+        private static string InstanceRegistryLockPath(string path)
+        {
+            return Path.Combine(path, "registry.locked");
+        }
+
+        public static bool IsInstanceMaybeLocked(string path)
+        {
+            return File.Exists(InstanceRegistryLockPath(path));
+        }
+
         // We require our constructor to be private so we can
         // enforce this being an instance (via Instance() above)
         private RegistryManager(string path, GameInstance ksp)
@@ -47,7 +57,7 @@ namespace CKAN
             this.ksp = ksp;
 
             this.path    = Path.Combine(path, "registry.json");
-            lockfilePath = Path.Combine(path, "registry.locked");
+            lockfilePath = InstanceRegistryLockPath(path);
 
             // Create a lock for this registry, so we cannot touch it again.
             if (!GetLock())
@@ -146,7 +156,7 @@ namespace CKAN
         private void CheckStaleLock()
         {
             log.DebugFormat("Checking for stale lock file at {0}", lockfilePath);
-            if (File.Exists(lockfilePath))
+            if (IsInstanceMaybeLocked(path))
             {
                 log.DebugFormat("Lock file found at {0}", lockfilePath);
                 string contents;

--- a/GUI/Dialogs/ErrorDialog.cs
+++ b/GUI/Dialogs/ErrorDialog.cs
@@ -34,6 +34,9 @@ namespace CKAN
                 );
                 if (!Visible)
                 {
+                    StartPosition = Main.Instance.actuallyVisible
+                        ? FormStartPosition.CenterParent
+                        : FormStartPosition.CenterScreen;
                     ShowDialog(Main.Instance);
                 }
             });

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -43,6 +43,7 @@ namespace CKAN
         {
             _user = user;
             InitializeComponent();
+            DialogResult = DialogResult.Cancel;
 
             if (centerScreen)
             {
@@ -74,7 +75,11 @@ namespace CKAN
                 .OrderByDescending(instance => instance.Value.Version())
                 .Select(instance => new ListViewItem(new string[]
                 {
-                    instance.Key,
+                    !instance.Value.Valid 
+                        ? string.Format(Properties.Resources.ManageGameInstancesNameColumnInvalid, instance.Key)
+                        : _manager.CurrentInstance != instance.Value && instance.Value.IsMaybeLocked
+                            ? string.Format(Properties.Resources.ManageGameInstancesNameColumnLocked, instance.Key)
+                            : instance.Key,
                     instance.Value.game.ShortName,
                     instance.Value.Version()?.ToString() ?? Properties.Resources.CompatibleGameVersionsDialogNone,
                     instance.Value.GameDir().Replace('/', Path.DirectorySeparatorChar)

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -764,6 +764,13 @@ namespace CKAN.Properties {
             get { return (string)(ResourceManager.GetObject("ManageGameInstancesDirectoryDeleted", resourceCulture)); }
         }
 
+        internal static string ManageGameInstancesNameColumnInvalid {
+            get { return (string)(ResourceManager.GetObject("ManageGameInstancesNameColumnInvalid", resourceCulture)); }
+        }
+        internal static string ManageGameInstancesNameColumnLocked {
+            get { return (string)(ResourceManager.GetObject("ManageGameInstancesNameColumnLocked", resourceCulture)); }
+        }
+
         internal static string NewRepoDialogFailed {
             get { return (string)(ResourceManager.GetObject("NewRepoDialogFailed", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -310,6 +310,8 @@ Wenn du ein Fehler mit dem CKAN Client vermutest: https://github.com/KSP-CKAN/CK
   <data name="MainWaitDone" xml:space="preserve"><value>Alles erledigt!</value></data>
   <data name="ManageGameInstancesNotValid" xml:space="preserve"><value>"{0}" ist kein gültiges Spielverzeichnis.</value></data>
   <data name="ManageGameInstancesDirectoryDeleted" xml:space="preserve"><value>Das Verzeichnis "{0}" existiert nicht.</value></data>
+  <data name="ManageGameInstancesNameColumnInvalid" xml:space="preserve"><value>{0} (UNGÜLTIG)</value></data>
+  <data name="ManageGameInstancesNameColumnLocked" xml:space="preserve"><value>{0} (GESPERRT)</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Die Master-Liste konnte nicht abgerufen werden.</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} Dateien, {1}</value></data>
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Ungültiger Pfad: "{0}"</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -338,6 +338,8 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="MainWaitDone" xml:space="preserve"><value>All done!</value></data>
   <data name="ManageGameInstancesNotValid" xml:space="preserve"><value>Directory {0} is not a valid game directory.</value></data>
   <data name="ManageGameInstancesDirectoryDeleted" xml:space="preserve"><value>Directory "{0}" doesn't exist.</value></data>
+  <data name="ManageGameInstancesNameColumnInvalid" xml:space="preserve"><value>{0} (INVALID)</value></data>
+  <data name="ManageGameInstancesNameColumnLocked" xml:space="preserve"><value>{0} (LOCKED)</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Failed to fetch master list.</value></data>
   <data name="PluginsDialogFilter" xml:space="preserve"><value>CKAN Plugins (*.dll)|*.dll</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}</value></data>

--- a/debian/ckan.1
+++ b/debian/ckan.1
@@ -30,7 +30,7 @@ search
 .Ar keyword
 .Op Ar keyword ...
 .Nm
-ksp
+instance
 .Op list | add | rename | forget | default
 .Nm
 repo
@@ -57,7 +57,7 @@ List installed mods
 .It available
 List available mods
 .It scan
-Scan for manually installed KSP mods
+Scan for manually installed mods
 .It repair
 Attempt various automatic repairs
 .It clean
@@ -72,8 +72,8 @@ Install a mod
 Upgrade an installed mod
 .It show Ar mod
 show information about a mod
-.It ksp Op list | add | rename | forget | default
-Manage KSP installs
+.It instance Op list | add | rename | forget | default
+Manage game installs
 .It repo Op list | add | rename | forget
 Manage CKAN repositories
 .El


### PR DESCRIPTION
## Problem

If you have multiple game instances, you've selected one as the default instance, and you open that instance in CKAN, then opening another copy of CKAN will cause it to print an error about the instance being locked and quit.

However, if you have no default instance, then in the same flow you will be prompted to choose an instance. The user shouldn't lose options because they've selected a default instance.

## Changes

Now if the default instance is locked by another process but there are other unlocked instances, the Manage Game Instances popup appears. Instances that have a `CKAN/registry.locked` file will have "(LOCKED)" appended to their names, so you can tell which ones are open in other instances of CKAN:

![image](https://user-images.githubusercontent.com/1559108/119552235-18789d80-bd60-11eb-9ad7-320d0ee920c8.png)

Also the Linux man page's documentation for the `ckan ksp` subcommand is updated to the current `ckan instance` naming.

Fixes #3375.

@CodeLeopard, there should be [a test build under the Checks tab](https://github.com/KSP-CKAN/CKAN/suites/2828224736/artifacts/63025613) shortly after this is submitted, if you wouldn't mind giving it a try.