### PR TITLE
Set bugtracker resource for SpaceDock mods with GitHub repos

### DIFF
--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -35,7 +35,7 @@ namespace CKAN.NetKAN.Transformers
             {
                 new StagingTransformer(),
                 new MetaNetkanTransformer(http, ghApi),
-                new SpacedockTransformer(new SpacedockApi(http)),
+                new SpacedockTransformer(new SpacedockApi(http), ghApi),
                 new CurseTransformer(new CurseApi(http)),
                 new GithubTransformer(ghApi, prerelease),
                 new HttpTransformer(),

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Linq;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
 using CKAN.Versioning;
 using CKAN.NetKAN;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Sources.Spacedock;
+using CKAN.NetKAN.Sources.Github;
 using CKAN.NetKAN.Transformers;
-using Moq;
-using Newtonsoft.Json.Linq;
-using NUnit.Framework;
 
 namespace Tests.NetKAN.Transformers
 {
@@ -38,8 +40,15 @@ namespace Tests.NetKAN.Transformers
                         }
                     }
                 });
+            
+            var mGhApi = new Mock<IGithubApi>();
+            mGhApi.Setup(i => i.GetRepo(It.IsAny<GithubRef>()))
+                .Returns(new GithubRepo
+                {
+                    HtmlUrl = "https://github.com/ExampleAccount/ExampleProject"
+                });
 
-            ITransformer sut = new SpacedockTransformer(mApi.Object);
+            ITransformer sut = new SpacedockTransformer(mApi.Object, mGhApi.Object);
 
             JObject json            = new JObject();
             json["spec_version"]    = 1;


### PR DESCRIPTION
## Motivation

The `resources.bugtracker` property links to a place where users can report problems with a mod. It is available in the GUI and the status page. It can be set manually in a netkan or automatically for mods hosted on GitHub (see #3061).

It would be nice to set this for mods on SpaceDock as well so we can jump to issues lists conveniently for more mods.

## Changes

Now if a mod on SpaceDock has a source code link of the form `https://github.com/owner/repo/whatever`, we will call out to the GitHub API to check whether that repo has issues enabled. If so, then `resources.bugtracker` will be set to the repo's issues link.