### PR TITLE
Make current instance settings easier to find in ConsoleUI

### DIFF
--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -280,6 +280,9 @@ namespace CKAN.ConsoleUI {
                     "Save your mod list",
                     true, ExportInstalled),
                 null,
+                new ConsoleMenuOption("Game instance settings...",    "",
+                    "Configure the current game instance",
+                    true, InstanceSettings),
                 new ConsoleMenuOption("Select game instance...",      "",
                     "Switch to a different game instance",
                     true, SelectInstall),
@@ -476,6 +479,22 @@ namespace CKAN.ConsoleUI {
             } catch (InconsistentKraken ex) {
                 // Warn about inconsistent state
                 RaiseError(ex.InconsistenciesPretty + " The repo has not been saved.");
+            }
+            return true;
+        }
+
+        private bool InstanceSettings(ConsoleTheme theme)
+        {
+            var prevRepos   = new SortedDictionary<string, Repository>(registry.Repositories);
+            var prevVerCrit = manager.CurrentInstance.VersionCriteria();
+            LaunchSubScreen(theme, new GameInstanceEditScreen(manager, manager.CurrentInstance));
+            if (!SortedDictionaryEquals(registry.Repositories, prevRepos)) {
+                // Repos changed, need to fetch them
+                UpdateRegistry(theme, false);
+                RefreshList(theme);
+            } else if (!manager.CurrentInstance.VersionCriteria().Equals(prevVerCrit)) {
+                // VersionCriteria changed, need to re-check what is compatible
+                RefreshList(theme);
             }
             return true;
         }


### PR DESCRIPTION
## Motivation

We just saw this in Discord:

![image](https://user-images.githubusercontent.com/1559108/119736015-c2305b00-be42-11eb-8ef5-5a78961089f3.png)

The referenced pinned message is:

![image](https://user-images.githubusercontent.com/1559108/119736089-d5dbc180-be42-11eb-8e80-151f7c569989.png)

It's there because this is the top FAQ for ConsoleUI by a large margin. People want/need to edit the compatible versions, and it's very non-obvious how to do that.

## Changes

Now a new "Game instance settings..." option is added as a shortcut to the screen to which the longer directions lead:

![image](https://user-images.githubusercontent.com/1559108/119735531-18e96500-be42-11eb-8cc4-b0c53f7683aa.png)

![image](https://user-images.githubusercontent.com/1559108/119735934-aaf16d80-be42-11eb-9c38-9a62d75122f2.png)

Just like in #3353, if you add or remove a repo, we will force a registry refresh after you save, and if you add or remove compatible versions, we will update the mod list.