### PR TITLE
Fill more info from GitHub for SpaceDock mods

### DIFF
--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -127,12 +127,54 @@ namespace CKAN.NetKAN.Transformers
 
             TryAddResourceURL(metadata.Identifier, resourcesJson, "homepage",   sdMod.website);
             TryAddResourceURL(metadata.Identifier, resourcesJson, "repository", sdMod.source_code);
-            TryAddResourceURL(metadata.Identifier, resourcesJson, "bugtracker", getBugtracker(sdMod.source_code));
             resourcesJson.SafeAdd("spacedock", sdMod.GetPageUrl().OriginalString);
 
             if (sdMod.background != null)
             {
                 TryAddResourceURL(metadata.Identifier, resourcesJson, "x_screenshot", sdMod.background.ToString());
+            }
+
+            if (!string.IsNullOrEmpty(sdMod.source_code))
+            {
+                try
+                {
+                    var uri = new Uri(sdMod.source_code);
+                    if (uri.Host == "github.com")
+                    {
+                        var match = githubUrlPathPattern.Match(uri.AbsolutePath);
+                        if (match.Success)
+                        {
+                            var owner = match.Groups["owner"].Value;
+                            var repo  = match.Groups["repo"].Value;
+                            var repoInfo = _githubApi.GetRepo(new GithubRef(
+                                $"#/ckan/github/{owner}/{repo}", false, false
+                            ));
+
+                            if (sdMod.source_code != repoInfo.HtmlUrl)
+                            {
+                                // Overwrite resources.repository with GitHub API's report of the true URL,
+                                // in case it has been moved or renamed
+                                resourcesJson.Remove("repository");
+                                TryAddResourceURL(metadata.Identifier, resourcesJson, "repository", repoInfo.HtmlUrl);
+                            }
+                            // Fall back to homepage from GitHub
+                            TryAddResourceURL(metadata.Identifier, resourcesJson, "homepage", repoInfo.Homepage);
+                            if (repoInfo.HasIssues)
+                            {
+                                // Set bugtracker if repo has issues list
+                                TryAddResourceURL(metadata.Identifier, resourcesJson, "bugtracker", $"{repoInfo.HtmlUrl}/issues");
+                            }
+                            if (repoInfo.Archived)
+                            {
+                                Log.Warn("Repo is archived, consider freezing");
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // Just give up, it's fine
+                }
             }
 
             Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
@@ -204,38 +246,6 @@ namespace CKAN.NetKAN.Transformers
                 result.AddRange(mod.shared_authors.Select(i => i.Username));
 
             return result;
-        }
-
-        private string getBugtracker(string repoUrl)
-        {
-            if (!string.IsNullOrEmpty(repoUrl))
-            {
-                try
-                {
-                    var uri = new Uri(repoUrl);
-                    if (uri.Host == "github.com")
-                    {
-                        var match = githubUrlPathPattern.Match(uri.AbsolutePath);
-                        if (match.Success)
-                        {
-                            var owner = match.Groups["owner"].Value;
-                            var repo  = match.Groups["repo"].Value;
-                            var repoInfo = _githubApi.GetRepo(new GithubRef(
-                                $"#/ckan/github/{owner}/{repo}", false, false
-                            ));
-                            if (repoInfo.HasIssues)
-                            {
-                                return $"{repoInfo.HtmlUrl}/issues";
-                            }
-                        }
-                    }
-                }
-                catch
-                {
-                    // Just give up, it's fine
-                }
-            }
-            return null;
         }
 
         private static readonly Regex githubUrlPathPattern = new Regex(


### PR DESCRIPTION
## Motivation

#3384 added the ability to set `resources.bugtracker` for SpaceDock mods with a source code link to a GitHub repo with the issues list enabled. This is nice, but there is more we can do.

## Changes

Now if a SpaceDock mod has a source code link that points to GitHub, we do a little more with the GitHub API info:

- `resources.repository` will be set to the proper URL of the repo, so the CKAN metadata will be current in case it has been moved or renamed (I think this will also remove suffixes like `/releases` from repo links that have them, which is probably good)
- If the SpaceDock mod entry has no homepage, then the homepage from GitHub will be populated into `resources.homepage` (this will probably be very rare, people usually set the homepage on SpaceDock and rarely set it on GitHub)
- If the repository has been archived, we emit a warning that suggests we might want to freeze the mod (see #3061)

The code is restructured slightly to allow for this, since `getBugtracker` is not a great place to put the new code.