### PR TITLE
Clarify that downloading to cache does not install

### DIFF
--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -103,12 +103,11 @@ namespace CKAN.ConsoleUI {
             AddTip("Esc", "Back");
             AddBinding(Keys.Escape, (object sender, ConsoleTheme theme) => false);
 
-            AddTip("Ctrl+D", "Download",
+            AddTip("Ctrl+D", "Download to cache (does not install)",
                 () => !manager.Cache.IsMaybeCachedZip(mod) && !mod.IsDLC
             );
             AddBinding(Keys.CtrlD, (object sender, ConsoleTheme theme) => {
-                if (!mod.IsDLC)
-                {
+                if (!mod.IsDLC) {
                     Download(theme);
                 }
                 return true;

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -181,8 +181,8 @@
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloads</value></data>
   <data name="Description.HeaderText" xml:space="preserve"><value>Description</value></data>
   <data name="reinstallToolStripMenuItem.Text" xml:space="preserve"><value>Reinstall</value></data>
-  <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Download Contents</value></data>
-  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Purge Contents</value></data>
+  <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Download to cache (does not install)</value></data>
+  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Purge from cache</value></data>
   <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels</value></data>
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Edit labels...</value></data>
 </root>

--- a/GUI/Localization/de-DE/ManageMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ManageMods.de-DE.resx
@@ -177,7 +177,7 @@
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloadanzahl</value></data>
   <data name="Description.HeaderText" xml:space="preserve"><value>Kurzbeschreibung</value></data>
   <data name="reinstallToolStripMenuItem.Text" xml:space="preserve"><value>Neu installieren</value></data>
-  <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Inhalt herunterladen</value></data>
-  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Inhalt löschen</value></data>
+  <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>In den Cache herunterladen (wird nicht installiert)</value></data>
+  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Aus dem Cache löschen</value></data>
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels bearbeiten...</value></data>
 </root>

--- a/GUI/Localization/fr-FR/EditModSearch.fr-FR.resx
+++ b/GUI/Localization/fr-FR/EditModSearch.fr-FR.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,4 +118,5 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>Rechercher:</value></data>
+  <data name="FilterOrLabel.Text" xml:space="preserve"><value>Ou:</value></data>
 </root>

--- a/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
+++ b/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -166,7 +166,7 @@
   <data name="FilterLabelsToolButton.Text" xml:space="preserve"><value>Labels</value></data>
   <data name="NavBackwardToolButton.ToolTipText" xml:space="preserve"><value>Mod sélectionné précédent...</value></data>
   <data name="NavForwardToolButton.ToolTipText" xml:space="preserve"><value>Mod sélectionné suivant...</value></data>
-  <data name="Installed.HeaderText" xml:space="preserve"><value>Inst</value></data>
+  <data name="Installed.HeaderText" xml:space="preserve"><value>Installé</value></data>
   <data name="AutoInstalled.HeaderText" xml:space="preserve"><value>Auto-installé</value></data>
   <data name="UpdateCol.HeaderText" xml:space="preserve"><value>MàJ</value></data>
   <data name="ReplaceCol.HeaderText" xml:space="preserve"><value>Remplace</value></data>
@@ -178,11 +178,11 @@
   <data name="SizeCol.HeaderText" xml:space="preserve"><value>Taille</value></data>
   <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Date de publication</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Date d'installation</value></data>
-  <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Téléchargements (nombre)</value></data>
+  <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Nombre de téléchargements</value></data>
   <data name="Description.HeaderText" xml:space="preserve"><value>Description</value></data>
   <data name="reinstallToolStripMenuItem.Text" xml:space="preserve"><value>Réinstaller</value></data>
-  <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Télécharger le contenu</value></data>
-  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Purger le contenu</value></data>
+  <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Télécharger dans le cache (sans installer)</value></data>
+  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Effacer du cache</value></data>
   <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels</value></data>
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Modifier les labels...</value></data>
 </root>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -184,6 +184,9 @@ Essayez de déplacer {2} en dehors de {3} et redémarrez CKAN.</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Impossible de trouver.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Voulez-vous réinstaller {0}?</value></data>
   <data name="MainCantInstallDLC" xml:space="preserve"><value>CKAN ne peut pas installer l'extension {0}!</value></data>
+  <data name="MainCorruptedRegistry" xml:space="preserve"><value>Registre corrompu archivé à {0}: {1}
+
+Cela veut dire que CKAN a oublié tous les mods que vous avez installé, mais ceux-ci sont toujours présents dans le dossier GameData. Vous pouvez les réinstaller en important le fichier {2}</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} n'est pas supporté par votre version de jeu actuelle and pourraît ne pas marcher du tout. Si vous avez des problème avec, vous NE devez PAS demander de l'aide à ses développeurs.
 
 Voulez-vous vraiment l'installer?</value></data>
@@ -311,6 +314,8 @@ Si vous suspectez un problème client: https://github.com/KSP-CKAN/CKAN/issues/n
   <data name="MainWaitDone" xml:space="preserve"><value>Terminé!</value></data>
   <data name="ManageGameInstancesNotValid" xml:space="preserve"><value>Le répertoire {0} n'est pas un répertoire de jeu valide.</value></data>
   <data name="ManageGameInstancesDirectoryDeleted" xml:space="preserve"><value>Le répertoire "{0}" n'existe pas.</value></data>
+    <data name="ManageGameInstancesNameColumnInvalid" xml:space="preserve"><value>{0} (INVALIDE)</value></data>
+  <data name="ManageGameInstancesNameColumnLocked" xml:space="preserve"><value>{0} (VERROUILLÉE)</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Échec de la récupération de la liste maître.</value></data>
   <data name="PluginsDialogFilter" xml:space="preserve"><value>Plugins CKAN (*.dll)|*.dll</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} fichiers, {1}</value></data>
@@ -376,11 +381,27 @@ Voulez-vous autoriser à faire cela? Si vous cliquer non, vous ne verrez plus ce
   <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Déplacer les mods sélectionnés dans le groupe ignoré. Ces mods ne seront pas inclus dans le modpack. </value></data>
   <data name="EditModpackTooltipCancel" xml:space="preserve"><value>Annuler la création du modpack</value></data>
   <data name="EditModpackTooltipExport" xml:space="preserve"><value>Choisir un nom de fichier et sauvegarder le modpack</value></data>
+  <data name="TriStateToggleYesTooltip" xml:space="preserve"><value>Oui</value></data>
+  <data name="TriStateToggleBothTooltip" xml:space="preserve"><value>Oui ou Non</value></data>
+  <data name="TriStateToggleNoTooltip" xml:space="preserve"><value>Non</value></data>
   <data name="ModSearchDescriptionPrefix" xml:space="preserve"><value>desc:</value></data>
   <data name="ModSearchLanguagePrefix" xml:space="preserve"><value>lang:</value></data>
   <data name="ModSearchDependsPrefix" xml:space="preserve"><value>dep:</value></data>
   <data name="ModSearchRecommendsPrefix" xml:space="preserve"><value>rec:</value></data>
   <data name="ModSearchSuggestsPrefix" xml:space="preserve"><value>sug:</value></data>
   <data name="ModSearchConflictsPrefix" xml:space="preserve"><value>conf:</value></data>
+  <data name="ModSearchTagPrefix" xml:space="preserve"><value>étiquette:</value></data>
+  <data name="ModSearchLabelPrefix" xml:space="preserve"><value>label:</value></data>
+  <data name="ModSearchYesPrefix" xml:space="preserve"><value>est:</value></data>
+  <data name="ModSearchNoPrefix" xml:space="preserve"><value>pas:</value></data>
+  <data name="ModSearchCompatibleSuffix" xml:space="preserve"><value>compatible</value></data>
+  <data name="ModSearchInstalledSuffix" xml:space="preserve"><value>installé</value></data>
+  <data name="ModSearchCachedSuffix" xml:space="preserve"><value>cache</value></data>
+  <data name="ModSearchNewlyCompatibleSuffix" xml:space="preserve"><value>nouveau</value></data>
+  <data name="ModSearchUpgradeableSuffix" xml:space="preserve"><value>MàJ</value></data>
+  <data name="ModSearchReplaceableSuffix" xml:space="preserve"><value>remplacable</value></data>
+
   <data name="EditModSearchTooltipExpandButton" xml:space="preserve"><value>Étendre ou réduire la taille du champ de recherche détaillé (Ctrl-Shift-F)</value></data>
+  <data name="EditModSearchesTooltipAddSearchButton" xml:space="preserve"><value>Combiner une nouvelle recherche avec vos recherches actuelles</value></data>
+  <data name="ManageModsInstallAllCheckboxTooltip" xml:space="preserve"><value>Décocher pour désinstaller tous les mods, cocher pour annuler les changements</value></data>
 </root>


### PR DESCRIPTION
## Problem

Mac users somewhat regularly ask why their mods are not installed after using this option:

![image](https://user-images.githubusercontent.com/1559108/123131553-6641fd80-d413-11eb-978a-cd8007208204.png)

## Cause

That hotkey is the equivalent of "Download Contents" in GUI; it's not supposed to install the mod, it just downloads the ZIP file into the cache, from which it can be installed later.

## Changes

Now the screen tip explains the option more verbosely, which hopefully will help to set more accurate expectations:

![image](https://user-images.githubusercontent.com/1559108/123131620-7823a080-d413-11eb-9776-9935bca49567.png)

GUI's right click menu is updated the same way for the following locales:

- English
  ![image](https://user-images.githubusercontent.com/1559108/123128848-17936400-d411-11eb-8f9e-b6ecdbb3ab93.png)
- French
- German

Changes for other locales may follow...