### PR TITLE
Match underscore in DLL to dash in identifier

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -863,7 +863,7 @@ namespace CKAN
                 log.WarnFormat("Attempted to index {0} which is not a DLL", relative_path);
                 return;
             }
-            string modName = match.Groups["modname"].Value;
+            string modName = match.Groups["modname"].Value.Replace("_", "-");
 
             log.InfoFormat("Registering {0} from {1}", modName, relative_path);
 

--- a/Netkan/Validators/PluginsValidator.cs
+++ b/Netkan/Validators/PluginsValidator.cs
@@ -41,7 +41,7 @@ namespace CKAN.NetKAN.Validators
                         var dllIdentifiers = dllPaths
                             .Select(p => pattern.Match(p))
                             .Where(m => m.Success)
-                            .Select(m => m.Groups["modname"].Value)
+                            .Select(m => m.Groups["modname"].Value.Replace("_", "-"))
                             .Where(ident => !identifiersToIgnore.Contains(ident))
                             .ToList();
                         if (dllIdentifiers.Any() && !dllIdentifiers.Contains(metadata.Identifier))


### PR DESCRIPTION
## Problem

1. Open [the status page](http://status.ksp-ckan.space/)
2. In the filter field, type an underscore (`_`)
3. Some of the warnings for "no plugin matching the identifier" are for cases where the DLL name has an underscore, which isn't allowed in an identifier anyway, and the corresponding identifier has a dash in the same place:
   NetKAN | Warning
   :-- | :--
   KSP-PartVolume | No plugin matching the identifier, manual installations won't be detected: GameData/KSP_PartVolume/Plugins/KSP_PartVolume.dll
   KerbalWeatherProject-Lite | No plugin matching the identifier, manual installations won't be detected: GameData/KerbalWeatherProject_Lite/KerbalWeatherProject_Lite.dll
   NASA-CountDown | No plugin matching the identifier, manual installations won't be detected: GameData/NASA_CountDown/Plugins/NASA_CountDown.dll

These warnings are accurate; if you install one of these mods manually, CKAN will not recognize it. But we should be able to.

## Changes

Now the code for finding manually installed mods (and the Netkan validation check for it) replaces underscores in DLL names with dashes. This will improve detection of such mods and clear some of these inflation errors.

Naturally, the CKAN client will not benefit from this until a new release includes this change, but the warnings will disappear from the status page right after merge, so for a while we will have some modules that are "missed" by this check. I think this is OK because this warning is pretty minor and not something we are actively trying to work on.