### PR TITLE
Don't include DLC in modpacks by default

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -494,7 +494,7 @@ namespace CKAN
                     try
                     {
                         var avail = registry.LatestAvailable(kvp.Key, null, null);
-                        return true;
+                        return !avail.IsDLC;
                     }
                     catch
                     {


### PR DESCRIPTION
## Problem

DLC have been making mischief for modpacks.

![image](https://user-images.githubusercontent.com/1559108/126206700-c80c6032-3fce-4561-a496-335715cb6661.png)

(We did **not** make a change to exclude DLC by default; I was thinking of #3139, which did this for modules from custom .ckan files.)

## Cause

When we generate a modpack, installed DLC modules are included by default. This doesn't make sense because CKAN can't install DLC, and modpacks should be lists of mods for CKAN to install.

## Changes

Now DLC appear in the Ignored list by default instead of Depends. If a user really wants them included in the pack, they can be moved to one of the other groups with the buttons. If any of the mods have a dependency on a DLC, this will already work normally.