### PR TITLE
Don't refresh search every keypress on Windows

### DIFF
--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -267,7 +267,6 @@ namespace CKAN
             filterTimer?.Stop();
             if (!string.IsNullOrEmpty(FilterCombinedTextBox.Text))
             {
-                // Delay updating to improve typing performance on OS X and Linux
                 RunFilterUpdateTimer();
             }
             else
@@ -277,9 +276,9 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Start or restart a timer to update the filter after an interval since the last keypress.
-        /// On Mac OS X, this prevents the search field from locking up due to DataGridViews being
-        /// slow and key strokes being interpreted incorrectly when slowed down:
+        /// Start or reset a timer to allow multiple changes to the filter criteria before automatically
+		/// refreshing the display. Refresh may take longer than the time between key strokes,
+		/// which makes the UI seem unresponsive or buggy:
         /// http://mono.1490590.n4.nabble.com/Incorrect-missing-and-duplicate-keypress-events-td4658863.html
         /// </summary>
         private void RunFilterUpdateTimer()
@@ -289,13 +288,12 @@ namespace CKAN
                 filterTimer = new Timer();
                 filterTimer.Tick += OnFilterUpdateTimer;
                 filterTimer.Interval = 500;
-                filterTimer.Start();
             }
             else
             {
                 filterTimer.Stop();
-                filterTimer.Start();
             }
+            filterTimer.Start();
         }
 
         /// <summary>

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -130,7 +130,7 @@ namespace CKAN
                     Main.Instance.ManageMods.mainModList.ModuleLabels.LabelsFor(Main.Instance.CurrentInstance.Name).ToList()
                 );
                 SearchToEditor();
-                TriggerSearchOrTimer();
+                QueueTriggerSearch();
             }
             catch (Kraken k)
             {
@@ -215,7 +215,7 @@ namespace CKAN
             }
             else
             {
-                TriggerSearchOrTimer();
+                QueueTriggerSearch();
             }
         }
 
@@ -246,8 +246,7 @@ namespace CKAN
                     // Bypass the timer for immediate update
                     e.Handled = true;
                     e.SuppressKeyPress = true;
-                    filterTimer?.Stop();
-                    TriggerSearch();
+                    QueueTriggerSearch();
                     break;
 
                 case Keys.Up:
@@ -263,9 +262,10 @@ namespace CKAN
             }
         }
 
-        private void TriggerSearchOrTimer()
+        private void QueueTriggerSearch()
         {
-            if (Platform.IsMono && !string.IsNullOrEmpty(FilterCombinedTextBox.Text))
+            filterTimer?.Stop();
+            if (!string.IsNullOrEmpty(FilterCombinedTextBox.Text))
             {
                 // Delay updating to improve typing performance on OS X and Linux
                 RunFilterUpdateTimer();
@@ -303,8 +303,8 @@ namespace CKAN
         /// </summary>
         private void OnFilterUpdateTimer(object source, EventArgs e)
         {
+            filterTimer?.Stop();
             TriggerSearch();
-            filterTimer.Stop();
         }
 
         private void TriggerSearch()


### PR DESCRIPTION
Rebuilding the mod list dataview every time a key was pressed takes a non-trivial amount of time that makes the ui feel unresponsive and sluggish.

There already existed a workaround for this for linux and macos, but it was still horribly slow on windows.

This change simply normalizes this behavior across the OSes so that there is always a small delay from the last, non-enter, keypress to the start of the refresh.


Fixes #3402.
Fixes #3620.
