### PR TITLE
Override provides prompt with relationship property, check first recommendation in any_of group

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -384,6 +384,10 @@
                             "max_version" : {
                                 "description" : "Optional maximum version",
                                 "$ref"        : "#/definitions/version"
+                            },
+                            "choice_help_text": {
+                                "description" : "Optional help text shown when user has to choose among multiple modules",
+                                "type"        : "string"
                             }
                         },
                         "required" : [ "name" ]
@@ -394,6 +398,10 @@
                             "any_of": {
                                 "description": "List of modules that can satisfy this relationship",
                                 "$ref": "#/definitions/relationship"
+                            },
+                            "choice_help_text": {
+                                "description" : "Optional help text shown when user has to choose among multiple modules",
+                                "type"        : "string"
                             }
                         },
                         "required": [ "any_of" ]

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -174,33 +174,25 @@ namespace CKAN.CmdLine
                 }
                 catch (TooManyModsProvideKraken ex)
                 {
-                    // Request the user selects one of the mods.
-                    string[] mods = new string[ex.modules.Count];
-
-                    for (int i = 0; i < ex.modules.Count; i++)
-                    {
-                        mods[i] = String.Format("{0} ({1})", ex.modules[i].identifier, ex.modules[i].name);
-                    }
-
-                    string message = String.Format("Too many mods provide {0}. Please pick from the following:\r\n", ex.requested);
-
+                    // Request the user selects one of the mods
                     int result;
-
                     try
                     {
-                        result = user.RaiseSelectionDialog(message, mods);
+                        result = user.RaiseSelectionDialog(
+                            ex.Message,
+                            ex.modules
+                                .Select(m => string.Format("{0} ({1})", m.identifier, m.name))
+                                .ToArray());
                     }
                     catch (Kraken e)
                     {
                         user.RaiseMessage(e.Message);
-
                         return Exit.ERROR;
                     }
 
                     if (result < 0)
                     {
-                        user.RaiseMessage(String.Empty); // Looks tidier.
-
+                        user.RaiseMessage("");
                         return Exit.ERROR;
                     }
 

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -230,7 +230,7 @@ namespace CKAN.CmdLine
                     catch (TooManyModsProvideKraken k)
                     {
                         int choice = user.RaiseSelectionDialog(
-                            $"Choose a module to provide {k.requested}:",
+                            k.Message,
                             k.modules.Select(m => $"{m.identifier} ({m.name})").ToArray());
                         if (choice < 0)
                         {

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -118,7 +118,7 @@ namespace CKAN.ConsoleUI {
                     } catch (TooManyModsProvideKraken ex) {
 
                         ConsoleChoiceDialog<CkanModule> ch = new ConsoleChoiceDialog<CkanModule>(
-                            $"Module {ex.requested} is provided by multiple modules. Which would you like to install?",
+                            ex.Message,
                             "Name",
                             ex.modules,
                             (CkanModule mod) => mod.ToString()

--- a/Core/Converters/JsonRelationshipConverter.cs
+++ b/Core/Converters/JsonRelationshipConverter.cs
@@ -26,9 +26,12 @@ namespace CKAN
                     if (child["any_of"] != null)
                     {
                         // Catch confused/invalid metadata
-                        if (child.Properties().Count() > 1)
+                        foreach (string forbiddenPropertyName in AnyOfRelationshipDescriptor.ForbiddenPropertyNames)
                         {
-                            throw new Kraken("`any_of` should not be combined with other properties");
+                            if (child.Property(forbiddenPropertyName) != null)
+                            {
+                                throw new Kraken($"`any_of` should not be combined with `{forbiddenPropertyName}`");
+                            }
                         }
                         rels.Add(child.ToObject<AnyOfRelationshipDescriptor>());
                     }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1183,6 +1183,7 @@ namespace CKAN
         )
         {
             Dictionary<CkanModule, List<string>> dependersIndex = getDependersIndex(sourceModules, registry, toInstall);
+            var instList = toInstall.ToList();
             recommendations = new Dictionary<CkanModule, Tuple<bool, List<string>>>();
             suggestions = new Dictionary<CkanModule, List<string>>();
             supporters = new Dictionary<CkanModule, HashSet<string>>();
@@ -1194,21 +1195,23 @@ namespace CKAN
                         registry,
                         ksp.VersionCriteria()
                     );
+                    int i = 0;
                     foreach (CkanModule provider in providers)
                     {
                         if (!registry.IsInstalled(provider.identifier)
                             && !toInstall.Any(m => m.identifier == provider.identifier)
                             && dependersIndex.TryGetValue(provider, out List<string> dependers)
                             && (provider.IsDLC || CanInstall(RelationshipResolver.DependsOnlyOpts(),
-                                toInstall.ToList().Concat(new List<CkanModule>() { provider }).ToList(), registry)))
+                                instList.Concat(new List<CkanModule>() { provider }).ToList(), registry)))
                         {
                             dependersIndex.Remove(provider);
                             recommendations.Add(
                                 provider,
                                 new Tuple<bool, List<string>>(
-                                    !provider.IsDLC && (providers.Count <= 1 || provider.identifier == (rel as ModuleRelationshipDescriptor)?.name),
+                                    !provider.IsDLC && (i == 0 || provider.identifier == (rel as ModuleRelationshipDescriptor)?.name),
                                     dependers)
                             );
+                            ++i;
                         }
                     }
                 }
@@ -1227,7 +1230,7 @@ namespace CKAN
                             && !toInstall.Any(m => m.identifier == provider.identifier)
                             && dependersIndex.TryGetValue(provider, out List<string> dependers)
                             && (provider.IsDLC || CanInstall(RelationshipResolver.DependsOnlyOpts(),
-                                toInstall.ToList().Concat(new List<CkanModule>() { provider }).ToList(), registry)))
+                                instList.Concat(new List<CkanModule>() { provider }).ToList(), registry)))
                         {
                             dependersIndex.Remove(provider);
                             suggestions.Add(provider, dependers);
@@ -1267,7 +1270,7 @@ namespace CKAN
             }
             supporters.RemoveWhere(kvp => !CanInstall(
                 RelationshipResolver.DependsOnlyOpts(),
-                toInstall.ToList().Concat(new List<CkanModule>() { kvp.Key }).ToList(),
+                instList.Concat(new List<CkanModule>() { kvp.Key }).ToList(),
                 registry
             ));
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -477,13 +477,13 @@ namespace CKAN
                         {
                             //We still have either nothing, or too many to pick from
                             //Just throw the TMP now
-                            throw new TooManyModsProvideKraken(descriptor.ToString(), candidates);
+                            throw new TooManyModsProvideKraken(descriptor.ToString(), candidates, descriptor.choice_help_text);
                         }
                         candidates[0] = provide.First();
                     }
                     else
                     {
-                        throw new TooManyModsProvideKraken(descriptor.ToString(), candidates);
+                        throw new TooManyModsProvideKraken(descriptor.ToString(), candidates, descriptor.choice_help_text);
                     }
                 }
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -149,20 +149,24 @@ namespace CKAN
 
     public class TooManyModsProvideKraken : Kraken
     {
-        public List<CkanModule> modules;
-        public string requested;
+        public readonly List<CkanModule> modules;
+        public readonly string requested;
+        public readonly string choice_help_text;
 
-        public TooManyModsProvideKraken(string requested, List<CkanModule> modules, Exception innerException = null)
-            : base(FormatMessage(requested, modules), innerException)
+        public TooManyModsProvideKraken(string requested, List<CkanModule> modules, string choice_help_text = null, Exception innerException = null)
+            : base(FormatMessage(requested, modules, choice_help_text), innerException)
         {
-            this.modules = modules;
-            this.requested = requested;
+            this.requested        = requested;
+            this.modules          = modules;
+            this.choice_help_text = choice_help_text;
         }
 
-        internal static string FormatMessage(string requested, List<CkanModule> modules)
+        private static string FormatMessage(string requested, List<CkanModule> modules, string choice_help_text = null)
         {
-            string oops = string.Format("Too many mods provide {0}:\r\n", requested);
-            return oops + String.Join("\r\n", modules.Select(m => $"* {m}"));
+            return choice_help_text
+                ?? string.Format(
+                    "Module {0} is provided by more than one available module. Please choose one of the following:",
+                    requested);
         }
     }
 

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -216,6 +216,14 @@ namespace CKAN
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor> any_of;
 
+        public static readonly List<string> ForbiddenPropertyNames = new List<string>()
+        {
+            "name",
+            "version",
+            "min_version",
+            "max_version"
+        };
+
         public override bool WithinBounds(CkanModule otherModule)
         {
             return any_of?.Any(r => r.WithinBounds(otherModule))

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -28,6 +28,9 @@ namespace CKAN
 
         public abstract bool StartsWith(string prefix);
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string choice_help_text;
+
         // virtual ToString() already present in 'object'
     }
 
@@ -41,7 +44,6 @@ namespace CKAN
         public /* required */ string name;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public ModuleVersion version;
-
 
         public override bool WithinBounds(CkanModule otherModule)
         {
@@ -168,7 +170,6 @@ namespace CKAN
         {
             return name.IndexOf(prefix, StringComparison.CurrentCultureIgnoreCase) == 0;
         }
-
 
         /// <summary>
         /// A user friendly message for what versions satisfies this descriptor.

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -245,7 +245,7 @@ namespace CKAN
             IEnumerable<CkanModule> toInstall = null
         )
         {
-            return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit, installed, toInstall)).ToList();
+            return any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit, installed, toInstall)).Distinct().ToList();
         }
 
         public override bool Equals(RelationshipDescriptor other)

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -13,14 +13,11 @@ namespace CKAN
             InitializeComponent();
         }
 
-        public void LoadProviders(string requested, List<CkanModule> modules, NetModuleCache cache)
+        public void LoadProviders(string message, List<CkanModule> modules, NetModuleCache cache)
         {
             Util.Invoke(this, () =>
             {
-                ChooseProvidedModsLabel.Text = String.Format(
-                    Properties.Resources.MainInstallProvidedBy,
-                    requested
-                );
+                ChooseProvidedModsLabel.Text = message;
     
                 ChooseProvidedModsListView.Items.Clear();
                 ChooseProvidedModsListView.Items.AddRange(modules

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -224,7 +224,7 @@ namespace CKAN
                 {
                     // Prompt user to choose which mod to use
                     tabController.ShowTab("ChooseProvidedModsTabPage", 3);
-                    ChooseProvidedMods.LoadProviders(k.requested, k.modules, Manager.Cache);
+                    ChooseProvidedMods.LoadProviders(k.Message, k.modules, Manager.Cache);
                     tabController.SetTabLock(true);
                     CkanModule chosen = ChooseProvidedMods.Wait();
                     // Close the selection prompt


### PR DESCRIPTION
## Motivation

The RSS/RO/RP-0/RP-1 team reached out to discuss ways to streamline their installation process, see KSP-CKAN/NetKAN#8615 and KSP-CKAN/NetKAN#8688. They hope to reduce the number of decisions the user has to make and provide more information to help the user make good choices.

We're still brainstorming options for improvements, but a few ideas seem to be clear wins so far. This is the first of possibly/hopefully several changes resulting from that discussion.

## Problems

- When a `depends` clause matches multiple modules (via either `provides` or `any_of`), only a standard prompt based on the identifier(s) is shown (and it varies between CmdLine/ConsoleUI/GUI). The RSS/RO/RP-0/RP-1 team would like to be able to override that prompt in order to give users additional help and clues about which module to pick.
- The RSS/RO/RP-0/RP-1 team has been taking advantage of `any_of` relationships for conflicting recommendations because they don't all show up as checked:
  ![image](https://user-images.githubusercontent.com/1559108/127796252-8d66683b-1331-45e0-b292-4585511f2b76.png)
  Rather, they're all _unchecked_, which is still not great because these are supposed to be _recommendations_, on-by-default:
  ![image](https://user-images.githubusercontent.com/1559108/127796211-233415ec-90cf-4ba5-a63b-c8c412463dc4.png)


## Changes

- Now the standard prompt for choosing a dependency is the same across CmdLine/ConsoleUI/GUI (copied from the existing English text for GUI)
- Now you can add a `choice_help_text` property to a relationship to override the text the user sees when choosing among multiple modules:
  ```yaml
  depends:
    - any_of:
      - name: Mod1
      - name: Mod2
      choice_help_text: Pick Mod1 unless you like Mod2
    - name: RSSTextures
      choice_help_text: Pick the 16K version if your computer can handle it
  ```
  ![image](https://user-images.githubusercontent.com/1559108/127795733-66c2a139-4343-4b67-ba66-7b9936f9ab91.png)
- Now if you recommend an `any_of` group or an identifier provided by multiple modules, the first one that shows up on screen will be checked, and the rest will be unchecked:
  ![image](https://user-images.githubusercontent.com/1559108/127796138-0358fb95-ea08-43b1-bba3-2ba90ca83182.png)

After this, it should be possible to guide users into a good RSS/RO/RP-0/RP-1 install more often and more easily.