### PR TITLE
Escape ampersands in mod info abstract label

### DIFF
--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -124,7 +124,7 @@ namespace CKAN
 
             Util.Invoke(MetadataModuleNameTextBox, () => MetadataModuleNameTextBox.Text = module.name);
             UpdateTagsAndLabels(module);
-            Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = module.@abstract);
+            Util.Invoke(MetadataModuleAbstractLabel, () => MetadataModuleAbstractLabel.Text = module.@abstract.Replace("&", "&&"));
             Util.Invoke(MetadataModuleDescriptionTextBox, () =>
             {
                 MetadataModuleDescriptionTextBox.Text = module.description


### PR DESCRIPTION
## Problem

If a mod has `&` in its abstract, it is hidden and the next character is underlind in the mod info abstract label:

![windows](https://user-images.githubusercontent.com/1124476/128133562-8edd9046-8287-4cb5-898b-a48feca9d5e4.png)

![linux](https://user-images.githubusercontent.com/1559108/128211981-80a48b79-d6cc-4094-b59c-2c87e725ac64.png)

A similar issue with the mod list was fixed in #3149.

## Cause

WinForms `Labels` (and some other controls) treat `&` as a hotkey indicator; the next character in the text is used as the hotkey such that if you press Alt and that key, the control (or the next control in the tab order) receives focus. This is indicated visually by hiding the `&` and underlining the next character.

Usually it's not a good idea to expose this functionality to external data sources such as abstracts entered into SpaceDock; they generally just want the `&` to display normally, which is accomplished by doubling it to `&&`.

## Changes

Now we double any ampersands in the abstract when populating them into the mod info abstract, which makes them display normally:

![image](https://user-images.githubusercontent.com/1559108/128222656-0b7096a2-eb21-400b-8a88-8acd972ae1d9.png)

Fixes #3428.