### PR TITLE
Don't prompt user to choose conflicting modules

### DIFF
--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -131,16 +131,31 @@ namespace CKAN
                     }
                 }
             }
+            var othersMinusSelf = others.Where(m => m.identifier != module.identifier).Memoize();
             if (module.conflicts != null)
             {
                 // Skip self-conflicts (but catch other modules providing self)
-                var othersMinusSelf = others.Where(m => m.identifier != module.identifier).Memoize();
                 foreach (RelationshipDescriptor rel in module.conflicts)
                 {
                     // If any of the conflicts are present, fail
                     if (rel.MatchesAny(othersMinusSelf, null, null))
                     {
                         return false;
+                    }
+                }
+            }
+            // Check reverse conflicts so user isn't prompted to choose modules that will error out immediately
+            var selfArray = new CkanModule[] { module };
+            foreach (CkanModule other in othersMinusSelf)
+            {
+                if (other.conflicts != null)
+                {
+                    foreach (RelationshipDescriptor rel in other.conflicts)
+                    {
+                        if (rel.MatchesAny(selfArray, null, null))
+                        {
+                            return false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

A module that tries to filter an option out of the "Too many mods provide" prompt with a conflict just ends up complaining to the user after the fact:

```yaml
depends:
  - name: CustomBarnKit
conflicts:
  - name: CustomBarnKit-RO
```

```
$ ckan compat add 1.7
$ ckan install Komplexity
Module CustomBarnKit is provided by more than one available module. Please choose one of the following:
1) CustomBarnKit-RO (Custom Barn Kit - RO build)
2) CustomBarnKit (Custom Barn Kit)
Enter a number between 1 and 2 (To cancel press "c" or "n".): 
1
The following inconsistencies were found:
* CustomBarnKit-RO 1.1.20.0 conflicts with Komplexity 0.9.3.0
Install canceled. Your files have been returned to their initial state.
```

Noticed while investigating KSP-CKAN/NetKAN#8656.

## Cause

The relationship resolver relies on `AvailableModule.Latest` to generate the modules for the user prompt, which filters modules with `AvailableModule.DependsAndConflictsOK`, which only checks conflicts unidirectionally.

## Changes

Now `AvailableModule.DependsAndConflictsOK` checks conflicts bidirectionally, so choices that the installing modules conflict with will be filtered out before (or without) prompting:

```
$ ckan compat add 1.7
$ ckan install Komplexity
About to install:

 * Komplexity 0.9.3.0 (cached)
 * Module Manager 4.2.1 (cached)
 * Custom Barn Kit 1.1.21.0 (cached)
 * Kerbal Changelog v1.4.2 (cached)

Continue? [Y/n]
```

### Concerns

This will probably pre-empt the "{conflicting_mod} conflicts with {candidate}" message in other cases, which might be confusing. I need help identifying those cases so I can figure out how to address them. Are there other situations where a mod might depend on its own conflict?