### PR TITLE
Suppress filter updates for unchanged semantic search meaning

### DIFF
--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -58,12 +58,22 @@ namespace CKAN
 
         public void SetSearches(List<ModSearch> newSearches)
         {
-            activeSearches = newSearches;
+            if (!SearchesEqual(activeSearches, newSearches))
+            {
+                activeSearches = newSearches;
+                
+                Main.Instance.configuration.DefaultSearches = activeSearches?.Select(s => s?.Combined ?? "").ToList()
+                    ?? new List<string>() { "" };
+                
+                ModFiltersUpdated?.Invoke(this);
+            }
+        }
 
-            Main.Instance.configuration.DefaultSearches = activeSearches?.Select(s => s?.Combined ?? "").ToList()
-                ?? new List<string>() { "" };
-
-            ModFiltersUpdated?.Invoke(this);
+        private static bool SearchesEqual(List<ModSearch> a, List<ModSearch> b)
+        {
+            return a == null ? b == null
+                 : b == null ? false
+                 : a.SequenceEqual(b);
         }
 
         private static string FilterName(GUIModFilter filter, ModuleTag tag = null, ModuleLabel label = null)

--- a/GUI/Model/ModSearch.cs
+++ b/GUI/Model/ModSearch.cs
@@ -9,7 +9,7 @@ namespace CKAN
     /// An object representing a search to be performed of the mod list.
     /// Create one with the constructor or Parse(), and use it with Matches().
     /// </summary>
-    public sealed class ModSearch
+    public sealed class ModSearch : IEquatable<ModSearch>
     {
         /// <summary>
         /// Initialize a mod search object.
@@ -524,6 +524,32 @@ namespace CKAN
         private bool MatchesReplaceable(GUIMod mod)
         {
             return !Replaceable.HasValue || Replaceable.Value == (mod.IsInstalled && mod.HasReplacement);
+        }
+
+        public bool Equals(ModSearch other)
+        {
+            return other != null
+                && Name            == other.Name
+                && Description     == other.Description
+                && Compatible      == other.Compatible
+                && Installed       == other.Installed
+                && Cached          == other.Cached
+                && NewlyCompatible == other.NewlyCompatible
+                && Upgradeable     == other.Upgradeable
+                && Replaceable     == other.Replaceable
+                && Authors.SequenceEqual(other.Authors)
+                && Localizations.SequenceEqual(other.Localizations)
+                && DependsOn.SequenceEqual(other.DependsOn)
+                && Recommends.SequenceEqual(other.Recommends)
+                && Suggests.SequenceEqual(other.Suggests)
+                && ConflictsWith.SequenceEqual(other.ConflictsWith)
+                && TagNames.SequenceEqual(other.TagNames)
+                && Labels.SequenceEqual(other.Labels);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ModSearch);
         }
     }
 }


### PR DESCRIPTION
## Problem

If you manually type a search for `is:compatible` (or various other similar searches like `not:compatible`, `is:cached`, etc.) rather than clicking the check/X buttons in the dropdown, the UI responds very sluggishly on Windows.

Notably, this doesn't happen for something like `dep:kopernicus` or searching for fragments of a name, where each keystroke is pretty snappy.

## Cause

A search for `is:compatibl` (note the missing `e` at the end) or any shorter substring is the same as an empty search, because we parse the `is:` prefix first and check whether the suffix matches any of our known strings, and if it doesn't, we just discard that part of the search. However, the UI still treats this as if it was a new search that needs a refresh at each keystroke, so we call `ManageMods.UpdateFilters` and re-generate the list. Since no mods are filtered out, this takes a while, especially when it happens repeatedly while you are typing.

For `dep:kopernicus`: `d`, `de`, and `dep:k` each filters the list significantly, so the refresh is quick enough to keep up with user keystrokes.

Linux and Mac appear to be unaffected because they use a timer to delay searches.

## Changes

Now we only update the filters if the new searches have a different semantic meaning than the old searches. So while you are typing `is:compatibl`, each intermediate search is determined to be equivalent to the default empty search, so nothing happens until you add the final `e`, at which point we show the list of compatible mods, which is quick because it's a shorter list.

To do this, `ModSearch.Equals` is now defined to return whether two searches have the same meaning, and `ModList.SearchesEqual` is a short wrapper around `SequenceEqual` to handle nulls. We only trigger a full refresh if `SearchesEqual` returns false.

Fixes #3402.