### PR TITLE
More Netkan validation for any_of

### DIFF
--- a/Netkan/Validators/LicensesValidator.cs
+++ b/Netkan/Validators/LicensesValidator.cs
@@ -37,7 +37,7 @@ namespace CKAN.NetKAN.Validators
             {
                 if (licenses == null || licenses.Count < 1)
                 {
-                    throw new Kraken("License should match spec. Set `x_netkan_license_ok` to suppress");
+                    throw new Kraken("License should match spec");
                 }
                 else foreach (var lic in licenses)
                 {
@@ -48,7 +48,7 @@ namespace CKAN.NetKAN.Validators
                     }
                     catch
                     {
-                        throw new Kraken($"License {lic} should match spec. Set `x_netkan_license_ok` to suppress");
+                        throw new Kraken($"License {lic} should match spec");
                     }
                 }
             }

--- a/Netkan/Validators/RelationshipsValidator.cs
+++ b/Netkan/Validators/RelationshipsValidator.cs
@@ -22,12 +22,23 @@ namespace CKAN.NetKAN.Validators
                             {
                                 throw new Kraken("spec_version v1.26+ required for 'any_of'");
                             }
+                            foreach (string forbiddenPropertyName in AnyOfRelationshipDescriptor.ForbiddenPropertyNames)
+                            {
+                                if (rel.ContainsKey(forbiddenPropertyName))
+                                {
+                                    throw new Kraken($"{forbiddenPropertyName} is not valid in the same relationship as 'any_of'");
+                                }
+                            }
+                            if (rel.ContainsKey("choice_help_text") && metadata.SpecVersion < v1p31)
+                            {
+                                throw new Kraken("spec_version v1.31+ required for choice_help_text in same relationship as 'any_of'");
+                            }
                             foreach (JObject opt in rel["any_of"])
                             {
                                 string name = (string)opt["name"];
                                 if (!Identifier.ValidIdentifierPattern.IsMatch(name))
                                 {
-                                    throw new Kraken($"{name} in {relName} any_of is not a valid CKAN identifier");
+                                    throw new Kraken($"{name} in {relName} 'any_of' is not a valid CKAN identifier");
                                 }
                             }
                         }
@@ -54,5 +65,6 @@ namespace CKAN.NetKAN.Validators
             "supports"
         };
         private static readonly ModuleVersion v1p26 = new ModuleVersion("v1.26");
+        private static readonly ModuleVersion v1p31 = new ModuleVersion("v1.31");
     }
 }

--- a/Spec.md
+++ b/Spec.md
@@ -542,6 +542,20 @@ which are not in themselves mutually compatible enough to use the `"provides"` p
     ]
 ```
 
+(**v1.31**) Clients implementing version `v1.31` or later of the spec *must* support
+the `choice_help_text` property in a relationship. This string is presented to the user
+if they must be prompted to choose between two or more mods to satisfy the relationship.
+
+```yaml
+depends:
+  - name: VirtualIdentifier1
+    choice_help_text: Choose the HR option for high resolution
+  - any_of:
+    - name: ModA
+    - name: ModB
+    choice_help_text: Pick ModA if you prefer polka dots, ModB otherwise
+```
+
 ##### depends
 
 A list of mods which are *required* for the current mod to operate.


### PR DESCRIPTION
## Motivation

In #3426 we added the ability to set `choice_help_text` for a relationship to change the prompt the user sees when choosing between multiple modules.

However, if you add `choice_help_text` to an `any_of` relationship, the current client will throw exceptions. So if any metanetkan does this, old clients could be disabled until we clean it up. This kind of incompatibility is usually managed with `spec_version` bumps.

## Changes

Now if Netkan finds `choice_help_text` in an `any_of` relationship, it requires the `spec_version` to be at least v1.31. This will ensure that the old clients will not attempt to load such metadata. This will require the next release to be v1.31.0.

### Side fixes

The spec is updated to explain `choice_help_text`, since it now has a version-specific component.

The "Set `x_netkan_license_ok` to suppress" sentence is removed from Netkan's output because this is bad advice. While that functionality does exist, almost all users should simply set the license to a valid license string.