### PR TITLE
Add user guide and Discord to GUI help menu

### DIFF
--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -178,6 +178,7 @@
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Spielstart-Befehlszeile</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Kompatible Spielversionen</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Hilfe</value></data>
+  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>Benutzerhandbuch</value></data>
   <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Fehler mit dem CKAN Client melden</value></data>
   <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Fehler mit Mod-Metadaten melden</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>Über</value></data>

--- a/GUI/Localization/fr-FR/Main.fr-FR.resx
+++ b/GUI/Localization/fr-FR/Main.fr-FR.resx
@@ -150,6 +150,7 @@
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Ligne de commande du jeu</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Versions de jeu compatibles</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Aide</value></data>
+  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>Guide d'utilisation</value></data>
   <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec le client CKAN</value></data>
   <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec les métadonnées de mod</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>À propos</value></data>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -50,6 +50,7 @@
             this.compatibleGameVersionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.userGuideToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.discordToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportClientIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportMetadataIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -264,6 +265,7 @@
             //
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.userGuideToolStripMenuItem,
+            this.discordToolStripMenuItem,
             this.reportClientIssueToolStripMenuItem,
             this.reportMetadataIssueToolStripMenuItem,
             this.aboutToolStripMenuItem});
@@ -277,6 +279,13 @@
             this.userGuideToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
             this.userGuideToolStripMenuItem.Click += new System.EventHandler(this.userGuideToolStripMenuItem_Click);
             resources.ApplyResources(this.userGuideToolStripMenuItem, "userGuideToolStripMenuItem");
+            //
+            // discordToolStripMenuItem
+            //
+            this.discordToolStripMenuItem.Name = "discordToolStripMenuItem";
+            this.discordToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.discordToolStripMenuItem.Click += new System.EventHandler(this.discordToolStripMenuItem_Click);
+            resources.ApplyResources(this.discordToolStripMenuItem, "discordToolStripMenuItem");
             //
             // reportClientIssueToolStripMenuItem
             //
@@ -735,6 +744,7 @@
         private System.Windows.Forms.ToolStripMenuItem compatibleGameVersionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem userGuideToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem discordToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportClientIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportMetadataIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -49,6 +49,7 @@
             this.GameCommandlineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compatibleGameVersionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.userGuideToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportClientIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportMetadataIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -262,12 +263,20 @@
             // helpToolStripMenuItem
             //
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.userGuideToolStripMenuItem,
             this.reportClientIssueToolStripMenuItem,
             this.reportMetadataIssueToolStripMenuItem,
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
             resources.ApplyResources(this.helpToolStripMenuItem, "helpToolStripMenuItem");
+            //
+            // userGuideToolStripMenuItem
+            //
+            this.userGuideToolStripMenuItem.Name = "userGuideToolStripMenuItem";
+            this.userGuideToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.userGuideToolStripMenuItem.Click += new System.EventHandler(this.userGuideToolStripMenuItem_Click);
+            resources.ApplyResources(this.userGuideToolStripMenuItem, "userGuideToolStripMenuItem");
             //
             // reportClientIssueToolStripMenuItem
             //
@@ -725,6 +734,7 @@
         private System.Windows.Forms.ToolStripMenuItem GameCommandlineToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem compatibleGameVersionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem userGuideToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportClientIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportMetadataIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -675,6 +675,11 @@ namespace CKAN
             }
         }
 
+        private void userGuideToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/wiki/User-guide");
+        }
+
         private void reportClientIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/issues/new/choose");

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -680,6 +680,11 @@ namespace CKAN
             Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/wiki/User-guide");
         }
 
+        private void discordToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Utilities.ProcessStartURL("https://discord.gg/Mb4nXQD");
+        }
+
         private void reportClientIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/issues/new/choose");

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -151,6 +151,7 @@
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Compatible game versions</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Help</value></data>
   <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>User guide</value></data>
+  <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>Discord</value></data>
   <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN client</value></data>
   <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod metadata</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>About</value></data>

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -150,6 +150,7 @@
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Game command-line</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Compatible game versions</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Help</value></data>
+  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>User guide</value></data>
   <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN client</value></data>
   <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod metadata</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>About</value></data>


### PR DESCRIPTION
## Motivation

CKAN has a pretty detailed user guide that answers most questions users might have. We frequently handle support questions by posting links to it:

- https://github.com/KSP-CKAN/CKAN/wiki/User-guide

However, GUI's help menu shows only:

![image](https://user-images.githubusercontent.com/1559108/130101942-5e698fa3-17b4-4b81-8bf1-0becb18cb418.png)

This means the user guide isn't discoverable, and the help menu doesn't provide help!

## Changes

Now new menu items in the Help menu link to the user guide and CKAN Discord:

![image](https://user-images.githubusercontent.com/1559108/133704396-2a483a62-adfd-4c8e-9446-bf1e3061a99c.png)

Hopefully this will mean that users seeking help will find the user guide and see their questions answered within it. If not, they can ask questions on Discord.

### Questions

Is "User guide" clear enough that a user would click on it? Checking a few older Windows applications, they use Help → View Help to open their main help documentation, which we could do as well.

![image](https://user-images.githubusercontent.com/1559108/130116950-7cf84b86-6ee2-4ce1-8d68-fbab85560acb.png)