### PR TITLE
Don't create no longer used directories in Dockerfile.metadata

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -9,6 +9,4 @@ RUN pip3 install 'git+https://github.com/KSP-CKAN/xKAN-meta_testing'
 ADD netkan.exe /usr/local/bin/.
 ADD ckan.exe /usr/local/bin/.
 
-RUN mkdir -p /ckans /repo
-
 ENTRYPOINT ["ckanmetatester"]


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/pull/8704 and https://github.com/KSP-CKAN/xKAN-meta_testing/pull/80, those directories have been moved into the working directory in the container (which is a volume mounted to `/github/workspace`), so we can access them after the xKAN_meta-testing action finished and the container exited.
Thus, there's no need to create them in the Dockerfile anymore.

As `/github/workspace` is mounted during runtime, we can't create `.ckans` and `.repo` beforehand (or better: the created directories would be lost). Instead they are created at runtime.