### PR TITLE
Default install stanza multi-game support, catch missing install_to

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -514,7 +514,7 @@ namespace CKAN
                 else
                 {
                     files.AddRange(ModuleInstallDescriptor
-                        .DefaultInstallStanza(module.identifier)
+                        .DefaultInstallStanza(ksp.game, module.identifier)
                         .FindInstallableFiles(zipfile, ksp));
                 }
             }

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -10,6 +10,7 @@ using Autofac;
 using log4net;
 using Newtonsoft.Json;
 using CKAN.Versioning;
+using CKAN.Games;
 
 namespace CKAN
 {
@@ -683,7 +684,7 @@ namespace CKAN
             return string.Format("{0} {1}", identifier, version);
         }
 
-        public string DescribeInstallStanzas()
+        public string DescribeInstallStanzas(IGame game)
         {
             List<string> descriptions = new List<string>();
             if (install != null)
@@ -695,7 +696,7 @@ namespace CKAN
             }
             else
             {
-                descriptions.Add(ModuleInstallDescriptor.DefaultInstallStanza(identifier).DescribeMatch());
+                descriptions.Add(ModuleInstallDescriptor.DefaultInstallStanza(game, identifier).DescribeMatch());
             }
             return string.Join(", ", descriptions);
         }

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -211,12 +211,12 @@ namespace CKAN
         /// <returns>
         /// { "find": "ident", "install_to": "GameData" }
         /// </returns>
-        public static ModuleInstallDescriptor DefaultInstallStanza(string ident)
+        public static ModuleInstallDescriptor DefaultInstallStanza(IGame game, string ident)
         {
             return new ModuleInstallDescriptor()
             {
                 find       = ident,
-                install_to = "GameData",
+                install_to = game.PrimaryModDirectoryRelative,
             };
         }
 

--- a/Netkan/Validators/InstallValidator.cs
+++ b/Netkan/Validators/InstallValidator.cs
@@ -14,6 +14,10 @@ namespace CKAN.NetKAN.Validators
                 foreach (JObject stanza in json["install"])
                 {
                     string install_to = (string)stanza["install_to"];
+                    if (string.IsNullOrEmpty(install_to))
+                    {
+                        throw new Kraken("install stanza missing `install_to`");
+                    }
                     if (metadata.SpecVersion < v1p2 && install_to.StartsWith("GameData/"))
                     {
                         throw new Kraken("spec_version v1.2+ required for GameData with path");

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -3,6 +3,7 @@ using System.Linq;
 ﻿using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.Extensions;
+using CKAN.Games;
 
 namespace CKAN.NetKAN.Validators
 {
@@ -29,7 +30,7 @@ namespace CKAN.NetKAN.Validators
                 {
                     throw new Kraken(string.Format(
                         "Module contains no files matching: {0}",
-                        mod.DescribeInstallStanzas()
+                        mod.DescribeInstallStanzas(new KerbalSpaceProgram())
                     ));
                 }
 

--- a/Spec.md
+++ b/Spec.md
@@ -326,15 +326,14 @@ In addition, any number of optional directives *may* be provided:
 
 If no install sections are provided, a CKAN client *must* find the
 top-most directory in the archive that matches the module identifier,
-and install that with a target of `GameData`.
-
-A typical install directive only has `file` and `install_to` sections:
+and install that with a target of `GameData`. In other words, the
+default install section is:
 
 ```json
-    "install" : [
+    "install": [
         {
-            "file"       : "GameData/ExampleMod",
-            "install_to" : "GameData"
+            "find": "<identifier>",
+            "install_to": "GameData"
         }
     ]
 ```

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -9,6 +9,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 
 using CKAN;
+using CKAN.Games;
 using Tests.Core.Configuration;
 using Tests.Data;
 
@@ -73,13 +74,13 @@ namespace Tests.Core
             string filename = TestData.DogeCoinFlagZip();
             using (var zipfile = new ZipFile(filename))
             {
-                ModuleInstallDescriptor stanza = ModuleInstallDescriptor.DefaultInstallStanza("DogeCoinFlag");
+                ModuleInstallDescriptor stanza = ModuleInstallDescriptor.DefaultInstallStanza(new KerbalSpaceProgram(), "DogeCoinFlag");
 
                 Assert.AreEqual("GameData", stanza.install_to);
                 Assert.AreEqual("DogeCoinFlag", stanza.find);
 
                 // Same again, but screwing up the case (we see this *all the time*)
-                ModuleInstallDescriptor stanza2 = ModuleInstallDescriptor.DefaultInstallStanza("DogecoinFlag");
+                ModuleInstallDescriptor stanza2 = ModuleInstallDescriptor.DefaultInstallStanza(new KerbalSpaceProgram(), "DogecoinFlag");
 
                 Assert.AreEqual("GameData", stanza2.install_to);
                 Assert.AreEqual("DogecoinFlag", stanza2.find);
@@ -362,7 +363,7 @@ namespace Tests.Core
             using (var zipfile = new ZipFile(corrupt_dogezip))
             {
                 // GenerateDefault Install
-                ModuleInstallDescriptor.DefaultInstallStanza("DogeCoinFlag");
+                ModuleInstallDescriptor.DefaultInstallStanza(new KerbalSpaceProgram(), "DogeCoinFlag");
 
                 // FindInstallableFiles
                 CkanModule dogemod = TestData.DogeCoinFlag_101_module();


### PR DESCRIPTION
## Problem

In KSP-CKAN/NetKAN#8735, this metadata:

```yaml
install:
  - find: GameData/InterstellarTechnologies
  - install_to: GameData
```

caused this error:

```
Error: 1459 [1] FATAL CKAN.NetKAN.Program (null) - Object reference not set to an instance of an object
```

## Cause

`install_to` is [required by the spec](https://github.com/KSP-CKAN/CKAN/blame/2a2b12e399818e39534070ccf888e3ac08fd47af/Spec.md#L292-L303), and `NetKAN.Validators.InstallValidator` assumes `install_to` will be set. In this instance, it wasn't, because that YAML translates to:

```json
  "install": [
    {
      "find": "GameData/InterstellarTechnologies"
    },
    {
      "install_to": "GameData"
    }
  ]
```

We should catch this explicitly rather than throwing a NRE.

## Motivation

That PR's changes were essentially trying to make the default install stanza's behavior more explicit, so they've been set aside. However, in the process of explaining this I realized that the default install stanza is KSP1-specific: it hard-codes `GameData`. This would make default stanzas unusable for any future supported game that uses a different folder for mod data.

## Changes

- Now if `install_to` isn't set, we throw an explicit error saying that
- Now the default install stanza uses the `PrimaryModDirectoryRelative` property of the module's game, which will be `GameData` for KSP1 and wherever mods are supposed to go instead for other games
- The spec is updated to hopefully be clearer about how the default install stanza works