### PR TITLE
Show context menu on menu key press

### DIFF
--- a/ConsoleUI/Toolkit/ConsolePopupMenu.cs
+++ b/ConsoleUI/Toolkit/ConsolePopupMenu.cs
@@ -76,6 +76,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                         break;
                     case ConsoleKey.F10:
                     case ConsoleKey.Escape:
+                    case ConsoleKey.Applications:
                         done = true;
                         break;
                 }

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -18,7 +18,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                 "F10", MenuTip(),
                 () => mainMenu != null
             );
-            AddBinding(Keys.F10, (object sender, ConsoleTheme theme) => {
+            AddBinding(new ConsoleKeyInfo[] {Keys.F10, Keys.Apps}, (object sender, ConsoleTheme theme) => {
                 bool val = true;
                 if (mainMenu != null) {
                     DrawSelectedHamburger(theme);

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -75,6 +75,13 @@ namespace CKAN.ConsoleUI.Toolkit {
         );
 
         /// <summary>
+        /// Representation of Apps for key bindings
+        /// </summary>
+        public static readonly ConsoleKeyInfo Apps = new ConsoleKeyInfo(
+            (System.Char)0, ConsoleKey.Applications, false, false, false
+        );
+
+        /// <summary>
         /// Representation of down arrow for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo DownArrow = new ConsoleKeyInfo(

--- a/ConsoleUI/Toolkit/ScreenContainer.cs
+++ b/ConsoleUI/Toolkit/ScreenContainer.cs
@@ -76,6 +76,18 @@ namespace CKAN.ConsoleUI.Toolkit {
         }
 
         /// <summary>
+        /// Add custom key bindings
+        /// </summary>
+        /// <param name="keys">Keys to bind</param>
+        /// <param name="a">Action to bind to key</param>
+        public void AddBinding(IEnumerable<ConsoleKeyInfo> keys, KeyAction a)
+        {
+            foreach (ConsoleKeyInfo k in keys) {
+                AddBinding(k, a);
+            }
+        }
+
+        /// <summary>
         /// Add a screen tip to show in the FooterBg
         /// </summary>
         /// <param name="key">User readable description of the key</param>
@@ -247,7 +259,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                 } while (!objects[focusIndex].Focusable());
             }
         }
-        
+
         private bool done = false;
 
         private List<ScreenObject> objects    = new List<ScreenObject>();

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -112,6 +112,7 @@ namespace CKAN
             this.menuStrip2.Location = new System.Drawing.Point(0, 0);
             this.menuStrip2.Name = "menuStrip2";
             this.menuStrip2.Size = new System.Drawing.Size(5876, 48);
+            this.menuStrip2.TabStop = true;
             this.menuStrip2.TabIndex = 4;
             this.menuStrip2.Text = "menuStrip2";
             //

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -643,6 +643,11 @@ namespace CKAN
                         }
                     }
                     break;
+
+                case Keys.Apps:
+                    ShowModContextMenu();
+                    e.Handled = true;
+                    break;
             }
         }
 
@@ -908,23 +913,31 @@ namespace CKAN
         {
             var rowIndex = ModGrid.HitTest(e.X, e.Y).RowIndex;
 
-            // Ignore header column to prevent errors.
+            // Ignore header column to prevent errors
             if (rowIndex != -1 && e.Button == MouseButtons.Right)
             {
-                // Detect the clicked cell and select the row.
+                // Detect the clicked cell and select the row
                 ModGrid.ClearSelection();
                 ModGrid.Rows[rowIndex].Selected = true;
 
-                // Show the context menu.
-                ModListContextMenuStrip.Show(ModGrid, new Point(e.X, e.Y));
+                // Show the context menu
+                ShowModContextMenu();
+            }
+        }
 
-                // Set the menu options.
-                var guiMod = (GUIMod)ModGrid.Rows[rowIndex].Tag;
-
+        private bool ShowModContextMenu()
+        {
+            var guiMod = SelectedModule;
+            if (guiMod != null)
+            {
+                ModListContextMenuStrip.Show(Cursor.Position);
+                // Set the menu options
                 downloadContentsToolStripMenuItem.Enabled = !guiMod.ToModule().IsMetapackage &&  !guiMod.IsCached;
                 purgeContentsToolStripMenuItem.Enabled = !guiMod.ToModule().IsMetapackage && guiMod.IsCached;
                 reinstallToolStripMenuItem.Enabled = guiMod.IsInstalled && !guiMod.IsAutodetected;
+                return true;
             }
+            return false;
         }
 
         private void ModList_Resize(object sender, EventArgs e)

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -118,6 +118,17 @@ namespace CKAN
             Util.HandleLinkClicked((sender as LinkLabel).Text, e);
         }
 
+        private void LinkLabel_KeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Apps:
+                    Util.LinkContextMenu((sender as LinkLabel).Text);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
         private void UpdateModInfo(GUIMod gui_module)
         {
             CkanModule module = gui_module.ToModule();
@@ -254,6 +265,7 @@ namespace CKAN
                     Text     = link.ToString(),
                 };
                 llbl.LinkClicked += new LinkLabelLinkClickedEventHandler(LinkLabel_LinkClicked);
+                llbl.KeyDown += new KeyEventHandler(LinkLabel_KeyDown);
                 int row = MetaDataLowerLayoutPanel.RowCount;
                 MetaDataLowerLayoutPanel.Controls.Add(lbl,  0, row);
                 MetaDataLowerLayoutPanel.Controls.Add(llbl, 1, row);

--- a/GUI/Dialogs/AboutDialog.Designer.cs
+++ b/GUI/Dialogs/AboutDialog.Designer.cs
@@ -87,6 +87,7 @@ namespace CKAN
             this.licenseLinkLabel.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.licenseLinkLabel.UseCompatibleTextRendering = true;
             this.licenseLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel_LinkClicked);
+            this.licenseLinkLabel.KeyDown += new System.Windows.Forms.KeyEventHandler(this.linkLabel_KeyDown);
             //
             // authorsLabel
             //
@@ -108,6 +109,7 @@ namespace CKAN
             this.authorsLinkLabel.TabStop = true;
             this.authorsLinkLabel.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.authorsLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel_LinkClicked);
+            this.authorsLinkLabel.KeyDown += new System.Windows.Forms.KeyEventHandler(this.linkLabel_KeyDown);
             //
             // sourceLabel
             //
@@ -129,6 +131,7 @@ namespace CKAN
             this.sourceLinkLabel.TabStop = true;
             this.sourceLinkLabel.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.sourceLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel_LinkClicked);
+            this.sourceLinkLabel.KeyDown += new System.Windows.Forms.KeyEventHandler(this.linkLabel_KeyDown);
             //
             // forumthreadLabel
             //
@@ -151,6 +154,7 @@ namespace CKAN
             this.forumthreadLinkLabel.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.forumthreadLinkLabel.UseCompatibleTextRendering = true;
             this.forumthreadLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel_LinkClicked);
+            this.forumthreadLinkLabel.KeyDown += new System.Windows.Forms.KeyEventHandler(this.linkLabel_KeyDown);
             //
             // homepageLabel
             //
@@ -172,6 +176,7 @@ namespace CKAN
             this.homepageLinkLabel.TabStop = true;
             this.homepageLinkLabel.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.homepageLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel_LinkClicked);
+            this.homepageLinkLabel.KeyDown += new System.Windows.Forms.KeyEventHandler(this.linkLabel_KeyDown);
             //
             // AboutDialog
             //

--- a/GUI/Dialogs/AboutDialog.cs
+++ b/GUI/Dialogs/AboutDialog.cs
@@ -17,5 +17,17 @@ namespace CKAN
             string url = (sender as LinkLabel).Text;
             Util.HandleLinkClicked(url, e);
         }
+
+        private void linkLabel_KeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Apps:
+                    Util.LinkContextMenu((sender as LinkLabel).Text);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
     }
 }

--- a/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
@@ -77,6 +77,7 @@
             this.GameInstancesListView.SelectedIndexChanged += new System.EventHandler(this.GameInstancesListView_SelectedIndexChanged);
             this.GameInstancesListView.DoubleClick += new System.EventHandler(this.GameInstancesListView_DoubleClick);
             this.GameInstancesListView.MouseClick += new System.Windows.Forms.MouseEventHandler(this.GameInstancesListView_Click);
+            this.GameInstancesListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GameInstancesListView_KeyDown);
             //
             // InstanceListContextMenuStrip
             //

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -232,6 +232,17 @@ namespace CKAN
             }
         }
 
+        private void GameInstancesListView_KeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Apps:
+                    InstanceListContextMenuStrip.Show(Cursor.Position);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
         private void OpenDirectoryMenuItem_Click(object sender, EventArgs e)
         {
             string path = _manager.Instances[(string) GameInstancesListView.SelectedItems[0].Tag].GameDir();


### PR DESCRIPTION
## Problem

Most keyboards have a key to open a context menu (mine requires pressing Fn+PrintScrn, but it's there). Currently this does nothing in CKAN, to the detriment of keyboard users.

## Cause

The mod list context menu is implemented in the grid's `MouseDown` event, and pressing the menu key triggers `KeyDown` and does nothing.

## Changes

Now the code to manage the menu is moved a new `ShowModContextMenu` function, which is called from `MouseDown` on a right click and `KeyDown` for `Key.Apps` (the code for the menu key).

Similar changes are also made for the URL link labels in mod info and the About dialog, as well as the list of instances in the manage game instances dialog. And this key also now opens and closes the F10 menu in ConsoleUI.

Fixes #3445.