### PR TITLE
Allow overriding resources.remote-avc

### DIFF
--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -69,13 +69,17 @@ namespace CKAN.NetKAN.Transformers
                 {
                     Log.Info("Found internal AVC version file");
 
-                    var remoteUri = GetRemoteAvcUri(avc);
+                    var resourcesJson = (JObject)json["resources"];
+                    var remoteUri = resourcesJson?["remote-avc"] != null
+                        ? new Uri((string)resourcesJson["remote-avc"])
+                        : GetRemoteAvcUri(avc);
 
                     if (remoteUri != null)
                     {
-                        if (json["resources"] == null)
-                            json["resources"] = new JObject();
-                        var resourcesJson = (JObject)json["resources"];
+                        if (resourcesJson == null)
+                        {
+                            json["resources"] = resourcesJson = new JObject();
+                        }
                         resourcesJson.SafeAdd("remote-avc", remoteUri.OriginalString);
 
                         try

--- a/Spec.md
+++ b/Spec.md
@@ -617,7 +617,7 @@ are described. Unless specified otherwise, these are URLs:
 - `curse` :  (**v1.20**) The mod on Curse.
 - `manual` : The mod's manual, if it exists.
 - `metanetkan` :  (**v1.27**) URL of the module's remote hosted netkan
-- `remote-avc` : URL of remote version file
+- `remote-avc` : URL of remote version file. If set in the netkan file, will be used to find the online copy of the version file. Otherwise the `URL` property from the internal version file will be assigned to this field and used instead.
 - `store`:  (**v1.28**) URL where you can purchase a DLC
 - `steamstore`:  (**v1.28**) URL where you can purchase a DLC on Steam
 


### PR DESCRIPTION
## Motivation

There are a lot of mods that have remote version files but a bad `URL` property in the version file such that the remote version file isn't found/used. This clutters our warnings list and potentially deprives CKAN of better metadata if any of them have been updated since release:

![image](https://user-images.githubusercontent.com/1559108/133652469-b6212c30-cfcd-4dd2-ac4e-aee6b1cb8448.png)

Currently these can only be resolved by submitting a pull request to the mod's repo, having it merged, and then a new release being made.

## Background

As of #3259, the `resources.remote-avc` property is set to the URL of the remote version file by the AVC transformer.

## Changes

Now if the `reources.remote-avc` property is set upstream of the AVC transformer (i.e. in the netkan or by a previous transformer), we use that value to override the remote version file to check. This will allow us to suppress these warnings and get the most accurate compatibility data by setting the correct URL in the netkans.