### PR TITLE
Suppress incompatibility warning at game launch

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -132,6 +132,10 @@ namespace CKAN
             log.InfoFormat("Initialised {0}", CkanDir());
         }
 
+        #endregion
+
+        #region Settings
+
         public void SetCompatibleVersions(List<GameVersion> compatibleVersions)
         {
             this._compatibleVersions = compatibleVersions.Distinct().ToList();
@@ -177,6 +181,19 @@ namespace CKAN
         {
             return new List<GameVersion>(this._compatibleVersions);
         }
+
+        public HashSet<string> GetSuppressedCompatWarningIdentifiers =>
+            SuppressedCompatWarningIdentifiers.LoadFrom(Version(), SuppressedCompatWarningIdentifiersFile).Identifiers;
+
+        public void AddSuppressedCompatWarningIdentifiers(HashSet<string> idents)
+        {
+            var scwi = SuppressedCompatWarningIdentifiers.LoadFrom(Version(), SuppressedCompatWarningIdentifiersFile);
+            scwi.Identifiers.UnionWith(idents);
+            scwi.SaveTo(SuppressedCompatWarningIdentifiersFile);
+        }
+
+        private string SuppressedCompatWarningIdentifiersFile =>
+            Path.Combine(CkanDir(), "suppressed_compat_warning_identifiers.json");
 
         #endregion
 

--- a/Core/SuppressedCompatWarningIdentifiers.cs
+++ b/Core/SuppressedCompatWarningIdentifiers.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using log4net;
+
+using CKAN.Versioning;
+
+namespace CKAN
+{
+    class SuppressedCompatWarningIdentifiers
+    {
+        public GameVersion GameVersionWhenWritten;
+        public HashSet<string> Identifiers = new HashSet<string>();
+
+        public static SuppressedCompatWarningIdentifiers LoadFrom(GameVersion gameVer, string filename)
+        {
+            try
+            {
+                var saved = JsonConvert.DeserializeObject<SuppressedCompatWarningIdentifiers>(File.ReadAllText(filename));
+                // Reset warnings if e.g. Steam auto-updates the game
+                if (saved.GameVersionWhenWritten == gameVer)
+                {
+                    return saved;
+                }
+            }
+            catch (Exception exc)
+            {
+                log.Debug("Failed to load", exc);
+            }
+            return new SuppressedCompatWarningIdentifiers()
+            {
+                GameVersionWhenWritten = gameVer
+            };
+        }
+
+        public void SaveTo(string filename)
+        {
+            File.WriteAllText(filename, JsonConvert.SerializeObject(this));
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(SuppressedCompatWarningIdentifiers));
+    }
+}

--- a/GUI/Dialogs/YesNoDialog.Designer.cs
+++ b/GUI/Dialogs/YesNoDialog.Designer.cs
@@ -32,6 +32,7 @@
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(YesNoDialog));
             this.panel1 = new System.Windows.Forms.Panel();
             this.DescriptionLabel = new TransparentTextBox();
+            this.SuppressCheckbox = new System.Windows.Forms.CheckBox();
             this.YesButton = new System.Windows.Forms.Button();
             this.NoButton = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
@@ -63,6 +64,18 @@
             this.DescriptionLabel.BorderStyle = System.Windows.Forms.BorderStyle.None;
             resources.ApplyResources(this.DescriptionLabel, "DescriptionLabel");
             // 
+            // SuppressCheckbox
+            // 
+            this.SuppressCheckbox.AutoSize = false;
+            this.SuppressCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
+            | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.SuppressCheckbox.Location = new System.Drawing.Point(13, 80);
+            this.SuppressCheckbox.Name = "SuppressCheckbox";
+            this.SuppressCheckbox.Size = new System.Drawing.Size(225, 50);
+            this.SuppressCheckbox.TabIndex = 1;
+            this.SuppressCheckbox.UseVisualStyleBackColor = true;
+            resources.ApplyResources(this.SuppressCheckbox, "SuppressCheckbox");
+            // 
             // YesButton
             // 
             this.YesButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
@@ -71,7 +84,7 @@
             this.YesButton.Location = new System.Drawing.Point(250, 92);
             this.YesButton.Name = "YesButton";
             this.YesButton.Size = new System.Drawing.Size(75, 23);
-            this.YesButton.TabIndex = 1;
+            this.YesButton.TabIndex = 2;
             this.YesButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.YesButton, "YesButton");
             // 
@@ -83,7 +96,7 @@
             this.NoButton.Location = new System.Drawing.Point(331, 92);
             this.NoButton.Name = "NoButton";
             this.NoButton.Size = new System.Drawing.Size(75, 23);
-            this.NoButton.TabIndex = 2;
+            this.NoButton.TabIndex = 3;
             this.NoButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.NoButton, "NoButton");
             // 
@@ -92,6 +105,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(418, 127);
+            this.Controls.Add(this.SuppressCheckbox);
             this.Controls.Add(this.NoButton);
             this.Controls.Add(this.YesButton);
             this.Controls.Add(this.panel1);
@@ -109,6 +123,7 @@
 
         private System.Windows.Forms.Panel panel1;
         private TransparentTextBox DescriptionLabel;
+        private System.Windows.Forms.CheckBox SuppressCheckbox;
         private System.Windows.Forms.Button YesButton;
         private System.Windows.Forms.Button NoButton;
     }

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -16,28 +16,55 @@ namespace CKAN
 
         public DialogResult ShowYesNoDialog(Form parentForm, string text, string yesText = null, string noText = null)
         {
-            task = new TaskCompletionSource<DialogResult>();
+            task = new TaskCompletionSource<Tuple<DialogResult, bool>>();
 
             Util.Invoke(parentForm, () =>
             {
-                var height = StringHeight(text, ClientSize.Width - 25) + 2 * 54;
-                DescriptionLabel.Text = text;
-                DescriptionLabel.TextAlign = text.Contains("\n")
-                    ? HorizontalAlignment.Left
-                    : HorizontalAlignment.Center;
-                DescriptionLabel.ScrollBars = height < maxHeight
-                    ? ScrollBars.None
-                    : ScrollBars.Vertical;
-                YesButton.Text = yesText ?? defaultYes;
-                NoButton.Text  = noText  ?? defaultNo;
-                ClientSize = new Size(
-                    ClientSize.Width,
-                    Math.Min(maxHeight, height)
-                );
-                task.SetResult(ShowDialog(parentForm));
+                Setup(text, yesText, noText);
+                task.SetResult(new Tuple<DialogResult, bool>(ShowDialog(parentForm), SuppressCheckbox.Checked));
+            });
+
+            return task.Task.Result.Item1;
+        }
+
+        public Tuple<DialogResult, bool> ShowSuppressableYesNoDialog(Form parentForm, string text, string suppressText, string yesText = null, string noText = null)
+        {
+            task = new TaskCompletionSource<Tuple<DialogResult, bool>>();
+
+            Util.Invoke(parentForm, () =>
+            {
+                SetupSuppressable(text, yesText, noText, suppressText);
+                task.SetResult(new Tuple<DialogResult, bool>(ShowDialog(parentForm), SuppressCheckbox.Checked));
             });
 
             return task.Task.Result;
+        }
+
+        private void Setup(string text, string yesText, string noText)
+        {
+            var height = StringHeight(text, ClientSize.Width - 25) + 2 * 54;
+            DescriptionLabel.Text = text;
+            DescriptionLabel.TextAlign = text.Contains("\n")
+                ? HorizontalAlignment.Left
+                : HorizontalAlignment.Center;
+            DescriptionLabel.ScrollBars = height < maxHeight
+                ? ScrollBars.None
+                : ScrollBars.Vertical;
+            YesButton.Text = yesText ?? defaultYes;
+            NoButton.Text  = noText  ?? defaultNo;
+            SuppressCheckbox.Visible = false;
+            ClientSize = new Size(
+                ClientSize.Width,
+                Math.Min(maxHeight, height)
+            );
+        }
+
+        private void SetupSuppressable(string text, string yesText, string noText, string suppressText)
+        {
+            Setup(text, yesText, noText);
+            SuppressCheckbox.Checked = false;
+            SuppressCheckbox.Text = suppressText;
+            SuppressCheckbox.Visible = true;
         }
 
         /// <summary>
@@ -59,7 +86,7 @@ namespace CKAN
         }
 
         private const int maxHeight = 600;
-        private TaskCompletionSource<DialogResult> task;
+        private TaskCompletionSource<Tuple<DialogResult, bool>> task;
         private string defaultYes;
         private string defaultNo;
     }

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -38,6 +38,16 @@ namespace CKAN
             return yesNoDialog.ShowYesNoDialog(this, text, yesText, noText) == DialogResult.Yes;
         }
 
+        /// <summary>
+        /// Show a yes/no dialog with a "don't show again" checkbox
+        /// </summary>
+        /// <returns>A tuple of the dialog result and a bool indicating whether
+        /// the suppress-checkbox has been checked (true)</returns>
+        public Tuple<DialogResult, bool> SuppressableYesNoDialog(string text, string suppressText, string yesText = null, string noText = null)
+        {
+            return yesNoDialog.ShowSuppressableYesNoDialog(this, text, suppressText, yesText, noText);
+        }
+
         public int SelectionDialog(string message, params object[] args)
         {
             return selectionDialog.ShowSelectionDialog(message, args);

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -408,6 +408,9 @@ namespace CKAN.Properties {
         internal static string MainLaunchWithIncompatible {
             get { return (string)(ResourceManager.GetObject("MainLaunchWithIncompatible", resourceCulture)); }
         }
+        internal static string MainLaunchDontShow {
+            get { return (string)(ResourceManager.GetObject("MainLaunchDontShow", resourceCulture)); }
+        }
         internal static string MainLaunch {
             get { return (string)(ResourceManager.GetObject("MainLaunch", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -173,6 +173,7 @@ Versuche {2} aus {3} zu verschieben und CKAN neu zu starten.</value></data>
 {0}</value>
   </data>
   <data name="MainLaunch" xml:space="preserve"><value>Starten</value></data>
+  <data name="MainLaunchDontShow" xml:space="preserve"><value>Für diese Mods und {0} {1} nicht mehr anzeigen</value></data>
   <data name="MainLaunchFailed" xml:space="preserve">
     <value>Das Spiel konnte nicht gestartet werden.
 

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -172,6 +172,7 @@ Essayez de déplacer {2} en dehors de {3} et redémarrez CKAN.</value></data>
 
 {0}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>Lancement</value></data>
+  <data name="MainLaunchDontShow" xml:space="preserve"><value>Ne plus demander pour ces mods sur {0} version {1}</value></data>
   <data name="MainLaunchFailed" xml:space="preserve"><value>Impossible de démarrer le jeu.
 
 {0}</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -192,6 +192,7 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="MainLaunchWithIncompatible" xml:space="preserve"><value>Some installed modules are incompatible! It might not be safe to launch the game. Really launch?
 
 {0}</value></data>
+  <data name="MainLaunchDontShow" xml:space="preserve"><value>Don't show this again for these mods on {0} {1}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>Launch</value></data>
   <data name="MainLaunchFailed" xml:space="preserve"><value>Couldn't start game.
 


### PR DESCRIPTION
## Background

In #2601 we added a pop-up that appears at game launch if the user has incompatible modules installed:

![image](https://user-images.githubusercontent.com/1559108/49485085-1ec8d700-f7ff-11e8-8c4f-710cd69ccc15.png)

The goal was to alert users that some previously compatible mods may stop working after Steam auto-updates the game (e.g., this would have happened with the upgrade from KSP 1.7 to 1.8), similar to what KSP-AVC and MiniAVC do. It was also hoped that prompting users in this way would have positive side effects for metadata accuracy (i.e., if they know a mod is compatible but not yet marked as such, they might submit pull requests for that mod's version file to update it), but for the most part that seems not to have happened.

## Motivation

Some power users install incompatible mods on purpose and experience alert fatigue with this popup. They would like to be able to suppress it, especially after they know that their install is working.

This is currently one of our more frequently received feature requests.

## Changes

Now the warning popup has a new "Don't show this again for these mods on KSP X.XX.X" checkbox in the lower left:

![image](https://user-images.githubusercontent.com/1559108/134813786-010f7e6e-9c94-4dd5-9f60-fc121a53cb4c.png)

If you check this checkbox and click Launch, then we write a file like this to `<KSP>/CKAN/suppressed_compat_warning_identifiers.json`:

```json
{"GameVersionWhenWritten":"1.12.2.3167","Identifiers":["HeapPadder","EvaFollower","AirParkContinued"]}
```

The next time you click Launch Game, we load this file and check whether `GameVersionWhenWritten` still matches your game version. If so, then the identifiers listed in the `Identifiers` property are excluded from the compatibility warning popup. If _all_ of your incompatible modules are already in the file, then the popup doesn't appear at all.

If your game version changes, or if you install new incompatible mods, then the warning will appear again, to ensure that we continue to warn in potentially crashy situations.

No means is provided to "revert" the suppression manually other than deleting that JSON file, since it's pretty unlikely a user would check the checkbox accidentally, and there are easier ways to check which of their mods are incompatible than launching the game.

Fixes #2955.