### PR TITLE
Append resource links to staging PRs

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Transformers\PropertySortTransformer.cs" />
     <Compile Include="Transformers\SpacedockTransformer.cs" />
     <Compile Include="Transformers\StagingTransformer.cs" />
+    <Compile Include="Transformers\StagingLinksTransformer.cs" />
     <Compile Include="Transformers\StripNetkanMetadataTransformer.cs" />
     <Compile Include="Transformers\VersionEditTransformer.cs" />
     <Compile Include="Transformers\VersionedOverrideTransformer.cs" />

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -43,6 +43,7 @@ namespace CKAN.NetKAN.Transformers
                 new AvcKrefTransformer(http, ghApi),
                 new InternalCkanTransformer(http, moduleService),
                 new AvcTransformer(http, moduleService, ghApi),
+                new StagingLinksTransformer(),
                 new LocalizationsTransformer(http, moduleService),
                 new VersionEditTransformer(),
                 new ForcedVTransformer(),

--- a/Netkan/Transformers/StagingLinksTransformer.cs
+++ b/Netkan/Transformers/StagingLinksTransformer.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using log4net;
+using Newtonsoft.Json.Linq;
+
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Transformers
+{
+    internal sealed class StagingLinksTransformer : ITransformer
+    {
+        public string Name { get { return "staging_links"; } }
+
+        public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
+        {
+            if (opts.Staged && !string.IsNullOrEmpty(opts.StagingReason))
+            {
+                var table = LinkTable(metadata);
+                if (!string.IsNullOrEmpty(table))
+                {
+                    log.DebugFormat("Adding links to staging reason: {0}",
+                        table);
+                    opts.StagingReason += table;
+                }
+            }
+            // This transformer never changes the metadata
+            yield return metadata;
+        }
+
+        private string LinkTable(Metadata metadata)
+        {
+            var resourcesJson = (JObject)metadata?.Json()?["resources"];
+            if (resourcesJson == null)
+            {
+                // No resources, no links to append
+                return "";
+            }
+            StringBuilder table = new StringBuilder();
+            // Blank lines to separate the table from the description
+            table.AppendLine("");
+            table.AppendLine("");
+            table.AppendLine("Resource | URL");
+            table.AppendLine(":-- | :--");
+            foreach (var prop in resourcesJson.Properties().OrderBy(prop => prop.Name))
+            {
+                table.AppendLine($"{prop.Name} | <{prop.Value}>");
+            }
+            return table.ToString();
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(StagingLinksTransformer));
+    }
+}


### PR DESCRIPTION
## Motivation

This staging reason explicitly mentions "the forum thread" but fails to provide it:

KSP-CKAN/CKAN-meta#2460

![image](https://user-images.githubusercontent.com/1559108/134816153-c603ff00-4cc4-488c-81be-935c752446b4.png)

That makes these PRs somewhat annoying to review, since you have to find that link yourself (probably via the status page or by checking the metadata).

## Changes

Now we append a table of the mod's `resources` links to the body of any staging pull request:

KSP-CKAN/CKAN-meta#2462 (manually inserted)

![image](https://user-images.githubusercontent.com/1559108/134816120-5a92711a-2e24-4d4f-acc5-c725057c5a91.png)

Behind the scenes:

- We add a new, later Netkan transformer because `StagingTransformer` has to run _before_ the `$kref` processors to be able to detect hard coded versions, but we usually only have the resources available _after_ those transformers run
- We use Markdown's `<link>` syntax for links because otherwise GitHub excludes a trailing `*` from the URL, which we use to abbreviate a lot of forum URLs
- Auto-epoch PRs are affected as well, which should be fine
- `--debug` prints the Markdown source of the table in case you want to see it
