### PR TITLE
Remove expired Let's Encrypt root certificate from Mono containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,17 @@ jobs:
         run: ./build --configuration=${{ matrix.configuration}}
       - name: Run tests
         run: xvfb-run ./build test+only --configuration=${{ matrix.configuration }} --where="Category!=FlakyNetwork"
+      - name: Run inflator container smoke test
+        run: |
+          cd _build
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sh get-docker.sh
+          docker build --tag inflator --file ../Dockerfile.netkan .
+          docker run --rm --name inflator --entrypoint /bin/bash inflator -c "
+            curl -O https://raw.githubusercontent.com/KSP-CKAN/NetKAN/master/NetKAN/ZeroMiniAVC.netkan && \
+            mono netkan.exe ZeroMiniAVC.netkan
+          "
+        if: matrix.configuration == 'release' && ( matrix.mono == '6.8' || matrix.mono == 'latest' )
 
       - name: Upload ckan.exe artifact
         uses: actions/upload-artifact@v2

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,5 +1,7 @@
 FROM mono:latest
 
+RUN /bin/sed -i 's/^mozilla\/DST_Root_CA_X3.crt$/!mozilla\/DST_Root_CA_X3.crt/' /etc/ca-certificates.conf && \
+    /usr/sbin/update-ca-certificates
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools git build-essential python3-dev && \
     apt-get clean

--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -1,4 +1,6 @@
 FROM mono:latest
+RUN /bin/sed -i 's/^mozilla\/DST_Root_CA_X3.crt$/!mozilla\/DST_Root_CA_X3.crt/' /etc/ca-certificates.conf && \
+    /usr/sbin/update-ca-certificates
 RUN useradd -ms /bin/bash netkan
 USER netkan
 WORKDIR /home/netkan


### PR DESCRIPTION
## Problem
We are seeing hundreds of SSL errors from our indexer for SpaceDock mods, and metadata CI is broken for those as well.

![errors](https://user-images.githubusercontent.com/28812678/135523798-bcf7f46e-a710-4730-aa02-3614c9ba56e9.png)

## Cause
An old root certificate used by Let's Encrypt (DST Root CA X3) has expired. It has largely been replaced by the ISRG Root X1, which is in the certificate trust stores of most modern systems.
However, to enhance compatibility with older clients (especially Android phones, which don't check whether root certs have expired), the X1 cert has a cross-signature from the old X3.

More information:
- https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
- https://scotthelme.co.uk/lets-encrypt-old-root-expiration/
- https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/

(The below is my best guess at where the exact issue with Mono is, I might be wrong)
Most clients don't care about this (e.g. OpenSSL as used by e.g. cURL), they go the certificate chain backwards and stop as soon as they see the X1 cert, which is valid and they trust. Mono however also looks at the cross-signature from X3, and throws an error, because it has expired.

Similar to older, broken OpenSSL versions:
> Unfortunately this does not apply to OpenSSL 1.0.2 which always prefers the untrusted chain and if that chain contains a path that leads to an expired trusted root certificate (DST Root CA X3), it will be selected for the certificate verification and the expiration will be reported.

This does not affect my normal Linux installation, as the X3 cert has already been removed from Ubuntu's trust store. Thus Mono "doesn't see" the expired cert and is happy with the valid X1.

## Workaround
If my above assumption is correct, it is a bug in Mono that needs fixing. And/or Debian should remove X3 from its trust store.

In the meantime, we can blocklist X3 in the Mono images, which forces Mono and other software to ignore it and only look at the X1 cert instead.
This works by prepending a `!` to the relevant line in `/etc/ca-certificates.conf` and running `update-ca-certificates` to apply the change.

We should monitor upstream changes and remove the line again when it is no longer needed. FWIW, `sed` doesn't fail when it didn't change something because the line is no longer present in the file.