### PR TITLE
Global install filters

### DIFF
--- a/Cmdline/Action/Filter.cs
+++ b/Cmdline/Action/Filter.cs
@@ -1,0 +1,289 @@
+using System.Linq;
+using System.Collections.Generic;
+
+using Autofac;
+using CommandLine;
+using CommandLine.Text;
+using log4net;
+
+namespace CKAN.CmdLine
+{
+    /// <summary>
+    /// Subcommand for managing installation filters
+    /// </summary>
+    public class Filter : ISubCommand
+    {
+        /// <summary>
+        /// Initialize the subcommand
+        /// </summary>
+        public Filter() { }
+
+        /// <summary>
+        /// Run the subcommand
+        /// </summary>
+        /// <param name="mgr">Manager to provide game instances</param>
+        /// <param name="opts">Command line parameters paritally handled by parser</param>
+        /// <param name="unparsed">Command line parameters not yet handled by parser</param>
+        /// <returns>
+        /// Exit code
+        /// </returns>
+        public int RunSubCommand(GameInstanceManager mgr, CommonOptions opts, SubCommandOptions unparsed)
+        {
+            string[] args = unparsed.options.ToArray();
+            int exitCode = Exit.OK;
+            // Parse and process our sub-verbs
+            Parser.Default.ParseArgumentsStrict(args, new FilterSubOptions(), (string option, object suboptions) =>
+            {
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions options = (CommonOptions)suboptions;
+                    options.Merge(opts);
+                    user     = new ConsoleUser(options.Headless);
+                    manager  = mgr ?? new GameInstanceManager(user);
+                    exitCode = options.Handle(manager, user);
+                    if (exitCode != Exit.OK)
+                        return;
+
+                    switch (option)
+                    {
+                        case "list":
+                            exitCode = ListFilters((FilterListOptions)suboptions, option);
+                            break;
+
+                        case "add":
+                            exitCode = AddFilters((FilterAddOptions)suboptions, option);
+                            break;
+
+                        case "remove":
+                            exitCode = RemoveFilters((FilterRemoveOptions)suboptions, option);
+                            break;
+
+                        default:
+                            user.RaiseMessage("Unknown command: filter {0}", option);
+                            exitCode = Exit.BADOPT;
+                            break;
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+            return exitCode;
+        }
+
+        private int ListFilters(FilterListOptions opts, string verb)
+        {
+            int exitCode = opts.Handle(manager, user);
+            if (exitCode != Exit.OK)
+            {
+                return exitCode;
+            }
+
+            var cfg = ServiceLocator.Container.Resolve<Configuration.IConfiguration>();
+            user.RaiseMessage("Global filters:");
+            foreach (string filter in cfg.GlobalInstallFilters)
+            {
+                user.RaiseMessage("\t- {0}", filter);
+            }
+            user.RaiseMessage("");
+
+            var instance = MainClass.GetGameInstance(manager);
+            user.RaiseMessage("Instance filters:");
+            foreach (string filter in instance.InstallFilters)
+            {
+                user.RaiseMessage("\t- {0}", filter);
+            }
+            return Exit.OK;
+        }
+
+        private int AddFilters(FilterAddOptions opts, string verb)
+        {
+            if (opts.filters.Count < 1)
+            {
+                user.RaiseMessage("Usage: ckan filter {0} filter1 [filter2 ...]", verb);
+                return Exit.BADOPT;
+            }
+
+            int exitCode = opts.Handle(manager, user);
+            if (exitCode != Exit.OK)
+            {
+                return exitCode;
+            }
+
+            if (opts.global)
+            {
+                var cfg = ServiceLocator.Container.Resolve<Configuration.IConfiguration>();
+                var duplicates = cfg.GlobalInstallFilters
+                    .Intersect(opts.filters)
+                    .ToArray();
+                if (duplicates.Length > 0)
+                {
+                    user.RaiseError(
+                        "Global filters already set: {0}",
+                        string.Join(", ", duplicates)
+                    );
+                    return Exit.BADOPT;
+                }
+                else
+                {
+                    cfg.GlobalInstallFilters = cfg.GlobalInstallFilters
+                        .Concat(opts.filters)
+                        .Distinct()
+                        .ToArray();
+                }
+            }
+            else
+            {
+                var instance = MainClass.GetGameInstance(manager);
+                var duplicates = instance.InstallFilters
+                    .Intersect(opts.filters)
+                    .ToArray();
+                    if (duplicates.Length > 0)
+                    {
+                        user.RaiseError(
+                            "Instance filters already set: {0}",
+                            string.Join(", ", duplicates)
+                        );
+                        return Exit.BADOPT;
+                    }
+                    else
+                    {
+                        instance.InstallFilters = instance.InstallFilters
+                            .Concat(opts.filters)
+                            .Distinct()
+                            .ToArray();
+                    }
+            }
+            return Exit.OK;
+        }
+
+        private int RemoveFilters(FilterRemoveOptions opts, string verb)
+        {
+            if (opts.filters.Count < 1)
+            {
+                user.RaiseMessage("Usage: ckan filter {0} filter1 [filter2 ...]", verb);
+                return Exit.BADOPT;
+            }
+
+            int exitCode = opts.Handle(manager, user);
+            if (exitCode != Exit.OK)
+            {
+                return exitCode;
+            }
+
+            if (opts.global)
+            {
+                var cfg = ServiceLocator.Container.Resolve<Configuration.IConfiguration>();
+                var notFound = opts.filters
+                    .Except(cfg.GlobalInstallFilters)
+                    .ToArray();
+                if (notFound.Length > 0)
+                {
+                    user.RaiseError(
+                        "Global filters not found: {0}",
+                        string.Join(", ", notFound)
+                    );
+                    return Exit.BADOPT;
+                }
+                else
+                {
+                    cfg.GlobalInstallFilters = cfg.GlobalInstallFilters
+                        .Except(opts.filters)
+                        .ToArray();
+                }
+            }
+            else
+            {
+                var instance = MainClass.GetGameInstance(manager);
+                var notFound = opts.filters
+                    .Except(instance.InstallFilters)
+                    .ToArray();
+                if (notFound.Length > 0)
+                {
+                    user.RaiseError(
+                        "Instance filters not found: {0}",
+                        string.Join(", ", notFound)
+                    );
+                    return Exit.BADOPT;
+                }
+                else
+                {
+                    instance.InstallFilters = instance.InstallFilters
+                        .Except(opts.filters)
+                        .ToArray();
+                }
+            }
+            return Exit.OK;
+        }
+
+        private GameInstanceManager manager { get; set; }
+        private IUser               user    { get; set; }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(Filter));
+    }
+
+    internal class FilterSubOptions : VerbCommandOptions
+    {
+        [VerbOption("list", HelpText = "List install filters")]
+        public FilterListOptions FilterListOptions { get; set; }
+
+        [VerbOption("add", HelpText = "Add install filters")]
+        public FilterAddOptions FilterAddOptions { get; set; }
+
+        [VerbOption("remove", HelpText = "Remove install filters")]
+        public FilterRemoveOptions FilterRemoveOptions { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            HelpText ht = HelpText.AutoBuild(this, verb);
+            // Add a usage prefix line
+            ht.AddPreOptionsLine(" ");
+            if (string.IsNullOrEmpty(verb))
+            {
+                ht.AddPreOptionsLine("ckan filter - View or edit installation filters");
+                ht.AddPreOptionsLine($"Usage: ckan filter <command> [options]");
+            }
+            else
+            {
+                ht.AddPreOptionsLine("filter " + verb + " - " + GetDescription(verb));
+                switch (verb)
+                {
+                    case "list":
+                        ht.AddPreOptionsLine($"Usage: ckan filter {verb}");
+                        break;
+
+                    case "add":
+                        ht.AddPreOptionsLine($"Usage: ckan filter {verb} [options] filter1 [filter2 ...]");
+                        break;
+
+                    case "remove":
+                        ht.AddPreOptionsLine($"Usage: ckan filter {verb} [options] filter1 [filter2 ...]");
+                        break;
+                }
+            }
+            return ht;
+        }
+    }
+
+    internal class FilterListOptions : InstanceSpecificOptions
+    {
+    }
+
+    internal class FilterAddOptions : InstanceSpecificOptions
+    {
+        [Option("global", DefaultValue = false, HelpText = "Add global filters")]
+        public bool global { get; set; }
+
+        [ValueList(typeof(List<string>))]
+        public List<string> filters { get; set; }
+    }
+
+    internal class FilterRemoveOptions : InstanceSpecificOptions
+    {
+        [Option("global", DefaultValue = false, HelpText = "Remove global filters")]
+        public bool global { get; set; }
+
+        [ValueList(typeof(List<string>))]
+        public List<string> filters { get; set; }
+    }
+
+}

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Action\Cache.cs" />
     <Compile Include="Action\Compare.cs" />
     <Compile Include="Action\Compat.cs" />
+    <Compile Include="Action\Filter.cs" />
     <Compile Include="Action\ICommand.cs" />
     <Compile Include="Action\Import.cs" />
     <Compile Include="Action\Install.cs" />

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -90,9 +90,13 @@ namespace CKAN.CmdLine
 
                     case "cache":
                         return (new Cache()).RunSubCommand(manager, opts, new SubCommandOptions(args));
-                        
+
                     case "mark":
                         return (new Mark()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+
+                    case "filter":
+                        return (new Filter()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+
                 }
             }
             catch (NoGameInstanceKraken)

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -115,6 +115,9 @@ namespace CKAN.CmdLine
         [VerbOption("version", HelpText = "Show the version of the CKAN client being used")]
         public VersionOptions Version { get; set; }
 
+        [VerbOption("filter", HelpText = "View or edit installation filters")]
+        public SubCommandOptions Filter { get; set; }
+
         [HelpVerbOption]
         public string GetUsage(string verb)
         {

--- a/ConsoleUI/CKAN-ConsoleUI.csproj
+++ b/ConsoleUI/CKAN-ConsoleUI.csproj
@@ -59,6 +59,8 @@
     <Compile Include="DependencyScreen.cs" />
     <Compile Include="DownloadImportDialog.cs" />
     <Compile Include="ExitScreen.cs" />
+    <Compile Include="InstallFilterAddDialog.cs" />
+    <Compile Include="InstallFiltersScreen.cs" />
     <Compile Include="InstallScreen.cs" />
     <Compile Include="GameInstanceAddScreen.cs" />
     <Compile Include="GameInstanceEditScreen.cs" />

--- a/ConsoleUI/InstallFilterAddDialog.cs
+++ b/ConsoleUI/InstallFilterAddDialog.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using CKAN.Versioning;
+using CKAN.Games;
+using CKAN.GameVersionProviders;
+using CKAN.ConsoleUI.Toolkit;
+using Autofac;
+
+namespace CKAN.ConsoleUI {
+
+    /// <summary>
+    /// Popup letting user enter an installation filter
+    /// </summary>
+    public class InstallFilterAddDialog : ConsoleDialog {
+
+        /// <summary>
+        /// Initialize the popup
+        /// </summary>
+        public InstallFilterAddDialog() : base()
+        {
+            int l = GetLeft(),
+                r = GetRight();
+            int t = GetTop(),
+                b = t + 4;
+            SetDimensions(l, t, r, b);
+
+            manualEntry = new ConsoleField(
+                l + 2, b - 2, r - 2
+            ) {
+                GhostText = () => "<Enter a filter>"
+            };
+            AddObject(manualEntry);
+            manualEntry.AddTip("Enter", "Accept value");
+            manualEntry.AddBinding(Keys.Enter, (object sender, ConsoleTheme theme) => {
+                choice = manualEntry.Value;
+                return false;
+            });
+
+            AddTip("Esc", "Cancel");
+            AddBinding(Keys.Escape, (object sender, ConsoleTheme theme) => {
+                choice = null;
+                return false;
+            });
+
+            CenterHeader = () => "Add Filter";
+        }
+
+        /// <summary>
+        /// Display the dialog and handle its interaction
+        /// </summary>
+        /// <param name="process">Function to control the dialog, default is normal user interaction</param>
+        /// <param name="theme">The visual theme to use to draw the dialog</param>
+        /// <returns>
+        /// User input
+        /// </returns>
+        public new string Run(ConsoleTheme theme, Action<ConsoleTheme> process = null)
+        {
+            base.Run(theme, process);
+            return choice;
+        }
+
+        private ConsoleField manualEntry;
+        private string       choice;
+    }
+}

--- a/ConsoleUI/InstallFiltersScreen.cs
+++ b/ConsoleUI/InstallFiltersScreen.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using CKAN.Configuration;
+using CKAN.ConsoleUI.Toolkit;
+
+namespace CKAN.ConsoleUI {
+
+    public class InstallFiltersScreen : ConsoleScreen {
+
+        public InstallFiltersScreen(IConfiguration globalConfig, GameInstance instance)
+        {
+            this.globalConfig = globalConfig;
+            this.instance     = instance;
+            globalFilters   = globalConfig.GlobalInstallFilters.ToList();
+            instanceFilters = instance.InstallFilters.ToList();
+
+            AddTip("F2", "Accept");
+            AddBinding(Keys.F2, (object sender, ConsoleTheme theme) => {
+                Save();
+                // Close screen
+                return false;
+            });
+            AddTip("Esc", "Cancel");
+            AddBinding(Keys.Escape, (object sender, ConsoleTheme theme) => {
+                // Discard changes
+                return false;
+            });
+
+            mainMenu = new ConsolePopupMenu(new List<ConsoleMenuOption>() {
+                new ConsoleMenuOption("Add MiniAVC", "",
+                    "Prevent MiniAVC from being installed",
+                    true, AddMiniAVC),
+            });
+
+            int vMid = Console.WindowHeight / 2;
+
+            globalList = new ConsoleListBox<string>(
+                2, 2, -2, vMid - 1,
+                globalFilters,
+                new List<ConsoleListBoxColumn<string>>() {
+                    new ConsoleListBoxColumn<string>() {
+                        Header   = "Global Filters",
+                        Width    = 40,
+                        Renderer = f => f,
+                    }
+                },
+                0
+            );
+            AddObject(globalList);
+            globalList.AddTip("A", "Add");
+            globalList.AddBinding(Keys.A, (object sender, ConsoleTheme theme) => {
+                AddFilter(theme, globalList, globalFilters);
+                return true;
+            });
+            globalList.AddTip("R", "Remove");
+            globalList.AddBinding(Keys.R, (object sender, ConsoleTheme theme) => {
+                RemoveFilter(globalList, globalFilters);
+                return true;
+            });
+            instanceList = new ConsoleListBox<string>(
+                2, vMid + 1, -2, -2,
+                instanceFilters,
+                new List<ConsoleListBoxColumn<string>>() {
+                    new ConsoleListBoxColumn<string>() {
+                        Header   = "Instance Filters",
+                        Width    = 40,
+                        Renderer = f => f,
+                    }
+                },
+                0
+            );
+            AddObject(instanceList);
+            instanceList.AddTip("A", "Add");
+            instanceList.AddBinding(Keys.A, (object sender, ConsoleTheme theme) => {
+                AddFilter(theme, instanceList, instanceFilters);
+                return true;
+            });
+            instanceList.AddTip("R", "Remove");
+            instanceList.AddBinding(Keys.R, (object sender, ConsoleTheme theme) => {
+                RemoveFilter(instanceList, instanceFilters);
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader()
+        {
+            return $"CKAN {Meta.GetVersion()}";
+        }
+
+        /// <summary>
+        /// Put description in top center
+        /// </summary>
+        protected override string CenterHeader()
+        {
+            return "Installation Filters";
+        }
+
+        private bool AddMiniAVC(ConsoleTheme theme)
+        {
+            globalFilters = globalFilters
+                .Concat(miniAVC)
+                .Distinct()
+                .ToList();
+            globalList.SetData(globalFilters);
+            return true;
+        }
+
+        private void AddFilter(ConsoleTheme theme, ConsoleListBox<string> box, List<string> filters)
+        {
+            string filter = new InstallFilterAddDialog().Run(theme);
+            DrawBackground(theme);
+            if (!string.IsNullOrEmpty(filter) && !filters.Contains(filter)) {
+                filters.Add(filter);
+                box.SetData(filters);
+            }
+        }
+
+        private void RemoveFilter(ConsoleListBox<string> box, List<string> filters)
+        {
+            filters.Remove(box.Selection);
+            box.SetData(filters);
+        }
+
+        private void Save()
+        {
+            globalConfig.GlobalInstallFilters = globalFilters.ToArray();
+            instance.InstallFilters           = instanceFilters.ToArray();
+        }
+
+        private IConfiguration globalConfig;
+        private GameInstance   instance;
+
+        private List<string> globalFilters;
+        private List<string> instanceFilters;
+
+        private ConsoleListBox<string> globalList;
+        private ConsoleListBox<string> instanceList;
+
+        private static readonly string[] miniAVC = new string[] {
+            "MiniAVC.dll",
+            "MiniAVC.xml",
+            "LICENSE-MiniAVC.txt",
+            "MiniAVC-V2.dll",
+            "MiniAVC-V2.dll.mdb",
+        };
+    }
+
+}

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Linq;
 using System.IO;
 using System.Collections.Generic;
 using System.ComponentModel;
+
+using Autofac;
+
 using CKAN.ConsoleUI.Toolkit;
-using System.Linq;
 
 namespace CKAN.ConsoleUI {
 
@@ -289,6 +292,9 @@ namespace CKAN.ConsoleUI {
                 new ConsoleMenuOption("Authentication tokens...",     "",
                     "Edit authentication tokens sent to download servers",
                     true, EditAuthTokens),
+                new ConsoleMenuOption("Installation filters...",     "",
+                    "Edit list of files and folders to exclude from installation",
+                    true, EditInstallFilters),
                 null,
                 new ConsoleMenuOption("Help",                  helpKey,
                     "Tips & tricks",
@@ -533,6 +539,15 @@ namespace CKAN.ConsoleUI {
         private bool EditAuthTokens(ConsoleTheme theme)
         {
             LaunchSubScreen(theme, new AuthTokenScreen());
+            return true;
+        }
+
+        private bool EditInstallFilters(ConsoleTheme theme)
+        {
+            LaunchSubScreen(theme, new InstallFiltersScreen(
+                ServiceLocator.Container.Resolve<Configuration.IConfiguration>(),
+                manager.CurrentInstance
+            ));
             return true;
         }
 

--- a/Core/Configuration/IConfiguration.cs
+++ b/Core/Configuration/IConfiguration.cs
@@ -54,5 +54,10 @@ namespace CKAN.Configuration
 
         void SetRegistryToInstances(SortedList<string, GameInstance> instances);
         IEnumerable<Tuple<string, string, string>> GetInstances();
+
+        /// <summary>
+        /// Paths that should be excluded from all installations
+        /// </summary>
+        string[] GlobalInstallFilters { get; set; }
     }
 }

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -22,6 +22,7 @@ namespace CKAN.Configuration
             public string Language { get; set; }
             public IList<GameInstanceEntry> GameInstances { get; set; } = new List<GameInstanceEntry>();
             public IDictionary<string, string> AuthTokens { get; set; } = new Dictionary<string, string>();
+            public string[] GlobalInstallFilters { get; set; } = new string[] { };
         }
 
         public class ConfigConverter : JsonPropertyNamesChangedConverter
@@ -302,6 +303,26 @@ namespace CKAN.Configuration
                 }
 
                 SaveConfig();
+            }
+        }
+
+        public string[] GlobalInstallFilters
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return config.GlobalInstallFilters;
+                }
+            }
+
+            set
+            {
+                lock (_lock)
+                {
+                    config.GlobalInstallFilters = value;
+                    SaveConfig();
+                }
             }
         }
 

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -173,6 +173,11 @@ namespace CKAN.Configuration
             }
         }
 
+        /// <summary>
+        /// Not implemented because the Windows registry is deprecated
+        /// </summary>
+        public string[] GlobalInstallFilters { get; set; }
+
         public static bool DoesRegistryConfigurationExist()
         {
             RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(CKAN_KEY_NO_PREFIX);

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -196,6 +196,23 @@ namespace CKAN
         private string SuppressedCompatWarningIdentifiersFile =>
             Path.Combine(CkanDir(), "suppressed_compat_warning_identifiers.json");
 
+        public string[] InstallFilters
+        {
+            get
+            {
+                return File.Exists(InstallFiltersFile)
+                    ? JsonConvert.DeserializeObject<string[]>(File.ReadAllText(InstallFiltersFile))
+                    : new string[] { };
+            }
+
+            set
+            {
+                File.WriteAllText(InstallFiltersFile, JsonConvert.SerializeObject(value));
+            }
+        }
+
+        private string InstallFiltersFile => Path.Combine(CkanDir(), "install_filters.json");
+
         #endregion
 
         #region KSP Directory Detection and Versioning

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -330,7 +330,13 @@ namespace CKAN
 
             using (ZipFile zipfile = new ZipFile(zip_filename))
             {
-                IEnumerable<InstallableFile> files = FindInstallableFiles(module, zipfile, ksp);
+                var filters = ServiceLocator.Container.Resolve<IConfiguration>().GlobalInstallFilters
+                    .Concat(ksp.InstallFilters)
+                    .ToHashSet();
+                var files = FindInstallableFiles(module, zipfile, ksp)
+                    .Where(instF => !filters.Any(filt =>
+                        instF.destination.Contains(filt)))
+                    .ToList();
 
                 try
                 {

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -98,6 +98,12 @@
     <Compile Include="Dialogs\GameCommandLineOptionsDialog.Designer.cs">
       <DependentUpon>GameCommandLineOptionsDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Dialogs\InstallFiltersDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Dialogs\InstallFiltersDialog.Designer.cs">
+      <DependentUpon>InstallFiltersDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\NewRepoDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -615,6 +621,15 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Localization\ja-JP\GameCommandLineOptionsDialog.ja-JP.resx">
       <DependentUpon>..\..\Dialogs\GameCommandLineOptionsDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\InstallFiltersDialog.resx">
+      <DependentUpon>InstallFiltersDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Localization\de-DE\InstallFiltersDialog.de-DE.resx">
+      <DependentUpon>..\..\Dialogs\InstallFiltersDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Localization\fr-FR\InstallFiltersDialog.fr-FR.resx">
+      <DependentUpon>..\..\Dialogs\InstallFiltersDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Main\Main.resx">
       <DependentUpon>Main.cs</DependentUpon>

--- a/GUI/Dialogs/InstallFiltersDialog.Designer.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.Designer.cs
@@ -1,0 +1,145 @@
+﻿namespace CKAN
+{
+    partial class InstallFiltersDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(InstallFiltersDialog));
+            this.GlobalFiltersGroupBox = new System.Windows.Forms.GroupBox();
+            this.InstanceFiltersGroupBox = new System.Windows.Forms.GroupBox();
+            this.GlobalFiltersTextBox = new System.Windows.Forms.TextBox();
+            this.InstanceFiltersTextBox = new System.Windows.Forms.TextBox();
+            this.AddMiniAVCButton = new System.Windows.Forms.Button();
+            this.WarningLabel = new System.Windows.Forms.Label();
+            this.GlobalFiltersGroupBox.SuspendLayout();
+            this.InstanceFiltersGroupBox.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // GlobalFiltersGroupBox
+            //
+            this.GlobalFiltersGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.GlobalFiltersGroupBox.Controls.Add(this.AddMiniAVCButton);
+            this.GlobalFiltersGroupBox.Controls.Add(this.GlobalFiltersTextBox);
+            this.GlobalFiltersGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.GlobalFiltersGroupBox.Location = new System.Drawing.Point(12, 12);
+            this.GlobalFiltersGroupBox.Name = "GlobalFiltersGroupBox";
+            this.GlobalFiltersGroupBox.Size = new System.Drawing.Size(360, 173);
+            this.GlobalFiltersGroupBox.TabIndex = 0;
+            this.GlobalFiltersGroupBox.TabStop = false;
+            resources.ApplyResources(this.GlobalFiltersGroupBox, "GlobalFiltersGroupBox");
+            //
+            // InstanceFiltersGroupBox
+            //
+            this.InstanceFiltersGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.InstanceFiltersGroupBox.Controls.Add(this.InstanceFiltersTextBox);
+            this.InstanceFiltersGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.InstanceFiltersGroupBox.Location = new System.Drawing.Point(12, 187);
+            this.InstanceFiltersGroupBox.Name = "InstanceFiltersGroupBox";
+            this.InstanceFiltersGroupBox.Size = new System.Drawing.Size(360, 167);
+            this.InstanceFiltersGroupBox.TabIndex = 3;
+            this.InstanceFiltersGroupBox.TabStop = false;
+            resources.ApplyResources(this.InstanceFiltersGroupBox, "InstanceFiltersGroupBox");
+            //
+            // GlobalFiltersTextBox
+            //
+            this.GlobalFiltersTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.GlobalFiltersTextBox.Location = new System.Drawing.Point(6, 17);
+            this.GlobalFiltersTextBox.Multiline = true;
+            this.GlobalFiltersTextBox.Name = "GlobalFiltersTextBox";
+            this.GlobalFiltersTextBox.Size = new System.Drawing.Size(219, 147);
+            this.GlobalFiltersTextBox.TabIndex = 1;
+            resources.ApplyResources(this.GlobalFiltersTextBox, "GlobalFiltersTextBox");
+            //
+            // AddMiniAVCButton
+            //
+            this.AddMiniAVCButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.AddMiniAVCButton.Location = new System.Drawing.Point(231, 17);
+            this.AddMiniAVCButton.Name = "AddMiniAVCButton";
+            this.AddMiniAVCButton.Size = new System.Drawing.Size(124, 23);
+            this.AddMiniAVCButton.TabIndex = 2;
+            this.AddMiniAVCButton.UseVisualStyleBackColor = true;
+            this.AddMiniAVCButton.Click += new System.EventHandler(this.AddMiniAVCButton_Click);
+            resources.ApplyResources(this.AddMiniAVCButton, "AddMiniAVCButton");
+            //
+            // InstanceFiltersTextBox
+            //
+            this.InstanceFiltersTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.InstanceFiltersTextBox.Location = new System.Drawing.Point(6, 19);
+            this.InstanceFiltersTextBox.Multiline = true;
+            this.InstanceFiltersTextBox.Name = "InstanceFiltersTextBox";
+            this.InstanceFiltersTextBox.Size = new System.Drawing.Size(219, 134);
+            this.InstanceFiltersTextBox.TabIndex = 4;
+            resources.ApplyResources(this.InstanceFiltersTextBox, "InstanceFiltersTextBox");
+            //
+            // WarningLabel
+            //
+            this.WarningLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.WarningLabel.ForeColor = System.Drawing.Color.Red;
+            this.WarningLabel.Location = new System.Drawing.Point(9, 354);
+            this.WarningLabel.Name = "WarningLabel";
+            this.WarningLabel.Size = new System.Drawing.Size(360, 32);
+            this.WarningLabel.TabIndex = 5;
+            resources.ApplyResources(this.WarningLabel, "WarningLabel");
+            //
+            // InstallFiltersDialog
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(379, 390);
+            this.Controls.Add(this.GlobalFiltersGroupBox);
+            this.Controls.Add(this.InstanceFiltersGroupBox);
+            this.Controls.Add(this.WarningLabel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = Properties.Resources.AppIcon;
+            this.Name = "InstallFiltersDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Load += new System.EventHandler(this.InstallFiltersDialog_Load);
+            this.Closing += new System.ComponentModel.CancelEventHandler(this.InstallFiltersDialog_Closing);
+            resources.ApplyResources(this, "$this");
+            this.GlobalFiltersGroupBox.ResumeLayout(false);
+            this.InstanceFiltersGroupBox.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox GlobalFiltersGroupBox;
+        private System.Windows.Forms.GroupBox InstanceFiltersGroupBox;
+        private System.Windows.Forms.Button AddMiniAVCButton;
+        private System.Windows.Forms.TextBox GlobalFiltersTextBox;
+        private System.Windows.Forms.TextBox InstanceFiltersTextBox;
+        private System.Windows.Forms.Label WarningLabel;
+    }
+}

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Forms;
+
+using CKAN.Configuration;
+
+namespace CKAN
+{
+    public partial class InstallFiltersDialog : Form
+    {
+        public InstallFiltersDialog(IConfiguration globalConfig, GameInstance instance)
+        {
+            InitializeComponent();
+            this.globalConfig = globalConfig;
+            this.instance     = instance;
+        }
+
+        private void InstallFiltersDialog_Load(object sender, EventArgs e)
+        {
+            GlobalFiltersTextBox.Text = string.Join(Environment.NewLine, globalConfig.GlobalInstallFilters);
+            InstanceFiltersTextBox.Text = string.Join(Environment.NewLine, instance.InstallFilters);
+            GlobalFiltersTextBox.DeselectAll();
+            InstanceFiltersTextBox.DeselectAll();
+        }
+
+        private void InstallFiltersDialog_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            globalConfig.GlobalInstallFilters = GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+            instance.InstallFilters = InstanceFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private void AddMiniAVCButton_Click(object sender, EventArgs e)
+        {
+            GlobalFiltersTextBox.Text = string.Join(Environment.NewLine,
+                GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries)
+                    .Concat(miniAVC)
+                    .Distinct()
+            );
+        }
+
+        private IConfiguration globalConfig;
+        private GameInstance   instance;
+
+        private static readonly string[] delimiters = new string[]
+        {
+            Environment.NewLine
+        };
+
+        private static readonly string[] miniAVC = new string[]
+        {
+            "MiniAVC.dll",
+            "MiniAVC.xml",
+            "LICENSE-MiniAVC.txt",
+            "MiniAVC-V2.dll",
+            "MiniAVC-V2.dll.mdb",
+        };
+    }
+}

--- a/GUI/Dialogs/InstallFiltersDialog.resx
+++ b/GUI/Dialogs/InstallFiltersDialog.resx
@@ -117,58 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>126, 17</value>
-  </metadata>
-  <metadata name="minimizeNotifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>546, 17</value>
-  </metadata>
-  <metadata name="minimizedContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>704, 17</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>32</value>
-  </metadata>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>Fichier</value></data>
-  <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>Gérer les instances de jeu</value></data>
-  <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Ouvrir le répertoire du jeu</value></data>
-  <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Installer depuis .ckan...</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Sauvegarder la liste des mods installés...</value></data>
-  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Exporter modpack...</value></data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Importer des &amp;mods téléchargés...</value></data>
-  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Auditionner les recommandations</value></data>
-  <data name="ExitToolButton.Text" xml:space="preserve"><value>&amp;Quitter</value></data>
-  <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>Options</value></data>
-  <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>Options CKAN</value></data>
-  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>Plugins CKAN</value></data>
-  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Filtres d'Installation</value></data>
-  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Ligne de commande du jeu</value></data>
-  <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Versions de jeu compatibles</value></data>
-  <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Aide</value></data>
-  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>Guide d'utilisation</value></data>
-  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec le client CKAN</value></data>
-  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec les métadonnées de mod</value></data>
-  <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>À propos</value></data>
-  <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Gérer les mods</value></data>
-  <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Résumé des changements</value></data>
-  <data name="WaitTabPage.Text" xml:space="preserve"><value>Registre</value></data>
-  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Choisir des mods</value></data>
-  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choisir des mods recommandés, suggérés, ou supportés</value></data>
-  <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Supprimer les dossiers</value></data>
-  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modifier le Modpack</value></data>
-  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
-  <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>Aucune Mise à jour disponible</value></data>
-  <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Rafraîchir</value></data>
-  <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Pause</value></data>
-  <data name="openCKANToolStripMenuItem.Text" xml:space="preserve"><value>Ouvrir CKAN</value></data>
-  <data name="openGameToolStripMenuItem.Text" xml:space="preserve"><value>Lancer le jeu</value></data>
-  <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Ouvrir le Répertoire du Jeu</value></data>
-  <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>Options CKAN</value></data>
-  <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quitter</value></data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="GlobalFiltersGroupBox.Text" xml:space="preserve"><value>Global Filters</value></data>
+  <data name="InstanceFiltersGroupBox.Text" xml:space="preserve"><value>Instance Filters</value></data>
+  <data name="AddMiniAVCButton.Text" xml:space="preserve"><value>Add MiniAVC</value></data>
+  <data name="WarningLabel.Text" xml:space="preserve"><value>NOTE: Changes to the install filters only take effect on future mod installations; already installed files are unaffected.</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Install Filters</value></data>
 </root>

--- a/GUI/Localization/de-DE/InstallFiltersDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/InstallFiltersDialog.de-DE.resx
@@ -117,58 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>126, 17</value>
-  </metadata>
-  <metadata name="minimizeNotifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>546, 17</value>
-  </metadata>
-  <metadata name="minimizedContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>704, 17</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>32</value>
-  </metadata>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>Fichier</value></data>
-  <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>Gérer les instances de jeu</value></data>
-  <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Ouvrir le répertoire du jeu</value></data>
-  <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Installer depuis .ckan...</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Sauvegarder la liste des mods installés...</value></data>
-  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Exporter modpack...</value></data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Importer des &amp;mods téléchargés...</value></data>
-  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Auditionner les recommandations</value></data>
-  <data name="ExitToolButton.Text" xml:space="preserve"><value>&amp;Quitter</value></data>
-  <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>Options</value></data>
-  <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>Options CKAN</value></data>
-  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>Plugins CKAN</value></data>
-  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Filtres d'Installation</value></data>
-  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Ligne de commande du jeu</value></data>
-  <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Versions de jeu compatibles</value></data>
-  <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Aide</value></data>
-  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>Guide d'utilisation</value></data>
-  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec le client CKAN</value></data>
-  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec les métadonnées de mod</value></data>
-  <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>À propos</value></data>
-  <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Gérer les mods</value></data>
-  <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Résumé des changements</value></data>
-  <data name="WaitTabPage.Text" xml:space="preserve"><value>Registre</value></data>
-  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Choisir des mods</value></data>
-  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choisir des mods recommandés, suggérés, ou supportés</value></data>
-  <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Supprimer les dossiers</value></data>
-  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modifier le Modpack</value></data>
-  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
-  <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>Aucune Mise à jour disponible</value></data>
-  <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Rafraîchir</value></data>
-  <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Pause</value></data>
-  <data name="openCKANToolStripMenuItem.Text" xml:space="preserve"><value>Ouvrir CKAN</value></data>
-  <data name="openGameToolStripMenuItem.Text" xml:space="preserve"><value>Lancer le jeu</value></data>
-  <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Ouvrir le Répertoire du Jeu</value></data>
-  <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>Options CKAN</value></data>
-  <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quitter</value></data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="GlobalFiltersGroupBox.Text" xml:space="preserve"><value>Globale Filter</value></data>
+  <data name="InstanceFiltersGroupBox.Text" xml:space="preserve"><value>Instanz-spezifische Filter</value></data>
+  <data name="AddMiniAVCButton.Text" xml:space="preserve"><value>MiniAVC hinzufügen</value></data>
+  <data name="WarningLabel.Text" xml:space="preserve"><value>HINWEIS: Änderungen an den Filtern wirken sich erst auf zukünftige Modinstallationen aus; bereits installierte Dateien bleiben bestehen.</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Installationsfilter</value></data>
 </root>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -175,6 +175,7 @@
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>Einstellungen</value></data>
   <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN Einstellungen</value></data>
   <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN Plugins</value></data>
+  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installationsfilter</value></data>
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Spielstart-Befehlszeile</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Kompatible Spielversionen</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Hilfe</value></data>

--- a/GUI/Localization/fr-FR/InstallFiltersDialog.fr-FR.resx
+++ b/GUI/Localization/fr-FR/InstallFiltersDialog.fr-FR.resx
@@ -117,58 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>126, 17</value>
-  </metadata>
-  <metadata name="minimizeNotifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>546, 17</value>
-  </metadata>
-  <metadata name="minimizedContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>704, 17</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>32</value>
-  </metadata>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>Fichier</value></data>
-  <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>Gérer les instances de jeu</value></data>
-  <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Ouvrir le répertoire du jeu</value></data>
-  <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Installer depuis .ckan...</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Sauvegarder la liste des mods installés...</value></data>
-  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Exporter modpack...</value></data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Importer des &amp;mods téléchargés...</value></data>
-  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Auditionner les recommandations</value></data>
-  <data name="ExitToolButton.Text" xml:space="preserve"><value>&amp;Quitter</value></data>
-  <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>Options</value></data>
-  <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>Options CKAN</value></data>
-  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>Plugins CKAN</value></data>
-  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Filtres d'Installation</value></data>
-  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Ligne de commande du jeu</value></data>
-  <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Versions de jeu compatibles</value></data>
-  <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Aide</value></data>
-  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>Guide d'utilisation</value></data>
-  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec le client CKAN</value></data>
-  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Signaler un problème avec les métadonnées de mod</value></data>
-  <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>À propos</value></data>
-  <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Gérer les mods</value></data>
-  <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Résumé des changements</value></data>
-  <data name="WaitTabPage.Text" xml:space="preserve"><value>Registre</value></data>
-  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Choisir des mods</value></data>
-  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choisir des mods recommandés, suggérés, ou supportés</value></data>
-  <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Supprimer les dossiers</value></data>
-  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modifier le Modpack</value></data>
-  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
-  <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>Aucune Mise à jour disponible</value></data>
-  <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Rafraîchir</value></data>
-  <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Pause</value></data>
-  <data name="openCKANToolStripMenuItem.Text" xml:space="preserve"><value>Ouvrir CKAN</value></data>
-  <data name="openGameToolStripMenuItem.Text" xml:space="preserve"><value>Lancer le jeu</value></data>
-  <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Ouvrir le Répertoire du Jeu</value></data>
-  <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>Options CKAN</value></data>
-  <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quitter</value></data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="GlobalFiltersGroupBox.Text" xml:space="preserve"><value>Filtres Globaux</value></data>
+  <data name="InstanceFiltersGroupBox.Text" xml:space="preserve"><value>Filtres de l'Instance</value></data>
+  <data name="AddMiniAVCButton.Text" xml:space="preserve"><value>Ajouter MiniAVC</value></data>
+  <data name="WarningLabel.Text" xml:space="preserve"><value>NOTE : Les changement de filtres prendront effet lors de l'installation des prochains mods ; les fichiers déjà présents ne sont pas affectés.</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Installer des Filtres</value></data>
 </root>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -46,6 +46,7 @@
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cKANSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pluginsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.installFiltersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.GameCommandlineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compatibleGameVersionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -228,7 +229,8 @@
             this.cKANSettingsToolStripMenuItem,
             this.pluginsToolStripMenuItem,
             this.GameCommandlineToolStripMenuItem,
-            this.compatibleGameVersionsToolStripMenuItem});
+            this.compatibleGameVersionsToolStripMenuItem,
+            this.installFiltersToolStripMenuItem});
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             this.settingsToolStripMenuItem.Size = new System.Drawing.Size(88, 29);
             resources.ApplyResources(this.settingsToolStripMenuItem, "settingsToolStripMenuItem");
@@ -246,6 +248,13 @@
             this.pluginsToolStripMenuItem.Size = new System.Drawing.Size(247, 30);
             this.pluginsToolStripMenuItem.Click += new System.EventHandler(this.pluginsToolStripMenuItem_Click);
             resources.ApplyResources(this.pluginsToolStripMenuItem, "pluginsToolStripMenuItem");
+            //
+            // installFiltersToolStripMenuItem
+            //
+            this.installFiltersToolStripMenuItem.Name = "installFiltersToolStripMenuItem";
+            this.installFiltersToolStripMenuItem.Size = new System.Drawing.Size(247, 30);
+            this.installFiltersToolStripMenuItem.Click += new System.EventHandler(this.installFiltersToolStripMenuItem_Click);
+            resources.ApplyResources(this.installFiltersToolStripMenuItem, "installFiltersToolStripMenuItem");
             //
             // GameCommandlineToolStripMenuItem
             //
@@ -740,6 +749,7 @@
         public System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem cKANSettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem pluginsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem installFiltersToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem GameCommandlineToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem compatibleGameVersionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -542,6 +542,14 @@ namespace CKAN
             Enabled = true;
         }
 
+        private void installFiltersToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Enabled = false;
+            var dlg = new InstallFiltersDialog(ServiceLocator.Container.Resolve<Configuration.IConfiguration>(), CurrentInstance);
+            dlg.ShowDialog(this);
+            Enabled = true;
+        }
+
         private void installFromckanToolStripMenuItem_Click(object sender, EventArgs e)
         {
             OpenFileDialog open_file_dialog = new OpenFileDialog()

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -147,6 +147,7 @@
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>Settings</value></data>
   <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN settings</value></data>
   <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN plugins</value></data>
+  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation filters</value></data>
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Game command-line</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Compatible game versions</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Help</value></data>

--- a/Tests/Core/Configuration/FakeConfiguration.cs
+++ b/Tests/Core/Configuration/FakeConfiguration.cs
@@ -127,17 +127,17 @@ namespace Tests.Core.Configuration
             BuildMap = buildMap;
         }
 
-        public IEnumerable<string> GetAuthTokenHosts ()
+        public IEnumerable<string> GetAuthTokenHosts()
         {
             throw new NotImplementedException();
         }
 
-        public void SetAuthToken (string host, string token)
+        public void SetAuthToken(string host, string token)
         {
             throw new NotImplementedException();
         }
 
-        public bool TryGetAuthToken (string host, out string token)
+        public bool TryGetAuthToken(string host, out string token)
         {
             throw new NotImplementedException();
         }
@@ -157,7 +157,9 @@ namespace Tests.Core.Configuration
                     _Language = value;
                 }
             }
-         }
+        }
+
+        public string[] GlobalInstallFilters { get; set; } = new string[] { };
 
         public void Dispose()
         {


### PR DESCRIPTION
## Motivation

As of some recent API changes, users might install somewhat older mods that _would_ work except that they bundle `MiniAVC.dll`, which crashes the game on startup. Even before the crashes, MiniAVC was annoying and unnecessary thanks to CKAN's own compatibility checking. It would be nice to prevent MiniAVC from being installed.

> NOTE: The crash was specific to KSP 1.12.2, and was fixed in 1.12.3.

Similarly, some power users may wish to customize the details of how certain mods are installed, often a cfg file that patches how two or more mods interact. Currently they can only do this by deleting them manually after installation, which means they will re-appear after upgrades.

## Changes

A new menu option under Settings opens a window with text boxes for installation filters that apply to all mods:

![image](https://user-images.githubusercontent.com/1559108/135957350-cc2a8b3f-822a-4da6-91d9-70d156f27189.png)

![image](https://user-images.githubusercontent.com/1559108/135957373-de2e35b7-e4de-4343-a49d-55beaa296a3f.png)

If you add a string to either of these boxes, then CKAN will not install any file where that string is contained in the full relative path. The top box applies to all game instances, and the bottom box applies only to the current instance. The target audience for this window is power users who are comfortable typing paths, but an Add MiniAVC button is available so typical users can more easily avoid installing MiniAVC.

Cmdline now has a `ckan filter` subcommand to manage these lists, and ConsoleUI has a new screen that works like the one in GUI.

Fixes #2490.
Fixes #3129.