### PR TITLE
Keep dependencies in the box in ConsoleUI

### DIFF
--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -252,6 +252,7 @@ namespace CKAN.ConsoleUI {
                 int h    = Math.Min(11, numDeps + numConfs + 2);
                 const int lblW = 16;
                 int nameW = midL - 2 - lblW - 2;
+                int depsH = (h - 2) * numDeps / (numDeps + numConfs);
 
                 AddObject(new ConsoleFrame(
                     1, top, midL, top + h - 1,
@@ -267,7 +268,7 @@ namespace CKAN.ConsoleUI {
                         th => th.DimLabelFg
                     ));
                     ConsoleTextBox tb = new ConsoleTextBox(
-                        3 + lblW, top + 1, midL - 2, top + 1 + numDeps - 1, false,
+                        3 + lblW, top + 1, midL - 2, top + 1 + depsH - 1, false,
                         TextAlign.Left,
                         th => th.MainBg,
                         th => th.LabelFg
@@ -284,13 +285,13 @@ namespace CKAN.ConsoleUI {
                 }
                 if (numConfs > 0) {
                     AddObject(new ConsoleLabel(
-                        3, top + 1 + numDeps, 3 + lblW - 1,
+                        3, top + 1 + depsH, 3 + lblW - 1,
                         () => $"Conflicts ({numConfs}):",
                         null,
                         th => th.DimLabelFg
                     ));
                     ConsoleTextBox tb = new ConsoleTextBox(
-                        3 + lblW, top + 1 + numDeps, midL - 2, top + h - 2, false,
+                        3 + lblW, top + 1 + depsH, midL - 2, top + h - 2, false,
                         TextAlign.Left,
                         th => th.MainBg,
                         th => th.LabelFg

--- a/ConsoleUI/Toolkit/Formatting.cs
+++ b/ConsoleUI/Toolkit/Formatting.cs
@@ -21,11 +21,9 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </returns>
         public static int ConvertCoord(int val, int max)
         {
-            if (val >= 0) {
-                return val;
-            } else {
-                return max + val - 1;
-            }
+            return val >= 0
+                ? Math.Min(max - 1, val)
+                : Math.Max(0, max - 1 + val);
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

```
Unhandled Exception:
System.ArgumentOutOfRangeException: Value must be positive and below the buffer height.
Parameter name: top
  at System.TermInfoDriver.SetCursorPosition (System.Int32 left, System.Int32 top) [0x0003e] in <533173d24dae460899d2b10975534bb0>:0 
  at System.ConsoleDriver.SetCursorPosition (System.Int32 left, System.Int32 top) [0x00000] in <533173d24dae460899d2b10975534bb0>:0 
  at System.Console.SetCursorPosition (System.Int32 left, System.Int32 top) [0x00000] in <533173d24dae460899d2b10975534bb0>:0 
  at CKAN.ConsoleUI.Toolkit.ConsoleTextBox.Draw (CKAN.ConsoleUI.Toolkit.ConsoleTheme theme, System.Boolean focused) [0x000c2] in <3ad907c2f8a0408085d33038b3a73567>:0 
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Draw (CKAN.ConsoleUI.Toolkit.ConsoleTheme theme) [0x00034] in <3ad907c2f8a0408085d33038b3a73567>:0 
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Interact (CKAN.ConsoleUI.Toolkit.ConsoleTheme theme) [0x00012] in <3ad907c2f8a0408085d33038b3a73567>:0 
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Run (CKAN.ConsoleUI.Toolkit.ConsoleTheme theme, System.Action`1[T] process) [0x0002d] in <3ad907c2f8a0408085d33038b3a73567>:0 
  at CKAN.ConsoleUI.Toolkit.ConsoleScreen.LaunchSubScreen (CKAN.ConsoleUI.Toolkit.ConsoleTheme theme, CKAN.ConsoleUI.Toolkit.ConsoleScreen cs, System.Action`1[T] newProc) [0x00001] in <3ad907c2f8a0408085d33038b3a73567>:0 
  at CKAN.ConsoleUI.ModListScreen.<.ctor>b__0_16 (System.Object sender, CKAN.ConsoleUI.Toolkit.ConsoleTheme theme) [0x00038] in <3ad907c2f8a0408085d33038b3a73567>:0 
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Interact (CKAN.ConsoleUI.Toolkit.ConsoleTheme theme) [0x000a2] in <3ad907c2f8a0408085d33038b3a73567>:0 
  at CKAN.ConsoleUI.Toolkit.ScreenContainer.Run (CKAN.ConsoleUI.Toolkit.ConsoleTheme theme, System.Action`1[T] process) [0x0002d] in <3ad907c2f8a0408085d33038b3a73567>:0 
```

![image](https://user-images.githubusercontent.com/1559108/136669791-1d6d75c8-3669-4f18-9697-58dedf525f40.png)

## Cause

The mod info screen only has room for a total of 9 dependencies and conflicts, and it assumes there will be fewer than that many. If there are more, they will overflow the dependencies box. If there are a lot more, they can overflow the screen and crash.

I think I couldn't conceive of a mod having more than 9 dependencies+conflicts when I wrote this. Now we have crazy mods like the RP1 express stuff with way more.

## Changes

- `Formatting.ConvertCoord` now coerces all coordinates to appear on-screen, so if we have other layout problems in the future, they won't cause a crash
- `ModInfoscreen.addDependencies` now allocates its 9 lines of text proportionally between dependencies and conflicts, and limits the size of the text boxes to fit within that range. If this isn't enough room, the text boxes will display scrollbars. The user is **not** able to scroll the box because we already use the scroll bindings for the description box, but hopefully they won't care.

![image](https://user-images.githubusercontent.com/1559108/136669891-e4a8fba8-7caa-4fd9-ac40-1c52f5786a36.png)
