### PR TITLE
Don't prompt to overwrite dirs

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -413,7 +413,8 @@ namespace CKAN
         {
             foreach (InstallableFile file in files)
             {
-                if (File.Exists(file.destination)
+                if (!file.source.IsDirectory
+                    && File.Exists(file.destination)
                     && registry.FileOwner(ksp.ToRelativeGameDir(file.destination)) == null)
                 {
                     log.DebugFormat("Comparing {0}", file.destination);


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/137635009-bbfbb905-0bcc-48a5-bc7a-41f046870770.png)

## Cause

If a ZIP includes a directory that already exists and isn't registered to an installed module, `ModuleInstaller.FindConflictingFiles` can return it.

## Changes

Now `ModuleInstaller.FindConflictingFiles` ignores directories.