### PR TITLE
Fix double-absolute SpaceDock URLs

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Sources\Jenkins\JenkinsOptions.cs" />
     <Compile Include="Sources\Jenkins\JenkinsRef.cs" />
     <Compile Include="Sources\Spacedock\ISpaceDock.cs" />
+    <Compile Include="Sources\Spacedock\JsonConvertFromRelativeSdUri.cs" />
     <Compile Include="Sources\Spacedock\SDVersion.cs" />
     <Compile Include="Sources\Spacedock\SpaceDockApi.cs" />
     <Compile Include="Sources\Spacedock\SpacedockError.cs" />

--- a/Netkan/Sources/Spacedock/JsonConvertFromRelativeSdUri.cs
+++ b/Netkan/Sources/Spacedock/JsonConvertFromRelativeSdUri.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Net;
+using System.Text.RegularExpressions;
+using CKAN.NetKAN.Services;
+using log4net;
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Spacedock
+{
+    /// <summary>
+    /// A simple helper class to prepend SpaceDock URLs.
+    /// </summary>
+    internal class JsonConvertFromRelativeSdUri : JsonConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value != null)
+                return ExpandPath(reader.Value.ToString());
+            return null;
+
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Returns the route with the SpaceDock URI (not the API URI) pre-pended.
+        /// </summary>
+        private static Uri ExpandPath(string route)
+        {
+            Log.DebugFormat("Expanding {0} to full SpaceDock URL", route);
+
+            // Alas, this isn't as simple as it may sound. For some reason
+            // some—but not all—SD mods don't work the same way if the path provided
+            // is escaped or un-escaped.
+
+            // Update: The Uri class under mono doesn't un-escape everything when
+            // .ToString() is called, even though the .NET documentation says that it
+            // should. Rather than using it and going through escaping hell, we'll simply
+            // concat our strings together and preserve escaping that way. If SD ever
+            // start returning fully qualified URLs then we should see everyting break
+            // pretty quickly, and we can rejoice because we won't need any of this code
+            // again. -- PJF, KSP-CKAN/CKAN#816.
+
+            // Step 1: Escape any spaces present. SD seems to escape everything else fine.
+            route = Regex.Replace(route, " ", "%20");
+
+            // Step 2: Trim leading slashes and prepend the SD host
+            var urlFixed = new Uri(SpacedockApi.SpacedockBase + route.TrimStart('/'));
+
+            // Step 3: Profit!
+            Log.DebugFormat("Expanded URL is {0}", urlFixed.OriginalString);
+            return urlFixed;
+        }
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(JsonConvertFromRelativeSdUri));
+    }
+}

--- a/Netkan/Sources/Spacedock/SDVersion.cs
+++ b/Netkan/Sources/Spacedock/SDVersion.cs
@@ -69,31 +69,5 @@ namespace CKAN.NetKAN.Sources.Spacedock
                 throw new NotImplementedException();
             }
         }
-
-        /// <summary>
-        /// A simple helper class to prepend SpaceDock URLs.
-        /// </summary>
-        internal class JsonConvertFromRelativeSdUri : JsonConverter
-        {
-            public override object ReadJson(
-                JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer
-            )
-            {
-                if (reader.Value != null)
-                    return SpacedockApi.ExpandPath(reader.Value.ToString());
-                return null;
-
-            }
-
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override bool CanConvert(Type objectType)
-            {
-                throw new NotImplementedException();
-            }
-        }
     }
 }

--- a/Netkan/Sources/Spacedock/SpaceDockApi.cs
+++ b/Netkan/Sources/Spacedock/SpaceDockApi.cs
@@ -11,7 +11,7 @@ namespace CKAN.NetKAN.Sources.Spacedock
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(SpacedockApi));
 
-        private static readonly Uri SpacedockBase = new Uri("https://spacedock.info/");
+        public static readonly Uri SpacedockBase = new Uri("https://spacedock.info/");
         private static readonly Uri SpacedockApiBase = new Uri(SpacedockBase, "/api/");
 
         private readonly IHttpService _http;
@@ -55,37 +55,6 @@ namespace CKAN.NetKAN.Sources.Spacedock
             }
 
             return SpacedockMod.FromJson(json);
-        }
-
-        // TODO: DBB: Make this private
-        /// <summary>
-        ///     Returns the route with the SpaceDock URI (not the API URI) pre-pended.
-        /// </summary>
-        public static Uri ExpandPath(string route)
-        {
-            Log.DebugFormat("Expanding {0} to full SpaceDock URL", route);
-
-            // Alas, this isn't as simple as it may sound. For some reason
-            // some—but not all—SD mods don't work the same way if the path provided
-            // is escaped or un-escaped.
-
-            // Update: The Uri class under mono doesn't un-escape everything when
-            // .ToString() is called, even though the .NET documentation says that it
-            // should. Rather than using it and going through escaping hell, we'll simply
-            // concat our strings together and preserve escaping that way. If SD ever
-            // start returning fully qualified URLs then we should see everyting break
-            // pretty quickly, and we can rejoice because we won't need any of this code
-            // again. -- PJF, KSP-CKAN/CKAN#816.
-
-            // Step 1: Escape any spaces present. SD seems to escape everything else fine.
-            route = Regex.Replace(route, " ", "%20");
-
-            // Step 2: Trim leading slashes and prepend the SD host
-            var urlFixed = new Uri(SpacedockBase + route.TrimStart('/'));
-
-            // Step 3: Profit!
-            Log.DebugFormat("Expanded URL is {0}", urlFixed.OriginalString);
-            return urlFixed;
         }
 
         private string Call(string path)

--- a/Netkan/Sources/Spacedock/SpacedockMod.cs
+++ b/Netkan/Sources/Spacedock/SpacedockMod.cs
@@ -17,7 +17,6 @@ namespace CKAN.NetKAN.Sources.Spacedock
         [JsonProperty] public string source_code;
         [JsonProperty] public int default_version_id;
         [JsonProperty] public SpacedockUser[] shared_authors;
-        [JsonConverter(typeof(SDVersion.JsonConvertFromRelativeSdUri))]
         public Uri background;
 
         public SDVersion Latest()
@@ -46,7 +45,7 @@ namespace CKAN.NetKAN.Sources.Spacedock
         /// <returns>The home.</returns>
         public Uri GetPageUrl()
         {
-            return SpacedockApi.ExpandPath(string.Format("/mod/{0}/{1}", id, name));
+            return new Uri($"{SpacedockApi.SpacedockBase}mod/{id}/{name.Replace(" ", "%20")}");
         }
 
         public override string ToString()

--- a/Tests/NetKAN/SDMod.cs
+++ b/Tests/NetKAN/SDMod.cs
@@ -33,7 +33,10 @@ namespace Tests.NetKAN
         // GH #816: Ensure URLs with & are encoded correctly.
         public string SD_URL_encode_816(string path)
         {
-            return SpacedockApi.ExpandPath(path).OriginalString;
+            return SpacedockMod.FromJson(string.Format(
+                @"{{""name"":""Mod"",""id"":69420,""game"":""Kerbal Space Program"",""game_id"":3102,""short_description"":""A mod"",""description"":""A mod"",""downloads"":0,""followers"":0,""author"":""linuxgurugamer"",""default_version_id"":1,""shared_authors"":[],""background"":null,""bg_offset_y"":null,""license"":""MIT"",""website"":null,""donations"":null,""source_code"":null,""url"":""/mod/69420/Mod"",""versions"":[{{""friendly_version"":""1"",""game_version"":""1.12.2"",""id"":1,""created"":""2021-07-16T20:46:12.309009+00:00"",""download_path"":""{0}"",""changelog"":"""",""downloads"":0}}]}}",
+                path
+            )).versions[0].download_path.OriginalString;
         }
 
         [Test]


### PR DESCRIPTION
## Problem

After KSP-SpaceDock/SpaceDock#388, lots and lots of SpaceDock mods had their `resources.x_screenshot` property updated to start with `https://spacedock.info/https://spacedock.info/`:

https://github.com/KSP-CKAN/CKAN-meta/compare/2de283f0cf...bea11c1193

## Cause

The SpaceDock mod API used to return `background` as a relative URL, and now it's absolute. Netkan has code to convert it from relative to absolute unconditionally, so now it's double-absolute.

## Changes

- The `JsonConvertFromRelativeSdUri` converter is removed from `SpacedockMod.background`
- The `JsonConvertFromRelativeSdUri` class is moved to its own file
- `SpaceDockApi.ExpandPath` is moved into `JsonConvertFromRelativeSdUri` and made private
- `SpacedockMod.GetPageUrl` is refactored to account for `ExpandPath` now being private
- `Tests.SDMod.SD_URL_encode_816` is refactored to test URL processing as part of full parsing of mod JSON rather than just the now-private `ExpandPath`

Now the absolute URL from SpaceDock will be used as-is, so most of those commits should revert after merge.