### PR TITLE
Use CRLF for resx files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,7 +28,7 @@
 *.config        text
 *.crt           text
 *.DotSettings   text
-*.resx          text
+*.resx          text eol=crlf
 *.settings      text
 
 # CKAN files


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/53821637/139573383-280b9bf4-1405-4cfc-bc50-43cb7be94b46.png)

![image](https://user-images.githubusercontent.com/1559108/139583859-f2446b21-7d12-429a-8285-e7d1e68bf13f.png)

We do already have a line break there:

https://github.com/KSP-CKAN/CKAN/blob/41a0143b5cfb48b5767db306f045ae1640143e0a/GUI/Properties/Resources.resx#L272-L274

## Cause

[It seems that `.resx` files are supposed to use CRLF line endings](https://github.com/dotnet/msbuild/issues/2206), but we have them as normalized to LF in the repo and OS-specific in the working dir (CRLF when checked out on Windows, LF on Linux and Mac), so it would be LF when we build in an Ubuntu container:

https://github.com/KSP-CKAN/CKAN/blob/41a0143b5cfb48b5767db306f045ae1640143e0a/.gitattributes#L31

Refresher for `.gitattributes` usage:

- `text` means to treat the matching files as text format. LF will be stored to the server, LF will be used on Linux and Mac, CRLF will be used on Windows.
  - `text=auto` means to run git's built-in algorithm to check whether each matching file is in text format, then treat it as `text` if so
- `eol=lf` means to use LF everywhere
- `eol=crlf` means to use CRLF at checkout on all platforms, and who cares what's on the server because you can't see it

So the resource DLLs are built with LF in them, which Windows sometimes doesn't like when those strings get passed to GUI controls. Especially helpfully, if you check out CKAN on Windows and build it there, git will give you `.resx` files with CRLF and therefore you will get functionally different resource DLLs and possibly not be able to reproduce the problem!

## Changes

Now our `.gitattributes` file specifies `eol=crlf` for `.resx` files. This should make git convert these files' line endings to CRLF at checkout on all platforms, so our resource files will contain CRLF as intended in .NET.

As far as I can tell this does not break anything on Linux/Mono. I ran this:

```
find . -name \*.resx -print0 | xargs -0 unix2dos
git add --renormalize
```

... as every tutorial says you should do, and it converted all my local `.resx` files to CRLF. Nothing was staged, however, and I think that's because these files will still have LF on the server, so auto-normalizing the local files from CRLF to LF in the background results in no change to be committed.

Fixes #2847.
Fixes #3470.