### PR TITLE
Properly determine the game when cloning instances

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -78,7 +78,7 @@ namespace CKAN.CmdLine
         /// The output is index 0 based.
         /// To supply a default option, make the first option an integer indicating the index of it.
         /// </summary>
-        /// <returns>The selection dialog</returns>
+        /// <returns>The selected index or -1 if cancelled</returns>
         /// <param name="message">Message</param>
         /// <param name="args">Array of available options</param>
         public int RaiseSelectionDialog(string message, params object[] args)

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -623,7 +623,7 @@ namespace CKAN
                 default:
                     // Prompt user to choose
                     int selection = user.RaiseSelectionDialog(
-                        $"Please select the game that is installed at {path}",
+                        $"Please select the game that is installed at {path.FullName.Replace('/', Path.DirectorySeparatorChar)}",
                         matchingGames.Select(g => g.ShortName).ToArray());
                     return selection >= 0 ? matchingGames[selection] : null;
             }

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -206,7 +206,7 @@ namespace CKAN
         {
             var game = DetermineGame(new DirectoryInfo(path), user);
             if (game == null)
-                throw new NotKSPDirKraken(path);
+                return null;
 
             return AddInstance(new GameInstance(game, path, name, user));
         }
@@ -608,14 +608,15 @@ namespace CKAN
         /// </summary>
         /// <param name="path">A DirectoryInfo of the path to check</param>
         /// <param name="user">IUser object for interaction</param>
-        /// <returns>An instance of the matching game, or null if none could be found</returns>
+        /// <returns>An instance of the matching game or null if the user cancelled</returns>
+        /// <exception cref="NotKSPDirKraken">Thrown when no games found</exception>
         public IGame DetermineGame(DirectoryInfo path, IUser user)
         {
             var matchingGames = knownGames.Where(g => g.GameInFolder(path)).ToList();
             switch (matchingGames.Count)
             {
                 case 0:
-                    return null;
+                    throw new NotKSPDirKraken(path.FullName);
 
                 case 1:
                     return matchingGames.First();

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -22,6 +22,11 @@ namespace CKAN
             new KerbalSpaceProgram()
         };
 
+        /// <summary>
+        /// An IUser object for user interaction.
+        /// It is initialized during the startup with a ConsoleUser,
+        /// do not use in functions that could be called by the GUI.
+        /// </summary>
         public IUser User { get; set; }
         public IConfiguration Configuration { get; set; }
         public GameInstance CurrentInstance { get; set; }
@@ -69,7 +74,7 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Returns the preferred KSP instance, or null if none can be found.
+        /// Returns the preferred game instance, or null if none can be found.
         ///
         /// This works by checking to see if we're in a KSP dir first, then the
         /// config for an autostart instance, then will try to auto-populate
@@ -170,45 +175,40 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Adds a KSP instance to config.
-        /// Returns the resulting KSP object.
+        /// Adds a game instance to config.
         /// </summary>
-        public GameInstance AddInstance(GameInstance ksp_instance)
+        /// <returns>The resulting GameInstance object</returns>
+        /// <exception cref="NotKSPDirKraken">Thrown if the instance is not a valid game instance.</exception>
+        public GameInstance AddInstance(GameInstance instance)
         {
-            if (ksp_instance.Valid)
+            if (instance.Valid)
             {
-                string name = ksp_instance.Name;
-                instances.Add(name, ksp_instance);
+                string name = instance.Name;
+                instances.Add(name, instance);
                 Configuration.SetRegistryToInstances(instances);
             }
             else
             {
-                throw new NotKSPDirKraken(ksp_instance.GameDir());
+                throw new NotKSPDirKraken(instance.GameDir());
             }
-            return ksp_instance;
+            return instance;
         }
 
+        /// <summary>
+        /// Adds a game instance to config.
+        /// </summary>
+        /// <param name="path">The path of the instance</param>
+        /// <param name="name">The name of the instance</param>
+        /// <param name="user">IUser object for interaction</param>
+        /// <returns>The resulting GameInstance object</returns>
+        /// <exception cref="NotKSPDirKraken">Thrown if the instance is not a valid game instance.</exception>
         public GameInstance AddInstance(string path, string name, IUser user)
         {
-            var matchingGames = knownGames
-                .Where(g => g.GameInFolder(new DirectoryInfo(path)))
-                .ToList();
-            switch (matchingGames.Count)
-            {
-                case 0:
-                    throw new NotKSPDirKraken(path);
+            var game = DetermineGame(new DirectoryInfo(path), user);
+            if (game == null)
+                throw new NotKSPDirKraken(path);
 
-                case 1:
-                    return AddInstance(new GameInstance(
-                        matchingGames.First(),
-                        path, name, user
-                    ));
-
-                default:
-                    // TODO: Prompt user to choose
-                    return null;
-
-            }
+            return AddInstance(new GameInstance(game, path, name, user));
         }
 
         /// <summary>
@@ -601,6 +601,32 @@ namespace CKAN
         public static bool IsGameInstanceDir(DirectoryInfo path)
         {
             return knownGames.Any(g => g.GameInFolder(path));
+        }
+
+        /// <summary>
+        /// Tries to determine the game that is installed at the given path
+        /// </summary>
+        /// <param name="path">A DirectoryInfo of the path to check</param>
+        /// <param name="user">IUser object for interaction</param>
+        /// <returns>An instance of the matching game, or null if none could be found</returns>
+        public IGame DetermineGame(DirectoryInfo path, IUser user)
+        {
+            var matchingGames = knownGames.Where(g => g.GameInFolder(path)).ToList();
+            switch (matchingGames.Count)
+            {
+                case 0:
+                    return null;
+
+                case 1:
+                    return matchingGames.First();
+
+                default:
+                    // Prompt user to choose
+                    int selection = user.RaiseSelectionDialog(
+                        $"Please select the game that is installed at {path}",
+                        matchingGames.Select(g => g.ShortName).ToArray());
+                    return selection >= 0 ? matchingGames[selection] : null;
+            }
         }
 
     }

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -10,6 +10,13 @@ namespace CKAN
         bool Headless { get; }
 
         bool RaiseYesNoDialog(string question);
+
+        /// <summary>
+        /// Ask the user to select one of the elements of the array.
+        /// The output is index 0 based.
+        /// To supply a default option, make the first option an integer indicating the index of it.
+        /// </summary>
+        /// <returns>The index of the item selected from the array or -1 if cancelled</returns>
         int  RaiseSelectionDialog(string message, params object[] args);
         void RaiseError(string message, params object[] args);
 

--- a/GUI/Dialogs/CloneFakeGameDialog.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.cs
@@ -146,13 +146,14 @@ namespace CKAN
                 try
                 {
                     IGame guessedGame = manager.DetermineGame(new DirectoryInfo(existingPath), user);
+                    if (guessedGame == null)
+                    {
+                        // User cancelled, let them try again
+                        reactivateDialog();
+                        return;
+                    }
                     await Task.Run(() =>
                     {
-                        if (guessedGame == null)
-                        {
-                            throw new NotKSPDirKraken(existingPath);
-                        }
-
                         GameInstance instanceToClone = new GameInstance(
                             guessedGame,
                             existingPath,

--- a/GUI/Dialogs/CloneFakeGameDialog.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.cs
@@ -145,22 +145,26 @@ namespace CKAN
 
                 try
                 {
-                    IGame guessedGame = manager.DetermineGame(new DirectoryInfo(existingPath), user);
-                    if (guessedGame == null)
+                    GameInstance instanceToClone = null;
+                    if (!manager.Instances.TryGetValue(comboBoxKnownInstance.SelectedItem as string, out instanceToClone)
+                        || existingPath != instanceToClone.GameDir().Replace('/', Path.DirectorySeparatorChar))
                     {
-                        // User cancelled, let them try again
-                        reactivateDialog();
-                        return;
-                    }
-                    await Task.Run(() =>
-                    {
-                        GameInstance instanceToClone = new GameInstance(
-                            guessedGame,
+                        IGame sourceGame = manager.DetermineGame(new DirectoryInfo(existingPath), user);
+                        if (sourceGame == null)
+                        {
+                            // User cancelled, let them try again
+                            reactivateDialog();
+                            return;
+                        }
+                        instanceToClone = new GameInstance(
+                            sourceGame,
                             existingPath,
                             "irrelevant",
                             user
                         );
-
+                    }
+                    await Task.Run(() =>
+                    {
                         if (instanceToClone.Valid)
                         {
                             manager.CloneInstance(instanceToClone, newName, newPath);

--- a/GUI/Dialogs/CloneFakeGameDialog.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.cs
@@ -53,7 +53,7 @@ namespace CKAN
             string sel = comboBoxKnownInstance.SelectedItem as string;
             textBoxClonePath.Text = string.IsNullOrEmpty(sel)
                 ? ""
-                : manager.Instances[sel].GameDir();
+                : manager.Instances[sel].GameDir().Replace('/', Path.DirectorySeparatorChar);
         }
 
         /// <summary>
@@ -178,13 +178,13 @@ namespace CKAN
                 }
                 catch (NotKSPDirKraken kraken)
                 {
-                    user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogInstanceNotValid, kraken.path));
+                    user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogInstanceNotValid, kraken.path.Replace('/', Path.DirectorySeparatorChar)));
                     reactivateDialog();
                     return;
                 }
                 catch (PathErrorKraken kraken)
                 {
-                    user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogDestinationNotEmpty, kraken.path));
+                    user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogDestinationNotEmpty, kraken.path.Replace('/', Path.DirectorySeparatorChar)));
                     reactivateDialog();
                     return;
                 }

--- a/GUI/Dialogs/CloneFakeGameDialog.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.cs
@@ -113,6 +113,7 @@ namespace CKAN
         /// </summary>
         private async void buttonOK_Click(object sender, EventArgs e)
         {
+            string existingPath = textBoxClonePath.Text;
             string newName = textBoxNewName.Text;
             string newPath = textBoxNewPath.Text;
 
@@ -144,13 +145,17 @@ namespace CKAN
 
                 try
                 {
+                    IGame guessedGame = manager.DetermineGame(new DirectoryInfo(existingPath), user);
                     await Task.Run(() =>
                     {
-                        GameInstance sourceInstance = manager.Instances.Values
-                            .FirstOrDefault(i => i.GameDir() == textBoxClonePath.Text);
+                        if (guessedGame == null)
+                        {
+                            throw new NotKSPDirKraken(existingPath);
+                        }
+
                         GameInstance instanceToClone = new GameInstance(
-                            sourceInstance.game,
-                            textBoxClonePath.Text,
+                            guessedGame,
+                            existingPath,
                             "irrelevant",
                             user
                         );

--- a/GUI/Dialogs/SelectionDialog.cs
+++ b/GUI/Dialogs/SelectionDialog.cs
@@ -80,7 +80,7 @@ namespace CKAN
                 if (defaultSelection == i)
                 {
                     Util.Invoke(OptionsList, () => OptionsList.Items.Add(String.Concat(args[i].ToString(), "  -- Default")));
-                    
+
                 }
                 else
                 {

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -83,7 +83,16 @@ namespace CKAN
             Instance = this;
 
             currentUser = new GUIUser(this, this.Wait);
-            manager = mgr ?? new GameInstanceManager(currentUser);
+            if (mgr != null)
+            {
+                // With a working GUI, assign a GUIUser to the GameInstanceManager to replace the ConsoleUser
+                mgr.User = currentUser;
+                manager = mgr;
+            }
+            else
+            {
+                manager = new GameInstanceManager(currentUser);
+            }
 
             controlFactory = new ControlFactory();
 


### PR DESCRIPTION
## Problem
A user reported a problem when trying to clone a KSP instance, they're getting a `Clone failed: Object reference not set to an instance of an object` error.
We couldn't quite figure out what the user was doing exactly, the messages were kinda vague:
> I remember I was messing around with the specific path, and I changed it, but the changes didn't show up, so I figured it hadn't saved my changes or something

But after looking at the clone UI logic, these lines stood out as a possible cause for a NRE:
https://github.com/KSP-CKAN/CKAN/blob/2564dfb3a0784cf82cedaf9cac1c0064a2b6b58a/GUI/Dialogs/CloneFakeGameDialog.cs#L149-L156

They were refactored in #3223 and didn't account for the possibility of a path being entered that didn't already belong to a known instance, which would result in a `null` `sourceInstance`.

## Changes
The underlying issue that forced this instance lookup was that we didn't have a good way to determine the game of the instance to clone.
In `GameInstanceManager.AddInstance()` we already had a basic layout for this, but it was missing the option to prompt the user to choose between multiple games if it detected multiple potential ones.

This logic is now moved into a new `DetermineGame()` method, which calls User.`RaiseDelectionDialog` in the aforementioned case.

Both the CloneFake dialog and the AddInstance button use the new `DetermineGame()` method.

For testing you can simply copy `KerbalSpaceProgram.cs`, rename the file and class, and add it to `GameInstanceManager.knownGames` to force multiple games to be detected.