### PR TITLE
Add Release Date column to GUI modinfo versions list

### DIFF
--- a/GUI/Controls/AllModVersions.Designer.cs
+++ b/GUI/Controls/AllModVersions.Designer.cs
@@ -30,13 +30,10 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(AllModVersions));
-            System.Windows.Forms.ListViewItem listViewItem4 = new System.Windows.Forms.ListViewItem(new string[] {
-            "",
-            "i1",
-            "i2"}, -1);
             this.label1 = new System.Windows.Forms.Label();
             this.ModVersion = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.CompatibleGameVersion = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.ReleaseDate = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.VersionsListView = new ThemedListView();
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
@@ -62,8 +59,13 @@
             //
             // CompatibleGameVersion
             //
-            this.CompatibleGameVersion.Width = 190;
+            this.CompatibleGameVersion.Width = 132;
             resources.ApplyResources(this.CompatibleGameVersion, "CompatibleGameVersion");
+            //
+            // ReleaseDate
+            //
+            this.ReleaseDate.Width = 140;
+            resources.ApplyResources(this.ReleaseDate, "ReleaseDate");
             //
             // VersionsListView
             //
@@ -72,11 +74,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.VersionsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.ModVersion,
-            this.CompatibleGameVersion});
+            this.CompatibleGameVersion,
+            this.ReleaseDate});
             this.VersionsListView.CheckBoxes = true;
             this.VersionsListView.FullRowSelect = true;
-            this.VersionsListView.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
-            listViewItem4});
             this.VersionsListView.Location = new System.Drawing.Point(3, 76);
             this.VersionsListView.Name = "VersionsListView";
             this.VersionsListView.Size = new System.Drawing.Size(348, 423);
@@ -165,6 +166,7 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ColumnHeader ModVersion;
         private System.Windows.Forms.ColumnHeader CompatibleGameVersion;
+        private System.Windows.Forms.ColumnHeader ReleaseDate;
         private System.Windows.Forms.ListView VersionsListView;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label3;

--- a/GUI/Controls/AllModVersions.cs
+++ b/GUI/Controls/AllModVersions.cs
@@ -180,7 +180,8 @@ namespace CKAN
                     ListViewItem toRet = new ListViewItem(new string[]
                         {
                             module.version.ToString(),
-                            GameVersionRange.VersionSpan(currentInstance.game, minKsp, maxKsp)
+                            GameVersionRange.VersionSpan(currentInstance.game, minKsp, maxKsp),
+                            module.release_date?.ToString("g") ?? ""
                         })
                     {
                         Tag  = module

--- a/GUI/Controls/AllModVersions.resx
+++ b/GUI/Controls/AllModVersions.resx
@@ -118,8 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label1.Text" xml:space="preserve"><value>All available versions of selected mod</value></data>
-  <data name="ModVersion.Text" xml:space="preserve"><value>Mod Version</value></data>
-  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Compatible Game Versions</value></data>
+  <data name="ModVersion.Text" xml:space="preserve"><value>Mod version</value></data>
+  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Game versions</value></data>
+  <data name="ReleaseDate.Text" xml:space="preserve"><value>Release date</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Green</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Light green</value></data>
   <data name="label4.Text" xml:space="preserve"><value>Bold</value></data>

--- a/GUI/Localization/de-DE/AllModVersions.de-DE.resx
+++ b/GUI/Localization/de-DE/AllModVersions.de-DE.resx
@@ -120,6 +120,7 @@
   <data name="label1.Text" xml:space="preserve"><value>Alle verfügbaren Versionen der ausgewählten Mod</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Mod-Version</value></data>
   <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Kompatible Spielversionen</value></data>
+  <data name="ReleaseDate.Text" xml:space="preserve"><value>Veröffentlichungsdatum</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Grün</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Hellgrün</value></data>
   <data name="label4.Text" xml:space="preserve"><value>Fett</value></data>

--- a/GUI/Localization/de-DE/AllModVersions.de-DE.resx
+++ b/GUI/Localization/de-DE/AllModVersions.de-DE.resx
@@ -119,7 +119,7 @@
   </resheader>
   <data name="label1.Text" xml:space="preserve"><value>Alle verfügbaren Versionen der ausgewählten Mod</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Mod-Version</value></data>
-  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Kompatible Spielversionen</value></data>
+  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Spielversionen</value></data>
   <data name="ReleaseDate.Text" xml:space="preserve"><value>Veröffentlichungsdatum</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Grün</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Hellgrün</value></data>

--- a/GUI/Localization/fr-FR/AllModVersions.fr-FR.resx
+++ b/GUI/Localization/fr-FR/AllModVersions.fr-FR.resx
@@ -120,6 +120,7 @@
   <data name="label1.Text" xml:space="preserve"><value>Toutes les versions disponibles du mod sélectionné</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Version du Mod</value></data>
   <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Versions de Jeu Compatibles</value></data>
+  <data name="ReleaseDate.Text" xml:space="preserve"><value>Date de publication</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Vert</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Vert Clair</value></data>
   <data name="label4.Text" xml:space="preserve"><value>Gras</value></data>

--- a/GUI/Localization/fr-FR/AllModVersions.fr-FR.resx
+++ b/GUI/Localization/fr-FR/AllModVersions.fr-FR.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -119,7 +119,7 @@
   </resheader>
   <data name="label1.Text" xml:space="preserve"><value>Toutes les versions disponibles du mod sélectionné</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Version du Mod</value></data>
-  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Versions de Jeu Compatibles</value></data>
+  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Versions de Jeu</value></data>
   <data name="ReleaseDate.Text" xml:space="preserve"><value>Date de publication</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Vert</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Vert Clair</value></data>

--- a/GUI/Localization/ja-JP/AllModVersions.ja-JP.resx
+++ b/GUI/Localization/ja-JP/AllModVersions.ja-JP.resx
@@ -120,6 +120,7 @@
   <data name="label1.Text" xml:space="preserve"><value>このModの全てのバージョン</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Modのバージョン</value></data>
   <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>対応するゲームのバージョン</value></data>
+  <data name="ReleaseDate.Text" xml:space="preserve"><value>リリース日時</value></data>
   <data name="label2.Text" xml:space="preserve"><value>緑</value></data>
   <data name="label3.Text" xml:space="preserve"><value>黄緑</value></data>
   <data name="label4.Text" xml:space="preserve"><value>太字</value></data>

--- a/GUI/Localization/pt-BR/AllModVersions.pt-BR.resx
+++ b/GUI/Localization/pt-BR/AllModVersions.pt-BR.resx
@@ -120,6 +120,7 @@
   <data name="label1.Text" xml:space="preserve"><value>Todas as versões disponíveis do mod selecionado</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Versão do mod</value></data>
   <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Versões do jogo compatíveis</value></data>
+  <data name="ReleaseDate.Text" xml:space="preserve"><value>Data do lançamento</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Verde</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Verde claro</value></data>
   <data name="label4.Text" xml:space="preserve"><value>Negrito</value></data>

--- a/GUI/Localization/pt-BR/AllModVersions.pt-BR.resx
+++ b/GUI/Localization/pt-BR/AllModVersions.pt-BR.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -119,7 +119,7 @@
   </resheader>
   <data name="label1.Text" xml:space="preserve"><value>Todas as versões disponíveis do mod selecionado</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Versão do mod</value></data>
-  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Versões do jogo compatíveis</value></data>
+  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Versões do jogo</value></data>
   <data name="ReleaseDate.Text" xml:space="preserve"><value>Data do lançamento</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Verde</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Verde claro</value></data>

--- a/GUI/Localization/ru-RU/AllModVersions.ru-RU.resx
+++ b/GUI/Localization/ru-RU/AllModVersions.ru-RU.resx
@@ -120,6 +120,7 @@
   <data name="label1.Text" xml:space="preserve"><value>Все доступные версии выбранной модификации</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Версия</value></data>
   <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Совместимые версии игры</value></data>
+  <data name="ReleaseDate.Text" xml:space="preserve"><value>Дата выпуска</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Зелёный</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Св.-зел.</value></data>
   <data name="label4.Text" xml:space="preserve"><value>Жирный</value></data>

--- a/GUI/Localization/ru-RU/AllModVersions.ru-RU.resx
+++ b/GUI/Localization/ru-RU/AllModVersions.ru-RU.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -119,7 +119,7 @@
   </resheader>
   <data name="label1.Text" xml:space="preserve"><value>Все доступные версии выбранной модификации</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Версия</value></data>
-  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Совместимые версии игры</value></data>
+  <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>версии игры</value></data>
   <data name="ReleaseDate.Text" xml:space="preserve"><value>Дата выпуска</value></data>
   <data name="label2.Text" xml:space="preserve"><value>Зелёный</value></data>
   <data name="label3.Text" xml:space="preserve"><value>Св.-зел.</value></data>


### PR DESCRIPTION
## Motivation

![image](https://user-images.githubusercontent.com/1559108/142677929-096a37ed-275e-4cf5-8c23-895451592e35.png)

## Changes

![image](https://user-images.githubusercontent.com/1559108/144720087-76dde49c-a697-4384-a3d5-2d84a85369c2.png)

The existing translations of the Release date column header in the mod grid are copied to the new column. Also changed the English capitalization of these column headers to match the mod grid (sentence capitalization instead of title capitalization) and removed "Compatible" to save space.

Fixes #3480.