### PR TITLE
Set bot useragent for Inflator

### DIFF
--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -6,4 +6,5 @@ USER netkan
 WORKDIR /home/netkan
 ADD netkan.exe .
 ENTRYPOINT /usr/bin/mono netkan.exe --queues $QUEUES \
+  --net-usergent 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)' \
   --github-token $GH_Token --cachedir ckan_cache -v

--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -6,5 +6,5 @@ USER netkan
 WORKDIR /home/netkan
 ADD netkan.exe .
 ENTRYPOINT /usr/bin/mono netkan.exe --queues $QUEUES \
-  --net-usergent 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)' \
+  --net-useragent 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)' \
   --github-token $GH_Token --cachedir ckan_cache -v


### PR DESCRIPTION
## Background

CKAN and Netkan both use a default `User-Agent` of `Mozilla/4.0 (compatible; CKAN)`.

## Motivation

This `User-Agent` does not identify the Inflator as a bot, which it most certainly is.

![image](https://user-images.githubusercontent.com/1559108/143908930-d292039e-abce-4b9e-bb05-cff5485e1131.png)

See KSP-SpaceDock/SpaceDock#436 for why we might want to do that.

## Changes

I don't know if there's a comprehensive reference on how to create a `User-Agent` string; the best reference I was able to find was:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#crawler_and_bot_ua_strings

Based on the examples presented there, the Inflator's `User-Agent` is now:

`Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)`

I think parsers will just check whether `bot` occurs in the browser family.

### Blocking external dependencies

The `HyperEdit` and `Graphotron` mods use a combination of strange URLs:

- <http://www.kerbaltek.com/_IamCKAN_Gimme_hyperedit_#cachebuster1>
- <http://www.kerbaltek.com/_IamCKAN_Gimme_graphotron_>

... and the `User-Agent` string to identify Netkan requests. Requesting these URLs with the wrong `User-Agent` string results in an HTTP status 403 error. Before we merge these changes, we must work with @Ezriilc to update the `kerbaltek.com` site to support the new `User-Agent` formats as well as the old format.