### PR TITLE
Sort Netkan warning lists

### DIFF
--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -271,7 +271,7 @@ namespace CKAN.NetKAN.Services
             {
                 throw new Kraken(
                     string.Format("Too many .version files located: {0}",
-                              string.Join(", ", files.Select(x => x.Name))));
+                              string.Join(", ", files.Select(x => x.Name).OrderBy(f => f))));
             }
             else
             {

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -87,7 +87,7 @@ namespace CKAN.NetKAN.Transformers
                             if (avc.version.CompareTo(remoteAvc.version) == 0)
                             {
                                 // Local AVC and Remote AVC describe the same version, prefer
-                                Log.Info("Remote AVC version file describes same version as local AVC version file, using it preferrentially.");
+                                Log.Info("Remote AVC version file describes same version as local AVC version file, using it preferentially.");
                                 avc = remoteAvc;
                             }
                         }

--- a/Netkan/Transformers/LocalizationsTransformer.cs
+++ b/Netkan/Transformers/LocalizationsTransformer.cs
@@ -64,6 +64,7 @@ namespace CKAN.NetKAN.Transformers
                         .Where(m => m.Groups["contents"].Value.Contains("="))
                         .Select(m => m.Groups["locale"].Value))
                     .Distinct()
+                    .OrderBy(l => l)
                     .Memoize();
                 log.Debug("Locales extracted");
 

--- a/Netkan/Validators/CraftsInShipsValidator.cs
+++ b/Netkan/Validators/CraftsInShipsValidator.cs
@@ -39,9 +39,7 @@ namespace CKAN.NetKAN.Validators
                     {
                         Log.WarnFormat(
                             "Craft files installed outside Ships folder: {0}",
-                            string.Join(", ", badCrafts.Select(f =>
-                                inst.ToRelativeGameDir(f.destination)
-                            ))
+                            string.Join(", ", badCrafts.Select(f => inst.ToRelativeGameDir(f.destination)).OrderBy(f => f))
                         );
                     }
                 }

--- a/Netkan/Validators/HarmonyValidator.cs
+++ b/Netkan/Validators/HarmonyValidator.cs
@@ -37,6 +37,7 @@ namespace CKAN.NetKAN.Validators
                     var harmonyDLLs = _moduleService.GetPlugins(mod, zip, inst)
                         .Select(instF => instF.source.Name)
                         .Where(f => f.IndexOf("Harmony", StringComparison.InvariantCultureIgnoreCase) != -1)
+                        .OrderBy(f => f)
                         .ToList();
                     bool bundlesHarmony   = harmonyDLLs.Any();
                     bool providesHarmony1 = mod.ProvidesList.Contains("Harmony1");

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -40,6 +40,7 @@ namespace CKAN.NetKAN.Validators
                 // Make sure no paths include GameData other than at the start
                 var gamedatas = allFiles
                     .Where(p => p.StartsWith("GameData") && p.LastIndexOf("/GameData/") > 0)
+                    .OrderBy(f => f)
                     .ToList();
                 if (gamedatas.Any())
                 {
@@ -50,7 +51,7 @@ namespace CKAN.NetKAN.Validators
                 // Make sure we won't try to overwrite our own files
                 var duplicates = allFiles
                     .GroupBy(f => f)
-                    .SelectMany(grp => grp.Skip(1))
+                    .SelectMany(grp => grp.Skip(1).OrderBy(f => f))
                     .ToList();
                 if (duplicates.Any())
                 {

--- a/Netkan/Validators/ModuleManagerDependsValidator.cs
+++ b/Netkan/Validators/ModuleManagerDependsValidator.cs
@@ -43,7 +43,7 @@ namespace CKAN.NetKAN.Validators
                     {
                         Log.WarnFormat(
                             "ModuleManager syntax used without ModuleManager dependency: {0}",
-                            string.Join(", ", mmConfigs.Select(cfg => cfg.source))
+                            string.Join(", ", mmConfigs.Select(cfg => cfg.source).OrderBy(f => f))
                         );
                     }
                     else if (dependsOnMM && !mmConfigs.Any())

--- a/Netkan/Validators/PluginsValidator.cs
+++ b/Netkan/Validators/PluginsValidator.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
+using CKAN.Extensions;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Model;
 using CKAN.Games;
@@ -36,14 +37,17 @@ namespace CKAN.NetKAN.Validators
                     bool hasPlugin = plugins.Any();
                     if (hasPlugin)
                     {
-                        var dllPaths = plugins.Select(f => inst.ToRelativeGameDir(f.destination)).ToList();
+                        var dllPaths = plugins
+                            .Select(f => inst.ToRelativeGameDir(f.destination))
+                            .OrderBy(f => f)
+                            .ToList();
                         var pattern = Registry.DllPattern(inst.game);
                         var dllIdentifiers = dllPaths
                             .Select(p => pattern.Match(p))
                             .Where(m => m.Success)
                             .Select(m => m.Groups["modname"].Value.Replace("_", "-"))
                             .Where(ident => !identifiersToIgnore.Contains(ident))
-                            .ToList();
+                            .ToHashSet();
                         if (dllIdentifiers.Any() && !dllIdentifiers.Contains(metadata.Identifier))
                         {
                             Log.WarnFormat(


### PR DESCRIPTION
## Problem

It was a surprise to see this for an established mod that probably isn't changing much from one release to the next:

![image](https://user-images.githubusercontent.com/1559108/144459889-a4ad481c-00c6-42ba-994f-239f0402cbc2.png)

It seems like the warning should remain the same and therefore not be sent to Discord.

## Cause

Same files, different order. The order of the list in the message depends on the order in the ZIP file, so if a succession of releases has the same warnings but the ZIP is created slightly differently, we get extra warning messages sent to Discord:

![image](https://user-images.githubusercontent.com/1559108/144460121-a72ca3d7-b200-450b-ab31-ca0ebce4dc94.png)

This could happen for any warning that contains a list of multiple things.

## Changes

Now the following messages are sorted alphabetically. This will probably cause a one-time cascade of new warnings sent to Discord as they all switch over to the proper sorted order:

- Multiple version files
- Craft files in wrong path
- Found copies of the Harmony DLL
- Paths with GameData contained in GameData
- Attempts to install same paths multiple times
- Config files using ModuleManager syntax without ModuleManager depends
- DLLs not matching the identifier for detecting manual installs

Also the `localizations` property will now be in alphabetical order. This might cause a large number of one-time re-indexings.