### PR TITLE
Enforce spec version requirements for more install properties

### DIFF
--- a/Netkan/Validators/InstallValidator.cs
+++ b/Netkan/Validators/InstallValidator.cs
@@ -42,6 +42,18 @@ namespace CKAN.NetKAN.Validators
                     {
                         throw new Kraken("spec_version v1.10+ required for install with 'find_regexp'");
                     }
+                    if (metadata.SpecVersion < v1p10 && stanza.ContainsKey("filter_regexp"))
+                    {
+                        throw new Kraken("spec_version v1.10+ required for install with 'filter_regexp'");
+                    }
+                    if (metadata.SpecVersion < v1p24 && stanza.ContainsKey("include_only"))
+                    {
+                        throw new Kraken("spec_version v1.24+ required for install with 'include_only'");
+                    }
+                    if (metadata.SpecVersion < v1p24 && stanza.ContainsKey("include_only_regexp"))
+                    {
+                        throw new Kraken("spec_version v1.24+ required for install with 'include_only_regexp'");
+                    }
                     if (metadata.SpecVersion < v1p16 && stanza.ContainsKey("find_matches_files"))
                     {
                         throw new Kraken("spec_version v1.16+ required for 'find_matches_files'");
@@ -73,6 +85,7 @@ namespace CKAN.NetKAN.Validators
         private static readonly ModuleVersion v1p12 = new ModuleVersion("v1.12");
         private static readonly ModuleVersion v1p16 = new ModuleVersion("v1.16");
         private static readonly ModuleVersion v1p18 = new ModuleVersion("v1.18");
+        private static readonly ModuleVersion v1p24 = new ModuleVersion("v1.24");
         private static readonly ModuleVersion v1p29 = new ModuleVersion("v1.29");
         private static readonly string[] pathProperties = {"find", "file", "install_to"};
     }


### PR DESCRIPTION
## Background

The spec says:

https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#install

>- `filter_regexp` : (**v1.10**) A string, or list of strings, which are treated as case-sensitive C# regular expressions which are matched against the full paths from the installing zip-file. If a file matches the regular expression, it is *not* installed.
>- `include_only` : (**v1.24**) A string, or list of strings, of file parts that should be installed. These are treated as literal things which must match a file name or directory. Examples of this may be `Settings.cfg`, or `Plugin`. These are considered case-insensitive.
>- `include_only_regexp` : (**v1.24**) A string, or list of strings, which are treated as case-sensitive C# regular expressions which are matched against the full paths from the installing zip-file. If a file matches the regular expression, it is installed.

The version numbers in parentheses are supposed to be the minimum `spec_version` required to use the given property.

## Problem

Currently you can use these properties with any `spec_version` and Netkan will not complain. This means that a client supporting an old spec version might be presented with metadata that it can't handle (but this is very unlikely to ever be a real problem because there is really only the one client, and versions of it that old won't even run anymore thanks to TLS changes on GitHub).

## Changes

Now Netkan's `InstallValidator` enforces these requirements.
