### PR TITLE
Log error and recover on instance loading exception

### DIFF
--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -507,11 +507,20 @@ namespace CKAN
                 var name = instance.Item1;
                 var path = instance.Item2;
                 var gameName = instance.Item3;
-                var game = knownGames.FirstOrDefault(g => g.ShortName == gameName)
-                    ?? knownGames[0];
-                log.DebugFormat("Loading {0} from {1}", name, path);
-                // Add unconditionally, sort out invalid instances downstream
-                instances.Add(name, new GameInstance(game, path, name, User));
+                try
+                {
+                    var game = knownGames.FirstOrDefault(g => g.ShortName == gameName)
+                        ?? knownGames[0];
+                    log.DebugFormat("Loading {0} from {1}", name, path);
+                    // Add unconditionally, sort out invalid instances downstream
+                    instances.Add(name, new GameInstance(game, path, name, User));
+                }
+                catch (Exception exc)
+                {
+                    // Skip malformed instances (e.g. empty path)
+                    log.Error($"Failed to load game instance with name=\"{name}\" path=\"{path}\" game=\"{gameName}\"",
+                        exc);
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

If you have no `config.json` file, and your Window registry has the `KSPInstanceCount` key set to a positive value but no `KSPInstancePath_<number>` properties, CKAN fails to start:

```
Unhandled Exception: System.ArgumentException: The path is not of a legal form.
   at System.IO.Path.LegacyNormalizePath(String path, Boolean fullCheck, Int32 maxPathLength, Boolean expandShortPaths)
   at System.IO.Path.GetFullPathInternal(String path)
   at CKAN.GameInstance..ctor(IGame game, String gameDir, String name, IUser user, Boolean scan)
   at CKAN.GameInstanceManager.LoadInstances()
   at CKAN.CmdLine.MainClass.Execute(GameInstanceManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

## Cause

`Win32RegistryConfiguration.GetInstance` calls `GetRegistryalue` with a default value of `string.Empty` for each property:

https://github.com/KSP-CKAN/CKAN/blob/cafa83268462cf70f03c43460625a9149e69c928/Core/Configuration/Win32RegistryConfiguration.cs#L112-L119

When the registry doesn't have these values, this returns `Tuple("", "", "")`. `GameInstanceManager.LoadInstances` then passes these values to the constructor of `GameInstance`, which passes the path to `Path.GetFullPath`:

https://github.com/KSP-CKAN/CKAN/blob/cafa83268462cf70f03c43460625a9149e69c928/Core/GameInstanceManager.cs#L505-L515

https://github.com/KSP-CKAN/CKAN/blob/cafa83268462cf70f03c43460625a9149e69c928/Core/GameInstance.cs#L57

`GetFullPath` throws if its parameter is the empty string.

## Changes

Now if anything goes wrong while we try to load the instances, we log the exception and skip that instance. This preserves the error info but allows the user to continue using CKAN.

```
355 [1] ERROR CKAN.GameInstanceManager (null) - Failed to load game instance with name="" path="" game=""
System.ArgumentException: The specified path is not of a legal form (empty).
  at System.IO.Path.InsecureGetFullPath (System.String path) [0x00025] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0 
  at System.IO.Path.GetFullPath (System.String path) [0x00000] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0 
  at CKAN.GameInstance..ctor (CKAN.Games.IGame game, System.String gameDir, System.String name, CKAN.IUser user, System.Boolean scan) [0x0002b] in <692144a1b5704a71accf4398207c02d3>:0 
  at CKAN.GameInstanceManager.LoadInstances () [0x000a6] in <692144a1b5704a71accf4398207c02d3>:0 
355 [1] ERROR CKAN.GameInstanceManager (null) - Failed to load game instance with name="" path="" game=""
System.ArgumentException: The specified path is not of a legal form (empty).
  at System.IO.Path.InsecureGetFullPath (System.String path) [0x00025] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0 
  at System.IO.Path.GetFullPath (System.String path) [0x00000] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0 
  at CKAN.GameInstance..ctor (CKAN.Games.IGame game, System.String gameDir, System.String name, CKAN.IUser user, System.Boolean scan) [0x0002b] in <692144a1b5704a71accf4398207c02d3>:0 
  at CKAN.GameInstanceManager.LoadInstances () [0x000a6] in <692144a1b5704a71accf4398207c02d3>:0 
```

Fixes #3495.