### PR TITLE
Sort exported modpack relationships by identifier

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -501,6 +501,8 @@ namespace CKAN
                         return false;
                     }
                 })
+                // Case insensitive sort by identifier
+                .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
                 .Select(kvp => (RelationshipDescriptor) new ModuleRelationshipDescriptor()
                     {
                         name    = kvp.Key,


### PR DESCRIPTION
## Problem

When you export a modpack into a `.ckan` file, the mods are in a non-deterministic order. Since the ordering changes from one export to the next, it is difficult to notice changes or track them with code tools like git or diff.

First reported here:

https://forum.kerbalspaceprogram.com/index.php?/topic/205890-%D1%81%D0%BE%D1%80%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D1%89%D0%B8%D0%BA-ckan-%D1%84%D0%B0%D0%B9%D0%BB%D0%B0/

(Found while searching the forum for "CKAN" because I don't have the official CKAN forum thread bookmarked.)

## Cause

The order is the order of `Registry.Installed()`, which is a `Dictionary` with the identifiers as keys. This is non-deterministic.

## Changes

Now we perform a case-insensitive sort by identifier after filtering the sequence and before making the `RelationshipDescriptor` objects. This should make the ordering consistent.

Documentation for `StringComparer.OrdinalIgnoreCase`:

https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparer.ordinalignorecase?view=netframework-4.7.2

> The StringComparer returned by the OrdinalIgnoreCase property treats the characters in the strings to compare as if they were converted to uppercase using the conventions of the invariant culture, and then performs a simple byte comparison that is independent of language. This is most appropriate when comparing strings that are generated programmatically or when comparing case-insensitive resources such as paths and filenames.
