### PR TITLE
Enforce a few more spec version requirements

### DIFF
--- a/Netkan/Validators/InstallValidator.cs
+++ b/Netkan/Validators/InstallValidator.cs
@@ -22,6 +22,14 @@ namespace CKAN.NetKAN.Validators
                     {
                         throw new Kraken("spec_version v1.2+ required for GameData with path");
                     }
+                    if (metadata.SpecVersion < v1p14 && install_to.Equals("Scenarios"))
+                    {
+                        throw new Kraken("spec_version v1.14+ required to install to Scenarios");
+                    }
+                    if (metadata.SpecVersion < v1p25 && install_to.Equals("Missions"))
+                    {
+                        throw new Kraken("spec_version v1.25+ required to install to Missions");
+                    }
                     if (metadata.SpecVersion < v1p29 && install_to.StartsWith("Ships/Script"))
                     {
                         throw new Kraken("spec_version v1.29+ required to install to Ships/Script");
@@ -83,9 +91,11 @@ namespace CKAN.NetKAN.Validators
         private static readonly ModuleVersion v1p4  = new ModuleVersion("v1.4");
         private static readonly ModuleVersion v1p10 = new ModuleVersion("v1.10");
         private static readonly ModuleVersion v1p12 = new ModuleVersion("v1.12");
+        private static readonly ModuleVersion v1p14 = new ModuleVersion("v1.14");
         private static readonly ModuleVersion v1p16 = new ModuleVersion("v1.16");
         private static readonly ModuleVersion v1p18 = new ModuleVersion("v1.18");
         private static readonly ModuleVersion v1p24 = new ModuleVersion("v1.24");
+        private static readonly ModuleVersion v1p25 = new ModuleVersion("v1.25");
         private static readonly ModuleVersion v1p29 = new ModuleVersion("v1.29");
         private static readonly string[] pathProperties = {"find", "file", "install_to"};
     }

--- a/Netkan/Validators/LicensesValidator.cs
+++ b/Netkan/Validators/LicensesValidator.cs
@@ -16,6 +16,10 @@ namespace CKAN.NetKAN.Validators
                     : new JArray() { json["license"] };
             if (licenses != null)
             {
+                if (metadata.SpecVersion < v1p8 && json["license"] is JArray)
+                {
+                    throw new Kraken("spec_version v1.8+ required for license as array");
+                }
                 foreach (var lic in licenses)
                 {
                     if (metadata.SpecVersion < v1p2 && (string)lic == "WTFPL")
@@ -59,6 +63,7 @@ namespace CKAN.NetKAN.Validators
             RegexOptions.Compiled
         );
         private static readonly ModuleVersion v1p2  = new ModuleVersion("v1.2");
+        private static readonly ModuleVersion v1p8  = new ModuleVersion("v1.8");
         private static readonly ModuleVersion v1p18 = new ModuleVersion("v1.18");
         private static readonly ModuleVersion v1p30 = new ModuleVersion("v1.30");
     }

--- a/Netkan/Validators/RelationshipsValidator.cs
+++ b/Netkan/Validators/RelationshipsValidator.cs
@@ -14,6 +14,10 @@ namespace CKAN.NetKAN.Validators
             {
                 if (json.ContainsKey(relName))
                 {
+                    if (metadata.SpecVersion < v1p2 && relName.Equals("supports"))
+                    {
+                        throw new Kraken("spec_version v1.2+ required for 'supports'");
+                    }
                     foreach (JObject rel in json[relName])
                     {
                         if (rel.ContainsKey("any_of"))
@@ -64,6 +68,7 @@ namespace CKAN.NetKAN.Validators
             "conflicts",
             "supports"
         };
+        private static readonly ModuleVersion v1p2  = new ModuleVersion("v1.2");
         private static readonly ModuleVersion v1p26 = new ModuleVersion("v1.26");
         private static readonly ModuleVersion v1p31 = new ModuleVersion("v1.31");
     }

--- a/Tests/NetKAN/Validators/LicensesValidatorTests.cs
+++ b/Tests/NetKAN/Validators/LicensesValidatorTests.cs
@@ -11,7 +11,7 @@ namespace Tests.NetKAN.Validators
         [Test,
             TestCase("v1.2",  @"""WTFPL"""),
             TestCase("v1.18", @"""Unlicense"""),
-            TestCase("v1.4",  @"[ ""GPL-3.0"", ""MIT"" ]"),
+            TestCase("v1.8",  @"[ ""GPL-3.0"", ""MIT"" ]"),
         ]
         public void Validate_GoodSpecVersionLicense_DoesNotThrow(string spec_version, string license)
         {
@@ -22,6 +22,7 @@ namespace Tests.NetKAN.Validators
             TestCase("1",     @"""WTFPL"""),
             TestCase("v1.17", @"""Unlicense"""),
             TestCase("v1.4",  @"""NotARealLicense"""),
+            TestCase("v1.4",  @"[ ""GPL-3.0"", ""MIT"" ]"),
             TestCase("v1.4",  @"[ ""GPL-3.0"", ""Unlicense"" ]"),
             TestCase("v1.4",  @"[ ""GPL-3.0"", ""NotARealLicense"" ]"),
         ]


### PR DESCRIPTION
#3494 and KSP-CKAN/NetKAN#8943 were fun, so I double checked the spec and found a few more requirements we aren't checking yet:

- Installing to Scenarios requires spec version v1.14
- Installing to Missions requires spec version v1.25
- `licenses` as an array requires spec version v1.8
- `supports` requires spec version v1.2
