### PR TITLE
Disable tx timeouts, add tx debug logging, static DLL pattern, fix docs

### DIFF
--- a/Core/CkanTransaction.cs
+++ b/Core/CkanTransaction.cs
@@ -1,23 +1,103 @@
+using System;
 using System.Transactions;
+using System.Reflection;
+using log4net;
 
 namespace CKAN
 {
 
     public static class CkanTransaction
     {
-
         // as per http://blogs.msdn.com/b/dbrowne/archive/2010/05/21/using-new-transactionscope-considered-harmful.aspx
+
+        static CkanTransaction()
+        {
+            // ChinhDo is incompatible with transaction timeouts on Windows; it can't
+            // be aborted by another thread while the main thread is still working.
+            // Disable transaction timeouts by maximizing the MaximumTimeout (49 days).
+            SetMaxTimeout(maxCoretimeout);
+        }
 
         public static TransactionScope CreateTransactionScope()
         {
+            log.DebugFormat("Starting transaction with timeout {0:g}", transOpts.Timeout);
             return new TransactionScope(TransactionScopeOption.Required, transOpts);
         }
+
+        // System.ArgumentOutOfRangeException : Time-out interval must be less than 2^32-2. (Parameter 'dueTime')
+        private const double timeoutMs = 4294967294d;
+        private static readonly TimeSpan maxCoretimeout = TimeSpan.FromMilliseconds(timeoutMs);
 
         private static TransactionOptions transOpts = new TransactionOptions()
         {
             IsolationLevel = IsolationLevel.ReadCommitted,
-            Timeout        = TransactionManager.MaximumTimeout
+            Timeout        = maxCoretimeout
         };
 
+        /// <summary>
+        /// Set TransactionManager.MaximumTimeout with reflection
+        /// </summary>
+        /// <param name="timeout">New maximum transaction timeout</param>
+        private static void SetMaxTimeout(TimeSpan timeout)
+        {
+            log.DebugFormat("Trying to set max timeout to {0:g}", timeout);
+            if (TransactionManager.MaximumTimeout < timeout)
+            {
+                // TransactionManager.MaximumTimeout should not exist; if
+                // app code tells TransactionScope's constructor that it needs
+                // 2 hours to run a transaction, it's probably not wrong, and
+                // the framework should listen and obey.  Instead,
+                // TransactionManager reduces the requested span to 10 minutes.
+                // But even worse, this limit can't be publicly changed!
+                // Someone at Microsoft has arbitrarily decided that 10 minutes
+                // is the maximum time for any transaction ever, without knowing
+                // what those transactions need to do, and app programmers who do
+                // know what they need to do can't override it no matter how dire
+                // the need.
+                // It can only be overridden by the end user, at the machine level,
+                // and we can't ask every CKAN user to add a bunch of XML to some
+                // random system file to ensure that core functionality works.
+                // TransactionManager is unsuitable for use as-is, since it has
+                // a built in time bomb ready to sabotage your application once you
+                // hit that arbitrary limit, and you can't do anything about it.
+
+                // To work around this design disaster, we commit our own
+                // cardinal sin by using reflection to set private properties.
+                // I wish TransactionManager did not force us to do this by
+                // imposing incorrect behavior with no escape hatch.
+
+                var t = typeof(TransactionManager);
+                if (Platform.IsMono)
+                {
+                    // Mono
+                    SetField(t, "machineSettings", null);
+                    SetField(t, "maxTimeout",      timeout);
+                }
+                else
+                {
+                    // Framework
+                    SetField(t, "_cachedMaxTimeout", true);
+                    SetField(t, "_maximumTimeout",   timeout);
+                    // Core
+                    SetField(t, "s_cachedMaxTimeout", true);
+                    SetField(t, "s_maximumTimeout",   timeout);
+                }
+            }            
+        }
+
+        private static void SetField(Type T, string fieldName, object value)
+        {
+            try
+            {
+                T.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)
+                    .SetValue(null, value);
+            }
+            catch
+            {
+                log.DebugFormat("Failed to set {0}", fieldName);
+            }
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(CkanTransaction));
     }
 }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -209,6 +209,7 @@ namespace CKAN
                 // leaves everything consistent, and this is just gravy. (And ScanGameData
                 // acts as a Tx, anyway, so we don't need to provide our own.)
                 User.RaiseProgress("Rescanning GameData", 90);
+                log.Debug("Scanning after install");
                 ksp.Scan();
             }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -239,6 +239,7 @@ namespace CKAN
         /// <param name="allowRepoUpdate">true if a repo update is allowed if needed (e.g. on initial load), false otherwise</param>
         private void CurrentInstanceUpdated(bool allowRepoUpdate)
         {
+            log.Debug("Current instance updated, scanning");
             CurrentInstance.Scan();
             Util.Invoke(this, () =>
             {

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -65,6 +65,7 @@ namespace CKAN
             try
             {
                 AddStatusMessage(Properties.Resources.MainRepoScanning);
+                log.Debug("Scanning before repo update");
                 bool scanChanged = CurrentInstance.Scan();
 
                 AddStatusMessage(Properties.Resources.MainRepoUpdating);

--- a/Netkan/Validators/PluginsValidator.cs
+++ b/Netkan/Validators/PluginsValidator.cs
@@ -41,12 +41,10 @@ namespace CKAN.NetKAN.Validators
                             .Select(f => inst.ToRelativeGameDir(f.destination))
                             .OrderBy(f => f)
                             .ToList();
-                        var pattern = Registry.DllPattern(inst.game);
                         var dllIdentifiers = dllPaths
-                            .Select(p => pattern.Match(p))
-                            .Where(m => m.Success)
-                            .Select(m => m.Groups["modname"].Value.Replace("_", "-"))
-                            .Where(ident => !identifiersToIgnore.Contains(ident))
+                            .Select(p => inst.DllPathToIdentifier(p))
+                            .Where(ident => !string.IsNullOrEmpty(ident)
+                                && !identifiersToIgnore.Contains(ident))
                             .ToHashSet();
                         if (dllIdentifiers.Any() && !dllIdentifiers.Contains(metadata.Identifier))
                         {


### PR DESCRIPTION
## Problems

I've been investigating several transaction-related issues lately.

- Something about trying to enlist in multiple transactions (see #3502)
- The manually installed DLL scan, which happens in a tx (see #3506)
  - `Registry.DllPattern` is compiled for every call to `RegisterDll`, which is not great because this regex will be evaluated on every DLL in GameData
  - A comment says the regex `works great for things like GameData/Foo/Foo-1.2.dll`, but that's wrong, it's for `GameData/Foo/Foo.1.2.dll`, the former would detect the identifier as `Foo-1`
  - `EnlistTransaction` is called in `RegisterDll` even if one of its validation checks decides we don't need to make any changes
- Cloning an instance can throw an exception if it takes more than 10 minutes
- Installing mods can throw the same exception if it takes more than 10 minutes

```
Unhandled exception:
System.Transactions.TransactionException: Failed to roll back. ---> System.IO.IOException: The directory is not empty.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at ChinhDo.Transactions.FileManager.Operations.CreateDirectory.Rollback()
   at ChinhDo.Transactions.FileManager.TxEnlistment.Rollback(Enlistment enlistment)
   --- End of inner exception stack trace ---
   at ChinhDo.Transactions.FileManager.TxEnlistment.Rollback(Enlistment enlistment)
   at System.Transactions.VolatileEnlistmentAborting.EnterState(InternalEnlistment enlistment)
   at System.Transactions.TransactionStateAborted.EnterState(InternalTransaction tx)
   at System.Transactions.EnlistableStates.Timeout(InternalTransaction tx)
   at System.Transactions.Bucket.TimeoutTransactions()
   at System.Transactions.BucketSet.TimeoutTransactions()
   at System.Transactions.TransactionTable.ThreadTimer(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.TimerQueueTimer.CallCallback()
   at System.Threading.TimerQueueTimer.Fire()
   at System.Threading.TimerQueue.FireNextTimers() 
```

## Causes

`TransactionManager` has a severe design flaw: Its `MaximumTimeout` property is 10 minutes, limits all transactions, and can't be changed by application code through normal means. When you start a transaction, a background thread is started that sleeps for 10 minutes and then tries to abort the transaction.

If you have a 1-hour operation that you want to have atomic rollback capabilities and you instantiate `TransactionScope` with a timeout of 1 hour plus padding, you're out of luck, all you get is 10 minutes. :facepalm:  And you won't find out about this until your code fails in production. :facepalm: :facepalm:  And you have no way to fix this problem once it's discovered :facepalm: :facepalm: :facepalm:, other than editing a `machine.config` XML file in your .NET Framework folder  :facepalm: :facepalm: :facepalm: :facepalm:, which would be completely unrealistic to attempt across CKAN's entire user base.

When the background thread tries to abort the transaction, the ChinhDo file manager tries to restore the disk to how it was before the transaction started, deleting new files and restoring deleted ones. However, this cannot succeed on Windows because the new files will still be locked by the foreground thread while the original transaction is in progress! So the (misguided, inappropriate) attempt to abort fails, and the whole application crashes. Needless to say this is not what we would ever want, especially when the original operation is actually working fine, chugging along towards its completion.

## Changes

- `log.Debug` calls are added so we can track how and when we enlist and de-enlist with transactions (this is what I added for the debug component uploaded in #3502)
- The manually installed DLL regex is now `static`, so it will not be compiled for every DLL in GameData
  - The comment now mentions the right file name format
  - The logic for translating a path to an identifier is refactored into `GameInstance.DllPathToIdentifier` and shared with Netkan's `PluginsValidator` to reduce code duplication
  - `Registry.RegisterDll` now only calls `EnlistTransaction` if all of its validation checks pass and it is going to make a change
- Since the transaction timeout can't be disabled directly, we set it to 49 days (the maximum allowed in .NET Core) by using reflection to set private properties of `TransactionManager`. This will ensure that cloning an instance and installing mods will not arbitrarily fail after 10 minutes.
  - "But what if we really do end up in a deadlock or an infinite loop and we _should_ abort?"
    Even if this happened, attempting to abort a ChinhDo-based tx from another thread **will always fail** on Windows. The transaction timeout simply can't solve such a problem. We would need to identify the deadlock or infinite loop and fix it through normal bug reporting means.

Fixes #3227.
Fixes #3294.
Fixes #3455.
Fixes #3483.
