### PR TITLE
Tab completion for `ckan prompt`

### DIFF
--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -6,79 +6,79 @@ using Autofac;
 
 namespace CKAN.CmdLine
 {
+    public class CacheSubOptions : VerbCommandOptions
+    {
+        [VerbOption("list", HelpText = "List the download cache path")]
+        public CommonOptions ListOptions { get; set; }
+
+        [VerbOption("set", HelpText = "Set the download cache path")]
+        public SetOptions SetOptions { get; set; }
+
+        [VerbOption("clear", HelpText = "Clear the download cache directory")]
+        public CommonOptions ClearOptions { get; set; }
+
+        [VerbOption("reset", HelpText = "Set the download cache path to the default")]
+        public CommonOptions ResetOptions { get; set; }
+
+        [VerbOption("showlimit", HelpText = "Show the cache size limit")]
+        public CommonOptions ShowLimitOptions { get; set; }
+
+        [VerbOption("setlimit", HelpText = "Set the cache size limit")]
+        public SetLimitOptions SetLimitOptions { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            HelpText ht = HelpText.AutoBuild(this, verb);
+            // Add a usage prefix line
+            ht.AddPreOptionsLine(" ");
+            if (string.IsNullOrEmpty(verb))
+            {
+                ht.AddPreOptionsLine("ckan cache - Manage the download cache path of CKAN");
+                ht.AddPreOptionsLine($"Usage: ckan cache <command> [options]");
+            }
+            else
+            {
+                ht.AddPreOptionsLine("cache " + verb + " - " + GetDescription(verb));
+                switch (verb)
+                {
+                    // First the commands with one string argument
+                    case "set":
+                        ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options] path");
+                        break;
+                    case "setlimit":
+                        ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options] megabytes");
+                        break;
+
+                    // Now the commands with only --flag type options
+                    case "list":
+                    case "clear":
+                    case "reset":
+                    case "showlimit":
+                    default:
+                        ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options]");
+                        break;
+                }
+            }
+            return ht;
+        }
+    }
+
+    public class SetOptions : CommonOptions
+    {
+        [ValueOption(0)]
+        public string Path { get; set; }
+    }
+
+    public class SetLimitOptions : CommonOptions
+    {
+        [ValueOption(0)]
+        public long Megabytes { get; set; } = -1;
+    }
+
     public class Cache : ISubCommand
     {
         public Cache() { }
-
-        private class CacheSubOptions : VerbCommandOptions
-        {
-            [VerbOption("list", HelpText = "List the download cache path")]
-            public CommonOptions ListOptions { get; set; }
-
-            [VerbOption("set", HelpText = "Set the download cache path")]
-            public SetOptions SetOptions { get; set; }
-
-            [VerbOption("clear", HelpText = "Clear the download cache directory")]
-            public CommonOptions ClearOptions { get; set; }
-
-            [VerbOption("reset", HelpText = "Set the download cache path to the default")]
-            public CommonOptions ResetOptions { get; set; }
-
-            [VerbOption("showlimit", HelpText = "Show the cache size limit")]
-            public CommonOptions ShowLimitOptions { get; set; }
-
-            [VerbOption("setlimit", HelpText = "Set the cache size limit")]
-            public SetLimitOptions SetLimitOptions { get; set; }
-
-            [HelpVerbOption]
-            public string GetUsage(string verb)
-            {
-                HelpText ht = HelpText.AutoBuild(this, verb);
-                // Add a usage prefix line
-                ht.AddPreOptionsLine(" ");
-                if (string.IsNullOrEmpty(verb))
-                {
-                    ht.AddPreOptionsLine("ckan cache - Manage the download cache path of CKAN");
-                    ht.AddPreOptionsLine($"Usage: ckan cache <command> [options]");
-                }
-                else
-                {
-                    ht.AddPreOptionsLine("cache " + verb + " - " + GetDescription(verb));
-                    switch (verb)
-                    {
-                        // First the commands with one string argument
-                        case "set":
-                            ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options] path");
-                            break;
-                        case "setlimit":
-                            ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options] megabytes");
-                            break;
-
-                        // Now the commands with only --flag type options
-                        case "list":
-                        case "clear":
-                        case "reset":
-                        case "showlimit":
-                        default:
-                            ht.AddPreOptionsLine($"Usage: ckan cache {verb} [options]");
-                            break;
-                    }
-                }
-                return ht;
-            }
-        }
-
-        private class SetOptions : CommonOptions
-        {
-            [ValueOption(0)]
-            public string Path { get; set; }
-        }
-
-        private class SetLimitOptions : CommonOptions
-        {
-            [ValueOption(0)]
-            public long Megabytes { get; set; } = -1;
-        }
 
         /// <summary>
         /// Execute a cache subcommand

--- a/Cmdline/Action/Compat.cs
+++ b/Cmdline/Action/Compat.cs
@@ -3,67 +3,67 @@ using CKAN.Versioning;
 using CommandLine;
 using CommandLine.Text;
 
-namespace CKAN.CmdLine.Action
+namespace CKAN.CmdLine
 {
+    public class CompatOptions : VerbCommandOptions
+    {
+        [VerbOption("list", HelpText = "List compatible KSP versions")]
+        public CompatListOptions List { get; set; }
+
+        [VerbOption("add", HelpText = "Add version to KSP compatibility list")]
+        public CompatAddOptions Add { get; set; }
+
+        [VerbOption("forget", HelpText = "Forget version on KSP compatibility list")]
+        public CompatForgetOptions Forget { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            HelpText ht = HelpText.AutoBuild(this, verb);
+            // Add a usage prefix line
+            ht.AddPreOptionsLine(" ");
+            if (string.IsNullOrEmpty(verb))
+            {
+                ht.AddPreOptionsLine("ckan compat - Manage KSP version compatibility");
+                ht.AddPreOptionsLine($"Usage: ckan compat <command> [options]");
+            }
+            else
+            {
+                ht.AddPreOptionsLine("compat " + verb + " - " + GetDescription(verb));
+                switch (verb)
+                {
+                    // First the commands with one string argument
+                    case "add":
+                    case "forget":
+                        ht.AddPreOptionsLine($"Usage: ckan compat {verb} [options] version");
+                        break;
+
+                    // Now the commands with only --flag type options
+                    case "list":
+                    default:
+                        ht.AddPreOptionsLine($"Usage: ckan compat {verb} [options]");
+                        break;
+                }
+            }
+            return ht;
+        }
+    }
+
+    public class CompatListOptions : InstanceSpecificOptions { }
+
+    public class CompatAddOptions : InstanceSpecificOptions
+    {
+        [ValueOption(0)] public string Version { get; set; }
+    }
+
+    public class CompatForgetOptions : InstanceSpecificOptions
+    {
+        [ValueOption(0)] public string Version { get; set; }
+    }
+
     public class Compat : ISubCommand
     {
         public Compat() { }
-
-        public class CompatOptions : VerbCommandOptions
-        {
-            [VerbOption("list", HelpText = "List compatible KSP versions")]
-            public CompatListOptions List { get; set; }
-
-            [VerbOption("add", HelpText = "Add version to KSP compatibility list")]
-            public CompatAddOptions Add { get; set; }
-
-            [VerbOption("forget", HelpText = "Forget version on KSP compatibility list")]
-            public CompatForgetOptions Forget { get; set; }
-
-            [HelpVerbOption]
-            public string GetUsage(string verb)
-            {
-                HelpText ht = HelpText.AutoBuild(this, verb);
-                // Add a usage prefix line
-                ht.AddPreOptionsLine(" ");
-                if (string.IsNullOrEmpty(verb))
-                {
-                    ht.AddPreOptionsLine("ckan compat - Manage KSP version compatibility");
-                    ht.AddPreOptionsLine($"Usage: ckan compat <command> [options]");
-                }
-                else
-                {
-                    ht.AddPreOptionsLine("compat " + verb + " - " + GetDescription(verb));
-                    switch (verb)
-                    {
-                        // First the commands with one string argument
-                        case "add":
-                        case "forget":
-                            ht.AddPreOptionsLine($"Usage: ckan compat {verb} [options] version");
-                            break;
-
-                        // Now the commands with only --flag type options
-                        case "list":
-                        default:
-                            ht.AddPreOptionsLine($"Usage: ckan compat {verb} [options]");
-                            break;
-                    }
-                }
-                return ht;
-            }
-        }
-
-        public class CompatListOptions : InstanceSpecificOptions { }
-
-        public class CompatAddOptions : InstanceSpecificOptions
-        {
-            [ValueOption(0)] public string Version { get; set; }
-        }
-
-        public class CompatForgetOptions : InstanceSpecificOptions
-        {
-            [ValueOption(0)] public string Version { get; set; }
-        }
 
         public int RunSubCommand(GameInstanceManager manager, CommonOptions opts, SubCommandOptions options)
         {

--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -10,130 +10,133 @@ using CKAN.Games;
 
 namespace CKAN.CmdLine
 {
+    internal class InstanceSubOptions : VerbCommandOptions
+    {
+        [VerbOption("list",    HelpText = "List game instances")]
+        public CommonOptions  ListOptions    { get; set; }
+
+        [VerbOption("add",     HelpText = "Add a game instance")]
+        public AddOptions     AddOptions     { get; set; }
+
+        [VerbOption("clone",   HelpText = "Clone an existing game instance")]
+        public CloneOptions   CloneOptions   { get; set; }
+
+        [VerbOption("rename",  HelpText = "Rename a game instance")]
+        public RenameOptions  RenameOptions  { get; set; }
+
+        [VerbOption("forget",  HelpText = "Forget a game instance")]
+        public ForgetOptions  ForgetOptions  { get; set; }
+
+        [VerbOption("default", HelpText = "Set the default game instance")]
+        public DefaultOptions DefaultOptions { get; set; }
+
+        [VerbOption("fake",    HelpText = "Fake a game instance")]
+        public FakeOptions    FakeOptions    { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            HelpText ht = HelpText.AutoBuild(this, verb);
+            // Add a usage prefix line
+            ht.AddPreOptionsLine(" ");
+            if (string.IsNullOrEmpty(verb))
+            {
+                ht.AddPreOptionsLine("ckan instance - Manage game instances");
+                ht.AddPreOptionsLine($"Usage: ckan instance <command> [options]");
+            }
+            else
+            {
+                ht.AddPreOptionsLine("instance " + verb + " - " + GetDescription(verb));
+                switch (verb)
+                {
+                    // First the commands with three string arguments
+                    case "fake":
+                        ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] name path version [--MakingHistory <version>] [--BreakingGround <version>]");
+                        break;
+
+                    case "clone":
+                        ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] instanceNameOrPath newname newpath");
+                        break;
+
+                    // Second the commands with two string arguments
+                    case "add":
+                        ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] name url");
+                        break;
+                    case "rename":
+                        ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] oldname newname");
+                        break;
+
+                    // Now the commands with one string argument
+                    case "remove":
+                    case "forget":
+                    case "use":
+                    case "default":
+                        ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] name");
+                        break;
+
+                    // Now the commands with only --flag type options
+                    case "list":
+                    default:
+                        ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options]");
+                        break;
+
+                }
+            }
+            return ht;
+        }
+    }
+
+    internal class AddOptions : CommonOptions
+    {
+        [ValueOption(0)] public string name { get; set; }
+        [ValueOption(1)] public string path { get; set; }
+    }
+
+    internal class CloneOptions : CommonOptions
+    {
+        [ValueOption(0)] public string nameOrPath { get; set; }
+        [ValueOption(1)] public string new_name { get; set; }
+        [ValueOption(2)] public string new_path { get; set; }
+    }
+
+    internal class RenameOptions : CommonOptions
+    {
+        [GameInstancesAttribute]
+        [ValueOption(0)] public string old_name { get; set; }
+        [ValueOption(1)] public string new_name { get; set; }
+    }
+
+    internal class ForgetOptions : CommonOptions
+    {
+        [GameInstancesAttribute]
+        [ValueOption(0)] public string name { get; set; }
+    }
+
+    internal class DefaultOptions : CommonOptions
+    {
+        [GameInstancesAttribute]
+        [ValueOption(0)] public string name { get; set; }
+    }
+
+    internal class FakeOptions : CommonOptions
+    {
+        [ValueOption(0)] public string name { get; set; }
+        [ValueOption(1)] public string path { get; set; }
+        [ValueOption(2)] public string version { get; set; }
+
+        [Option("MakingHistory", DefaultValue = "none", HelpText = "The version of the Making History DLC to be faked.")]
+        public string makingHistoryVersion { get; set; }
+        [Option("BreakingGround", DefaultValue = "none", HelpText = "The version of the Breaking Ground DLC to be faked.")]
+        public string breakingGroundVersion { get; set; }
+
+        [Option("set-default", DefaultValue = false, HelpText = "Set the new instance as the default one.")]
+        public bool setDefault { get; set; }
+    }
+
     public class GameInstance : ISubCommand
     {
         public GameInstance() { }
         protected static readonly ILog log = LogManager.GetLogger(typeof(GameInstance));
-
-        internal class InstanceSubOptions : VerbCommandOptions
-        {
-            [VerbOption("list",    HelpText = "List game instances")]
-            public CommonOptions  ListOptions    { get; set; }
-
-            [VerbOption("add",     HelpText = "Add a game instance")]
-            public AddOptions     AddOptions     { get; set; }
-
-            [VerbOption("clone",   HelpText = "Clone an existing game instance")]
-            public CloneOptions   CloneOptions   { get; set; }
-
-            [VerbOption("rename",  HelpText = "Rename a game instance")]
-            public RenameOptions  RenameOptions  { get; set; }
-
-            [VerbOption("forget",  HelpText = "Forget a game instance")]
-            public ForgetOptions  ForgetOptions  { get; set; }
-
-            [VerbOption("default", HelpText = "Set the default game instance")]
-            public DefaultOptions DefaultOptions { get; set; }
-
-            [VerbOption("fake",    HelpText = "Fake a game instance")]
-            public FakeOptions    FakeOptions    { get; set; }
-
-            [HelpVerbOption]
-            public string GetUsage(string verb)
-            {
-                HelpText ht = HelpText.AutoBuild(this, verb);
-                // Add a usage prefix line
-                ht.AddPreOptionsLine(" ");
-                if (string.IsNullOrEmpty(verb))
-                {
-                    ht.AddPreOptionsLine("ckan instance - Manage game instances");
-                    ht.AddPreOptionsLine($"Usage: ckan instance <command> [options]");
-                }
-                else
-                {
-                    ht.AddPreOptionsLine("instance " + verb + " - " + GetDescription(verb));
-                    switch (verb)
-                    {
-                        // First the commands with three string arguments
-                        case "fake":
-                            ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] name path version [--MakingHistory <version>] [--BreakingGround <version>]");
-                            break;
-
-                        case "clone":
-                            ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] instanceNameOrPath newname newpath");
-                            break;
-
-                        // Second the commands with two string arguments
-                        case "add":
-                            ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] name url");
-                            break;
-                        case "rename":
-                            ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] oldname newname");
-                            break;
-
-                        // Now the commands with one string argument
-                        case "remove":
-                        case "forget":
-                        case "use":
-                        case "default":
-                            ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options] name");
-                            break;
-
-                        // Now the commands with only --flag type options
-                        case "list":
-                        default:
-                            ht.AddPreOptionsLine($"Usage: ckan instance {verb} [options]");
-                            break;
-
-                    }
-                }
-                return ht;
-            }
-        }
-
-        internal class AddOptions : CommonOptions
-        {
-            [ValueOption(0)] public string name { get; set; }
-            [ValueOption(1)] public string path { get; set; }
-        }
-
-        internal class CloneOptions : CommonOptions
-        {
-            [ValueOption(0)] public string nameOrPath { get; set; }
-            [ValueOption(1)] public string new_name { get; set; }
-            [ValueOption(2)] public string new_path { get; set; }
-        }
-
-        internal class RenameOptions : CommonOptions
-        {
-            [ValueOption(0)] public string old_name { get; set; }
-            [ValueOption(1)] public string new_name { get; set; }
-        }
-
-        internal class ForgetOptions : CommonOptions
-        {
-            [ValueOption(0)] public string name { get; set; }
-        }
-
-        internal class DefaultOptions : CommonOptions
-        {
-            [ValueOption(0)] public string name { get; set; }
-        }
-
-        internal class FakeOptions : CommonOptions
-        {
-            [ValueOption(0)] public string name { get; set; }
-            [ValueOption(1)] public string path { get; set; }
-            [ValueOption(2)] public string version { get; set; }
-
-            [Option("MakingHistory", DefaultValue = "none", HelpText = "The version of the Making History DLC to be faked.")]
-            public string makingHistoryVersion { get; set; }
-            [Option("BreakingGround", DefaultValue = "none", HelpText = "The version of the Breaking Ground DLC to be faked.")]
-            public string breakingGroundVersion { get; set; }
-
-            [Option("set-default", DefaultValue = false, HelpText = "Set the new instance as the default one.")]
-            public bool setDefault { get; set; }
-        }
 
         // This is required by ISubCommand
         public int RunSubCommand(GameInstanceManager manager, CommonOptions opts, SubCommandOptions unparsed)

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -161,6 +161,7 @@ namespace CKAN.CmdLine
     internal class MarkAutoOptions : InstanceSpecificOptions
     {
         [ValueList(typeof(List<string>))]
+        [InstalledIdentifiers]
         public List<string> modules { get; set; }
     }
 }

--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Reflection;
+using System.Linq;
+using System.Collections.Generic;
+
 using CommandLine;
 using CommandLine.Text;
 using log4net;
@@ -8,9 +12,12 @@ namespace CKAN.CmdLine
 
     public class Prompt
     {
-        public Prompt() { }
+        public Prompt(GameInstanceManager mgr)
+        {
+            manager = mgr;
+        }
 
-        public int RunCommand(GameInstanceManager manager, object raw_options)
+        public int RunCommand(object raw_options)
         {
             CommonOptions opts = raw_options as CommonOptions;
             // Print an intro if not in headless mode
@@ -21,6 +28,7 @@ namespace CKAN.CmdLine
                 Console.WriteLine("To get help, type help and press enter.");
                 Console.WriteLine("");
             }
+            ReadLine.AutoCompletionHandler = GetSuggestions;
             bool done = false;
             while (!done)
             {
@@ -33,28 +41,153 @@ namespace CKAN.CmdLine
                             : $"CKAN {Meta.GetVersion()}> "
                     );
                 }
-                // Get input
-                string command = Console.ReadLine();
-                if (command == null || command == exitCommand)
+                try
                 {
-                    done = true;
-                }
-                else if (command != "")
-                {
-                    // Parse input as if it was a normal command line,
-                    // but with a persistent GameInstanceManager object.
-                    int cmdExitCode = MainClass.Execute(manager, opts, command.Split(' '));
-                    if ((opts?.Headless ?? false) && cmdExitCode != Exit.OK)
+                    // Get input
+                    string command = ReadLineWithCompletion();
+                    if (command == null || command == exitCommand)
                     {
-                        // Pass failure codes to calling process in headless mode
-                        // (in interactive mode the user can see the error and try again)
-                        return cmdExitCode;
+                        done = true;
                     }
+                    else if (command != "")
+                    {
+                        // Parse input as if it was a normal command line,
+                        // but with a persistent GameInstanceManager object.
+                        int cmdExitCode = MainClass.Execute(manager, opts, command.Split(' '));
+                        // Clear the command if no exception was thrown
+                        if ((opts?.Headless ?? false) && cmdExitCode != Exit.OK)
+                        {
+                            // Pass failure codes to calling process in headless mode
+                            // (in interactive mode the user can see the error and try again)
+                            return cmdExitCode;
+                        }
+                    }
+                }
+                catch (NoGameInstanceKraken)
+                {
+                    Console.WriteLine("");
+                    Console.WriteLine("No game instance selected, identifier completion not available.");
+                    Console.WriteLine("Use the `instance default` command to choose an instance.");
                 }
             }
             return Exit.OK;
         }
 
+        private string ReadLineWithCompletion()
+        {
+            try
+            {
+                return ReadLine.Read("");
+            }
+            catch (InvalidOperationException)
+            {
+                // InvalidOperationException is thrown in a mintty on Windows
+                return Console.ReadLine();
+            }
+        }
+
+        private string[] GetSuggestions(string text, int index)
+        {
+            string[]     pieces = text.Split(new char[] { ' ' });
+            TypeInfo     ti     = typeof(Actions).GetTypeInfo();
+            List<string> extras = new List<string> { exitCommand, "help" };
+            foreach (string piece in pieces.Take(pieces.Length - 1))
+            {
+                PropertyInfo pi = ti.DeclaredProperties
+                    .FirstOrDefault(p => p?.GetCustomAttribute<VerbOptionAttribute>()?.LongName == piece);
+                if (pi == null)
+                {
+                    // Couldn't find it, no suggestions
+                    return null;
+                }
+                ti = pi.PropertyType.GetTypeInfo();
+                extras.Clear();
+            }
+            var lastPiece = pieces.LastOrDefault() ?? "";
+            return lastPiece.StartsWith("--") ? GetOptions(ti, lastPiece.Substring(2))
+                : HasVerbs(ti)                ? GetVerbs(ti, lastPiece, extras)
+                : WantsAvailIdentifiers(ti)   ? GetAvailIdentifiers(lastPiece)
+                : WantsInstIdentifiers(ti)    ? GetInstIdentifiers(lastPiece)
+                : WantsGameInstances(ti)      ? GetGameInstances(lastPiece)
+                :                               null;
+        }
+
+        private string[] GetOptions(TypeInfo ti, string prefix)
+        {
+            return ti.DeclaredProperties
+                .Select(p => p.GetCustomAttribute<OptionAttribute>()?.LongName)
+                .Where(o => o != null && o.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
+                .OrderBy(o => o)
+                .Select(o => $"--{o}")
+                .ToArray();
+        }
+
+        private bool HasVerbs(TypeInfo ti)
+        {
+            return ti.DeclaredProperties
+                .Any(p => p.GetCustomAttribute<VerbOptionAttribute>() != null);
+        }
+
+        private string[] GetVerbs(TypeInfo ti, string prefix, IEnumerable<string> extras)
+        {
+            return ti.DeclaredProperties
+                .Select(p => p.GetCustomAttribute<VerbOptionAttribute>()?.LongName)
+                .Where(v => v != null)
+                .Concat(extras)
+                .Where(v => v.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
+                .OrderBy(v => v)
+                .ToArray();
+        }
+
+        private bool WantsAvailIdentifiers(TypeInfo ti)
+        {
+            return ti.DeclaredProperties
+                .Any(p => p.GetCustomAttribute<AvailableIdentifiersAttribute>() != null);
+        }
+
+        private string[] GetAvailIdentifiers(string prefix)
+        {
+            CKAN.GameInstance inst = MainClass.GetGameInstance(manager);
+            return RegistryManager.Instance(inst).registry
+                .CompatibleModules(inst.VersionCriteria())
+                .Where(m => !m.IsDLC)
+                .Select(m => m.identifier)
+                .Where(ident => ident.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
+                .ToArray();
+        }
+
+        private bool WantsInstIdentifiers(TypeInfo ti)
+        {
+            return ti.DeclaredProperties
+                .Any(p => p.GetCustomAttribute<InstalledIdentifiersAttribute>() != null);
+        }
+
+        private string[] GetInstIdentifiers(string prefix)
+        {
+            CKAN.GameInstance inst = MainClass.GetGameInstance(manager);
+            var registry = RegistryManager.Instance(inst).registry;
+            return registry.Installed(false, false)
+                .Select(kvp => kvp.Key)
+                .Where(ident => ident.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
+                    && !registry.GetInstalledVersion(ident).IsDLC)
+                .ToArray();
+        }
+
+        private bool WantsGameInstances(TypeInfo ti)
+        {
+            return ti.DeclaredProperties
+                .Any(p => p.GetCustomAttribute<GameInstancesAttribute>() != null);
+        }
+
+        private string[] GetGameInstances(string prefix)
+        {
+            return manager.Instances
+                .Select(kvp => kvp.Key)
+                .Where(ident => ident.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
+                .ToArray();
+        }
+
+        private readonly GameInstanceManager manager;
         private const string exitCommand = "exit";
     }
 

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -3,41 +3,41 @@ using CommandLine.Text;
 
 namespace CKAN.CmdLine
 {
+    internal class RepairSubOptions : VerbCommandOptions
+    {
+        [VerbOption("registry", HelpText = "Try to repair the CKAN registry")]
+        public InstanceSpecificOptions Registry { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            HelpText ht = HelpText.AutoBuild(this, verb);
+            // Add a usage prefix line
+            ht.AddPreOptionsLine(" ");
+            if (string.IsNullOrEmpty(verb))
+            {
+                ht.AddPreOptionsLine("ckan repair - Attempt various automatic repairs");
+                ht.AddPreOptionsLine($"Usage: ckan repair <command> [options]");
+            }
+            else
+            {
+                ht.AddPreOptionsLine("repair " + verb + " - " + GetDescription(verb));
+                switch (verb)
+                {
+                    // Commands with only --flag type options
+                    case "registry":
+                    default:
+                        ht.AddPreOptionsLine($"Usage: ckan repair {verb} [options]");
+                        break;
+                }
+            }
+            return ht;
+        }
+    }
+
     public class Repair : ISubCommand
     {
         public Repair() { }
-
-        internal class RepairSubOptions : VerbCommandOptions
-        {
-            [VerbOption("registry", HelpText = "Try to repair the CKAN registry")]
-            public InstanceSpecificOptions Registry { get; set; }
-
-            [HelpVerbOption]
-            public string GetUsage(string verb)
-            {
-                HelpText ht = HelpText.AutoBuild(this, verb);
-                // Add a usage prefix line
-                ht.AddPreOptionsLine(" ");
-                if (string.IsNullOrEmpty(verb))
-                {
-                    ht.AddPreOptionsLine("ckan repair - Attempt various automatic repairs");
-                    ht.AddPreOptionsLine($"Usage: ckan repair <command> [options]");
-                }
-                else
-                {
-                    ht.AddPreOptionsLine("repair " + verb + " - " + GetDescription(verb));
-                    switch (verb)
-                    {
-                        // Commands with only --flag type options
-                        case "registry":
-                        default:
-                            ht.AddPreOptionsLine($"Usage: ckan repair {verb} [options]");
-                            break;
-                    }
-                }
-                return ht;
-            }
-        }
 
         public int RunSubCommand(GameInstanceManager manager, CommonOptions opts, SubCommandOptions unparsed)
         {

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="ReadLine" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using CKAN.CmdLine.Action;
+
 using log4net;
 using log4net.Core;
 
@@ -184,7 +184,7 @@ namespace CKAN.CmdLine
                         return ConsoleUi(manager, (ConsoleUIOptions)options, args);
 
                     case "prompt":
-                        return new Prompt().RunCommand(manager, cmdline.options);
+                        return new Prompt(manager).RunCommand(cmdline.options);
 
                     case "version":
                         return Version(user);

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -86,28 +86,28 @@ namespace CKAN.CmdLine
         public CleanOptions Clean { get; set; }
 
         [VerbOption("repair", HelpText = "Attempt various automatic repairs")]
-        public SubCommandOptions Repair { get; set; }
+        public RepairSubOptions Repair { get; set; }
 
         [VerbOption("replace", HelpText = "Replace list of replaceable mods")]
         public ReplaceOptions Replace { get; set; }
 
         [VerbOption("repo", HelpText = "Manage CKAN repositories")]
-        public SubCommandOptions Repo { get; set; }
+        public RepoSubOptions Repo { get; set; }
 
         [VerbOption("mark", HelpText = "Edit flags on modules")]
-        public SubCommandOptions Mark { get; set; }
+        public MarkSubOptions Mark { get; set; }
 
         [VerbOption("instance", HelpText = "Manage game instances")]
-        public SubCommandOptions Instance { get; set; }
+        public InstanceSubOptions Instance { get; set; }
 
         [VerbOption("authtoken", HelpText = "Manage authentication tokens")]
         public AuthTokenSubOptions AuthToken { get; set; }
 
         [VerbOption("cache", HelpText = "Manage download cache path")]
-        public SubCommandOptions Cache { get; set; }
+        public CacheSubOptions Cache { get; set; }
 
         [VerbOption("compat", HelpText = "Manage game version compatibility")]
-        public SubCommandOptions Compat { get; set; }
+        public CompatOptions Compat { get; set; }
 
         [VerbOption("compare", HelpText = "Compare version strings")]
         public CompareOptions Compare { get; set; }
@@ -116,7 +116,7 @@ namespace CKAN.CmdLine
         public VersionOptions Version { get; set; }
 
         [VerbOption("filter", HelpText = "View or edit installation filters")]
-        public SubCommandOptions Filter { get; set; }
+        public FilterSubOptions Filter { get; set; }
 
         [HelpVerbOption]
         public string GetUsage(string verb)
@@ -403,6 +403,7 @@ namespace CKAN.CmdLine
         public bool allow_incompatible { get; set; }
 
         [ValueList(typeof(List<string>))]
+        [AvailableIdentifiers]
         public List<string> modules { get; set; }
     }
 
@@ -424,6 +425,7 @@ namespace CKAN.CmdLine
         public bool upgrade_all { get; set; }
 
         [ValueList(typeof (List<string>))]
+        [InstalledIdentifiers]
         public List<string> modules { get; set; }
     }
 
@@ -449,6 +451,7 @@ namespace CKAN.CmdLine
 
         // TODO: How do we provide helptext on this?
         [ValueList(typeof (List<string>))]
+        [InstalledIdentifiers]
         public List<string> modules { get; set; }
     }
 
@@ -505,6 +508,7 @@ namespace CKAN.CmdLine
         public bool regex { get; set; }
 
         [ValueList(typeof(List<string>))]
+        [InstalledIdentifiers]
         public List<string> modules { get; set; }
 
         [Option("all", DefaultValue = false, HelpText = "Remove all installed mods.")]
@@ -538,6 +542,7 @@ namespace CKAN.CmdLine
         public bool with_versions { get; set; }
 
         [ValueList(typeof(List<string>))]
+        [AvailableIdentifiers]
         public List<string> modules { get; set; }
     }
 
@@ -564,4 +569,13 @@ namespace CKAN.CmdLine
         [ValueOption(0)] public string Left  { get; set; }
         [ValueOption(1)] public string Right { get; set; }
     }
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public class AvailableIdentifiersAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public class InstalledIdentifiersAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public class GameInstancesAttribute : Attribute { }
 }


### PR DESCRIPTION
## Motivation

Currently with CmdLine you have to type everything, including all the commands and subcommands and the full identifier of every mod. This is inconvenient.

## Changes

Now if you run `ckan prompt`, you can use tab completion for commands/subcommands, `--` options, module identifiers, instance names:

![image](https://user-images.githubusercontent.com/1559108/149648054-d45967fd-a4f9-489b-a0db-372cad0e2573.png)

Press tab:

![image](https://user-images.githubusercontent.com/1559108/149647731-11284c9e-3b4d-4c91-8896-7f2aeb902e02.png)

Type part of an identifier, case insensitive:

![image](https://user-images.githubusercontent.com/1559108/149647741-be6e02d8-6eb2-412e-937a-a55fbc8aa1cd.png)

Press tab:

![image](https://user-images.githubusercontent.com/1559108/149647752-650408a2-2b70-4fd4-8497-f0e329e5ae53.png)

To make this work:

- A project reference for `ReadLine` 1.2.0 is added to CmdLine (more recent versions require .NET Core)
- All of the subcommands' option classes are now publicly available and used in `Options.cs` to describe the options of the corresponding subcommands
- New attributes `[AvailableIdentifiers]`, `[InstalledIdentifiers]`, and `[GameInstances]` are defined and used to tag options that use each kind of input
- `Prompt` uses `ReadLine.Read` instead of `Console.ReadLine`, and we set `ReadLine.AutoCompletionHandler` to a function that inspects the command line option classes with reflection to determine what strings are available

As a side effect, `ckan prompt` has also gained many standard terminal editing hotkeys like ctrl-W to delete a word, ctrl-U to delete to start of the line, ctrl-E to move cursor to end of line, etc.

Fixes #888.