### PR TITLE
Get licenses from embedded schema, skip bad modules in deserialize

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -477,6 +477,41 @@
                 "open-source", "restricted", "unrestricted", "unknown"
             ]
         },
+        "redistributable_license": {
+            "description" : "A license that grants us the right to redistribute.",
+            "enum" : [
+                "public-domain",
+                "Apache", "Apache-1.0", "Apache-2.0",
+                "Artistic", "Artistic-1.0", "Artistic-2.0",
+                "BSD-2-clause", "BSD-3-clause", "BSD-4-clause",
+                "ISC",
+                "CC-BY", "CC-BY-1.0", "CC-BY-2.0", "CC-BY-2.5", "CC-BY-3.0", "CC-BY-4.0",
+                "CC-BY-SA", "CC-BY-SA-1.0", "CC-BY-SA-2.0", "CC-BY-SA-2.5", "CC-BY-SA-3.0", "CC-BY-SA-4.0",
+                "CC-BY-NC", "CC-BY-NC-1.0", "CC-BY-NC-2.0", "CC-BY-NC-2.5", "CC-BY-NC-3.0", "CC-BY-NC-4.0",
+                "CC-BY-NC-SA", "CC-BY-NC-SA-1.0", "CC-BY-NC-SA-2.0", "CC-BY-NC-SA-2.5", "CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0",
+                "CC-BY-NC-ND", "CC-BY-NC-ND-1.0", "CC-BY-NC-ND-2.0", "CC-BY-NC-ND-2.5", "CC-BY-NC-ND-3.0", "CC-BY-NC-ND-4.0",
+                "CC-BY-ND", "CC-BY-ND-1.0", "CC-BY-ND-2.0", "CC-BY-ND-2.5", "CC-BY-ND-3.0", "CC-BY-ND-4.0",
+                "CC0",
+                "CDDL", "CPL",
+                "EFL-1.0", "EFL-2.0",
+                "Expat", "MIT",
+                "GPL-1.0", "GPL-2.0", "GPL-3.0",
+                "LGPL-2.0", "LGPL-2.1", "LGPL-3.0",
+                "GFDL-1.0", "GFDL-1.1", "GFDL-1.2", "GFDL-1.3",
+                "GFDL-NIV-1.0", "GFDL-NIV-1.1", "GFDL-NIV-1.2", "GFDL-NIV-1.3",
+                "LPPL-1.0", "LPPL-1.1", "LPPL-1.2", "LPPL-1.3c",
+                "MPL-1.1", "MPL-2.0",
+                "Perl",
+                "Python-2.0",
+                "QPL-1.0",
+                "W3C",
+                "Zlib",
+                "Zope",
+                "WTFPL",
+                "Unlicense",
+                "open-source", "unrestricted"
+            ]
+        },
         "licenses" : {
             "description" : "A license, or array of licenses",
             "anyOf" : [

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NJsonSchema" Version="10.0.27" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="ChinhDo.Transactions.FileManager" Version="1.2.0" />
@@ -64,6 +65,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="builds.json" />
+    <EmbeddedResource Include="..\CKAN.schema">
+      <LogicalName>CKAN.Core.CKAN.schema</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Content Include="log4net.xml">

--- a/Core/Converters/JsonLeakySortedDictionaryConverter.cs
+++ b/Core/Converters/JsonLeakySortedDictionaryConverter.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+using log4net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CKAN
+{
+    /// <summary>
+    /// [De]serializes a dictionary that might have some questionably
+    /// valid data in it.
+    /// If exceptions are thrown for any key/value pair, leave it out.
+    /// Removes CkanModule objects from AvailableModule.module_version
+    /// if License throws BadMetadataKraken.
+    /// </summary>
+    public class JsonLeakySortedDictionaryConverter<K, V> : JsonConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var dict = new SortedDictionary<K, V>();
+            foreach (var kvp in JObject.Load(reader))
+            {
+                try
+                {
+                    dict.Add(
+                        (K)Activator.CreateInstance(typeof(K), kvp.Key),
+                        kvp.Value.ToObject<V>());
+                }
+                catch (Exception exc)
+                {
+                    log.Warn($"Failed to deserialize {kvp.Key}: {kvp.Value}", exc);
+                }
+            }
+            return dict;
+        }
+
+        /// <summary>
+        /// Use default serializer for writing
+        /// </summary>
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// We *only* want to be triggered for types that have explicitly
+        /// set an attribute in their class saying they can be converted.
+        /// By returning false here, we declare we're not interested in participating
+        /// in any other conversions.
+        /// </summary>
+        /// <returns>
+        /// false
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return false;
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(JsonLeakySortedDictionaryConverter<K, V>));
+    }
+}

--- a/Core/Converters/JsonSimpleStringConverter.cs
+++ b/Core/Converters/JsonSimpleStringConverter.cs
@@ -1,32 +1,38 @@
 using System;
+
 using Newtonsoft.Json;
 
-namespace CKAN {
-    // A lovely class for serialising things that can be converted
-    // to simple strings and back.
-
-    public class JsonSimpleStringConverter : JsonConverter {
-
+namespace CKAN
+{
+    /// <summary>
+    /// Serialises things that can be converted
+    /// to simple strings and back.
+    /// </summary>
+    public class JsonSimpleStringConverter : JsonConverter
+    {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteValue (value.ToString ());
+            writer.WriteValue(value.ToString());
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-
             // If we find a null, then that might be okay, so we pass it down to our
             // activator. Otherwise we convert to string, since that's our job.
-            string value = reader.Value == null ? null : reader.Value.ToString();
-            return Activator.CreateInstance (objectType, value);
+            return Activator.CreateInstance(objectType, reader.Value?.ToString());
         }
 
+        /// <summary>
+        /// We *only* want to be triggered for types that have explicitly
+        /// set an attribute in their class saying they can be converted.
+        /// By returning false here, we declare we're not interested in participating
+        /// in any other conversions.
+        /// </summary>
+        /// <returns>
+        /// false
+        /// </returns>
         public override bool CanConvert(Type objectType)
         {
-            // We *only* want to be triggered for types that have explicitly
-            // set an attribute in their class saying they can be converted.
-            // By returning false here, we declare we're not interested in participating
-            // in any other conversions.
             return false;
         }
     }

--- a/Core/Converters/JsonSingleOrArrayConverter.cs
+++ b/Core/Converters/JsonSingleOrArrayConverter.cs
@@ -1,25 +1,17 @@
 using System;
 using System.Collections.Generic;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace CKAN
 {
-
-    // With thanks to 
-    // https://stackoverflow.com/questions/18994685/how-to-handle-both-a-single-item-and-an-array-for-the-same-property-using-json-n
-
+    /// <summary>
+    /// With thanks to 
+    /// https://stackoverflow.com/questions/18994685/how-to-handle-both-a-single-item-and-an-array-for-the-same-property-using-json-n
+    /// </summary>
     public class JsonSingleOrArrayConverter<T> : JsonConverter
     {
-        public override bool CanConvert(Type object_type)
-        {
-            // We *only* want to be triggered for types that have explicitly
-            // set an attribute in their class saying they can be converted.
-            // By returning false here, we declare we're not interested in participating
-            // in any other conversions.
-            return false;
-        }
-
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             JToken token = JToken.Load(reader);
@@ -32,15 +24,25 @@ namespace CKAN
             return token.ToObject<T>() == null ? null : new List<T> { token.ToObject<T>() };
         }
 
-        public override bool CanWrite
-        {
-            get { return false; }
-        }
+        public override bool CanWrite => false;
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// We *only* want to be triggered for types that have explicitly
+        /// set an attribute in their class saying they can be converted.
+        /// By returning false here, we declare we're not interested in participating
+        /// in any other conversions.
+        /// </summary>
+        /// <returns>
+        /// false
+        /// </returns>
+        public override bool CanConvert(Type object_type)
+        {
+            return false;
+        }
     }
 }
-

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -5,11 +5,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
-using CKAN.Extensions;
-using CKAN.Versioning;
+
 using log4net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+
+using CKAN.Extensions;
+using CKAN.Versioning;
 
 namespace CKAN
 {
@@ -32,10 +34,8 @@ namespace CKAN
         [OnDeserialized]
         internal void DeserialisationFixes(StreamingContext context)
         {
-            // Set identifier
-            var mod = module_version.Values.LastOrDefault();
-            identifier = mod.identifier;
-            Debug.Assert(module_version.Values.All(m=>identifier.Equals(m.identifier)));
+            identifier = module_version.Values.LastOrDefault()?.identifier;
+            Debug.Assert(module_version.Values.All(m => identifier.Equals(m.identifier)));
         }
 
         /// <param name="identifier">The module to keep track of</param>
@@ -49,6 +49,7 @@ namespace CKAN
         // The map of versions -> modules, that's what we're about!
         // First element is the oldest version, last is the newest.
         [JsonProperty]
+        [JsonConverter(typeof(JsonLeakySortedDictionaryConverter<ModuleVersion, CkanModule>))]
         internal SortedDictionary<ModuleVersion, CkanModule> module_version =
             new SortedDictionary<ModuleVersion, CkanModule>();
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -25,12 +25,13 @@ namespace CKAN
     public class Registry : IEnlistmentNotification, IRegistryQuerier
     {
         [JsonIgnore] private const int LATEST_REGISTRY_VERSION = 3;
-        [JsonIgnore] private static readonly ILog log = LogManager.GetLogger(typeof (Registry));
+        [JsonIgnore] private static readonly ILog log = LogManager.GetLogger(typeof(Registry));
 
         [JsonProperty] private int registry_version;
 
+        // name => Repository
         [JsonProperty("sorted_repositories")]
-        private SortedDictionary<string, Repository> repositories; // name => Repository
+        private SortedDictionary<string, Repository> repositories;
 
         // TODO: These may be good as custom types, especially those which process
         // paths (and flip from absolute to relative, and vice-versa).

--- a/Core/Types/License.cs
+++ b/Core/Types/License.cs
@@ -1,89 +1,32 @@
+using System.Linq;
 ﻿using System.Collections.Generic;
+
 using Newtonsoft.Json;
+
+using CKAN.Extensions;
 
 namespace CKAN
 {
     /// <summary>
-    /// A Spec compliment license string.
+    /// A spec complement license string
     /// </summary>
     [JsonConverter(typeof(JsonSimpleStringConverter))]
     public class License
     {
-        static License _unknownLicense;
-        public static License UnknownLicense => _unknownLicense ?? (_unknownLicense = new License("unknown"));
+        public static readonly HashSet<string> valid_licenses =
+            CKANSchema.schema.Definitions["license"]
+                .Enumeration
+                .Select(obj => obj.ToString())
+                .ToHashSet();
 
-        // TODO: It would be lovely for our build system to write these for us.
-        public static readonly HashSet<string> valid_licenses = new HashSet<string>()
-        {
-            "public-domain",
-            "AFL-3.0",
-            "AGPL-3.0",
-            "Apache", "Apache-1.0", "Apache-2.0",
-            "APSL-2.0",
-            "Artistic", "Artistic-1.0", "Artistic-2.0",
-            "BSD-2-clause", "BSD-3-clause", "BSD-4-clause",
-            "ISC",
-            "CC-BY", "CC-BY-1.0", "CC-BY-2.0", "CC-BY-2.5", "CC-BY-3.0", "CC-BY-4.0",
-            "CC-BY-SA", "CC-BY-SA-1.0", "CC-BY-SA-2.0", "CC-BY-SA-2.5", "CC-BY-SA-3.0", "CC-BY-SA-4.0",
-            "CC-BY-NC", "CC-BY-NC-1.0", "CC-BY-NC-2.0", "CC-BY-NC-2.5", "CC-BY-NC-3.0", "CC-BY-NC-4.0",
-            "CC-BY-NC-SA", "CC-BY-NC-SA-1.0", "CC-BY-NC-SA-2.0", "CC-BY-NC-SA-2.5", "CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0",
-            "CC-BY-NC-ND", "CC-BY-NC-ND-1.0", "CC-BY-NC-ND-2.0", "CC-BY-NC-ND-2.5", "CC-BY-NC-ND-3.0", "CC-BY-NC-ND-4.0",
-            "CC-BY-ND", "CC-BY-ND-1.0", "CC-BY-ND-2.0", "CC-BY-ND-2.5", "CC-BY-ND-3.0", "CC-BY-ND-4.0",
-            "CC0",
-            "CDDL", "CPL",
-            "EFL-1.0", "EFL-2.0",
-            "Expat", "MIT",
-            "GPL-1.0", "GPL-2.0", "GPL-3.0",
-            "LGPL-2.0", "LGPL-2.1", "LGPL-3.0",
-            "GFDL-1.0", "GFDL-1.1", "GFDL-1.2", "GFDL-1.3",
-            "GFDL-NIV-1.0", "GFDL-NIV-1.1", "GFDL-NIV-1.2", "GFDL-NIV-1.3",
-            "LPPL-1.0", "LPPL-1.1", "LPPL-1.2", "LPPL-1.3c",
-            "MPL-1.0", "MPL-1.1", "MPL-2.0",
-            "Ms-PL", "Ms-RL",
-            "Perl",
-            "Python-2.0",
-            "QPL-1.0",
-            "Unlicense",
-            "W3C",
-            "WTFPL",
-            "Zlib",
-            "Zope",
-            "open-source", "restricted", "unrestricted", "unknown"
-        };
+        private static readonly HashSet<string> redistributable_licenses =
+            CKANSchema.schema.Definitions["redistributable_license"]
+                .Enumeration
+                .Select(obj => obj.ToString())
+                .ToHashSet();
 
-        private static readonly HashSet<string> redistributable_licenses = new HashSet<string>()
-        {
-            "public-domain",
-            "Apache", "Apache-1.0", "Apache-2.0",
-            "Artistic", "Artistic-1.0", "Artistic-2.0",
-            "BSD-2-clause", "BSD-3-clause", "BSD-4-clause",
-            "ISC",
-            "CC-BY", "CC-BY-1.0", "CC-BY-2.0", "CC-BY-2.5", "CC-BY-3.0", "CC-BY-4.0",
-            "CC-BY-SA", "CC-BY-SA-1.0", "CC-BY-SA-2.0", "CC-BY-SA-2.5", "CC-BY-SA-3.0", "CC-BY-SA-4.0",
-            "CC-BY-NC", "CC-BY-NC-1.0", "CC-BY-NC-2.0", "CC-BY-NC-2.5", "CC-BY-NC-3.0", "CC-BY-NC-4.0",
-            "CC-BY-NC-SA", "CC-BY-NC-SA-1.0", "CC-BY-NC-SA-2.0", "CC-BY-NC-SA-2.5", "CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0",
-            "CC-BY-NC-ND", "CC-BY-NC-ND-1.0", "CC-BY-NC-ND-2.0", "CC-BY-NC-ND-2.5", "CC-BY-NC-ND-3.0", "CC-BY-NC-ND-4.0",
-            "CC-BY-ND", "CC-BY-ND-1.0", "CC-BY-ND-2.0", "CC-BY-ND-2.5", "CC-BY-ND-3.0", "CC-BY-ND-4.0",
-            "CC0",
-            "CDDL", "CPL",
-            "EFL-1.0", "EFL-2.0",
-            "Expat", "MIT",
-            "GPL-1.0", "GPL-2.0", "GPL-3.0",
-            "LGPL-2.0", "LGPL-2.1", "LGPL-3.0",
-            "GFDL-1.0", "GFDL-1.1", "GFDL-1.2", "GFDL-1.3",
-            "GFDL-NIV-1.0", "GFDL-NIV-1.1", "GFDL-NIV-1.2", "GFDL-NIV-1.3",
-            "LPPL-1.0", "LPPL-1.1", "LPPL-1.2", "LPPL-1.3c",
-            "MPL-1.1", "MPL-2.0",
-            "Perl",
-            "Python-2.0",
-            "QPL-1.0",
-            "W3C",
-            "Zlib",
-            "Zope",
-            "WTFPL",
-            "Unlicense",
-            "open-source", "unrestricted"
-        };
+        // Make sure this is the last static field so the others will be ready for the instance constructor!
+        public static readonly License UnknownLicense = new License("unknown");
 
         private string license;
 
@@ -94,7 +37,7 @@ namespace CKAN
         /// <param name="license">License.</param>
         public License(string license)
         {
-            if (! valid_licenses.Contains(license))
+            if (!valid_licenses.Contains(license))
             {
                 throw new BadMetadataKraken(
                     null,
@@ -112,13 +55,7 @@ namespace CKAN
         /// <returns>
         /// True if redistributable, false otherwise.
         /// </returns>
-        public bool Redistributable
-        {
-            get
-            {
-                return redistributable_licenses.Contains(license);
-            }
-        }
+        public bool Redistributable => redistributable_licenses.Contains(license);
 
         /// <summary>
         /// Returns the license as a string.

--- a/Core/Types/Schema.cs
+++ b/Core/Types/Schema.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Reflection;
+
+using Newtonsoft.Json;
+using NJsonSchema;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A static container for a JsonSchema object representing CKAN.schema
+    /// </summary>
+    public static class CKANSchema
+    {
+        /// <summary>
+        /// Parsed representation of our embedded CKAN.schema resource
+        /// </summary>
+        public static readonly JsonSchema schema =
+            JsonSchema.FromJsonAsync(
+                // ♫ Ooh-ooh StreamReader, I believe you can get me all the lines ♫
+                // ♫ Ooh-ooh StreamReader, I believe we can reach the end of file ♫
+                new StreamReader(
+                    Assembly.GetExecutingAssembly()
+                        .GetManifestResourceStream(embeddedSchema)
+                ).ReadToEnd()
+            ).Result;
+
+        private const string embeddedSchema = "CKAN.Core.CKAN.schema";
+    }
+}

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -46,7 +46,6 @@
     <PackageReference Include="Namotion.Reflection" Version="1.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet" Version="9.1.0" />
-    <PackageReference Include="NJsonSchema" Version="10.0.27" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -153,11 +152,6 @@
     <Compile Include="Validators\TagsValidator.cs" />
     <Compile Include="Validators\VersionStrictValidator.cs" />
     <Compile Include="Validators\VrefValidator.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="..\CKAN.schema">
-      <LogicalName>CKAN.NetKAN.CKAN.schema</LogicalName>
-    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Netkan/Validators/ObeysCKANSchemaValidator.cs
+++ b/Netkan/Validators/ObeysCKANSchemaValidator.cs
@@ -1,25 +1,14 @@
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using NJsonSchema;
+
 using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Validators
 {
     internal sealed class ObeysCKANSchemaValidator : IValidator
     {
-        static ObeysCKANSchemaValidator()
-        {
-            var resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(embeddedSchema);
-            using (var reader = new StreamReader(resourceStream))
-            {
-                schema = JsonSchema.FromJsonAsync(reader.ReadToEnd()).Result;
-            }
-        }
-
         public void Validate(Metadata metadata)
         {
-            var errors = schema.Validate(metadata.Json());
+            var errors = CKANSchema.schema.Validate(metadata.Json());
             if (errors.Any())
             {
                 string msg = errors
@@ -28,8 +17,5 @@ namespace CKAN.NetKAN.Validators
                 throw new Kraken($"Schema validation failed: {msg}");
             }
         }
-
-        private static readonly JsonSchema schema;
-        private const string embeddedSchema = "CKAN.NetKAN.CKAN.schema";
     }
 }


### PR DESCRIPTION
## Problems

- Every time we add a new license, the previous version of the CKAN client is unable to read modules that use it. This is supposed to be handled by `spec_version`, but the user can bypass this protection by updating the registry with a new client and then running an old client, and they have actually done this (see #3331 and #3410 and a reply on the forum thread).
- We currently maintain the list of valid licenses in three places, which is annoying:
  - `CKAN/Core/Types/License.cs`
  - `CKAN/CKAN.schema`
  - `NetKAN-Infra/netkan/netkan/mirrorer.py`

## Changes

- Now if any `CkanModule` in the available modules list throws an exception during deserialization, including but not limited to an unsupported license, we log a warning and omit that module from its `AvailableModule` collection. This allows the user to keep using the client, albeit without access to such modules.
  - This is done with a new `JsonConverter` that adds each version/module pair to a `SortedDictionary` one at a time and returns it containing whatever values didn't throw.
- Now `CKAN.schema` is an embedded resource in Core, and `Licenses.cs` retrieves its license data from there.
  - A `CKANSchema` class holds a `schema` object generated by extracting the embedded resource and then parsing it with `NJsonSchema`
  - Netkan's schema validator now uses `CKANSchema.schema` instead of its own embedded resource
  - A `.definitions.redistributable_license` enum is added to the schema to document which licenses allow us to redistribute.