### PR TITLE
Only delete diversely capitalized directories once on Windows

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -716,7 +716,10 @@ namespace CKAN
                 // Walk our registry to find all files for this mod.
                 IEnumerable<string> files = mod.Files;
 
-                var directoriesToDelete = new HashSet<string>();
+                // We need case insensitive path matching on Windows
+                var directoriesToDelete = Platform.IsWindows
+                    ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    : new HashSet<string>();
 
                 foreach (string file in files)
                 {


### PR DESCRIPTION
## Problem

1. Reboot into Windows
2. Install `LTechContinued 1:0.5.2.2` or earlier
3. Try to uninstall it

```
Kan een gedeelte van het pad C:\Games\Kerbal Space Program\GameData\LTech\Parts\Science\SkyLab niet vinden.
Error during installation!
If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
```

## Cause

Up until its latest release (see linuxgurugamer/L-Tech#2), this mod had a `Skylab` folder and a `SkyLab` folder right next to each other:

![ZIP](https://user-images.githubusercontent.com/1559108/151730621-01a3d5be-e5c9-430d-91a4-225511e30246.png)
![contents](https://i.imgur.com/3V9Cg23.png)

On Windows, these install into a single `SkyLab` folder, but the `Registry` remembers the different names.

At uninstall, CKAN tries to remove both directory names. The first succeeds, and the second throws an error because it's already gone.

## Changes

Now the `HashSet<string>` that we use to track folders to delete is case insensitive on Windows, similar to what we did in #3479. This will make sure that we only delete such folders one time.

Fixes #3527.