### PR TITLE
Bump SharpZipLib from 1.3.1 to 1.3.3

### DIFF
--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.3.103.64" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.102.31" />
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Namotion.Reflection" Version="1.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
#3529, #3530, and #3531 all failed to build due to dependabot's dumb practice of creating multiple pull requests for the same repo (the three projects need to use the same version).

Now they're merged together here.