### PR TITLE
Combine staging reasons

### DIFF
--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -148,7 +148,7 @@ namespace CKAN.NetKAN.Processors
             IEnumerable<Metadata> ckans = null;
             bool   caught        = false;
             string caughtMessage = null;
-            var    opts          = new TransformOptions(releases, null, highVer);
+            var    opts          = new TransformOptions(releases, null, highVer, netkan.Staged, netkan.StagingReason);
             try
             {
                 ckans = inflator.Inflate($"{netkan.Identifier}.netkan", netkan, opts);
@@ -178,11 +178,6 @@ namespace CKAN.NetKAN.Processors
 
         private SendMessageBatchRequestEntry inflationMessage(Metadata ckan, Metadata netkan, TransformOptions opts, bool success, string err = null)
         {
-            bool staged = netkan.Staged || opts.Staged;
-            string stagingReason =
-                  !string.IsNullOrEmpty(netkan.StagingReason) ? netkan.StagingReason
-                : !string.IsNullOrEmpty(opts.StagingReason)   ? opts.StagingReason
-                : null;
             var attribs = new Dictionary<string, MessageAttributeValue>()
             {
                 {
@@ -198,7 +193,7 @@ namespace CKAN.NetKAN.Processors
                     new MessageAttributeValue()
                     {
                         DataType    = "String",
-                        StringValue = staged.ToString()
+                        StringValue = opts.Staged.ToString()
                     }
                 },
                 {
@@ -252,14 +247,14 @@ namespace CKAN.NetKAN.Processors
                 );
                 warningAppender.Warnings.Clear();
             }
-            if (staged && stagingReason != null)
+            if (opts.Staged && opts.StagingReasons.Count > 0)
             {
                 attribs.Add(
                     "StagingReason",
                     new MessageAttributeValue()
                     {
                         DataType    = "String",
-                        StringValue = stagingReason,
+                        StringValue = string.Join("\r\n\r\n", opts.StagingReasons),
                     }
                 );
             }

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -97,7 +97,9 @@ namespace CKAN.NetKAN
                         new TransformOptions(
                             ParseReleases(Options.Releases),
                             ParseSkipReleases(Options.SkipReleases),
-                            ParseHighestVersion(Options.HighestVersion)
+                            ParseHighestVersion(Options.HighestVersion),
+                            netkan.Staged,
+                            netkan.StagingReason
                         )
                     );
                     foreach (Metadata ckan in ckans)

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -65,7 +65,7 @@ namespace CKAN.NetKAN.Transformers
                 {
                     // New file, tell the Indexer to be careful
                     opts.Staged = true;
-                    opts.StagingReason = $"Auto-epoching out of order version: {startV} < {opts.HighestVersion} < {currentV}";
+                    opts.StagingReasons.Add($"Auto-epoching out of order version: {startV} < {opts.HighestVersion} < {currentV}");
                 }
                 json["version"] = currentV.ToString();
             }

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -6,18 +6,24 @@ namespace CKAN.NetKAN.Transformers
 {
     internal class TransformOptions
     {
-        public TransformOptions(int? releases, int? skipReleases, ModuleVersion highVer)
+        public TransformOptions(int? releases, int? skipReleases, ModuleVersion highVer, bool staged, string stagingReason)
         {
             Releases       = releases;
             SkipReleases   = skipReleases;
             HighestVersion = highVer;
+            Staged         = staged;
+            StagingReasons = new List<string>();
+            if (!string.IsNullOrEmpty(stagingReason))
+            {
+                StagingReasons.Add(stagingReason);
+            }
         }
 
         public readonly int?          Releases;
         public readonly int?          SkipReleases;
         public readonly ModuleVersion HighestVersion;
         public          bool          Staged;
-        public          string        StagingReason;
+        public readonly List<string>  StagingReasons;
     }
 
     /// <summary>

--- a/Netkan/Transformers/StagingLinksTransformer.cs
+++ b/Netkan/Transformers/StagingLinksTransformer.cs
@@ -14,14 +14,14 @@ namespace CKAN.NetKAN.Transformers
 
         public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
         {
-            if (opts.Staged && !string.IsNullOrEmpty(opts.StagingReason))
+            if (opts.Staged && opts.StagingReasons.Count > 0)
             {
                 var table = LinkTable(metadata);
                 if (!string.IsNullOrEmpty(table))
                 {
                     log.DebugFormat("Adding links to staging reason: {0}",
                         table);
-                    opts.StagingReason += table;
+                    opts.StagingReasons.Add(table);
                 }
             }
             // This transformer never changes the metadata
@@ -38,8 +38,6 @@ namespace CKAN.NetKAN.Transformers
             }
             StringBuilder table = new StringBuilder();
             // Blank lines to separate the table from the description
-            table.AppendLine("");
-            table.AppendLine("");
             table.AppendLine("Resource | URL");
             table.AppendLine(":-- | :--");
             foreach (var prop in resourcesJson.Properties().OrderBy(prop => prop.Name))

--- a/Netkan/Transformers/StagingTransformer.cs
+++ b/Netkan/Transformers/StagingTransformer.cs
@@ -25,7 +25,7 @@ namespace CKAN.NetKAN.Transformers
             if (VersionsNeedManualReview(metadata, out string reason))
             {
                 Log.DebugFormat("Enabling staging, reason: {0}", reason);
-                opts.StagingReason = reason;
+                opts.StagingReasons.Add(reason);
                 opts.Staged = true;
             }
             // This transformer never changes the metadata

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN
     [TestFixture]
     public class MainClassTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
         public void FixVersionStringsUnharmed()

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -11,7 +11,7 @@ namespace Tests.NetKAN
     public class NetkanOverride
     {
         JObject such_metadata;
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [SetUp]
         public void Setup()

--- a/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcKrefTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test,
             TestCase(

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
         public void AddsMissingVersionInfo()

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class CurseTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
@@ -13,7 +13,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class DownloadAttributeTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
         public void AddsDownloadAttributes()

--- a/Tests/NetKAN/Transformers/EpochTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/EpochTransformerTests.cs
@@ -36,7 +36,9 @@ namespace Tests.NetKAN.Transformers
                 null,
                 string.IsNullOrEmpty(highVer)
                     ? null
-                    : new ModuleVersion(highVer)
+                    : new ModuleVersion(highVer),
+                false,
+                null
             );
 
             // Act

--- a/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
@@ -9,7 +9,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GeneratedByTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
         public void AddsGeneratedByProperty()

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GithubTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         private Mock<IGithubApi> apiMockUp;
         [OneTimeSetUp]
@@ -191,7 +191,7 @@ namespace Tests.NetKAN.Transformers
             // Act
             var results = sut.Transform(
                 new Metadata(json),
-                new TransformOptions(2, null, null)
+                new TransformOptions(2, null, null, false, null)
             );
             var transformedJsons = results.Select(result => result.Json()).ToArray();
 
@@ -229,7 +229,7 @@ namespace Tests.NetKAN.Transformers
             // Act
             var results = sut.Transform(
                 new Metadata(json),
-                new TransformOptions(1, 3, null)
+                new TransformOptions(1, 3, null, false, null)
             );
             var transformedJsons = results.Select(result => result.Json()).ToArray();
 
@@ -267,7 +267,7 @@ namespace Tests.NetKAN.Transformers
             // Act
             var results = sut.Transform(
                 new Metadata(json),
-                new TransformOptions(2, 1, null)
+                new TransformOptions(2, 1, null, false, null)
             ).ToArray();
 
             // Assert

--- a/Tests/NetKAN/Transformers/HttpTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/HttpTransformerTests.cs
@@ -9,7 +9,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class HttpTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [TestCase("#/ckan/github/foo/bar")]
         [TestCase("#/ckan/netkan/http://awesomemod.example/awesomemod.netkan")]

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class InternalCkanTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
         public void AddsMiddingProperties()

--- a/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
@@ -13,7 +13,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class MetaNetkanTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -16,7 +16,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class SpacedockTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class StripNetkanMetadataTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [TestCaseSource("StripNetkanMetadataTestCaseSource")]
         public void StripNetkanMetadata(string json, string expected)

--- a/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class VersionEditTransformerTests
     {
-        private TransformOptions opts = new TransformOptions(1, null, null);
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()


### PR DESCRIPTION
## Background

Since about 2022-02-23 (earliest example I found was KSP-CKAN/CKAN-meta#2585), we have been getting auto-epoch pull requests from the bot indicating that it inflated an older release from GitHub instead of the latest release. The reason for this is unknown, but we presume the GitHub API is acting weird. We currently have no ideas for how to address this (but it would be nice!).

## Problems

That phenomenon generated these pull requests:

- KSP-CKAN/CKAN-meta#2620
- KSP-CKAN/CKAN-meta#2621
- KSP-CKAN/CKAN-meta#2622
- KSP-CKAN/CKAN-meta#2623

I thought these were for a new release, but in fact they were auto-epochs for an old release.

Also, they don't have the link table, which would be nice for investigating what happened.

## Cause

The pull request description was populated from the netkan's staging reason only. The auto-epoch staging reason was set into `TransformOptions.StagingReason`, but overridden by the one from the netkan when the module was sent to the queue.

## Changes

- Now `TransformOptions.StagingReason` is replaced by a list `TransformOptions.StagingReasons`
- Now the values for staged and staging reason are copied from the netkan to `TransformOptions`
- Now transformers that set staging (including the one that appends the link table) will append their staging reason to the list rather than overwriting it (or being ignored)
- When we finally send the inflated module to the queue, we join all the staging reasons together separated by blank lines

The next time we get an auto-epoch pull request for a mod with a staging reason set in the netkan, the auto-epoch reason will also be visible, and we will see the link table.
