### PR TITLE
Show dependencies of upgrading mods in change set

### DIFF
--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -20,19 +20,17 @@ namespace CKAN
             ChangesListView.Items.Clear();
             if (changes != null)
             {
-                // We're going to split our change-set into two parts: updated/removed mods,
-                // and everything else (which right now is replacing and installing mods, but we may have
+                // We're going to split our change-set into two parts: removed mods,
+                // and everything else (right now, replacing, upgrading, and installing mods, but we may have
                 // other types in the future).
 
                 sortedChangeSet.Clear();
                 sortedChangeSet.AddRange(changes.Where(change => change.ChangeType == GUIModChangeType.Remove));
-                sortedChangeSet.AddRange(changes.Where(change => change.ChangeType == GUIModChangeType.Update));
 
                 // Now make our list more human-friendly (dependencies for a mod are listed directly
                 // after it.)
                 CreateSortedModList(changes
-                    .Where(change => change.ChangeType != GUIModChangeType.Remove
-                                  && change.ChangeType != GUIModChangeType.Update)
+                    .Where(change => change.ChangeType != GUIModChangeType.Remove)
                     .ToList());
 
                 ChangesListView.Items.AddRange(sortedChangeSet

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -130,6 +130,8 @@ namespace CKAN
                     case GUIModChangeType.None:
                         break;
                     case GUIModChangeType.Update:
+                        modules_to_install.Add((change as ModUpgrade)?.targetMod ?? change.Mod);
+                        break;
                     case GUIModChangeType.Install:
                         modules_to_install.Add(change.Mod);
                         break;


### PR DESCRIPTION
## Problem

1. Install xScience 5.26
2. Upgrade to the latest version
3. The change set shows just the upgrade:
   ![image](https://user-images.githubusercontent.com/1559108/162083790-2528703e-056b-4cae-817d-992fce69d5e2.png)
4. However, the install screen shows that new dependencies will be installed:
   ![image](https://user-images.githubusercontent.com/1559108/162083951-bf9bdcec-4d72-41dc-9c65-1283acb035b3.png)
   The user should be told about this in the change set screen.

## Cause

The change set screen has always only looked for dependencies for modules being installed, not upgraded.

I think the expectation was that all of the complicated stuff would happen for installs, while upgrades would be simple replacements of one version of a module with a newer version, even though the underlying relationship logic in Core can handle more complicated scenarios.

## Changes

Now upgrades will be treated more like installs, in that any new dependencies they introduce will be displayed:

![image](https://user-images.githubusercontent.com/1559108/162088464-34d6b5c9-c345-49e6-b16a-93c9d6ca5261.png)

To make this work, we also need to fix `ComputeChangeSetFromModList` to use the upgraded version in calculating the change set. It was using the old version; luckily this only affects the change set screen and not the actual install, which is handled in Core.

Fixes #3559.