### PR TITLE
Context sensitive help

### DIFF
--- a/Core/HelpURLs.cs
+++ b/Core/HelpURLs.cs
@@ -1,0 +1,23 @@
+namespace CKAN
+{
+    /// <summary>
+    /// Holds URLs that we launch for F1 help
+    /// </summary>
+    public static class HelpURLs
+    {
+        public const string UserGuide = "https://github.com/KSP-CKAN/CKAN/wiki/User-guide";
+        public const string ManageInstances = "https://github.com/KSP-CKAN/CKAN/wiki/User-guide#adding-game-folders";
+        public const string CompatibleGameVersions = "https://github.com/KSP-CKAN/CKAN/wiki/User-guide#choosing-compatible-game-versions";
+        public const string ModPacks = "https://github.com/KSP-CKAN/CKAN/wiki/Sharing-a-modlist-%28metapackages%29";
+        public const string AuthTokens = "https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-GitHub-API-authtoken";
+        public const string CertificateErrors = "https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors";
+
+        public const string CloneFakeInstances = "https://github.com/KSP-CKAN/CKAN/pull/2627";
+        public const string DeleteDirectories = "https://github.com/KSP-CKAN/CKAN/pull/2962";
+        public const string Filters = "https://github.com/KSP-CKAN/CKAN/pull/3458";
+        public const string Labels = "https://github.com/KSP-CKAN/CKAN/pull/2936";
+        public const string PlayTime = "https://github.com/KSP-CKAN/CKAN/pull/3543";
+
+        public const string Discord = "https://discord.gg/Mb4nXQD";
+    }
+}

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -31,7 +31,7 @@ namespace CKAN
         {
             {
                 "api.github.com",
-                new Uri("https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-GitHub-API-authtoken")
+                new Uri(HelpURLs.AuthTokens)
             }
         };
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -422,8 +422,8 @@ namespace CKAN
             if (Platform.IsUnix)
             {
                 return "Oh no! Our download failed with a certificate error!\r\n\r\n"
-                    + "Consult this page for help:\r\n"
-                    + "\thttps://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors";
+                    + "Consult this page for help:\r\n\t"
+                    + HelpURLs.CertificateErrors;
             }
             else
             {

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>CKAN-GUI</AssemblyName>

--- a/GUI/Controls/DeleteDirectories.cs
+++ b/GUI/Controls/DeleteDirectories.cs
@@ -79,6 +79,14 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.DeleteDirectories);
+        }
+
         private void DirectoriesListView_ItemSelectionChanged(Object sender, ListViewItemSelectionChangedEventArgs e)
         {
             ContentsListView.Items.Clear();

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -121,6 +121,14 @@ namespace CKAN
             RelationshipsListView_ItemSelectionChanged(null, null);
         }
 
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.ModPacks);
+        }
+
         private void AddGroup(List<RelationshipDescriptor> relationships, ListViewGroup group, IRegistryQuerier registry)
         {
             if (relationships != null)

--- a/GUI/Controls/PlayTime.cs
+++ b/GUI/Controls/PlayTime.cs
@@ -42,6 +42,14 @@ namespace CKAN
         /// </summary>
         public event Action Done;
 
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.PlayTime);
+        }
+
         private void ShowTotal()
         {
             if (rows != null)

--- a/GUI/Dialogs/CloneFakeGameDialog.Designer.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.Designer.cs
@@ -358,6 +358,7 @@
             this.Icon = Properties.Resources.AppIcon;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.HelpButton = true;
             this.Name = "CloneFakeKspDialog";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/GUI/Dialogs/CloneFakeGameDialog.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Autofac;
 using CKAN.Versioning;
@@ -332,5 +333,22 @@ namespace CKAN
             }
 
         }
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.CloneFakeInstances);
+        }
+
+        /// <summary>
+        /// Open the user guide when the user clicks the help button
+        /// </summary>
+        protected override void OnHelpButtonClicked(CancelEventArgs evt)
+        {
+            evt.Cancel = Util.TryOpenWebPage(HelpURLs.CloneFakeInstances);
+        }
+
     }
 }

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
@@ -224,6 +224,7 @@
             this.Icon = Properties.Resources.AppIcon;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.HelpButton = true;
             this.Name = "CompatibleGameVersionsDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Shown += new System.EventHandler(this.CompatibleGameVersionsDialog_Shown);

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.IO;
+using System.ComponentModel;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using Autofac;
@@ -40,6 +41,22 @@ namespace CKAN
             SortAndAddVersionsToList(compatibleVersionsLeftOthers, compatibleVersions);
             SortAndAddVersionsToList(majorVersionsList, compatibleVersions);
             SortAndAddVersionsToList(knownVersions, compatibleVersions);
+        }
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.CompatibleGameVersions);
+        }
+
+        /// <summary>
+        /// Open the user guide when the user clicks the help button
+        /// </summary>
+        protected override void OnHelpButtonClicked(CancelEventArgs evt)
+        {
+            evt.Cancel = Util.TryOpenWebPage(HelpURLs.CompatibleGameVersions);
         }
 
         private void CompatibleGameVersionsDialog_Shown(object sender, EventArgs e)
@@ -91,7 +108,7 @@ namespace CKAN
             {
                 return;
             }
-            if (AddVersionToListTextBox.Text.ToLower() == "any") 
+            if (AddVersionToListTextBox.Text.ToLower() == "any")
             {
                 MessageBox.Show(
                     Properties.Resources.CompatibleGameVersionsDialogInvalidFormat,

--- a/GUI/Dialogs/EditLabelsDialog.Designer.cs
+++ b/GUI/Dialogs/EditLabelsDialog.Designer.cs
@@ -336,6 +336,7 @@ namespace CKAN
             this.Icon = Properties.Resources.AppIcon;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.HelpButton = true;
             this.Name = "EditLabelsDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");

--- a/GUI/Dialogs/EditLabelsDialog.cs
+++ b/GUI/Dialogs/EditLabelsDialog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Drawing;
+using System.ComponentModel;
 using System.Windows.Forms;
 using log4net;
 
@@ -70,6 +71,22 @@ namespace CKAN
             }
             LabelSelectionTree.ExpandAll();
             LabelSelectionTree.EndUpdate();
+        }
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.Labels);
+        }
+
+        /// <summary>
+        /// Open the user guide when the user clicks the help button
+        /// </summary>
+        protected override void OnHelpButtonClicked(CancelEventArgs evt)
+        {
+            evt.Cancel = Util.TryOpenWebPage(HelpURLs.Labels);
         }
 
         private void LabelSelectionTree_BeforeSelect(Object sender, TreeViewCancelEventArgs e)

--- a/GUI/Dialogs/InstallFiltersDialog.Designer.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.Designer.cs
@@ -122,6 +122,9 @@
             this.Controls.Add(this.WarningLabel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = Properties.Resources.AppIcon;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.HelpButton = true;
             this.Name = "InstallFiltersDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Load += new System.EventHandler(this.InstallFiltersDialog_Load);

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 using CKAN.Configuration;
@@ -13,6 +14,22 @@ namespace CKAN
             InitializeComponent();
             this.globalConfig = globalConfig;
             this.instance     = instance;
+        }
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.Filters);
+        }
+
+        /// <summary>
+        /// Open the user guide when the user clicks the help button
+        /// </summary>
+        protected override void OnHelpButtonClicked(CancelEventArgs evt)
+        {
+            evt.Cancel = Util.TryOpenWebPage(HelpURLs.Filters);
         }
 
         private void InstallFiltersDialog_Load(object sender, EventArgs e)

--- a/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
@@ -217,6 +217,9 @@
             this.Controls.Add(this.AddNewButton);
             this.Controls.Add(this.SelectButton);
             this.Controls.Add(this.GameInstancesListView);
+            this.MinimizeBox = false;
+            this.MaximizeBox = false;
+            this.HelpButton = true;
             this.Icon = Properties.Resources.AppIcon;
             this.MinimumSize = new System.Drawing.Size(560, 200);
             this.Name = "ManageGameInstancesDialog";

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.ComponentModel;
 using System.Windows.Forms;
 using System.IO;
 
@@ -126,6 +127,22 @@ namespace CKAN
 
             list.Add(instance.GameDir().Replace('/', Path.DirectorySeparatorChar));
             return list.ToArray();
+        }
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.ManageInstances);
+        }
+
+        /// <summary>
+        /// Open the user guide when the user clicks the help button
+        /// </summary>
+        protected override void OnHelpButtonClicked(CancelEventArgs evt)
+        {
+            evt.Cancel = Util.TryOpenWebPage(HelpURLs.ManageInstances);
         }
 
         private static string FormatVersion(GameVersion v)

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -336,6 +336,14 @@ namespace CKAN
             base.OnShown(e);
         }
 
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.UserGuide);
+        }
+
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
             // Stop all running play time timers
@@ -711,12 +719,12 @@ namespace CKAN
 
         private void userGuideToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/wiki/User-guide");
+            Utilities.ProcessStartURL(HelpURLs.UserGuide);
         }
 
         private void discordToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Utilities.ProcessStartURL("https://discord.gg/Mb4nXQD");
+            Utilities.ProcessStartURL(HelpURLs.Discord);
         }
 
         private void reportClientIssueToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Motivation

We had somebody stop by the Discord asking how to use the Manage Game Instances popup, which appears by itself, blank, if you have no game instances and CKAN can't find one in Steam.

We added some help menu options in #3437, but these not accessible from the Manage Game Instances popup. (And that pull request's changes have not been released yet.)

## Changes

- Now [`.HelpButton`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.form.helpbutton?view=netframework-4.7.2) is `true` for most of our popup dialogs
- Now `.MinimizeBox` and `.MaximizeBox` are `false` for Manage Game Instances and Install Filters, which they probably should have been anyway because maximizing and minimizing these popups is not useful
- Now we override [`OnHelpButtonClicked`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.form.onhelpbuttonclicked?view=netframework-4.7.2#system-windows-forms-form-onhelpbuttonclicked(system-componentmodel-canceleventargs)) and [`OnHelpRequested`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.control.onhelprequested?view=netframework-4.7.2#system-windows-forms-control-onhelprequested(system-windows-forms-helpeventargs)) to open the most relevant help page for each context (the user guide by default, more specific links such as PRs when available)

Now to access help, users will be able to press F1 anywhere or click this question mark button for most of our popups:

![image](https://user-images.githubusercontent.com/1559108/163087119-fedd7aa0-97e1-4cb8-908f-f69ee4c093a0.png)

(Note that this button is _not_ added to the main form because it is mutually exclusive with the minimize and maximize buttons, which we should keep for the main form.)

This should allow some users to find help on their own, and it will simplify many support requests down to telling users, "You can press F1 for help on that".