### PR TITLE
Add install size to metadata and display in clients

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -82,6 +82,10 @@
             "description" : "The content type of the download",
             "type"        : "string"
         },
+        "install_size": {
+            "description" : "The size of the installed files",
+            "type"        : "integer"
+        },
         "license" : {
             "description" : "Machine readable license, or array of licenses",
             "$ref"        : "#/definitions/licenses"

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -65,9 +65,22 @@ namespace CKAN.ConsoleUI {
                 th => th.DimLabelFg
             ));
             AddObject(new ConsoleLabel(
-                13, 5, midL - 2,
+                13, 5, midL / 2,
                 () => CkanModule.FmtSize(mod.download_size)
             ));
+            if (mod.install_size > 0)
+            {
+                AddObject(new ConsoleLabel(
+                    midL / 2, 5, midL / 2 + 9,
+                    () => "Install:",
+                    null,
+                    th => th.DimLabelFg
+                ));
+                AddObject(new ConsoleLabel(
+                    midL / 2 + 9, 5, midL - 2,
+                    () => CkanModule.FmtSize(mod.install_size)
+                ));
+            }
             AddObject(new ConsoleLabel(
                 3, 6, midL - 2,
                 HostedOn

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -658,7 +658,9 @@ namespace CKAN.ConsoleUI {
         {
             long total = 0;
             foreach (InstalledModule im in registry.InstalledModules) {
-                total += im.Module.download_size;
+                total += im.Module.install_size > 0
+                    ? im.Module.install_size
+                    : im.Module.download_size;
             }
             return total;
         }

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -230,6 +230,10 @@ Do you wish to reinstall now?", sb)))
                         return false;
                 }
             }
+            if (metadata.install_size != oldMetadata.install_size)
+            {
+                return false;
+            }
 
             if (!RelationshipsAreEquivalent(metadata.conflicts,  oldMetadata.conflicts))
                 return false;

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -106,7 +106,7 @@ namespace CKAN
 
         // Package type: in spec v1.6 can be either "package" or "metapackage"
         // In spec v1.28, "dlc"
-        [JsonProperty("kind", Order = 29, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("kind", Order = 31, NullValueHandling = NullValueHandling.Ignore)]
         public string kind;
 
         [JsonProperty("author", Order = 7, NullValueHandling = NullValueHandling.Ignore)]
@@ -140,6 +140,10 @@ namespace CKAN
         [JsonProperty("download_content_type", Order = 28, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [DefaultValue("application/zip")]
         public string download_content_type;
+
+        [JsonProperty("install_size", Order = 29, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [DefaultValue(0)]
+        public long install_size;
 
         [JsonProperty("identifier", Order = 3, Required = Required.Always)]
         public string identifier;

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -65,7 +65,8 @@ namespace CKAN
             this.InstalledVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.LatestVersion = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.GameCompatibility = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SizeCol = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DownloadSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.InstallSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ReleaseDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.InstallDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.DownloadCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -314,7 +315,8 @@ namespace CKAN
             this.InstalledVersion,
             this.LatestVersion,
             this.GameCompatibility,
-            this.SizeCol,
+            this.DownloadSize,
+            this.InstallSize,
             this.ReleaseDate,
             this.InstallDate,
             this.DownloadCount,
@@ -413,13 +415,21 @@ namespace CKAN
             this.GameCompatibility.Width = 78;
             resources.ApplyResources(this.GameCompatibility, "GameCompatibility");
             //
-            // SizeCol
+            // DownloadSize
             //
-            this.SizeCol.Name = "SizeCol";
-            this.SizeCol.ReadOnly = true;
-            this.SizeCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.SizeCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
-            resources.ApplyResources(this.SizeCol, "SizeCol");
+            this.DownloadSize.Name = "DownloadSize";
+            this.DownloadSize.ReadOnly = true;
+            this.DownloadSize.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.DownloadSize.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            resources.ApplyResources(this.DownloadSize, "DownloadSize");
+            //
+            // InstallSize
+            //
+            this.InstallSize.Name = "InstallSize";
+            this.InstallSize.ReadOnly = true;
+            this.InstallSize.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.InstallSize.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            resources.ApplyResources(this.InstallSize, "InstallSize");
             //
             // ReleaseDate
             //
@@ -580,7 +590,8 @@ namespace CKAN
         private System.Windows.Forms.DataGridViewTextBoxColumn InstalledVersion;
         private System.Windows.Forms.DataGridViewTextBoxColumn LatestVersion;
         private System.Windows.Forms.DataGridViewTextBoxColumn GameCompatibility;
-        private System.Windows.Forms.DataGridViewTextBoxColumn SizeCol;
+        private System.Windows.Forms.DataGridViewTextBoxColumn DownloadSize;
+        private System.Windows.Forms.DataGridViewTextBoxColumn InstallSize;
         private System.Windows.Forms.DataGridViewTextBoxColumn ReleaseDate;
         private System.Windows.Forms.DataGridViewTextBoxColumn InstallDate;
         private System.Windows.Forms.DataGridViewTextBoxColumn DownloadCount;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1377,8 +1377,10 @@ namespace CKAN
                         {
                             return modB.release_date.HasValue ? -1 : 0;
                         }
-                    case "SizeCol":
+                    case "DownloadSize":
                         return modA.download_size.CompareTo(modB.download_size);
+                    case "InstallSize":
+                        return modA.install_size.CompareTo(modB.install_size);
                     case "DownloadCount":
                         if (gmodA.DownloadCount.HasValue)
                         {

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -135,7 +135,10 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="InstallSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -175,7 +178,8 @@
   <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>Installed version</value></data>
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Latest version</value></data>
   <data name="GameCompatibility.HeaderText" xml:space="preserve"><value>Max game version</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>Download</value></data>
+  <data name="DownloadSize.HeaderText" xml:space="preserve"><value>Download</value></data>
+  <data name="InstallSize.HeaderText" xml:space="preserve"><value>Install</value></data>
   <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Release date</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Install date</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloads</value></data>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -141,7 +141,7 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/GUI/Localization/de-DE/ManageMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ManageMods.de-DE.resx
@@ -135,7 +135,7 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -171,7 +171,7 @@
   <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>Installierte Version</value></data>
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Neueste Version</value></data>
   <data name="GameCompatibility.HeaderText" xml:space="preserve"><value>Max. Spielversion</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>Downloadgröße</value></data>
+  <data name="DownloadSize.HeaderText" xml:space="preserve"><value>Downloadgröße</value></data>
   <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Veröffentlichungsdatum</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Installationsdatum</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloadanzahl</value></data>

--- a/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
+++ b/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
@@ -135,7 +135,7 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -175,7 +175,7 @@
   <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>Version installée</value></data>
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Dernière version</value></data>
   <data name="GameCompatibility.HeaderText" xml:space="preserve"><value>Version de jeu maximale</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>Taille</value></data>
+  <data name="DownloadSize.HeaderText" xml:space="preserve"><value>Taille</value></data>
   <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Date de publication</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Date d'installation</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Nombre de téléchargements</value></data>

--- a/GUI/Localization/ja-JP/ManageMods.ja-JP.resx
+++ b/GUI/Localization/ja-JP/ManageMods.ja-JP.resx
@@ -135,7 +135,7 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -175,7 +175,7 @@
   <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>インストール済みのバージョン</value></data>
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>最新バージョン</value></data>
   <data name="GameCompatibility.HeaderText" xml:space="preserve"><value>対応バージョン</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>サイズ</value></data>
+  <data name="DownloadSize.HeaderText" xml:space="preserve"><value>サイズ</value></data>
   <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>リリース日時</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>インストール日時</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>ダウンロード数</value></data>

--- a/GUI/Localization/pt-BR/ManageMods.pt-BR.resx
+++ b/GUI/Localization/pt-BR/ManageMods.pt-BR.resx
@@ -135,7 +135,7 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -175,7 +175,7 @@
   <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>Versão Instalada</value></data>
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Última versão</value></data>
   <data name="GameCompatibility.HeaderText" xml:space="preserve"><value>Versão do jogo máxima</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>Download</value></data>
+  <data name="DownloadSize.HeaderText" xml:space="preserve"><value>Download</value></data>
   <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Data do lançamento</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Data da instalação</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloads</value></data>

--- a/GUI/Localization/ru-RU/ManageMods.ru-RU.resx
+++ b/GUI/Localization/ru-RU/ManageMods.ru-RU.resx
@@ -135,7 +135,7 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -175,7 +175,7 @@
   <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>Установленная версия</value></data>
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Последняя версия</value></data>
   <data name="GameCompatibility.HeaderText" xml:space="preserve"><value>Поддерживаемая версия игры</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>Размер</value></data>
+  <data name="DownloadSize.HeaderText" xml:space="preserve"><value>Размер</value></data>
   <data name="ReleaseDate.HeaderText" xml:space="preserve"><value>Дата выпуска</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>Дата установки</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Загрузки</value></data>

--- a/GUI/Localization/zh-CN/EditModSearch.zh-CN.resx
+++ b/GUI/Localization/zh-CN/EditModSearch.zh-CN.resx
@@ -120,27 +120,6 @@
   <metadata name="menuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>236, 17</value>
   </metadata>
-  <metadata name="Installed.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ModName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Author.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="InstalledVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="ModListContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>351, 17</value>
   </metadata>

--- a/GUI/Localization/zh-CN/EditModSearchDetails.zh-CN.resx
+++ b/GUI/Localization/zh-CN/EditModSearchDetails.zh-CN.resx
@@ -120,27 +120,6 @@
   <metadata name="menuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>236, 17</value>
   </metadata>
-  <metadata name="Installed.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ModName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Author.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="InstalledVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="ModListContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>351, 17</value>
   </metadata>

--- a/GUI/Localization/zh-CN/Main.zh-CN.resx
+++ b/GUI/Localization/zh-CN/Main.zh-CN.resx
@@ -126,27 +126,6 @@
   <metadata name="menuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>236, 17</value>
   </metadata>
-  <metadata name="Installed.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ModName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Author.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="InstalledVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="ModListContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>351, 17</value>
   </metadata>

--- a/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
+++ b/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
@@ -135,7 +135,7 @@
   <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="DownloadSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -175,7 +175,7 @@
   <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>已安装版本</value></data>
   <data name="LatestVersion.HeaderText" xml:space="preserve"><value>最新版本</value></data>
   <data name="GameCompatibility.HeaderText" xml:space="preserve"><value>最高游戏版本</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>下载大小</value></data>
+  <data name="DownloadSize.HeaderText" xml:space="preserve"><value>下载大小</value></data>
   <data name="InstallDate.HeaderText" xml:space="preserve"><value>安装日期</value></data>
   <data name="DownloadCount.HeaderText" xml:space="preserve"><value>下载量</value></data>
   <data name="Description.HeaderText" xml:space="preserve"><value>描述</value></data>

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -175,20 +175,25 @@ namespace CKAN
             bool needsSave = false;
 
             // KSPCompatibility column got renamed to GameCompatibility
-            int kspCompatibilitySortIndex = configuration.SortColumns.IndexOf("KSPCompatibility");
-            if (kspCompatibilitySortIndex > -1)
-            {
-                configuration.SortColumns[kspCompatibilitySortIndex] = "GameCompatibility";
-                needsSave = true;
-            }
-            int kspCompatibilityHiddenIndex = configuration.HiddenColumnNames.IndexOf("KSPCompatibility");
-            if (kspCompatibilityHiddenIndex > -1)
-            {
-                configuration.HiddenColumnNames[kspCompatibilityHiddenIndex] = "GameCompatibility";
-                needsSave = true;
-            }
+            needsSave = FixColumnName(configuration.SortColumns,       "KSPCompatibility", "GameCompatibility") || needsSave;
+            needsSave = FixColumnName(configuration.HiddenColumnNames, "KSPCompatibility", "GameCompatibility") || needsSave;
+
+            // SizeCol column got renamed to DownloadSize
+            needsSave = FixColumnName(configuration.SortColumns,       "SizeCol", "DownloadSize") || needsSave;
+            needsSave = FixColumnName(configuration.HiddenColumnNames, "SizeCol", "DownloadSize") || needsSave;
 
             return needsSave;
+        }
+
+        private static bool FixColumnName(List<string> columnNames, string oldName, string newName)
+        {
+            int columnIndex = columnNames.IndexOf("KSPCompatibility");
+            if (columnIndex > -1)
+            {
+                columnNames[columnIndex] = "GameCompatibility";
+                return true;
+            }
+            return false;
         }
 
         private static void SaveConfiguration(GUIConfiguration configuration)

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -74,6 +74,7 @@ namespace CKAN
         public DateTime? InstallDate { get; private set; }
         public string LatestVersion { get; private set; }
         public string DownloadSize { get; private set; }
+        public string InstallSize { get; private set; }
         public int? DownloadCount { get; private set; }
         public bool IsCached { get; private set; }
 
@@ -167,6 +168,7 @@ namespace CKAN
             HasUpdate      = registry.HasUpdate(mod.identifier, current_game_version);
             HasReplacement = registry.GetReplacement(mod, current_game_version) != null;
             DownloadSize   = mod.download_size == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.download_size);
+            InstallSize    = mod.install_size  == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.install_size);
 
             // Get the Searchables.
             SearchableName        = mod.SearchableName;

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -358,12 +358,13 @@ namespace CKAN
 
             var downloadCount = new DataGridViewTextBoxCell { Value = $"{mod.DownloadCount:N0}"       };
             var compat        = new DataGridViewTextBoxCell { Value = mod.GameCompatibility           };
-            var size          = new DataGridViewTextBoxCell { Value = mod.DownloadSize                };
+            var downloadSize  = new DataGridViewTextBoxCell { Value = mod.DownloadSize                };
+            var installSize   = new DataGridViewTextBoxCell { Value = mod.InstallSize                 };
             var releaseDate   = new DataGridViewTextBoxCell { Value = mod.ToModule().release_date     };
             var installDate   = new DataGridViewTextBoxCell { Value = mod.InstallDate                 };
             var desc          = new DataGridViewTextBoxCell { Value = mod.Abstract.Replace("&", "&&") };
 
-            item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, size, releaseDate, installDate, downloadCount, desc);
+            item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, downloadSize, installSize, releaseDate, installDate, downloadCount, desc);
 
             selecting.ReadOnly     = selecting     is DataGridViewTextBoxCell;
             autoInstalled.ReadOnly = autoInstalled is DataGridViewTextBoxCell;

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Transformers\HttpTransformer.cs" />
     <Compile Include="Transformers\InternalCkanTransformer.cs" />
     <Compile Include="Transformers\ITransformer.cs" />
+    <Compile Include="Transformers\InstallSizeTransformer.cs" />
     <Compile Include="Transformers\JenkinsTransformer.cs" />
     <Compile Include="Transformers\LocalizationsTransformer.cs" />
     <Compile Include="Transformers\MetaNetkanTransformer.cs" />

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
-using CKAN.NetKAN.Sources.Avc;
+
 using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json.Linq;
+
+using CKAN.NetKAN.Sources.Avc;
 
 namespace CKAN.NetKAN.Services
 {
@@ -15,8 +17,9 @@ namespace CKAN.NetKAN.Services
 
         IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip, GameInstance inst);
         IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip, GameInstance inst);
-        IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, GameInstance ksp);
+        IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, GameInstance inst);
 
+        IEnumerable<ZipEntry> FileSources(CkanModule module, ZipFile zip, GameInstance inst);
         IEnumerable<string> FileDestinations(CkanModule module, string filePath);
     }
 }

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -78,27 +78,22 @@ namespace CKAN.NetKAN.Services
         }
 
         public IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip, GameInstance inst)
-        {
-            return GetFilesBySuffix(module, zip, ".cfg", inst);
-        }
+            => GetFilesBySuffix(module, zip, ".cfg", inst);
 
         public IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip, GameInstance inst)
-        {
-            return GetFilesBySuffix(module, zip, ".dll", inst);
-        }
+            => GetFilesBySuffix(module, zip, ".dll", inst);
 
         public IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, GameInstance inst)
-        {
-            return GetFilesBySuffix(module, zip, ".craft", inst);
-        }
+            => GetFilesBySuffix(module, zip, ".craft", inst);
 
         private IEnumerable<InstallableFile> GetFilesBySuffix(CkanModule module, ZipFile zip, string suffix, GameInstance inst)
-        {
-            return ModuleInstaller
-                .FindInstallableFiles(module, zip, inst)
-                .Where(instF => instF.destination.EndsWith(suffix,
-                    StringComparison.InvariantCultureIgnoreCase));
-        }
+            => ModuleInstaller.FindInstallableFiles(module, zip, inst)
+                              .Where(instF => instF.destination.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase));
+
+        public IEnumerable<ZipEntry> FileSources(CkanModule module, ZipFile zip, GameInstance inst)
+            => ModuleInstaller.FindInstallableFiles(module, zip, inst)
+                              .Select(instF => instF.source)
+                              .Where(ze => !ze.IsDirectory);
 
         public IEnumerable<string> FileDestinations(CkanModule module, string filePath)
         {

--- a/Netkan/Transformers/InstallSizeTransformer.cs
+++ b/Netkan/Transformers/InstallSizeTransformer.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Collections.Generic;
+
+using ICSharpCode.SharpZipLib.Zip;
+
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Services;
+using CKAN.Games;
+
+namespace CKAN.NetKAN.Transformers
+{
+    internal sealed class InstallSizeTransformer : ITransformer
+    {
+        public string Name { get { return "install_size"; } }
+
+        public InstallSizeTransformer(IHttpService http, IModuleService moduleService)
+        {
+            _http = http;
+            _moduleService = moduleService;
+        }
+
+        public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
+        {
+            if (metadata.Download != null)
+            {
+                var json = metadata.Json();
+                CkanModule mod = CkanModule.FromJson(json.ToString());
+                ZipFile    zip = new ZipFile(_http.DownloadModule(metadata));
+                GameInstance inst = new GameInstance(new KerbalSpaceProgram(), "/", "dummy", new NullUser());
+                json["install_size"] = _moduleService.FileSources(mod, zip, inst)
+                                                     .Select(ze => ze.Size)
+                                                     .Sum();
+                yield return new Metadata(json);
+            }
+            else
+            {
+                yield return metadata;
+            }
+        }
+
+        private readonly IHttpService   _http;
+        private readonly IModuleService _moduleService;
+    }
+}

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -52,6 +52,7 @@ namespace CKAN.NetKAN.Transformers
                 // specify a before or after property.
                 new VersionedOverrideTransformer(before: new string[] { null }, after: new string[] { null }),
                 new DownloadAttributeTransformer(http, fileService),
+                new InstallSizeTransformer(http, moduleService),
                 new GeneratedByTransformer(),
                 new OptimusPrimeTransformer(),
                 new StripNetkanMetadataTransformer(),

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -45,6 +45,7 @@ namespace CKAN.NetKAN.Transformers
             "download_size",
             "download_hash",
             "download_content_type",
+            "install_size",
             "release_date",
         }
             .Select((str, index) => new {index, str})

--- a/Spec.md
+++ b/Spec.md
@@ -471,6 +471,12 @@ and not filled in by hand.
     "download_content_type": "application/zip"
 ```
 
+##### install_size
+
+If supplied, `install_size` is the number of bytes consumed by the module
+when it is installed. It is recommended that this field is only generated
+by automated tools (where it is encouraged), and not filled in by hand.
+
 ##### release_date
 
 If supplied, `release_date` is the timestamp when the described version

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -168,7 +168,7 @@ namespace Tests.GUI
 
             // TODO: Refactor the column header code to allow mocking of the GUI without creating columns
             const int numCheckboxCols = 4;
-            const int numTextCols     = 10;
+            const int numTextCols     = 11;
             listGui.Columns.AddRange(
                 Enumerable.Range(1, numCheckboxCols)
                     .Select(i => (DataGridViewColumn)new DataGridViewCheckBoxColumn())

--- a/Tests/NetKAN/Transformers/InstallSizeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InstallSizeTransformerTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Moq;
+
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Transformers;
+using Tests.Data;
+
+namespace Tests.NetKAN.Transformers
+{
+    [TestFixture]
+    public sealed class InstallSizeTransformerTests
+    {
+        [Test]
+        public void Transform_NormalModule_CorrectInstallSize()
+        {
+            // Arrange
+            var json = JObject.Parse(TestData.DogeCoinFlag_101());
+
+            var mHttp = new Mock<IHttpService>();
+            mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
+                 .Returns(TestData.DogeCoinFlagZip());
+
+            var modSvc = new ModuleService();
+
+            ITransformer sut = new InstallSizeTransformer(mHttp.Object, modSvc);
+
+            // Act
+            var result = sut.Transform(new Metadata(json), opts).First();
+            var transformedJson = result.Json();
+
+            // Assert
+            Assert.AreEqual(52291, (int)transformedJson["install_size"]);
+        }
+
+        private TransformOptions opts = new TransformOptions(1, null, null, false, null);
+    }
+}


### PR DESCRIPTION
## Motivation

This looks a little silly, since each of these modules installs a different, smaller subset of the download:

![image](https://user-images.githubusercontent.com/1559108/163728750-d506fb57-c580-4cfd-ba07-b4bca7f6989f.png)

And this isn't accurate because it sums the `download_size` properties of the installed modules, not their installed sizes:

![image](https://user-images.githubusercontent.com/1559108/163728853-9827763f-0d7e-42db-a4f0-500534128fdd.png)

## Changes

- Now an `install_size` property is added to the schema, spec, and `CkanModule`, and `InstallSize` is added to `GUIModule`
- Now Netkan populates `install_size` based on the sum of the `Size` properties of the list of the `ZipEntry` objects that the module installs
- Now the `ConsoleUI` uses this property instead of and falling back to `download_size`
- Now a column for install size is added to GUI
