### PR TITLE
Fix play time column if no playtime, hide game column if single game

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -690,6 +690,9 @@
     <EmbeddedResource Include="Controls\PlayTime.resx">
       <DependentUpon>PlayTime.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Localization\de-DE\PlayTime.de-DE.resx">
+      <DependentUpon>..\..\Controls\PlayTime.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Localization\fr-FR\PlayTime.fr-FR.resx">
       <DependentUpon>..\..\Controls\PlayTime.cs</DependentUpon>
     </EmbeddedResource>

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -74,20 +74,11 @@ namespace CKAN
             GameInstancesListView.Items.Clear();
             UpdateButtonState();
 
-
-            if (!GameInstancesListView.Columns.Contains(Game))
-            {
-                // Always show the game column so our rows load correctly
-                GameInstancesListView.Columns.Insert(Game.Index, Game);
-            }
-            if (!GameInstancesListView.Columns.Contains(GamePlayTime))
-            {
-                // Always show the play time column so our rows load correctly
-                GameInstancesListView.Columns.Insert(GamePlayTime.Index, GamePlayTime);
-            }
-
             var allSameGame = _manager.Instances.Select(i => i.Value.game).Distinct().Count() <= 1;
             var hasPlayTime = _manager.Instances.Any(instance => (instance.Value.playTime?.Time ?? TimeSpan.Zero) > TimeSpan.Zero);
+
+            AddOrRemoveColumn(GameInstancesListView, Game, !allSameGame);
+            AddOrRemoveColumn(GameInstancesListView, GamePlayTime, hasPlayTime);
 
             GameInstancesListView.Items.AddRange(_manager.Instances
                 .OrderByDescending(instance => instance.Value.Version())
@@ -98,19 +89,20 @@ namespace CKAN
                 .ToArray()
             );
 
-            if (allSameGame && GameInstancesListView.Columns.Contains(Game))
-            {
-                // Hide the game column if not in use
-                GameInstancesListView.Columns.Remove(Game);
-            }
-            if (!hasPlayTime && GameInstancesListView.Columns.Contains(GamePlayTime))
-            {
-                // Hide the play time column if not in use
-                GameInstancesListView.Columns.Remove(GamePlayTime);
-            }
-
             GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
             GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+        }
+
+        private void AddOrRemoveColumn(ListView listView, ColumnHeader column, bool condition)
+        {
+            if (condition && !listView.Columns.Contains(column))
+            {
+                listView.Columns.Insert(column.Index, column);
+            }
+            else if (!condition && listView.Columns.Contains(column))
+            {
+                listView.Columns.Remove(column);
+            }
         }
 
         private string[] rowItems(GameInstance instance, bool includeGame, bool includePlayTime)

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using System.IO;
@@ -73,42 +74,66 @@ namespace CKAN
             GameInstancesListView.Items.Clear();
             UpdateButtonState();
 
+
+            if (!GameInstancesListView.Columns.Contains(Game))
+            {
+                // Always show the game column so our rows load correctly
+                GameInstancesListView.Columns.Insert(Game.Index, Game);
+            }
             if (!GameInstancesListView.Columns.Contains(GamePlayTime))
             {
                 // Always show the play time column so our rows load correctly
-                GameInstancesListView.Columns.Insert(
-                    GameInstallPath.Index, GamePlayTime);
+                GameInstancesListView.Columns.Insert(GamePlayTime.Index, GamePlayTime);
             }
+
+            var allSameGame = _manager.Instances.Select(i => i.Value.game).Distinct().Count() <= 1;
+            var hasPlayTime = _manager.Instances.Any(instance => (instance.Value.playTime?.Time ?? TimeSpan.Zero) > TimeSpan.Zero);
 
             GameInstancesListView.Items.AddRange(_manager.Instances
                 .OrderByDescending(instance => instance.Value.Version())
-                .Select(instance => new ListViewItem(new string[]
-                {
-                    !instance.Value.Valid
-                        ? string.Format(Properties.Resources.ManageGameInstancesNameColumnInvalid, instance.Key)
-                        : _manager.CurrentInstance != instance.Value && instance.Value.IsMaybeLocked
-                            ? string.Format(Properties.Resources.ManageGameInstancesNameColumnLocked, instance.Key)
-                            : instance.Key,
-                    instance.Value.game.ShortName,
-                    FormatVersion(instance.Value.Version()),
-                    instance.Value.playTime?.ToString() ?? "",
-                    instance.Value.GameDir().Replace('/', Path.DirectorySeparatorChar)
-                })
+                .Select(instance => new ListViewItem(rowItems(instance.Value, !allSameGame, hasPlayTime))
                 {
                     Tag = instance.Key
                 })
                 .ToArray()
             );
 
-            GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
-            GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
-
-            var hasPlayTime = _manager.Instances.Any(instance => (instance.Value.playTime?.Time ?? TimeSpan.Zero) > TimeSpan.Zero);
+            if (allSameGame && GameInstancesListView.Columns.Contains(Game))
+            {
+                // Hide the game column if not in use
+                GameInstancesListView.Columns.Remove(Game);
+            }
             if (!hasPlayTime && GameInstancesListView.Columns.Contains(GamePlayTime))
             {
                 // Hide the play time column if not in use
                 GameInstancesListView.Columns.Remove(GamePlayTime);
             }
+
+            GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+            GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+        }
+
+        private string[] rowItems(GameInstance instance, bool includeGame, bool includePlayTime)
+        {
+            var list = new List<string>
+            {
+                !instance.Valid
+                    ? string.Format(Properties.Resources.ManageGameInstancesNameColumnInvalid, instance.Name)
+                    : !(_manager.CurrentInstance?.Equals(instance) ?? false) && instance.IsMaybeLocked
+                        ? string.Format(Properties.Resources.ManageGameInstancesNameColumnLocked, instance.Name)
+                        : instance.Name
+            };
+
+            if (includeGame)
+                list.Add(instance.game.ShortName);
+
+            list.Add(FormatVersion(instance.Version()));
+
+            if (includePlayTime)
+                list.Add(instance.playTime?.ToString() ?? "");
+
+            list.Add(instance.GameDir().Replace('/', Path.DirectorySeparatorChar));
+            return list.ToArray();
         }
 
         private static string FormatVersion(GameVersion v)

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -188,6 +188,8 @@
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Statuslog</value></data>
   <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Wähle Mods</value></data>
   <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Auswahl von Empfehlungen, Vorschlägen und unterstützenden Mods</value></data>
+  <data name="PlayTimeTabPage.Text" xml:space="preserve"><value>Spielzeit</value></data>
+  <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Ordner entfernen</value></data>
   <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modpack bearbeiten</value></data>
   <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N verfügbare Updates</value></data>
   <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Aktualisieren</value></data>
@@ -197,4 +199,5 @@
   <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Spielverzeichnis öffnen</value></data>
   <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Einstellungen</value></data>
   <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Beenden</value></data>
+  <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Spielzeit</value></data>
 </root>

--- a/GUI/Localization/de-DE/PlayTime.de-DE.resx
+++ b/GUI/Localization/de-DE/PlayTime.de-DE.resx
@@ -117,21 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="AddNewMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="openDirectoryMenuItem.Text" xml:space="preserve"><value>Verzeichnis öffnen</value></data>
-  <data name="GameInstallName.Text" xml:space="preserve"><value>Name</value></data>
-  <data name="Game.Text" xml:space="preserve"><value>Spiel</value></data>
-  <data name="GamePlayTime.Text" xml:space="preserve"><value>Spielstunden</value></data>
-  <data name="GameInstallPath.Text" xml:space="preserve"><value>Pfad</value></data>
-  <data name="SelectButton.Text" xml:space="preserve"><value>Wählen</value></data>
-  <data name="AddNewButton.Text" xml:space="preserve"><value>Neue Spielinstanz</value></data>
-  <data name="AddToCKANMenuItem.Text" xml:space="preserve"><value>Instanz hinzufügen</value></data>
-  <data name="CloneFakeInstanceMenuItem.Text" xml:space="preserve"><value>Instanz klonen oder fälschen</value></data>
-  <data name="RenameButton.Text" xml:space="preserve"><value>Umbenennen</value></data>
-  <data name="SetAsDefaultCheckbox.Text" xml:space="preserve"><value>Als Standardinstanz setzen</value></data>
-  <data name="ForgetButton.Text" xml:space="preserve"><value>Vergessen</value></data>
-  <data name="$this.Text" xml:space="preserve"><value>Spielinstanzen verwalten</value></data>
+  <data name="EditHelpLabel.Text" xml:space="preserve"><value>Zum Ändern das Stundenfeld anklicken und einfach einen neuen Wert eingeben oder F2 drücken um den alten Wert zu bearbeiten</value></data>
+  <data name="NameColumn.HeaderText" xml:space="preserve"><value>Instanzname</value></data>
+  <data name="TimeColumn.HeaderText" xml:space="preserve"><value>Spielzeit in Stunden</value></data>
+  <data name="OKButton.Text" xml:space="preserve"><value>OK</value></data>
 </root>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -336,6 +336,7 @@ Möchtest du CKAN dies erlauben?
 Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   </data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Linkadresse kopieren</value></data>
+  <data name="StatusInstanceLabelTextWithPlayTime" xml:space="preserve"><value>Spielinstanz: {0} ({1} {2}, {3}h gespielt)</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Spielinstanz: {0} ({1} {2})</value></data>
   <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoriten</value></data>
   <data name="ModuleLabelListHidden" xml:space="preserve"><value>Versteckt</value></data>
@@ -389,4 +390,5 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="EditModSearchTooltipExpandButton" xml:space="preserve"><value>Detailierte Suchfelder ein-/ausklappen (Strg-Shift-F)</value></data>
   <data name="EditModSearchesTooltipAddSearchButton" xml:space="preserve"><value>Füge eine weitere Suche hinzu</value></data>
   <data name="ManageModsInstallAllCheckboxTooltip" xml:space="preserve"><value>Abwählen um alle Mods zu deinstallieren, anwählen um die Änderungsliste zu leeren</value></data>
+  <data name="TotalPlayTime" xml:space="preserve"><value>Gesamtspielzeit: {0} Stunden</value></data>
 </root>


### PR DESCRIPTION
## Problem
#3543 introduced play time tracking and tries to conditionally display it in the "Manage game instances" dialog only if any instance has a playtime > 0.

This is broken, because the `0,0` string for the playtime is added to the `ListViewItem` contents array all the time, and if the column is removed it shows under `Path`:
![broken-game-time](https://user-images.githubusercontent.com/28812678/164713299-db3099a3-48ce-48b6-ad32-419bfc895e71.png)

## Changes
Now the string array for the column contents is factored out into a separate function. It includes the play time string only if the column (header) will actually be present in the end.
The same is applied to the "Game" column now as well, for those that only have instances of a single type of game registered with CKAN (currently the case all the time for everyone as we don't support another game yet).
The auto-resizing needs to be done after removing columns as it applies it to the incorrect columns otherwise.

![new-shiny-and-fixed](https://user-images.githubusercontent.com/28812678/164719286-abf9017c-5c0b-45a4-af12-bc37da8d7a50.png)
(Ignore the Factorio instance being present, it is detected as KSP as this current branch doesn't have Factorio support)

I've also added the German localization for the play time strings.