### PR TITLE
Sort GitHub releases

### DIFF
--- a/Netkan/Sources/Github/GithubRelease.cs
+++ b/Netkan/Sources/Github/GithubRelease.cs
@@ -1,20 +1,48 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 using CKAN.Versioning;
 
 namespace CKAN.NetKAN.Sources.Github
 {
-    public sealed class GithubRelease
+    internal sealed class GithubRelease
     {
-        public string        Author { get; }
-        public ModuleVersion Tag    { get; }
-        public List<GithubReleaseAsset> Assets { get; }
+        public readonly string                   Author;
+        public readonly ModuleVersion            Tag;
+        public readonly List<GithubReleaseAsset> Assets;
+        public readonly bool                     PreRelease;
+        public readonly DateTime?                PublishedAt;
+
+        public GithubRelease(GithubRef reference, JToken json)
+        {
+            PreRelease  = (bool)json["prerelease"];
+            Tag         = new ModuleVersion((string)json["tag_name"]);
+            Author      = (string)json["author"]["login"];
+            PublishedAt = (DateTime?)json["published_at"];
+            Assets      = reference.UseSourceArchive
+                ? new List<GithubReleaseAsset> {
+                    new GithubReleaseAsset(
+                        Tag.ToString(),
+                        new Uri((string)json["zipball_url"]),
+                        PublishedAt)
+                } : ((JArray)json["assets"])
+                    .Where(asset => reference.Filter.IsMatch((string)asset["name"]))
+                    .Select(asset => new GithubReleaseAsset(
+                        (string)asset["name"],
+                        new Uri((string)asset["browser_download_url"]),
+                        (DateTime?)asset["updated_at"]))
+                    .ToList();
+        }
 
         public GithubRelease(string author, ModuleVersion tag, List<GithubReleaseAsset> assets)
         {
-            Author       = author;
-            Tag          = tag;
-            Assets       = assets;
+            Author = author;
+            Tag    = tag;
+            Assets = assets;
         }
     }
 }


### PR DESCRIPTION
## Problems

For several months now the bot has been submitting bogus auto-epoch pull requests, about 0.7 times per day:

<https://github.com/KSP-CKAN/CKAN-meta/pulls?q=is%3Apr+author%3Anetkan-bot+is%3Aunmerged+is%3Aclosed>

This seems to happen completely randomly, only for GitHub krefs, as if the most recent release for that mod has disappeared. However, when we check the repo, it is still there. So somehow the wrong release is being inflated.

## Cause (guesses)

We don't know for sure why this happens (it's very hard to investigate something that only happens once out of 297 unique unfrozen GitHub krefs * 2 inflations per hour * 24 hours per day / 0.7 per day = 20366 attempts), but I have two main guesses at this point:

1. The GitHub API somehow glitches out and skips the most recent release completely, so the most recent release appears to be the one before that
2. The GitHub API returns all the releases, but it somehow glitches out and returns the releases out of order, so the most recent release is included, but it's listed further back in the list than it should be

To further the investigation of this problem, I will be attempting to rule out cause 2 here.

## Changes

Now when we receive a group of releases from the API, before we choose which ones to inflate, we sort them by the `published_at` property, in descending order. If the API has returned the releases out of order, this will ensure that we will identify the most recent one correctly.

If the problem stops after this, then that confirms cause 2 as the culprit. If it continues, then cause 1 looks likely.

In addition, the interpretation of the `JToken` objects returned from the API for releases is moved from `GithubApi` to a new `GithubRelease` constructor, which allows `GithubApi` to deal only in properties of a release object rather than having to cast JSON tokens, etc.
