### PR TITLE
Trigger deploy workflow on repo dispatch deploy event

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   workflow_dispatch:
+  repository_dispatch:
+    types:
+      - deploy
 
 jobs:
   deploy:


### PR DESCRIPTION
## Motivation

Currently we need to trigger the `deploy` workflow manually anytime the `xKAN-meta_testing` repo changes or if `NetKAN-Infra` changes in a way that affects the metadata validation image, because it uses both the `ckan.exe` and `netkan.exe` files and the Python code from `NetKAN-Infra` and `xKAN-meta_testing`:

https://github.com/KSP-CKAN/CKAN/blob/d724a0f28e827954cae0de98ec5aa8d480a11c47/Dockerfile.metadata#L8-L12

See c1a41d545fa7fb691d0bfcf9d64a4393ab8dd61d for a previous effort to deal with this by making it easier to trigger manually; before that we had to find the most recent `deploy` workflow run from a push to `master` and re-run it (which isn't viable if they're all too old for that).

## Background

GitHub provides a mechanism to trigger workflows via a web hook:

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch

## Changes

Now the `deploy` repository dispatch event triggers the `deploy` workflow. This can be triggered by workflows in other repos, see KSP-CKAN/NetKAN-Infra#267 and KSP-CKAN/xKAN-meta_testing#86.

I'm planning to self-review this because it's a small infrastructure change that shouldn't affect anything else.
