### PR TITLE
Auto-size buttons in bottom panels

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -224,6 +224,9 @@
     <Compile Include="Controls\EditModSearchDetails.Designer.cs">
       <DependentUpon>EditModSearchDetails.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\LeftRightRowPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="Controls\ManageMods.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/GUI/Controls/Changeset.Designer.cs
+++ b/GUI/Controls/Changeset.Designer.cs
@@ -34,10 +34,11 @@
             this.Mod = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChangeType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.Reason = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomButtonPanel = new LeftRightRowPanel();
             this.ConfirmChangesButton = new System.Windows.Forms.Button();
             this.BackButton = new System.Windows.Forms.Button();
             this.CancelChangesButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
             // ChangesListView
@@ -75,18 +76,17 @@
             // 
             // BottomButtonPanel
             // 
-            this.BottomButtonPanel.Controls.Add(this.ConfirmChangesButton);
-            this.BottomButtonPanel.Controls.Add(this.BackButton);
-            this.BottomButtonPanel.Controls.Add(this.CancelChangesButton);
+            this.BottomButtonPanel.RightControls.Add(this.ConfirmChangesButton);
+            this.BottomButtonPanel.RightControls.Add(this.CancelChangesButton);
+            this.BottomButtonPanel.RightControls.Add(this.BackButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
             //
             // BackButton
             //
-            this.BackButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.BackButton.AutoSize = true;
+            this.BackButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.BackButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.BackButton.Location = new System.Drawing.Point(149, 5);
             this.BackButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.BackButton.Name = "BackButton";
             this.BackButton.Size = new System.Drawing.Size(112, 30);
@@ -96,9 +96,9 @@
             //
             // CancelChangesButton
             //
-            this.CancelChangesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.CancelChangesButton.AutoSize = true;
+            this.CancelChangesButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.CancelChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelChangesButton.Location = new System.Drawing.Point(266, 5);
             this.CancelChangesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.CancelChangesButton.Name = "CancelChangesButton";
             this.CancelChangesButton.Size = new System.Drawing.Size(112, 30);
@@ -108,9 +108,9 @@
             //
             // ConfirmChangesButton
             //
-            this.ConfirmChangesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ConfirmChangesButton.AutoSize = true;
+            this.ConfirmChangesButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.ConfirmChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ConfirmChangesButton.Location = new System.Drawing.Point(383, 5);
             this.ConfirmChangesButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ConfirmChangesButton.Name = "ConfirmChangesButton";
             this.ConfirmChangesButton.Size = new System.Drawing.Size(112, 30);
@@ -128,6 +128,8 @@
             this.Name = "Changeset";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -138,7 +140,7 @@
         private System.Windows.Forms.ColumnHeader Mod;
         private System.Windows.Forms.ColumnHeader ChangeType;
         private System.Windows.Forms.ColumnHeader Reason;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Button BackButton;
         private System.Windows.Forms.Button CancelChangesButton;
         private System.Windows.Forms.Button ConfirmChangesButton;

--- a/GUI/Controls/ChooseProvidedMods.Designer.cs
+++ b/GUI/Controls/ChooseProvidedMods.Designer.cs
@@ -34,9 +34,10 @@
             this.ChooseProvidedModsListView = new ThemedListView();
             this.modNameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.modDescriptionColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomButtonPanel = new LeftRightRowPanel();
             this.ChooseProvidedModsCancelButton = new System.Windows.Forms.Button();
             this.ChooseProvidedModsContinueButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
             // ChooseProvidedModsLabel
@@ -82,17 +83,16 @@
             // 
             // BottomButtonPanel
             // 
-            this.BottomButtonPanel.Controls.Add(this.ChooseProvidedModsCancelButton);
-            this.BottomButtonPanel.Controls.Add(this.ChooseProvidedModsContinueButton);
+            this.BottomButtonPanel.RightControls.Add(this.ChooseProvidedModsContinueButton);
+            this.BottomButtonPanel.RightControls.Add(this.ChooseProvidedModsCancelButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
             //
             // ChooseProvidedModsCancelButton
             //
-            this.ChooseProvidedModsCancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ChooseProvidedModsCancelButton.AutoSize = true;
+            this.ChooseProvidedModsCancelButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.ChooseProvidedModsCancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChooseProvidedModsCancelButton.Location = new System.Drawing.Point(266, 5);
             this.ChooseProvidedModsCancelButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseProvidedModsCancelButton.Name = "ChooseProvidedModsCancelButton";
             this.ChooseProvidedModsCancelButton.Size = new System.Drawing.Size(112, 30);
@@ -102,9 +102,9 @@
             //
             // ChooseProvidedModsContinueButton
             //
-            this.ChooseProvidedModsContinueButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ChooseProvidedModsContinueButton.AutoSize = true;
+            this.ChooseProvidedModsContinueButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.ChooseProvidedModsContinueButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChooseProvidedModsContinueButton.Location = new System.Drawing.Point(383, 5);
             this.ChooseProvidedModsContinueButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChooseProvidedModsContinueButton.Name = "ChooseProvidedModsContinueButton";
             this.ChooseProvidedModsContinueButton.Size = new System.Drawing.Size(112, 30);
@@ -123,6 +123,8 @@
             this.Name = "ChooseProvidedMods";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -133,7 +135,7 @@
         private System.Windows.Forms.ListView ChooseProvidedModsListView;
         private System.Windows.Forms.ColumnHeader modNameColumnHeader;
         private System.Windows.Forms.ColumnHeader modDescriptionColumnHeader;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Button ChooseProvidedModsCancelButton;
         private System.Windows.Forms.Button ChooseProvidedModsContinueButton;
     }

--- a/GUI/Controls/ChooseRecommendedMods.Designer.cs
+++ b/GUI/Controls/ChooseRecommendedMods.Designer.cs
@@ -38,10 +38,11 @@
             this.ModNameHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.SourceModulesHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.DescriptionHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomButtonPanel = new LeftRightRowPanel();
             this.RecommendedModsToggleCheckbox = new System.Windows.Forms.CheckBox();
             this.RecommendedModsCancelButton = new System.Windows.Forms.Button();
             this.RecommendedModsContinueButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
             // RecommendedDialogLabel
@@ -112,19 +113,16 @@
             // 
             // BottomButtonPanel
             // 
-            this.BottomButtonPanel.Controls.Add(this.RecommendedModsToggleCheckbox);
-            this.BottomButtonPanel.Controls.Add(this.RecommendedModsCancelButton);
-            this.BottomButtonPanel.Controls.Add(this.RecommendedModsContinueButton);
+            this.BottomButtonPanel.LeftControls.Add(this.RecommendedModsToggleCheckbox);
+            this.BottomButtonPanel.RightControls.Add(this.RecommendedModsContinueButton);
+            this.BottomButtonPanel.RightControls.Add(this.RecommendedModsCancelButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
             //
             // RecommendedModsToggleCheckbox
             //
-            this.RecommendedModsToggleCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.RecommendedModsToggleCheckbox.AutoSize = true;
             this.RecommendedModsToggleCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsToggleCheckbox.Location = new System.Drawing.Point(5, 5);
             this.RecommendedModsToggleCheckbox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RecommendedModsToggleCheckbox.Name = "RecommendedModsToggleCheckbox";
             this.RecommendedModsToggleCheckbox.Size = new System.Drawing.Size(131, 24);
@@ -134,9 +132,9 @@
             //
             // RecommendedModsCancelButton
             //
-            this.RecommendedModsCancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.RecommendedModsCancelButton.AutoSize = true;
+            this.RecommendedModsCancelButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.RecommendedModsCancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsCancelButton.Location = new System.Drawing.Point(266, 5);
             this.RecommendedModsCancelButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RecommendedModsCancelButton.Name = "RecommendedModsCancelButton";
             this.RecommendedModsCancelButton.Size = new System.Drawing.Size(112, 30);
@@ -146,9 +144,9 @@
             //
             // RecommendedModsContinueButton
             //
-            this.RecommendedModsContinueButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.RecommendedModsContinueButton.AutoSize = true;
+            this.RecommendedModsContinueButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.RecommendedModsContinueButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendedModsContinueButton.Location = new System.Drawing.Point(383, 5);
             this.RecommendedModsContinueButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RecommendedModsContinueButton.Name = "RecommendedModsContinueButton";
             this.RecommendedModsContinueButton.Size = new System.Drawing.Size(112, 30);
@@ -167,6 +165,8 @@
             this.Name = "ChooseRecommendedMods";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -181,7 +181,7 @@
         private System.Windows.Forms.ColumnHeader ModNameHeader;
         private System.Windows.Forms.ColumnHeader SourceModulesHeader;
         private System.Windows.Forms.ColumnHeader DescriptionHeader;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.CheckBox RecommendedModsToggleCheckbox;
         private System.Windows.Forms.Button RecommendedModsCancelButton;
         private System.Windows.Forms.Button RecommendedModsContinueButton;

--- a/GUI/Controls/DeleteDirectories.Designer.cs
+++ b/GUI/Controls/DeleteDirectories.Designer.cs
@@ -37,7 +37,7 @@
             this.ContentsListView = new ThemedListView();
             this.FileColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.SelectDirPrompt = new System.Windows.Forms.ListViewItem();
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomButtonPanel = new LeftRightRowPanel();
             this.OpenDirectoryButton = new System.Windows.Forms.Button();
             this.KeepAllButton = new System.Windows.Forms.Button();
             this.DeleteButton = new System.Windows.Forms.Button();
@@ -45,6 +45,7 @@
             this.Splitter.Panel1.SuspendLayout();
             this.Splitter.Panel2.SuspendLayout();
             this.Splitter.SuspendLayout();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // ExplanationLabel
@@ -123,19 +124,17 @@
             // 
             // BottomButtonPanel
             // 
-            this.BottomButtonPanel.Controls.Add(this.OpenDirectoryButton);
-            this.BottomButtonPanel.Controls.Add(this.KeepAllButton);
-            this.BottomButtonPanel.Controls.Add(this.DeleteButton);
+            this.BottomButtonPanel.LeftControls.Add(this.OpenDirectoryButton);
+            this.BottomButtonPanel.RightControls.Add(this.DeleteButton);
+            this.BottomButtonPanel.RightControls.Add(this.KeepAllButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
             // 
             // OpenDirectoryButton
             // 
-            this.OpenDirectoryButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left));
+            this.OpenDirectoryButton.AutoSize = true;
+            this.OpenDirectoryButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.OpenDirectoryButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.OpenDirectoryButton.Location = new System.Drawing.Point(5, 5);
             this.OpenDirectoryButton.Name = "OpenDirectoryButton";
             this.OpenDirectoryButton.Size = new System.Drawing.Size(112, 30);
             this.OpenDirectoryButton.TabIndex = 2;
@@ -145,10 +144,9 @@
             // 
             // KeepAllButton
             // 
-            this.KeepAllButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Right));
+            this.KeepAllButton.AutoSize = true;
+            this.KeepAllButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.KeepAllButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.KeepAllButton.Location = new System.Drawing.Point(266, 5);
             this.KeepAllButton.Name = "KeepAllButton";
             this.KeepAllButton.Size = new System.Drawing.Size(112, 30);
             this.KeepAllButton.TabIndex = 3;
@@ -158,10 +156,9 @@
             // 
             // DeleteButton
             // 
-            this.DeleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Right));
+            this.DeleteButton.AutoSize = true;
+            this.DeleteButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.DeleteButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.DeleteButton.Location = new System.Drawing.Point(383, 5);
             this.DeleteButton.Name = "DeleteButton";
             this.DeleteButton.Size = new System.Drawing.Size(112, 30);
             this.DeleteButton.TabIndex = 4;
@@ -175,8 +172,8 @@
             this.Controls.Add(this.Splitter);
             this.Controls.Add(this.ExplanationLabel);
             this.Controls.Add(this.BottomButtonPanel);
-            this.Margin = new System.Windows.Forms.Padding(0,0,0,0);
-            this.Padding = new System.Windows.Forms.Padding(0,0,0,0);
+            this.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
+            this.Padding = new System.Windows.Forms.Padding(0, 0, 0, 0);
             this.Name = "DeleteDirectories";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
@@ -184,6 +181,8 @@
             this.Splitter.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.Splitter)).EndInit();
             this.Splitter.ResumeLayout(false);
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -197,7 +196,7 @@
         private System.Windows.Forms.ListView ContentsListView;
         private System.Windows.Forms.ColumnHeader FileColumn;
         private System.Windows.Forms.ListViewItem SelectDirPrompt;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Button OpenDirectoryButton;
         private System.Windows.Forms.Button KeepAllButton;
         private System.Windows.Forms.Button DeleteButton;

--- a/GUI/Controls/EditModpack.Designer.cs
+++ b/GUI/Controls/EditModpack.Designer.cs
@@ -56,13 +56,14 @@ namespace CKAN
             this.RecommendationsGroup = new System.Windows.Forms.ListViewGroup();
             this.SuggestionsGroup = new System.Windows.Forms.ListViewGroup();
             this.IgnoredGroup = new System.Windows.Forms.ListViewGroup();
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomButtonPanel = new LeftRightRowPanel();
             this.DependsRadioButton = new System.Windows.Forms.RadioButton();
             this.RecommendsRadioButton = new System.Windows.Forms.RadioButton();
             this.SuggestsRadioButton = new System.Windows.Forms.RadioButton();
             this.IgnoreRadioButton = new System.Windows.Forms.RadioButton();
             this.CancelExportButton = new System.Windows.Forms.Button();
             this.ExportModpackButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // ToolTip
@@ -317,23 +318,19 @@ namespace CKAN
             // 
             // BottomButtonPanel
             // 
-            this.BottomButtonPanel.Controls.Add(this.DependsRadioButton);
-            this.BottomButtonPanel.Controls.Add(this.RecommendsRadioButton);
-            this.BottomButtonPanel.Controls.Add(this.SuggestsRadioButton);
-            this.BottomButtonPanel.Controls.Add(this.IgnoreRadioButton);
-            this.BottomButtonPanel.Controls.Add(this.CancelExportButton);
-            this.BottomButtonPanel.Controls.Add(this.ExportModpackButton);
+            this.BottomButtonPanel.LeftControls.Add(this.DependsRadioButton);
+            this.BottomButtonPanel.LeftControls.Add(this.RecommendsRadioButton);
+            this.BottomButtonPanel.LeftControls.Add(this.SuggestsRadioButton);
+            this.BottomButtonPanel.LeftControls.Add(this.IgnoreRadioButton);
+            this.BottomButtonPanel.RightControls.Add(this.ExportModpackButton);
+            this.BottomButtonPanel.RightControls.Add(this.CancelExportButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
             // 
             // DependsRadioButton
             // 
-            this.DependsRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left));
             this.DependsRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
             this.DependsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.DependsRadioButton.Location = new System.Drawing.Point(5, 5);
             this.DependsRadioButton.Name = "DependsRadioButton";
             this.DependsRadioButton.Size = new System.Drawing.Size(112, 30);
             this.DependsRadioButton.TabIndex = 16;
@@ -343,11 +340,8 @@ namespace CKAN
             // 
             // RecommendsRadioButton
             // 
-            this.RecommendsRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left));
             this.RecommendsRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
             this.RecommendsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RecommendsRadioButton.Location = new System.Drawing.Point(116, 5);
             this.RecommendsRadioButton.Name = "RecommendsRadioButton";
             this.RecommendsRadioButton.Size = new System.Drawing.Size(112, 30);
             this.RecommendsRadioButton.TabIndex = 17;
@@ -357,11 +351,8 @@ namespace CKAN
             // 
             // SuggestsRadioButton
             // 
-            this.SuggestsRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left));
             this.SuggestsRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
             this.SuggestsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.SuggestsRadioButton.Location = new System.Drawing.Point(227, 5);
             this.SuggestsRadioButton.Name = "SuggestsRadioButton";
             this.SuggestsRadioButton.Size = new System.Drawing.Size(112, 30);
             this.SuggestsRadioButton.TabIndex = 18;
@@ -371,11 +362,8 @@ namespace CKAN
             // 
             // IgnoreRadioButton
             // 
-            this.IgnoreRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Left));
             this.IgnoreRadioButton.Appearance = System.Windows.Forms.Appearance.Button;
             this.IgnoreRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.IgnoreRadioButton.Location = new System.Drawing.Point(338, 5);
             this.IgnoreRadioButton.Name = "IgnoreRadioButton";
             this.IgnoreRadioButton.Size = new System.Drawing.Size(112, 30);
             this.IgnoreRadioButton.TabIndex = 19;
@@ -385,10 +373,9 @@ namespace CKAN
             // 
             // CancelExportButton
             // 
-            this.CancelExportButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Right));
+            this.CancelExportButton.AutoSize = true;
+            this.CancelExportButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.CancelExportButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelExportButton.Location = new System.Drawing.Point(266, 5);
             this.CancelExportButton.Name = "CancelExportButton";
             this.CancelExportButton.Size = new System.Drawing.Size(112, 30);
             this.CancelExportButton.TabIndex = 20;
@@ -398,10 +385,9 @@ namespace CKAN
             // 
             // ExportModpackButton
             // 
-            this.ExportModpackButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
-            | System.Windows.Forms.AnchorStyles.Right));
+            this.ExportModpackButton.AutoSize = true;
+            this.ExportModpackButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.ExportModpackButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ExportModpackButton.Location = new System.Drawing.Point(383, 5);
             this.ExportModpackButton.Name = "ExportModpackButton";
             this.ExportModpackButton.Size = new System.Drawing.Size(112, 30);
             this.ExportModpackButton.TabIndex = 22;
@@ -420,6 +406,8 @@ namespace CKAN
             this.Name = "EditModpack";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -452,7 +440,7 @@ namespace CKAN
         private System.Windows.Forms.ListViewGroup RecommendationsGroup;
         private System.Windows.Forms.ListViewGroup SuggestionsGroup;
         private System.Windows.Forms.ListViewGroup IgnoredGroup;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.RadioButton DependsRadioButton;
         private System.Windows.Forms.RadioButton RecommendsRadioButton;
         private System.Windows.Forms.RadioButton SuggestsRadioButton;

--- a/GUI/Controls/LeftRightRowPanel.cs
+++ b/GUI/Controls/LeftRightRowPanel.cs
@@ -1,0 +1,90 @@
+using System.Windows.Forms;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A panel containing two groups of controls in flow layouts,
+    /// one on the right side and one on the left.
+    /// Intended to allow autosizing of Buttons.
+    /// </summary>
+    public class LeftRightRowPanel : TableLayoutPanel
+    {
+        /// <summary>
+        /// Initialize the control.
+        /// </summary>
+        public LeftRightRowPanel()
+        {
+            LeftPanel = new FlowLayoutPanel()
+            {
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                // Bottom-align the groups if one wraps and the other doesn't
+                Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Bottom,
+            };
+            RightPanel = new FlowLayoutPanel()
+            {
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                // Bottom-align the groups if one wraps and the other doesn't
+                Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Bottom,
+                // Right align the controls on the right
+                FlowDirection = FlowDirection.RightToLeft,
+            };
+
+            AutoSize = true;
+            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            // Throw exceptions if the table gets bigger than a 2x1 layout
+            GrowStyle = TableLayoutPanelGrowStyle.FixedSize;
+
+            ColumnCount = 2;
+            ColumnStyles.Add(new ColumnStyle());
+            ColumnStyles.Add(new ColumnStyle());
+
+            RowCount = 1;
+            RowStyles.Add(new RowStyle());
+
+            Controls.Add(LeftPanel);
+            Controls.Add(RightPanel);
+        }
+
+        /// <summary>
+        /// Controls to be placed in the left half,
+        /// first added will be at the left/top.
+        /// </summary>
+        public ControlCollection LeftControls  => LeftPanel.Controls;
+        /// <summary>
+        /// Controls to be placed in the right half,
+        /// first added will be at the right/top.
+        /// </summary>
+        public ControlCollection RightControls => RightPanel.Controls;
+
+        /// <summary>
+        /// true if the borders of the panels should be shown, false to hide them.
+        /// Useful for debugging.
+        /// </summary>
+        private bool BordersVisible
+        {
+            get => BorderStyle == BorderStyle.FixedSingle;
+            set
+            {
+                if (value)
+                {
+                    BorderStyle = BorderStyle.FixedSingle;
+                    CellBorderStyle = TableLayoutPanelCellBorderStyle.Single;
+                    LeftPanel.BorderStyle = BorderStyle.FixedSingle;
+                    RightPanel.BorderStyle = BorderStyle.FixedSingle;
+                }
+                else
+                {
+                    BorderStyle = BorderStyle.None;
+                    CellBorderStyle = TableLayoutPanelCellBorderStyle.None;
+                    LeftPanel.BorderStyle = BorderStyle.None;
+                    RightPanel.BorderStyle = BorderStyle.None;
+                }
+            }
+        }
+
+        private FlowLayoutPanel LeftPanel;
+        private FlowLayoutPanel RightPanel;
+    }
+}

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -116,6 +116,7 @@
             // splitContainer2
             //
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer2.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitContainer2.Location = new System.Drawing.Point(3, 3);
             this.splitContainer2.Name = "splitContainer2";
             this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;

--- a/GUI/Controls/PlayTime.Designer.cs
+++ b/GUI/Controls/PlayTime.Designer.cs
@@ -34,9 +34,10 @@
             this.PlayTimeGrid = new System.Windows.Forms.DataGridView();
             this.NameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.TimeColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomButtonPanel = new LeftRightRowPanel();
             this.TotalLabel = new System.Windows.Forms.Label();
             this.OKButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
             // EditHelpLabel
@@ -45,7 +46,7 @@
             this.EditHelpLabel.Dock = System.Windows.Forms.DockStyle.Top;
             this.EditHelpLabel.BackColor = System.Drawing.Color.Transparent;
             this.EditHelpLabel.Location = new System.Drawing.Point(4, 5);
-            this.EditHelpLabel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.EditHelpLabel.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
             this.EditHelpLabel.Name = "EditHelpLabel";
             this.EditHelpLabel.Size = new System.Drawing.Size(147, 20);
             this.EditHelpLabel.TabIndex = 0;
@@ -71,7 +72,7 @@
             this.NameColumn,
             this.TimeColumn});
             this.PlayTimeGrid.Location = new System.Drawing.Point(0, 111);
-            this.PlayTimeGrid.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.PlayTimeGrid.Margin = new System.Windows.Forms.Padding(0, 5, 0, 5);
             this.PlayTimeGrid.MultiSelect = false;
             this.PlayTimeGrid.Name = "PlayTimeGrid";
             this.PlayTimeGrid.RowHeadersVisible = false;
@@ -101,18 +102,16 @@
             // 
             // BottomButtonPanel
             // 
-            this.BottomButtonPanel.Controls.Add(this.OKButton);
-            this.BottomButtonPanel.Controls.Add(this.TotalLabel);
+            this.BottomButtonPanel.RightControls.Add(this.OKButton);
+            this.BottomButtonPanel.LeftControls.Add(this.TotalLabel);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
             //
             // TotalLabel
             //
             this.TotalLabel.AutoSize = true;
             this.TotalLabel.BackColor = System.Drawing.Color.Transparent;
-            this.TotalLabel.Location = new System.Drawing.Point(0, 8);
-            this.TotalLabel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.TotalLabel.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
             this.TotalLabel.Name = "TotalLabel";
             this.TotalLabel.Size = new System.Drawing.Size(147, 20);
             this.TotalLabel.TabIndex = 2;
@@ -121,10 +120,9 @@
             //
             // OKButton
             //
-            this.OKButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.OKButton.AutoSize = true;
+            this.OKButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.OKButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.OKButton.Location = new System.Drawing.Point(383, 5);
-            this.OKButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.OKButton.Name = "OKButton";
             this.OKButton.Size = new System.Drawing.Size(112, 30);
             this.OKButton.TabIndex = 3;
@@ -140,6 +138,8 @@
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "PlayTime";
             this.Size = new System.Drawing.Size(500, 500);
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -149,7 +149,7 @@
         private System.Windows.Forms.DataGridView PlayTimeGrid;
         private System.Windows.Forms.DataGridViewTextBoxColumn NameColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn TimeColumn;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Label TotalLabel;
         private System.Windows.Forms.Button OKButton;
     }

--- a/GUI/Controls/Wait.Designer.cs
+++ b/GUI/Controls/Wait.Designer.cs
@@ -34,10 +34,11 @@
             this.MessageTextBox = new System.Windows.Forms.TextBox();
             this.DialogProgressBar = new System.Windows.Forms.ProgressBar();
             this.LogTextBox = new System.Windows.Forms.TextBox();
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomButtonPanel = new LeftRightRowPanel();
             this.CancelCurrentActionButton = new System.Windows.Forms.Button();
             this.RetryCurrentActionButton = new System.Windows.Forms.Button();
             this.OkButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
             // TopPanel
@@ -51,7 +52,9 @@
             // MessageTextBox
             //
             this.MessageTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));            this.MessageTextBox.BackColor = System.Drawing.SystemColors.Control;
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.MessageTextBox.BackColor = System.Drawing.SystemColors.Control;
+            this.MessageTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.MessageTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.MessageTextBox.Enabled = false;
             this.MessageTextBox.Location = new System.Drawing.Point(5, 5);
@@ -86,6 +89,7 @@
             this.LogTextBox.Multiline = true;
             this.LogTextBox.Name = "LogTextBox";
             this.LogTextBox.ReadOnly = true;
+            this.LogTextBox.BackColor = System.Drawing.SystemColors.Control;
             this.LogTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.LogTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.LogTextBox.Size = new System.Drawing.Size(500, 400);
@@ -93,19 +97,17 @@
             //
             // BottomButtonPanel
             //
-            this.BottomButtonPanel.Controls.Add(this.RetryCurrentActionButton);
-            this.BottomButtonPanel.Controls.Add(this.CancelCurrentActionButton);
-            this.BottomButtonPanel.Controls.Add(this.OkButton);
+            this.BottomButtonPanel.RightControls.Add(this.OkButton);
+            this.BottomButtonPanel.RightControls.Add(this.CancelCurrentActionButton);
+            this.BottomButtonPanel.RightControls.Add(this.RetryCurrentActionButton);
             this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 40);
             //
             // RetryCurrentActionButton
             //
-            this.RetryCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.RetryCurrentActionButton.AutoSize = true;
+            this.RetryCurrentActionButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.RetryCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RetryCurrentActionButton.Location = new System.Drawing.Point(149, 5);
-            this.RetryCurrentActionButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RetryCurrentActionButton.Name = "RetryCurrentActionButton";
             this.RetryCurrentActionButton.Size = new System.Drawing.Size(112, 30);
             this.RetryCurrentActionButton.TabIndex = 3;
@@ -114,10 +116,9 @@
             //
             // CancelCurrentActionButton
             //
-            this.CancelCurrentActionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.CancelCurrentActionButton.AutoSize = true;
+            this.CancelCurrentActionButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.CancelCurrentActionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelCurrentActionButton.Location = new System.Drawing.Point(266, 5);
-            this.CancelCurrentActionButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.CancelCurrentActionButton.Name = "CancelCurrentActionButton";
             this.CancelCurrentActionButton.Size = new System.Drawing.Size(112, 30);
             this.CancelCurrentActionButton.TabIndex = 4;
@@ -126,10 +127,9 @@
             //
             // OkButton
             //
-            this.OkButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.OkButton.AutoSize = true;
+            this.OkButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.OkButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.OkButton.Location = new System.Drawing.Point(383, 5);
-            this.OkButton.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.OkButton.Name = "OkButton";
             this.OkButton.Size = new System.Drawing.Size(112, 30);
             this.OkButton.TabIndex = 5;
@@ -147,6 +147,8 @@
             this.Name = "Wait";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -157,7 +159,7 @@
         private System.Windows.Forms.TextBox MessageTextBox;
         private System.Windows.Forms.ProgressBar DialogProgressBar;
         private System.Windows.Forms.TextBox LogTextBox;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Button RetryCurrentActionButton;
         private System.Windows.Forms.Button CancelCurrentActionButton;
         private System.Windows.Forms.Button OkButton;

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -24,7 +24,7 @@ namespace CKAN
             set
             {
                 Util.Invoke(this, () =>
-                    RetryCurrentActionButton.Enabled = value);
+                    RetryCurrentActionButton.Visible = value);
             }
         }
 
@@ -198,8 +198,8 @@ namespace CKAN
                 ClearModuleBars();
                 ProgressValue = DialogProgressBar.Minimum;
                 ProgressIndeterminate = true;
-                RetryCurrentActionButton.Enabled = false;
-                CancelCurrentActionButton.Enabled = cancelable;
+                RetryCurrentActionButton.Visible = false;
+                CancelCurrentActionButton.Visible = cancelable;
                 OkButton.Enabled = false;
                 MessageTextBox.Text = Properties.Resources.MainWaitPleaseWait;
             });
@@ -212,8 +212,8 @@ namespace CKAN
                 MessageTextBox.Text = Properties.Resources.MainWaitDone;
                 ProgressValue = 100;
                 ProgressIndeterminate = false;
-                RetryCurrentActionButton.Enabled = !success;
-                CancelCurrentActionButton.Enabled = false;
+                RetryCurrentActionButton.Visible = !success;
+                CancelCurrentActionButton.Visible = false;
                 OkButton.Enabled = true;
             });
         }

--- a/GUI/Dialogs/NewRepoDialog.Designer.cs
+++ b/GUI/Dialogs/NewRepoDialog.Designer.cs
@@ -35,7 +35,7 @@
             this.RepoNameTextBox = new System.Windows.Forms.TextBox();
             this.RepoUrlLabel = new System.Windows.Forms.Label();
             this.RepoUrlTextBox = new System.Windows.Forms.TextBox();
-            this.BottomButtonPanel = new System.Windows.Forms.Panel();
+            this.BottomPanel = new System.Windows.Forms.Panel();
             this.RepoCancel = new System.Windows.Forms.Button();
             this.RepoOK = new System.Windows.Forms.Button();
             this.ReposListBox = new ThemedListView();
@@ -82,17 +82,17 @@
             this.RepoURLHeader.Width = 370;
             resources.ApplyResources(this.RepoURLHeader, "RepoURLHeader");
             // 
-            // BottomButtonPanel
+            // BottomPanel
             // 
-            this.BottomButtonPanel.Controls.Add(this.RepoNameLabel);
-            this.BottomButtonPanel.Controls.Add(this.RepoNameTextBox);
-            this.BottomButtonPanel.Controls.Add(this.RepoUrlLabel);
-            this.BottomButtonPanel.Controls.Add(this.RepoUrlTextBox);
-            this.BottomButtonPanel.Controls.Add(this.RepoOK);
-            this.BottomButtonPanel.Controls.Add(this.RepoCancel);
-            this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.BottomButtonPanel.Name = "BottomButtonPanel";
-            this.BottomButtonPanel.Size = new System.Drawing.Size(500, 94);
+            this.BottomPanel.Controls.Add(this.RepoNameLabel);
+            this.BottomPanel.Controls.Add(this.RepoNameTextBox);
+            this.BottomPanel.Controls.Add(this.RepoUrlLabel);
+            this.BottomPanel.Controls.Add(this.RepoUrlTextBox);
+            this.BottomPanel.Controls.Add(this.RepoOK);
+            this.BottomPanel.Controls.Add(this.RepoCancel);
+            this.BottomPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.BottomPanel.Name = "BottomPanel";
+            this.BottomPanel.Size = new System.Drawing.Size(500, 94);
             //
             // RepoNameLabel
             //
@@ -163,7 +163,7 @@
             this.ClientSize = new System.Drawing.Size(500, 220);
             this.MinimumSize = new System.Drawing.Size(520, 260);
             this.Controls.Add(this.RepositoryGroupBox);
-            this.Controls.Add(this.BottomButtonPanel);
+            this.Controls.Add(this.BottomPanel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
             this.Icon = Properties.Resources.AppIcon;
             this.Name = "NewRepoDialog";
@@ -184,7 +184,7 @@
         private System.Windows.Forms.TextBox RepoNameTextBox;
         private System.Windows.Forms.Label RepoUrlLabel;
         private System.Windows.Forms.TextBox RepoUrlTextBox;
-        private System.Windows.Forms.Panel BottomButtonPanel;
+        private System.Windows.Forms.Panel BottomPanel;
         private System.Windows.Forms.Button RepoOK;
         private System.Windows.Forms.Button RepoCancel;
     }

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -41,7 +41,7 @@ namespace CKAN
 
             Wait.SetDescription(Properties.Resources.MainRepoContacting);
             Wait.ClearLog();
-            ShowWaitDialog();
+            ShowWaitDialog(false);
         }
 
         private bool _enabled = true;
@@ -49,7 +49,7 @@ namespace CKAN
         {
             _enabled = !_enabled;
             menuStrip1.Enabled = _enabled;
-            MainTabControl.Enabled = _enabled;
+            tabController.SetTabLock(!_enabled);
             /* Windows (7 & 8 only?) bug #1548 has extra facets.
              * parent.childcontrol.Enabled = false seems to disable the parent,
              * if childcontrol had focus. Depending on optimization steps,


### PR DESCRIPTION
## Problems

- The bottom right button in Delete Directories is supposed to say "Delete Checked," since only the folders with checked checkboxes will be deleted, but on Windows it only says "Delete":
  https://github.com/KSP-CKAN/CKAN/blob/4f3da572f14a3a46e9ca7ddf3190f341574f7dc0/GUI/Controls/DeleteDirectories.resx#L126
  ![screenshot](https://i.imgur.com/niZzSh2.png)
  - This potentially can happen anywhere, especially if a translator picks a long string for a button
- The text of the progress bar screen's log text box is unreadable black-on-dark when I install things in Windows using the dark theme from #3489, but readable light-on-dark for refreshing the mod list and repo updates.

## Causes

- Most of our buttons use `Anchor` to position themselves and have hard coded sizes, and if those sizes aren't big enough to fit the text, it is truncated. Due to differences in fonts, we have enough space for "Delete Checked" on Linux bot not on Windows.
- The `ForeColor` we set is ignored because we aren't setting `BackColor`. The text color change happens because `MainTabControl` is disabled, which cascades into disabling the log text box.

## Changes

- A new `LeftRightRowPanel` control hosts two groups of controls, one in `.LeftControls` and the other in `.RightControls`. These are passed through to a pair of `FlowLayoutPanel`s, which themselves are hosted in the cells of a one-row `TableLayoutPanel`. Controls hosted in such a way will be positioned nicely while also being able to autosize themselves.
  - Most of the controls where we have a `BottomButtonPanel` now use `LeftRightRowPanel` for it, and the buttons contained therein have autosizing enabled in `GrowOnly` mode, so they will expand if needed to fit their contents but otherwise keep a nice friendly width for easy clicking:
    ![image](https://user-images.githubusercontent.com/1559108/166335237-a9a5d2fc-4a16-490f-b520-096c7743f10c.png)
    As a bonus, the buttons even wrap nicely when space is very limited:
    ![image](https://user-images.githubusercontent.com/1559108/166336482-bdf9c8e6-2476-49e5-88e8-7ad87869d4f9.png)
  - The exception is the add repo popup, which has several non-Button controls on its `BottomButtonPanel` which cannot be easily split into left and right flow layout groups. This panel is now renamed `BottomPanel` to distinguish it from the ones that only contain Buttons.
  - The Depends/Recommends/etc. buttons in Export Modpack are radio buttons, which have an `AutoSize` property but not `AutoSizeMode`, so we have to choose between static sizes and making them smaller in some cases. For now I have left them with static sizes.
  - Since this layout logic is more robust than what we had before, the "Retry" and "Cancel" buttons on the progress bar tab are now hidden rather than disabled when they're not usable. And the update repo action is now properly treated as non-cancellable.
- Now we set the log text box's `BackColor`, which makes the text color render correctly in all cases. The disabling of `MainTabControl` is replaced with calls to `tabController.SetTabLock`, which is how we are supposed to disable the tab control.
- The splitter in mod info is now set to treat its top panel as fixed size, which should make it less likely to end up weird sizes.