### PR TITLE
Filter duplicate co-authors from SpaceDock

### DIFF
--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -239,7 +239,7 @@ namespace CKAN.NetKAN.Transformers
             var result = new List<string> { mod.author };
 
             if (mod.shared_authors != null)
-                result.AddRange(mod.shared_authors.Select(i => i.Username));
+                result.AddRange(mod.shared_authors.Select(i => i.Username).Distinct());
 
             return result;
         }


### PR DESCRIPTION
## Problem

This mod:

https://spacedock.info/mod/2992/SRB%20Waterfall%20Effects%20(SWE)

... gave me this inflation error locally after fixing the `install` to match the latest download:

```
Schema validation failed: #/author: NotOneOf
```

## Cause

The co-author was added twice:

![image](https://user-images.githubusercontent.com/1559108/176746967-a9b70de3-948c-4bc8-8ee7-aad6d2848a30.png)

... which we simply dumped into a `List<string>`, but it's not allowed in the schema (note `uniqueItems`):

https://github.com/KSP-CKAN/CKAN/blob/4f3da572f14a3a46e9ca7ddf3190f341574f7dc0/CKAN.schema#L47-L57

Since neither the simple string format nor the unique-array format matched, the validator considered the `oneOf` to be the thing that failed.

## Changes

Now the SpaceDock translator ensures co-author uniqueness with `.Distinct()`. Initially I looked at using a `HashSet`, but then we would lose the ordering of the authors. I wanted to avoid generating more temporary values, and since you can't add yourself as a co-author, this seemed sufficient to cover the problematic cases.

I audited the GitHub translator and as far as I can tell it already ensures uniqueness with `.Contains()` calls. I don't think any of the other translators can generate multiple authors.

This should probably also be fixed on the SpaceDock side at some point, but it's good to satisfy constraints in the same project that imposes them.
