### PR TITLE
Ability to build .deb and .rpm package in Debug config

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -172,6 +172,7 @@ private void MakeIn(string dir, string args = null)
     int exitCode = StartProcess("make", new ProcessSettings {
         WorkingDirectory = dir,
         Arguments = args,
+        EnvironmentVariables = new Dictionary<string, string> { { "CONFIGURATION", configuration } }
     });
     if (exitCode != 0)
     {

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -1,7 +1,8 @@
 .PHONY: clean test repo sign
 
 DESTDIR:=../_build/deb/fakeroot
-EXESRC:=../_build/repack/Release/ckan.exe
+CONFIGURATION?=Release
+EXESRC:=../_build/repack/$(CONFIGURATION)/ckan.exe
 EXEDEST:=$(DESTDIR)/usr/lib/ckan/ckan.exe
 SCRIPTSRC:=ckan
 SCRIPTDEST:=$(DESTDIR)/usr/bin/ckan
@@ -92,7 +93,7 @@ $(EXEDEST): $(EXESRC)
 	umask 0022 && cp $< $@
 
 $(EXESRC):
-	cd .. && ./build --configuration=Release
+	cd .. && ./build --configuration=$(CONFIGURATION)
 
 $(CONTROLDEST): $(CONTROLSRC) $(CHANGELOGSRC)
 	umask 0022 && mkdir -p $(shell dirname $@)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -9,7 +9,8 @@ MANSRC:=$(DEBDIR)/ckan.1
 DESKTOPSRC:=$(DEBDIR)/ckan.desktop
 CONSOLEUIDESKTOPSRC:=$(DEBDIR)/ckan-consoleui.desktop
 ICONSRC:=$(DEBDIR)/ckan.ico
-EXESRC:=$(shell pwd)/../_build/repack/Release/ckan.exe
+CONFIGURATION?=Release
+EXESRC:=$(shell pwd)/../_build/repack/$(CONFIGURATION)/ckan.exe
 CHANGELOGSRC:=../CHANGELOG.md
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-/_/g' )
 RPM:=$(shell pwd)/../_build/rpm/RPMS/noarch/ckan-$(VERSION)-1.noarch.rpm
@@ -22,6 +23,9 @@ $(RPM): $(SCRIPTSRC) $(EXESRC) $(MANSRC) $(DESKTOPSRC) $(ICONSRC) $(CONSOLEUIDES
 	mkdir -p "${TOPDIR}/SOURCES"
 	cp $^ "${TOPDIR}/SOURCES"
 	rpmbuild --define "_topdir ${TOPDIR}" --define "_version $(VERSION)" -bb ckan.spec
+
+$(EXESRC):
+	cd .. && ./build --configuration=$(CONFIGURATION)
 
 clean:
 	rm -r "$(TOPDIR)"


### PR DESCRIPTION
## Problem

If you run `./build rpm` in a fresh checkout, the build fails.

```
========================================
rpm
========================================
make: *** No rule to make target '/home/user/Downloads/KSP/CKAN/rpm/../_build/repack/Release/ckan.exe', needed by '/home/user/Downloads/KSP/CKAN/rpm/../_build/rpm/RPMS/noarch/ckan-1.31.1-1.noarch.rpm'.  Stop.
An error occurred when executing task 'rpm'.
```

(Found in the early stages of investigating how to set up a yum repo.)

## Cause

The default configuration for the `.exe` file is Debug, but the `.deb` and `.rpm` Makefiles assume the configuration will be Release. `debian/Makefile` has a rule to generate the Release `.exe` if it's missing by running `./build --configuration=Release` in the parent dir, but this isn't present for RPM (and it's kind of a hack anyway).

## Changes

- Now `build.cake` sets the `CONFIGURATION` environment variable to the active configuration before it runs `make`, so the `Makefile`s will know which configuration they're in
- The `Makefile`s check the `CONFIGURATION` environment variable (defaulting to `Release` if not set) to find the `.exe` file
- `debian/Makefile` uses that same `CONFIGURATION` variable to build the correct version of the `.exe` file if it's missing
- The hack to build the `.exe` if missing is reluctantly copied over to `rpm/Makefile` for consistency

I will probably self-review this since it's a small build detail that should only affect developers in rare circumstances.