### PR TITLE
Generate RPM repo for releases and under dev builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Installing build dependencies
-        run: apt-get update && apt-get install -y git make sed gzip fakeroot lintian dpkg-dev
+        run: apt-get update && apt-get install -y git make sed gzip fakeroot lintian dpkg-dev gpg createrepo-c
       - name: Installing runtime dependencies
         run: apt-get install -y xvfb
       - name: Install Docker
@@ -67,14 +67,27 @@ jobs:
           CODENAME: nightly
         run: ./build deb --configuration=Release --exclusive
         if: ${{ steps.check_version.outputs.odd_build }}
-      - name: Sign deb release
+      - name: Build rpm
+        run: ./build rpm --configuration=Release --exclusive
+        if: ${{ steps.check_version.outputs.odd_build }}
+      - name: Import GPG key
         env:
-          CODENAME: nightly
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: |
           echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
-          ./build deb-sign --configuration=Release --exclusive
+        if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
+      - name: Sign deb release
+        env:
+          CODENAME: nightly
+          DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
+        run: ./build deb-sign --configuration=Release --exclusive
+        if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
+      - name: Build rpm repository
+        env:
+          CODENAME: nightly
+          DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
+        run: ./build rpm-repo --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
 
       - name: Run tests
@@ -126,7 +139,7 @@ jobs:
           SOURCE_DIR: _build/deb/apt-repo-root
           DEST_DIR: deb
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
-      - name: Push Release file to S3
+      - name: Push nightly APT repo to S3
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --follow-symlinks
@@ -137,6 +150,18 @@ jobs:
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/deb/apt-repo-dist
           DEST_DIR: deb/dists/nightly
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
+      - name: Push nightly RPM repo to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/rpm/repo
+          DEST_DIR: rpm/nightly
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
 
       - name: Send Discord Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Installing build dependencies
-        run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq dpkg-dev
+        run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq dpkg-dev gpg createrepo-c
       - name: Installing runtime dependencies
         run: apt-get install -y xvfb
 
@@ -31,17 +31,27 @@ jobs:
         env:
           CODENAME: stable
         run: ./build deb --configuration=Release --exclusive
-      - name: Sign deb release
+      - name: Build rpm
+        run: ./build rpm --configuration=Release --exclusive
+      - name: Import GPG key
         env:
-          CODENAME: stable
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: |
           echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
-          ./build deb-sign --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
-      - name: Build rpm
-        run: ./build rpm --configuration=Release --exclusive
+      - name: Sign deb release
+        env:
+          CODENAME: stable
+          DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
+        run: ./build deb-sign --configuration=Release --exclusive
+        if: ${{ env.DEBIAN_PRIVATE_KEY }}
+      - name: Build rpm repository
+        env:
+          CODENAME: stable
+          DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
+        run: ./build rpm-repo --configuration=Release --exclusive
+        if: ${{ env.DEBIAN_PRIVATE_KEY }}
 
       - name: Get release data
         id: release_data
@@ -67,7 +77,7 @@ jobs:
           SOURCE_DIR: _build/deb/apt-repo-root
           DEST_DIR: deb
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
-      - name: Push Release file to S3
+      - name: Push stable APT repo to S3
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --follow-symlinks
@@ -78,6 +88,18 @@ jobs:
           AWS_REGION: us-east-1
           SOURCE_DIR: _build/deb/apt-repo-dist
           DEST_DIR: deb/dists/stable
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+      - name: Push stable RPM repo to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks
+        env:
+          AWS_S3_BUCKET: ksp-ckan
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          SOURCE_DIR: _build/rpm/repo
+          DEST_DIR: rpm/stable
         if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload ckan.exe

--- a/build.cake
+++ b/build.cake
@@ -158,6 +158,11 @@ Task("rpm")
     .IsDependentOn("Ckan")
     .Does(() => MakeIn("rpm"));
 
+Task("rpm-repo")
+    .Description("Build the rpm repository for RPM-based distros.")
+    .IsDependentOn("Ckan")
+    .Does(() => MakeIn("rpm", "repo"));
+
 Task("rpm-test")
     .Description("Test the rpm packaging.")
     .IsDependentOn("Ckan")

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: http://webchat.esper.net/?channels=ckan
 Source: https://github.com/KSP-CKAN/CKAN/
 
 Files: *
-Copyright: 2014-2020, the Comprehensive Kerbal Archive Network (CKAN) Authors:
+Copyright: 2014-2022, the Comprehensive Kerbal Archive Network (CKAN) Authors:
     https://github.com/KSP-CKAN/CKAN/graphs/contributors
 Comment: You can use the CKAN and its associated files under the MIT license,
     reproduced below. This includes the right to sublicense under compatible

--- a/doc/rpm-repo.md
+++ b/doc/rpm-repo.md
@@ -1,0 +1,23 @@
+## CKAN'S RPM repository
+
+We have created an RPM repository that you can add to your RPM-based OS to install CKAN. This will allow you to run CKAN from the system app menus or via `ckan` from your command line. Your system's package manager will pull in dependencies and update CKAN automatically. There's even a man page.
+
+## Stable builds
+
+These are [the main releases](https://github.com/KSP-CKAN/CKAN/releases), recommended for most users. You will have the same features at the same time as everyone else, but you will have the added conveniences of APT managing the updates for you.
+
+```
+sudo dnf config-manager --add-repo https://ksp-ckan.s3-us-west-2.amazonaws.com/rpm/stable/ckan_stable.repo
+sudo dnf install ckan
+```
+
+## Nightly builds
+
+If you like to live dangerously, these are the bleeding edge builds that are generated every time we merge changes to the main branch. On the plus side, you'll get fixes and enhancements faster than everyone else. On the minus side, these builds are essentially untested; we don't know whether they're reliable until we take a close look at them and make sure they're complete and won't break things, at which point they turn into a stable build (if that sounds more like what you want, scroll up to the previous section).
+
+Things may break! But if they do and you report it to us, you'll be a hero to CKAN users everywhere, whether they know it or not.
+
+```
+sudo dnf config-manager --add-repo https://ksp-ckan.s3-us-west-2.amazonaws.com/rpm/nightly/ckan_nightly.repo
+sudo dnf install ckan
+```

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean test
+.PHONY: clean test repo
 
 # Borrow files from .deb
 DEBDIR:=$(shell pwd)/../debian
@@ -13,7 +13,15 @@ CONFIGURATION?=Release
 EXESRC:=$(shell pwd)/../_build/repack/$(CONFIGURATION)/ckan.exe
 CHANGELOGSRC:=../CHANGELOG.md
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-/_/g' )
-RPM:=$(shell pwd)/../_build/rpm/RPMS/noarch/ckan-$(VERSION)-1.noarch.rpm
+RPM:=$(TOPDIR)/RPMS/noarch/ckan-$(VERSION)-1.noarch.rpm
+
+REPODIR:=$(TOPDIR)/repo
+CODENAME?=nightly
+REPOFILE:=ckan_$(CODENAME).repo
+REPORPM:=$(REPODIR)/ckan-$(VERSION)-1.noarch.rpm
+REPOXML:=$(REPODIR)/repodata/repomd.xml
+REPOSIG:=$(REPOXML).asc
+GPGNAME:=KSP CKAN <debian@ksp-ckan.space>
 
 # rpmbuild tries to use $HOME/rpmbuild by default
 # rpmbuild can't handle relative paths for its topdir
@@ -23,6 +31,21 @@ $(RPM): $(SCRIPTSRC) $(EXESRC) $(MANSRC) $(DESKTOPSRC) $(ICONSRC) $(CONSOLEUIDES
 	mkdir -p "${TOPDIR}/SOURCES"
 	cp $^ "${TOPDIR}/SOURCES"
 	rpmbuild --define "_topdir ${TOPDIR}" --define "_version $(VERSION)" -bb ckan.spec
+
+repo: $(REPOSIG)
+
+$(REPOSIG): $(REPOXML)
+	gpg --detach-sign --armor $<
+
+$(REPOXML): $(REPORPM)
+	createrepo_c "$(REPODIR)"
+
+$(REPORPM): $(RPM) $(REPOFILE)
+	mkdir -p "$(REPODIR)"
+	cp $^ "$(REPODIR)"
+	rpm --define '%_gpg_name $(GPGNAME)' \
+	    --define '%__gpg $(shell which gpg)' \
+	    --addsign $@
 
 $(EXESRC):
 	cd .. && ./build --configuration=$(CONFIGURATION)

--- a/rpm/ckan_nightly.repo
+++ b/rpm/ckan_nightly.repo
@@ -1,0 +1,6 @@
+[ckan-nightly-repo]
+name=CKAN Nightly Repo
+baseurl=https://ksp-ckan.s3-us-west-2.amazonaws.com/rpm/nightly
+enabled=1
+gpgcheck=1
+gpgkey=https://github.com/KSP-CKAN/CKAN/raw/master/debian/repo.pub

--- a/rpm/ckan_stable.repo
+++ b/rpm/ckan_stable.repo
@@ -1,0 +1,6 @@
+[ckan-stable-repo]
+name=CKAN Stable Repo
+baseurl=https://ksp-ckan.s3-us-west-2.amazonaws.com/rpm/stable
+enabled=1
+gpgcheck=1
+gpgkey=https://github.com/KSP-CKAN/CKAN/raw/master/debian/repo.pub


### PR DESCRIPTION
## Motivation

Currently we provide `.rpm` packages, but somewhat ironically (given what CKAN is for), the user must download a new `.rpm` file and install it manually when a new version is released.

See #3197 for when we did this for APT/deb, and #2757 for when we started making RPMs.

## Changes

Now a new `./build rpm-repo` command creates a `_build/rpm/repo` folder containing the `.rpm` file (signed with our GPG key) and the additional metadata files needed to host an RPM repo. Just like we did with APT, the test builds (odd build number in version) go into a `nightly` repo, and the releases go into a `stable` repo.

I followed these instructions:

- https://earthly.dev/blog/creating-and-hosting-your-own-rpm-packages-and-yum-repo/

User instructions will be in [doc/rpm-repo.md](https://github.com/HebaruSan/CKAN/blob/feature/rpm-repo/doc/rpm-repo.md).

Using this (with some hacks to work around the servers and GPG keys being different), I was able to use the GNOME Software app to upgrade my 3-year-old Fedora VM from CKAN v1.26.3 to v1.31.0.
