### PR TITLE
Switch build from createrepo-c to createrepo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Installing build dependencies
-        run: apt-get update && apt-get install -y git make sed gzip fakeroot lintian dpkg-dev gpg createrepo-c
+        run: apt-get update && apt-get install -y git make sed gzip fakeroot lintian dpkg-dev gpg createrepo
       - name: Installing runtime dependencies
         run: apt-get install -y xvfb
       - name: Install Docker

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -15,6 +15,7 @@ CHANGELOGSRC:=../CHANGELOG.md
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-/_/g' )
 RPM:=$(TOPDIR)/RPMS/noarch/ckan-$(VERSION)-1.noarch.rpm
 
+CREATEREPO:=$(if $(shell which createrepo),createrepo,createrepo_c)
 REPODIR:=$(TOPDIR)/repo
 CODENAME?=nightly
 REPOFILE:=ckan_$(CODENAME).repo
@@ -38,7 +39,7 @@ $(REPOSIG): $(REPOXML)
 	gpg --detach-sign --armor $<
 
 $(REPOXML): $(REPORPM)
-	createrepo_c "$(REPODIR)"
+	$(CREATEREPO) "$(REPODIR)"
 
 $(REPORPM): $(RPM) $(REPOFILE)
 	mkdir -p "$(REPODIR)"


### PR DESCRIPTION
## Problem

After #3605, the build failed:

![screenshot](https://user-images.githubusercontent.com/1559108/180277257-21ae8b3a-1a1b-4e13-8392-fb643b1ab52d.png)

## Cause

Ubuntu and Debian have `createrepo-c` for generating RPM repos. I hoped that `mono:latest` would be the same :crossed_fingers:, but it was not to be.

```
$ docker run -it --entrypoint sh mono:latest

# apt-cache search createrepo
createrepo - tool to generate the metadata for a yum repository
```

## Changes

- The `deploy.yml` file is updated to install `createrepo` instead of `createrepo-c`
- The RPM `Makefile` now uses `createrepo` if you have it, or `createrepo_c` if you don't, so local dev will still work

I'll merge this shortly.