### PR TITLE
Add year and day of year to RPM versions

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -12,7 +12,7 @@ ICONSRC:=$(DEBDIR)/ckan.ico
 CONFIGURATION?=Release
 EXESRC:=$(shell pwd)/../_build/repack/$(CONFIGURATION)/ckan.exe
 CHANGELOGSRC:=../CHANGELOG.md
-VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-/_/g' )
+VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-/_/g' ).$(shell date +'%g%j')
 RPM:=$(TOPDIR)/RPMS/noarch/ckan-$(VERSION)-1.noarch.rpm
 
 CREATEREPO:=$(if $(shell which createrepo),createrepo,createrepo_c)


### PR DESCRIPTION
## Problem

#3609 worked, but the nightly repo only has `ckan-1.31.1-1.noarch`, which lacks a daily incrementing version number part, so all the builds until the next release will share the same version number and RPM won't update them.

## Changes

Now the version has a new piece added to it made up of the year concatenated with the day of the year, just like we did for the `.deb`s in #3215.

I'll merge this as soon as the validation scripts finish.