### PR TITLE
Implement a new tab in mod info to show changelogs where available

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -51,6 +51,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controls\Changelogs.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\Changelogs.Designer.cs">
+      <DependentUpon>Changelogs.cs</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\AboutDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -353,6 +359,9 @@
     <Compile Include="X11.cs" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Controls\Changelogs.resx">
+      <DependentUpon>Changelogs.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Localization\de-DE\AboutDialog.de-DE.resx">
       <DependentUpon>..\..\Dialogs\AboutDialog.cs</DependentUpon>
     </EmbeddedResource>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/GUI/Controls/Changelogs.Designer.cs
+++ b/GUI/Controls/Changelogs.Designer.cs
@@ -1,0 +1,98 @@
+﻿namespace CKAN
+{
+    partial class Changelogs
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.richTextBox1 = new System.Windows.Forms.RichTextBox();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(0, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(244, 17);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "All available versions of selected mod";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.label4.Location = new System.Drawing.Point(3, 17);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(36, 15);
+            this.label4.TabIndex = 4;
+            this.label4.Text = "Bold";
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(68, 17);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(178, 17);
+            this.label7.TabIndex = 7;
+            this.label7.Text = "- currently installed version";
+            // 
+            // richTextBox1
+            // 
+            this.richTextBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.richTextBox1.Location = new System.Drawing.Point(0, 36);
+            this.richTextBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.richTextBox1.Name = "richTextBox1";
+            this.richTextBox1.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+            this.richTextBox1.Size = new System.Drawing.Size(354, 464);
+            this.richTextBox1.TabIndex = 8;
+            this.richTextBox1.Text = "";
+            // 
+            // Changelogs
+            // 
+            this.Controls.Add(this.richTextBox1);
+            this.Controls.Add(this.label7);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label1);
+            this.Name = "Changelogs";
+            this.Size = new System.Drawing.Size(354, 502);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.RichTextBox richTextBox1;
+    }
+}

--- a/GUI/Controls/Changelogs.Designer.cs
+++ b/GUI/Controls/Changelogs.Designer.cs
@@ -32,6 +32,7 @@
             this.label4 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
+            this.button1 = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // label1
@@ -75,8 +76,19 @@
             this.richTextBox1.TabIndex = 8;
             this.richTextBox1.Text = "";
             // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(250, 8);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(127, 23);
+            this.button1.TabIndex = 9;
+            this.button1.Text = "Load Changelog";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
             // Changelogs
             // 
+            this.Controls.Add(this.button1);
             this.Controls.Add(this.richTextBox1);
             this.Controls.Add(this.label7);
             this.Controls.Add(this.label4);
@@ -94,5 +106,6 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.RichTextBox richTextBox1;
+        private System.Windows.Forms.Button button1;
     }
 }

--- a/GUI/Controls/Changelogs.cs
+++ b/GUI/Controls/Changelogs.cs
@@ -155,12 +155,10 @@ namespace CKAN
                 {
                     apiEndpoint.Path = apiEndpoint.Path + "/releases"; // some modules already had /releases list in their repo url
                 }
-                var client = new System.Net.WebClient();
-                client.Headers.Set(System.Net.HttpRequestHeader.UserAgent, "jkavalik/CKAN-dev");
                 List <ChangelogResultRow> results;
                 try
                 {
-                    string jsonResponse = client.DownloadString(apiEndpoint.Uri);
+                    string jsonResponse = Net.DownloadText(apiEndpoint.Uri);
                     Newtonsoft.Json.Linq.JToken json = Newtonsoft.Json.Linq.JToken.Parse(jsonResponse);
                     var data = from r in json select new ChangelogResultRow((string)r.SelectToken("$.tag_name"), (string)r.SelectToken("$.body"));
                     results = data.ToList();

--- a/GUI/Controls/Changelogs.cs
+++ b/GUI/Controls/Changelogs.cs
@@ -19,12 +19,18 @@ namespace CKAN
 
         readonly List<IChangelogGetter> getters = new List<IChangelogGetter>();
 
+        private GUIMod _selectedModule;
         public GUIMod SelectedModule
         {
             set
             {
+                richTextBox1.Text = "... Changelog not loaded - press the button to start loading ...";
+                button1.Enabled = true;
+                this._selectedModule = value;
                 if (value == null)
                 {
+                    richTextBox1.Text = "... Changelog not available ...";
+                    button1.Enabled = false;
                     return;
                 }
 
@@ -33,21 +39,50 @@ namespace CKAN
                 IRegistryQuerier registry = RegistryManager.Instance(currentInstance).registry;
 
                 ModuleVersion installedVersion = registry.InstalledVersion(value.Identifier);
-
-                richTextBox1.Text = installedVersion.ToString();
-                richTextBox1.Text = "";
-                string outtext = "";
-                foreach(var getter in getters)
+                CkanModule latest = registry.LatestAvailable(value.Identifier, currentInstance.VersionCriteria());
+                if (latest == null) return;
+                if (latest.version.IsEqualTo(installedVersion)) return;
+                if (latest.version.IsGreaterThan(installedVersion))
                 {
-                    Uri repository = registry.GetModuleByVersion(value.Identifier, installedVersion).resources.repository;
-                    if (getter.CanHandle(repository))
-                    {
-                        var result = getter.GetChangelog(repository);
-                        outtext = String.Join("\n\n------------------------\n\n", from r in result select r.tagName + " := " + r.body);
-                        break;
-                    }
+                    ShowChangelogs();
                 }
+            }
+            get
+            {
+                return this._selectedModule;
+            }
+        }
+
+        private void ShowChangelogs()
+        {
+            button1.Enabled = false;
+            GUIMod value = this.SelectedModule;
+            if (value == null) return;
+            GameInstance currentInstance = Main.Instance.Manager.CurrentInstance;
+            IRegistryQuerier registry = RegistryManager.Instance(currentInstance).registry;
+            ModuleVersion installedVersion = registry.InstalledVersion(value.Identifier);
+
+            richTextBox1.Text = "";
+            string outtext = "";
+            foreach (var getter in getters)
+            {
+                Uri repository = registry.GetModuleByVersion(value.Identifier, installedVersion).resources.repository;
+                if (getter.CanHandle(repository))
+                {
+                    var result = getter.GetChangelog(repository);
+                    outtext = String.Join("\n\n------------------------\n\n", from r in result select r.tagName + " := " + r.body);
+                    break;
+                }
+            }
+
+            if (outtext.Length > 0)
+            {
                 richTextBox1.AppendText(outtext);
+                richTextBox1.SelectionStart = 0;
+                richTextBox1.ScrollToCaret();
+            } else
+            {
+                richTextBox1.Text = "... Changelog could not be loaded ...";
             }
         }
 
@@ -105,6 +140,11 @@ namespace CKAN
                 
                 return results;
             }
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            ShowChangelogs();
         }
     }
 }

--- a/GUI/Controls/Changelogs.cs
+++ b/GUI/Controls/Changelogs.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+using CKAN.Versioning;
+
+namespace CKAN
+{
+    public partial class Changelogs : UserControl
+    {
+        public Changelogs()
+        {
+            InitializeComponent();
+            getters.Add(new GithubChangelogGetter());
+        }
+
+        readonly List<IChangelogGetter> getters = new List<IChangelogGetter>();
+
+        public GUIMod SelectedModule
+        {
+            set
+            {
+                if (value == null)
+                {
+                    return;
+                }
+
+                // Get all the data; can put this in bg if slow
+                GameInstance currentInstance = Main.Instance.Manager.CurrentInstance;
+                IRegistryQuerier registry = RegistryManager.Instance(currentInstance).registry;
+
+                ModuleVersion installedVersion = registry.InstalledVersion(value.Identifier);
+
+                richTextBox1.Text = installedVersion.ToString();
+                richTextBox1.Text = "";
+                string outtext = "";
+                foreach(var getter in getters)
+                {
+                    Uri repository = registry.GetModuleByVersion(value.Identifier, installedVersion).resources.repository;
+                    if (getter.CanHandle(repository))
+                    {
+                        var result = getter.GetChangelog(repository);
+                        outtext = String.Join("\n\n------------------------\n\n", from r in result select r.tagName + " := " + r.body);
+                        break;
+                    }
+                }
+                richTextBox1.AppendText(outtext);
+            }
+        }
+
+        private class ChangelogResultRow
+        {
+            public string tagName;
+            public string body;
+            public ChangelogResultRow(string tagName, string body)
+            {
+                this.tagName = tagName;
+                this.body = body;
+            }
+        }
+
+        private interface IChangelogGetter
+        {
+            bool CanHandle(Uri repository);
+            List<ChangelogResultRow> GetChangelog(Uri repository);
+        }
+
+        private class GithubChangelogGetter : IChangelogGetter
+        {
+            public bool CanHandle(Uri repository)
+            {
+                if (repository == null) return false;
+                return repository.Host.Equals("github.com");
+            }
+
+            public List<ChangelogResultRow> GetChangelog(Uri repository)
+            {
+                System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+                UriBuilder apiEndpoint = new UriBuilder(repository);
+                apiEndpoint.Host = "api.github.com";
+                apiEndpoint.Path = "/repos" + apiEndpoint.Path;
+                if (!apiEndpoint.Path.EndsWith("/releases"))
+                {
+                    apiEndpoint.Path = apiEndpoint.Path + "/releases"; // some modules already had /releases list in their repo url
+                }
+                var client = new System.Net.WebClient();
+                client.Headers.Set(System.Net.HttpRequestHeader.UserAgent, "jkavalik/CKAN-dev");
+                List <ChangelogResultRow> results;
+                try
+                {
+                    string jsonResponse = client.DownloadString(apiEndpoint.Uri);
+                    Newtonsoft.Json.Linq.JToken json = Newtonsoft.Json.Linq.JToken.Parse(jsonResponse);
+                    var data = from r in json select new ChangelogResultRow((string)r.SelectToken("$.tag_name"), (string)r.SelectToken("$.body"));
+                    results = data.ToList();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    results = new List<ChangelogResultRow>();
+                    return results;
+                }
+                
+                return results;
+            }
+        }
+    }
+}

--- a/GUI/Controls/Changelogs.resx
+++ b/GUI/Controls/Changelogs.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -28,31 +28,29 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(ModInfo));
-            this.ModInfoTabControl = new ThemedTabControl();
-            this.MetadataTabPage = new System.Windows.Forms.TabPage();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.MetaDataUpperLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-            this.MetadataModuleNameTextBox = new TransparentTextBox();
+            this.MetadataModuleNameTextBox = new CKAN.TransparentTextBox();
             this.MetadataTagsLabelsPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.MetadataModuleAbstractLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleDescriptionTextBox = new TransparentTextBox();
+            this.MetadataModuleDescriptionTextBox = new CKAN.TransparentTextBox();
+            this.ModInfoTabControl = new CKAN.ThemedTabControl();
+            this.MetadataTabPage = new System.Windows.Forms.TabPage();
             this.MetaDataLowerLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-            this.IdentifierLabel = new System.Windows.Forms.Label();
-            this.MetadataIdentifierTextBox = new TransparentTextBox();
-            this.ReplacementLabel = new System.Windows.Forms.Label();
-            this.ReplacementTextBox = new TransparentTextBox();
-            this.GameCompatibilityLabel = new System.Windows.Forms.Label();
-            this.ReleaseLabel = new System.Windows.Forms.Label();
-            this.AuthorLabel = new System.Windows.Forms.Label();
-            this.LicenseLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleVersionTextBox = new TransparentTextBox();
-            this.MetadataModuleLicenseTextBox = new TransparentTextBox();
-            this.MetadataModuleAuthorTextBox = new TransparentTextBox();
             this.VersionLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleReleaseStatusTextBox = new TransparentTextBox();
-            this.MetadataModuleGameCompatibilityTextBox = new TransparentTextBox();
+            this.LicenseLabel = new System.Windows.Forms.Label();
+            this.AuthorLabel = new System.Windows.Forms.Label();
+            this.ReleaseLabel = new System.Windows.Forms.Label();
+            this.GameCompatibilityLabel = new System.Windows.Forms.Label();
+            this.IdentifierLabel = new System.Windows.Forms.Label();
+            this.ReplacementLabel = new System.Windows.Forms.Label();
+            this.MetadataModuleVersionTextBox = new CKAN.TransparentTextBox();
+            this.MetadataModuleLicenseTextBox = new CKAN.TransparentTextBox();
+            this.MetadataModuleAuthorTextBox = new CKAN.TransparentTextBox();
+            this.MetadataModuleReleaseStatusTextBox = new CKAN.TransparentTextBox();
+            this.MetadataModuleGameCompatibilityTextBox = new CKAN.TransparentTextBox();
+            this.MetadataIdentifierTextBox = new CKAN.TransparentTextBox();
+            this.ReplacementTextBox = new CKAN.TransparentTextBox();
             this.RelationshipTabPage = new System.Windows.Forms.TabPage();
             this.DependsGraphTree = new System.Windows.Forms.TreeView();
             this.LegendDependsImage = new System.Windows.Forms.PictureBox();
@@ -72,71 +70,51 @@
             this.NotCachedLabel = new System.Windows.Forms.Label();
             this.AllModVersionsTabPage = new System.Windows.Forms.TabPage();
             this.AllModVersions = new CKAN.AllModVersions();
-            this.ModInfoTabControl.SuspendLayout();
-            this.MetadataTabPage.SuspendLayout();
+            this.ChangelogTab = new System.Windows.Forms.TabPage();
+            this.changelogs1 = new CKAN.Changelogs();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
             this.splitContainer2.Panel1.SuspendLayout();
             this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
             this.MetaDataUpperLayoutPanel.SuspendLayout();
+            this.ModInfoTabControl.SuspendLayout();
+            this.MetadataTabPage.SuspendLayout();
             this.MetaDataLowerLayoutPanel.SuspendLayout();
             this.RelationshipTabPage.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendDependsImage)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendRecommendsImage)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendSuggestsImage)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendSupportsImage)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendConflictsImage)).BeginInit();
             this.ContentTabPage.SuspendLayout();
-            this.AllModVersions.SuspendLayout();
             this.AllModVersionsTabPage.SuspendLayout();
+            this.ChangelogTab.SuspendLayout();
             this.SuspendLayout();
-            //
-            // ModInfoTabControl
-            //
-            this.ModInfoTabControl.Appearance = System.Windows.Forms.TabAppearance.Normal;
-            this.ModInfoTabControl.BackColor = System.Drawing.SystemColors.Control;
-            this.ModInfoTabControl.Multiline = true;
-            this.ModInfoTabControl.Controls.Add(this.MetadataTabPage);
-            this.ModInfoTabControl.Controls.Add(this.RelationshipTabPage);
-            this.ModInfoTabControl.Controls.Add(this.ContentTabPage);
-            this.ModInfoTabControl.Controls.Add(this.AllModVersionsTabPage);
-            this.ModInfoTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ModInfoTabControl.Location = new System.Drawing.Point(0, 0);
-            this.ModInfoTabControl.Name = "ModInfoTabControl";
-            this.ModInfoTabControl.Size = new System.Drawing.Size(362, 531);
-            this.ModInfoTabControl.TabIndex = 1;
-            this.ModInfoTabControl.SelectedIndexChanged += new System.EventHandler(this.ModInfoIndexChanged);
-            //
-            // MetadataTabPage
-            //
-            this.MetadataTabPage.BackColor = System.Drawing.SystemColors.Control;
-            this.MetadataTabPage.Controls.Add(this.MetaDataLowerLayoutPanel);
-            this.MetadataTabPage.Location = new System.Drawing.Point(4, 25);
-            this.MetadataTabPage.Name = "MetadataTabPage";
-            this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.MetadataTabPage.Size = new System.Drawing.Size(354, 502);
-            this.MetadataTabPage.TabIndex = 0;
-            resources.ApplyResources(this.MetadataTabPage, "MetadataTabPage");
-            //
+            // 
             // splitContainer2
-            //
+            // 
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer2.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitContainer2.Location = new System.Drawing.Point(3, 3);
             this.splitContainer2.Name = "splitContainer2";
             this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            //
+            // 
             // splitContainer2.Panel1
-            //
+            // 
             this.splitContainer2.Panel1.Controls.Add(this.MetaDataUpperLayoutPanel);
             this.splitContainer2.Panel1MinSize = 75;
-            //
+            // 
             // splitContainer2.Panel2
-            //
+            // 
             this.splitContainer2.Panel2.Controls.Add(this.ModInfoTabControl);
             this.splitContainer2.Panel2MinSize = 225;
-            this.splitContainer2.Size = new System.Drawing.Size(348, 496);
-            this.splitContainer2.SplitterWidth = 10;
-            this.splitContainer2.SplitterDistance = 235;
+            this.splitContainer2.Size = new System.Drawing.Size(483, 654);
+            this.splitContainer2.SplitterDistance = 309;
+            this.splitContainer2.SplitterWidth = 12;
             this.splitContainer2.TabIndex = 0;
-            //
+            // 
             // MetaDataUpperLayoutPanel
-            //
+            // 
             this.MetaDataUpperLayoutPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.MetaDataUpperLayoutPanel.ColumnCount = 1;
             this.MetaDataUpperLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -146,68 +124,106 @@
             this.MetaDataUpperLayoutPanel.Controls.Add(this.MetadataModuleDescriptionTextBox, 0, 3);
             this.MetaDataUpperLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetaDataUpperLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.MetaDataUpperLayoutPanel.Margin = new System.Windows.Forms.Padding(4);
             this.MetaDataUpperLayoutPanel.Name = "MetaDataUpperLayoutPanel";
             this.MetaDataUpperLayoutPanel.RowCount = 4;
-            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize, 20F));
-            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
-            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize, 30F));
+            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 39F));
+            this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.MetaDataUpperLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 80F));
-            this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(346, 283);
+            this.MetaDataUpperLayoutPanel.Size = new System.Drawing.Size(483, 309);
             this.MetaDataUpperLayoutPanel.TabIndex = 0;
-            //
+            // 
             // MetadataModuleNameTextBox
-            //
+            // 
+            this.MetadataModuleNameTextBox.BackColor = this.MetaDataUpperLayoutPanel.BackColor;
+            this.MetadataModuleNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.MetadataModuleNameTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetadataModuleNameTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MetadataModuleNameTextBox.Location = new System.Drawing.Point(3, 0);
-            this.MetadataModuleNameTextBox.Name = "MetadataModuleNameTextBox";
-            this.MetadataModuleNameTextBox.Size = new System.Drawing.Size(340, 46);
-            this.MetadataModuleNameTextBox.TabIndex = 0;
-            this.MetadataModuleNameTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.MetadataModuleNameTextBox.ReadOnly = true;
-            this.MetadataModuleNameTextBox.BackColor = MetaDataUpperLayoutPanel.BackColor;
             this.MetadataModuleNameTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataModuleNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataModuleNameTextBox, "MetadataModuleNameTextBox");
+            this.MetadataModuleNameTextBox.Location = new System.Drawing.Point(4, 4);
+            this.MetadataModuleNameTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataModuleNameTextBox.Multiline = true;
+            this.MetadataModuleNameTextBox.Name = "MetadataModuleNameTextBox";
+            this.MetadataModuleNameTextBox.ReadOnly = true;
+            this.MetadataModuleNameTextBox.Size = new System.Drawing.Size(475, 57);
+            this.MetadataModuleNameTextBox.TabIndex = 0;
+            this.MetadataModuleNameTextBox.Text = "Mod Name";
+            this.MetadataModuleNameTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // MetadataTagsLabelsPanel
             // 
             this.MetadataTagsLabelsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataTagsLabelsPanel.Padding = new System.Windows.Forms.Padding(0);
-            this.MetadataTagsLabelsPanel.Location = new System.Drawing.Point(0, 0);
+            this.MetadataTagsLabelsPanel.Location = new System.Drawing.Point(4, 69);
+            this.MetadataTagsLabelsPanel.Margin = new System.Windows.Forms.Padding(4);
             this.MetadataTagsLabelsPanel.Name = "MetadataTagsLabelsPanel";
-            this.MetadataTagsLabelsPanel.Size = new System.Drawing.Size(340, 12);
-            //
+            this.MetadataTagsLabelsPanel.Size = new System.Drawing.Size(475, 31);
+            this.MetadataTagsLabelsPanel.TabIndex = 1;
+            // 
             // MetadataModuleAbstractLabel
-            //
+            // 
+            this.MetadataModuleAbstractLabel.AutoSize = true;
             this.MetadataModuleAbstractLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetadataModuleAbstractLabel.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataModuleAbstractLabel.Location = new System.Drawing.Point(3, 49);
+            this.MetadataModuleAbstractLabel.Location = new System.Drawing.Point(4, 104);
+            this.MetadataModuleAbstractLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.MetadataModuleAbstractLabel.Name = "MetadataModuleAbstractLabel";
-            this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(340, 61);
-            this.MetadataModuleAbstractLabel.AutoSize = true;
+            this.MetadataModuleAbstractLabel.Size = new System.Drawing.Size(475, 17);
             this.MetadataModuleAbstractLabel.TabIndex = 27;
-            this.MetadataModuleAbstractLabel.Text = "";
-            //
+            // 
             // MetadataModuleDescriptionTextBox
-            //
-            this.MetadataModuleDescriptionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleDescriptionTextBox.Location = new System.Drawing.Point(3, 129);
-            this.MetadataModuleDescriptionTextBox.Name = "MetadataModuleDescriptionLabel";
-            this.MetadataModuleDescriptionTextBox.Size = new System.Drawing.Size(340, 121);
-            this.MetadataModuleDescriptionTextBox.TabIndex = 28;
-            this.MetadataModuleDescriptionTextBox.Text = "";
-            this.MetadataModuleDescriptionTextBox.ReadOnly = true;
-            this.MetadataModuleDescriptionTextBox.BackColor = MetaDataUpperLayoutPanel.BackColor;
-            this.MetadataModuleDescriptionTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            // 
+            this.MetadataModuleDescriptionTextBox.BackColor = this.MetaDataUpperLayoutPanel.BackColor;
             this.MetadataModuleDescriptionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            //
+            this.MetadataModuleDescriptionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleDescriptionTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleDescriptionTextBox.Location = new System.Drawing.Point(4, 125);
+            this.MetadataModuleDescriptionTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataModuleDescriptionTextBox.Multiline = true;
+            this.MetadataModuleDescriptionTextBox.Name = "MetadataModuleDescriptionTextBox";
+            this.MetadataModuleDescriptionTextBox.ReadOnly = true;
+            this.MetadataModuleDescriptionTextBox.Size = new System.Drawing.Size(475, 180);
+            this.MetadataModuleDescriptionTextBox.TabIndex = 28;
+            // 
+            // ModInfoTabControl
+            // 
+            this.ModInfoTabControl.Controls.Add(this.MetadataTabPage);
+            this.ModInfoTabControl.Controls.Add(this.RelationshipTabPage);
+            this.ModInfoTabControl.Controls.Add(this.ContentTabPage);
+            this.ModInfoTabControl.Controls.Add(this.AllModVersionsTabPage);
+            this.ModInfoTabControl.Controls.Add(this.ChangelogTab);
+            this.ModInfoTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ModInfoTabControl.DrawMode = System.Windows.Forms.TabDrawMode.OwnerDrawFixed;
+            this.ModInfoTabControl.Location = new System.Drawing.Point(0, 0);
+            this.ModInfoTabControl.Margin = new System.Windows.Forms.Padding(4);
+            this.ModInfoTabControl.Multiline = true;
+            this.ModInfoTabControl.Name = "ModInfoTabControl";
+            this.ModInfoTabControl.SelectedIndex = 0;
+            this.ModInfoTabControl.Size = new System.Drawing.Size(483, 333);
+            this.ModInfoTabControl.TabIndex = 1;
+            this.ModInfoTabControl.SelectedIndexChanged += new System.EventHandler(this.ModInfoIndexChanged);
+            // 
+            // MetadataTabPage
+            // 
+            this.MetadataTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.MetadataTabPage.Controls.Add(this.MetaDataLowerLayoutPanel);
+            this.MetadataTabPage.Location = new System.Drawing.Point(4, 25);
+            this.MetadataTabPage.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataTabPage.Name = "MetadataTabPage";
+            this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.MetadataTabPage.Size = new System.Drawing.Size(475, 304);
+            this.MetadataTabPage.TabIndex = 0;
+            this.MetadataTabPage.Text = "Metadata";
+            // 
             // MetaDataLowerLayoutPanel
-            //
+            // 
+            this.MetaDataLowerLayoutPanel.AutoScroll = true;
+            this.MetaDataLowerLayoutPanel.AutoScrollMinSize = new System.Drawing.Size(346, 255);
+            this.MetaDataLowerLayoutPanel.AutoSize = true;
             this.MetaDataLowerLayoutPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.MetaDataLowerLayoutPanel.ColumnCount = 2;
-            this.MetaDataLowerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 90F));
-            this.MetaDataLowerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.MetaDataLowerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 120F));
+            this.MetaDataLowerLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.MetaDataLowerLayoutPanel.Controls.Add(this.VersionLabel, 0, 0);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.LicenseLabel, 0, 1);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.AuthorLabel, 0, 2);
@@ -223,202 +239,212 @@
             this.MetaDataLowerLayoutPanel.Controls.Add(this.MetadataIdentifierTextBox, 1, 5);
             this.MetaDataLowerLayoutPanel.Controls.Add(this.ReplacementTextBox, 1, 6);
             this.MetaDataLowerLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetaDataLowerLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.MetaDataLowerLayoutPanel.Location = new System.Drawing.Point(4, 4);
+            this.MetaDataLowerLayoutPanel.Margin = new System.Windows.Forms.Padding(4);
             this.MetaDataLowerLayoutPanel.Name = "MetaDataLowerLayoutPanel";
-            this.MetaDataLowerLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 8, 0, 0);
+            this.MetaDataLowerLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
             this.MetaDataLowerLayoutPanel.RowCount = 7;
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetaDataLowerLayoutPanel.Size = new System.Drawing.Size(346, 255);
-            this.MetaDataLowerLayoutPanel.AutoSize = true;
-            this.MetaDataLowerLayoutPanel.AutoScroll = true;
-            this.MetaDataLowerLayoutPanel.AutoScrollMinSize = new System.Drawing.Size(MetaDataLowerLayoutPanel.Width, MetaDataLowerLayoutPanel.Height + 20);
-            this.MetaDataLowerLayoutPanel.VerticalScroll.Enabled = true;
-            this.MetaDataLowerLayoutPanel.HorizontalScroll.Enabled = true;
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.MetaDataLowerLayoutPanel.Size = new System.Drawing.Size(467, 296);
             this.MetaDataLowerLayoutPanel.TabIndex = 0;
-            //
-            // IdentifierLabel
-            //
-            this.IdentifierLabel.AutoSize = true;
-            this.IdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.IdentifierLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.IdentifierLabel.Location = new System.Drawing.Point(3, 210);
-            this.IdentifierLabel.Name = "IdentifierLabel";
-            this.IdentifierLabel.Size = new System.Drawing.Size(84, 20);
-            this.IdentifierLabel.TabIndex = 28;
-            resources.ApplyResources(this.IdentifierLabel, "IdentifierLabel");
-            //
-            // MetadataIdentifierTextBox
-            //
-            this.MetadataIdentifierTextBox.AutoSize = true;
-            this.MetadataIdentifierTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataIdentifierTextBox.Location = new System.Drawing.Point(93, 210);
-            this.MetadataIdentifierTextBox.Name = "MetadataIdentifierTextBox";
-            this.MetadataIdentifierTextBox.Size = new System.Drawing.Size(250, 20);
-            this.MetadataIdentifierTextBox.TabIndex = 27;
-            this.MetadataIdentifierTextBox.ReadOnly = true;
-            this.MetadataIdentifierTextBox.BackColor = MetadataTabPage.BackColor;
-            this.MetadataIdentifierTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataIdentifierTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataIdentifierTextBox, "MetadataIdentifierTextBox");
-            //
-            // ReplacementLabel
-            //
-            this.ReplacementLabel.AutoSize = true;
-            this.ReplacementLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReplacementLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.ReplacementLabel.Location = new System.Drawing.Point(3, 240);
-            this.ReplacementLabel.Name = "ReplacementLabel";
-            this.ReplacementLabel.Size = new System.Drawing.Size(84, 20);
-            this.ReplacementLabel.TabIndex = 28;
-            resources.ApplyResources(this.ReplacementLabel, "ReplacementLabel");
-            //
-            // ReplacementTextBox
-            //
-            this.ReplacementTextBox.AutoSize = true;
-            this.ReplacementTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReplacementTextBox.Location = new System.Drawing.Point(93, 240);
-            this.ReplacementTextBox.Name = "ReplacementTextBox";
-            this.ReplacementTextBox.Size = new System.Drawing.Size(250, 20);
-            this.ReplacementTextBox.TabIndex = 27;
-            this.ReplacementTextBox.ReadOnly = true;
-            this.ReplacementTextBox.BackColor = MetadataTabPage.BackColor;
-            this.ReplacementTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.ReplacementTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.ReplacementTextBox, "ReplacementTextBox");
-            //
-            // GameCompatibilityLabel
-            //
-            this.GameCompatibilityLabel.AutoSize = true;
-            this.GameCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GameCompatibilityLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.GameCompatibilityLabel.Location = new System.Drawing.Point(3, 180);
-            this.GameCompatibilityLabel.Name = "GameCompatibilityLabel";
-            this.GameCompatibilityLabel.Size = new System.Drawing.Size(84, 30);
-            this.GameCompatibilityLabel.TabIndex = 13;
-            resources.ApplyResources(this.GameCompatibilityLabel, "GameCompatibilityLabel");
-            //
-            // ReleaseLabel
-            //
-            this.ReleaseLabel.AutoSize = true;
-            this.ReleaseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReleaseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.ReleaseLabel.Location = new System.Drawing.Point(3, 150);
-            this.ReleaseLabel.Name = "ReleaseLabel";
-            this.ReleaseLabel.Size = new System.Drawing.Size(84, 30);
-            this.ReleaseLabel.TabIndex = 12;
-            resources.ApplyResources(this.ReleaseLabel, "ReleaseLabel");
-            //
-            // AuthorLabel
-            //
-            this.AuthorLabel.AutoSize = true;
-            this.AuthorLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AuthorLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.AuthorLabel.Location = new System.Drawing.Point(3, 60);
-            this.AuthorLabel.Name = "AuthorLabel";
-            this.AuthorLabel.Size = new System.Drawing.Size(84, 30);
-            this.AuthorLabel.TabIndex = 5;
-            resources.ApplyResources(this.AuthorLabel, "AuthorLabel");
-            //
-            // LicenseLabel
-            //
-            this.LicenseLabel.AutoSize = true;
-            this.LicenseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.LicenseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.LicenseLabel.Location = new System.Drawing.Point(3, 30);
-            this.LicenseLabel.Name = "LicenseLabel";
-            this.LicenseLabel.Size = new System.Drawing.Size(84, 30);
-            this.LicenseLabel.TabIndex = 3;
-            resources.ApplyResources(this.LicenseLabel, "LicenseLabel");
-            //
-            // MetadataModuleVersionTextBox
-            //
-            this.MetadataModuleVersionTextBox.AutoSize = true;
-            this.MetadataModuleVersionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleVersionTextBox.Location = new System.Drawing.Point(93, 0);
-            this.MetadataModuleVersionTextBox.Name = "MetadataModuleVersionTextBox";
-            this.MetadataModuleVersionTextBox.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleVersionTextBox.TabIndex = 2;
-            this.MetadataModuleVersionTextBox.ReadOnly = true;
-            this.MetadataModuleVersionTextBox.BackColor = MetadataTabPage.BackColor;
-            this.MetadataModuleVersionTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataModuleVersionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataModuleVersionTextBox, "MetadataModuleVersionTextBox");
-            //
-            // MetadataModuleLicenseTextBox
-            //
-            this.MetadataModuleLicenseTextBox.AutoSize = true;
-            this.MetadataModuleLicenseTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleLicenseTextBox.Location = new System.Drawing.Point(93, 30);
-            this.MetadataModuleLicenseTextBox.Name = "MetadataModuleLicenseTextBox";
-            this.MetadataModuleLicenseTextBox.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleLicenseTextBox.TabIndex = 4;
-            this.MetadataModuleLicenseTextBox.ReadOnly = true;
-            this.MetadataModuleLicenseTextBox.BackColor = MetadataTabPage.BackColor;
-            this.MetadataModuleLicenseTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataModuleLicenseTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataModuleLicenseTextBox, "MetadataModuleLicenseTextBox");
-            //
-            // MetadataModuleAuthorTextBox
-            //
-            this.MetadataModuleAuthorTextBox.AutoSize = true;
-            this.MetadataModuleAuthorTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleAuthorTextBox.Location = new System.Drawing.Point(93, 60);
-            this.MetadataModuleAuthorTextBox.Name = "MetadataModuleAuthorTextBox";
-            this.MetadataModuleAuthorTextBox.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleAuthorTextBox.TabIndex = 6;
-            this.MetadataModuleAuthorTextBox.ReadOnly = true;
-            this.MetadataModuleAuthorTextBox.BackColor = MetadataTabPage.BackColor;
-            this.MetadataModuleAuthorTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataModuleAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataModuleAuthorTextBox, "MetadataModuleAuthorTextBox");
-            //
+            // 
             // VersionLabel
-            //
+            // 
             this.VersionLabel.AutoSize = true;
             this.VersionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.VersionLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.VersionLabel.Location = new System.Drawing.Point(3, 0);
+            this.VersionLabel.Location = new System.Drawing.Point(4, 10);
+            this.VersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.VersionLabel.Name = "VersionLabel";
-            this.VersionLabel.Size = new System.Drawing.Size(84, 30);
+            this.VersionLabel.Size = new System.Drawing.Size(112, 37);
             this.VersionLabel.TabIndex = 1;
-            resources.ApplyResources(this.VersionLabel, "VersionLabel");
-            //
+            this.VersionLabel.Text = "Version:";
+            // 
+            // LicenseLabel
+            // 
+            this.LicenseLabel.AutoSize = true;
+            this.LicenseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.LicenseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.LicenseLabel.Location = new System.Drawing.Point(4, 47);
+            this.LicenseLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LicenseLabel.Name = "LicenseLabel";
+            this.LicenseLabel.Size = new System.Drawing.Size(112, 37);
+            this.LicenseLabel.TabIndex = 3;
+            this.LicenseLabel.Text = "Licence:";
+            // 
+            // AuthorLabel
+            // 
+            this.AuthorLabel.AutoSize = true;
+            this.AuthorLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.AuthorLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.AuthorLabel.Location = new System.Drawing.Point(4, 84);
+            this.AuthorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.AuthorLabel.Name = "AuthorLabel";
+            this.AuthorLabel.Size = new System.Drawing.Size(112, 37);
+            this.AuthorLabel.TabIndex = 5;
+            this.AuthorLabel.Text = "Author:";
+            // 
+            // ReleaseLabel
+            // 
+            this.ReleaseLabel.AutoSize = true;
+            this.ReleaseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ReleaseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.ReleaseLabel.Location = new System.Drawing.Point(4, 121);
+            this.ReleaseLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.ReleaseLabel.Name = "ReleaseLabel";
+            this.ReleaseLabel.Size = new System.Drawing.Size(112, 37);
+            this.ReleaseLabel.TabIndex = 12;
+            this.ReleaseLabel.Text = "Release status:";
+            // 
+            // GameCompatibilityLabel
+            // 
+            this.GameCompatibilityLabel.AutoSize = true;
+            this.GameCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.GameCompatibilityLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.GameCompatibilityLabel.Location = new System.Drawing.Point(4, 158);
+            this.GameCompatibilityLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.GameCompatibilityLabel.Name = "GameCompatibilityLabel";
+            this.GameCompatibilityLabel.Size = new System.Drawing.Size(112, 37);
+            this.GameCompatibilityLabel.TabIndex = 13;
+            this.GameCompatibilityLabel.Text = "Max game ver.:";
+            // 
+            // IdentifierLabel
+            // 
+            this.IdentifierLabel.AutoSize = true;
+            this.IdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.IdentifierLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.IdentifierLabel.Location = new System.Drawing.Point(4, 195);
+            this.IdentifierLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.IdentifierLabel.Name = "IdentifierLabel";
+            this.IdentifierLabel.Size = new System.Drawing.Size(112, 37);
+            this.IdentifierLabel.TabIndex = 28;
+            this.IdentifierLabel.Text = "Identifier:";
+            // 
+            // ReplacementLabel
+            // 
+            this.ReplacementLabel.AutoSize = true;
+            this.ReplacementLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ReplacementLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.ReplacementLabel.Location = new System.Drawing.Point(4, 232);
+            this.ReplacementLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.ReplacementLabel.Name = "ReplacementLabel";
+            this.ReplacementLabel.Size = new System.Drawing.Size(112, 64);
+            this.ReplacementLabel.TabIndex = 28;
+            this.ReplacementLabel.Text = "Replaced by:";
+            // 
+            // MetadataModuleVersionTextBox
+            // 
+            this.MetadataModuleVersionTextBox.BackColor = this.MetadataTabPage.BackColor;
+            this.MetadataModuleVersionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.MetadataModuleVersionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleVersionTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleVersionTextBox.Location = new System.Drawing.Point(124, 14);
+            this.MetadataModuleVersionTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataModuleVersionTextBox.Multiline = true;
+            this.MetadataModuleVersionTextBox.Name = "MetadataModuleVersionTextBox";
+            this.MetadataModuleVersionTextBox.ReadOnly = true;
+            this.MetadataModuleVersionTextBox.Size = new System.Drawing.Size(339, 29);
+            this.MetadataModuleVersionTextBox.TabIndex = 2;
+            this.MetadataModuleVersionTextBox.Text = "0.0.0";
+            // 
+            // MetadataModuleLicenseTextBox
+            // 
+            this.MetadataModuleLicenseTextBox.BackColor = this.MetadataTabPage.BackColor;
+            this.MetadataModuleLicenseTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.MetadataModuleLicenseTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleLicenseTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleLicenseTextBox.Location = new System.Drawing.Point(124, 51);
+            this.MetadataModuleLicenseTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataModuleLicenseTextBox.Multiline = true;
+            this.MetadataModuleLicenseTextBox.Name = "MetadataModuleLicenseTextBox";
+            this.MetadataModuleLicenseTextBox.ReadOnly = true;
+            this.MetadataModuleLicenseTextBox.Size = new System.Drawing.Size(339, 29);
+            this.MetadataModuleLicenseTextBox.TabIndex = 4;
+            this.MetadataModuleLicenseTextBox.Text = "None";
+            // 
+            // MetadataModuleAuthorTextBox
+            // 
+            this.MetadataModuleAuthorTextBox.BackColor = this.MetadataTabPage.BackColor;
+            this.MetadataModuleAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.MetadataModuleAuthorTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleAuthorTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleAuthorTextBox.Location = new System.Drawing.Point(124, 88);
+            this.MetadataModuleAuthorTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataModuleAuthorTextBox.Multiline = true;
+            this.MetadataModuleAuthorTextBox.Name = "MetadataModuleAuthorTextBox";
+            this.MetadataModuleAuthorTextBox.ReadOnly = true;
+            this.MetadataModuleAuthorTextBox.Size = new System.Drawing.Size(339, 29);
+            this.MetadataModuleAuthorTextBox.TabIndex = 6;
+            this.MetadataModuleAuthorTextBox.Text = "Nobody";
+            // 
             // MetadataModuleReleaseStatusTextBox
-            //
-            this.MetadataModuleReleaseStatusTextBox.AutoSize = true;
-            this.MetadataModuleReleaseStatusTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleReleaseStatusTextBox.Location = new System.Drawing.Point(93, 150);
-            this.MetadataModuleReleaseStatusTextBox.Name = "MetadataModuleReleaseStatusTextBox";
-            this.MetadataModuleReleaseStatusTextBox.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleReleaseStatusTextBox.TabIndex = 11;
-            this.MetadataModuleReleaseStatusTextBox.ReadOnly = true;
-            this.MetadataModuleReleaseStatusTextBox.BackColor = MetadataTabPage.BackColor;
-            this.MetadataModuleReleaseStatusTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            // 
+            this.MetadataModuleReleaseStatusTextBox.BackColor = this.MetadataTabPage.BackColor;
             this.MetadataModuleReleaseStatusTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataModuleReleaseStatusTextBox, "MetadataModuleReleaseStatusTextBox");
-            //
+            this.MetadataModuleReleaseStatusTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleReleaseStatusTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleReleaseStatusTextBox.Location = new System.Drawing.Point(124, 125);
+            this.MetadataModuleReleaseStatusTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataModuleReleaseStatusTextBox.Multiline = true;
+            this.MetadataModuleReleaseStatusTextBox.Name = "MetadataModuleReleaseStatusTextBox";
+            this.MetadataModuleReleaseStatusTextBox.ReadOnly = true;
+            this.MetadataModuleReleaseStatusTextBox.Size = new System.Drawing.Size(339, 29);
+            this.MetadataModuleReleaseStatusTextBox.TabIndex = 11;
+            this.MetadataModuleReleaseStatusTextBox.Text = "Stable";
+            // 
             // MetadataModuleGameCompatibilityTextBox
-            //
-            this.MetadataModuleGameCompatibilityTextBox.AutoSize = true;
-            this.MetadataModuleGameCompatibilityTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleGameCompatibilityTextBox.Location = new System.Drawing.Point(93, 180);
-            this.MetadataModuleGameCompatibilityTextBox.Name = "MetadataModuleGameCompatibilityTextBox";
-            this.MetadataModuleGameCompatibilityTextBox.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleGameCompatibilityTextBox.TabIndex = 14;
-            this.MetadataModuleGameCompatibilityTextBox.ReadOnly = true;
-            this.MetadataModuleGameCompatibilityTextBox.BackColor = MetadataTabPage.BackColor;
-            this.MetadataModuleGameCompatibilityTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            // 
+            this.MetadataModuleGameCompatibilityTextBox.BackColor = this.MetadataTabPage.BackColor;
             this.MetadataModuleGameCompatibilityTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataModuleGameCompatibilityTextBox, "MetadataModuleGameCompatibilityTextBox");
-            //
+            this.MetadataModuleGameCompatibilityTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataModuleGameCompatibilityTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataModuleGameCompatibilityTextBox.Location = new System.Drawing.Point(124, 162);
+            this.MetadataModuleGameCompatibilityTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataModuleGameCompatibilityTextBox.Multiline = true;
+            this.MetadataModuleGameCompatibilityTextBox.Name = "MetadataModuleGameCompatibilityTextBox";
+            this.MetadataModuleGameCompatibilityTextBox.ReadOnly = true;
+            this.MetadataModuleGameCompatibilityTextBox.Size = new System.Drawing.Size(339, 29);
+            this.MetadataModuleGameCompatibilityTextBox.TabIndex = 14;
+            this.MetadataModuleGameCompatibilityTextBox.Text = "0.0.0";
+            // 
+            // MetadataIdentifierTextBox
+            // 
+            this.MetadataIdentifierTextBox.BackColor = this.MetadataTabPage.BackColor;
+            this.MetadataIdentifierTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.MetadataIdentifierTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MetadataIdentifierTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.MetadataIdentifierTextBox.Location = new System.Drawing.Point(124, 199);
+            this.MetadataIdentifierTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.MetadataIdentifierTextBox.Multiline = true;
+            this.MetadataIdentifierTextBox.Name = "MetadataIdentifierTextBox";
+            this.MetadataIdentifierTextBox.ReadOnly = true;
+            this.MetadataIdentifierTextBox.Size = new System.Drawing.Size(339, 29);
+            this.MetadataIdentifierTextBox.TabIndex = 27;
+            this.MetadataIdentifierTextBox.Text = "-";
+            // 
+            // ReplacementTextBox
+            // 
+            this.ReplacementTextBox.BackColor = this.MetadataTabPage.BackColor;
+            this.ReplacementTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.ReplacementTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ReplacementTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.ReplacementTextBox.Location = new System.Drawing.Point(124, 236);
+            this.ReplacementTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.ReplacementTextBox.Multiline = true;
+            this.ReplacementTextBox.Name = "ReplacementTextBox";
+            this.ReplacementTextBox.ReadOnly = true;
+            this.ReplacementTextBox.Size = new System.Drawing.Size(339, 56);
+            this.ReplacementTextBox.TabIndex = 27;
+            this.ReplacementTextBox.Text = "-";
+            // 
             // RelationshipTabPage
-            //
+            // 
             this.RelationshipTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.RelationshipTabPage.Controls.Add(this.DependsGraphTree);
             this.RelationshipTabPage.Controls.Add(this.LegendDependsImage);
@@ -432,217 +458,279 @@
             this.RelationshipTabPage.Controls.Add(this.LegendSupportsLabel);
             this.RelationshipTabPage.Controls.Add(this.LegendConflictsLabel);
             this.RelationshipTabPage.Location = new System.Drawing.Point(4, 25);
+            this.RelationshipTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.RelationshipTabPage.Name = "RelationshipTabPage";
-            this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.RelationshipTabPage.Size = new System.Drawing.Size(354, 502);
+            this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.RelationshipTabPage.Size = new System.Drawing.Size(475, 304);
             this.RelationshipTabPage.TabIndex = 1;
-            resources.ApplyResources(this.RelationshipTabPage, "RelationshipTabPage");
-            //
+            this.RelationshipTabPage.Text = "Relationships";
+            // 
             // DependsGraphTree
-            //
-            this.DependsGraphTree.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.DependsGraphTree.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.DependsGraphTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.DependsGraphTree.Location = new System.Drawing.Point(3, 96);
+            this.DependsGraphTree.Location = new System.Drawing.Point(4, 118);
+            this.DependsGraphTree.Margin = new System.Windows.Forms.Padding(4);
             this.DependsGraphTree.Name = "DependsGraphTree";
-            this.DependsGraphTree.Size = new System.Drawing.Size(345, 400);
+            this.DependsGraphTree.ShowNodeToolTips = true;
+            this.DependsGraphTree.Size = new System.Drawing.Size(478, 516);
             this.DependsGraphTree.TabIndex = 0;
             this.DependsGraphTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.DependsGraphTree_NodeMouseDoubleClick);
-            this.DependsGraphTree.ShowNodeToolTips = true;
-            this.DependsGraphTree.ImageList = new System.Windows.Forms.ImageList()
-            {
-                // ImageList's default makes icons look like garbage
-                ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit
-            };
-            this.DependsGraphTree.ImageList.Images.Add("Root", global::CKAN.Properties.Resources.ksp);
-            this.DependsGraphTree.ImageList.Images.Add("Depends", global::CKAN.Properties.Resources.star);
-            this.DependsGraphTree.ImageList.Images.Add("Recommends", global::CKAN.Properties.Resources.thumbup);
-            this.DependsGraphTree.ImageList.Images.Add("Suggests", global::CKAN.Properties.Resources.info);
-            this.DependsGraphTree.ImageList.Images.Add("Supports", global::CKAN.Properties.Resources.smile);
-            this.DependsGraphTree.ImageList.Images.Add("Conflicts", global::CKAN.Properties.Resources.alert);
-            //
+            // 
             // LegendDependsImage
-            //
+            // 
             this.LegendDependsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendDependsImage.Image = global::CKAN.Properties.Resources.star;
-            this.LegendDependsImage.Location = new System.Drawing.Point(6, 3);
+            this.LegendDependsImage.Location = new System.Drawing.Point(8, 4);
+            this.LegendDependsImage.Margin = new System.Windows.Forms.Padding(4);
+            this.LegendDependsImage.Name = "LegendDependsImage";
+            this.LegendDependsImage.Size = new System.Drawing.Size(19, 17);
             this.LegendDependsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.LegendDependsImage.ClientSize = new System.Drawing.Size(14, 14);
-            //
+            this.LegendDependsImage.TabIndex = 1;
+            this.LegendDependsImage.TabStop = false;
+            // 
             // LegendRecommendsImage
-            //
+            // 
             this.LegendRecommendsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendRecommendsImage.Image = global::CKAN.Properties.Resources.thumbup;
-            this.LegendRecommendsImage.Location = new System.Drawing.Point(6, 21);
+            this.LegendRecommendsImage.Location = new System.Drawing.Point(8, 26);
+            this.LegendRecommendsImage.Margin = new System.Windows.Forms.Padding(4);
+            this.LegendRecommendsImage.Name = "LegendRecommendsImage";
+            this.LegendRecommendsImage.Size = new System.Drawing.Size(19, 17);
             this.LegendRecommendsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.LegendRecommendsImage.ClientSize = new System.Drawing.Size(14, 14);
-            //
+            this.LegendRecommendsImage.TabIndex = 2;
+            this.LegendRecommendsImage.TabStop = false;
+            // 
             // LegendSuggestsImage
-            //
+            // 
             this.LegendSuggestsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendSuggestsImage.Image = global::CKAN.Properties.Resources.info;
-            this.LegendSuggestsImage.Location = new System.Drawing.Point(6, 39);
+            this.LegendSuggestsImage.Location = new System.Drawing.Point(8, 48);
+            this.LegendSuggestsImage.Margin = new System.Windows.Forms.Padding(4);
+            this.LegendSuggestsImage.Name = "LegendSuggestsImage";
+            this.LegendSuggestsImage.Size = new System.Drawing.Size(19, 17);
             this.LegendSuggestsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.LegendSuggestsImage.ClientSize = new System.Drawing.Size(14, 14);
-            //
+            this.LegendSuggestsImage.TabIndex = 3;
+            this.LegendSuggestsImage.TabStop = false;
+            // 
             // LegendSupportsImage
-            //
+            // 
             this.LegendSupportsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendSupportsImage.Image = global::CKAN.Properties.Resources.smile;
-            this.LegendSupportsImage.Location = new System.Drawing.Point(6, 57);
+            this.LegendSupportsImage.Location = new System.Drawing.Point(8, 70);
+            this.LegendSupportsImage.Margin = new System.Windows.Forms.Padding(4);
+            this.LegendSupportsImage.Name = "LegendSupportsImage";
+            this.LegendSupportsImage.Size = new System.Drawing.Size(19, 17);
             this.LegendSupportsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.LegendSupportsImage.ClientSize = new System.Drawing.Size(14, 14);
-            //
+            this.LegendSupportsImage.TabIndex = 4;
+            this.LegendSupportsImage.TabStop = false;
+            // 
             // LegendConflictsImage
-            //
+            // 
             this.LegendConflictsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendConflictsImage.Image = global::CKAN.Properties.Resources.alert;
-            this.LegendConflictsImage.Location = new System.Drawing.Point(6, 75);
+            this.LegendConflictsImage.Location = new System.Drawing.Point(8, 92);
+            this.LegendConflictsImage.Margin = new System.Windows.Forms.Padding(4);
+            this.LegendConflictsImage.Name = "LegendConflictsImage";
+            this.LegendConflictsImage.Size = new System.Drawing.Size(19, 17);
             this.LegendConflictsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.LegendConflictsImage.ClientSize = new System.Drawing.Size(14, 14);
-            //
+            this.LegendConflictsImage.TabIndex = 5;
+            this.LegendConflictsImage.TabStop = false;
+            // 
             // LegendDependsLabel
-            //
+            // 
             this.LegendDependsLabel.AutoSize = true;
-            this.LegendDependsLabel.Location = new System.Drawing.Point(24, 3);
-            resources.ApplyResources(this.LegendDependsLabel, "LegendDependsLabel");
-            //
+            this.LegendDependsLabel.Location = new System.Drawing.Point(32, 4);
+            this.LegendDependsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LegendDependsLabel.Name = "LegendDependsLabel";
+            this.LegendDependsLabel.Size = new System.Drawing.Size(65, 17);
+            this.LegendDependsLabel.TabIndex = 6;
+            this.LegendDependsLabel.Text = "Depends";
+            // 
             // LegendRecommendsLabel
-            //
+            // 
             this.LegendRecommendsLabel.AutoSize = true;
-            this.LegendRecommendsLabel.Location = new System.Drawing.Point(24, 21);
-            resources.ApplyResources(this.LegendRecommendsLabel, "LegendRecommendsLabel");
-            //
+            this.LegendRecommendsLabel.Location = new System.Drawing.Point(32, 26);
+            this.LegendRecommendsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LegendRecommendsLabel.Name = "LegendRecommendsLabel";
+            this.LegendRecommendsLabel.Size = new System.Drawing.Size(94, 17);
+            this.LegendRecommendsLabel.TabIndex = 7;
+            this.LegendRecommendsLabel.Text = "Recommends";
+            // 
             // LegendSuggestsLabel
-            //
+            // 
             this.LegendSuggestsLabel.AutoSize = true;
-            this.LegendSuggestsLabel.Location = new System.Drawing.Point(24, 39);
-            resources.ApplyResources(this.LegendSuggestsLabel, "LegendSuggestsLabel");
-            //
+            this.LegendSuggestsLabel.Location = new System.Drawing.Point(32, 48);
+            this.LegendSuggestsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LegendSuggestsLabel.Name = "LegendSuggestsLabel";
+            this.LegendSuggestsLabel.Size = new System.Drawing.Size(67, 17);
+            this.LegendSuggestsLabel.TabIndex = 8;
+            this.LegendSuggestsLabel.Text = "Suggests";
+            // 
             // LegendSupportsLabel
-            //
+            // 
             this.LegendSupportsLabel.AutoSize = true;
-            this.LegendSupportsLabel.Location = new System.Drawing.Point(24, 57);
-            resources.ApplyResources(this.LegendSupportsLabel, "LegendSupportsLabel");
-            //
+            this.LegendSupportsLabel.Location = new System.Drawing.Point(32, 70);
+            this.LegendSupportsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LegendSupportsLabel.Name = "LegendSupportsLabel";
+            this.LegendSupportsLabel.Size = new System.Drawing.Size(65, 17);
+            this.LegendSupportsLabel.TabIndex = 9;
+            this.LegendSupportsLabel.Text = "Supports";
+            // 
             // LegendConflictsLabel
-            //
+            // 
             this.LegendConflictsLabel.AutoSize = true;
-            this.LegendConflictsLabel.Location = new System.Drawing.Point(24, 75);
-            resources.ApplyResources(this.LegendConflictsLabel, "LegendConflictsLabel");
-            //
+            this.LegendConflictsLabel.Location = new System.Drawing.Point(32, 92);
+            this.LegendConflictsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LegendConflictsLabel.Name = "LegendConflictsLabel";
+            this.LegendConflictsLabel.Size = new System.Drawing.Size(61, 17);
+            this.LegendConflictsLabel.TabIndex = 10;
+            this.LegendConflictsLabel.Text = "Conflicts";
+            // 
             // ContentTabPage
-            //
+            // 
             this.ContentTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.ContentTabPage.Controls.Add(this.ContentsPreviewTree);
             this.ContentTabPage.Controls.Add(this.ContentsDownloadButton);
             this.ContentTabPage.Controls.Add(this.ContentsOpenButton);
             this.ContentTabPage.Controls.Add(this.NotCachedLabel);
             this.ContentTabPage.Location = new System.Drawing.Point(4, 25);
+            this.ContentTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ContentTabPage.Name = "ContentTabPage";
-            this.ContentTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.ContentTabPage.Size = new System.Drawing.Size(354, 502);
+            this.ContentTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.ContentTabPage.Size = new System.Drawing.Size(475, 304);
             this.ContentTabPage.TabIndex = 2;
-            resources.ApplyResources(this.ContentTabPage, "ContentTabPage");
-            //
+            this.ContentTabPage.Text = "Contents";
+            // 
             // ContentsPreviewTree
-            //
-            this.ContentsPreviewTree.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.ContentsPreviewTree.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ContentsPreviewTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.ContentsPreviewTree.Enabled = false;
+            this.ContentsPreviewTree.Indent = 12;
+            this.ContentsPreviewTree.Location = new System.Drawing.Point(8, 80);
+            this.ContentsPreviewTree.Margin = new System.Windows.Forms.Padding(4);
+            this.ContentsPreviewTree.Name = "ContentsPreviewTree";
             this.ContentsPreviewTree.ShowPlusMinus = false;
             this.ContentsPreviewTree.ShowRootLines = false;
-            this.ContentsPreviewTree.Indent = 12;
-            this.ContentsPreviewTree.Enabled = false;
-            this.ContentsPreviewTree.Location = new System.Drawing.Point(6, 65);
-            this.ContentsPreviewTree.Name = "ContentsPreviewTree";
-            this.ContentsPreviewTree.Size = new System.Drawing.Size(342, 434);
+            this.ContentsPreviewTree.Size = new System.Drawing.Size(474, 558);
             this.ContentsPreviewTree.TabIndex = 2;
             this.ContentsPreviewTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.ContentsPreviewTree_NodeMouseDoubleClick);
-            //
+            // 
             // ContentsDownloadButton
-            //
+            // 
             this.ContentsDownloadButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ContentsDownloadButton.Location = new System.Drawing.Point(6, 36);
+            this.ContentsDownloadButton.Location = new System.Drawing.Point(8, 44);
+            this.ContentsDownloadButton.Margin = new System.Windows.Forms.Padding(4);
             this.ContentsDownloadButton.Name = "ContentsDownloadButton";
-            this.ContentsDownloadButton.Size = new System.Drawing.Size(103, 23);
+            this.ContentsDownloadButton.Size = new System.Drawing.Size(137, 28);
             this.ContentsDownloadButton.TabIndex = 1;
+            this.ContentsDownloadButton.Text = "Download";
             this.ContentsDownloadButton.UseVisualStyleBackColor = true;
             this.ContentsDownloadButton.Click += new System.EventHandler(this.ContentsDownloadButton_Click);
-            resources.ApplyResources(this.ContentsDownloadButton, "ContentsDownloadButton");
-            //
+            // 
             // ContentsOpenButton
-            //
+            // 
             this.ContentsOpenButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ContentsOpenButton.Location = new System.Drawing.Point(115, 36);
+            this.ContentsOpenButton.Location = new System.Drawing.Point(153, 44);
+            this.ContentsOpenButton.Margin = new System.Windows.Forms.Padding(4);
             this.ContentsOpenButton.Name = "ContentsOpenButton";
-            this.ContentsOpenButton.Size = new System.Drawing.Size(103, 23);
+            this.ContentsOpenButton.Size = new System.Drawing.Size(137, 28);
             this.ContentsOpenButton.TabIndex = 1;
+            this.ContentsOpenButton.Text = "Open ZIP";
             this.ContentsOpenButton.UseVisualStyleBackColor = true;
             this.ContentsOpenButton.Click += new System.EventHandler(this.ContentsOpenButton_Click);
-            resources.ApplyResources(this.ContentsOpenButton, "ContentsOpenButton");
-            //
+            // 
             // NotCachedLabel
-            //
-            this.NotCachedLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.NotCachedLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.NotCachedLabel.Location = new System.Drawing.Point(6, 3);
+            this.NotCachedLabel.Location = new System.Drawing.Point(8, 4);
+            this.NotCachedLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.NotCachedLabel.Name = "NotCachedLabel";
-            this.NotCachedLabel.Size = new System.Drawing.Size(342, 434);
+            this.NotCachedLabel.Size = new System.Drawing.Size(475, 558);
             this.NotCachedLabel.TabIndex = 0;
-            resources.ApplyResources(this.NotCachedLabel, "NotCachedLabel");
-            //
+            this.NotCachedLabel.Text = "This mod is not in the cache, click \'Download\' to preview contents";
+            // 
             // AllModVersionsTabPage
-            //
+            // 
             this.AllModVersionsTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.AllModVersionsTabPage.Controls.Add(this.AllModVersions);
             this.AllModVersionsTabPage.Location = new System.Drawing.Point(4, 25);
-            this.AllModVersionsTabPage.Margin = new System.Windows.Forms.Padding(2);
+            this.AllModVersionsTabPage.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.AllModVersionsTabPage.Name = "AllModVersionsTabPage";
-            this.AllModVersionsTabPage.Size = new System.Drawing.Size(354, 502);
+            this.AllModVersionsTabPage.Size = new System.Drawing.Size(475, 304);
             this.AllModVersionsTabPage.TabIndex = 1;
-            resources.ApplyResources(this.AllModVersionsTabPage, "AllModVersionsTabPage");
-            //
+            this.AllModVersionsTabPage.Text = "Versions";
+            // 
             // AllModVersions
-            //
+            // 
             this.AllModVersions.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AllModVersions.Location = new System.Drawing.Point(0, 0);
-            this.AllModVersions.Margin = new System.Windows.Forms.Padding(2);
+            this.AllModVersions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.AllModVersions.Name = "AllModVersions";
-            this.AllModVersions.Size = new System.Drawing.Size(354, 502);
+            this.AllModVersions.Size = new System.Drawing.Size(475, 304);
             this.AllModVersions.TabIndex = 0;
-            //
+            // 
+            // ChangelogTab
+            // 
+            this.ChangelogTab.Controls.Add(this.changelogs1);
+            this.ChangelogTab.Location = new System.Drawing.Point(4, 25);
+            this.ChangelogTab.Name = "ChangelogTab";
+            this.ChangelogTab.Padding = new System.Windows.Forms.Padding(3);
+            this.ChangelogTab.Size = new System.Drawing.Size(475, 304);
+            this.ChangelogTab.TabIndex = 3;
+            this.ChangelogTab.Text = "Changelogs";
+            this.ChangelogTab.UseVisualStyleBackColor = true;
+            // 
+            // changelogs1
+            // 
+            this.changelogs1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.changelogs1.Location = new System.Drawing.Point(0, 0);
+            this.changelogs1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.changelogs1.Name = "changelogs1";
+            this.changelogs1.Size = new System.Drawing.Size(475, 304);
+            this.changelogs1.TabIndex = 0;
+            // 
             // ModInfo
-            //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.splitContainer2);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "ModInfo";
-            this.Size = new System.Drawing.Size(362, 531);
-            resources.ApplyResources(this, "$this");
-            this.ModInfoTabControl.ResumeLayout(false);
-            this.MetadataTabPage.ResumeLayout(false);
+            this.Size = new System.Drawing.Size(483, 654);
             this.splitContainer2.Panel1.ResumeLayout(false);
             this.splitContainer2.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
             this.splitContainer2.ResumeLayout(false);
             this.MetaDataUpperLayoutPanel.ResumeLayout(false);
+            this.MetaDataUpperLayoutPanel.PerformLayout();
+            this.ModInfoTabControl.ResumeLayout(false);
+            this.MetadataTabPage.ResumeLayout(false);
+            this.MetadataTabPage.PerformLayout();
             this.MetaDataLowerLayoutPanel.ResumeLayout(false);
             this.MetaDataLowerLayoutPanel.PerformLayout();
             this.RelationshipTabPage.ResumeLayout(false);
+            this.RelationshipTabPage.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendDependsImage)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendRecommendsImage)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendSuggestsImage)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendSupportsImage)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LegendConflictsImage)).EndInit();
             this.ContentTabPage.ResumeLayout(false);
-            this.AllModVersions.ResumeLayout(false);
             this.AllModVersionsTabPage.ResumeLayout(false);
+            this.ChangelogTab.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.PerformLayout();
+
         }
 
         #endregion
-
-        private System.Windows.Forms.TabControl ModInfoTabControl;
         private System.Windows.Forms.TabPage MetadataTabPage;
         private System.Windows.Forms.SplitContainer splitContainer2;
         private System.Windows.Forms.TableLayoutPanel MetaDataUpperLayoutPanel;
@@ -684,5 +772,8 @@
         private System.Windows.Forms.Label NotCachedLabel;
         private System.Windows.Forms.TabPage AllModVersionsTabPage;
         private AllModVersions AllModVersions;
+        private System.Windows.Forms.TabPage ChangelogTab;
+        private ThemedTabControl ModInfoTabControl;
+        private Changelogs changelogs1;
     }
 }

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -50,6 +50,7 @@ namespace CKAN
                         UpdateModDependencyGraph(module);
                         UpdateModContentsTree(module);
                         AllModVersions.SelectedModule = value;
+                        changelogs1.SelectedModule = value;
                     }
                     selectedModule = value;
                 }


### PR DESCRIPTION
I wanted to see the changelog of updated modules.
This change shows changelogs (well, a list of release notes) from github based repositories.
It checks the module repository and if it is github.com then it loads releases info from github api.
Current limitations:
- it can only load release notes from github
- it is subject to rate limiting by github api (60req/h/IP) without a token, I can use my personal token for development, getting 5000req/hour but I am not sure if such limit would be reasonable for release usage

Todo:
- [x] Add some kind of caching - cache response json per repo in memory could be enough, with some etag check or something similar to be able to invalidate without restart
- [x] Do not load the changelog automatically but instead add a button (only for supported repos) or info (for unsupported repos)
- [x] After ^ maybe load changelogs automatically for mods which have an update available
- [ ] Format the changelog text in some way - at least show current version in bold and highlight newer available versions
- [ ] try other sources - it might be possible to scrap data from https://spacedock.info/mod/918/Deflatable%20Heat%20Shield#changelog or https://forum.kerbalspaceprogram.com/index.php?/topic/64987-18x-110x-smokescreen-2814-extended-fx-plugin-18-april-2020/ etc