### PR TITLE
Internal .ckan file compatibility with bundled mods

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -336,7 +336,10 @@ namespace CKAN
                     .ToHashSet();
                 var files = FindInstallableFiles(module, zipfile, ksp)
                     .Where(instF => !filters.Any(filt =>
-                        instF.destination.Contains(filt)))
+                                        instF.destination.Contains(filt))
+                                    // Skip the file if it's a ckan file, these should never be copied to GameData
+                                    && !instF.source.Name.EndsWith(
+                                        ".ckan", StringComparison.InvariantCultureIgnoreCase))
                     .ToList();
 
                 try

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -63,9 +63,6 @@ namespace CKAN
         [JsonIgnore]
         private Regex inst_pattern = null;
 
-        private static Regex ckanPattern = new Regex(".ckan$",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         private static Regex trailingSlashPattern = new Regex("/$",
             RegexOptions.Compiled);
 
@@ -272,12 +269,6 @@ namespace CKAN
             else if (matchWhere.HasValue && match.Index != matchWhere.Value)
             {
                 // Matches too late in the string, not our folder
-                return false;
-            }
-
-            // Skip the file if it's a ckan file, these should never be copied to GameData.
-            if (ckanPattern.IsMatch(normalised_path))
-            {
                 return false;
             }
 

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -10,7 +10,7 @@ namespace CKAN.NetKAN.Services
     {
         Tuple<ZipEntry, bool> FindInternalAvc(CkanModule module, ZipFile zipfile, string internalFilePath);
         AvcVersion GetInternalAvc(CkanModule module, string filePath, string internalFilePath = null);
-        JObject GetInternalCkan(string filePath);
+        JObject GetInternalCkan(CkanModule module, string zipPath, GameInstance inst);
         bool HasInstallableFiles(CkanModule module, string filePath);
 
         IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip, GameInstance inst);

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using log4net;
+
 using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
+using CKAN.Games;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -32,9 +34,10 @@ namespace CKAN.NetKAN.Transformers
             {
                 var json = metadata.Json();
 
-                string file = _http.DownloadModule(metadata);
+                CkanModule mod = CkanModule.FromJson(json.ToString());
+                GameInstance inst = new GameInstance(new KerbalSpaceProgram(), "/", "dummy", new NullUser());
 
-                var internalJson = _moduleService.GetInternalCkan(file);
+                var internalJson = _moduleService.GetInternalCkan(mod, _http.DownloadModule(metadata), inst);
 
                 if (internalJson != null)
                 {

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -188,6 +188,10 @@ namespace Tests.Data
                         ""install_to"": ""GameData"",
                         ""filter"" : [ ""Thumbs.db"", ""README.md"" ],
                         ""filter_regexp"" : ""\\.bak$""
+                        },
+                        {
+                        ""file"": ""DogeCoinFlag-1.01/META.ckan"",
+                        ""install_to"": ""GameData""
                         }
                     ],
                     ""resources"": {

--- a/Tests/NetKAN/Services/ModuleServiceTests.cs
+++ b/Tests/NetKAN/Services/ModuleServiceTests.cs
@@ -1,9 +1,12 @@
-using CKAN;
-using CKAN.NetKAN.Services;
-using CKAN.Versioning;
+using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Tests.Data;
+
+using CKAN;
+using CKAN.NetKAN.Services;
+using CKAN.Versioning;
+using CKAN.Games;
 
 namespace Tests.NetKAN.Services
 {
@@ -52,9 +55,11 @@ namespace Tests.NetKAN.Services
         {
             // Arrange
             var sut = new ModuleService();
+            CkanModule mod = CkanModule.FromJson(TestData.DogeCoinFlag_101());
+            GameInstance inst = new GameInstance(new KerbalSpaceProgram(), "/", "dummy", new NullUser());
 
             // Act
-            var result = sut.GetInternalCkan(TestData.DogeCoinFlagZip());
+            var result = sut.GetInternalCkan(mod, TestData.DogeCoinFlagZip(), inst);
 
             // Assert
             Assert.That(result, Is.Not.Null,

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Linq;
+
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using ICSharpCode.SharpZipLib.Zip;
+
+using CKAN;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Transformers;
@@ -15,7 +19,7 @@ namespace Tests.NetKAN.Transformers
         private TransformOptions opts = new TransformOptions(1, null, null, false, null);
 
         [Test]
-        public void AddsMiddingProperties()
+        public void AddsMissingProperties()
         {
             // Arrange
             const string filePath = "/DoesNotExist.zip";
@@ -30,13 +34,17 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
-            mModuleService.Setup(i => i.GetInternalCkan(filePath))
+            mModuleService.Setup(i => i.GetInternalCkan(
+                    It.IsAny<CkanModule>(), It.IsAny<string>(),
+                    It.IsAny<GameInstance>()))
                 .Returns(internalCkan);
 
             var sut = new InternalCkanTransformer(mHttp.Object, mModuleService.Object);
 
             var json = new JObject();
             json["spec_version"] = 1;
+            json["identifier"] = "DoesNotExist";
+            json["version"] = "1.0";
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act
@@ -65,13 +73,17 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
-            mModuleService.Setup(i => i.GetInternalCkan(filePath))
+            mModuleService.Setup(i => i.GetInternalCkan(
+                    It.IsAny<CkanModule>(), It.IsAny<string>(),
+                    It.IsAny<GameInstance>()))
                 .Returns(internalCkan);
 
             var sut = new InternalCkanTransformer(mHttp.Object, mModuleService.Object);
 
             var json = new JObject();
             json["spec_version"] = 1;
+            json["identifier"] = "DoesNotExist";
+            json["version"] = "1.0";
             json["foo"] = "baz";
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
@@ -103,13 +115,17 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
-            mModuleService.Setup(i => i.GetInternalCkan(filePath))
+            mModuleService.Setup(i => i.GetInternalCkan(
+                    It.IsAny<CkanModule>(), It.IsAny<string>(),
+                    It.IsAny<GameInstance>()))
                 .Returns(internalCkan);
 
             var sut = new InternalCkanTransformer(mHttp.Object, mModuleService.Object);
 
             var json = new JObject();
             json["spec_version"] = specVersion;
+            json["identifier"] = "DoesNotExist";
+            json["version"] = "1.0";
             json["download"] = "https://awesomemod.example/AwesomeMod.zip";
 
             // Act


### PR DESCRIPTION
## Background

If a mod author puts a file with a `.ckan` extension in a mod's ZIP, Netkan automatically parses the file as YAML or JSON and merges its properties into the inflated output .ckan file, as if they were part of the .netkan (but the main .netkan takes precedence). This is extremely convenient for properties that can change from one release to the next, such as relationships, since no NetKAN pull request is needed and the concerns about whether to merge a pull request before or after the release is uploaded are mooted. In effect, the main netkan tells us how to download the mod, and the internal .ckan file describes what's inside it. It's a nice model, and I use it for most or all of my own mods, if I'm not mistaken.

For more details:

- https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#internal-ckan-files
- https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-mod-to-the-CKAN#internal-ckan-files

## Problems

As far as I know it hasn't happened yet, but the internal .ckan file finding logic has a structural conflict with a common practice for packaging mods:

- Suppose Mod1 has an internal .ckan file specifying some of its metadata (because it's very convenient)
- Suppose the author of Mod2 chooses to "bundle" Mod1, meaning that Mod2's ZIP has a `GameData/Mod1` folder containing everything in Mod1's ZIP, _including the internal .ckan file_

If we were asked to index Mod2, its metadata would be polluted by metadata intended for Mod1 from the internal .ckan file, because we search the whole ZIP file for internal .ckan files. Our options to work around this would be very limited: Ask the author of Mod2 to remove Mod1's internal .ckan file from Mod2's ZIP, explicitly override every property the internal .ckan file sets in the netkan, or don't index Mod2.

We need some way to turn off or control an internal .ckan file.

## Additional motivation

In the PRs linked from KSP-CKAN/NetKAN#9239, we added several "Extra" modules from alternate paths of Spectra's main ZIP file:

![image](https://user-images.githubusercontent.com/1559108/181301545-c77d548d-9041-47c4-a50d-b864341d678a.png)

The author @Avera9eJoe would like to be able to control the relationships more easily than with a pull request. Internal .ckan files would be great for this, **except** that they are global; all six modules sharing the ZIP would also share everything in the one shared internal .ckan file, despite being different modules with different functional requirements. Ideally each of those submodule subfolders would be able to have its own `VibrantSunsets.ckan` or `MinmusScatterer.ckan` etc. file, and Netkan would be smart enough to only apply the right metadata to the right modules.

## Changes

- Now `ModuleInstallDescriptor.IsWanted` is no longer hard coded to skip all files with names ending in `.ckan`; instead, this duty is moved to `ModuleInstaller.InstallModule`. This is necessary so other code can use `ModuleInstaller.FindInstallableFiles` to find a `.ckan` file that matches the install stanzas.
- Now `IModuleService.GetInternalCkan` has new parameters for a `CkanModule` and a `GameInstance`, which it needs to be able to determine which files would be installed from the ZIP.
  (The ideal signature of this function would use a `ZipFile` instead of a `string`, but we have four tests that need to call it without a ZIP file using mocked components, so keeping the `string` works better for now.)
- Now if a module has an `install` property, `ModuleService.GetInternalCkan` will only consider `.ckan` files that match the install stanzas. If there is no `install` property, the whole ZIP is searched, as before. This provides a way to select which internal .ckan files are used by which modules sharing a ZIP.
- Several tests are updated to work with this new API and to account for installing the sample .ckan file.

After merge, I will watch the bot to see if it makes any undesirable changes to indexed modules, in the form of metadata from internal .ckan files vanishing suddenly. If so, I will amend the `install` stanzas of the affected modules to install the `.ckan` files so their metadata will be reapplied.

### Known limitation

Lacking an `install` property doesn't mean we won't install anything. We have a default install stanza that finds a folder matching the identifier and installs it to GameData. So if a mod intentionally uses the default install stanza (as mine do), the old whole-ZIP search will remain in effect, meaning that Netkan will be able to import metadata from internal .ckan files that would not match the default install stanza.

It's also possible to specify the `install` property _inside the internal .ckan file_. Again this represents a case where the internal .ckan file might not match the install stanzas. I assume that someone doing this knows what they are doing. :crossed_fingers: 
