### PR TITLE
Create a system menu entry for command prompt

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -22,6 +22,8 @@ DESKTOPSRC:=ckan.desktop
 DESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan.desktop
 CONSOLEUIDESKTOPSRC:=ckan-consoleui.desktop
 CONSOLEUIDESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan-consoleui.desktop
+CMDPROMPTDESKTOPSRC:=ckan-cmdprompt.desktop
+CMDPROMPTDESKTOPDEST:=$(DESTDIR)/usr/share/applications/ckan-cmdprompt.desktop
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' ).$(shell date +'%g%j')
 DEB:=../_build/deb/ckan_$(VERSION)_all.deb
 
@@ -80,7 +82,7 @@ $(INRELEASE): $(DISTRELEASEDEST)
 $(SIGNEDDISTRELEASEDEST): $(DISTRELEASEDEST)
 	gpg -abs -o $@ $<
 
-$(DEB): $(EXEDEST) $(SCRIPTDEST) $(CONTROLDEST) $(CHANGELOGDEST) $(DEBCHANGEDEST) $(MANDEST) $(ICONDEST) $(COPYRIGHTDEST) $(DESKTOPDEST) $(CONSOLEUIDESKTOPDEST)
+$(DEB): $(EXEDEST) $(SCRIPTDEST) $(CONTROLDEST) $(CHANGELOGDEST) $(DEBCHANGEDEST) $(MANDEST) $(ICONDEST) $(COPYRIGHTDEST) $(DESKTOPDEST) $(CONSOLEUIDESKTOPDEST) $(CMDPROMPTDESKTOPDEST)
 	umask 0022 && mkdir -p $(shell dirname $@)
 	fakeroot dpkg-deb --build $(DESTDIR)/ $@
 
@@ -124,6 +126,10 @@ $(DESKTOPDEST): $(DESKTOPSRC)
 	umask 0022 && cp $< $@
 
 $(CONSOLEUIDESKTOPDEST): $(CONSOLEUIDESKTOPSRC)
+	umask 0022 && mkdir -p $(shell dirname $@)
+	umask 0022 && cp $< $@
+
+$(CMDPROMPTDESKTOPDEST): $(CMDPROMPTDESKTOPSRC)
 	umask 0022 && mkdir -p $(shell dirname $@)
 	umask 0022 && cp $< $@
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 ckan (1.28.0) unstable; urgency=low
 
+  * Added Command Prompt desktop file.
+
+ -- The CKAN Authors <debian@ksp-ckan.space>  Wed, 8 Aug 2022 13:30:00 +0600
+
+ckan (1.28.0) unstable; urgency=low
+
   * Added ConsoleUI desktop file.
 
  -- The CKAN Authors <debian@ksp-ckan.space>  Wed, 15 May 2020 19:12:00 +0600

--- a/debian/ckan-cmdprompt.desktop
+++ b/debian/ckan-cmdprompt.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=CKAN Command Propmt
+Comment=Comprehensive Kerbal Archive Network Command Prompt
+Icon=/usr/share/icons/ckan.ico
+Categories=Game;Utility
+Exec=/usr/bin/ckan prompt
+Terminal=true
+Type=Application
+Version=1.0
+X-GNOME-SingleWindow=true

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -8,6 +8,7 @@ SCRIPTSRC:=$(DEBDIR)/ckan
 MANSRC:=$(DEBDIR)/ckan.1
 DESKTOPSRC:=$(DEBDIR)/ckan.desktop
 CONSOLEUIDESKTOPSRC:=$(DEBDIR)/ckan-consoleui.desktop
+CMDPROMPTDESKTOPSRC:=$(DEBDIR)/ckan-cmdprompt.desktop
 ICONSRC:=$(DEBDIR)/ckan.ico
 CONFIGURATION?=Release
 EXESRC:=$(shell pwd)/../_build/repack/$(CONFIGURATION)/ckan.exe
@@ -28,7 +29,7 @@ GPGNAME:=KSP CKAN <debian@ksp-ckan.space>
 # rpmbuild can't handle relative paths for its topdir
 # rpmbuild assumes we'll copy files into its SOURCES dir for it
 
-$(RPM): $(SCRIPTSRC) $(EXESRC) $(MANSRC) $(DESKTOPSRC) $(ICONSRC) $(CONSOLEUIDESKTOPSRC)
+$(RPM): $(SCRIPTSRC) $(EXESRC) $(MANSRC) $(DESKTOPSRC) $(ICONSRC) $(CONSOLEUIDESKTOPSRC) $(CMDPROMPTDESKTOPSRC)
 	mkdir -p "${TOPDIR}/SOURCES"
 	cp $^ "${TOPDIR}/SOURCES"
 	rpmbuild --define "_topdir ${TOPDIR}" --define "_version $(VERSION)" -bb ckan.spec

--- a/rpm/ckan.spec
+++ b/rpm/ckan.spec
@@ -14,6 +14,7 @@ Source2: ckan.1
 Source3: ckan.desktop
 Source4: ckan.ico
 Source5: ckan-consoleui.desktop
+Source6: ckan-cmdprompt.desktop
 
 %description
 KSP-CKAN official client.
@@ -35,6 +36,7 @@ cp %{SOURCE2} %{buildroot}%{_mandir}/man1
 mkdir -p %{buildroot}%{_datadir}/applications
 cp %{SOURCE3} %{buildroot}%{_datadir}/applications
 cp %{SOURCE5} %{buildroot}%{_datadir}/applications
+cp %{SOURCE6} %{buildroot}%{_datadir}/applications
 mkdir -p %{buildroot}%{_datadir}/icons
 cp %{SOURCE4} %{buildroot}%{_datadir}/icons
 
@@ -46,6 +48,9 @@ cp %{SOURCE4} %{buildroot}%{_datadir}/icons
 %{_mandir}/man1/*
 
 %changelog
+* Mon Aug 8 2022 The CKAN authors <rpm@ksp-ckan.space> 1.31.2
+- Added Command Prompt desktop file
+
 * Fri May 15 2020 The CKAN authors <rpm@ksp-ckan.space> 1.28.0
 - Added ConsoleUI desktop file
 


### PR DESCRIPTION
## Motivation

Now that we have integrated tab completion in #3515, it might be nice to make the `ckan prompt` UI more easily discoverable, similar to what we did for ConsoleUI in #3052.

## Changes

Now a new "CKAN Command Line" option is added to the system menus when installing the .deb or .rpm packages:

![image](https://user-images.githubusercontent.com/1559108/183519178-c432d2c9-2b44-414e-bcbe-eec65e047eb8.png)

Clicking it runs `ckan prompt` in a terminal.
