### PR TITLE
Cache remote build map, fetch in registry refresh

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -49,6 +49,18 @@ namespace CKAN.CmdLine
             }
 
             Logging.Initialize();
+            // We need to load the game instance manager before parsing the args,
+            // which is too late for debug flags if we want them active during the instance loading
+            if (args.Contains("--debug"))
+            {
+                LogManager.GetRepository().Threshold = Level.Debug;
+                log.Info("Debug logging enabled");
+            }
+            else if (args.Contains("--verbose"))
+            {
+                LogManager.GetRepository().Threshold = Level.Info;
+                log.Info("Verbose logging enabled");
+            }
             log.Info("CKAN started.");
 
             // Force-allow TLS 1.2 for HTTPS URLs, because GitHub requires it.

--- a/Core/Games/KerbalSpaceProgram/GameVersionProviders/IKspBuildMap.cs
+++ b/Core/Games/KerbalSpaceProgram/GameVersionProviders/IKspBuildMap.cs
@@ -9,6 +9,9 @@ namespace CKAN.GameVersionProviders
 
         List<GameVersion> KnownVersions { get; }
 
+        /// <summary>
+        /// Download the build map from the server to the cache
+        /// </summary>
         void Refresh();
     }
 }

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -37,6 +37,11 @@ namespace CKAN
         public static RepoUpdateResult UpdateAllRepositories(RegistryManager registry_manager, GameInstance ksp, NetModuleCache cache, IUser user)
         {
             SortedDictionary<string, Repository> sortedRepositories = registry_manager.registry.Repositories;
+
+            // First get latest copy of the game versions data
+            user.RaiseMessage(Properties.Resources.NetRepoUpdatingBuildMap);
+            ServiceLocator.Container.Resolve<IKspBuildMap>().Refresh();
+
             user.RaiseProgress(Properties.Resources.NetRepoCheckingForUpdates, 0);
             if (sortedRepositories.Values.All(repo => !string.IsNullOrEmpty(repo.last_server_etag) && repo.last_server_etag == Net.CurrentETag(repo.uri)))
             {

--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -114,6 +114,9 @@ namespace CKAN.Properties {
             get { return (string)(ResourceManager.GetObject("NetModuleCacheMismatchSHA256", resourceCulture)); }
         }
 
+        internal static string NetRepoUpdatingBuildMap {
+            get { return (string)(ResourceManager.GetObject("NetRepoUpdatingBuildMap", resourceCulture)); }
+        }
         internal static string NetRepoCheckingForUpdates {
             get { return (string)(ResourceManager.GetObject("NetRepoCheckingForUpdates", resourceCulture)); }
         }

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -136,6 +136,7 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="NetModuleCacheNotValidZIP" xml:space="preserve"><value>{0}: {1} is not a valid ZIP file: {2}</value></data>
   <data name="NetModuleCacheMismatchSHA1" xml:space="preserve"><value>{0}: {1} has SHA1 {2}, should be {3}</value></data>
   <data name="NetModuleCacheMismatchSHA256" xml:space="preserve"><value>{0}: {1} has SHA256 {2}, should be {3}</value></data>
+  <data name="NetRepoUpdatingBuildMap" xml:space="preserve"><value>Refreshing game version data</value></data>
   <data name="NetRepoCheckingForUpdates" xml:space="preserve"><value>Checking for updates</value></data>
   <data name="NetRepoAlreadyUpToDate" xml:space="preserve"><value>Already up to date</value></data>
   <data name="NetRepoNoChanges" xml:space="preserve"><value>No changes since last update</value></data>


### PR DESCRIPTION
## Problems

My network has been a bit unreliable lately, and I've found that during periods of downtime, not only can I not download mods, but even commands like `ckan instance list` simply hang. (First noticed while working on the Electron UI project previewed in the comments of #2848, which just wraps around `CKAN.dll` without additional C# code being run.)

## Cause

When CKAN starts, it loads all the game instances pretty early. To do this, it first has to load the known game versions so it can check each instance's version. Currently we always use the remote build map for this, via an HTTPS request to GitHub. If the network isn't working, it just sits there waiting for timeout.

This isn't a great model. As pointed out in #2108, CKAN should refrain from creating network connections without the user's awareness, especially if it isn't necessary. Furthermore, we already have an embedded build map compiled into CKAN that we essentially never use, because the remote build map is always retrieved first.

An additional quirk is that the command line parameters are handled _after_ all this, so even if you pass `--debug`, the `log.Debug` output of these steps is never printed.

## Changes

- Now instead of retrieving the remote build map at every startup, we check for a locally cached copy (in the same directory as `config.json`). If found, we use it, otherwise we fall back to the embedded build map. This eliminates the network call at startup and would allow commands like `ckan instance list` to complete while offline.
- The updating code used by `ckan update` and GUI's Refresh button is updated to fetch the remote build map and save a cached copy for future startups, since this represents a time when the user has authorized network activity.
- Now before full parsing of the command line parameters, we check for `--debug` or `--verbose` and set the log level if found. This way these arguments can be used to see activity before the full parsing happens, including the build map's initialization.
