### PR TITLE
Log errors instead of PRs for OOO mods on GitHub

### DIFF
--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -63,9 +63,16 @@ namespace CKAN.NetKAN.Transformers
                 if (!opts.HighestVersion.EpochEquals(currentV)
                     && startV < opts.HighestVersion && opts.HighestVersion < currentV)
                 {
-                    // New file, tell the Indexer to be careful
-                    opts.Staged = true;
-                    opts.StagingReasons.Add($"Auto-epoching out of order version: {startV} < {opts.HighestVersion} < {currentV}");
+                    if (opts.FlakyAPI)
+                    {
+                        throw new Kraken($"Out-of-order version found on unreliable server: {startV} < {opts.HighestVersion} < {currentV}");
+                    }
+                    else
+                    {
+                        // New file, tell the Indexer to be careful
+                        opts.Staged = true;
+                        opts.StagingReasons.Add($"Auto-epoching out of order version: {startV} < {opts.HighestVersion} < {currentV}");
+                    }
                 }
                 json["version"] = currentV.ToString();
             }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -38,6 +38,9 @@ namespace CKAN.NetKAN.Transformers
             {
                 var json = metadata.Json();
 
+                // Tell downstream translators that this host's API is unreliable
+                opts.FlakyAPI = true;
+
                 Log.InfoFormat("Executing GitHub transformation with {0}", metadata.Kref);
                 Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, json);
 

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -24,6 +24,7 @@ namespace CKAN.NetKAN.Transformers
         public readonly ModuleVersion HighestVersion;
         public          bool          Staged;
         public readonly List<string>  StagingReasons;
+        public          bool          FlakyAPI = false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

For many months now we have been getting hammered with bogus auto-epoch pull requests. Lately it has gotten worse, with occasional giant waves of many, many mods affected. Cleaning these up is very tedious and has by far eclipsed the usefulness of auto-epoching as a feature. #3571 didn't seem to help.

## Cause

GitHub's API seems to be unreliable. We ask it for the list of releases for mods constantly, and something like 0.004% of the time it skips one or more releases (much more often if there's a "wave" in progress), and we get a bogus pull request because it looks like the versions went backwards.

## Changes

Now we no longer auto-generate auto-epoch pull requests for mods on GitHub. All other mods can still benefit from this feature, but mods hosted on GitHub will now simply emit an error to the log. This will appear as an inflation error in Discord and the status page, and if it's a true out-of-order release, it will stay there for multiple passes and we can go look at it, otherwise it'll go away on its own in the next pass.

I'm planning to self-review this since I can just revert it if something goes wrong.
