### PR TITLE
Check free space before downloading

### DIFF
--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -1,8 +1,9 @@
 using CommandLine;
 using CommandLine.Text;
 using log4net;
-using CKAN.Configuration;
 using Autofac;
+
+using CKAN.Configuration;
 
 namespace CKAN.CmdLine
 {
@@ -229,10 +230,11 @@ namespace CKAN.CmdLine
 
         private void printCacheInfo()
         {
-            int fileCount;
-            long bytes;
-            manager.Cache.GetSizeInfo(out fileCount, out bytes);
-            user.RaiseMessage(Properties.Resources.CacheInfo, fileCount, CkanModule.FmtSize(bytes));
+            manager.Cache.GetSizeInfo(out int fileCount, out long bytes, out long bytesFree);
+            user.RaiseMessage(Properties.Resources.CacheInfo,
+                              fileCount,
+                              CkanModule.FmtSize(bytes),
+                              CkanModule.FmtSize(bytesFree));
         }
 
         private IUser               user;

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -161,7 +161,7 @@ Update recommended!</value></data>
   <data name="CacheReset" xml:space="preserve"><value>Download cache reset to {0}</value></data>
   <data name="CacheResetFailed" xml:space="preserve"><value>Can't reset cache path: {0}</value></data>
   <data name="CacheUnlimited" xml:space="preserve"><value>Unlimited</value></data>
-  <data name="CacheInfo" xml:space="preserve"><value>{0} files, {1}</value></data>
+  <data name="CacheInfo" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>
   <data name="CompareSame" xml:space="preserve"><value>"{0}" and "{1}" are the same versions.</value></data>
   <data name="CompareLower" xml:space="preserve"><value>"{0}" is lower than "{1}".</value></data>
   <data name="CompareHigher" xml:space="preserve"><value>"{0}" is higher than "{1}".</value></data>

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -3,9 +3,11 @@ using System.IO;
 using System.Text.RegularExpressions;
 using log4net;
 
+using CKAN.Extensions;
+
 namespace CKAN
 {
-    public class CKANPathUtils
+    public static class CKANPathUtils
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(CKANPathUtils));
 
@@ -194,5 +196,20 @@ namespace CKAN
             // the un-prettiest slashes.
             return NormalizePath(Path.Combine(root, path));
         }
+
+        public static void CheckFreeSpace(DirectoryInfo where, long bytesToStore, string errorDescription)
+        {
+            var bytesFree = where.GetDrive()?.AvailableFreeSpace;
+            if (bytesFree.HasValue && bytesToStore > bytesFree.Value) {
+                throw new NotEnoughSpaceKraken(errorDescription, where,
+                                               bytesFree.Value, bytesToStore);
+            }
+            log.DebugFormat("Storing {0} to {1} ({2} free)...",
+                            CkanModule.FmtSize(bytesToStore),
+                            where.FullName,
+                            bytesFree.HasValue ? CkanModule.FmtSize(bytesFree.Value)
+                                               : "unknown bytes");
+        }
+
     }
 }

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace CKAN.Extensions
+{
+    public static class IOExtensions
+    {
+
+        private static bool StringArrayStartsWith(string[] child, string[] parent)
+        {
+            if (parent.Length > child.Length)
+                // Only child is allowed to have extra pieces
+                return false;
+            var opt = Platform.IsWindows ? StringComparison.InvariantCultureIgnoreCase
+                                         : StringComparison.InvariantCulture;
+            for (int i = 0; i < parent.Length; ++i) {
+                if (!parent[i].Equals(child[i], opt)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Check whether a given path is an ancestor of another
+        /// </summary>
+        /// <param name="parent">The path to treat as potential ancestor</param>
+        /// <param name="child">The path to treat as potential descendant</param>
+        /// <returns>true if child is a descendant of parent, false otherwise</returns>
+        public static bool IsAncestorOf(this DirectoryInfo parent, DirectoryInfo child)
+            => StringArrayStartsWith(
+                child.FullName.Split(new char[] {Path.DirectorySeparatorChar},
+                                     StringSplitOptions.RemoveEmptyEntries),
+                parent.FullName.Split(new char[] {Path.DirectorySeparatorChar},
+                                      StringSplitOptions.RemoveEmptyEntries));
+
+        /// <summary>
+        /// Extension method to fill in the gap of getting from a
+        /// directory to its drive in .NET.
+        /// Returns the drive with the longest RootDirectory.FullName
+        /// that's a prefix of the dir's FullName.
+        /// </summary>
+        /// <param name="dir">Any DirectoryInfo object</param>
+        /// <returns>The DriveInfo associated with this directory</returns>
+        public static DriveInfo GetDrive(this DirectoryInfo dir)
+            => DriveInfo.GetDrives()
+                        .Where(dr => dr.RootDirectory.IsAncestorOf(dir))
+                        .OrderByDescending(dr => dr.RootDirectory.FullName.Length)
+                        .FirstOrDefault();
+
+    }
+}

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -139,6 +139,12 @@ namespace CKAN
             var modsToInstall = resolver.ModList().ToList();
             List<CkanModule> downloads = new List<CkanModule>();
 
+            // Make sure we have enough space to install this stuff
+            CKANPathUtils.CheckFreeSpace(new DirectoryInfo(ksp.GameDir()),
+                                         modsToInstall.Select(m => m.install_size)
+                                                      .Sum(),
+                                         Properties.Resources.NotEnoughSpaceToInstall);
+
             // TODO: All this user-stuff should be happening in another method!
             // We should just be installing mods as a transaction.
 
@@ -177,6 +183,13 @@ namespace CKAN
 
                 downloader.DownloadModules(downloads);
             }
+
+            // Make sure we STILL have enough space to install this stuff
+            // now that the downloads have been stored to the cache
+            CKANPathUtils.CheckFreeSpace(new DirectoryInfo(ksp.GameDir()),
+                                         modsToInstall.Select(m => m.install_size)
+                                                      .Sum(),
+                                         Properties.Resources.NotEnoughSpaceToInstall);
 
             // We're about to install all our mods; so begin our transaction.
             using (TransactionScope transaction = CkanTransaction.CreateTransactionScope())

--- a/Core/Net/IDownloader.cs
+++ b/Core/Net/IDownloader.cs
@@ -1,5 +1,5 @@
 using System;
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace CKAN
 {

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+
+using ChinhDo.Transactions.FileManager;
 using log4net;
 
 namespace CKAN
@@ -61,6 +63,14 @@ namespace CKAN
                 .GroupBy(module => module.download)
                 .Where(group => !currentlyActive.Contains(group.Key))
                 .ToDictionary(group => group.Key, group => group.First());
+
+            // Make sure we have enough space to download this stuff
+            var downloadSize = unique_downloads.Values.Select(m => m.download_size).Sum();
+            CKANPathUtils.CheckFreeSpace(new DirectoryInfo(new TxFileManager().GetTempDirectory()),
+                                         downloadSize,
+                                         Properties.Resources.NotEnoughSpaceToDownload);
+            // Make sure we have enough space to cache this stuff
+            cache.CheckFreeSpace(downloadSize);
 
             this.modules.AddRange(unique_downloads.Values);
 

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -277,11 +277,13 @@ namespace CKAN
         /// </summary>
         /// <param name="numFiles">Output parameter set to number of files in cache</param>
         /// <param name="numBytes">Output parameter set to number of bytes in cache</param>
-        public void GetSizeInfo(out int numFiles, out long numBytes)
+        /// <param name="bytesFree">Output parameter set to number of bytes free</param>
+        public void GetSizeInfo(out int numFiles, out long numBytes, out long bytesFree)
         {
             numFiles = 0;
             numBytes = 0;
             GetSizeInfo(cachePath, ref numFiles, ref numBytes);
+            bytesFree = new DirectoryInfo(cachePath).GetDrive()?.AvailableFreeSpace ?? 0;
             foreach (var legacyDir in legacyDirs())
             {
                 GetSizeInfo(legacyDir, ref numFiles, ref numBytes);
@@ -298,6 +300,13 @@ namespace CKAN
             }
         }
 
+        public void CheckFreeSpace(long bytesToStore)
+        {
+            CKANPathUtils.CheckFreeSpace(new DirectoryInfo(cachePath),
+                                         bytesToStore,
+                                         Properties.Resources.NotEnoughSpaceToCache);
+        }
+
         private HashSet<string> legacyDirs()
         {
             return manager?.Instances.Values
@@ -310,9 +319,7 @@ namespace CKAN
 
         public void EnforceSizeLimit(long bytes, Registry registry)
         {
-            int numFiles;
-            long curBytes;
-            GetSizeInfo(out numFiles, out curBytes);
+            GetSizeInfo(out int numFiles, out long curBytes, out long _);
             if (curBytes > bytes)
             {
                 // This object will let us determine whether a module is compatible with any of our instances

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -70,14 +70,19 @@ namespace CKAN
         {
             return cache.GetCachedZip(m.download);
         }
-        public void GetSizeInfo(out int numFiles, out long numBytes)
+        public void GetSizeInfo(out int numFiles, out long numBytes, out long bytesFree)
         {
-            cache.GetSizeInfo(out numFiles, out numBytes);
+            cache.GetSizeInfo(out numFiles, out numBytes, out bytesFree);
         }
         public void EnforceSizeLimit(long bytes, Registry registry)
         {
             cache.EnforceSizeLimit(bytes, registry);
         }
+        public void CheckFreeSpace(long bytesToStore)
+        {
+            cache.CheckFreeSpace(bytesToStore);
+        }
+
 
         /// <summary>
         /// Calculate the SHA1 hash of a file

--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -513,6 +513,18 @@ namespace CKAN.Properties {
         internal static string KrakenReinstallModule {
             get { return (string)(ResourceManager.GetObject("KrakenReinstallModule", resourceCulture)); }
         }
+        internal static string NotEnoughSpaceToDownload {
+            get { return (string)(ResourceManager.GetObject("NotEnoughSpaceToDownload", resourceCulture)); }
+        }
+        internal static string NotEnoughSpaceToCache {
+            get { return (string)(ResourceManager.GetObject("NotEnoughSpaceToCache", resourceCulture)); }
+        }
+        internal static string NotEnoughSpaceToInstall {
+            get { return (string)(ResourceManager.GetObject("NotEnoughSpaceToInstall", resourceCulture)); }
+        }
+        internal static string KrakenNotEnoughSpace {
+            get { return (string)(ResourceManager.GetObject("KrakenNotEnoughSpace", resourceCulture)); }
+        }
 
         internal static string RelationshipResolverConflictsWith {
             get { return (string)(ResourceManager.GetObject("RelationshipResolverConflictsWith", resourceCulture)); }

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -280,6 +280,13 @@ Consider adding an authentication token to increase the throttling limit.</value
 If you're certain this is not the case, then delete:
 "{0}"</value></data>
   <data name="KrakenReinstallModule" xml:space="preserve"><value>Metadata changed, reinstallation recommended: {0}</value></data>
+  <data name="NotEnoughSpaceToDownload" xml:space="preserve"><value>Not enough space in temp folder to download modules!</value></data>
+  <data name="NotEnoughSpaceToCache" xml:space="preserve"><value>Not enough space in cache folder to store modules!</value></data>
+  <data name="NotEnoughSpaceToInstall" xml:space="preserve"><value>Not enough space in game folder to install modules!</value></data>
+  <data name="KrakenNotEnoughSpace" xml:space="preserve"><value>{0}
+Need to store {3} to {1}, but only {2} is available!
+Free up space on that device or change your settings to use another location.
+</value></data>
   <data name="RelationshipResolverConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="RelationshipResolverRequiredButResolver" xml:space="preserve"><value>{0} required, but an incompatible version is in the resolver</value></data>
   <data name="RelationshipResolverRequiredButInstalled" xml:space="preserve"><value>{0} required, but an incompatible version is installed</value></data>

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -727,26 +727,22 @@ namespace CKAN
             }
         }
 
+        private const double K = 1024;
+
         /// <summary>
         /// Format a byte count into readable file size
         /// </summary>
         /// <param name="bytes">Number of bytes in a file</param>
         /// <returns>
-        /// ### bytes or ### KB or ### MB or ### GB
+        /// ### bytes or ### KiB or ### MiB or ### GiB or ### TiB
         /// </returns>
         public static string FmtSize(long bytes)
-        {
-            const double K = 1024;
-            if (bytes < K) {
-                return $"{bytes} B";
-            } else if (bytes < K * K) {
-                return $"{bytes / K :N1} KiB";
-            } else if (bytes < K * K * K) {
-                return $"{bytes / K / K :N1} MiB";
-            } else {
-                return $"{bytes / K / K / K :N1} GiB";
-            }
-        }
+            => bytes < K       ? $"{bytes} B"
+             : bytes < K*K     ? $"{bytes /K :N1} KiB"
+             : bytes < K*K*K   ? $"{bytes /K/K :N1} MiB"
+             : bytes < K*K*K*K ? $"{bytes /K/K/K :N1} GiB"
+             :                   $"{bytes /K/K/K/K :N1} TiB";
+
     }
 
     public class InvalidModuleAttributesException : Exception

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -35,6 +36,24 @@ namespace CKAN
             : base(reason, innerException)
         {
             this.directory = directory;
+        }
+    }
+
+    public class NotEnoughSpaceKraken : Kraken
+    {
+        public DirectoryInfo destination;
+        public long          bytesFree;
+        public long          bytesToStore;
+
+        public NotEnoughSpaceKraken(string description, DirectoryInfo destination, long bytesFree, long bytesToStore)
+            : base(string.Format(Properties.Resources.KrakenNotEnoughSpace,
+                                 description, destination,
+                                 CkanModule.FmtSize(bytesFree),
+                                 CkanModule.FmtSize(bytesToStore)))
+        {
+            this.destination  = destination;
+            this.bytesFree    = bytesFree;
+            this.bytesToStore = bytesToStore;
         }
     }
 

--- a/GUI/Dialogs/NewRepoDialog.cs
+++ b/GUI/Dialogs/NewRepoDialog.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-﻿using System.Linq;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace CKAN.GUI

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -17,7 +17,8 @@ namespace CKAN.GUI
 
         private IUser m_user;
         private long m_cacheSize;
-        private int m_cacheFileCount;
+        private int  m_cacheFileCount;
+        private long m_cacheFreeSpace;
         private IConfiguration config;
 
         private List<Repository> _sortedRepos = new List<Repository>();
@@ -128,7 +129,7 @@ namespace CKAN.GUI
                 Task.Factory.StartNew(() =>
                 {
                     // This might take a little while if the cache is big
-                    Main.Instance.Manager.Cache.GetSizeInfo(out m_cacheFileCount, out m_cacheSize);
+                    Main.Instance.Manager.Cache.GetSizeInfo(out m_cacheFileCount, out m_cacheSize, out long m_cacheFreeSpace);
                     Util.Invoke(this, () =>
                     {
                         if (config.CacheSizeLimit.HasValue)
@@ -137,7 +138,7 @@ namespace CKAN.GUI
                             CacheLimit.Text = (config.CacheSizeLimit.Value / 1024 / 1024).ToString();
                         }
                         CachePath.Text = config.DownloadCacheDir;
-                        CacheSummary.Text = string.Format(Properties.Resources.SettingsDialogSummmary, m_cacheFileCount, CkanModule.FmtSize(m_cacheSize));
+                        CacheSummary.Text = string.Format(Properties.Resources.SettingsDialogSummmary, m_cacheFileCount, CkanModule.FmtSize(m_cacheSize), CkanModule.FmtSize(m_cacheFreeSpace));
                         CacheSummary.ForeColor   = SystemColors.ControlText;
                         OpenCacheButton.Enabled  = true;
                         ClearCacheButton.Enabled = (m_cacheSize > 0);

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -320,6 +320,10 @@ namespace CKAN.GUI
                         currentUser.RaiseMessage(Properties.Resources.MainInstallBadMetadata, exc.module, exc.Message);
                         break;
 
+                    case NotEnoughSpaceKraken exc:
+                        currentUser.RaiseMessage(exc.Message);
+                        break;
+
                     case FileExistsKraken exc:
                         if (exc.owningModule != null)
                         {

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -340,7 +340,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ManageGameInstancesNameColumnLocked" xml:space="preserve"><value>{0} (LOCKED)</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Failed to fetch master list.</value></data>
   <data name="PluginsDialogFilter" xml:space="preserve"><value>CKAN Plugins (*.dll)|*.dll</value></data>
-  <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}</value></data>
+  <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Invalid path: {0}</value></data>
   <data name="SettingsDialogCacheDescrip" xml:space="preserve"><value>Choose a folder for storing CKAN's mod downloads:</value></data>
   <data name="SettingsDialogDeleteConfirm" xml:space="preserve"><value>Do you really want to delete {0} cached files, freeing {1}?</value></data>


### PR DESCRIPTION
## Motivation

Users periodically report issues with running out of disk space. (Given how cheap storage is these days, we can only credit the extremely creative developers of planet packs for taking up so many gigabytes with their beautiful textures.) This can happen at three points:

- The downloader downloads ZIP files to the `%TEMP%` folder, which can fill up
- Then it copies/moves downloaded files into the cache folder, which can fill up
- Then the installer extracts mod content from the ZIPs into the game folder, which can fill up

Currently CKAN does not attempt to handle or prevent this. The exception is simply thrown and the user gets to read a stack trace.

## Previous investigations

Last time I looked at this I hit a speedbump due to the lack of a built-in mapping from directories to drives in .NET, which is probably because of cross-platform considerations. Whereas on Windows, all `DriveInfo.RootDirectory.FullName` properties return something like `C:\`, `D:\`, etc., on Unix these can be just about any path since Unix is much more flexible regarding where you can mount devices. The logic needs to work for both.

## Considered and not done

It would be nice to catch and handle these exceptions. Unfortunately, they're generic `IOException`s rather than something specific to disk space, and there's no programmatic way to check whether the exception relates to disk space. So we would be catching a lot of other unrelated exceptions in the same spot, and we would not be able to generate a useful error message from them.

## Changes

- Now a new extension method allows `DirectoryInfo.GetDrive()` to return the `DriveInfo` object associated with a folder. It works by comparing (case-insensitive on Windows) the pieces of the `FullName` properties of the given dir and `DriveInfo.RootDirectory`. Empty pieces are pruned to make sure `"C:\\".Split("\\")` doesn't return `["C:", ""]` which would fail to match a longer path without a blank piece in that position.
- Now `CKANPathUtils` is `static` (it always should have been, just an oversight)
- Now `CKANPathUtils.CheckFreeSpace` uses the new `.GetDrive()` to check the free space of a given folder and throws an instance of new class `NotEnoughSpaceKraken` if it isn't enough, with a custom error message, which GUI catches and pretty-prints in the install log
- Now we `CheckFreeSpace` in the game dir before installing, using the `install_size` metadata from #3568
- Now we `CheckFreeSpace` in the temp dir and the cache dir before downloading
- Now we `CheckFreeSpace` in the game dir again after the downloads complete, just in case the game dir and cache dir are on the same device
- Now `CkanModule.FmtSize` goes up to TiB rather than just GiB, since we're going to be reporting disk sizes
- Now `ckan cache list` prints the free space of your cache's device
- Now GUI's settings window also shows the free space of the cache dir

This will alert users to disk space problems earlier in the install flow so they can free up space in response to a friendlier message.

Fixes #3581.

![image](https://user-images.githubusercontent.com/1559108/183710769-f3db4099-fb45-4cbf-9f7c-b457428c1eb9.png)

![image](https://user-images.githubusercontent.com/1559108/183711651-db17180a-81c7-4249-93f5-3dffb1ba77eb.png)

![image](https://user-images.githubusercontent.com/1559108/183706793-2c2037c7-be2e-4e2d-876e-c9363fd6c51a.png)
