### PR TITLE
Many improvements for failed downloads

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -288,7 +288,10 @@ namespace CKAN.CmdLine
             // TODO: Sometimes when the GUI exits, we get a System.ArgumentException,
             // but trying to catch it here doesn't seem to help. Dunno why.
 
-            GUI.GUI.Main_(args, manager, options.ShowConsole);
+            // GUI expects its first param to be an identifier, don't confuse it
+            GUI.GUI.Main_(args.Except(new string[] {"--verbose", "--debug", "--show-console"})
+                              .ToArray(),
+                          manager, options.ShowConsole);
 
             return Exit.OK;
         }

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Transactions;
 using System.Collections.Generic;
+
 using CKAN.ConsoleUI.Toolkit;
 
 namespace CKAN.ConsoleUI {

--- a/Core/HelpURLs.cs
+++ b/Core/HelpURLs.cs
@@ -17,6 +17,7 @@ namespace CKAN
         public const string Filters = "https://github.com/KSP-CKAN/CKAN/pull/3458";
         public const string Labels = "https://github.com/KSP-CKAN/CKAN/pull/2936";
         public const string PlayTime = "https://github.com/KSP-CKAN/CKAN/pull/3543";
+        public const string DownloadsFailed = "https://github.com/KSP-CKAN/CKAN/pull/3635";
 
         public const string Discord = "https://discord.gg/Mb4nXQD";
     }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -4,11 +4,13 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Transactions;
+
 using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
 using ChinhDo.Transactions.FileManager;
 using Autofac;
+
 using CKAN.Extensions;
 using CKAN.Versioning;
 using CKAN.Configuration;

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -91,15 +91,16 @@ namespace CKAN
                             : $"{item.Value.download_content_type};q=1.0,{defaultMimeType};q=0.9"
                     )).ToList()
                 );
-                if (AllComplete != null)
-                {
-                    AllComplete();
-                }
+                this.modules.Clear();
+                AllComplete?.Invoke();
             }
             catch (DownloadErrorsKraken kraken)
             {
                 // Associate the errors with the affected modules
-                throw new ModuleDownloadErrorsKraken(this.modules, kraken);
+                var exc = new ModuleDownloadErrorsKraken(this.modules.ToList(), kraken);
+                // Clear this.modules because we're done with these
+                this.modules.Clear();
+                throw exc;
             }
         }
 

--- a/Core/Registry/AvailableModule.cs
+++ b/Core/Registry/AvailableModule.cs
@@ -97,7 +97,6 @@ namespace CKAN
             IEnumerable<CkanModule> toInstall    = null
         )
         {
-            log.DebugFormat("Our dictionary has {0} keys", module_version.Keys.Count);
             IEnumerable<CkanModule> modules = module_version.Values.Reverse();
             if (relationship != null)
             {
@@ -128,6 +127,7 @@ namespace CKAN
                     // If 'others' matches an identifier, it must also match the versions, else fail
                     if (rel.ContainsAny(others.Select(m => m.identifier)) && !rel.MatchesAny(others, null, null))
                     {
+                        log.DebugFormat("Unsatisfied dependency {0}, rejecting", rel);
                         return false;
                     }
                 }
@@ -139,8 +139,9 @@ namespace CKAN
                 foreach (RelationshipDescriptor rel in module.conflicts)
                 {
                     // If any of the conflicts are present, fail
-                    if (rel.MatchesAny(othersMinusSelf, null, null))
+                    if (rel.MatchesAny(othersMinusSelf, null, null, out CkanModule matched))
                     {
+                        log.DebugFormat("Found conflict with {0}, rejecting", matched);
                         return false;
                     }
                 }
@@ -155,6 +156,7 @@ namespace CKAN
                     {
                         if (rel.MatchesAny(selfArray, null, null))
                         {
+                            log.DebugFormat("Found reverse conflict with {0}, rejecting", other);
                             return false;
                         }
                     }

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -79,7 +79,7 @@ namespace CKAN
         /// Finds and returns all modules that could not exist without the listed modules installed, including themselves.
         /// </summary>
         IEnumerable<string> FindReverseDependencies(
-            IEnumerable<string> modulesToRemove, IEnumerable<CkanModule> modulesToInstall = null
+            IEnumerable<string> modulesToRemove, IEnumerable<CkanModule> modulesToInstall = null, Func<RelationshipDescriptor, bool> satisfiedFilter = null
         );
 
         /// <summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1098,7 +1098,7 @@ namespace CKAN
         )
         {
             modulesToRemove = modulesToRemove.Memoize();
-            origInstalled    = origInstalled.Memoize();
+            origInstalled   = origInstalled.Memoize();
             var dllSet = dlls.ToHashSet();
             // The empty list has no reverse dependencies
             // (Don't remove broken modules if we're only installing)

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -544,9 +544,10 @@ namespace CKAN
         /// </summary>
         public bool IsCompatibleKSP(GameVersionCriteria version)
         {
-            log.DebugFormat("Testing if {0} is compatible with game versions {1}", this, version.ToString());
-
-            return _comparator.Compatible(version, this);
+            var compat = _comparator.Compatible(version, this);
+            log.DebugFormat("Checking compat of {0} with game versions {1}: {2}",
+                this, version.ToString(), compat ? "Compatible": "Incompatible");
+            return compat;
         }
 
         /// <summary>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -291,19 +291,19 @@ namespace CKAN
     /// </summary>
     public class DownloadErrorsKraken : Kraken
     {
-        public readonly List<KeyValuePair<int, Exception>> exceptions
+        public readonly List<KeyValuePair<int, Exception>> Exceptions
             = new List<KeyValuePair<int, Exception>>();
 
         public DownloadErrorsKraken(List<KeyValuePair<int, Exception>> errors) : base()
         {
-            exceptions = new List<KeyValuePair<int, Exception>>(errors);
+            Exceptions = new List<KeyValuePair<int, Exception>>(errors);
         }
 
         public override string ToString()
         {
             return String.Join("\r\n",
                 new string[] { Properties.Resources.KrakenDownloadErrorsHeader, "" }
-                .Concat(exceptions.Select(e => e.ToString())));
+                .Concat(Exceptions.Select(e => e.ToString())));
         }
     }
 
@@ -313,6 +313,9 @@ namespace CKAN
     /// </summary>
     public class ModuleDownloadErrorsKraken : Kraken
     {
+        public readonly List<KeyValuePair<CkanModule, Exception>> Exceptions
+            = new List<KeyValuePair<CkanModule, Exception>>();
+
         /// <summary>
         /// Initialize the exception.
         /// </summary>
@@ -321,9 +324,9 @@ namespace CKAN
         public ModuleDownloadErrorsKraken(IList<CkanModule> modules, DownloadErrorsKraken kraken)
             : base()
         {
-            foreach (var kvp in kraken.exceptions)
+            foreach (var kvp in kraken.Exceptions)
             {
-                exceptions.Add(new KeyValuePair<CkanModule, Exception>(
+                Exceptions.Add(new KeyValuePair<CkanModule, Exception>(
                     modules[kvp.Key], kvp.Value.GetBaseException() ?? kvp.Value
                 ));
             }
@@ -345,7 +348,7 @@ namespace CKAN
                 builder = new StringBuilder();
                 builder.AppendLine(Properties.Resources.KrakenModuleDownloadErrorsHeader);
                 builder.AppendLine("");
-                foreach (KeyValuePair<CkanModule, Exception> kvp in exceptions)
+                foreach (KeyValuePair<CkanModule, Exception> kvp in Exceptions)
                 {
                     builder.AppendLine(string.Format(
                         Properties.Resources.KrakenModuleDownloadError, kvp.Key.ToString(), kvp.Value.Message));
@@ -354,8 +357,6 @@ namespace CKAN
             return builder.ToString();
         }
 
-        private readonly List<KeyValuePair<CkanModule, Exception>> exceptions
-            = new List<KeyValuePair<CkanModule, Exception>>();
         private StringBuilder builder = null;
     }
 

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -81,6 +81,12 @@
     <Compile Include="Dialogs\CompatibleGameVersionsDialog.Designer.cs">
       <DependentUpon>CompatibleGameVersionsDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Dialogs\DownloadsFailedDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Dialogs\DownloadsFailedDialog.Designer.cs">
+      <DependentUpon>DownloadsFailedDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\EditLabelsDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -571,6 +577,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Localization\ja-JP\DeleteDirectories.ja-JP.resx">
       <DependentUpon>..\..\Controls\DeleteDirectories.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dialogs\DownloadsFailedDialog.resx">
+      <DependentUpon>DownloadsFailedDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Dialogs\EditLabelsDialog.resx">
       <DependentUpon>EditLabelsDialog.cs</DependentUpon>

--- a/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
@@ -1,0 +1,193 @@
+namespace CKAN.GUI
+{
+    partial class DownloadsFailedDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(DownloadsFailedDialog));
+            this.ExplanationLabel = new System.Windows.Forms.Label();
+            this.DownloadsGrid = new System.Windows.Forms.DataGridView();
+            this.RetryColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.SkipColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.ModColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ErrorColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.BottomButtonPanel = new LeftRightRowPanel();
+            this.RetryButton = new System.Windows.Forms.Button();
+            this.AbortButton = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.DownloadsGrid)).BeginInit();
+            this.BottomButtonPanel.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // ExplanationLabel
+            //
+            this.ExplanationLabel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.ExplanationLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 12, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Pixel);
+            this.ExplanationLabel.Location = new System.Drawing.Point(5, 0);
+            this.ExplanationLabel.Name = "ExplanationLabel";
+            this.ExplanationLabel.Padding = new System.Windows.Forms.Padding(5,5,5,5);
+            this.ExplanationLabel.Size = new System.Drawing.Size(490, 60);
+            resources.ApplyResources(this.ExplanationLabel, "ExplanationLabel");
+            //
+            // DownloadsGrid
+            //
+            this.DownloadsGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DownloadsGrid.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.DownloadsGrid.AllowUserToAddRows = false;
+            this.DownloadsGrid.AllowUserToDeleteRows = false;
+            this.DownloadsGrid.AllowUserToResizeRows = false;
+            this.DownloadsGrid.BackgroundColor = System.Drawing.SystemColors.Window;
+            this.DownloadsGrid.EnableHeadersVisualStyles = false;
+            this.DownloadsGrid.ColumnHeadersDefaultCellStyle.BackColor = System.Drawing.SystemColors.Control;
+            this.DownloadsGrid.ColumnHeadersDefaultCellStyle.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.DownloadsGrid.DefaultCellStyle.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.DownloadsGrid.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
+            this.DownloadsGrid.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.DownloadsGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.DownloadsGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.RetryColumn,
+            this.SkipColumn,
+            this.ModColumn,
+            this.ErrorColumn});
+            this.DownloadsGrid.Location = new System.Drawing.Point(0, 111);
+            this.DownloadsGrid.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.DownloadsGrid.Padding = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.DownloadsGrid.MultiSelect = false;
+            this.DownloadsGrid.Name = "DownloadsGrid";
+            this.DownloadsGrid.RowHeadersVisible = false;
+            this.DownloadsGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.DownloadsGrid.Size = new System.Drawing.Size(1536, 837);
+            this.DownloadsGrid.StandardTab = true;
+            this.DownloadsGrid.TabIndex = 0;
+            this.DownloadsGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DownloadsGrid_CellContentClick);
+            this.DownloadsGrid.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DownloadsGrid_CellMouseDoubleClick);
+            this.DownloadsGrid.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.DownloadsGrid_CellEndEdit);
+            this.DownloadsGrid.SelectionChanged += new System.EventHandler(DownloadsGrid_SelectionChanged);
+            //
+            // RetryColumn
+            //
+            this.RetryColumn.Name = "RetryColumn";
+            this.RetryColumn.DataPropertyName = "Retry";
+            this.RetryColumn.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.RetryColumn.Width = 46;
+            this.RetryColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            resources.ApplyResources(this.RetryColumn, "RetryColumn");
+            //
+            // SkipColumn
+            //
+            this.SkipColumn.Name = "SkipColumn";
+            this.SkipColumn.DataPropertyName = "Skip";
+            this.SkipColumn.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.SkipColumn.Width = 46;
+            this.SkipColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            resources.ApplyResources(this.SkipColumn, "SkipColumn");
+            //
+            // ModColumn
+            //
+            this.ModColumn.Name = "ModColumn";
+            this.ModColumn.DataPropertyName = "Module";
+            this.ModColumn.ReadOnly = true;
+            this.ModColumn.Width = 250;
+            this.ModColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ModColumn.FillWeight = 250;
+            resources.ApplyResources(this.ModColumn, "ModColumn");
+            //
+            // ErrorColumn
+            //
+            this.ErrorColumn.Name = "ErrorColumn";
+            this.ErrorColumn.DataPropertyName = "Error";
+            this.ErrorColumn.ReadOnly = true;
+            this.ErrorColumn.Width = 500;
+            this.ErrorColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ErrorColumn.FillWeight = 500;
+            resources.ApplyResources(this.ErrorColumn, "ErrorColumn");
+            //
+            // BottomButtonPanel
+            //
+            this.BottomButtonPanel.RightControls.Add(this.AbortButton);
+            this.BottomButtonPanel.RightControls.Add(this.RetryButton);
+            this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.BottomButtonPanel.Name = "BottomButtonPanel";
+            //
+            // RetryButton
+            //
+            this.RetryButton.AutoSize = true;
+            this.RetryButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.RetryButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.RetryButton.Name = "RetryButton";
+            this.RetryButton.Size = new System.Drawing.Size(112, 30);
+            this.RetryButton.TabIndex = 3;
+            this.RetryButton.Click += new System.EventHandler(this.RetryButton_Click);
+            resources.ApplyResources(this.RetryButton, "RetryButton");
+            //
+            // AbortButton
+            //
+            this.AbortButton.AutoSize = true;
+            this.AbortButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.AbortButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.AbortButton.Name = "AbortButton";
+            this.AbortButton.Size = new System.Drawing.Size(112, 30);
+            this.AbortButton.TabIndex = 3;
+            this.AbortButton.Click += new System.EventHandler(this.AbortButton_Click);
+            resources.ApplyResources(this.AbortButton, "AbortButton");
+            //
+            // DownloadsFailedDialog
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.Controls.Add(this.DownloadsGrid);
+            this.Controls.Add(this.ExplanationLabel);
+            this.Controls.Add(this.BottomButtonPanel);
+            this.ClientSize = new System.Drawing.Size(800, 300);
+            this.MinimumSize = new System.Drawing.Size(675, 200);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
+            this.Icon = Properties.Resources.AppIcon;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.HelpButton = true;
+            this.Name = "DownloadsFailedDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            resources.ApplyResources(this, "$this");
+            ((System.ComponentModel.ISupportInitialize)(this.DownloadsGrid)).EndInit();
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label ExplanationLabel;
+        private System.Windows.Forms.DataGridView DownloadsGrid;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn RetryColumn;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn SkipColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ModColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ErrorColumn;
+        private LeftRightRowPanel BottomButtonPanel;
+        private System.Windows.Forms.Button RetryButton;
+        private System.Windows.Forms.Button AbortButton;
+    }
+}

--- a/GUI/Dialogs/DownloadsFailedDialog.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+using log4net;
+
+namespace CKAN.GUI
+{
+    public partial class DownloadsFailedDialog : Form
+    {
+        public DownloadsFailedDialog(IEnumerable<KeyValuePair<CkanModule[], Exception>> Exceptions)
+        {
+            InitializeComponent();
+            rows = Exceptions
+                // One row per affected mod (mods can share downloads)
+                .SelectMany(kvp => kvp.Key.Select(m => new DownloadRow(m, kvp.Value)))
+                .ToList();
+            DownloadsGrid.DataSource = new BindingList<DownloadRow>(rows);
+            ClientSize = new Size(ClientSize.Width,
+                ExplanationLabel.Height
+                + DownloadsGrid.RowCount
+                    * DownloadsGrid.RowTemplate.Height
+                + BottomButtonPanel.Height);
+        }
+
+        public bool         Abort { get; private set; } = false;
+        public CkanModule[] Retry => rows.Where(r => r.Retry)
+                                         .Select(r => r.Module)
+                                         .ToArray();
+        public CkanModule[] Skip  => rows.Where(r => r.Skip)
+                                         .Select(r => r.Module)
+                                         .ToArray();
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.DownloadsFailed);
+        }
+
+        /// <summary>
+        /// Open the user guide when the user clicks the help button
+        /// </summary>
+        protected override void OnHelpButtonClicked(CancelEventArgs evt)
+        {
+            evt.Cancel = Util.TryOpenWebPage(HelpURLs.DownloadsFailed);
+        }
+
+        private void DownloadsGrid_SelectionChanged(object sender, EventArgs e)
+        {
+            // Don't clutter the screen with a highlight we don't use
+            DownloadsGrid.ClearSelection();
+        }
+
+        /// <summary>
+        /// React to checkboxes by triggering CellValueChanged
+        /// </summary>
+        private void DownloadsGrid_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            DownloadsGrid.EndEdit();
+        }
+
+        /// <summary>
+        /// Have to react to double clicks separately because CellContentClick doesn't fire
+        /// </summary>
+        private void DownloadsGrid_CellMouseDoubleClick(object sender, DataGridViewCellMouseEventArgs e)
+        {
+            DownloadsGrid.EndEdit();
+        }
+
+        /// <summary>
+        /// Luckily the data object's properties are always correct,
+        /// so all we have to do is force a refresh
+        /// </summary>
+        private async void DownloadsGrid_CellEndEdit(object sender, DataGridViewCellEventArgs e)
+        {
+            var binding  = (BindingList<DownloadRow>) DownloadsGrid.DataSource;
+            var download = rows[e.RowIndex].Module.download;
+            var retry    = rows[e.RowIndex].Retry;
+            // Update all rows with this download
+            for (int i = 0; i < rows.Count; ++i)
+            {
+                if (rows[i].Module.download == download)
+                {
+                    if (i != e.RowIndex)
+                    {
+                        rows[i].Retry = retry;
+                    }
+                    binding.ResetItem(i);
+                }
+            }
+        }
+
+        private void RetryButton_Click(object sender, EventArgs e)
+        {
+            Abort = false;
+            Close();
+        }
+
+        private void AbortButton_Click(object sender, EventArgs e)
+        {
+            Abort = true;
+            Close();
+        }
+
+        private List<DownloadRow> rows;
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(DownloadsFailedDialog));
+    }
+
+    public class DownloadRow
+    {
+        public DownloadRow(CkanModule module, Exception exc)
+        {
+            Retry   = true;
+            Module  = module;
+            Error   = exc.Message;
+        }
+
+        public bool       Retry   { get; set; }
+        public bool       Skip    { get => !Retry; set { Retry = !value; } }
+        public CkanModule Module  { get; private set; }
+        public string     Error   { get; private set; }
+    }
+}

--- a/GUI/Dialogs/DownloadsFailedDialog.resx
+++ b/GUI/Dialogs/DownloadsFailedDialog.resx
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.Text" xml:space="preserve"><value>Downloads Failed</value></data>
+  <data name="ExplanationLabel.Text" xml:space="preserve"><value>The following mods failed to download. You can retry or abort, and if you retry, you can choose to remove some mods (and any mods that depend on them) from the changeset. Mods that share the same download link will automatically be updated to the same choice.</value></data>
+  <data name="RetryColumn.HeaderText" xml:space="preserve"><value>Retry?</value></data>
+  <data name="SkipColumn.HeaderText" xml:space="preserve"><value>Skip?</value></data>
+  <data name="ModColumn.HeaderText" xml:space="preserve"><value>Mod</value></data>
+  <data name="ErrorColumn.HeaderText" xml:space="preserve"><value>Error</value></data>
+  <data name="RetryButton.Text" xml:space="preserve"><value>Retry</value></data>
+  <data name="AbortButton.Text" xml:space="preserve"><value>Abort whole changeset</value></data>
+</root>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -507,7 +507,6 @@
             this.Wait.Size = new System.Drawing.Size(500, 500);
             this.Wait.TabIndex = 32;
             this.Wait.OnRetry += Wait_OnRetry;
-            this.Wait.OnCancel += Wait_OnCancel;
             this.Wait.OnOk += Wait_OnOk;
             //
             // ChooseRecommendedModsTabPage

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -53,17 +53,18 @@ namespace CKAN.GUI
         public void UpdateCKAN()
         {
             ResetProgress();
-            ShowWaitDialog(false);
+            ShowWaitDialog();
             SwitchEnabledState();
-            Wait.ClearLog();
             tabController.RenameTab("WaitTabPage", Properties.Resources.MainUpgradingWaitTitle);
             Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo, AutoUpdate.Instance.latestUpdate.Version));
 
             log.Info("Start ckan update");
-            BackgroundWorker updateWorker = new BackgroundWorker();
-            updateWorker.DoWork += (sender, args) => AutoUpdate.Instance.StartUpdateProcess(true, currentUser);
-            updateWorker.RunWorkerCompleted += UpdateReady;
-            updateWorker.RunWorkerAsync();
+            Wait.StartWaiting(
+                (sender, args) => AutoUpdate.Instance.StartUpdateProcess(true, currentUser),
+                UpdateReady,
+                false,
+                null
+            );
         }
 
         private void UpdateReady(object sender, RunWorkerCompletedEventArgs e)

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -40,7 +40,7 @@ namespace CKAN.GUI
             // TODO Work out why this is.
             try
             {
-                installWorker.RunWorkerAsync(
+                Wait.StartWaiting(InstallMods, PostInstallMods, true,
                     new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                         ManageMods.mainModList
                             .ComputeUserChangeSet(RegistryManager.Instance(Main.Instance.CurrentInstance).registry)

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Transactions;
+
 using CKAN.Extensions;
 
 namespace CKAN.GUI
@@ -10,12 +12,6 @@ namespace CKAN.GUI
     using ModChanges = List<ModChange>;
     public partial class Main
     {
-        private BackgroundWorker installWorker;
-
-        // Used to signal the install worker that the user canceled the install process.
-        // This may happen on the recommended/suggested mods dialogs or during the download.
-        private volatile bool installCanceled;
-
         /// <summary>
         /// Initiate the GUI installer flow for one specific module
         /// </summary>
@@ -45,7 +41,7 @@ namespace CKAN.GUI
                 if (userChangeSet.Count > 0)
                 {
                     // Resolve the provides relationships in the dependencies
-                    installWorker.RunWorkerAsync(
+                    Wait.StartWaiting(InstallMods, PostInstallMods, true,
                         new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                             userChangeSet,
                             RelationshipResolver.DependsOnlyOpts()
@@ -64,9 +60,7 @@ namespace CKAN.GUI
         // this probably needs to be refactored
         private void InstallMods(object sender, DoWorkEventArgs e)
         {
-            installCanceled = false;
-            Wait.ClearLog();
-
+            bool canceled = false;
             var opts = (KeyValuePair<ModChanges, RelationshipResolverOptions>) e.Argument;
 
             RegistryManager registry_manager = RegistryManager.Instance(manager.CurrentInstance);
@@ -128,25 +122,17 @@ namespace CKAN.GUI
                     recommendations, suggestions, supporters);
                 tabController.SetTabLock(true);
                 var result = ChooseRecommendedMods.Wait();
+                tabController.SetTabLock(false);
+                tabController.HideTab("ChooseRecommendedModsTabPage");
                 if (result == null)
                 {
-                    installCanceled = true;
+                    e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
+                    throw new CancelledActionKraken();
                 }
                 else
                 {
                     toInstall.UnionWith(result);
                 }
-                tabController.SetTabLock(false);
-                tabController.HideTab("ChooseRecommendedModsTabPage");
-            }
-
-            if (installCanceled)
-            {
-                Util.Invoke(this, () => Enabled = true);
-                Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
-                tabController.ShowTab("ManageModsTabPage");
-                e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
-                return;
             }
 
             // Now let's make all our changes.
@@ -161,93 +147,102 @@ namespace CKAN.GUI
             IDownloader downloader = new NetAsyncModulesDownloader(currentUser, Manager.Cache);
             downloader.Progress    += Wait.SetModuleProgress;
             downloader.AllComplete += Wait.DownloadsComplete;
-            cancelCallback = () =>
-            {
+
+            Wait.OnCancel += () => {
+                canceled = true;
                 downloader.CancelDownload();
-                installCanceled = true;
             };
 
             HashSet<string> possibleConfigOnlyDirs = null;
 
-            // checks if all actions were successfull
-            bool processSuccessful = false;
-            bool resolvedAllProvidedMods = false;
-            // uninstall/installs/upgrades until every list is empty
-            // if the queue is NOT empty, resolvedAllProvidedMods is set to false until the action is done
-            while (!resolvedAllProvidedMods)
+            // Treat whole changeset as atomic
+            using (TransactionScope transaction = CkanTransaction.CreateTransactionScope())
             {
-                try
+                // Checks if all actions were successful
+                // Uninstall/installs/upgrades until every list is empty
+                // If the queue is NOT empty, resolvedAllProvidedMods is false until the action is done
+                for (bool resolvedAllProvidedMods = false; !resolvedAllProvidedMods;)
                 {
-                    e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
-                    if (toUninstall.Count > 0)
+                    try
                     {
-                        processSuccessful = false;
-                        if (!installCanceled)
+                        e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
+                        if (!canceled && toUninstall.Count > 0)
                         {
                             installer.UninstallList(toUninstall.Select(m => m.identifier),
                                 ref possibleConfigOnlyDirs, registry_manager, false, toInstall);
                             toUninstall.Clear();
-                            processSuccessful = true;
                         }
-                    }
-                    if (toInstall.Count > 0)
-                    {
-                        processSuccessful = false;
-                        if (!installCanceled)
+                        if (!canceled && toInstall.Count > 0)
                         {
                             installer.InstallList(toInstall, opts.Value, registry_manager, ref possibleConfigOnlyDirs, downloader, false);
                             toInstall.Clear();
-                            processSuccessful = true;
                         }
-                    }
-                    if (toUpgrade.Count > 0)
-                    {
-                        processSuccessful = false;
-                        if (!installCanceled)
+                        if (!canceled && toUpgrade.Count > 0)
                         {
                             installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager, true, true, false);
                             toUpgrade.Clear();
-                            processSuccessful = true;
+                        }
+                        if (canceled)
+                        {
+                            e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
+                            throw new CancelledActionKraken();
+                        }
+                        resolvedAllProvidedMods = true;
+                    }
+                    catch (ModuleDownloadErrorsKraken k)
+                    {
+                        var dfd = new DownloadsFailedDialog(
+                            k.Exceptions.Select(kvp => new KeyValuePair<CkanModule[], Exception>(
+                                toInstall.Where(m => m.download == kvp.Key.download).ToArray(),
+                                kvp.Value)));
+                        dfd.ShowDialog(this);
+                        var abort = dfd.Abort;
+                        var skip  = dfd.Skip;
+                        dfd.Dispose();
+                        if (abort)
+                        {
+                            canceled = true;
+                            e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
+                            throw new CancelledActionKraken();
+                        }
+
+                        // Remove mods from changeset that user chose to skip
+                        // and any mods depending on them
+                        var dependers = registry.FindReverseDependencies(
+                            skip.Select(s => s.identifier), toInstall)
+                            .ToHashSet();
+                        toInstall.RemoveWhere(m => dependers.Contains(m.identifier));
+
+                        // Now we loop back around again
+                    }
+                    catch (TooManyModsProvideKraken k)
+                    {
+                        // Prompt user to choose which mod to use
+                        tabController.ShowTab("ChooseProvidedModsTabPage", 3);
+                        ChooseProvidedMods.LoadProviders(k.Message, k.modules, Manager.Cache);
+                        tabController.SetTabLock(true);
+                        CkanModule chosen = ChooseProvidedMods.Wait();
+                        // Close the selection prompt
+                        tabController.SetTabLock(false);
+                        tabController.HideTab("ChooseProvidedModsTabPage");
+                        if (chosen != null)
+                        {
+                            // User picked a mod, queue it up for installation
+                            toInstall.Add(chosen);
+                            // DON'T return so we can loop around and try the above InstallList call again
+                            tabController.ShowTab("WaitTabPage");
+                        }
+                        else
+                        {
+                            e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
+                            throw new CancelledActionKraken();
                         }
                     }
-
-                    HandlePossibleConfigOnlyDirs(registry, possibleConfigOnlyDirs);
-
-                    e.Result = new KeyValuePair<bool, ModChanges>(processSuccessful, opts.Key);
-                    if (installCanceled)
-                    {
-                        return;
-                    }
-                    resolvedAllProvidedMods = true;
                 }
-                catch (TooManyModsProvideKraken k)
-                {
-                    // Prompt user to choose which mod to use
-                    tabController.ShowTab("ChooseProvidedModsTabPage", 3);
-                    ChooseProvidedMods.LoadProviders(k.Message, k.modules, Manager.Cache);
-                    tabController.SetTabLock(true);
-                    CkanModule chosen = ChooseProvidedMods.Wait();
-                    // Close the selection prompt
-                    tabController.SetTabLock(false);
-                    tabController.HideTab("ChooseProvidedModsTabPage");
-                    if (chosen != null)
-                    {
-                        // User picked a mod, queue it up for installation
-                        toInstall.Add(chosen);
-                        // DON'T return so we can loop around and try the above InstallList call again
-                        tabController.ShowTab("WaitTabPage");
-                    }
-                    else
-                    {
-                        // User cancelled, get out
-                        tabController.ShowTab("ManageModsTabPage");
-                        Util.Invoke(this, () => Enabled = true);
-                        Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
-                        e.Result = new KeyValuePair<bool, ModChanges>(false, opts.Key);
-                        return;
-                    }
-                }
+                transaction.Complete();
             }
+            HandlePossibleConfigOnlyDirs(registry, possibleConfigOnlyDirs);
+            e.Result = new KeyValuePair<bool, ModChanges>(true, opts.Key);
         }
 
         private void HandlePossibleConfigOnlyDirs(Registry registry, HashSet<string> possibleConfigOnlyDirs)
@@ -298,12 +293,6 @@ namespace CKAN.GUI
 
         private void PostInstallMods(object sender, RunWorkerCompletedEventArgs e)
         {
-            okCallback = () =>
-            {
-                ManageMods.UpdateModsList(null);
-                okCallback = null;
-            };
-
             if (e.Error != null)
             {
                 switch (e.Error)
@@ -348,8 +337,11 @@ namespace CKAN.GUI
                         break;
 
                     case CancelledActionKraken exc:
-                        currentUser.RaiseMessage(exc.Message);
-                        installCanceled = true;
+                        // User already knows they cancelled, get out
+                        HideWaitDialog(false);
+                        tabController.SetTabLock(false);
+                        Util.Invoke(this, () => Enabled = true);
+                        Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
                         break;
 
                     case MissingCertificateKraken exc:
@@ -401,56 +393,25 @@ namespace CKAN.GUI
                         break;
                 }
 
+                Wait.RetryEnabled = true;
                 FailWaitDialog(
                     Properties.Resources.MainInstallErrorInstalling,
                     Properties.Resources.MainInstallKnownError,
-                    Properties.Resources.MainInstallFailed,
-                    false
-                );
+                    Properties.Resources.MainInstallFailed);
             }
             else
             {
                 // The Result property throws if InstallMods threw (!!!)
                 KeyValuePair<bool, ModChanges> result = (KeyValuePair<bool, ModChanges>) e.Result;
-                if (!installCanceled)
-                {
-                    // Rebuilds the list of GUIMods
-                    ManageMods.UpdateModsList(null);
+                // Rebuilds the list of GUIMods
+                ManageMods.UpdateModsList();
 
-                    if (modChangedCallback != null)
-                    {
-                        foreach (var mod in result.Value)
-                        {
-                            modChangedCallback(mod.Mod, mod.ChangeType);
-                        }
-                    }
+                Util.Invoke(this, () => Enabled = true);
+                Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
+                tabController.SetTabLock(false);
 
-                    Util.Invoke(this, () => Enabled = true);
-                    Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
-                    tabController.SetTabLock(false);
-
-                    AddStatusMessage(Properties.Resources.MainInstallSuccess);
-                    HideWaitDialog(true);
-                }
-                else
-                {
-                    // User cancelled the installation
-                    if (result.Key) {
-                        FailWaitDialog(
-                            Properties.Resources.MainInstallCancelTooLate,
-                            Properties.Resources.MainInstallCancelAfterInstall,
-                            Properties.Resources.MainInstallProcessComplete,
-                            true
-                        );
-                    } else {
-                        FailWaitDialog(
-                            Properties.Resources.MainInstallProcessCanceled,
-                            Properties.Resources.MainInstallCanceledManually,
-                            Properties.Resources.MainInstallInstallCanceled,
-                            false
-                        );
-                    }
-                }
+                AddStatusMessage(Properties.Resources.MainInstallSuccess);
+                HideWaitDialog(true);
             }
         }
     }

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -52,7 +52,7 @@ namespace CKAN.GUI
                 tabController.HideTab("ChooseRecommendedModsTabPage");
                 if (result != null && result.Any())
                 {
-                    installWorker.RunWorkerAsync(
+                    Wait.StartWaiting(InstallMods, PostInstallMods, true,
                         new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                             result.Select(mod => new ModChange(
                                 mod,

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -1,19 +1,15 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 
 namespace CKAN.GUI
 {
     public partial class Main
     {
-        private Action cancelCallback;
-        private Action okCallback;
-
-        public void ShowWaitDialog(bool cancelable = true)
+        public void ShowWaitDialog()
         {
             Util.Invoke(this, () =>
             {
                 tabController.ShowTab("WaitTabPage", 2);
-                Wait.Reset(cancelable);
                 StatusProgress.Value = 0;
                 StatusProgress.Style = ProgressBarStyle.Marquee;
                 StatusProgress.Visible = true;
@@ -27,6 +23,7 @@ namespace CKAN.GUI
                 Wait.Finish(success);
                 RecreateDialogs();
 
+                tabController.HideTab("WaitTabPage");
                 tabController.SetActiveTab("ManageModsTabPage");
 
                 StatusProgress.Value = 0;
@@ -41,7 +38,7 @@ namespace CKAN.GUI
         /// <param name="statusMsg">Message for the lower status bar</param>
         /// <param name="logMsg">Message to display on WaitDialog-Log (not the real log!)</param>
         /// <param name="description">Message displayed above the DialogProgress bar</param>
-        public void FailWaitDialog(string statusMsg, string logMsg, string description, bool success)
+        public void FailWaitDialog(string statusMsg, string logMsg, string description)
         {
             Util.Invoke(statusStrip1, () => {
                 StatusProgress.Visible = false;
@@ -83,23 +80,12 @@ namespace CKAN.GUI
             tabController.ShowTab("ChangesetTabPage", 1);
         }
 
-        public void Wait_OnCancel()
-        {
-            if (cancelCallback != null)
-            {
-                cancelCallback();
-            }
-        }
-
         public void Wait_OnOk()
         {
-            if (okCallback != null)
-            {
-                okCallback();
-            }
             Util.Invoke(this, () => Enabled = true);
             Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
             tabController.SetTabLock(false);
+            HideWaitDialog(false);
         }
     }
 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -608,6 +608,9 @@ namespace CKAN.GUI.Properties {
         internal static string ModInfoSteamStoreLabel {
             get { return (string)(ResourceManager.GetObject("ModInfoSteamStoreLabel", resourceCulture)); }
         }
+        internal static string DownloadFailed {
+            get { return (string)(ResourceManager.GetObject("DownloadFailed", resourceCulture)); }
+        }
 
         internal static string MainModListWaitTitle {
             get { return (string)(ResourceManager.GetObject("MainModListWaitTitle", resourceCulture)); }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -293,6 +293,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ModInfoRemoteAvcLabel" xml:space="preserve"><value>Remote version file:</value></data>
   <data name="ModInfoStoreLabel" xml:space="preserve"><value>Store:</value></data>
   <data name="ModInfoSteamStoreLabel" xml:space="preserve"><value>Steam store:</value></data>
+  <data name="DownloadFailed" xml:space="preserve"><value>Download failed!</value></data>
   <data name="MainModListWaitTitle" xml:space="preserve"><value>Loading modules</value></data>
   <data name="MainModListLoadingRegistry" xml:space="preserve"><value>Loading registry...</value></data>
   <data name="MainModListLoadingInstalled" xml:space="preserve"><value>Loading installed modules...</value></data>


### PR DESCRIPTION
## Background

We have had a lot of recent user frustration with how CKAN reacts when downloads fail. Such errors are hard to reproduce with the full app running because they happen randomly according to users' network conditions. However, I recently hit upon a strategy: edit `CKAN/registry.json` and change the `download` properties of the latest versions of some mods so they're invalid (I added `/BROKEN_LINK/` at the start of each URL's path). Note that this will only work for mods with non-redistributable licenses (generally `restricted`), because otherwise the downloader will fall back to `archive.org` and succeed. The ones in the screenshot below work well for this, if it saves reviewers the trouble of finding them; you can right click them to purge them from the cache if they're already downloaded.

## Problems

With my mildly corrupted registry in place, I was finally able to conduct a proper investigation with failures-on-demand, and I discovered several more issues, some of which may simply be root causes of mysterious unreproducible issues that were reported previously:

- `ckan gui --show-console` gets confused and thinks `--show-console` is an identifier that you want it to highlight, resulting in a superfluous "Not found" message in the log :facepalm: 
- The async downloader has a potential race condition in its manipulation of `queuedDownloads` with `FirstOrDefault`: one thread can change the list while the other is searching it, which throws an exception
- The async downloader considers failed downloads to still be active, so they block downloads from the same host from starting (see #3557)
- If you try to cancel a download, the async downloader halts the currently in progress downloads but then proceeds to start up any remaining queued downloads
- The async modules downloader can't be re-used to retry a batch of downloads because it already has all the modules in `this.modules` and therefore thinks they're in progress
- If you choose the `not:cached` filter and then download a mod to cache, it doesn't disappear even though it no longer matches the filter
- If your changeset contains both removals and installs, and one of the installs fails, the removal step is not rolled back. This is bad if you were intending to switch from the removed mods to the installed mods, because now you need to fall back to your old mods and have to go find them and reinstall, if you can even remember what they were.
- The code related to the `Wait` tab is messy and hard to change without breaking something else

## Changes

Now if any downloads in your changeset fail, this popup appears over the install progress screen:

![image](https://user-images.githubusercontent.com/1559108/185250390-23d13ebd-ca37-48bc-8c91-71fe19b59673.png)

Clicking either checkbox in a row will toggle both of that row's checkboxes; rather than representing this with a single checkbox, I wanted to make it clear that both choices are actions, and you are sorting the mods into one group or the other.

If you click "Abort whole changeset", then any uninstallations are rolled back and you are returned to the main mod list with your changeset intact. If you click "Retry", then any mods with a check mark in the "Skip" column will be removed from your changeset, along with any mods depending on them, and CKAN will try again with the mods with check marks in the Retry column plus the ones that didn't fail.

- Now `--show-console` isn't passed to GUI since it's handled before that
- Now a `lock` mutex protects the queued downloads collection, so only one thread can change it at a time
- Now if a download fails, the async downloader allows a queued download from the same host to replace it (since we will be reporting and handling download errors later in the popup)
- Now cancelling downloads purges the queued downloads
- Now the async module downloader clears `this.modules` after a batch finishes, successfully or otherwise, so it can be used to retry failed downloads
- Now all of GUI's many `BackgroundWorker`s used for interacting with `Wait` are replaced by one that lives inside `Wait`, for better encapsulation. The functions formerly assigned to `DoWork` and `RunWorkerCompleted` are now parameters to `StartWaiting`. In addition, some of `Wait`'s functions are changed from `public` to `private` and only manipulated from well defined, well known interfaces. This will make it easier to keep track of where these things are being used and ensure they don't end up in a weird state.
- `Wait.OnCancel` is now used by other code to react to cancellation instead of `Main.cancelCallback`, and the Cancel button is only available if the `cancelable` parameter to `StartWaiting` is `true` (which it is for installation and downloading to cache)
- The Retry button starts out hidden and is shown with `Wait.RetryEnabled = true` when the failure handler supports it
- Now `ModuleDownloadErrorsKraken`'s list of modules and their corresponding download errors is public, so we can use it in the popup
- `InstallMods` now catches `ModuleDownloadErrorsKraken` and passes its module/exception info to the new popup, then either throws a cancellation kraken or removes the skipped mods and their depending mods from `toInstall`
- Now we always show the selected mod's info on returning to `ManageMods`
- Now if you cancel an install or a download to cache, we return you to `ManageMods` immediately since you don't benefit from reading text that says you cancelled
- Now the changeset is **not** cleared after a failed install, so users will no longer have the experience of selecting dozens of mods and then trying to re-select them after a failure
- Now we refresh the mod list after downloading to cache
- Now one big transaction covers the entire remove / install / upgrade flow, so if the install fails, the whole changeset is reverted
- `Registry.FindReverseDependencies` now has a `satisfiedFilter` parameter that accepts a function from `RelationshipDescriptor` to `bool`, which we use to avoid removing a depending mod from the changeset if the broken dependency is virtual; this way, the user can Skip a virtual dependency and then make a different choice

This should provide a much more stable and pleasant experience when downloads fail.

Fixes #873.
Fixes #1636.
Fixes #3588.
Fixes #3604.