### PR TITLE
Update mod list through Wait.StartWaiting

### DIFF
--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -455,8 +455,7 @@
             this.ManageMods.OnSelectedModuleChanged += ManageMods_OnSelectedModuleChanged;
             this.ManageMods.OnChangeSetChanged += ManageMods_OnChangeSetChanged;
             this.ManageMods.OnRegistryChanged += ManageMods_OnRegistryChanged;
-            this.ManageMods.OpenProgressTab += ManageMods_OpenProgressTab;
-            this.ManageMods.CloseProgressTab += ManageMods_CloseProgressTab;
+            this.ManageMods.OnRefresh += ManageMods_OnRefresh;
             this.ManageMods.LabelsAfterUpdate += ManageMods_LabelsAfterUpdate;
             this.ManageMods.StartChangeSet += ManageMods_StartChangeSet;
             //

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -291,7 +291,7 @@ namespace CKAN.GUI
                 else
                 {
                     SetupDefaultSearch();
-                    ManageMods.UpdateModsList();
+                    ManageMods_OnRefresh();
                 }
             }
             ManageMods.InstanceUpdated(CurrentInstance);
@@ -607,7 +607,7 @@ namespace CKAN.GUI
             if (dialog.ShowDialog() != DialogResult.Cancel)
             {
                 // This takes a while, so don't do it if they cancel out
-                ManageMods.UpdateModsList();
+                ManageMods_OnRefresh();
             }
         }
 
@@ -811,20 +811,22 @@ namespace CKAN.GUI
                     changeset, RelationshipResolver.DependsOnlyOpts()));
         }
 
-        private void ManageMods_OpenProgressTab()
+        private void ManageMods_OnRefresh(Dictionary<string, bool> oldModules = null)
         {
-            ResetProgress();
+            tabController.RenameTab("WaitTabPage", Properties.Resources.MainModListWaitTitle);
             ShowWaitDialog();
+            Util.Invoke(this, SwitchEnabledState);
             tabController.SetTabLock(true);
-            Util.Invoke(this, SwitchEnabledState);
-        }
-
-        private void ManageMods_CloseProgressTab()
-        {
-            Util.Invoke(this, UpdateTrayInfo);
-            HideWaitDialog(true);
-            tabController.SetTabLock(false);
-            Util.Invoke(this, SwitchEnabledState);
+            Wait.StartWaiting(
+                ManageMods.Update,
+                (sender, e) => {
+                    HideWaitDialog(true);
+                    tabController.SetTabLock(false);
+                    Util.Invoke(this, SwitchEnabledState);
+                    SetupDefaultSearch();
+                },
+                false,
+                oldModules);
         }
     }
 }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -82,8 +82,7 @@ namespace CKAN.GUI
         {
             module.UpdateIsCached();
             // Update mod list in case is:cached or not:cached filters are active
-            ManageMods.UpdateModsList();
-            HideWaitDialog(true);
+            ManageMods_OnRefresh();
             // User might have selected another row. Show current in tree.
             UpdateModContentsTree(ModInfo.SelectedModule.ToCkanModule(), true);
         }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -413,7 +413,7 @@ namespace CKAN.GUI
                 // The Result property throws if InstallMods threw (!!!)
                 KeyValuePair<bool, ModChanges> result = (KeyValuePair<bool, ModChanges>) e.Result;
                 // Rebuilds the list of GUIMods
-                ManageMods.UpdateModsList();
+                ManageMods_OnRefresh();
 
                 Util.Invoke(this, () => Enabled = true);
                 Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -140,30 +140,34 @@ namespace CKAN.GUI
                     // Load rows if grid empty, otherwise keep current
                     if (ManageMods.ModGrid.Rows.Count < 1)
                     {
-                        ManageMods.UpdateModsList();
+                        ManageMods_OnRefresh();
                     }
+                    else
+                    {
+                        Util.Invoke(this, SwitchEnabledState);
+                        Util.Invoke(this, ManageMods.ModGrid.Select);
+                    }
+                    SetupDefaultSearch();
                     break;
 
                 case RepoUpdateResult.Failed:
                     AddStatusMessage(Properties.Resources.MainRepoFailed);
                     HideWaitDialog(false);
+                    Util.Invoke(this, SwitchEnabledState);
+                    Util.Invoke(this, ManageMods.ModGrid.Select);
+                    SetupDefaultSearch();
                     break;
 
                 case RepoUpdateResult.Updated:
                 default:
-                    ManageMods.UpdateModsList(oldModules);
                     AddStatusMessage(Properties.Resources.MainRepoSuccess);
                     ShowRefreshQuestion();
-                    HideWaitDialog(true);
                     UpgradeNotification();
+                    Util.Invoke(this, SwitchEnabledState);
+                    ManageMods_OnRefresh(oldModules);
                     break;
             }
 
-            tabController.HideTab("WaitTabPage");
-            Util.Invoke(this, SwitchEnabledState);
-            Util.Invoke(this, RecreateDialogs);
-            Util.Invoke(this, ManageMods.ModGrid.Select);
-            SetupDefaultSearch();
         }
 
         private void ShowRefreshQuestion()


### PR DESCRIPTION
## Background

Both refreshing the registry and updating the mod list use the `Wait` tab to log their progress, so the user can see what is happening and can tell the app hasn't frozen (see #2617).

## Problems

Recently (dev builds only), if you refresh the registry in GUI, the log messages for repo update remain visible while the mod list is being refreshed. The progress tab should reset because they're separate processes.

Similarly (also dev builds only), if you use the download to cache option for a mod, we open the progress tab for the download and then refresh the mod list, which also uses the progress tab, but we jump back to the mod list in between.

## Cause

In #3635 we refactored the `Wait` tab to clean up error handling and make its use more consistent. All of the many `BackgroundWorkers` were combined into one and encapsulated inside `Wait`. As part of this, `Wait.ClearLog` was made `private` and moved from the many places where it was called previously to `Wait.StartWaiting` as a way to guarantee proper state when the tab starts up.

This missed the mod list refresh because it was not using a `BackgroundWorker`, but rather started a background thread with `await Task.Factory.StartNew`. So while `Wait.ClearLog()` was removed from the end of repo update, it was not added to the start of mod list updating.

#3635 added a call to refresh the mod list after a download to cache but didn't remove the logic that closed it when done.

## Changes

- Now the mod list refresh is refactored to use `Wait.StartWaiting`, like all the other users of the progress tab. The logic for refreshing the list is still in `ManageMods`, but the parts that manipulate the overall window state are moved to `Main.ManageMods_OnRefresh`.
- Now the post-repo refresh actions for updating the mod list are cleaned up to make sure everything is opened, cleared, and closed properly.
- Now the download to cache logic relies on the mod list refresh to close the progress tab when done. It also clears the log.

This way, when you update the registry, the `Wait` tab remains active (we do **not** want it to flicker-jump back to and from the mod list tab) but clears itself between the two flows.
