### PR TITLE
Hide tray icon at exit via ctrl-C

### DIFF
--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -48,9 +48,6 @@ namespace CKAN.GUI
 
         public GUIUser currentUser;
 
-        private bool enableTrayIcon;
-        private bool minimizeToTray;
-
         public static Main Instance { get; private set; }
 
         public Main(string[] cmdlineArgs, GameInstanceManager mgr, bool showConsole)
@@ -391,6 +388,11 @@ namespace CKAN.GUI
 
             bool autoUpdating = CheckForCKANUpdate();
             CheckTrayState();
+            Console.CancelKeyPress += (sender, evt) =>
+            {
+                // Hide tray icon on Ctrl-C
+                minimizeNotifyIcon.Visible = false;
+            };
             InitRefreshTimer();
 
             URLHandlers.RegisterURLHandler(configuration, currentUser);
@@ -462,7 +464,7 @@ namespace CKAN.GUI
             // Copy metadata panel split height to app settings
             configuration.ModInfoPosition = ModInfo.ModMetaSplitPosition;
 
-            // Save settings.
+            // Save settings
             configuration.Save();
 
             if (needRegistrySave)
@@ -530,7 +532,7 @@ namespace CKAN.GUI
         {
             // Flipping enabled here hides the main form itself.
             Enabled = false;
-            new SettingsDialog(currentUser).ShowDialog();
+            new SettingsDialog(currentUser).ShowDialog(this);
             Enabled = true;
         }
 

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -174,4 +174,5 @@
   <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Settings</value></data>
   <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quit</value></data>
   <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play time...</value></data>
+  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
 </root>

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -370,7 +370,7 @@ namespace CKAN.GUI
                             }
                             // Now pretend they clicked the menu option for the settings
                             Enabled = false;
-                            new SettingsDialog(currentUser).ShowDialog();
+                            new SettingsDialog(currentUser).ShowDialog(this);
                             Enabled = true;
                         }
                         break;

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -10,6 +10,9 @@ namespace CKAN.GUI
     {
         #region Tray Behaviour
 
+        private bool enableTrayIcon;
+        private bool minimizeToTray;
+
         public void CheckTrayState()
         {
             enableTrayIcon = configuration.EnableTrayIcon;
@@ -112,7 +115,7 @@ namespace CKAN.GUI
         private void cKANSettingsToolStripMenuItem1_Click(object sender, EventArgs e)
         {
             OpenWindow();
-            new SettingsDialog(currentUser).ShowDialog();
+            new SettingsDialog(currentUser).ShowDialog(this);
         }
 
         private void minimizedContextMenuStrip_Opening(object sender, CancelEventArgs e)


### PR DESCRIPTION
## Problems

- On Windows, the tray icon doesn't disappear at close if you kill CKAN with ctrl-C in the console. (You need to use the `--show-console` parameter to keep it visible after the GUI appears.) You can even accumulate several of them if you do it over and over:
  ![image](https://user-images.githubusercontent.com/1559108/185726421-e27e786f-e85a-4acd-92c4-5da1e082f5c6.png)
- If you use the tray icon to open the settings while CKAN doesn't have focus, it appears at the upper left corner of your monitor
- Tray icons have the ability to display tooltips, but we don't have one

## Changes

- Now the `Console.CancelKeyPress` ctrl-C event handler hides the tray icon
- Now we always pass a reference to the main form when we show the settings dialog, which will ensure it is properly centered on the main window
- Now the tray icon has a tooltip that says "CKAN"
