### PR TITLE
Debounce search events on all platforms

### DIFF
--- a/GUI/Controls/EditModSearch.Designer.cs
+++ b/GUI/Controls/EditModSearch.Designer.cs
@@ -80,8 +80,6 @@
             this.FilterCombinedTextBox.Size = new System.Drawing.Size(247, 26);
             this.FilterCombinedTextBox.TabIndex = 17;
             this.FilterCombinedTextBox.Enter += new System.EventHandler(this.FilterTextBox_Enter);
-            this.FilterCombinedTextBox.TextChanged += new System.EventHandler(this.FilterCombinedTextBox_TextChanged);
-            this.FilterCombinedTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
             resources.ApplyResources(this.FilterCombinedTextBox, "FilterCombinedTextBox");
             //
             // ExpandButton

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -24,10 +24,9 @@ namespace CKAN.GUI
 
         /// <summary>
         /// Event fired when a search needs to be executed.
-        /// The parameter is true if the search should be executed immediately,
-        /// or false if the keystroke timer should be used.
+        /// Upstream source event is passed along.
         /// </summary>
-        public event Action<bool> ApplySearch;
+        public event EventHandler ApplySearch;
 
         /// <summary>
         /// Event fired when user wants to switch focus away from this control.
@@ -64,20 +63,14 @@ namespace CKAN.GUI
 
         protected override void OnLeave(EventArgs e)
         {
-            if (SurrenderFocus != null)
-            {
-                SurrenderFocus();
-            }
+            SurrenderFocus?.Invoke();
         }
 
         private static readonly ILog log = LogManager.GetLogger(typeof(EditModSearchDetails));
 
         private void FilterTextBox_TextChanged(object sender, EventArgs e)
         {
-            if (ApplySearch != null)
-            {
-                ApplySearch(string.IsNullOrEmpty((sender as TextBox)?.Text));
-            }
+            ApplySearch?.Invoke(sender, e);
         }
 
         private void FilterTextBox_KeyDown(object sender, KeyEventArgs e)
@@ -85,41 +78,25 @@ namespace CKAN.GUI
             // Switch focus from filters to mod list on enter, down, or pgdn
             switch (e.KeyCode)
             {
-                case Keys.Enter:
-                    if (ApplySearch != null)
-                    {
-                        ApplySearch(true);
-                        e.Handled = true;
-                        e.SuppressKeyPress = true;
-                    }
-                    break;
-
                 case Keys.Escape:
                     if (SurrenderFocus != null
                         && string.IsNullOrEmpty((sender as HintTextBox)?.Text ?? null))
                     {
-                        SurrenderFocus();
+                        SurrenderFocus?.Invoke();
                         e.Handled = true;
                         e.SuppressKeyPress = true;
                     }
                     break;
 
-                case Keys.Up:
-                case Keys.Down:
-                case Keys.PageUp:
-                case Keys.PageDown:
-                    if (SurrenderFocus != null)
-                    {
-                        SurrenderFocus();
-                        e.Handled = true;
-                    }
+                default:
+                    ApplySearch?.Invoke(sender, e);
                     break;
             }
         }
 
         private void TriStateChanged(bool? val)
         {
-            ApplySearch?.Invoke(true);
+            ApplySearch?.Invoke(null, null);
         }
 
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
@@ -127,7 +104,7 @@ namespace CKAN.GUI
             switch (keyData)
             {
                 case Keys.Control | Keys.Shift | Keys.F:
-                    SurrenderFocus();
+                    SurrenderFocus?.Invoke();
                     return true;
             }
             return base.ProcessCmdKey(ref msg, keyData);


### PR DESCRIPTION
## Problem

Mod searches in GUI that return many results can be noticeably slow on Windows. Usually this means one- or two-character searches.

## Cause

The search logic that we perform is quick, but adding a lot of rows to `DataGridView` is unavoidably slow. Since WinForms requires that all UI updates happen in the foreground GUI thread, we can't improve this by simply moving logic to a background thread.

## Background

Mono platforms already have a delay between keystrokes and search, so they don't suffer as much from this today. However, the implementation of the delay is embedded within and very specific to `EditModSearch`, even though this is a generic operation that could be useful elsewhere.

## Changes

- Now there is no longer anything platform-specific in the mod search logic
- Now a new `Util.Debounce` function implements a generic "[debounce](https://www.freecodecamp.org/news/javascript-debounce-example/)" operation, which is a term for handling a very busy event queue by postponing slow operations until there's a given delay between the events
- Now `EditModSearch` uses `Util.Debounce` instead of its own `Timer` object to debounce the search editing events. The logic to control it is now consolidated into new functions `ImmediateHandler`, `SkipDelayIf`, `AbortIf`, and `DelayedHandler`.
  - Pressing Enter still triggers an immediate search
  - Typing more than 4 characters without a prefix (e.g `dep:`) also triggers an immediate search, because such a search will match a small number of rows and therefore be fast
- Now `EditModSearchDetails` forwards events to `EditModSearch` rather than determining on its own when an immediate search should happen, so it can share in the generic debounce logic

Fixes #3402.
Fixes #3620.
Closes #3419 (breaks immediate searching on Enter keypress).
