### PR TITLE
Clean up window disabling

### DIFF
--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -241,7 +241,7 @@ namespace CKAN.GUI
             });
         }
 
-        public void Finish(bool success)
+        public void Finish()
         {
             OnCancel = null;
             Util.Invoke(this, () =>

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -590,8 +590,6 @@ namespace CKAN.GUI
                         continue;
                     }
 
-                    menuStrip1.Enabled = false;
-
                     InstallModuleDriver(registry_manager.registry, module);
                 }
                 registry_manager.Save(true);
@@ -815,18 +813,43 @@ namespace CKAN.GUI
         {
             tabController.RenameTab("WaitTabPage", Properties.Resources.MainModListWaitTitle);
             ShowWaitDialog();
-            Util.Invoke(this, SwitchEnabledState);
-            tabController.SetTabLock(true);
+            DisableMainWindow();
             Wait.StartWaiting(
                 ManageMods.Update,
                 (sender, e) => {
-                    HideWaitDialog(true);
-                    tabController.SetTabLock(false);
-                    Util.Invoke(this, SwitchEnabledState);
+                    HideWaitDialog();
+                    EnableMainWindow();
                     SetupDefaultSearch();
                 },
                 false,
                 oldModules);
         }
+
+        private void EnableMainWindow()
+        {
+            Util.Invoke(this, () =>
+            {
+                Enabled = true;
+                menuStrip1.Enabled = true;
+                tabController.SetTabLock(false);
+                /* Windows (7 & 8 only?) bug #1548 has extra facets.
+                 * parent.childcontrol.Enabled = false seems to disable the parent,
+                 * if childcontrol had focus. Depending on optimization steps,
+                 * parent.childcontrol.Enabled = true does not necessarily
+                 * re-enable the parent.*/
+                this.Focus();
+            });
+        }
+
+        private void DisableMainWindow()
+        {
+            Util.Invoke(this, () =>
+            {
+                Enabled = false;
+                menuStrip1.Enabled = false;
+                tabController.SetTabLock(true);
+            });
+        }
+
     }
 }

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -54,7 +54,7 @@ namespace CKAN.GUI
         {
             ResetProgress();
             ShowWaitDialog();
-            SwitchEnabledState();
+            DisableMainWindow();
             tabController.RenameTab("WaitTabPage", Properties.Resources.MainUpgradingWaitTitle);
             Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo, AutoUpdate.Instance.latestUpdate.Version));
 
@@ -70,7 +70,7 @@ namespace CKAN.GUI
         private void UpdateReady(object sender, RunWorkerCompletedEventArgs e)
         {
             // Close will be cancelled if the window is still disabled
-            SwitchEnabledState();
+            EnableMainWindow();
             Close();
         }
 

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -33,7 +33,7 @@ namespace CKAN.GUI
 
         private void Changeset_OnConfirmChanges()
         {
-            menuStrip1.Enabled = false;
+            DisableMainWindow();
 
             // Using the changeset passed in can cause issues with versions.
             // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -58,10 +58,8 @@ namespace CKAN.GUI
 
                     case CancelledActionKraken exc:
                         // User already knows they cancelled, get out
-                        HideWaitDialog(false);
-                        tabController.SetTabLock(false);
-                        Util.Invoke(this, () => Enabled = true);
-                        Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
+                        HideWaitDialog();
+                        EnableMainWindow();
                         break;
 
                     default:

--- a/GUI/Main/MainExport.cs
+++ b/GUI/Main/MainExport.cs
@@ -20,17 +20,15 @@ namespace CKAN.GUI
             Task.Factory.StartNew(() =>
             {
                 AddStatusMessage("");
-                Util.Invoke(this, () => menuStrip1.Enabled = false);
                 tabController.ShowTab("EditModpackTabPage", 2);
-                tabController.SetTabLock(true);
+                DisableMainWindow();
                 var mgr = RegistryManager.Instance(CurrentInstance);
                 EditModpack.LoadModule(mgr.GenerateModpack(false, true), mgr.registry);
                 // This will block till the user is done
                 EditModpack.Wait(currentUser);
                 tabController.ShowTab("ManageModsTabPage");
                 tabController.HideTab("EditModpackTabPage");
-                tabController.SetTabLock(false);
-                Util.Invoke(this, () => menuStrip1.Enabled = true);
+                EnableMainWindow();
             });
         }
 

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -31,8 +31,8 @@ namespace CKAN.GUI
             {
                 // Show WaitTabPage (status page) and lock it.
                 tabController.RenameTab("WaitTabPage", Properties.Resources.MainImportWaitTitle);
-                tabController.ShowTab("WaitTabPage");
-                tabController.SetTabLock(true);
+                ShowWaitDialog();
+                DisableMainWindow();
 
                 try
                 {
@@ -46,8 +46,8 @@ namespace CKAN.GUI
                 finally
                 {
                     // Put GUI back the way we found it
-                    tabController.SetTabLock(false);
-                    tabController.HideTab("WaitTabPage");
+                    EnableMainWindow();
+                    HideWaitDialog();
                 }
             }
         }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -21,6 +21,7 @@ namespace CKAN.GUI
         {
             try
             {
+                DisableMainWindow();
                 var userChangeSet = new List<ModChange>();
                 InstalledModule installed = registry.InstalledModule(module.identifier);
                 if (installed != null)
@@ -52,8 +53,8 @@ namespace CKAN.GUI
             catch
             {
                 // If we failed, do the clean-up normally done by PostInstallMods.
-                HideWaitDialog(false);
-                menuStrip1.Enabled = true;
+                HideWaitDialog();
+                EnableMainWindow();
             }
         }
 
@@ -347,10 +348,8 @@ namespace CKAN.GUI
 
                     case CancelledActionKraken exc:
                         // User already knows they cancelled, get out
-                        HideWaitDialog(false);
-                        tabController.SetTabLock(false);
-                        Util.Invoke(this, () => Enabled = true);
-                        Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
+                        HideWaitDialog();
+                        EnableMainWindow();
                         break;
 
                     case MissingCertificateKraken exc:
@@ -412,15 +411,9 @@ namespace CKAN.GUI
             {
                 // The Result property throws if InstallMods threw (!!!)
                 KeyValuePair<bool, ModChanges> result = (KeyValuePair<bool, ModChanges>) e.Result;
+                AddStatusMessage(Properties.Resources.MainInstallSuccess);
                 // Rebuilds the list of GUIMods
                 ManageMods_OnRefresh();
-
-                Util.Invoke(this, () => Enabled = true);
-                Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
-                tabController.SetTabLock(false);
-
-                AddStatusMessage(Properties.Resources.MainInstallSuccess);
-                HideWaitDialog(true);
             }
         }
     }

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -35,27 +35,11 @@ namespace CKAN.GUI
             }
             catch { }
 
-            Util.Invoke(this, SwitchEnabledState);
+            DisableMainWindow();
 
             Wait.SetDescription(Properties.Resources.MainRepoContacting);
             ShowWaitDialog();
         }
-
-        private bool _enabled = true;
-        private void SwitchEnabledState()
-        {
-            _enabled = !_enabled;
-            menuStrip1.Enabled = _enabled;
-            tabController.SetTabLock(!_enabled);
-            /* Windows (7 & 8 only?) bug #1548 has extra facets.
-             * parent.childcontrol.Enabled = false seems to disable the parent,
-             * if childcontrol had focus. Depending on optimization steps,
-             * parent.childcontrol.Enabled = true does not necessarily
-             * re-enable the parent.*/
-            if (_enabled)
-                this.Focus();
-        }
-
 
         private void UpdateRepo(object sender, DoWorkEventArgs e)
         {
@@ -114,7 +98,7 @@ namespace CKAN.GUI
                 {
                     case ReinstallModuleKraken rmk:
                         // Re-enable the UI for the install flow
-                        Util.Invoke(this, SwitchEnabledState);
+                        EnableMainWindow();
                         Wait.StartWaiting(InstallMods, PostInstallMods, true,
                             new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                                 rmk.Modules
@@ -136,7 +120,7 @@ namespace CKAN.GUI
             {
                 case RepoUpdateResult.NoChanges:
                     AddStatusMessage(Properties.Resources.MainRepoUpToDate);
-                    HideWaitDialog(true);
+                    HideWaitDialog();
                     // Load rows if grid empty, otherwise keep current
                     if (ManageMods.ModGrid.Rows.Count < 1)
                     {
@@ -144,7 +128,7 @@ namespace CKAN.GUI
                     }
                     else
                     {
-                        Util.Invoke(this, SwitchEnabledState);
+                        EnableMainWindow();
                         Util.Invoke(this, ManageMods.ModGrid.Select);
                     }
                     SetupDefaultSearch();
@@ -152,8 +136,8 @@ namespace CKAN.GUI
 
                 case RepoUpdateResult.Failed:
                     AddStatusMessage(Properties.Resources.MainRepoFailed);
-                    HideWaitDialog(false);
-                    Util.Invoke(this, SwitchEnabledState);
+                    HideWaitDialog();
+                    EnableMainWindow();
                     Util.Invoke(this, ManageMods.ModGrid.Select);
                     SetupDefaultSearch();
                     break;
@@ -163,7 +147,7 @@ namespace CKAN.GUI
                     AddStatusMessage(Properties.Resources.MainRepoSuccess);
                     ShowRefreshQuestion();
                     UpgradeNotification();
-                    Util.Invoke(this, SwitchEnabledState);
+                    EnableMainWindow();
                     ManageMods_OnRefresh(oldModules);
                     break;
             }

--- a/GUI/Main/MainTime.cs
+++ b/GUI/Main/MainTime.cs
@@ -9,9 +9,8 @@ namespace CKAN.GUI
         private void viewPlayTimeStripMenuItem_Click(object sender, EventArgs e)
         {
             PlayTime.loadAllPlayTime(manager);
-            menuStrip1.Enabled = false;
             tabController.ShowTab("PlayTimeTabPage", 2);
-            tabController.SetTabLock(true);
+            DisableMainWindow();
         }
 
         private void PlayTime_Done()
@@ -19,8 +18,7 @@ namespace CKAN.GUI
             UpdateStatusBar();
             tabController.ShowTab("ManageModsTabPage");
             tabController.HideTab("PlayTimeTabPage");
-            tabController.SetTabLock(false);
-            menuStrip1.Enabled = true;
+            EnableMainWindow();
         }
     }
 }

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -16,11 +16,11 @@ namespace CKAN.GUI
             });
         }
 
-        public void HideWaitDialog(bool success)
+        public void HideWaitDialog()
         {
             Util.Invoke(this, () =>
             {
-                Wait.Finish(success);
+                Wait.Finish();
                 RecreateDialogs();
 
                 tabController.HideTab("WaitTabPage");
@@ -46,7 +46,7 @@ namespace CKAN.GUI
             });
             Util.Invoke(WaitTabPage, () => {
                 RecreateDialogs();
-                Wait.Finish(false);
+                Wait.Finish();
                 SetProgress(100);
             });
             Wait.AddLogMessage(logMsg);
@@ -82,10 +82,8 @@ namespace CKAN.GUI
 
         public void Wait_OnOk()
         {
-            Util.Invoke(this, () => Enabled = true);
-            Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
-            tabController.SetTabLock(false);
-            HideWaitDialog(false);
+            EnableMainWindow();
+            HideWaitDialog();
         }
     }
 }


### PR DESCRIPTION
## Problem

In current dev builds, if you turn on automatic registry refreshing at launch in the settings, you can sometimes end up with the main menu disabled and the close button not working at startup.

## Causes

- In #3635 and #3637 we tried to improve the `Wait` tab's encapsulation and how it's used, and some of those updates must have created a state where we disable the window and don't re-enable it, but I have not been able to pin down exactly how it happened.
- `Main.SwitchEnabledState` is a toggle that keeps state in a private `_enabled` variable, but every place that calls it wants specifically to either enable or disable the window; there is no point where a toggle actually makes sense like it does with a checkbox. If that state gets out of sync unexpectedly, then those calls all flip, we disable when we mean to enable and vice versa, and we end up with a disabled window that can't be re-enabled.

## Changes

- `Main.SwitchEnabledState` from `MainRepo.cs` is split into `Main.EnableMainWindow` and `Main.DisableMainWindow` in `Main.cs`, and all calling code is updated to use the right one based on what is being done at that point
- Every other place that I could find that enables or disables the tabs and menus is also updated to use `Main.EnableMainWindow` and `Main.DisableMainWindow`
- The unused parameter of `Wait.Finish` and `HideWaitDialog` is removed

This fixes the bug and should help keep things more consistent in the future.
