### PR TITLE
Disable parallel runs of deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
     types:
       - deploy
 
+concurrency: deploy
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problems

Our deploy workflow can mess up our APT repos if we run multiple jobs of it at once, as can happen if multiple pull requests are approved and merged rapidly in sequence. I think what I've seen is that the checksums in the metadata files don't match the downloads. We have made a habit of waiting until the "Passed" notification appears in Discord before merging, but this is inconvenient since [this job takes about 13 minutes to run](https://github.com/KSP-CKAN/CKAN/actions/workflows/deploy.yml).

## Background

GitHub workflows can be configured to only run one instance of a given job at a time:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be `pending`. Any previously pending job or workflow in the concurrency group will be canceled.

(That part about cancelling pending jobs is an unexpected boon; if we merge five pull requests at once, we don't really need all 5 builds; just the most recent one is good enough. For now I have left out `cancel-in-progress` since I don't trust that things would be left in a consistent state if the job is cancelled while running.)

## Changes

Now `deploy.xml` sets `concurrency: deploy` (the value is any arbitrary string that we choose), which should put all jobs from that workflow in the same concurrency group, ensuring that the previous job completes before the next one is run no matter how many pull requests we merge at once.
