### PR TITLE
Improvements for failed repo updates

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -139,7 +139,9 @@ namespace CKAN.CmdLine
         {
             RegistryManager registry_manager = RegistryManager.Instance(instance);
 
-            CKAN.Repo.UpdateAllRepositories(registry_manager, instance, manager.Cache, user);
+            var downloader = new NetAsyncDownloader(user);
+
+            CKAN.Repo.UpdateAllRepositories(registry_manager, instance, downloader, manager.Cache, user);
 
             user.RaiseMessage(Properties.Resources.UpdateSummary, registry_manager.registry.CompatibleModules(instance.VersionCriteria()).Count());
         }

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -40,22 +40,9 @@ namespace CKAN.CmdLine
                 compatible_prior = registry.CompatibleModules(instance.VersionCriteria()).ToList();
             }
 
-            // If no repository is selected, select all.
-            if (options.repo == null)
-            {
-                options.update_all = true;
-            }
-
             try
             {
-                if (options.update_all)
-                {
-                    UpdateRepository(instance);
-                }
-                else
-                {
-                    UpdateRepository(instance, options.repo);
-                }
+                UpdateRepository(instance);
             }
             catch (ReinstallModuleKraken rmk)
             {
@@ -148,13 +135,11 @@ namespace CKAN.CmdLine
         /// </summary>
         /// <param name="instance">The KSP instance to work on.</param>
         /// <param name="repository">Repository to update. If null all repositories are used.</param>
-        private void UpdateRepository(CKAN.GameInstance instance, string repository = null)
+        private void UpdateRepository(CKAN.GameInstance instance)
         {
             RegistryManager registry_manager = RegistryManager.Instance(instance);
 
-            var updated = repository == null
-                ? CKAN.Repo.UpdateAllRepositories(registry_manager, instance, manager.Cache, user) != CKAN.RepoUpdateResult.Failed
-                : CKAN.Repo.Update(registry_manager, instance, user, repository);
+            CKAN.Repo.UpdateAllRepositories(registry_manager, instance, manager.Cache, user);
 
             user.RaiseMessage(Properties.Resources.UpdateSummary, registry_manager.registry.CompatibleModules(instance.VersionCriteria()).Count());
         }

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -494,13 +494,6 @@ namespace CKAN.CmdLine
 
     internal class UpdateOptions : InstanceSpecificOptions
     {
-        // This option is really meant for devs testing their CKAN-meta forks.
-        [Option('r', "repo", HelpText = "CKAN repository to use (experimental!)")]
-        public string repo { get; set; }
-
-        [Option("all", DefaultValue = false, HelpText = "Upgrade all available updated modules")]
-        public bool update_all { get; set; }
-
         [Option("list-changes", DefaultValue = false, HelpText = "List new and removed modules")]
         public bool list_changes { get; set; }
     }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -437,9 +437,12 @@ namespace CKAN.ConsoleUI {
                 );
                 recent.Clear();
                 try {
+                    var downloader = new NetAsyncDownloader(ps);
+
                     Repo.UpdateAllRepositories(
                         RegistryManager.Instance(manager.CurrentInstance),
                         manager.CurrentInstance,
+                        downloader,
                         manager.Cache,
                         ps
                     );

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -67,6 +67,18 @@ namespace CKAN.Extensions
         public static TimeSpan Sum(this IEnumerable<TimeSpan> source)
             => source.Aggregate(TimeSpan.Zero,
                                 (a, b) => a + b);
+
+
+        /// <summary>
+        /// Select : SelectMany :: Zip : ZipMany
+        /// </summary>
+        /// <param name="seq1">Sequence from which to get first values</param>
+        /// <param name="seq2">Sequence from which to get second values</param>
+        /// <param name="func">Function to transform a value from each input sequence into a sequence of multiple outputs</param>
+        /// <returns>Flattened sequence of values from func applies to seq1 and seq2</returns>
+        public static IEnumerable<V> ZipMany<T, U, V>(this IEnumerable<T> seq1, IEnumerable<U> seq2, Func<T, U, IEnumerable<V>> func)
+            => seq1.Zip(seq2, func).SelectMany(seqs => seqs);
+
     }
 
     /// <summary>

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -180,20 +180,19 @@ namespace CKAN
 
         public static void DownloadWithProgress(ICollection<DownloadTarget> downloadTargets, IUser user = null)
         {
-            new NetAsyncDownloader(user ?? new NullUser())
+            var downloader = new NetAsyncDownloader(user ?? new NullUser());
+            downloader.onOneCompleted += (url, filename, error, etag) =>
             {
-                onOneCompleted = (url, filename, error) =>
+                if (error != null)
                 {
-                    if (error != null)
-                    {
-                        user?.RaiseError(error.ToString());
-                    }
-                    else
-                    {
-                        File.Move(filename, downloadTargets.First(p => p.url == url).filename);
-                    }
+                    user?.RaiseError(error.ToString());
                 }
-            }.DownloadAndWait(downloadTargets);
+                else
+                {
+                    File.Move(filename, downloadTargets.First(p => p.url == url).filename);
+                }
+            };
+            downloader.DownloadAndWait(downloadTargets);
         }
 
         /// <summary>

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -35,11 +35,9 @@ namespace CKAN
         public NetAsyncModulesDownloader(IUser user, NetModuleCache cache)
         {
             modules    = new List<CkanModule>();
-            downloader = new NetAsyncDownloader(user)
-            {
-                // Schedule us to process each module on completion.
-                onOneCompleted = ModuleDownloadComplete
-            };
+            downloader = new NetAsyncDownloader(user);
+            // Schedule us to process each module on completion.
+            downloader.onOneCompleted += ModuleDownloadComplete;
             downloader.Progress += (target, remaining, total) =>
             {
                 var mod = modules.FirstOrDefault(m => m.download == target.url);
@@ -104,7 +102,7 @@ namespace CKAN
             }
         }
 
-        private void ModuleDownloadComplete(Uri url, string filename, Exception error)
+        private void ModuleDownloadComplete(Uri url, string filename, Exception error, string etag)
         {
             if (error != null)
             {

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -90,7 +90,7 @@ namespace CKAN
                 ShowUserInconsistencies(registry_manager.registry, user);
 
                 List<CkanModule> metadataChanges = GetChangedInstalledModules(registry_manager.registry);
-                if (metadataChanges.Count > 0)
+                if (metadataChanges.Count > 0 && cache != null)
                 {
                     HandleModuleChanges(metadataChanges, user, ksp, cache, registry_manager);
                 }
@@ -284,55 +284,6 @@ namespace CKAN
             }
 
             // If we couldn't find any differences they must be equivalent
-            return true;
-        }
-
-        /// <summary>
-        /// Set a registry's available modules to the list from just one repo
-        /// </summary>
-        /// <param name="registry_manager">Manager of the regisry of interest</param>
-        /// <param name="ksp">Game instance</param>
-        /// <param name="user">Object for user interaction callbacks</param>
-        /// <param name="repo">Repository to check</param>
-        /// <returns>
-        /// Number of modules found in repo
-        /// </returns>
-        public static bool Update(RegistryManager registry_manager, GameInstance ksp, IUser user, string repo = null)
-        {
-            if (repo == null)
-            {
-                return Update(registry_manager, ksp, user, (Uri)null);
-            }
-
-            return Update(registry_manager, ksp, user, new Uri(repo));
-        }
-
-        // Same as above, just with a Uri instead of string for the repo
-        public static bool Update(RegistryManager registry_manager, GameInstance ksp, IUser user, Uri repo = null)
-        {
-            // Use our default repo, unless we've been told otherwise.
-            if (repo == null)
-            {
-                repo = ksp.game.DefaultRepositoryURL;
-            }
-
-            SortedDictionary<string, int> downloadCounts;
-            string newETag;
-            List<CkanModule> newAvail = UpdateRegistry(repo, ksp, user, out downloadCounts, out newETag);
-
-            registry_manager.registry.SetDownloadCounts(downloadCounts);
-
-            if (newAvail != null && newAvail.Count > 0)
-            {
-                registry_manager.registry.SetAllAvailable(newAvail);
-                // Save our changes!
-                registry_manager.Save(enforce_consistency: false);
-            }
-
-            ShowUserInconsistencies(registry_manager.registry, user);
-
-            // Registry.CompatibleModules is slow, just return success,
-            // caller can check it if it's really needed
             return true;
         }
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -294,16 +294,12 @@ namespace CKAN
         public readonly List<KeyValuePair<int, Exception>> Exceptions
             = new List<KeyValuePair<int, Exception>>();
 
-        public DownloadErrorsKraken(List<KeyValuePair<int, Exception>> errors) : base()
+        public DownloadErrorsKraken(List<KeyValuePair<int, Exception>> errors)
+            : base(String.Join("\r\n",
+                new string[] { Properties.Resources.KrakenDownloadErrorsHeader, "" }
+                .Concat(errors.Select(e => e.ToString()))))
         {
             Exceptions = new List<KeyValuePair<int, Exception>>(errors);
-        }
-
-        public override string ToString()
-        {
-            return String.Join("\r\n",
-                new string[] { Properties.Resources.KrakenDownloadErrorsHeader, "" }
-                .Concat(Exceptions.Select(e => e.ToString())));
         }
     }
 

--- a/GUI/Dialogs/DownloadsFailedDialog.resx
+++ b/GUI/Dialogs/DownloadsFailedDialog.resx
@@ -119,11 +119,8 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Text" xml:space="preserve"><value>Downloads Failed</value></data>
-  <data name="ExplanationLabel.Text" xml:space="preserve"><value>The following mods failed to download. You can retry or abort, and if you retry, you can choose to remove some mods (and any mods that depend on them) from the changeset. Mods that share the same download link will automatically be updated to the same choice.</value></data>
   <data name="RetryColumn.HeaderText" xml:space="preserve"><value>Retry?</value></data>
   <data name="SkipColumn.HeaderText" xml:space="preserve"><value>Skip?</value></data>
-  <data name="ModColumn.HeaderText" xml:space="preserve"><value>Mod</value></data>
   <data name="ErrorColumn.HeaderText" xml:space="preserve"><value>Error</value></data>
   <data name="RetryButton.Text" xml:space="preserve"><value>Retry</value></data>
-  <data name="AbortButton.Text" xml:space="preserve"><value>Abort whole changeset</value></data>
 </root>

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -149,7 +149,8 @@ namespace CKAN.GUI
             downloader.Progress    += Wait.SetModuleProgress;
             downloader.AllComplete += Wait.DownloadsComplete;
 
-            Wait.OnCancel += () => {
+            Wait.OnCancel += () =>
+            {
                 canceled = true;
                 downloader.CancelDownload();
             };
@@ -196,12 +197,16 @@ namespace CKAN.GUI
                         var crit = CurrentInstance.VersionCriteria();
                         var fullChangeset = new RelationshipResolver(toInstall, null, opts.Value, registry, crit).ModList().ToList();
                         var dfd = new DownloadsFailedDialog(
-                            k.Exceptions.Select(kvp => new KeyValuePair<CkanModule[], Exception>(
+                            Properties.Resources.ModDownloadsFailedMessage,
+                            Properties.Resources.ModDownloadsFailedColHdr,
+                            Properties.Resources.ModDownloadsFailedAbortBtn,
+                            k.Exceptions.Select(kvp => new KeyValuePair<object[], Exception>(
                                 fullChangeset.Where(m => m.download == kvp.Key.download).ToArray(),
-                                kvp.Value)));
+                                kvp.Value)),
+                            (m1, m2) => (m1 as CkanModule)?.download == (m2 as CkanModule)?.download);
                         dfd.ShowDialog(this);
                         var abort = dfd.Abort;
-                        var skip  = dfd.Skip;
+                        var skip  = dfd.Skip.Select(m => m as CkanModule).ToArray();
                         dfd.Dispose();
                         if (abort)
                         {
@@ -220,8 +225,7 @@ namespace CKAN.GUI
                                 // Consider virtual dependencies satisfied so user can make a new choice if they skip
                                 rel => rel.LatestAvailableWithProvides(registry, crit).Count > 1)
                                 .ToHashSet();
-                            toInstall.RemoveAll(m =>
-                             dependers.Contains(m.identifier));
+                            toInstall.RemoveAll(m => dependers.Contains(m.identifier));
                         }
 
                         // Now we loop back around again
@@ -374,11 +378,6 @@ namespace CKAN.GUI
                             new SettingsDialog(currentUser).ShowDialog(this);
                             Enabled = true;
                         }
-                        break;
-
-                    case ModuleDownloadErrorsKraken exc:
-                        currentUser.RaiseMessage(exc.ToString());
-                        currentUser.RaiseError(exc.ToString());
                         break;
 
                     case DirectoryNotFoundKraken exc:

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Timers;
@@ -31,7 +31,7 @@ namespace CKAN.GUI
 
             try
             {
-                Wait.StartWaiting(UpdateRepo, PostUpdateRepo, false, null);
+                Wait.StartWaiting(UpdateRepo, PostUpdateRepo, true, null);
             }
             catch { }
 
@@ -43,50 +43,100 @@ namespace CKAN.GUI
 
         private void UpdateRepo(object sender, DoWorkEventArgs e)
         {
-            try
+            // Don't repeat this stuff if downloads fail
+            AddStatusMessage(Properties.Resources.MainRepoScanning);
+            log.Debug("Scanning before repo update");
+            bool scanChanged = CurrentInstance.Scan();
+
+            AddStatusMessage(Properties.Resources.MainRepoUpdating);
+
+            // Note the current mods' compatibility for the NewlyCompatible filter
+            GameVersionCriteria versionCriteria = CurrentInstance.VersionCriteria();
+            var registry = RegistryManager.Instance(CurrentInstance).registry;
+            Dictionary<string, bool> oldModules = registry.CompatibleModules(versionCriteria)
+                .ToDictionary(m => m.identifier, m => false);
+            registry.IncompatibleModules(versionCriteria)
+                .Where(m => !oldModules.ContainsKey(m.identifier))
+                .ToList()
+                .ForEach(m => oldModules.Add(m.identifier, true));
+
+            using (var transaction = CkanTransaction.CreateTransactionScope())
             {
-                AddStatusMessage(Properties.Resources.MainRepoScanning);
-                log.Debug("Scanning before repo update");
-                bool scanChanged = CurrentInstance.Scan();
-
-                AddStatusMessage(Properties.Resources.MainRepoUpdating);
-
-                // Note the current mods' compatibility for the NewlyCompatible filter
-                GameVersionCriteria versionCriteria = CurrentInstance.VersionCriteria();
-                IRegistryQuerier registry = RegistryManager.Instance(CurrentInstance).registry;
-                Dictionary<string, bool> oldModules = registry.CompatibleModules(versionCriteria)
-                    .ToDictionary(m => m.identifier, m => false);
-                registry.IncompatibleModules(versionCriteria)
-                    .Where(m => !oldModules.ContainsKey(m.identifier))
-                    .ToList()
-                    .ForEach(m => oldModules.Add(m.identifier, true));
-
-                RepoUpdateResult result = Repo.UpdateAllRepositories(
-                    RegistryManager.Instance(CurrentInstance),
-                    CurrentInstance, Manager.Cache, currentUser);
-                if (result == RepoUpdateResult.NoChanges && scanChanged)
+                // Only way out is to return or throw
+                while (true)
                 {
-                    result = RepoUpdateResult.Updated;
+                    var repos = registry.Repositories.Values.ToArray();
+                    try
+                    {
+                        bool canceled = false;
+                        var downloader = new NetAsyncDownloader(currentUser);
+                        downloader.Progress += (target, remaining, total) =>
+                        {
+                            var repo = repos
+                                .Where(r => r.uri == target.url)
+                                .FirstOrDefault();
+                            if (repo != null)
+                            {
+                                Wait.SetProgress(repo.name, remaining, total);
+                            }
+                        };
+                        Wait.OnCancel += () =>
+                        {
+                            canceled = true;
+                            downloader.CancelDownload();
+                        };
+
+                        RepoUpdateResult result = Repo.UpdateAllRepositories(
+                            RegistryManager.Instance(CurrentInstance),
+                            CurrentInstance, downloader, Manager.Cache, currentUser);
+
+                        if (canceled)
+                        {
+                            throw new CancelledActionKraken();
+                        }
+
+                        if (result == RepoUpdateResult.NoChanges && scanChanged)
+                        {
+                            result = RepoUpdateResult.Updated;
+                        }
+                        e.Result = new KeyValuePair<RepoUpdateResult, Dictionary<string, bool>>(
+                            result, oldModules);
+
+                        // If we make it to the end, we are done
+                        transaction.Complete();
+                        return;
+                    }
+                    catch (DownloadErrorsKraken k)
+                    {
+                        var dfd = new DownloadsFailedDialog(
+                            Properties.Resources.RepoDownloadsFailedMessage,
+                            Properties.Resources.RepoDownloadsFailedColHdr,
+                            Properties.Resources.RepoDownloadsFailedAbortBtn,
+                            k.Exceptions.Select(kvp => new KeyValuePair<object[], Exception>(
+                                new object[] { repos[kvp.Key] }, kvp.Value)),
+                            // Rows are only linked to themselves
+                            (r1, r2) => r1 == r2);
+                        dfd.ShowDialog(this);
+                        var abort = dfd.Abort;
+                        var skip  = dfd.Skip.Select(r => r as Repository).ToArray();
+                        dfd.Dispose();
+                        if (abort)
+                        {
+                            e.Result = new KeyValuePair<RepoUpdateResult, Dictionary<string, bool>>(
+                                RepoUpdateResult.Failed, oldModules);
+                            throw new CancelledActionKraken();
+                        }
+                        if (skip.Length > 0)
+                        {
+                            foreach (var r in skip)
+                            {
+                                registry.Repositories.Remove(r.name);
+                            }
+                        }
+
+                        // Loop back around to retry
+                    }
                 }
-                e.Result = new KeyValuePair<RepoUpdateResult, Dictionary<string, bool>>(
-                    result, oldModules);
-            }
-            catch (UriFormatException ex)
-            {
-                errorDialog.ShowErrorDialog(ex.Message);
-            }
-            catch (MissingCertificateKraken ex)
-            {
-                errorDialog.ShowErrorDialog(ex.ToString());
-            }
-            catch (ReinstallModuleKraken)
-            {
-                // Bypass the generic error dialog so the Post can handle this
-                throw;
-            }
-            catch (Exception ex)
-            {
-                errorDialog.ShowErrorDialog(string.Format(Properties.Resources.MainRepoFailedToConnect, ex.Message));
             }
         }
 
@@ -96,6 +146,11 @@ namespace CKAN.GUI
             {
                 switch (e.Error)
                 {
+                    case CancelledActionKraken k:
+                        HideWaitDialog();
+                        EnableMainWindow();
+                        break;
+
                     case ReinstallModuleKraken rmk:
                         // Re-enable the UI for the install flow
                         EnableMainWindow();
@@ -108,50 +163,50 @@ namespace CKAN.GUI
                             )
                         );
                         // Don't mess with the UI, let the install flow control it
-                        return;
+                        break;
+
+                    case Exception exc:
+                        AddStatusMessage(Properties.Resources.MainRepoFailed);
+                        currentUser.RaiseMessage(exc.Message);
+                        Wait.Finish();
+                        EnableMainWindow();
+                        break;
                 }
             }
-
-            var resultPair = e.Result as KeyValuePair<RepoUpdateResult, Dictionary<string, bool>>?;
-            RepoUpdateResult? result = resultPair?.Key;
-            Dictionary<string, bool> oldModules = resultPair?.Value;
-
-            switch (result)
+            else
             {
-                case RepoUpdateResult.NoChanges:
-                    AddStatusMessage(Properties.Resources.MainRepoUpToDate);
-                    HideWaitDialog();
-                    // Load rows if grid empty, otherwise keep current
-                    if (ManageMods.ModGrid.Rows.Count < 1)
-                    {
-                        RefreshModList();
-                    }
-                    else
-                    {
+                var resultPair = e.Result as KeyValuePair<RepoUpdateResult, Dictionary<string, bool>>?;
+                RepoUpdateResult? result = resultPair?.Key;
+                Dictionary<string, bool> oldModules = resultPair?.Value;
+
+                switch (result)
+                {
+                    case RepoUpdateResult.NoChanges:
+                        AddStatusMessage(Properties.Resources.MainRepoUpToDate);
+                        HideWaitDialog();
+                        // Load rows if grid empty, otherwise keep current
+                        if (ManageMods.ModGrid.Rows.Count < 1)
+                        {
+                            RefreshModList();
+                        }
+                        else
+                        {
+                            EnableMainWindow();
+                            Util.Invoke(this, ManageMods.ModGrid.Select);
+                        }
+                        SetupDefaultSearch();
+                        break;
+
+                    case RepoUpdateResult.Updated:
+                    default:
+                        AddStatusMessage(Properties.Resources.MainRepoSuccess);
+                        ShowRefreshQuestion();
+                        UpgradeNotification();
                         EnableMainWindow();
-                        Util.Invoke(this, ManageMods.ModGrid.Select);
-                    }
-                    SetupDefaultSearch();
-                    break;
-
-                case RepoUpdateResult.Failed:
-                    AddStatusMessage(Properties.Resources.MainRepoFailed);
-                    HideWaitDialog();
-                    EnableMainWindow();
-                    Util.Invoke(this, ManageMods.ModGrid.Select);
-                    SetupDefaultSearch();
-                    break;
-
-                case RepoUpdateResult.Updated:
-                default:
-                    AddStatusMessage(Properties.Resources.MainRepoSuccess);
-                    ShowRefreshQuestion();
-                    UpgradeNotification();
-                    EnableMainWindow();
-                    RefreshModList(oldModules);
-                    break;
+                        RefreshModList(oldModules);
+                        break;
+                }
             }
-
         }
 
         private void ShowRefreshQuestion()
@@ -218,23 +273,6 @@ namespace CKAN.GUI
                     );
                 });
             }
-        }
-
-        private void minimizeNotifyIcon_BalloonTipClicked(object sender, EventArgs e)
-        {
-            // Unminimize
-            OpenWindow();
-
-            // Check all the upgrade checkboxes
-            ManageMods.MarkAllUpdates();
-
-            // Install
-            Wait.StartWaiting(InstallMods, PostInstallMods, true,
-                new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                    ManageMods.mainModList.ComputeUserChangeSet(RegistryManager.Instance(CurrentInstance).registry, CurrentInstance.VersionCriteria()).ToList(),
-                    RelationshipResolver.DependsOnlyOpts()
-                )
-            );
         }
     }
 }

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -1,8 +1,12 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Forms;
-using CKAN.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+
 using Autofac;
+
+using CKAN.Configuration;
 
 namespace CKAN.GUI
 {
@@ -128,6 +132,22 @@ namespace CKAN.GUI
             );
         }
 
+        private void minimizeNotifyIcon_BalloonTipClicked(object sender, EventArgs e)
+        {
+            // Unminimize
+            OpenWindow();
+
+            // Check all the upgrade checkboxes
+            ManageMods.MarkAllUpdates();
+
+            // Install
+            Wait.StartWaiting(InstallMods, PostInstallMods, true,
+                new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
+                    ManageMods.mainModList.ComputeUserChangeSet(RegistryManager.Instance(CurrentInstance).registry, CurrentInstance.VersionCriteria()).ToList(),
+                    RelationshipResolver.DependsOnlyOpts()
+                )
+            );
+        }
         #endregion
     }
 }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -1081,5 +1081,25 @@ namespace CKAN.GUI.Properties {
         internal static string ChangeTypeReplace {
             get { return (string)(ResourceManager.GetObject("ChangeTypeReplace", resourceCulture)); }
         }
+
+        internal static string ModDownloadsFailedMessage {
+            get { return (string)(ResourceManager.GetObject("ModDownloadsFailedMessage", resourceCulture)); }
+        }
+        internal static string ModDownloadsFailedColHdr {
+            get { return (string)(ResourceManager.GetObject("ModDownloadsFailedColHdr", resourceCulture)); }
+        }
+        internal static string ModDownloadsFailedAbortBtn {
+            get { return (string)(ResourceManager.GetObject("ModDownloadsFailedAbortBtn", resourceCulture)); }
+        }
+
+        internal static string RepoDownloadsFailedMessage {
+            get { return (string)(ResourceManager.GetObject("RepoDownloadsFailedMessage", resourceCulture)); }
+        }
+        internal static string RepoDownloadsFailedColHdr {
+            get { return (string)(ResourceManager.GetObject("RepoDownloadsFailedColHdr", resourceCulture)); }
+        }
+        internal static string RepoDownloadsFailedAbortBtn {
+            get { return (string)(ResourceManager.GetObject("RepoDownloadsFailedAbortBtn", resourceCulture)); }
+        }
     }
 }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -441,4 +441,10 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="ChangeTypeRemove" xml:space="preserve"><value>Remove</value></data>
   <data name="ChangeTypeUpdate" xml:space="preserve"><value>Update</value></data>
   <data name="ChangeTypeReplace" xml:space="preserve"><value>Replace</value></data>
+  <data name="ModDownloadsFailedMessage" xml:space="preserve"><value>The following mods failed to download. You can retry or abort, and if you retry, you can choose to remove some mods (and any mods that depend on them) from the changeset. Mods that share the same download link will automatically be updated to the same choice.</value></data>
+  <data name="ModDownloadsFailedColHdr" xml:space="preserve"><value>Mod</value></data>
+  <data name="ModDownloadsFailedAbortBtn" xml:space="preserve"><value>Abort whole changeset</value></data>
+  <data name="RepoDownloadsFailedMessage" xml:space="preserve"><value>The following repositories failed to download. You can retry or abort, and if you retry, you can choose to remove some repositories. Note that any repositories you skip will be PERMANENTLY removed from your configuration!</value></data>
+  <data name="RepoDownloadsFailedColHdr" xml:space="preserve"><value>Repository</value></data>
+  <data name="RepoDownloadsFailedAbortBtn" xml:space="preserve"><value>Abort whole update</value></data>
 </root>

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
-using CKAN;
+
 using log4net;
 using NUnit.Framework;
+
 using Tests.Data;
+using CKAN;
 
 namespace Tests.Core.Net
 {
@@ -33,7 +35,16 @@ namespace Tests.Core.Net
             registry.ClearDlls();
             registry.Installed().Clear();
             // Make sure we have a registry we can use.
-            CKAN.Repo.Update(registry_manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
+
+            registry.Repositories = new SortedDictionary<string, Repository>()
+            {
+                {
+                    "testRepo",
+                    new Repository("testRepo", TestData.TestKANZip())
+                }
+            };
+
+            CKAN.Repo.UpdateAllRepositories(registry_manager, ksp.KSP, null, new NullUser());
 
             // Ready our downloader.
             async = new CKAN.NetAsyncModulesDownloader(new NullUser(), manager.Cache);

--- a/Tests/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloader.cs
@@ -21,6 +21,7 @@ namespace Tests.Core.Net
         private DisposableKSP        ksp;
         private CKAN.IDownloader     async;
         private NetModuleCache       cache;
+        private NetAsyncDownloader   downloader;
 
         private static readonly ILog log = LogManager.GetLogger(typeof (NetAsyncModulesDownloader));
 
@@ -44,7 +45,9 @@ namespace Tests.Core.Net
                 }
             };
 
-            CKAN.Repo.UpdateAllRepositories(registry_manager, ksp.KSP, null, new NullUser());
+            downloader = new NetAsyncDownloader(new NullUser());
+
+            CKAN.Repo.UpdateAllRepositories(registry_manager, ksp.KSP, downloader, null, new NullUser());
 
             // Ready our downloader.
             async = new CKAN.NetAsyncModulesDownloader(new NullUser(), manager.Cache);

--- a/Tests/Core/Net/Repo.cs
+++ b/Tests/Core/Net/Repo.cs
@@ -15,6 +15,7 @@ namespace Tests.Core.Net
         private CKAN.RegistryManager manager;
         private CKAN.Registry registry;
         private DisposableKSP ksp;
+        private NetAsyncDownloader downloader;
 
         [SetUp]
         public void Setup()
@@ -24,6 +25,7 @@ namespace Tests.Core.Net
             registry = manager.registry;
             registry.ClearDlls();
             registry.Installed().Clear();
+            downloader = new NetAsyncDownloader(new NullUser());
         }
 
         [TearDown]
@@ -42,7 +44,7 @@ namespace Tests.Core.Net
                     new Repository("testRepo", TestData.TestKANTarGz())
                 }
             };
-            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
+            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, downloader, null, new NullUser());
             // Test we've got an expected module.
             CkanModule far = registry.LatestAvailable("FerramAerospaceResearch", new GameVersionCriteria(GameVersion.Parse("0.25.0")));
 
@@ -59,7 +61,7 @@ namespace Tests.Core.Net
                     new Repository("testRepo", TestData.TestKANZip())
                 }
             };
-            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
+            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, downloader, null, new NullUser());
 
             // Test we've got an expected module.
             CkanModule far = registry.LatestAvailable("FerramAerospaceResearch", new GameVersionCriteria(GameVersion.Parse("0.25.0")));
@@ -79,7 +81,7 @@ namespace Tests.Core.Net
                         new Repository("testRepo", TestData.BadKANTarGz())
                     }
                 };
-                CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
+                CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, downloader, null, new NullUser());
             });
         }
 
@@ -95,7 +97,7 @@ namespace Tests.Core.Net
                         new Repository("testRepo", TestData.BadKANZip())
                     }
                 };
-                CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
+                CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, downloader, null, new NullUser());
             });
         }
     }

--- a/Tests/Core/Net/Repo.cs
+++ b/Tests/Core/Net/Repo.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Tests.Data;
+
 using CKAN;
 using CKAN.Versioning;
-using NUnit.Framework;
-using Tests.Data;
 
 namespace Tests.Core.Net
 {
@@ -31,8 +35,14 @@ namespace Tests.Core.Net
         [Test]
         public void UpdateRegistryTarGz()
         {
-            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANTarGz());
-
+            manager.registry.Repositories = new SortedDictionary<string, Repository>()
+            {
+                {
+                    "testRepo",
+                    new Repository("testRepo", TestData.TestKANTarGz())
+                }
+            };
+            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
             // Test we've got an expected module.
             CkanModule far = registry.LatestAvailable("FerramAerospaceResearch", new GameVersionCriteria(GameVersion.Parse("0.25.0")));
 
@@ -42,7 +52,14 @@ namespace Tests.Core.Net
         [Test]
         public void UpdateRegistryZip()
         {
-            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
+            manager.registry.Repositories = new SortedDictionary<string, Repository>()
+            {
+                {
+                    "testRepo",
+                    new Repository("testRepo", TestData.TestKANZip())
+                }
+            };
+            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
 
             // Test we've got an expected module.
             CkanModule far = registry.LatestAvailable("FerramAerospaceResearch", new GameVersionCriteria(GameVersion.Parse("0.25.0")));
@@ -55,7 +72,14 @@ namespace Tests.Core.Net
         {
             Assert.DoesNotThrow(delegate
             {
-                CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.BadKANTarGz());
+                manager.registry.Repositories = new SortedDictionary<string, Repository>()
+                {
+                    {
+                        "testRepo",
+                        new Repository("testRepo", TestData.BadKANTarGz())
+                    }
+                };
+                CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
             });
         }
 
@@ -64,7 +88,14 @@ namespace Tests.Core.Net
         {
             Assert.DoesNotThrow(delegate
             {
-                CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.BadKANZip());
+                manager.registry.Repositories = new SortedDictionary<string, Repository>()
+                {
+                    {
+                        "testRepo",
+                        new Repository("testRepo", TestData.BadKANZip())
+                    }
+                };
+                CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
             });
         }
     }

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -38,7 +38,8 @@ namespace Tests.Core.Relationships
                     new Repository("testRepo", TestData.TestKANZip())
                 }
             };
-            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
+            var downloader = new NetAsyncDownloader(new NullUser());
+            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, downloader, null, new NullUser());
         }
 
         [OneTimeTearDown]

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using System.Linq;
+
+using NUnit.Framework;
+using Tests.Data;
+
 using CKAN;
 using CKAN.Extensions;
 using CKAN.Versioning;
-using NUnit.Framework;
-using Tests.Data;
 
 // We're exercising FindReverseDependencies in here, because:
 // - We need a registry
@@ -28,7 +30,15 @@ namespace Tests.Core.Relationships
             registry = manager.registry;
             registry.ClearDlls();
             registry.Installed().Clear();
-            CKAN.Repo.Update(manager, ksp.KSP, new NullUser(), TestData.TestKANZip());
+
+            registry.Repositories = new SortedDictionary<string, Repository>()
+            {
+                {
+                    "testRepo",
+                    new Repository("testRepo", TestData.TestKANZip())
+                }
+            };
+            CKAN.Repo.UpdateAllRepositories(manager, ksp.KSP, null, new NullUser());
         }
 
         [OneTimeTearDown]

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -453,13 +453,13 @@ namespace Tests.Data
         // TestKAN in tar.gz format.
         public static Uri TestKANTarGz()
         {
-            return new Uri(DataDir("CKAN-meta-testkan.tar.gz"), UriKind.Relative);
+            return new Uri(DataDir("CKAN-meta-testkan.tar.gz"));
         }
 
         // TestKAN in zip format.
         public static Uri TestKANZip()
         {
-            return new Uri(DataDir("CKAN-meta-testkan.zip"), UriKind.Relative);
+            return new Uri(DataDir("CKAN-meta-testkan.zip"));
         }
 
         // A repo full of deliciously bad metadata in tar.gz format.


### PR DESCRIPTION
## Problems

- `Repo.Update` defines an inherently incoherent operation: Refreshing metadata from just one repository to the exclusion of any others that may be configured. This is not something you would ever want to do, because you would end up with an incomplete set of modules in your registry. Registry updates should be from all repos or none.
- Repo updates can't be cancelled, and if one fails, you can't recover

## Changes

- Now the ability to update only one repo in isolation is eliminated
  - `Repo.Update` is removed
  - The `ckan update` command no longer takes a parameter and always update all repos
  - `ckan update`'s `--all` parameter is removed (note that its documentation incorrectly described upgrading modules, which it never did)
- Now `DownloadTarget.filename` is used as the default for `NetAsyncDownloaderDownloadPart.path`, so users of `NetAsyncDownloader` can find the files they requested
- Now `NetAsyncDownloaderDownloadPart.Done` and `NetAsyncDownloader.onOneCompleted` pass the download's ETag (see #2682) as a third parameter if available, so users of `NetAsyncDownloader` can save this information after downloading if desired
- Now `Repo.UpdateAllRepositories` accepts a `NetAsyncDownloader` parameter and uses it to perform its downloads asynchronously, in parallel, with progress bar updates, and with the possibility of cancellation
- Now `Repo.UpdateRegistryFromTarGz` is renamed to `Repo.ModulesFromTarGz`
- Now `Repo.UpdateRegistryFromZip` is renamed to `Repo.ModulesFromZip`
- Now `Repo.ModulesFromTarGz` and `Repo.ModulesFromZip` provide progress bar updates as they process their input files
- Now the parts of `Wait` that were specific to `CkanModule` are made generic and able to handle `string`s instead
- Now the `DownloadsFailedDialog` from #3635 is made generic and accepts `object`s instead of `CkanModule`s, and the module-specific strings it contained are parameters to be supplied by the calling code
  - `MainInstall.cs` is updated to pass module-specific strings to the `DownloadsFailedDialog`
- `GUI.Main.UpdateRepo` now:
  - Loops inside a transaction to allow retries and rollback
  - Enables the Cancel button in the `Wait` dialog, and clicking it cancels in progress downloads
  - Calls the `DownloadsFailedDialog` from #3635 to allow the user to retry or abort the refresh or remove a bad repository:
    ![image](https://user-images.githubusercontent.com/1559108/186543029-65397c66-2532-4c10-b7b5-20316257a71c.png)
- `minimizeNotifyIcon_BalloonTipClicked` is moved from `MainRepo.cs` to `MainTrayIcon.cs` because it is about the tray icon

Fixes #1070.
Fixes #1114 (proper transaction handling).
Fixes #1238.
Fixes #1981.
