### PR TITLE
Only show DLL location error if installing DLL

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -374,7 +374,10 @@ namespace CKAN
                                     && f.destination.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase))
                             .Select(f => Path.GetDirectoryName(ksp.ToRelativeGameDir(f.destination)))
                             .ToHashSet();
-                        if (!dllFolders.Contains(Path.GetDirectoryName(dll)))
+                        // Make sure that the DLL is actually included in the install
+                        // (NearFutureElectrical, NearFutureElectrical-Core)
+                        if (dllFolders.Count > 0
+                            && !dllFolders.Contains(Path.GetDirectoryName(dll)))
                         {
                             // Manually installed DLL is somewhere else where we're not installing files,
                             // probable bad install, alert user and abort


### PR DESCRIPTION
## Problem

If you manually install NearFutureElectrical, CKAN detects it and shows it as "AD". If you then tell CKAN to take over management of it via the "upgrade" checkbox, it always fails with the error from #3043:

> About to install:
> 
>  * Near Future Electrical 1.2.3 (cached)
>  * B9 Part Switch v2.20.0 (cached)
>  * Module Manager 4.2.2 (cached)
>  * Community Resource Pack v112.0.1 (cached)
>  * Near Future Electrical Core 1.2.3 (cached)
>  * Dynamic Battery Storage 2:2.2.5.0 (cached)
>
> DLL for module NearFutureElectrical found at GameData/NearFutureElectrical/Plugins/NearFutureElectrical.dll, but it's not where CKAN would install it. Aborting to prevent multiple copies of the same mod being installed. To install this module, uninstall it manually and try again.
> Error during installation!
> If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
> If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
> If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose

Note that the plain meaning of the text is false; `GameData/NearFutureElectrical/Plugins/NearFutureElectrical.dll` **is** _exactly_ where CKAN would install it. (In fact I captured this error by installing with CKAN and then purging the `installed_dlls` and `installed_files` collections in my registry to make it look like a manual install).

Reported by Discord user Jreg:

![image](https://user-images.githubusercontent.com/1559108/186990372-5450f6b5-fdf4-4b9d-b197-6423d611c55e.png)

## Cause

`NearFutureElectrical` doesn't install `NearFutureElectrical.dll`! That honor is reserved for `NearFutureElectrical-Core`, for reasons that were not documented (see KSP-CKAN/NetKAN#1536 and KSP-CKAN/NetKAN#1539 for when this was done).

The first consequence of this is that if you install just `NearFutureElectrical-Core` and then scrub your registry, CKAN would detect that as _`NearFutureElectrical`_ being installed, not `-Core`. Which frankly is probably fine, since you most likely **do** have it installed and would want to have CKAN take it over when upgrading.

The second consequence is that when CKAN tries to install `NearFutureElectrical` when it is already AD status, it looks in the ZIP for where the DLL is supposed to be and doesn't find it, which triggers the install error.

## Changes

Now we only raise that error if the module actually installs the DLL in question. This allows the upgrade of NFE to succeed.
