### PR TITLE
Self review option for merge script

### DIFF
--- a/bin/ckan-merge-pr.py
+++ b/bin/ckan-merge-pr.py
@@ -82,8 +82,8 @@ class CkanPullRequest:
     def merge_commit_message(self) -> str:
         return f'Merge #{self.pull_request.number} {self.pull_request.title}'
 
-    def merge_into(self, repo: CkanRepo) -> bool:
-        if not self.approvers():
+    def merge_into(self, repo: CkanRepo, self_review: bool) -> bool:
+        if not self_review and not self.approvers():
             print(f'PR #{self.pull_request.number} is not approved!')
             return False
         if not repo.on_master():
@@ -111,12 +111,13 @@ class CkanPullRequest:
 @option('--repo-path', type=click.Path(exists=True, file_okay=False),
         default='.', help='Path to CKAN working copy')
 @option('--token', required=False, envvar='GITHUB_TOKEN')
+@option('--self-review', is_flag=True, default=False)
 @argument('pr_num', type=click.INT)
-def merge_pr(repo_path: str, token: str, pr_num: int) -> None:
+def merge_pr(repo_path: str, token: str, self_review: bool, pr_num: int) -> None:
     ckr = CkanRepo(repo_path)
     ckpr = CkanPullRequest(Github(token).get_repo('KSP-CKAN/CKAN').get_pull(pr_num))
     sys.exit(ExitStatus.success
-             if ckpr.merge_into(ckr)
+             if ckpr.merge_into(ckr, self_review)
              else ExitStatus.failure)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

For a very small, uncontroversial fix like #3649, it may make sense to submit a pull request with documentation of the bug and the fix (so team members know what happened), but then merge it without review, to keep the `master` branch working.

Currently the merge script from #3263 can't do this because it absolutely requires approval by at least one reviewer. I've been making a live temporary edit to add `False and` to bypass that check as needed, which is not a great solution.

## Changes

Now the merge script has a `--self-review` option that skips the approval check if present. The default is `False` (obviously). This should only be used for small fixes in which we have high confidence. This has already been tested in the merge of #3649.
