### PR TITLE
Highlight incompatible mods recursively

### DIFF
--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -125,6 +125,14 @@ namespace CKAN
         /// <param name="with_provides">If set to false will not check for provided versions.</param>
         /// <returns>The version of the mod or null if not found</returns>
         ModuleVersion InstalledVersion(string identifier, bool with_provides = true);
+
+        /// <summary>
+        /// Check whether any versions of this mod are installable (including dependencies) on the given game versions
+        /// </summary>
+        /// <param name="identifier">Identifier of mod</param>
+        /// <param name="crit">Game versions</param>
+        /// <returns>true if any version is recursively compatible, false otherwise</returns>
+        bool IdentifierCompatible(string identifier, GameVersionCriteria crit);
     }
 
     /// <summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -538,6 +538,20 @@ namespace CKAN
         }
 
         /// <summary>
+        /// Check whether any versions of this mod are installable (including dependencies) on the given game versions.
+        /// Quicker than checking CompatibleModules for one identifier.
+        /// </summary>
+        /// <param name="identifier">Identifier of mod</param>
+        /// <param name="crit">Game versions</param>
+        /// <returns>true if any version is recursively compatible, false otherwise</returns>
+        public bool IdentifierCompatible(string identifier, GameVersionCriteria crit)
+        {
+            // Set up our compatibility partition
+            SetCompatibleVersion(crit);
+            return sorter.Compatible.ContainsKey(identifier);
+        }
+
+        /// <summary>
         /// <see cref="IRegistryQuerier.LatestAvailable" />
         /// </summary>
         public CkanModule LatestAvailable(


### PR DESCRIPTION
## Problem

If you try to install RP-1 on KSP 1.12 without following [the instructions (which call for marking KSP 1.11 compatible)](https://github.com/KSP-RO/RP-0/wiki/RO-&-RP-1-Express-Installation-for-1.12.3), you'll find you can't install it, and the reason is not apparent on the Relationships tab, which has increasingly become the place to investigate compatibility:

![screenshot1](https://user-images.githubusercontent.com/5272443/187332824-4bb29898-bda6-4d56-bc7a-0b60e43e7d8d.png)

If you expand dependencies (or try to install the depending mod from the Versions tab), you can discover that RP-0 depends on SXTContinued, which depends on Firespitter, which is only compatible up to KSP 1.11:

![screenshot2](https://user-images.githubusercontent.com/1559108/187334301-e5109ac1-f64c-4765-96b2-9d072e86b5f7.png)

Noted in KSP-CKAN/NetKAN#9306.

## Cause

The relationships tab's red highlighting only indicates whether the mod itself is compatible, not including its dependencies. It doesn't load all relationships recursively, for performance reasons; instead, it only loads two generations, so it can show which nodes are expandable, and then more generations are loaded if the user expands a node. This structure means that it may not know whether a mod is indirectly incompatible until multiple layers have been expanded and the user finds the issue.

But another component does know all mods' recursive compatibility: the `CompatibilitySorter` from #2963.

## Changes

- Now the registry provides `IdentifierCompatible` to allow quick recursive compatibility checks via the `CompatibilitySorter` object
- Now the relationships tab uses `Registry.IdentifierCompatible` to check compatibility instead of simple game version checks

This causes SXTContinued to be highlighted red even though it's individually compatible, and you can still expand it to see Firespitter:

![image](https://user-images.githubusercontent.com/1559108/187439037-efc8ff2a-ad71-4194-aac7-54562d074af7.png)

![image](https://user-images.githubusercontent.com/1559108/187440008-1c2495db-32f2-48e2-bf41-18f2741febd0.png)
