### PR TITLE
update repo instructions for new Debian policy

### DIFF
--- a/doc/apt-repo.md
+++ b/doc/apt-repo.md
@@ -4,13 +4,16 @@ We have created an APT repository that you can add to your Debian-based OS to in
 
 (These instructions are here instead of a wiki because the `curl` command adds our trusted key to your APT configuration, and we do not want that line to be editable by the entire world, in case it might be altered maliciously.)
 
+See https://wiki.debian.org/DebianRepository/UseThirdParty for the Debian policy that we used to generate these steps.
+
 ## Stable builds
 
 These are [the main releases](https://github.com/KSP-CKAN/CKAN/releases), recommended for most users. You will have the same features at the same time as everyone else, but you will have the added conveniences of APT managing the updates for you.
 
 ```
-sudo curl -sS -o /usr/share/keyrings/ckan-archive-keyring.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
-sudo apt-add-repository -u -y 'deb [arch=amd64 signed-by=/usr/share/keyrings/ckan-archive-keyring.gpg] https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable main'
+sudo curl -sS -o /usr/share/keyrings/ksp-ckan-archive-keyring.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
+echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/ksp-ckan-archive-keyring.gpg] https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable main' | sudo tee /etc/apt/sources.list.d/ksp-ckan.list > /dev/null
+sudo apt update
 sudo apt install ckan
 ```
 
@@ -18,10 +21,11 @@ sudo apt install ckan
 
 If you like to live dangerously, these are the bleeding edge builds that are generated every time we merge changes to the main branch. On the plus side, you'll get fixes and enhancements faster than everyone else. On the minus side, these builds are essentially untested; we don't know whether they're reliable until we take a close look at them and make sure they're complete and won't break things, at which point they turn into a stable build (if that sounds more like what you want, scroll up to the previous section).
 
-Things may break! But if they do and you report it to us, you'll be a hero to CKAN users everywhere, whether they know it or not.
+Things may break! But if they do and you [report it to us](https://github.com/KSP-CKAN/CKAN/issues/new/choose), you'll be a hero to CKAN users everywhere, whether they know it or not.
 
 ```
-sudo curl -sS -o /usr/share/keyrings/ckan-archive-keyring.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
-sudo apt-add-repository -u -y 'deb [arch=amd64 signed-by=/usr/share/keyrings/ckan-archive-keyring.gpg] https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly main'
+sudo curl -sS -o /usr/share/keyrings/ksp-ckan-archive-keyring.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
+echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/ksp-ckan-archive-keyring.gpg] https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly main' | sudo tee /etc/apt/sources.list.d/ksp-ckan.list > /dev/null
+sudo apt update
 sudo apt install ckan
 ```

--- a/doc/apt-repo.md
+++ b/doc/apt-repo.md
@@ -9,8 +9,8 @@ We have created an APT repository that you can add to your Debian-based OS to in
 These are [the main releases](https://github.com/KSP-CKAN/CKAN/releases), recommended for most users. You will have the same features at the same time as everyone else, but you will have the added conveniences of APT managing the updates for you.
 
 ```
-sudo curl -sS -o /etc/apt/trusted.gpg.d/ksp-ckan.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
-sudo apt-add-repository -u -y 'deb https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable main'
+sudo curl -sS -o /usr/share/keyrings/ckan-archive-keyring.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
+sudo apt-add-repository -u -y 'deb [arch=amd64 signed-by=/usr/share/keyrings/ckan-archive-keyring.gpg] https://ksp-ckan.s3-us-west-2.amazonaws.com/deb stable main'
 sudo apt install ckan
 ```
 
@@ -21,7 +21,7 @@ If you like to live dangerously, these are the bleeding edge builds that are gen
 Things may break! But if they do and you report it to us, you'll be a hero to CKAN users everywhere, whether they know it or not.
 
 ```
-sudo curl -sS -o /etc/apt/trusted.gpg.d/ksp-ckan.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
-sudo apt-add-repository -u -y 'deb https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly main'
+sudo curl -sS -o /usr/share/keyrings/ckan-archive-keyring.gpg https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/debian/ksp-ckan.gpg
+sudo apt-add-repository -u -y 'deb [arch=amd64 signed-by=/usr/share/keyrings/ckan-archive-keyring.gpg] https://ksp-ckan.s3-us-west-2.amazonaws.com/deb nightly main'
 sudo apt install ckan
 ```

--- a/doc/rpm-repo.md
+++ b/doc/rpm-repo.md
@@ -15,7 +15,7 @@ sudo dnf install ckan
 
 If you like to live dangerously, these are the bleeding edge builds that are generated every time we merge changes to the main branch. On the plus side, you'll get fixes and enhancements faster than everyone else. On the minus side, these builds are essentially untested; we don't know whether they're reliable until we take a close look at them and make sure they're complete and won't break things, at which point they turn into a stable build (if that sounds more like what you want, scroll up to the previous section).
 
-Things may break! But if they do and you report it to us, you'll be a hero to CKAN users everywhere, whether they know it or not.
+Things may break! But if they do and you [report it to us](https://github.com/KSP-CKAN/CKAN/issues/new/choose), you'll be a hero to CKAN users everywhere, whether they know it or not.
 
 ```
 sudo dnf config-manager --add-repo https://ksp-ckan.s3-us-west-2.amazonaws.com/rpm/nightly/ckan_nightly.repo


### PR DESCRIPTION
Current Debian policy guidelines state that 3rd party repositories should use the "signed-by" option and install a keyring file to `/usr/share/keyrings` named `reponame-archive-keyring.gpg` rather than using a key file in `trusted.gpg.d`, as the latter is deprecated and will no longer work in future versions of Debian and derivatives. This change updates the repo installation instructions to comply with current Debian Third-Party repository guidelines. The guidelines as currently outlined are available here: https://wiki.debian.org/DebianRepository/UseThirdParty

Additionally, there is a small change to add the `arch=amd64` option, as this prevents an error otherwise presented by APT due to the repository lacking support for i386.
