### PR TITLE
Fix second search box disappearing

### DIFF
--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using Timer = System.Windows.Forms.Timer;
+
 using log4net;
 
 namespace CKAN.GUI
@@ -137,6 +138,10 @@ namespace CKAN.GUI
                             keyEvt.Handled = true;
                             keyEvt.SuppressKeyPress = true;
                             return true;
+
+                        // Let the runtime update the text box first for any other keys
+                        default:
+                            return false;
                     }
                     break;
             }


### PR DESCRIPTION
## Problem

1. Type a search
2. Click the `+` button to add a second search box
3. Type into the second search box
4. Second search box disappears

## Cause

In #3641 we refactored the search box timer to use the same event handler for keystrokes and text change events. It uses a timer to delay the search by default, but this is bypassed for an immediate search if the user presses Enter or if the text box is empty.

The keystroke handler fires before the runtime updates the text box's contents, so it was always empty for the first keystroke, and we were firing the update immediately with an empty search string.

## Changes

Now we don't bypass the delay for a keystroke event for any keys other than Enter.
