### PR TITLE
Inflation error for version_min and version_max

### DIFF
--- a/Netkan/Validators/RelationshipsValidator.cs
+++ b/Netkan/Validators/RelationshipsValidator.cs
@@ -53,6 +53,14 @@ namespace CKAN.NetKAN.Validators
                             {
                                 throw new Kraken($"{name} in {relName} is not a valid CKAN identifier");
                             }
+                            if (rel.ContainsKey("version_min"))
+                            {
+                                throw new Kraken($"'version_min' found in relationship, the correct form is 'min_version'");
+                            }
+                            if (rel.ContainsKey("version_max"))
+                            {
+                                throw new Kraken($"'version_max' found in relationship, the correct form is 'max_version'");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

See KSP-CKAN/NetKAN#9321 and KSP-CKAN/NetKAN#9323, we inadvertently marked the latest version of Parallax as conflicting with it own dependencies by using `max_version` instead of `version_max`, which made it impossible to install (but made it easier to install the previous version correctly).

This happened previously in KSP-CKAN/NetKAN#8880 and KSP-CKAN/NetKAN#8881.

## Causes

For game version requirements, `ksp_version_min` and `ksp_version_max` are the correct forms.

For mod version requirements, `min_version` and `max_version` are the correct forms. For metadata maintainers who routinely deal with game version requirements and much more rarely with mod version requirements, this is surprising and very hard to keep in mind.

## Changes

Now if a relationship contains `version_min` or `version_max`, we raise an inflation error.
