### PR TITLE
Report progress in validating downloads

### DIFF
--- a/Core/Extensions/CryptoExtensions.cs
+++ b/Core/Extensions/CryptoExtensions.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Security.Cryptography;
+
+namespace CKAN.Extensions
+{
+    /// <summary>
+    /// Extensions for cryptographic operations
+    /// </summary>
+    public static class CryptoExtensions
+    {
+
+        /// <summary>
+        /// A version of ComputeHash with progress updates.
+        /// Based on https://stackoverflow.com/a/53966139 with lots of cleaning up.
+        /// </summary>
+        /// <param name="hashAlgo">The crypto object to use for the operation, like SHA1, SHA256, etc.</param>
+        /// <param name="stream">Input stream to hash</param>
+        /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <param name="cancelToken">A cancellation token that can be used to abort the hash</param>
+        /// <returns>The requested hash of the input stream</returns>
+        public static byte[] ComputeHash(this HashAlgorithm hashAlgo, Stream stream,
+            IProgress<long> progress, CancellationToken cancelToken = default(CancellationToken))
+        {
+            const int bufSize = 1024 * 1024;
+            var buffer = new byte[bufSize];
+            long totalBytesRead = 0;
+            while (true)
+            {
+                var bytesRead = stream.Read(buffer, 0, bufSize);
+                cancelToken.ThrowIfCancellationRequested();
+
+                if (bytesRead < bufSize)
+                {
+                    // Done!
+                    hashAlgo.TransformFinalBlock(buffer, 0, bytesRead);
+                    break;
+                }
+                else
+                {
+                    hashAlgo.TransformBlock(buffer, 0, bytesRead, buffer, 0);
+                }
+
+                totalBytesRead += bytesRead;
+                progress.Report(100 * totalBytesRead / stream.Length);
+            }
+            return hashAlgo.Hash;
+        }
+    }
+}

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -68,7 +68,7 @@ namespace CKAN
 
             string tmp_file = Net.Download(module.download);
 
-            return cache.Store(module, tmp_file, filename, true);
+            return cache.Store(module, tmp_file, new Progress<long>(bytes => {}), filename, true);
         }
 
         /// <summary>
@@ -1481,7 +1481,7 @@ namespace CKAN
                 int percent = i * 100 / files.Count;
                 user.RaiseProgress(string.Format(Properties.Resources.ModuleInstallerImporting, f.Name, percent), percent);
                 // Calc SHA-1 sum
-                string sha1 = Cache.GetFileHashSha1(f.FullName);
+                string sha1 = Cache.GetFileHashSha1(f.FullName, new Progress<long>(bytes => {}));
                 // Find SHA-1 sum in registry (potentially multiple)
                 if (index.ContainsKey(sha1))
                 {
@@ -1501,7 +1501,7 @@ namespace CKAN
                         {
                             user.RaiseMessage(Properties.Resources.ModuleInstallerImportingMod,
                                 mod.identifier, StripEpoch(mod.version));
-                            Cache.Store(mod, f.FullName);
+                            Cache.Store(mod, f.FullName, new Progress<long>(bytes => {}));
                         }
                     }
                 }

--- a/Core/Net/IDownloader.cs
+++ b/Core/Net/IDownloader.cs
@@ -20,6 +20,11 @@ namespace CKAN
         event Action<CkanModule, long, long> Progress;
 
         /// <summary>
+        /// Raised while we are checking that a ZIP is valid
+        /// </summary>
+        event Action<CkanModule, long, long> StoreProgress;
+
+        /// <summary>
         /// Raised when a batch of downloads is all done
         /// </summary>
         event Action AllComplete;

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -121,7 +121,6 @@ namespace CKAN
                 default:
                     throw new UnsupportedKraken($"Not a .tar.gz or .zip, cannot process: {filename}");
             }
-            return Enumerable.Empty<CkanModule>();
         }
 
         /// <summary>

--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -85,6 +85,9 @@ namespace CKAN.Properties {
         internal static string NetAsyncDownloaderTryingFallback {
             get { return (string)(ResourceManager.GetObject("NetAsyncDownloaderTryingFallback", resourceCulture)); }
         }
+        internal static string NetAsyncDownloaderValidating {
+            get { return (string)(ResourceManager.GetObject("NetAsyncDownloaderValidating", resourceCulture)); }
+        }
 
         internal static string NetFileCacheCannotFind {
             get { return (string)(ResourceManager.GetObject("NetFileCacheCannotFind", resourceCulture)); }

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -125,6 +125,7 @@
   <data name="NetAsyncDownloaderCancelled" xml:space="preserve"><value>Download cancelled by user</value></data>
   <data name="NetAsyncDownloaderProgress" xml:space="preserve"><value>{0}/sec - downloading - {1} left</value></data>
   <data name="NetAsyncDownloaderTryingFallback" xml:space="preserve"><value>Failed to download "{0}", trying fallback "{1}"</value></data>
+  <data name="NetAsyncDownloaderValidating" xml:space="preserve"><value>Finished downloading {0}, validating and storing to cache...</value></data>
   <data name="NetFileCacheCannotFind" xml:space="preserve"><value>Cannot find cache directory: {0}</value></data>
   <data name="NetFileCacheZipError" xml:space="preserve"><value>Error in step {0} for {1}: {2}</value></data>
   <data name="NetFileCacheZipTestArchiveFalse" xml:space="preserve"><value>ZipFile.TestArchive(true) returned false</value></data>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -19,7 +19,7 @@ namespace CKAN
 
     public class FileNotFoundKraken : Kraken
     {
-        public string file;
+        public readonly string file;
 
         public FileNotFoundKraken(string file, string reason = null, Exception innerException = null)
             : base(reason, innerException)
@@ -30,7 +30,7 @@ namespace CKAN
 
     public class DirectoryNotFoundKraken : Kraken
     {
-        public string directory;
+        public readonly string directory;
 
         public DirectoryNotFoundKraken(string directory, string reason = null, Exception innerException = null)
             : base(reason, innerException)
@@ -41,9 +41,9 @@ namespace CKAN
 
     public class NotEnoughSpaceKraken : Kraken
     {
-        public DirectoryInfo destination;
-        public long          bytesFree;
-        public long          bytesToStore;
+        public readonly DirectoryInfo destination;
+        public readonly long          bytesFree;
+        public readonly long          bytesToStore;
 
         public NotEnoughSpaceKraken(string description, DirectoryInfo destination, long bytesFree, long bytesToStore)
             : base(string.Format(Properties.Resources.KrakenNotEnoughSpace,
@@ -74,8 +74,8 @@ namespace CKAN
 
     public class ModuleNotFoundKraken : Kraken
     {
-        public string module;
-        public string version;
+        public readonly string module;
+        public readonly string version;
 
         // TODO: Is there a way to set the stringify version of this?
         public ModuleNotFoundKraken(string module, string version, string reason, Exception innerException = null)
@@ -124,7 +124,7 @@ namespace CKAN
 
     public class NotKSPDirKraken : Kraken
     {
-        public string path;
+        public readonly string path;
 
         public NotKSPDirKraken(string path, string reason = null, Exception innerException = null)
             : base(reason, innerException)
@@ -161,7 +161,7 @@ namespace CKAN
     /// </summary>
     public class RegistryVersionNotSupportedKraken : Kraken
     {
-        public int requestVersion;
+        public readonly int requestVersion;
 
         public RegistryVersionNotSupportedKraken(int v, string reason = null, Exception innerException = null)
             : base(reason, innerException)
@@ -199,13 +199,13 @@ namespace CKAN
     /// </summary>
     public class InconsistentKraken : Kraken
     {
-        public ICollection<string> inconsistencies;
+        public readonly ICollection<string> inconsistencies;
 
         public string InconsistenciesPretty
         {
             get
             {
-                return String.Join("\r\n",
+                return String.Join(Environment.NewLine,
                     new string[] { Properties.Resources.KrakenInconsistenciesHeader }
                     .Concat(inconsistencies.Select(msg => $"* {msg}")));
             }
@@ -233,7 +233,7 @@ namespace CKAN
 
         public override string ToString()
         {
-            return InconsistenciesPretty + "\r\n\r\n" + StackTrace;
+            return InconsistenciesPretty + Environment.NewLine + Environment.NewLine + StackTrace;
         }
     }
 
@@ -260,8 +260,8 @@ namespace CKAN
                 ?? new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();
         }
 
-        public List<KeyValuePair<CkanModule, RelationshipDescriptor>> Depends   { get; private set; }
-        public List<KeyValuePair<CkanModule, RelationshipDescriptor>> Conflicts { get; private set; }
+        public readonly List<KeyValuePair<CkanModule, RelationshipDescriptor>> Depends;
+        public readonly List<KeyValuePair<CkanModule, RelationshipDescriptor>> Conflicts;
     }
 
     /// <summary>
@@ -295,9 +295,9 @@ namespace CKAN
             = new List<KeyValuePair<int, Exception>>();
 
         public DownloadErrorsKraken(List<KeyValuePair<int, Exception>> errors)
-            : base(String.Join("\r\n",
+            : base(String.Join(Environment.NewLine,
                 new string[] { Properties.Resources.KrakenDownloadErrorsHeader, "" }
-                .Concat(errors.Select(e => e.ToString()))))
+                .Concat(errors.Select(e => e.Value.Message))))
         {
             Exceptions = new List<KeyValuePair<int, Exception>>(errors);
         }
@@ -386,7 +386,7 @@ namespace CKAN
     /// </summary>
     public class PathErrorKraken : Kraken
     {
-        public string path;
+        public readonly string path;
 
         public PathErrorKraken(string path, string reason = null, Exception innerException = null)
             : base(reason, innerException)
@@ -402,7 +402,7 @@ namespace CKAN
     /// </summary>
     public class ModNotInstalledKraken : Kraken
     {
-        public string mod;
+        public readonly string mod;
 
         public override string Message
         {
@@ -592,7 +592,7 @@ namespace CKAN
 
     public class InvalidKSPInstanceKraken : Kraken
     {
-        public string instance;
+        public readonly string instance;
 
         public InvalidKSPInstanceKraken(string instance, string reason = null, Exception innerException = null)
             : base(reason, innerException)

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Forms;
+using System.Windows.Forms;
 
 namespace CKAN.GUI
 {
@@ -330,18 +330,18 @@ namespace CKAN.GUI
             this.ModGrid.Size = new System.Drawing.Size(1536, 837);
             this.ModGrid.StandardTab = true;
             this.ModGrid.TabIndex = 12;
-            this.ModGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModList_CellContentClick);
-            this.ModGrid.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModList_CellMouseDoubleClick);
-            this.ModGrid.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModList_HeaderMouseClick);
-            this.ModGrid.SelectionChanged += new System.EventHandler(this.ModList_SelectionChanged);
-            this.ModGrid.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ModList_KeyDown);
-            this.ModGrid.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ModList_KeyPress);
-            this.ModGrid.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ModList_MouseDown);
-            this.ModGrid.GotFocus += new System.EventHandler(this.ModList_GotFocus);
-            this.ModGrid.LostFocus += new System.EventHandler(this.ModList_LostFocus);
-            this.ModGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.ModList_CurrentCellDirtyStateChanged);
-            this.ModGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModList_CellValueChanged);
-            this.ModGrid.Resize += new System.EventHandler(this.ModList_Resize);
+            this.ModGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModGrid_CellContentClick);
+            this.ModGrid.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModGrid_CellMouseDoubleClick);
+            this.ModGrid.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModGrid_HeaderMouseClick);
+            this.ModGrid.SelectionChanged += new System.EventHandler(this.ModGrid_SelectionChanged);
+            this.ModGrid.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ModGrid_KeyDown);
+            this.ModGrid.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ModGrid_KeyPress);
+            this.ModGrid.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ModGrid_MouseDown);
+            this.ModGrid.GotFocus += new System.EventHandler(this.ModGrid_GotFocus);
+            this.ModGrid.LostFocus += new System.EventHandler(this.ModGrid_LostFocus);
+            this.ModGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.ModGrid_CurrentCellDirtyStateChanged);
+            this.ModGrid.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModGrid_CellValueChanged);
+            this.ModGrid.Resize += new System.EventHandler(this.ModGrid_Resize);
             //
             // Installed
             //

--- a/GUI/Controls/ModInfoTabs/Metadata.resx
+++ b/GUI/Controls/ModInfoTabs/Metadata.resx
@@ -118,9 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="IdentifierLabel.Text" xml:space="preserve"><value>Identifier:</value></data>
-  <data name="MetadataIdentifierTextBox.Text" xml:space="preserve"><value>-</value></data>
   <data name="ReplacementLabel.Text" xml:space="preserve"><value>Replaced by:</value></data>
-  <data name="ReplacementTextBox.Text" xml:space="preserve"><value>-</value></data>
   <data name="GameCompatibilityLabel.Text" xml:space="preserve"><value>Max game ver.:</value></data>
   <data name="ReleaseLabel.Text" xml:space="preserve"><value>Release status:</value></data>
   <data name="AuthorLabel.Text" xml:space="preserve"><value>Author:</value></data>

--- a/GUI/Controls/Wait.Designer.cs
+++ b/GUI/Controls/Wait.Designer.cs
@@ -33,11 +33,13 @@
             this.TopPanel = new System.Windows.Forms.Panel();
             this.MessageTextBox = new System.Windows.Forms.TextBox();
             this.DialogProgressBar = new System.Windows.Forms.ProgressBar();
+            this.ProgressBarTable = new System.Windows.Forms.TableLayoutPanel();
             this.LogTextBox = new System.Windows.Forms.TextBox();
             this.BottomButtonPanel = new LeftRightRowPanel();
             this.CancelCurrentActionButton = new System.Windows.Forms.Button();
             this.RetryCurrentActionButton = new System.Windows.Forms.Button();
             this.OkButton = new System.Windows.Forms.Button();
+            this.ProgressBarTable.SuspendLayout();
             this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
@@ -45,6 +47,7 @@
             //
             this.TopPanel.Controls.Add(this.MessageTextBox);
             this.TopPanel.Controls.Add(this.DialogProgressBar);
+            this.TopPanel.Controls.Add(this.ProgressBarTable);
             this.TopPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.TopPanel.Name = "TopPanel";
             this.TopPanel.Size = new System.Drawing.Size(500, 85);
@@ -79,6 +82,24 @@
             this.DialogProgressBar.Size = new System.Drawing.Size(490, 25);
             this.DialogProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
             this.DialogProgressBar.TabIndex = 1;
+            //
+            // ProgressBarTable
+            //
+            this.ProgressBarTable.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ProgressBarTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ProgressBarTable.ColumnCount = 2;
+            this.ProgressBarTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.ProgressBarTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.ProgressBarTable.Location = new System.Drawing.Point(0, 70);
+            this.ProgressBarTable.Name = "ProgressBarTable";
+            this.ProgressBarTable.Padding = new System.Windows.Forms.Padding(0, 6, 0, 6);
+            this.ProgressBarTable.Size = new System.Drawing.Size(500, 0);
+            this.ProgressBarTable.AutoSize = false;
+            this.ProgressBarTable.AutoScroll = false;
+            this.ProgressBarTable.VerticalScroll.Visible = false;
+            this.ProgressBarTable.HorizontalScroll.Visible = false;
+            this.ProgressBarTable.TabIndex = 0;
             //
             // LogTextBox
             //
@@ -142,11 +163,13 @@
             this.Controls.Add(this.LogTextBox);
             this.Controls.Add(this.TopPanel);
             this.Controls.Add(this.BottomButtonPanel);
-            this.Margin = new System.Windows.Forms.Padding(0,0,0,0);
-            this.Padding = new System.Windows.Forms.Padding(0,0,0,0);
+            this.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
+            this.Padding = new System.Windows.Forms.Padding(0, 0, 0, 0);
             this.Name = "Wait";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.ProgressBarTable.ResumeLayout(false);
+            this.ProgressBarTable.PerformLayout();
             this.BottomButtonPanel.ResumeLayout(false);
             this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
@@ -158,6 +181,7 @@
         private System.Windows.Forms.Panel TopPanel;
         private System.Windows.Forms.TextBox MessageTextBox;
         private System.Windows.Forms.ProgressBar DialogProgressBar;
+        private System.Windows.Forms.TableLayoutPanel ProgressBarTable;
         private System.Windows.Forms.TextBox LogTextBox;
         private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Button RetryCurrentActionButton;

--- a/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
@@ -109,7 +109,7 @@ namespace CKAN.GUI
             // ModColumn
             //
             this.ModColumn.Name = "ModColumn";
-            this.ModColumn.DataPropertyName = "Module";
+            this.ModColumn.DataPropertyName = "Data";
             this.ModColumn.ReadOnly = true;
             this.ModColumn.Width = 250;
             this.ModColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;

--- a/GUI/Dialogs/DownloadsFailedDialog.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
+using System.Threading.Tasks;
 
 using log4net;
 
@@ -56,10 +57,16 @@ namespace CKAN.GUI
             DownloadsGrid.DataSource = new BindingList<DownloadRow>(rows);
             ClientSize = new Size(ClientSize.Width,
                 ExplanationLabel.Height
+                + ExplanationLabel.Padding.Vertical
+                + DownloadsGrid.ColumnHeadersHeight
                 + DownloadsGrid.RowCount
                     * DownloadsGrid.RowTemplate.Height
+                + DownloadsGrid.Margin.Vertical
+                + DownloadsGrid.Padding.Vertical
                 + BottomButtonPanel.Height);
         }
+
+        public object[] Wait() => task.Task.Result;
 
         /// <summary>
         /// True if user clicked the abort button, false otherwise
@@ -141,17 +148,20 @@ namespace CKAN.GUI
         private void RetryButton_Click(object sender, EventArgs e)
         {
             Abort = false;
+            task.SetResult(Skip);
             Close();
         }
 
         private void AbortButton_Click(object sender, EventArgs e)
         {
             Abort = true;
+            task.SetResult(null);
             Close();
         }
 
         private List<DownloadRow> rows;
         private Func<object, object, bool> rowsLinked;
+        private TaskCompletionSource<object[]> task = new TaskCompletionSource<object[]>();
 
         private static readonly ILog log = LogManager.GetLogger(typeof(DownloadsFailedDialog));
     }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -42,6 +42,11 @@ namespace CKAN.GUI
 
             GUIMod gm = e.Argument as GUIMod;
             downloader = new NetAsyncModulesDownloader(currentUser, Manager.Cache);
+            downloader.Progress      += Wait.SetModuleProgress;
+            downloader.AllComplete   += Wait.DownloadsComplete;
+            downloader.StoreProgress += (module, remaining, total) =>
+                Wait.SetProgress(string.Format(Properties.Resources.ValidatingDownload, module),
+                    remaining, total);
             Wait.OnCancel += downloader.CancelDownload;
             downloader.DownloadModules(new List<CkanModule> { gm.ToCkanModule() });
             e.Result = e.Argument;
@@ -49,6 +54,7 @@ namespace CKAN.GUI
 
         public void PostModCaching(object sender, RunWorkerCompletedEventArgs e)
         {
+            Wait.OnCancel -= downloader.CancelDownload;
             downloader = null;
             // Can't access e.Result if there's an error
             if (e.Error != null)

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -138,8 +138,11 @@ namespace CKAN.GUI
             tabController.SetTabLock(true);
 
             IDownloader downloader = new NetAsyncModulesDownloader(currentUser, Manager.Cache);
-            downloader.Progress    += Wait.SetModuleProgress;
-            downloader.AllComplete += Wait.DownloadsComplete;
+            downloader.Progress      += Wait.SetModuleProgress;
+            downloader.AllComplete   += Wait.DownloadsComplete;
+            downloader.StoreProgress += (module, remaining, total) =>
+                Wait.SetProgress(string.Format(Properties.Resources.ValidatingDownload, module),
+                    remaining, total);
 
             Wait.OnCancel += () =>
             {
@@ -196,9 +199,9 @@ namespace CKAN.GUI
                                 fullChangeset.Where(m => m.download == kvp.Key.download).ToArray(),
                                 kvp.Value)),
                             (m1, m2) => (m1 as CkanModule)?.download == (m2 as CkanModule)?.download);
-                        dfd.ShowDialog(this);
+                        Util.Invoke(this, () => dfd.ShowDialog(this));
+                        var skip = dfd.Wait()?.Select(m => m as CkanModule).ToArray();
                         var abort = dfd.Abort;
-                        var skip  = dfd.Skip.Select(m => m as CkanModule).ToArray();
                         dfd.Dispose();
                         if (abort)
                         {

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -120,9 +120,9 @@ namespace CKAN.GUI
                                 new object[] { repos[kvp.Key] }, kvp.Value)),
                             // Rows are only linked to themselves
                             (r1, r2) => r1 == r2);
-                        dfd.ShowDialog(this);
+                        Util.Invoke(this, () => dfd.ShowDialog(this));
+                        var skip  = dfd.Wait()?.Select(r => r as Repository).ToArray();
                         var abort = dfd.Abort;
-                        var skip  = dfd.Skip.Select(r => r as Repository).ToArray();
                         dfd.Dispose();
                         if (abort)
                         {

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using System.Linq;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+
 using CKAN.Versioning;
 
 namespace CKAN.GUI
@@ -303,7 +304,7 @@ namespace CKAN.GUI
                 ?? true;
             if (IsInstalled && (IsInstallChecked && HasUpdate && IsUpgradeChecked))
             {
-                yield return new ModUpgrade(Mod, GUIModChangeType.Update, null, SelectedMod);
+                yield return new ModUpgrade(Mod, GUIModChangeType.Update, SelectedMod);
             }
             else if (IsReplaceChecked)
             {
@@ -386,17 +387,16 @@ namespace CKAN.GUI
                     IsInstallChecked = changeTo;
                 }
                 SelectedMod = changeTo ? (SelectedMod ?? Mod) : null;
-                // Setting this property causes ModList_CellValueChanged to be called,
+                // Setting this property causes ModGrid_CellValueChanged to be called,
                 // which calls SetInstallChecked again. Treat it conservatively.
                 if ((bool)install_cell.Value != IsInstallChecked)
                 {
                     install_cell.Value = IsInstallChecked;
                     if (row.DataGridView != null)
                     {
-                        // These calls are needed to force the UI to update,
+                        // This call is needed to force the UI to update,
                         // otherwise the checkbox will look checked when it's unchecked or vice versa
                         row.DataGridView.RefreshEdit();
-                        row.DataGridView.Refresh();
                     }
                 }
             }

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -109,8 +109,8 @@ namespace CKAN.GUI
 
     public class ModUpgrade : ModChange
     {
-        public ModUpgrade(CkanModule mod, GUIModChangeType changeType, IEnumerable<SelectionReason> reasons, CkanModule targetMod)
-            : base(mod, changeType, reasons)
+        public ModUpgrade(CkanModule mod, GUIModChangeType changeType, CkanModule targetMod)
+            : base(mod, changeType)
         {
             this.targetMod = targetMod;
         }

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -655,6 +655,9 @@ namespace CKAN.GUI.Properties {
         internal static string DownloadFailed {
             get { return (string)(ResourceManager.GetObject("DownloadFailed", resourceCulture)); }
         }
+        internal static string ValidatingDownload {
+            get { return (string)(ResourceManager.GetObject("ValidatingDownload", resourceCulture)); }
+        }
 
         internal static string MainModListWaitTitle {
             get { return (string)(ResourceManager.GetObject("MainModListWaitTitle", resourceCulture)); }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -297,6 +297,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ModInfoSteamStoreLabel" xml:space="preserve"><value>Steam store:</value></data>
   <data name="ModInfoToolTipReverseRelationships" xml:space="preserve"><value>Ctrl-click or Shift-click to make sticky</value></data>
   <data name="DownloadFailed" xml:space="preserve"><value>Download failed!</value></data>
+  <data name="ValidatingDownload" xml:space="preserve"><value>Validating {0}</value></data>
   <data name="MainModListWaitTitle" xml:space="preserve"><value>Loading modules</value></data>
   <data name="MainModListLoadingRegistry" xml:space="preserve"><value>Loading registry...</value></data>
   <data name="MainModListLoadingInstalled" xml:space="preserve"><value>Loading installed modules...</value></data>

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -87,7 +87,7 @@ namespace CKAN.NetKAN.Services
                     case FileType.Zip:
                         extension = "zip";
                         string invalidReason;
-                        if (!NetFileCache.ZipValid(downloadedFile, out invalidReason))
+                        if (!NetFileCache.ZipValid(downloadedFile, out invalidReason, null))
                         {
                             log.Debug($"{url} is not a valid ZIP file: {invalidReason}");
                             File.Delete(downloadedFile);

--- a/Netkan/Services/FileService.cs
+++ b/Netkan/Services/FileService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace CKAN.NetKAN.Services
@@ -18,14 +19,14 @@ namespace CKAN.NetKAN.Services
         {
             // Use shared implementation from Core.
             // Also needs to be an instance method so it can be Moq'd for testing.
-            return cache.GetFileHashSha1(filePath);
+            return cache.GetFileHashSha1(filePath, new Progress<long>(bytes => {}));
         }
 
         public string GetFileHashSha256(string filePath)
         {
             // Use shared implementation from Core.
             // Also needs to be an instance method so it can be Moq'd for testing.
-            return cache.GetFileHashSha256(filePath);
+            return cache.GetFileHashSha256(filePath, new Progress<long>(bytes => {}));
         }
 
         public string GetMimetype(string filePath)

--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -113,18 +113,14 @@ namespace Tests.Core
             Assert.Throws<FileNotFoundKraken>(() =>
                 module_cache.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    "/DoesNotExist.zip"
-                )
-            );
+                    "/DoesNotExist.zip", new Progress<long>(bytes => {})));
 
             // Try to store the LZMA-format DogeCoin zip into a NetModuleCache
             // and expect an InvalidModuleFileKraken
             Assert.Throws<InvalidModuleFileKraken>(() =>
                 module_cache.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    TestData.DogeCoinFlagZipLZMA
-                )
-            );
+                    TestData.DogeCoinFlagZipLZMA, new Progress<long>(bytes => {})));
 
             // Try to store the normal DogeCoin zip into a NetModuleCache
             // using the WRONG metadata (file size and hashes)
@@ -132,9 +128,7 @@ namespace Tests.Core
             Assert.Throws<InvalidModuleFileKraken>(() =>
                 module_cache.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    TestData.DogeCoinFlagZip()
-                )
-            );
+                    TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {})));
         }
 
         [Test]
@@ -193,7 +187,7 @@ namespace Tests.Core
             bool valid = false;
             string reason = "";
             Assert.DoesNotThrow(() =>
-                valid = NetFileCache.ZipValid(TestData.ZipWithBadChars, out reason));
+                valid = NetFileCache.ZipValid(TestData.ZipWithBadChars, out reason, null));
 
             // The file is considered valid on Linux;
             // only check the reason if found invalid
@@ -216,7 +210,7 @@ namespace Tests.Core
             string reason = null;
 
             Assert.DoesNotThrow(() =>
-                valid = NetFileCache.ZipValid(TestData.ZipWithUnicodeChars, out reason));
+                valid = NetFileCache.ZipValid(TestData.ZipWithUnicodeChars, out reason, null));
             Assert.IsTrue(valid, reason);
         }
 

--- a/Tests/Core/ModuleInstaller.cs
+++ b/Tests/Core/ModuleInstaller.cs
@@ -438,7 +438,7 @@ namespace Tests.Core
                 // Copy the zip file to the cache directory.
                 Assert.IsFalse(manager.Cache.IsCachedZip(TestData.DogeCoinFlag_101_module()));
 
-                string cache_path = manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
+                string cache_path = manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
 
                 Assert.IsTrue(manager.Cache.IsCachedZip(TestData.DogeCoinFlag_101_module()));
                 Assert.IsTrue(File.Exists(cache_path));
@@ -486,7 +486,7 @@ namespace Tests.Core
                 string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);
                 CkanModule mod = TestData.DogeCoinFlag_101_module();
                 registry.AddAvailable(mod);
-                manager.Cache.Store(mod, TestData.DogeCoinFlagZip());
+                manager.Cache.Store(mod, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 List<string> modules = new List<string>()
                 {
                     $"{mod.identifier}={mod.version}"
@@ -525,7 +525,7 @@ namespace Tests.Core
 
                 // Install the test mod.
                 var registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
-                manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
+                manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 registry.AddAvailable(TestData.DogeCoinFlag_101_module());
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
@@ -569,7 +569,7 @@ namespace Tests.Core
                 // Install the base test mod.
 
                 var registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;
-                manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
+                manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 registry.AddAvailable(TestData.DogeCoinFlag_101_module());
 
                 List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
@@ -580,7 +580,7 @@ namespace Tests.Core
                 modules.Clear();
 
                 // Install the plugin test mod.
-                manager.Cache.Store(TestData.DogeCoinPlugin_module(), TestData.DogeCoinPluginZip());
+                manager.Cache.Store(TestData.DogeCoinPlugin_module(), TestData.DogeCoinPluginZip(), new Progress<long>(bytes => {}));
                 registry.AddAvailable(TestData.DogeCoinPlugin_module());
 
                 modules.Add(TestData.DogeCoinPlugin_module().identifier);
@@ -629,7 +629,7 @@ namespace Tests.Core
                         };
 
                         // Copy the zip file to the cache directory.
-                        manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
+                        manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
 
                         // Mark it as available in the registry.
                         var registry = CKAN.RegistryManager.Instance(ksp.KSP).registry;

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -50,7 +50,7 @@ namespace Tests.Core
             _gameDataDir = _instance.KSP.game.PrimaryModDirectory(_instance.KSP);
             _registry.AddAvailable(_testModule);
             var testModFile = TestData.DogeCoinFlagZip();
-            _manager.Cache.Store(_testModule, testModFile);
+            _manager.Cache.Store(_testModule, testModFile, new Progress<long>(bytes => {}));
             HashSet<string> possibleConfigOnlyDirs = null;
             _installer.InstallList(
                 new List<string>() { _testModule.identifier },

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -150,7 +150,7 @@ namespace Tests.GUI
             // Act
 
             // Install module and set it as pre-installed
-            manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip());
+            manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
             registry.RegisterModule(anyVersionModule, new string[] { }, instance.KSP, false);
             registry.AddAvailable(anyVersionModule);
 


### PR DESCRIPTION
## Motivation

- After a mod finishes downloading and before we install it, we check that it's a valid ZIP file and that it matches the hashes in that module's metadata. This takes a noticeable amount of time for mods larger than about ~30MB (several seconds), which frighteningly probably scales linearly to the GB+ mods that we index, and there is no indication of what's happening; it looks like CKAN has frozen. As part of the general improvements for downloading in the next release, I want to increase the transparency of this process.
- The per-module progress bars in the install flow can be overlapped by their labels when a module name is long
  - The code from #3054 that handles these progress bars does a lot of low-level logic to position them, which isn't easy for maintenance
- Per-module progress bars aren't shown when downloading a mod to cache without installing, even though you can download multiple in parallel by jumping back to the mod list and starting more

## Changes

- Now a new `CKAN.Extensions.CryptoExtensions.ComputeHash` extension function supports progress updates from 0 to 100 via an `IProgress` parameter and cancellation via a cancellation token (cancellation not used yet but could be taken advantage of in the future)
- Now `NetFileCache.ZipValid`, `NetFileCache.GetFileHashSha1`, `NetFileCache.GetFileHashSha256`, and `NetModuleCache.Store` also have an `IProgress` parameter for reporting progress from 0 to 100 in each of their respective tasks. `NetModuleCache.Store` scales and combines the updates from its sub-tasks in a 60:20:20 ratio for `ZipValid`:`GetFileHashSha1`:`GetFileHashSha256`, since that seems to be about how long they take in practice.
  - The nearly identical `NetFileCache.GetFileHashSha1` and `NetFileCache.GetFileHashSha256` are mostly factored out into a new generic function `NetFileCache.GetFileHash<T>` that they call
- Now the `Wait` tab uses a `TableLayoutPanel` to manage the per-module progress bars
  - The labels and progress bars always fit neatly into 2 columns without overlapping
  - The code is simpler and no longer micro-manages locations or sizes
- Now `IDownloader` has a new `StoreProgress` event for reporting progress as it validates a ZIP file
- `NetAsyncModulesDownloader` fires its `StoreProgress` event in response to progress updates from `NetModuleCache.Store`
- Now the install and download to cache flows use the new `StoreProgress` event to show a per-module progress bar while downloads are being validated so the user can see what's happening
  - Download to cache also shows regular per-module download progress bars
  - We also print one additional message to the log when we have finished downloading and are starting validation of a download, so users can see what's happening there as well (and for CmdLine)

### Additional fixes

With the major features of my ongoing network handling revamp completed, but mainly developed on Windows, I decided to take the master branch for a spin in an Ubuntu VM. I found myself on a very lively bug hunt, but understanding what was happening in various confusing cases required this PR's progress bars for ZIP validation, so I rebased and added the fixes here:

- The failed downloads dialog from #3635 was opened on a background thread instead of the UI thread, which completely crashed it on Mono (but worked on Windows). Now it opens on the UI thread as it should, and a `TaskCompletionSource` tells us when it's done, as in several existing spots.
  - The failed downloads dialog's auto-sizing wasn't tall enough on Mono, now it includes the grid headers and padding
  - #3645 renamed the `DownloadRow.Module` property to `Data`, but the grid was still looking for `Module`. Now it's updated to `Data`.
- You can cancel downloads, and they really cancel, leaving behind the partial file as per #3666
  - The async downloader no longer tries to cancel downloads that already finished or failed
  - The async downloader no longer starts queued downloads after cancellation
- If `ResumingWebClient` finds that it already has the entire file in the in progress folder, it closes the stream, but Mono's WebClient seems to re-open it (whereas Windows leaves it closed), so now we also treat a download as unnecessary if `contentLength` is 0
  - Download progress updates now only fire once per 200 milliseconds, which should help with the `EWOULDBLOCK` errors from #3343
  - The activity timeout for downloads is now set to 30 seconds
- The checkbox above the mod list that can uninstall all mods or clear the changeset now operates much quicker by updating the changeset once at the end instead of for every row
- #3667 broke mod upgrades because the `ModUpgrade` class's constructor no longer handled the parameters `GUIMod` gave it correctly, now this is fixed
- `Wait.SetProgress` will no longer divide by 0 if you pass 0 in its `total` param
- `ManageMods.ModGrid` was renamed from `ModList` in #3041, but its event handlers still had a `ModList_` prefix; now they finally start with `ModGrid_`
- Unreachable code is removed from `Repo.ModulesFromFile`
- Kraken classes that used `\r\n` now use `Environment.NewLine` instead to match the host platform
  - Various public fields in the `Kraken` classes are now marked `readonly` where possible
- Several debug messages are shortened from printing whole exceptions to just `Exception.Message`, to make them easier to browse
