### PR TITLE
GitLab kref

### DIFF
--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -89,6 +89,12 @@
     <Compile Include="Sources\Github\GithubReleaseAsset.cs" />
     <Compile Include="Sources\Github\GithubRepo.cs" />
     <Compile Include="Sources\Github\IGithubApi.cs" />
+    <Compile Include="Sources\Gitlab\GitlabApi.cs" />
+    <Compile Include="Sources\Gitlab\GitlabOptions.cs" />
+    <Compile Include="Sources\Gitlab\GitlabProject.cs" />
+    <Compile Include="Sources\Gitlab\GitlabRef.cs" />
+    <Compile Include="Sources\Gitlab\GitlabRelease.cs" />
+    <Compile Include="Sources\Gitlab\IGitlabApi.cs" />
     <Compile Include="Sources\Jenkins\IJenkinsApi.cs" />
     <Compile Include="Sources\Jenkins\JenkinsApi.cs" />
     <Compile Include="Sources\Jenkins\JenkinsArtifact.cs" />
@@ -110,6 +116,7 @@
     <Compile Include="Transformers\ForcedVTransformer.cs" />
     <Compile Include="Transformers\GeneratedByTransformer.cs" />
     <Compile Include="Transformers\GithubTransformer.cs" />
+    <Compile Include="Transformers\GitlabTransformer.cs" />
     <Compile Include="Transformers\HttpTransformer.cs" />
     <Compile Include="Transformers\InternalCkanTransformer.cs" />
     <Compile Include="Transformers\ITransformer.cs" />

--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -25,6 +25,9 @@ namespace CKAN.NetKAN
         [Option("github-token", HelpText = "GitHub OAuth token for API access")]
         public string GitHubToken { get; set; }
 
+        [Option("gitlab-token", HelpText = "GitLab OAuth token for API access")]
+        public string GitLabToken { get; set; }
+
         [Option("net-useragent", DefaultValue = null, HelpText = "Set the default User-Agent string for HTTP requests")]
         public string NetUserAgent { get; set; }
 

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -15,7 +15,7 @@ namespace CKAN.NetKAN.Processors
 {
     public class Inflator
     {
-        public Inflator(string cacheDir, bool overwriteCache, string githubToken, bool prerelease)
+        public Inflator(string cacheDir, bool overwriteCache, string githubToken, string gitlabToken, bool prerelease)
         {
             log.Debug("Initializing inflator");
             cache = FindCache(
@@ -28,7 +28,7 @@ namespace CKAN.NetKAN.Processors
             IFileService   fileService   = new FileService(cache);
             http          = new CachingHttpService(cache, overwriteCache);
             ckanValidator = new CkanValidator(http, moduleService);
-            transformer   = new NetkanTransformer(http, fileService, moduleService, githubToken, prerelease, netkanValidator);
+            transformer   = new NetkanTransformer(http, fileService, moduleService, githubToken, gitlabToken, prerelease, netkanValidator);
         }
 
         internal IEnumerable<Metadata> Inflate(string filename, Metadata netkan, TransformOptions opts)
@@ -56,8 +56,15 @@ namespace CKAN.NetKAN.Processors
             }
             catch (Exception)
             {
-                // Purge anything we download for a failed indexing attempt from the cache to allow re-downloads
-                PurgeDownloads(http, cache);
+                try
+                {
+                    // Purge anything we download for a failed indexing attempt from the cache to allow re-downloads
+                    PurgeDownloads(http, cache);
+                }
+                catch
+                {
+                    // Don't freak out if we can't delete
+                }
                 throw;
             }
         }

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -22,13 +22,13 @@ namespace CKAN.NetKAN.Processors
 {
     public class QueueHandler
     {
-        public QueueHandler(string inputQueueName, string outputQueueName, string cacheDir, bool overwriteCache, string githubToken, bool prerelease)
+        public QueueHandler(string inputQueueName, string outputQueueName, string cacheDir, bool overwriteCache, string githubToken, string gitlabToken, bool prerelease)
         {
             warningAppender = GetQueueLogAppender();
             (LogManager.GetRepository() as Hierarchy)?.Root.AddAppender(warningAppender);
 
             log.Debug("Initializing SQS queue handler");
-            inflator = new Inflator(cacheDir, overwriteCache, githubToken, prerelease);
+            inflator = new Inflator(cacheDir, overwriteCache, githubToken, gitlabToken, prerelease);
 
             inputQueueURL  = getQueueUrl(inputQueueName);
             outputQueueURL = getQueueUrl(outputQueueName);

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -54,6 +54,7 @@ namespace CKAN.NetKAN
                         Options.CacheDir,
                         Options.OverwriteCache,
                         Options.GitHubToken,
+                        Options.GitLabToken,
                         Options.PreRelease
                     );
                     inf.ValidateCkan(ckan);
@@ -72,6 +73,7 @@ namespace CKAN.NetKAN
                         Options.CacheDir,
                         Options.OverwriteCache,
                         Options.GitHubToken,
+                        Options.GitLabToken,
                         Options.PreRelease
                     );
                     qh.Process();
@@ -89,6 +91,7 @@ namespace CKAN.NetKAN
                         Options.CacheDir,
                         Options.OverwriteCache,
                         Options.GitHubToken,
+                        Options.GitLabToken,
                         Options.PreRelease
                     );
                     var ckans = inf.Inflate(

--- a/Netkan/Sources/Gitlab/GitlabApi.cs
+++ b/Netkan/Sources/Gitlab/GitlabApi.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using CKAN.NetKAN.Services;
+
+namespace CKAN.NetKAN.Sources.Gitlab
+{
+    /// <summary>
+    /// Provides convenient access to the GitLab API
+    /// https://docs.gitlab.com/ee/api/
+    /// </summary>
+    internal sealed class GitlabApi : IGitlabApi
+    {
+        /// <summary>
+        /// Initialize the API object
+        /// </summary>
+        /// <param name="http">HTTP service for getting URLs</param>
+        /// <param name="token">GitLab API token</param>
+        public GitlabApi(IHttpService http, string token = null)
+        {
+            this.http  = http;
+            this.token = token;
+        }
+
+        /// <summary>
+        /// Retrieve info about a GitLab project from the API
+        /// </summary>
+        /// <param name="reference">Specification of which project to retrieve</param>
+        /// <returns>A project object</returns>
+        public GitlabProject GetProject(GitlabRef reference)
+        {
+            // https://docs.gitlab.com/ee/api/projects
+            return JsonConvert.DeserializeObject<GitlabProject>(
+                http.DownloadText(
+                    new Uri(apiBase, $"{reference.Account}%2F{reference.Project}"),
+                    token, null));
+        }
+
+        /// <summary>
+        /// Retrieve info about a GitLab project's releases from the API
+        /// </summary>
+        /// <param name="reference">Specification of which project's releases to retrieve</param>
+        /// <returns>Sequence of release objects from the API</returns>
+        public IEnumerable<GitlabRelease> GetAllReleases(GitlabRef reference)
+        {
+            // https://docs.gitlab.com/ee/api/releases/
+            return JArray.Parse(
+                http.DownloadText(
+                    new Uri(apiBase, $"{reference.Account}%2F{reference.Project}/releases"),
+                        token, null))
+                .Select(releaseJson => releaseJson.ToObject<GitlabRelease>());
+        }
+
+        private IHttpService http;
+        private string       token;
+
+        private static readonly Uri apiBase = new Uri("https://gitlab.com/api/v4/projects/");
+    }
+}

--- a/Netkan/Sources/Gitlab/GitlabOptions.cs
+++ b/Netkan/Sources/Gitlab/GitlabOptions.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Gitlab
+{
+    /// <summary>
+    /// Represents the x_netkan_gitlab object from a netkan
+    /// </summary>
+    internal sealed class GitlabOptions
+    {
+        /// <summary>
+        /// True to use source ZIP for a release.
+        /// Note that this MUST be true because GitLab only provides source ZIPs!
+        /// If they add other assets in the future, this requirement can be relaxed.
+        /// </summary>
+        [JsonProperty("use_source_archive")]
+        public readonly bool UseSourceArchive = false;
+    }
+}

--- a/Netkan/Sources/Gitlab/GitlabProject.cs
+++ b/Netkan/Sources/Gitlab/GitlabProject.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Gitlab
+{
+    /// <summary>
+    /// Represents a project from the GitLab API
+    /// </summary>
+    public sealed class GitlabProject
+    {
+        [JsonProperty("name")]
+        public readonly string Name;
+
+        [JsonProperty("description")]
+        public readonly string Description;
+
+        [JsonProperty("web_url")]
+        public readonly string WebURL;
+
+        [JsonProperty("issues_enabled")]
+        public readonly bool IssuesEnabled;
+
+        [JsonProperty("readme_url")]
+        public readonly string ReadMeURL;
+    }
+}

--- a/Netkan/Sources/Gitlab/GitlabRef.cs
+++ b/Netkan/Sources/Gitlab/GitlabRef.cs
@@ -1,0 +1,44 @@
+using System.Text.RegularExpressions;
+
+using CKAN.NetKAN.Model;
+
+namespace CKAN.NetKAN.Sources.Gitlab
+{
+    /// <summary>
+    /// Represents a GitLab $kref
+    /// </summary>
+    internal sealed class GitlabRef : RemoteRef
+    {
+        /// <summary>
+        /// Initialize the GitLab reference
+        /// </summary>
+        /// <param name="reference">The base $kref object from a netkan</param>
+        public GitlabRef(RemoteRef reference)
+            : base(reference)
+        {
+            var match = Pattern.Match(reference.Id);
+            if (match.Success)
+            {
+                Account = match.Groups["account"].Value;
+                Project = match.Groups["project"].Value;
+            }
+            else
+            {
+                throw new Kraken(string.Format(@"Could not parse reference: ""{0}""", reference));
+            }
+        }
+
+        /// <summary>
+        /// The first part of the "account/project" path from GitLab
+        /// </summary>
+        public readonly string Account;
+        /// <summary>
+        /// The second part of the "account/project" path from GitLab
+        /// </summary>
+        public readonly string Project;
+
+        private static readonly Regex Pattern = new Regex(
+            @"^(?<account>[^/]+)/(?<project>[^/]+)$",
+            RegexOptions.Compiled);
+    }
+}

--- a/Netkan/Sources/Gitlab/GitlabRelease.cs
+++ b/Netkan/Sources/Gitlab/GitlabRelease.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Gitlab
+{
+    /// <summary>
+    /// Represents a release from the GitLab API
+    /// </summary>
+    internal sealed class GitlabRelease
+    {
+        [JsonProperty("tag_name")]
+        public readonly string TagName;
+
+        [JsonProperty("author")]
+        public readonly GitlabReleaseAuthor Author = new GitlabReleaseAuthor();
+
+        [JsonProperty("released_at")]
+        public readonly DateTime ReleasedAt;
+
+        [JsonProperty("assets")]
+        public readonly GitlabReleaseAssets Assets = new GitlabReleaseAssets();
+    }
+
+    /// <summary>
+    /// Represents an author from the GitLab API
+    /// </summary>
+    internal sealed class GitlabReleaseAuthor
+    {
+        [JsonProperty("name")]
+        public readonly string Name;
+    }
+
+    /// <summary>
+    /// Represents an assets object from the GitLab API
+    /// </summary>
+    internal sealed class GitlabReleaseAssets
+    {
+        [JsonProperty("sources")]
+        public readonly List<GitlabReleaseAssetSource> Sources = new List<GitlabReleaseAssetSource>();
+    }
+
+    /// <summary>
+    /// Represents an assets source object from the GitLab API
+    /// </summary>
+    internal sealed class GitlabReleaseAssetSource
+    {
+        [JsonProperty("format")]
+        public readonly string Format;
+
+        [JsonProperty("url")]
+        public readonly string URL;
+    }
+}

--- a/Netkan/Sources/Gitlab/IGitlabApi.cs
+++ b/Netkan/Sources/Gitlab/IGitlabApi.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace CKAN.NetKAN.Sources.Gitlab
+{
+    /// <summary>
+    /// Interface for classes providing access to the GitLab API
+    /// Allows mocking up in tests
+    /// </summary>
+    internal interface IGitlabApi
+    {
+        /// <summary>
+        /// Retrieve info about a GitLab project from the API
+        /// </summary>
+        /// <param name="reference">Specification of which project to retrieve</param>
+        /// <returns>A project object</returns>
+        GitlabProject GetProject(GitlabRef reference);
+
+        /// <summary>
+        /// Retrieve info about a GitLab project's releases from the API
+        /// </summary>
+        /// <param name="reference">Specification of which project's releases to retrieve</param>
+        /// <returns>Sequence of release objects from the API</returns>
+        IEnumerable<GitlabRelease> GetAllReleases(GitlabRef reference);
+    }
+}

--- a/Netkan/Transformers/GitlabTransformer.cs
+++ b/Netkan/Transformers/GitlabTransformer.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Newtonsoft.Json.Linq;
+using log4net;
+
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Extensions;
+using CKAN.NetKAN.Sources.Gitlab;
+
+namespace CKAN.NetKAN.Transformers
+{
+    /// <summary>
+    /// An <see cref="ITransformer"/> that looks up data from GitHub.
+    /// </summary>
+    internal sealed class GitlabTransformer : ITransformer
+    {
+        /// <summary>
+        /// Initialize the transformer
+        /// </summary>
+        /// <param name="api">Object to use for accessing the GitLab API</param>
+        public GitlabTransformer(IGitlabApi api)
+        {
+            if (api == null)
+            {
+                throw new ArgumentNullException("api");
+            }
+            this.api = api;
+        }
+
+        /// <summary>
+        /// Defines the name of this transformer
+        /// </summary>
+        public string Name => "gitlab";
+
+        /// <summary>
+        /// If input metadata has a GitLab kref, inflate it with whatever info we can get,
+        /// otherwise return it unchanged
+        /// </summary>
+        /// <param name="metadata">Input netkan</param>
+        /// <param name="opts">Inflation options from command line</param>
+        /// <returns></returns>
+        public IEnumerable<Metadata> Transform(Metadata metadata, TransformOptions opts)
+        {
+            if (metadata.Kref?.Source == Name)
+            {
+                var reference = new GitlabRef(metadata.Kref);
+                var project   = api.GetProject(reference);
+                var releases  = api.GetAllReleases(reference)
+                    .Skip(opts.SkipReleases ?? 0)
+                    .Take(opts.Releases     ?? 1)
+                    .ToArray();
+                if (releases.Length < 1)
+                {
+                    log.WarnFormat("No releases found for {0}", reference);
+                    return Enumerable.Repeat(metadata, 1);
+                }
+                return releases.Select(release => TransformOne(
+                    metadata, metadata.Json(), reference, project, release));
+            }
+            else
+            {
+                // Passthrough for non-GitLab mods
+                return Enumerable.Repeat(metadata, 1);
+            }
+        }
+
+        private Metadata TransformOne(Metadata metadata, JObject json, GitlabRef reference, GitlabProject project, GitlabRelease release)
+        {
+            var opts = (json["x_netkan_gitlab"] as JObject)?.ToObject<GitlabOptions>()
+                ?? new GitlabOptions();
+            if (!opts.UseSourceArchive)
+            {
+                throw new Exception("'x_netkan_gitlab.use_source_archive' missing or false; GitLab ONLY supports source archives!");
+            }
+
+            json.SafeAdd("name",     project.Name);
+            json.SafeAdd("abstract", project.Description);
+            json.SafeAdd("author",   release.Author.Name);
+            json.SafeAdd("version",  release.TagName);
+            json.SafeMerge("resources", JObject.FromObject(new Dictionary<string, string>()
+            {
+                { "repository", project.WebURL },
+                { "bugtracker", project.IssuesEnabled ? $"{project.WebURL}/-/issues" : null },
+                { "manual",     project.ReadMeURL },
+            }));
+            json.SafeAdd("download",
+                release.Assets.Sources
+                    .Where(src => src.Format == "zip")
+                    .Select(src => src.URL)
+                    .FirstOrDefault());
+            json.SafeAdd(Metadata.UpdatedPropertyName, release.ReleasedAt);
+
+            json.Remove("$kref");
+
+            return new Metadata(json);
+        }
+
+        private static readonly ILog       log = LogManager.GetLogger(typeof(GitlabTransformer));
+        private                 IGitlabApi api;
+    }
+}

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Validators;
 using CKAN.NetKAN.Sources.Curse;
 using CKAN.NetKAN.Sources.Github;
+using CKAN.NetKAN.Sources.Gitlab;
 using CKAN.NetKAN.Sources.Jenkins;
 using CKAN.NetKAN.Sources.Spacedock;
 
@@ -25,12 +27,14 @@ namespace CKAN.NetKAN.Transformers
             IFileService fileService,
             IModuleService moduleService,
             string githubToken,
+            string gitlabToken,
             bool prerelease,
             IValidator validator
         )
         {
             _validator = validator;
             var ghApi = new GithubApi(http, githubToken);
+            var glApi = new GitlabApi(http, gitlabToken);
             _transformers = InjectVersionedOverrideTransformers(new List<ITransformer>
             {
                 new StagingTransformer(),
@@ -38,6 +42,7 @@ namespace CKAN.NetKAN.Transformers
                 new SpacedockTransformer(new SpacedockApi(http), ghApi),
                 new CurseTransformer(new CurseApi(http)),
                 new GithubTransformer(ghApi, prerelease),
+                new GitlabTransformer(glApi),
                 new HttpTransformer(),
                 new JenkinsTransformer(new JenkinsApi(http)),
                 new AvcKrefTransformer(http, ghApi),

--- a/Netkan/Validators/KrefValidator.cs
+++ b/Netkan/Validators/KrefValidator.cs
@@ -16,6 +16,7 @@ namespace CKAN.NetKAN.Validators
                 case null:
                 case "curse":
                 case "github":
+                case "gitlab":
                 case "http":
                 case "ksp-avc":
                 case "jenkins":

--- a/Spec.md
+++ b/Spec.md
@@ -808,6 +808,38 @@ An `x_netkan_github` field may be provided to customize how the metadata is fetc
 - `use_source_archive` (type: `boolean`) (default: `false`)<br/>
   Specifies that the source ZIP of the repository itself will be used instead of any assets in the release.
 
+###### `#/ckan/gitlab/:user/:repo`
+
+Indicates that data should be fetched from GitLab, using the `:user` and `:repo` provided.
+For example: `#/ckan/gitlab/Ailex-/starilex-mk1-iva`.
+
+When used, the following fields will be auto-filled if not already present:
+
+- `name`
+- `abstract`
+- `author`
+- `version`
+- `resources.repository`
+- `resources.bugtracker`
+- `resources.manual`
+- `download`
+- `download_size`
+- `download_hash`
+- `download_content_type`
+- `release_date`
+
+An example `.netkan` excerpt:
+
+```yaml
+$kref: '#/ckan/gitlab/Ailex-/starilex-mk1-iva'
+```
+
+An `x_netkan_gitlab` field must be provided to customize how the metadata is fetched from GitLab. It is an `object` with the following fields:
+
+- `use_source_archive` (type: `boolean`) (default: `false`)<br/>
+  Specifies that the source ZIP of the release will be used instead of any discrete assets.<br/>
+  Note that this must be `true`! GitLab only offers source ZIP assets, so we can only index mods that use them. If at some point in the future GitLab adds support for non-source assets, we will be able to add support for setting this property to `false` or omitting it.
+
 ###### `#/ckan/jenkins/:joburl`
 
 Indicates data should be fetched from a [Jenkins CI server](https://jenkins-ci.org/) using the `:joburl` provided. For


### PR DESCRIPTION
## Motivation

See KSP-CKAN/NetKAN#9325, the author of a mod hosted on GitLab has requested to have it added to CKAN. Currently we don't have a way to do that without hard coding the download URL, which is bad for maintenance.

## Changes

- A `netkan.exe --gitlab-token` command line option is now added and works just like `--github-token` but for GitLab
- If `PurgeDownloads` fails after a failed inflation, we ignore it so the original error can be printed
- A new kref format `#/ckan/gitlab/<account>/<project>` is added for indexing GitLab projects
- A new `GitlabTransfomer` uses a `GitlabApi` and accompanying data classes from a `Netkan/Sources/Gitlab` folder to inflate modules with GitLab krefs
- The spec is updated to describe the new kref

After this, we can inflate a netkan for the mod from KSP-CKAN/NetKAN#9325.

Fixes #2554.

### Known limitations

Whereas GitHub allows the user to custom-build a special ZIP and attach it as a release asset, GitLab appears to only support source ZIPs (which we can support for GitHub as well using `x_netkan_github.use_source_archive`). This means that mods with build steps such as compiling a plugin may not be indexable from GitLab, but some mods without such steps can be correctly installed from a source ZIP if the repo is structured the same as the installed folder.

While it would be great if GitLab added support for non-source assets, we don't have to wait for that to get some value out of a GitLab kref. However, we do need to make sure that any future changes don't break the mods we index in the meantime. For this reason, `x_netkan_gitlab.use_source_archive` **must** be set to `true` for now! This will ensure that we only index GitLab mods that can be properly installed from a source ZIP, while allowing for future enhancements to the API for non-source assets.
