### PR TITLE
Trivial code style clean-up

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Linq;
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Transactions;
+
 using log4net;
+
 using CKAN.Versioning;
 
 namespace CKAN.CmdLine
@@ -38,7 +40,7 @@ namespace CKAN.CmdLine
             UpgradeOptions options = (UpgradeOptions) raw_options;
 
             if (options.ckan_file != null)
-            {                
+            {
                 options.modules.Add(MainClass.LoadCkanFromFile(instance, options.ckan_file).identifier);
             }
 
@@ -195,7 +197,7 @@ namespace CKAN.CmdLine
             );
         }
 
-        // System.Action<ref T> isn't allowed
+        // Action<ref T> isn't allowed
         private delegate void AttemptUpgradeAction(ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs);
 
         /// <summary>
@@ -212,7 +214,7 @@ namespace CKAN.CmdLine
         private static void UpgradeModules(
             GameInstanceManager manager, IUser user, CKAN.GameInstance instance,
             AttemptUpgradeAction attemptUpgradeCallback,
-            System.Action<CkanModule> addUserChoiceCallback)
+            Action<CkanModule> addUserChoiceCallback)
         {
             using (TransactionScope transact = CkanTransaction.CreateTransactionScope()) {
                 var installer  = new ModuleInstaller(instance, manager.Cache, user);

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-﻿using System.Linq;
+using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
 

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Threading;
+
 using CKAN.Versioning;
 using CKAN.ConsoleUI.Toolkit;
 
@@ -249,7 +251,7 @@ namespace CKAN.ConsoleUI {
             ConsoleMessageDialog d = new ConsoleMessageDialog(Properties.Resources.ModInfoURLLaunching, new List<string>());
             d.Run(theme, (ConsoleTheme th) => {
                 Utilities.ProcessStartURL(u.ToString());
-                System.Threading.Thread.Sleep(1500);
+                Thread.Sleep(1500);
             });
             return true;
         }

--- a/ConsoleUI/Properties/AssemblyInfo.cs
+++ b/ConsoleUI/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Resources;
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("CKAN-ConsoleUI")]

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -7,8 +7,8 @@ namespace CKAN.ConsoleUI.Toolkit {
     /// </summary>
     public static class Keys {
 
-        private const char LinuxEnter   = (System.Char)10;
-        private const char WindowsEnter = (System.Char)13;
+        private const char LinuxEnter   = (Char)10;
+        private const char WindowsEnter = (Char)13;
 
         /// <summary>
         /// Representation of enter key for key bindings
@@ -29,98 +29,98 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Representation of escape key for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo Escape = new ConsoleKeyInfo(
-            (System.Char)27, ConsoleKey.Escape, false, false, false
+            (Char)27, ConsoleKey.Escape, false, false, false
         );
 
         /// <summary>
         /// Representation of F1 for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo F1 = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.F1, false, false, false
+            (Char)0, ConsoleKey.F1, false, false, false
         );
 
         /// <summary>
         /// Representation of F2 for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo F2 = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.F2, false, false, false
+            (Char)0, ConsoleKey.F2, false, false, false
         );
 
         /// <summary>
         /// Representation of F5 for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo F5 = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.F5, false, false, false
+            (Char)0, ConsoleKey.F5, false, false, false
         );
 
         /// <summary>
         /// Representation of F8 for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo F8 = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.F8, false, false, false
+            (Char)0, ConsoleKey.F8, false, false, false
         );
 
         /// <summary>
         /// Representation of F9 for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo F9 = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.F9, false, false, false
+            (Char)0, ConsoleKey.F9, false, false, false
         );
 
         /// <summary>
         /// Representation of F10 for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo F10 = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.F10, false, false, false
+            (Char)0, ConsoleKey.F10, false, false, false
         );
 
         /// <summary>
         /// Representation of Apps for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo Apps = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.Applications, false, false, false
+            (Char)0, ConsoleKey.Applications, false, false, false
         );
 
         /// <summary>
         /// Representation of down arrow for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo DownArrow = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.DownArrow, false, false, false
+            (Char)0, ConsoleKey.DownArrow, false, false, false
         );
 
         /// <summary>
         /// Representation of up arrow for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo UpArrow = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.UpArrow, false, false, false
+            (Char)0, ConsoleKey.UpArrow, false, false, false
         );
 
         /// <summary>
         /// Representation of home for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo Home = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.Home, false, false, false
+            (Char)0, ConsoleKey.Home, false, false, false
         );
 
         /// <summary>
         /// Representation of end for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo End = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.End, false, false, false
+            (Char)0, ConsoleKey.End, false, false, false
         );
 
         /// <summary>
         /// Representation of page up for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo PageUp = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.PageUp, false, false, false
+            (Char)0, ConsoleKey.PageUp, false, false, false
         );
 
         /// <summary>
         /// Representation of page down for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo PageDown = new ConsoleKeyInfo(
-            (System.Char)0, ConsoleKey.PageDown, false, false, false
+            (Char)0, ConsoleKey.PageDown, false, false, false
         );
 
         /// <summary>
@@ -129,11 +129,11 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         public static readonly ConsoleKeyInfo[] Plus = new ConsoleKeyInfo[] {
             new ConsoleKeyInfo(
-                (System.Char)'+',
+                (Char)'+',
                 Platform.IsWindows ? ConsoleKey.OemPlus : ConsoleKey.Add,
                 false, false, false
             ), new ConsoleKeyInfo(
-                (System.Char)'+',
+                (Char)'+',
                 Platform.IsWindows ? ConsoleKey.OemPlus : ConsoleKey.Add,
                 true, false, false
             )
@@ -143,7 +143,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Representation of minus key for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo Minus = new ConsoleKeyInfo(
-            (System.Char)'-',
+            (Char)'-',
             Platform.IsWindows ? ConsoleKey.OemMinus : ConsoleKey.Subtract,
             false, false, false
         );
@@ -152,56 +152,56 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Representation of Ctrl+A for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlA = new ConsoleKeyInfo(
-            (System.Char)1, ConsoleKey.A, false, false, true
+            (Char)1, ConsoleKey.A, false, false, true
         );
 
         /// <summary>
         /// Representation of Ctrl+D for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlD = new ConsoleKeyInfo(
-            (System.Char)4, ConsoleKey.D, false, false, true
+            (Char)4, ConsoleKey.D, false, false, true
         );
 
         /// <summary>
         /// Representation of Ctrl+F for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlF = new ConsoleKeyInfo(
-            (System.Char)6, ConsoleKey.F, false, false, true
+            (Char)6, ConsoleKey.F, false, false, true
         );
 
         /// <summary>
         /// Representation of Ctrl+L for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlL = new ConsoleKeyInfo(
-            (System.Char)12, ConsoleKey.Clear, false, false, false
+            (Char)12, ConsoleKey.Clear, false, false, false
         );
 
         /// <summary>
         /// Representation of Ctrl+Q for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlQ = new ConsoleKeyInfo(
-            (System.Char)17, ConsoleKey.Q, false, false, true
+            (Char)17, ConsoleKey.Q, false, false, true
         );
 
         /// <summary>
         /// Representation of Ctrl+R for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlR = new ConsoleKeyInfo(
-            (System.Char)18, ConsoleKey.R, false, false, true
+            (Char)18, ConsoleKey.R, false, false, true
         );
 
         /// <summary>
         /// Representation of Ctrl+U for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlU = new ConsoleKeyInfo(
-            (System.Char)21, ConsoleKey.U, false, false, true
+            (Char)21, ConsoleKey.U, false, false, true
         );
 
         /// <summary>
         /// Representation of Alt+H for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo AltH = new ConsoleKeyInfo(
-            (System.Char)'h', ConsoleKey.H, false, true, false
+            (Char)'h', ConsoleKey.H, false, true, false
         );
 
         /// <summary>
@@ -209,49 +209,49 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Does not work on MacOSX, so we
         /// </summary>
         public static readonly ConsoleKeyInfo AltX = new ConsoleKeyInfo(
-            (System.Char)'x', ConsoleKey.X, false, true, false
+            (Char)'x', ConsoleKey.X, false, true, false
         );
 
         /// <summary>
         /// Representation of letter 'a' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo A = new ConsoleKeyInfo(
-            (System.Char)'a', ConsoleKey.A, false, false, false
+            (Char)'a', ConsoleKey.A, false, false, false
         );
 
         /// <summary>
         /// Representation of letter 'd' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo D = new ConsoleKeyInfo(
-            (System.Char)'d', ConsoleKey.D, false, false, false
+            (Char)'d', ConsoleKey.D, false, false, false
         );
 
         /// <summary>
         /// Representation of letter 'e' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo E = new ConsoleKeyInfo(
-            (System.Char)'e', ConsoleKey.E, false, false, false
+            (Char)'e', ConsoleKey.E, false, false, false
         );
 
         /// <summary>
         /// Representation of letter 'n' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo N = new ConsoleKeyInfo(
-            (System.Char)'n', ConsoleKey.N, false, false, false
+            (Char)'n', ConsoleKey.N, false, false, false
         );
 
         /// <summary>
         /// Representation of letter 'r' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo R = new ConsoleKeyInfo(
-            (System.Char)'r', ConsoleKey.R, false, false, false
+            (Char)'r', ConsoleKey.R, false, false, false
         );
 
         /// <summary>
         /// Representation of letter 'y' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo Y = new ConsoleKeyInfo(
-            (System.Char)'y', ConsoleKey.Y, false, false, false
+            (Char)'y', ConsoleKey.Y, false, false, false
         );
 
     }

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -11,12 +11,16 @@ namespace CKAN.Extensions
         private static bool StringArrayStartsWith(string[] child, string[] parent)
         {
             if (parent.Length > child.Length)
+            {
                 // Only child is allowed to have extra pieces
                 return false;
+            }
             var opt = Platform.IsWindows ? StringComparison.InvariantCultureIgnoreCase
                                          : StringComparison.InvariantCulture;
-            for (int i = 0; i < parent.Length; ++i) {
-                if (!parent[i].Equals(child[i], opt)) {
+            for (int i = 0; i < parent.Length; ++i)
+            {
+                if (!parent[i].Equals(child[i], opt))
+                {
                     return false;
                 }
             }

--- a/Core/Net/AutoUpdate.cs
+++ b/Core/Net/AutoUpdate.cs
@@ -3,8 +3,10 @@ using System.IO;
 using System.Diagnostics;
 using System.Net;
 using System.Reflection;
+
 using log4net;
 using Newtonsoft.Json;
+
 using CKAN.Versioning;
 
 namespace CKAN
@@ -143,8 +145,8 @@ namespace CKAN
             var pid = Process.GetCurrentProcess().Id;
 
             // download updater app and new ckan.exe
-            string updaterFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
-            string ckanFilename    = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
+            string updaterFilename = Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
+            string ckanFilename    = Path.GetTempPath() + Guid.NewGuid().ToString() + ".exe";
             Net.DownloadWithProgress(
                 new[]
                 {

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -4,11 +4,14 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Runtime.Serialization;
+
 using ChinhDo.Transactions.FileManager;
-using CKAN.DLC;
-using CKAN.Versioning;
 using log4net;
 using Newtonsoft.Json;
+
+using CKAN.DLC;
+using CKAN.Versioning;
 
 namespace CKAN
 {
@@ -303,10 +306,7 @@ namespace CKAN
             // after deserialisation.
             var settings = new JsonSerializerSettings
             {
-                Context = new System.Runtime.Serialization.StreamingContext(
-                    System.Runtime.Serialization.StreamingContextStates.Other,
-                    ksp
-                    )
+                Context = new StreamingContext(StreamingContextStates.Other, ksp)
             };
 
             log.DebugFormat("Trying to load registry from {0}", path);
@@ -478,7 +478,7 @@ namespace CKAN
                 name,
                 string.Format(Properties.Resources.RegistryManagerDefaultModpackAbstract, kspInstanceName),
                 null,
-                new List<string>() { System.Environment.UserName },
+                new List<string>() { Environment.UserName },
                 new List<License>() { new License("unknown") },
                 new ModuleVersion(DateTime.UtcNow.ToString("yyyy.MM.dd.hh.mm.ss")),
                 null,

--- a/Core/Types/License.cs
+++ b/Core/Types/License.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Newtonsoft.Json;
 

--- a/GUI/Controls/HintTextBox.cs
+++ b/GUI/Controls/HintTextBox.cs
@@ -49,12 +49,10 @@ namespace CKAN.GUI
         {
             if (ClearIcon.Image != null)
             {
-                ClearIcon.Location = new Point(
-                    // align with right edge of textbox minus 5px
-                    Width - ClearIcon.Width - 5,
-                    // need to divide these as decimals and drop back to int at the end
-                    (int)Math.Ceiling(Height / 2d - (ClearIcon.Height / 2d))
-                );
+                // Fit the X just inside the text box's borders
+                ClearIcon.Size = new Size(Height - 2, Height - 2);
+                // Align with right edge of textbox minus 1px
+                ClearIcon.Location = new Point(Width - ClearIcon.Width - 1, 1);
             }
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -185,14 +185,14 @@ namespace CKAN.GUI
 
         #region Filter dropdown
 
-        private void FilterToolButton_DropDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void FilterToolButton_DropDown_Opening(object sender, CancelEventArgs e)
         {
             // The menu items' dropdowns can't be accessed if they're empty
             FilterTagsToolButton_DropDown_Opening(null, null);
             FilterLabelsToolButton_DropDown_Opening(null, null);
         }
 
-        private void FilterTagsToolButton_DropDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void FilterTagsToolButton_DropDown_Opening(object sender, CancelEventArgs e)
         {
             FilterTagsToolButton.DropDownItems.Clear();
             foreach (var kvp in mainModList.ModuleTags.Tags.OrderBy(kvp => kvp.Key))
@@ -215,7 +215,7 @@ namespace CKAN.GUI
             });
         }
 
-        private void FilterLabelsToolButton_DropDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void FilterLabelsToolButton_DropDown_Opening(object sender, CancelEventArgs e)
         {
             FilterLabelsToolButton.DropDownItems.Clear();
             foreach (ModuleLabel mlbl in mainModList.ModuleLabels.LabelsFor(Main.Instance.CurrentInstance.Name))
@@ -234,7 +234,7 @@ namespace CKAN.GUI
 
         #region Filter right click menu
 
-        private void LabelsContextMenuStrip_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void LabelsContextMenuStrip_Opening(object sender, CancelEventArgs e)
         {
             LabelsContextMenuStrip.Items.Clear();
 
@@ -571,7 +571,7 @@ namespace CKAN.GUI
         /// <summary>
         /// Called if a ToolStripButton of the header context menu is pressed.
         /// </summary>
-        private void ModListHeaderContextMenuStrip_ItemClicked(object sender, System.Windows.Forms.ToolStripItemClickedEventArgs e)
+        private void ModListHeaderContextMenuStrip_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             // ClickedItem is of type ToolStripItem, we need ToolStripButton.
             ToolStripMenuItem  clickedItem = e.ClickedItem    as ToolStripMenuItem;

--- a/GUI/Controls/TransparentTextBox.cs
+++ b/GUI/Controls/TransparentTextBox.cs
@@ -1,4 +1,6 @@
-﻿namespace CKAN.GUI
+﻿using System.Windows.Forms;
+
+namespace CKAN.GUI
 {
     /// <summary>
     /// Create a new TransparentTextBox control that allows the backcolor of textboxes to be transparent.
@@ -7,15 +9,15 @@
     /// Multiline is set to true.
     /// Used in <see cref="MainModInfo"/>.</para>
     /// </summary>
-    public class TransparentTextBox : System.Windows.Forms.TextBox
+    public class TransparentTextBox : TextBox
     {
         public TransparentTextBox()
         {
-            SetStyle(
-                System.Windows.Forms.ControlStyles.SupportsTransparentBackColor |
-                System.Windows.Forms.ControlStyles.ResizeRedraw |
-                System.Windows.Forms.ControlStyles.OptimizedDoubleBuffer |
-                System.Windows.Forms.ControlStyles.AllPaintingInWmPaint, true);
+            SetStyle(ControlStyles.SupportsTransparentBackColor
+                     | ControlStyles.ResizeRedraw
+                     | ControlStyles.OptimizedDoubleBuffer
+                     | ControlStyles.AllPaintingInWmPaint,
+                     true);
             Multiline = true;
         }
     }

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.cs
@@ -4,7 +4,10 @@ using System.IO;
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Collections.Generic;
+using System.Drawing;
+
 using Autofac;
+
 using CKAN.Versioning;
 using CKAN.GameVersionProviders;
 
@@ -26,7 +29,7 @@ namespace CKAN.GUI
 
             if (centerScreen)
             {
-                StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+                StartPosition = FormStartPosition.CenterScreen;
             }
 
             List<GameVersion> compatibleVersions = inst.GetCompatibleVersions();
@@ -70,7 +73,7 @@ namespace CKAN.GUI
                     _inst.Version(),
                     _inst.GameVersionWhenCompatibleVersionsWereStored
                 );
-                GameVersionLabel.ForeColor = System.Drawing.Color.Red;
+                GameVersionLabel.ForeColor = Color.Red;
             }
         }
 

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -40,7 +40,7 @@ namespace CKAN.GUI
             InstanceFiltersTextBox.DeselectAll();
         }
 
-        private void InstallFiltersDialog_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        private void InstallFiltersDialog_Closing(object sender, CancelEventArgs e)
         {
             globalConfig.GlobalInstallFilters = GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
             instance.InstallFilters = InstanceFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.IO;
+using System.Drawing;
 
 using CKAN.Versioning;
 
@@ -277,7 +278,7 @@ namespace CKAN.GUI
         {
             if (e.Button == MouseButtons.Right)
             {
-                InstanceListContextMenuStrip.Show(this, new System.Drawing.Point(e.X, e.Y));
+                InstanceListContextMenuStrip.Show(this, new Point(e.X, e.Y));
             }
         }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using Timer = System.Windows.Forms.Timer;
+
 using log4net;
 using Autofac;
 
@@ -68,7 +69,7 @@ namespace CKAN.GUI
             }
             else
             {
-                CultureInfo.DefaultThreadCurrentUICulture = Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo(mainConfig.Language);
+                CultureInfo.DefaultThreadCurrentUICulture = Thread.CurrentThread.CurrentUICulture = new CultureInfo(mainConfig.Language);
             }
 
             Application.AddMessageFilter(this);

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -3,10 +3,14 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Timers;
 using System.Linq;
+using System.Windows.Forms;
+using Timer = System.Timers.Timer;
+
 using Newtonsoft.Json;
+using Autofac;
+
 using CKAN.Versioning;
 using CKAN.Configuration;
-using Autofac;
 
 namespace CKAN.GUI
 {
@@ -269,7 +273,7 @@ namespace CKAN.GUI
                         10000,
                         string.Format(Properties.Resources.MainRepoBalloonTipDetails, numUpgradeable),
                         Properties.Resources.MainRepoBalloonTipTooltip,
-                        System.Windows.Forms.ToolTipIcon.Info
+                        ToolTipIcon.Info
                     );
                 });
             }

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Xml;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -131,16 +133,16 @@ namespace CKAN.GUI
                 {
                     configuration = (GUIConfiguration) serializer.Deserialize(stream);
                 }
-                catch (System.Exception e)
+                catch (Exception e)
                 {
                     string additionalErrorData = "";
 
-                    if (e is System.InvalidOperationException) // Exception thrown in Windows / .NET
+                    if (e is InvalidOperationException) // Exception thrown in Windows / .NET
                     {
                         if (e.InnerException != null)
                             additionalErrorData = ": " + e.InnerException.Message;
                     }
-                    else if (e is System.Xml.XmlException) // Exception thrown in Mono
+                    else if (e is XmlException) // Exception thrown in Mono
                     {
                         additionalErrorData = ": " + e.Message;
                     }

--- a/GUI/NavigationHistory.cs
+++ b/GUI/NavigationHistory.cs
@@ -1,7 +1,8 @@
-﻿namespace CKAN.GUI
+﻿using System;
+using System.Collections.Generic;
+
+namespace CKAN.GUI
 {
-    using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Generic class for keeping a browser-like navigation history.
@@ -79,17 +80,17 @@
             /*
              * This operation removes all history AHEAD of the current index,
              * adds a new item to the head of the list, and advances the index.
-             * 
+             *
              * Let's say this is your current state:
-             * 
+             *
              * =============
              * |x|y|z|a|b|c|
              * =============
              *      ^
-             * 
+             *
              * When you add an item to the history ('d'),
              * the next state will be:
-             * 
+             *
              * =========
              * |x|y|z|d|
              * =========

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Microsoft.Win32;
+
 using IniParser;
 using IniParser.Exceptions;
 using IniParser.Model;
@@ -186,7 +187,7 @@ namespace CKAN.GUI
             data.Sections.AddSection("Desktop Entry");
             data["Desktop Entry"].AddKey("Version", "1.0");
             data["Desktop Entry"].AddKey("Type", "Application");
-            data["Desktop Entry"].AddKey("Exec", "mono \"" + System.Reflection.Assembly.GetExecutingAssembly().Location + "\" gui %u");
+            data["Desktop Entry"].AddKey("Exec", "mono \"" + Assembly.GetExecutingAssembly().Location + "\" gui %u");
             data["Desktop Entry"].AddKey("Icon", "ckan");
             data["Desktop Entry"].AddKey("StartupNotify", "true");
             data["Desktop Entry"].AddKey("NoDisplay", "true");

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -2,14 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using Timer = System.Windows.Forms.Timer;
 
 using log4net;
 
 namespace CKAN.GUI
 {
-    using System.Runtime.InteropServices;
-    using System.Windows.Forms;
 
     public static class Util
     {

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-﻿using System.Linq;
+using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
 

--- a/Netkan/Sources/Curse/CurseApi.cs
+++ b/Netkan/Sources/Curse/CurseApi.cs
@@ -2,9 +2,12 @@
 using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Net;
-using CKAN.NetKAN.Services;
+using System.Text;
+
 using log4net;
 using Newtonsoft.Json;
+
+using CKAN.NetKAN.Services;
 
 namespace CKAN.NetKAN.Sources.Curse
 {
@@ -32,7 +35,7 @@ namespace CKAN.NetKAN.Sources.Curse
             catch (WebException e)
             {
                 // CurseForge returns a valid json with an error message in some cases.
-                json = new StreamReader(e.Response.GetResponseStream(), System.Text.Encoding.UTF8).ReadToEnd();
+                json = new StreamReader(e.Response.GetResponseStream(), Encoding.UTF8).ReadToEnd();
             }
             // Check if the mod has been removed from Curse and if it corresponds to a KSP mod.
             var error = JsonConvert.DeserializeObject<CurseError>(json);

--- a/Netkan/Sources/Spacedock/SpaceDockApi.cs
+++ b/Netkan/Sources/Spacedock/SpaceDockApi.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.IO;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
-using CKAN.NetKAN.Services;
+
 using log4net;
 using Newtonsoft.Json;
+
+using CKAN.NetKAN.Services;
 
 namespace CKAN.NetKAN.Sources.Spacedock
 {
@@ -37,7 +41,7 @@ namespace CKAN.NetKAN.Sources.Spacedock
                 }
 
                 // SpaceDock returns a valid json with an error message in case of non 200 codes.
-                json = new System.IO.StreamReader(e.Response.GetResponseStream(), System.Text.Encoding.UTF8).ReadToEnd();
+                json = new StreamReader(e.Response.GetResponseStream(), Encoding.UTF8).ReadToEnd();
                 if (string.IsNullOrEmpty(json))
                 {
                     // ... sometimes. Other times we get nothing.

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 
-﻿using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.Extensions;
 using CKAN.Games;


### PR DESCRIPTION
## Motivation

I've been accumulating trivial changes while working on unrelated pull requests.
Now they've been dumped into a branch so I don't have to keep stashing and popping them.

## Changes

- Redundant namespace specifications are removed
- BOMs are removed from lines where they don't belong
- Missing or misaligned `{` and `}` characters are fixed
- Some `using` statements are moved to the top of the file and split into system, third party, and CKAN sections
- The `X` icon in the `HintTextBox` is made to fit the text box rather than just being centered on top of it

I'll probably self-review this since it's so minor.
