### PR TITLE
Pass GitLab token from env to inflator param

### DIFF
--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -7,4 +7,4 @@ WORKDIR /home/netkan
 ADD netkan.exe .
 ENTRYPOINT /usr/bin/mono netkan.exe --queues $QUEUES \
   --net-useragent 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)' \
-  --github-token $GH_Token --cachedir ckan_cache -v
+  --github-token $GH_Token --gitlab-token $GL_Token --cachedir ckan_cache -v


### PR DESCRIPTION
## Motivation

In KSP-CKAN/CKAN#3661 we added the ability to index mods hosted on GitLab. This included the ability to provide a GitLab authentication token from the command line, but the Inflator isn't using this capability yet. We should add that eventually for completeness, see https://github.com/KSP-CKAN/CKAN/pull/3661#discussion_r966544529.

## Changes

Now the `$GL_Token` environment variable is passed to the inflator's `--gitlab-token` parameter.
KSP-CKAN/NetKAN-Infra#276 will handle providing this env var based on the configured secrets.

I tested `netkan.exe --gitlab-token ''` and it still worked, so I think there is no harm in setting this parameter before we create a GitLab token.
