### PR TITLE
Resume failed downloads

### DIFF
--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -54,5 +54,28 @@ namespace CKAN.Extensions
                         .OrderByDescending(dr => dr.RootDirectory.FullName.Length)
                         .FirstOrDefault();
 
+        /// <summary>
+        /// A version of Stream.CopyTo with progress updates.
+        /// </summary>
+        /// <param name="src">Stream from which to copy</param>
+        /// <param name="dest">Stream to which to copy</param>
+        /// <param name="progress">Callback to notify as we traverse the input, called with count of bytes received</param>
+        public static void CopyTo(this Stream src, Stream dest, IProgress<long> progress)
+        {
+            // CopyTo says its default buffer is 81920, but we want more than 1 update for a 100 KiB file
+            const int bufSize = 8192;
+            var buffer = new byte[bufSize];
+            long total = 0;
+            while (true)
+            {
+                var bytesRead = src.Read(buffer, 0, bufSize);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+                dest.Write(buffer, 0, bytesRead);
+                progress.Report(total += bytesRead);
+            }
+        }
     }
 }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -155,19 +155,10 @@ namespace CKAN
 
             foreach (CkanModule module in modsToInstall)
             {
+                User.RaiseMessage(" * {0}", Cache.DescribeAvailability(module));
                 if (!Cache.IsMaybeCachedZip(module))
                 {
-                    User.RaiseMessage(" * {0} {1} ({2}, {3})",
-                        module.name,
-                        module.version,
-                        module.download.Host,
-                        CkanModule.FmtSize(module.download_size)
-                    );
                     downloads.Add(module);
-                }
-                else
-                {
-                    User.RaiseMessage(Properties.Resources.ModuleInstallerModuleCached, module.name, module.version);
                 }
             }
 
@@ -1053,12 +1044,21 @@ namespace CKAN
                 {
                     if (!Cache.IsMaybeCachedZip(module))
                     {
-                        User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingUncached,
-                            module.name,
-                            module.version,
-                            module.download.Host,
-                            CkanModule.FmtSize(module.download_size)
-                        );
+                        var inProgressFile = new FileInfo(Cache.GetInProgressFileName(module));
+                        if (inProgressFile.Exists)
+                        {
+                            User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingResuming,
+                                module.name, module.version,
+                                module.download.Host,
+                                CkanModule.FmtSize(module.download_size - inProgressFile.Length));
+                        }
+                        else
+                        {
+                            User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingUncached,
+                                module.name, module.version,
+                                module.download.Host,
+                                CkanModule.FmtSize(module.download_size));
+                        }
                     }
                     else
                     {
@@ -1086,13 +1086,19 @@ namespace CKAN
                     {
                         if (!Cache.IsMaybeCachedZip(module))
                         {
-                            User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingUncached,
-                                module.name,
-                                installed.version,
-                                module.version,
-                                module.download.Host,
-                                CkanModule.FmtSize(module.download_size)
-                            );
+                            var inProgressFile = new FileInfo(Cache.GetInProgressFileName(module));
+                            if (inProgressFile.Exists)
+                            {
+                                User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingResuming,
+                                    module.name, installed.version, module.version,
+                                    module.download.Host, CkanModule.FmtSize(module.download_size - inProgressFile.Length));
+                            }
+                            else
+                            {
+                                User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingUncached,
+                                    module.name, installed.version, module.version,
+                                    module.download.Host, CkanModule.FmtSize(module.download_size));
+                            }
                         }
                         else
                         {

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -6,9 +6,11 @@ using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+
 using Autofac;
 using ChinhDo.Transactions.FileManager;
 using log4net;
+
 using CKAN.Configuration;
 
 namespace CKAN
@@ -25,7 +27,7 @@ namespace CKAN
         private const int MaxRetries             = 3;
         private const int RetryDelayMilliseconds = 100;
 
-        private static readonly ILog          log             = LogManager.GetLogger(typeof(Net));
+        private static readonly ILog log = LogManager.GetLogger(typeof(Net));
 
         public static readonly Dictionary<string, Uri> ThrottledHosts = new Dictionary<string, Uri>()
         {
@@ -353,110 +355,6 @@ namespace CKAN
             else
             {
                 return remoteUri;
-            }
-        }
-
-        /// <summary>
-        /// A WebClient with some CKAN-sepcific adjustments:
-        /// - A user agent string (required by GitHub API policy)
-        /// - Sets the Accept header to a given MIME type (needed to get raw files from GitHub API)
-        /// - Times out after a specified amount of time in milliseconds, 100 000 milliseconds (=100 seconds) by default (https://stackoverflow.com/a/3052637)
-        /// - Handles permanent redirects to the same host without clearing the Authorization header (needed to get files from renamed GitHub repositories via API)
-        /// </summary>
-        private sealed class RedirectingTimeoutWebClient : WebClient
-        {
-            /// <summary>
-            /// Initialize our special web client
-            /// </summary>
-            /// <param name="timeout">Timeout for the request in milliseconds, defaulting to 100 000 (=100 seconds)</param>
-            /// <param name="mimeType">A mime type sent with the "Accept" header</param>
-            public RedirectingTimeoutWebClient(int timeout = 100000, string mimeType = "")
-            {
-                this.timeout  = timeout;
-                this.mimeType = mimeType;
-            }
-
-            protected override WebRequest GetWebRequest(Uri address)
-            {
-                // Set user agent and MIME type for every request. including redirects
-                Headers.Add("User-Agent", UserAgentString);
-                if (!string.IsNullOrEmpty(mimeType))
-                {
-                    log.InfoFormat("Setting MIME type {0}", mimeType);
-                    Headers.Add("Accept", mimeType);
-                }
-                if (permanentRedirects.TryGetValue(address, out Uri redirUri))
-                {
-                    // Obey a previously received permanent redirect
-                    address = redirUri;
-                }
-                var request = base.GetWebRequest(address);
-                if (request is HttpWebRequest hwr)
-                {
-                    // GitHub API tokens cannot be passed via auto-redirect
-                    hwr.AllowAutoRedirect = false;
-                    hwr.Timeout           = timeout;
-                }
-                return request;
-            }
-
-            protected override WebResponse GetWebResponse(WebRequest request)
-            {
-                if (request == null)
-                    return null;
-                var response = base.GetWebResponse(request);
-                if (response == null)
-                    return null;
-
-                if (response is HttpWebResponse hwr)
-                {
-                    int statusCode = (int)hwr.StatusCode;
-                    var location = hwr.Headers["Location"];
-                    if (statusCode >= 300 && statusCode <= 399 && location != null)
-                    {
-                        log.InfoFormat("Redirecting to {0}", location);
-                        hwr.Close();
-                        var redirUri = new Uri(request.RequestUri, location);
-                        if (Headers.AllKeys.Contains("Authorization")
-                            && request.RequestUri.Host != redirUri.Host)
-                        {
-                            log.InfoFormat("Host mismatch, purging token for redirect");
-                            Headers.Remove("Authorization");
-                        }
-                        // Moved or PermanentRedirect
-                        if (statusCode == 301 || statusCode == 308)
-                        {
-                            permanentRedirects.Add(request.RequestUri, redirUri);
-                        }
-                        return GetWebResponse(GetWebRequest(redirUri));
-                    }
-                }
-                return response;
-            }
-
-            private int    timeout;
-            private string mimeType;
-            private static readonly Dictionary<Uri, Uri> permanentRedirects = new Dictionary<Uri, Uri>();
-        }
-
-        // HACK: The ancient WebClient doesn't support setting the request type to HEAD and WebRequest doesn't support
-        // setting the User-Agent header.
-        // Maybe one day we'll be able to use HttpClient (https://msdn.microsoft.com/en-us/library/system.net.http.httpclient%28v=vs.118%29.aspx)
-        private sealed class RedirectWebClient : WebClient
-        {
-            public RedirectWebClient()
-            {
-                Headers.Add("User-Agent", UserAgentString);
-            }
-
-            protected override WebRequest GetWebRequest(Uri address)
-            {
-                var webRequest = (HttpWebRequest)base.GetWebRequest(address);
-                webRequest.AllowAutoRedirect = false;
-
-                webRequest.Method = "HEAD";
-
-                return webRequest;
             }
         }
     }

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -83,6 +83,23 @@ namespace CKAN
             cache.CheckFreeSpace(bytesToStore);
         }
 
+        public string GetInProgressFileName(CkanModule m)
+            => cache.GetInProgressFileName(m.download, m.StandardName());
+
+        private static string DescribeUncachedAvailability(CkanModule m, FileInfo fi)
+            => fi.Exists
+                ? string.Format(Properties.Resources.NetModuleCacheModuleResuming,
+                    m.name, m.version, m.download.Host ?? "",
+                    CkanModule.FmtSize(m.download_size - fi.Length))
+                : string.Format(Properties.Resources.NetModuleCacheModuleHostSize,
+                    m.name, m.version, m.download.Host ?? "", CkanModule.FmtSize(m.download_size));
+
+        public string DescribeAvailability(CkanModule m)
+            => m.IsMetapackage
+                ? string.Format(Properties.Resources.NetModuleCacheMetapackage, m.name, m.version)
+                : IsMaybeCachedZip(m)
+                    ? string.Format(Properties.Resources.NetModuleCacheModuleCached, m.name, m.version)
+                    : DescribeUncachedAvailability(m, new FileInfo(GetInProgressFileName(m)));
 
         /// <summary>
         /// Calculate the SHA1 hash of a file

--- a/Core/Net/RedirectWebClient.cs
+++ b/Core/Net/RedirectWebClient.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net;
+
+namespace CKAN
+{
+    // HACK: The ancient WebClient doesn't support setting the request type to HEAD and WebRequest doesn't support
+    // setting the User-Agent header.
+    // Maybe one day we'll be able to use HttpClient (https://msdn.microsoft.com/en-us/library/system.net.http.httpclient%28v=vs.118%29.aspx)
+    internal sealed class RedirectWebClient : WebClient
+    {
+        public RedirectWebClient()
+        {
+            Headers.Add("User-Agent", Net.UserAgentString);
+        }
+
+        protected override WebRequest GetWebRequest(Uri address)
+        {
+            var webRequest = (HttpWebRequest)base.GetWebRequest(address);
+            webRequest.AllowAutoRedirect = false;
+
+            webRequest.Method = "HEAD";
+
+            return webRequest;
+        }
+    }
+}

--- a/Core/Net/RedirectingTimeoutWebClient.cs
+++ b/Core/Net/RedirectingTimeoutWebClient.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Net;
+using System.Collections.Generic;
+using System.Linq;
+
+using log4net;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A WebClient with some CKAN-sepcific adjustments:
+    /// - A user agent string (required by GitHub API policy)
+    /// - Sets the Accept header to a given MIME type (needed to get raw files from GitHub API)
+    /// - Times out after a specified amount of time in milliseconds, 100 000 milliseconds (=100 seconds) by default (https://stackoverflow.com/a/3052637)
+    /// - Handles permanent redirects to the same host without clearing the Authorization header (needed to get files from renamed GitHub repositories via API)
+    /// </summary>
+    internal sealed class RedirectingTimeoutWebClient : WebClient
+    {
+        /// <summary>
+        /// Initialize our special web client
+        /// </summary>
+        /// <param name="timeout">Timeout for the request in milliseconds, defaulting to 100 000 (=100 seconds)</param>
+        /// <param name="mimeType">A mime type sent with the "Accept" header</param>
+        public RedirectingTimeoutWebClient(int timeout = 100000, string mimeType = "")
+        {
+            this.timeout  = timeout;
+            this.mimeType = mimeType;
+        }
+
+        protected override WebRequest GetWebRequest(Uri address)
+        {
+            // Set user agent and MIME type for every request. including redirects
+            Headers.Add("User-Agent", Net.UserAgentString);
+            if (!string.IsNullOrEmpty(mimeType))
+            {
+                log.InfoFormat("Setting MIME type {0}", mimeType);
+                Headers.Add("Accept", mimeType);
+            }
+            if (permanentRedirects.TryGetValue(address, out Uri redirUri))
+            {
+                // Obey a previously received permanent redirect
+                address = redirUri;
+            }
+            var request = base.GetWebRequest(address);
+            if (request is HttpWebRequest hwr)
+            {
+                // GitHub API tokens cannot be passed via auto-redirect
+                hwr.AllowAutoRedirect = false;
+                hwr.Timeout           = timeout;
+            }
+            return request;
+        }
+
+        protected override WebResponse GetWebResponse(WebRequest request)
+        {
+            if (request == null)
+                return null;
+            var response = base.GetWebResponse(request);
+            if (response == null)
+                return null;
+
+            if (response is HttpWebResponse hwr)
+            {
+                int statusCode = (int)hwr.StatusCode;
+                var location = hwr.Headers["Location"];
+                if (statusCode >= 300 && statusCode <= 399 && location != null)
+                {
+                    log.InfoFormat("Redirecting to {0}", location);
+                    hwr.Close();
+                    var redirUri = new Uri(request.RequestUri, location);
+                    if (Headers.AllKeys.Contains("Authorization")
+                        && request.RequestUri.Host != redirUri.Host)
+                    {
+                        log.InfoFormat("Host mismatch, purging token for redirect");
+                        Headers.Remove("Authorization");
+                    }
+                    // Moved or PermanentRedirect
+                    if (statusCode == 301 || statusCode == 308)
+                    {
+                        permanentRedirects.Add(request.RequestUri, redirUri);
+                    }
+                    return GetWebResponse(GetWebRequest(redirUri));
+                }
+            }
+            return response;
+        }
+
+        private int    timeout;
+        private string mimeType;
+        private static readonly Dictionary<Uri, Uri> permanentRedirects = new Dictionary<Uri, Uri>();
+        private static readonly ILog log = LogManager.GetLogger(typeof(RedirectingTimeoutWebClient));
+    }
+}

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Net;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+using log4net;
+
+using CKAN.Extensions;
+
+namespace CKAN
+{
+    internal class ResumingWebClient : WebClient
+    {
+        /// <summary>
+        /// A version of DownloadFileAsync that appends to its destination
+        /// file if it already exists and skips downloading the bytes
+        /// we already have.
+        /// </summary>
+        /// <param name="url">What to download</param>
+        /// <param name="path">Where to save it</param>
+        public void DownloadFileAsyncWithResume(Uri url, string path)
+        {
+            Task.Factory.StartNew(() =>
+            {
+                var fi = new FileInfo(path);
+                if (fi.Exists)
+                {
+                    log.DebugFormat("File exists at {0}, {1} bytes", path, fi.Length);
+                    bytesToSkip = fi.Length;
+                }
+                else
+                {
+                    // Reset in case we try multiple with same webclient
+                    bytesToSkip = 0;
+                }
+                // Ideally the bytes to skip would be passed in the userToken param,
+                // but GetWebRequest can't access it!!
+                OpenReadAsync(url, path);
+            });
+        }
+
+        /// <summary>
+        /// Same as DownloadProgressChanged, but usable by us.
+        /// Called with percent, bytes received, total bytes to receive.
+        ///
+        /// DownloadProgressChangedEventArg has an internal constructor
+        /// and readonly properties, and everyplace that does make one
+        /// is private instead of protected, so we have to reinvent this wheel.
+        /// (Meanwhile AsyncCompletedEventArgs has none of these problems.)
+        /// </summary>
+        public event Action<int, long, long> DownloadProgress;
+
+        protected override WebRequest GetWebRequest(Uri address)
+        {
+            var request = base.GetWebRequest(address);
+            if (request is HttpWebRequest webRequest && bytesToSkip > 0)
+            {
+                log.DebugFormat("Skipping {0} bytes of {1}", bytesToSkip, address);
+                webRequest.AddRange(bytesToSkip);
+            }
+            return request;
+        }
+
+        protected override WebResponse GetWebResponse(WebRequest request, IAsyncResult result)
+        {
+            try
+            {
+                var response = base.GetWebResponse(request, result);
+                contentLength = response.ContentLength;
+                return response;
+            }
+            catch (WebException wexc)
+            when (wexc.Status == WebExceptionStatus.ProtocolError
+                  && wexc.Response is HttpWebResponse response
+                  && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+            {
+                log.Debug("GetWebResponse failed with range error, closing stream and suppressing exception");
+                // Don't save the error page into a file
+                response.Close();
+                return response;
+            }
+            catch (Exception exc)
+            {
+                log.Debug("Failed to get web response", exc);
+                OnDownloadFileCompleted(new AsyncCompletedEventArgs(exc, false, null));
+                throw;
+            }
+        }
+
+        protected override void OnOpenReadCompleted(OpenReadCompletedEventArgs e)
+        {
+            base.OnOpenReadCompleted(e);
+            if (!e.Cancelled && e.Error == null)
+            {
+                var destination = e.UserState as string;
+                using (var netStream = e.Result)
+                {
+                    if (!netStream.CanRead)
+                    {
+                        log.Debug("OnOpenReadCompleted got closed stream, skipping download");
+                    }
+                    else
+                    {
+                        log.DebugFormat("OnOpenReadCompleted got open stream, appending to {0}", destination);
+                        using (var fileStream = new FileStream(destination, FileMode.Append, FileAccess.Write))
+                        {
+                            netStream.CopyTo(fileStream, new Progress<long>(bytesDownloaded =>
+                            {
+                                DownloadProgress?.Invoke(100 * (int)(bytesDownloaded / contentLength),
+                                                         bytesDownloaded, contentLength);
+                            }));
+                        }
+                    }
+                }
+            }
+            OnDownloadFileCompleted(new AsyncCompletedEventArgs(e.Error, e.Cancelled, e.UserState));
+        }
+
+        private long bytesToSkip   = 0;
+        private long contentLength = 0;
+        private static readonly ILog log = LogManager.GetLogger(typeof(ResumingWebClient));
+    }
+}

--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -340,6 +340,19 @@ namespace CKAN.Properties {
             get { return (string)(ResourceManager.GetObject("GameInstancePathNotFound", resourceCulture)); }
         }
 
+        internal static string NetModuleCacheMetapackage {
+            get { return (string)(ResourceManager.GetObject("NetModuleCacheModuleHostSize", resourceCulture)); }
+        }
+        internal static string NetModuleCacheModuleHostSize {
+            get { return (string)(ResourceManager.GetObject("NetModuleCacheModuleHostSize", resourceCulture)); }
+        }
+        internal static string NetModuleCacheModuleCached {
+            get { return (string)(ResourceManager.GetObject("NetModuleCacheModuleCached", resourceCulture)); }
+        }
+        internal static string NetModuleCacheModuleResuming {
+            get { return (string)(ResourceManager.GetObject("NetModuleCacheModuleResuming", resourceCulture)); }
+        }
+
         internal static string ModuleInstallerDownloading {
             get { return (string)(ResourceManager.GetObject("ModuleInstallerDownloading", resourceCulture)); }
         }
@@ -348,9 +361,6 @@ namespace CKAN.Properties {
         }
         internal static string ModuleInstallerAboutToInstall {
             get { return (string)(ResourceManager.GetObject("ModuleInstallerAboutToInstall", resourceCulture)); }
-        }
-        internal static string ModuleInstallerModuleCached {
-            get { return (string)(ResourceManager.GetObject("ModuleInstallerModuleCached", resourceCulture)); }
         }
         internal static string ModuleInstallerUserDeclined {
             get { return (string)(ResourceManager.GetObject("ModuleInstallerUserDeclined", resourceCulture)); }
@@ -418,6 +428,9 @@ namespace CKAN.Properties {
         internal static string ModuleInstallerUpgradeInstallingUncached {
             get { return (string)(ResourceManager.GetObject("ModuleInstallerUpgradeInstallingUncached", resourceCulture)); }
         }
+        internal static string ModuleInstallerUpgradeInstallingResuming {
+            get { return (string)(ResourceManager.GetObject("ModuleInstallerUpgradeInstallingResuming", resourceCulture)); }
+        }
         internal static string ModuleInstallerUpgradeInstallingCached {
             get { return (string)(ResourceManager.GetObject("ModuleInstallerUpgradeInstallingCached", resourceCulture)); }
         }
@@ -432,6 +445,9 @@ namespace CKAN.Properties {
         }
         internal static string ModuleInstallerUpgradeUpgradingCached {
             get { return (string)(ResourceManager.GetObject("ModuleInstallerUpgradeUpgradingCached", resourceCulture)); }
+        }
+        internal static string ModuleInstallerUpgradeUpgradingResuming {
+            get { return (string)(ResourceManager.GetObject("ModuleInstallerUpgradeUpgradingResuming", resourceCulture)); }
         }
         internal static string ModuleInstallerUpgradeUserDeclined {
             get { return (string)(ResourceManager.GetObject("ModuleInstallerUpgradeUserDeclined", resourceCulture)); }

--- a/Core/Properties/Resources.fr-FR.resx
+++ b/Core/Properties/Resources.fr-FR.resx
@@ -213,7 +213,6 @@ Souhaitez-vous réinstaller maintenant ?</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve"><value>Téléchargement de "{0}"</value></data>
   <data name="ModuleInstallerNothingToInstall" xml:space="preserve"><value>Rien à installer</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>Vont être installés :</value></data>
-  <data name="ModuleInstallerModuleCached" xml:space="preserve"><value> * {0} {1} (en cache)</value></data>
   <data name="ModuleInstallerUserDeclined" xml:space="preserve"><value>L'utilisateur a refusé la liste d'installation</value></data>
   <data name="ModuleInstallerInstallingMod" xml:space="preserve"><value>Installation du mod "{0}"</value></data>
   <data name="ModuleInstallerUpdatingRegistry" xml:space="preserve"><value>Mise à jour du registre</value></data>
@@ -294,4 +293,7 @@ Si vous êtes certain que ce n'est pas le cas, alors supprimez :
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>Recommandé par {0}</value></data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve"><value>{0} a une dépendance non-satisfaite : {1} n'est pas installé</value></data>
   <data name="SanityCheckerConflictsWith" xml:space="preserve"><value>{0} est en conflit avec {1}</value></data>
+  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (méta-paquet)</value></data>
+  <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (en cache)</value></data>
+  <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
 </root>

--- a/Core/Properties/Resources.ja-JP.resx
+++ b/Core/Properties/Resources.ja-JP.resx
@@ -117,6 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="RelationshipResolverUserReason" xml:space="preserve"><value>Neue Mod-Installation ausgewählt vom Nutzer</value></data>
-  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (Metapacket)</value></data>
+  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (メタパッケージ)</value></data>
+  <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (キャッシュ済)</value></data>
+  <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
 </root>

--- a/Core/Properties/Resources.ko-KR.resx
+++ b/Core/Properties/Resources.ko-KR.resx
@@ -117,6 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="RelationshipResolverUserReason" xml:space="preserve"><value>Neue Mod-Installation ausgewählt vom Nutzer</value></data>
-  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (Metapacket)</value></data>
+  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (메타패키지)</value></data>
+  <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (캐시됨)</value></data>
+  <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
 </root>

--- a/Core/Properties/Resources.pt-BR.resx
+++ b/Core/Properties/Resources.pt-BR.resx
@@ -118,4 +118,7 @@
     <value>System.Resources.ResXResourceWriter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RelationshipResolverUserReason" xml:space="preserve"><value>Nova instalação de mod selecionada pelo usuário</value></data>
+  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
+  <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (Em cache)</value></data>
+  <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
 </root>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -214,7 +214,6 @@ Do you wish to reinstall now?</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve"><value>Downloading "{0}"</value></data>
   <data name="ModuleInstallerNothingToInstall" xml:space="preserve"><value>Nothing to install</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>About to install:</value></data>
-  <data name="ModuleInstallerModuleCached" xml:space="preserve"><value> * {0} {1} (cached)</value></data>
   <data name="ModuleInstallerUserDeclined" xml:space="preserve"><value>User declined install list</value></data>
   <data name="ModuleInstallerInstallingMod" xml:space="preserve"><value>Installing mod "{0}"</value></data>
   <data name="ModuleInstallerUpdatingRegistry" xml:space="preserve"><value>Updating registry</value></data>
@@ -302,4 +301,10 @@ Free up space on that device or change your settings to use another location.
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>Recommended by {0}</value></data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve"><value>{0} has an unsatisfied dependency: {1} is not installed</value></data>
   <data name="SanityCheckerConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
+  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
+  <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (cached)</value></data>
+  <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
+  <data name="NetModuleCacheModuleResuming" xml:space="preserve"><value>{0} {1} ({2}, {3} remaining)</value></data>
+  <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3} remaining)</value></data>
+  <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve"><value> * Upgrade: {0} {1} to {2} ({3}, {4} remaining)</value></data>
 </root>

--- a/Core/Properties/Resources.ru-RU.resx
+++ b/Core/Properties/Resources.ru-RU.resx
@@ -213,7 +213,6 @@
   <data name="ModuleInstallerDownloading" xml:space="preserve"><value>Загружается «{0}»</value></data>
   <data name="ModuleInstallerNothingToInstall" xml:space="preserve"><value>Нечего устанавливать</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>Будут установлены:</value></data>
-  <data name="ModuleInstallerModuleCached" xml:space="preserve"><value> * {0} {1} (кэшировано)</value></data>
   <data name="ModuleInstallerUserDeclined" xml:space="preserve"><value>Пользователь отклонил установку</value></data>
   <data name="ModuleInstallerInstallingMod" xml:space="preserve"><value>Установка модификации «{0}»</value></data>
   <data name="ModuleInstallerUpdatingRegistry" xml:space="preserve"><value>Обновление реестра</value></data>
@@ -294,4 +293,7 @@ https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors</value></data>
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>Рекомендуется {0}</value></data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve"><value>{0} имеет неудовлетворённую зависимость: {1} не установлен</value></data>
   <data name="SanityCheckerConflictsWith" xml:space="preserve"><value>{0} конфликтует с {1}</value></data>
+  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (метапакет)</value></data>
+  <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (кэшировано)</value></data>
+  <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
 </root>

--- a/Core/Properties/Resources.zh-CN.resx
+++ b/Core/Properties/Resources.zh-CN.resx
@@ -213,7 +213,6 @@
   <data name="ModuleInstallerDownloading" xml:space="preserve"><value>正在下载 "{0}"</value></data>
   <data name="ModuleInstallerNothingToInstall" xml:space="preserve"><value>没有需要安装的</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>中止安装:</value></data>
-  <data name="ModuleInstallerModuleCached" xml:space="preserve"><value> * {0} {1} (已缓存)</value></data>
   <data name="ModuleInstallerUserDeclined" xml:space="preserve"><value>用户取消安装列表</value></data>
   <data name="ModuleInstallerInstallingMod" xml:space="preserve"><value>安装模组 "{0}"</value></data>
   <data name="ModuleInstallerUpdatingRegistry" xml:space="preserve"><value>正在更新注册表</value></data>
@@ -293,4 +292,7 @@ https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors</value></data>
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>由 {0} 推荐</value></data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve"><value>{0} 有一个未满足的依赖项: {1} 未安装</value></data>
   <data name="SanityCheckerConflictsWith" xml:space="preserve"><value>{0} 与 {1} 冲突</value></data>
+  <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
+  <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (已缓存)</value></data>
+  <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
 </root>

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -18,18 +18,16 @@ namespace CKAN.GUI
             Util.Invoke(this, () =>
             {
                 ChooseProvidedModsLabel.Text = message;
-    
+
                 ChooseProvidedModsListView.Items.Clear();
                 ChooseProvidedModsListView.Items.AddRange(modules
                     .Select(module => new ListViewItem(new string[]
                     {
-                        cache.IsMaybeCachedZip(module)
-                            ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
-                            : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download.Host ?? "", CkanModule.FmtSize(module.download_size)),
+                        cache.DescribeAvailability(module),
                         module.@abstract
                     })
                     {
-                        Tag = module,
+                        Tag     = module,
                         Checked = false
                     })
                     .ToArray());

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -173,10 +173,7 @@ namespace CKAN.GUI
         {
             return new ListViewItem(new string[]
             {
-                module.IsDLC ? module.name
-                    : cache.IsMaybeCachedZip(module)
-                        ? string.Format(Properties.Resources.MainChangesetCached, module.name, module.version)
-                        : string.Format(Properties.Resources.MainChangesetHostSize, module.name, module.version, module.download?.Host ?? "", CkanModule.FmtSize(module.download_size)),
+                module.IsDLC ? module.name : cache.DescribeAvailability(module),
                 descrip,
                 module.@abstract
             })

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -117,12 +117,7 @@ namespace CKAN.GUI
         /// <param name="total">Number of bytes in complete download</param>
         public void SetModuleProgress(CkanModule module, long remaining, long total)
         {
-            SetProgress(string.Format(Properties.Resources.MainChangesetHostSize,
-                                      module.name,
-                                      module.version,
-                                      module.download.Host ?? "",
-                                      CkanModule.FmtSize(module.download_size)),
-                        remaining, total);
+            SetProgress(module.ToString(), remaining, total);
         }
 
         private Action<object, DoWorkEventArgs>             bgLogic;

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -75,21 +75,11 @@ namespace CKAN.GUI
             return $"{ChangeType.ToI18nString()} {Mod} ({Reason})";
         }
 
-        protected string modNameAndStatus(CkanModule m)
-        {
-            return m.IsMetapackage
-                ? string.Format(Properties.Resources.MainChangesetMetapackage, m.name, m.version)
-                : Main.Instance.Manager.Cache.IsMaybeCachedZip(m)
-                    ? string.Format(Properties.Resources.MainChangesetCached, m.name, m.version)
-                    : string.Format(Properties.Resources.MainChangesetHostSize,
-                        m.name, m.version, m.download.Host ?? "", CkanModule.FmtSize(m.download_size));
-        }
-
         public virtual string NameAndStatus
         {
             get
             {
-                return modNameAndStatus(Mod);
+                return Main.Instance.Manager.Cache.DescribeAvailability(Mod);
             }
         }
 
@@ -114,7 +104,7 @@ namespace CKAN.GUI
         {
             get
             {
-                return modNameAndStatus(targetMod);
+                return Main.Instance.Manager.Cache.DescribeAvailability(targetMod);
             }
         }
 

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -488,15 +488,6 @@ namespace CKAN.GUI.Properties {
             get { return (string)(ResourceManager.GetObject("AllModVersionsInstallNo", resourceCulture)); }
         }
 
-        internal static string MainChangesetMetapackage {
-            get { return (string)(ResourceManager.GetObject("MainChangesetMetapackage", resourceCulture)); }
-        }
-        internal static string MainChangesetCached {
-            get { return (string)(ResourceManager.GetObject("MainChangesetCached", resourceCulture)); }
-        }
-        internal static string MainChangesetHostSize {
-            get { return (string)(ResourceManager.GetObject("MainChangesetHostSize", resourceCulture)); }
-        }
         internal static string MainChangesetUpdateSelected {
             get { return (string)(ResourceManager.GetObject("MainChangesetUpdateSelected", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -192,7 +192,6 @@ Das bedeuted, dass CKAN alle installierten Mods vergessen hat, sie befinden sich
 Möchten Sie es wirklich installieren?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Installieren</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Abbrechen</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (Metapacket)</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Mod-Update ausgewählt vom Nutzer {0}.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Mod-Import</value></data>
   <data name="MainImportWaitTitle" xml:space="preserve"><value>Statuslog</value></data>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -193,9 +193,6 @@ Cela veut dire que CKAN a oublié tous les mods que vous avez installé, mais ce
 Voulez-vous vraiment l'installer?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Installer</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Annuler</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (méta-paquet)</value></data>
-  <data name="MainChangesetCached" xml:space="preserve"><value>{0} {1} (en cache)</value></data>
-  <data name="MainChangesetHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Mise à jour demandée vers la version {0}.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Importer des Mods</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Mods (*.zip)|*.zip</value></data>

--- a/GUI/Properties/Resources.ja-JP.resx
+++ b/GUI/Properties/Resources.ja-JP.resx
@@ -194,9 +194,6 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
 本当にインストールしますか？</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>インストール</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>取消</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (メタパッケージ)</value></data>
-  <data name="MainChangesetCached" xml:space="preserve"><value>{0} {1} (キャッシュ済)</value></data>
-  <data name="MainChangesetHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>選択されたものをバージョン{0}にアップデートする。</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Modインポート</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Mod (*.zip)|*.zip</value></data>

--- a/GUI/Properties/Resources.ko-KR.resx
+++ b/GUI/Properties/Resources.ko-KR.resx
@@ -214,9 +214,6 @@
 정말 이 모드를 설치할까요?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>설치</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>취소하기</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (메타패키지)</value></data>
-  <data name="MainChangesetCached" xml:space="preserve"><value>{0} {1} (캐시됨)</value></data>
-  <data name="MainChangesetHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>유저가 선택한 것을 버전 {0}으로 업데이트 하기.</value></data>
   <data name="MainChangesetNewInstall" xml:space="preserve"><value>유저가 선택한 모드를 설치하기.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>모드들 가져오기</value></data>

--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -189,9 +189,6 @@ Tentando mover {2} de {3} e reiniciar o CKAN.</value></data>
 Você quer realmente instalá-la?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Instalar</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Cancelar</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
-  <data name="MainChangesetCached" xml:space="preserve"><value>{0} {1} (Em cache)</value></data>
-  <data name="MainChangesetHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Atualização selecionada pelo usuário para a versão {0}.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Importar mods</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Mods (*.zip)|*.zip</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -217,9 +217,6 @@ This means that CKAN forgot about all your installed mods, but they are still in
 Do you really want to install it?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Install</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Cancel</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
-  <data name="MainChangesetCached" xml:space="preserve"><value>{0} {1} (cached)</value></data>
-  <data name="MainChangesetHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Update selected by user to version {0}.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Import Mods</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Mods (*.zip)|*.zip</value></data>

--- a/GUI/Properties/Resources.ru-RU.resx
+++ b/GUI/Properties/Resources.ru-RU.resx
@@ -192,9 +192,6 @@
 Вы действительно хотите установить его?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Установить</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Отмена</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (метапакет)</value></data>
-  <data name="MainChangesetCached" xml:space="preserve"><value>{0} {1} (загружено)</value></data>
-  <data name="MainChangesetHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Обновить выбранное пользователем до версии {0}.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Импортировать модификации</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Модификации (*.zip)|*.zip</value></data>

--- a/GUI/Properties/Resources.zh-CN.resx
+++ b/GUI/Properties/Resources.zh-CN.resx
@@ -188,9 +188,6 @@
 您真的想要安装它吗？</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>安装</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>取消</value></data>
-  <data name="MainChangesetMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
-  <data name="MainChangesetCached" xml:space="preserve"><value>{0} {1} (cached)</value></data>
-  <data name="MainChangesetHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>用户选择更新到 {0} 版本.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>导入Mod</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Mods (*.zip)|*.zip</value></data>


### PR DESCRIPTION
## Motivations

Currently if a mod download fails partway through, the already downloaded bytes are lost and have to be re-downloaded, which wastes time and network capacity.

Mods are initially downloaded to the system temp folder, which the user may not know how to control and which may not be very large, whereas the user would probably choose a high capacity drive for their download cache.

I've been trying to improve our network handling for the next release, see #3624, #3631, #3635, #3645, and #3659. This is the next big piece now that I'm warmed up.

## Changes

- Mods are now downloaded to a `downloading` subfolder of the main cache folder, so they will be included on that same device unless the user does some really crazy `mount` commands to mess with us
  - A download that fails partway through will leave behind the in progress file in that folder
  - The same `{hash}-{description}.zip` file name format is used and queried as for the main cache, so we can easily find the matching file
  - A download that starts with an in progress file already available will skip the bytes already on disk and resume the download where the previous one left off
  - The cache folder size displayed in the settings now includes this extra folder
  - The cache limit setting now includes partial downloads in its enforcement
  - We no longer check the temp folder's free space (see #3631)
- We had two `WebClient` derived classes in `Net.cs`, which are now moved to their own files under `Core/Net`
- A third `WebClient` derived class, `ResumingWebClient`, is created in its own file and:
  - Opens its output file for appending rather than truncating it
  - Calls `HttpWebRequest.AddRange` to tell the server to skip bytes we already have
  - Handles HTTP code 416 by skipping the download, since this is thrown if we have the complete file already in the in progress folder (special corner case)
  - Uses a special `CopyTo` variant with progress reporting, because contrary to the documentation, `DownloadProgressChanged` is **not** fired after using `OpenReadAsync`
    - And we use our own event because we aren't allowed to create the parameter objects of `DownloadProgressChanged`
- `NetAsyncDownloader` uses `ResumingWebClient` to support resuming interrupted downloads
- If a mod is not cached but has a partial download on disk, the changelog, recommendations, and dependency-choosing screens show the size remaining instead of the total:
  ![image](https://user-images.githubusercontent.com/1559108/189557151-cade9cb3-05a9-4ff8-b520-7aec08c7762d.png)
  - The code for this is now centralized in `NetModuleCache.DescribeAvailability`, and the corresponding i18n strings are migrated from GUI to Core

After these changes, if a download fails partway through and you try it again, it resumes where it left off. Completed downloads must still pass the gauntlet of `NetModuleCache.Store`, which checks file sizes, hashes, and ZIP validity, so if the network corrupts a download, we will throw errors rather than trying to use it.
