### PR TITLE
Install dependencies first

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -112,12 +112,11 @@ namespace CKAN
             var resolver = new RelationshipResolver(modules, null, options, registry_manager.registry, ksp.VersionCriteria());
             // Only pass the CkanModules of the parameters, so we can tell which are auto-installed,
             // and relationships of metapackages, since metapackages aren't included in the RR modlist.
-            var list = resolver.ModList().Where(
-                m =>
-                {
-                    var reason = resolver.ReasonFor(m);
-                    return reason is SelectionReason.UserRequested || (reason.Parent?.IsMetapackage ?? false);
-                }).ToList();
+            var list = resolver.ModList()
+                .Where(m => resolver.ReasonsFor(m).Any(reason =>
+                    reason is SelectionReason.UserRequested
+                    || (reason.Parent?.IsMetapackage ?? false)))
+                .ToList();
             InstallList(list, options, registry_manager, ref possibleConfigOnlyDirs, downloader);
         }
 

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -298,7 +298,7 @@ Free up space on that device or change your settings to use another location.
   <data name="RelationshipResolverNoLongerUsedReason" xml:space="preserve"><value>Auto-installed, depending modules removed</value></data>
   <data name="RelationshipResolverReplacementReason" xml:space="preserve"><value>Replacing {0}</value></data>
   <data name="RelationshipResolverSuggestedReason" xml:space="preserve"><value>Suggested by {0}</value></data>
-  <data name="RelationshipResolverDependsReason" xml:space="preserve"><value>To satisfy dependency from {0}</value></data>
+  <data name="RelationshipResolverDependsReason" xml:space="preserve"><value>Dependency of {0}</value></data>
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>Recommended by {0}</value></data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve"><value>{0} has an unsatisfied dependency: {1} is not installed</value></data>
   <data name="SanityCheckerConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>

--- a/GUI/Controls/Changeset.Designer.cs
+++ b/GUI/Controls/Changeset.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace CKAN.GUI
+namespace CKAN.GUI
 {
     partial class Changeset
     {
@@ -54,6 +54,7 @@
             this.ChangesListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ChangesListView.Name = "ChangesListView";
             this.ChangesListView.Size = new System.Drawing.Size(1532, 886);
+            this.ChangesListView.ShowItemToolTips = true;
             this.ChangesListView.TabIndex = 0;
             this.ChangesListView.UseCompatibleStateImageBehavior = false;
             this.ChangesListView.View = System.Windows.Forms.View.Details;

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Drawing;
 using System.Collections.Generic;
 using System.Windows.Forms;
+
 using CKAN.Extensions;
 
 namespace CKAN.GUI
@@ -20,20 +21,8 @@ namespace CKAN.GUI
             ChangesListView.Items.Clear();
             if (changes != null)
             {
-                // We're going to split our change-set into two parts: removed mods,
-                // and everything else (right now, replacing, upgrading, and installing mods, but we may have
-                // other types in the future).
-
-                sortedChangeSet.Clear();
-                sortedChangeSet.AddRange(changes.Where(change => change.ChangeType == GUIModChangeType.Remove));
-
-                // Now make our list more human-friendly (dependencies for a mod are listed directly
-                // after it.)
-                CreateSortedModList(changes
-                    .Where(change => change.ChangeType != GUIModChangeType.Remove)
-                    .ToList());
-
-                ChangesListView.Items.AddRange(sortedChangeSet
+                // Changeset sorting is handled upstream in the resolver
+                ChangesListView.Items.AddRange(changes
                     .Where(ch => ch.ChangeType != GUIModChangeType.None)
                     .Select(makeItem)
                     .ToArray());
@@ -67,38 +56,27 @@ namespace CKAN.GUI
 
         private void ChangesListView_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (OnSelectedItemsChanged != null)
-            {
-                OnSelectedItemsChanged(ChangesListView.SelectedItems);
-            }
+            OnSelectedItemsChanged?.Invoke(ChangesListView.SelectedItems);
         }
 
         private void ConfirmChangesButton_Click(object sender, EventArgs e)
         {
-            if (OnConfirmChanges != null)
-            {
-                OnConfirmChanges();
-            }
+            OnConfirmChanges?.Invoke();
         }
 
         private void CancelChangesButton_Click(object sender, EventArgs e)
         {
-            if (OnCancelChanges != null)
-            {
-                OnCancelChanges(true);
-            }
+            OnCancelChanges?.Invoke(true);
         }
 
         private void BackButton_Click(object sender, EventArgs e)
         {
-            if (OnCancelChanges != null)
-            {
-                OnCancelChanges(false);
-            }
+            OnCancelChanges?.Invoke(false);
         }
 
         private ListViewItem makeItem(ModChange change)
         {
+            var descr = change.Description;
             CkanModule m = change.Mod;
             ModuleLabel warnLbl = alertLabels?.FirstOrDefault(l => l.ModuleIdentifiers.Contains(m.identifier));
             return new ListViewItem(new string[]
@@ -109,46 +87,16 @@ namespace CKAN.GUI
                     ? string.Format(
                         Properties.Resources.MainChangesetWarningInstallingModuleWithLabel,
                         warnLbl.Name,
-                        change.Description
-                      )
-                    : change.Description
+                        descr)
+                    : descr
             })
             {
-                Tag = m,
-                ForeColor = warnLbl != null ? Color.Red : SystemColors.WindowText
+                Tag         = m,
+                ForeColor   = warnLbl != null ? Color.Red : SystemColors.WindowText,
+                ToolTipText = descr,
             };
         }
 
-        /// <summary>
-        /// This method creates the Install part of the changeset
-        /// It arranges the changeset in a human-friendly order
-        /// The requested mod is listed first, its dependencies right after it
-        /// So we get for example "ModuleRCSFX" directly after "USI Exploration Pack"
-        ///
-        /// It is very likely that this is forward-compatible with new ChangeTypes's,
-        /// like a "reconfigure" changetype, but only the future will tell
-        /// </summary>
-        /// <param name="changes">Every leftover ModChange that should be sorted</param>
-        /// <param name="parent"></param>
-        private void CreateSortedModList(IEnumerable<ModChange> changes, ModChange parent = null)
-        {
-            var notUserReq = changes
-                .Where(c => !(c.Reason is SelectionReason.UserRequested))
-                .Memoize();
-            foreach (ModChange change in changes)
-            {
-                bool goDeeper = parent == null || change.Reason.Parent.identifier == parent.Mod.identifier;
-
-                if (goDeeper)
-                {
-                    if (!sortedChangeSet.Any(c => c.Mod.identifier == change.Mod.identifier && c.ChangeType != GUIModChangeType.Remove))
-                        sortedChangeSet.Add(change);
-                    CreateSortedModList(notUserReq, change);
-                }
-            }
-        }
-
-        private List<ModChange>   sortedChangeSet = new List<ModChange>();
         private List<ModuleLabel> alertLabels;
     }
 }

--- a/GUI/Controls/Changeset.resx
+++ b/GUI/Controls/Changeset.resx
@@ -119,7 +119,7 @@
   </resheader>
   <data name="Mod.Text" xml:space="preserve"><value>Mod</value></data>
   <data name="ChangeType.Text" xml:space="preserve"><value>Change</value></data>
-  <data name="Reason.Text" xml:space="preserve"><value>Reason for action</value></data>
+  <data name="Reason.Text" xml:space="preserve"><value>Reasons for action</value></data>
   <data name="BackButton.Text" xml:space="preserve"><value>Back</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>Clear</value></data>
   <data name="ConfirmChangesButton.Text" xml:space="preserve"><value>Apply</value></data>

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -962,7 +962,7 @@ namespace CKAN.GUI
             // Build the list of changes, first the mod to remove:
             List<ModChange> toReinstall = new List<ModChange>()
             {
-                new ModChange(module.ToModule(), GUIModChangeType.Remove, null)
+                new ModChange(module.ToModule(), GUIModChangeType.Remove)
             };
             // Then everything we need to re-install:
             var revdep = registry.FindReverseDependencies(new List<string>() { module.Identifier });
@@ -977,9 +977,7 @@ namespace CKAN.GUI
             {
                 toReinstall.Add(new ModChange(
                     (mainModList.full_list_of_mod_rows[id]?.Tag as GUIMod).ToModule(),
-                    GUIModChangeType.Install,
-                    null
-                ));
+                    GUIModChangeType.Install));
             }
             if (StartChangeSet != null)
             {

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -27,18 +27,10 @@ namespace CKAN.GUI
                 if (installed != null)
                 {
                     // Already installed, remove it first
-                    userChangeSet.Add(new ModChange(
-                        installed.Module,
-                        GUIModChangeType.Remove,
-                        null
-                    ));
+                    userChangeSet.Add(new ModChange(installed.Module, GUIModChangeType.Remove));
                 }
                 // Install the selected mod
-                userChangeSet.Add(new ModChange(
-                    module,
-                    GUIModChangeType.Install,
-                    null
-                ));
+                userChangeSet.Add(new ModChange(module, GUIModChangeType.Install));
                 if (userChangeSet.Count > 0)
                 {
                     // Resolve the provides relationships in the dependencies

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -54,11 +54,8 @@ namespace CKAN.GUI
                 {
                     Wait.StartWaiting(InstallMods, PostInstallMods, true,
                         new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                            result.Select(mod => new ModChange(
-                                mod,
-                                GUIModChangeType.Install,
-                                null
-                            )).ToList(),
+                            result.Select(mod => new ModChange(mod, GUIModChangeType.Install))
+                                .ToList(),
                             RelationshipResolver.DependsOnlyOpts()
                         )
                     );

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -157,7 +157,7 @@ namespace CKAN.GUI
                         Wait.StartWaiting(InstallMods, PostInstallMods, true,
                             new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                                 rmk.Modules
-                                    .Select(m => new ModChange(m, GUIModChangeType.Update, null))
+                                    .Select(m => new ModChange(m, GUIModChangeType.Update))
                                     .ToList(),
                                 RelationshipResolver.DependsOnlyOpts()
                             )

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -307,17 +307,17 @@ namespace CKAN.GUI
             }
             else if (IsReplaceChecked)
             {
-                yield return new ModChange(Mod, GUIModChangeType.Replace, null);
+                yield return new ModChange(Mod, GUIModChangeType.Replace);
             }
             else if (!selectedIsInstalled)
             {
                 if (InstalledMod != null)
                 {
-                    yield return new ModChange(InstalledMod.Module, GUIModChangeType.Remove, null);
+                    yield return new ModChange(InstalledMod.Module, GUIModChangeType.Remove);
                 }
                 if (SelectedMod != null)
                 {
-                    yield return new ModChange(SelectedMod, GUIModChangeType.Install, null);
+                    yield return new ModChange(SelectedMod, GUIModChangeType.Install);
                 }
             }
         }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -173,7 +173,7 @@ namespace CKAN.GUI
                     CkanModule module_by_version = registry.GetModuleByVersion(depMod.identifier,
                     depMod.version)
                         ?? registry.InstalledModule(dependent).Module;
-                    changeSet.Add(new ModChange(module_by_version, GUIModChangeType.Remove, null));
+                    changeSet.Add(new ModChange(module_by_version, GUIModChangeType.Remove));
                     modules_to_remove.Add(module_by_version);
                 }
             }
@@ -202,11 +202,13 @@ namespace CKAN.GUI
                 modules_to_remove,
                 opts, registry, version);
 
-            changeSet.UnionWith(
-                resolver.ModList()
-                    .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonFor(m))));
-
-            return changeSet.Where(m => !m.Mod.IsMetapackage);
+            // Replace Install entries in changeset with the ones from resolver to get all the reasons
+            return changeSet
+                .Where(ch => !(ch.ChangeType is GUIModChangeType.Install))
+                .OrderBy(ch => ch.Mod.identifier)
+                .Union(resolver.ModList()
+                    .Where(m => !m.IsMetapackage)
+                    .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonsFor(m))));
         }
 
         public bool IsVisible(GUIMod mod, string instanceName)

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -816,7 +816,7 @@ namespace Tests.Core.Relationships
 
             var mod_not_in_resolver_list = generator.GeneratorRandomModule();
             CollectionAssert.DoesNotContain(relationship_resolver.ModList(),mod_not_in_resolver_list);
-            Assert.Throws<ArgumentException>(() => relationship_resolver.ReasonFor(mod_not_in_resolver_list));
+            Assert.Throws<ArgumentException>(() => relationship_resolver.ReasonsFor(mod_not_in_resolver_list));
         }
 
         [Test]
@@ -829,8 +829,8 @@ namespace Tests.Core.Relationships
             AddToRegistry(mod);
 
             var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
-            var reason = relationship_resolver.ReasonFor(mod);
-            Assert.That(reason, Is.AssignableTo<SelectionReason.UserRequested>());
+            var reasons = relationship_resolver.ReasonsFor(mod);
+            Assert.That(reasons[0], Is.AssignableTo<SelectionReason.UserRequested>());
         }
 
         [Test]
@@ -846,10 +846,10 @@ namespace Tests.Core.Relationships
 
             options.with_all_suggests = true;
             var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
-            var reason = relationship_resolver.ReasonFor(suggested);
+            var reasons = relationship_resolver.ReasonsFor(suggested);
 
-            Assert.That(reason, Is.AssignableTo<SelectionReason.Suggested>());
-            Assert.That(reason.Parent, Is.EqualTo(mod));
+            Assert.That(reasons[0], Is.AssignableTo<SelectionReason.Suggested>());
+            Assert.That(reasons[0].Parent, Is.EqualTo(mod));
         }
 
         [Test]
@@ -877,13 +877,13 @@ namespace Tests.Core.Relationships
             options.with_all_suggests = true;
             options.with_recommends = true;
             var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
-            var reason = relationship_resolver.ReasonFor(recommendedA);
-            Assert.That(reason, Is.AssignableTo<SelectionReason.Recommended>());
-            Assert.That(reason.Parent, Is.EqualTo(suggested));
+            var reasons = relationship_resolver.ReasonsFor(recommendedA);
+            Assert.That(reasons[0], Is.AssignableTo<SelectionReason.Recommended>());
+            Assert.That(reasons[0].Parent, Is.EqualTo(suggested));
 
-            reason = relationship_resolver.ReasonFor(recommendedB);
-            Assert.That(reason, Is.AssignableTo<SelectionReason.Recommended>());
-            Assert.That(reason.Parent, Is.EqualTo(suggested));
+            reasons = relationship_resolver.ReasonsFor(recommendedB);
+            Assert.That(reasons[0], Is.AssignableTo<SelectionReason.Recommended>());
+            Assert.That(reasons[0].Parent, Is.EqualTo(suggested));
         }
 
         // The whole point of autodetected mods is they can participate in relationships.


### PR DESCRIPTION
## Motivation

@siimav reports that many RP-1 users have been having problems with `TexturesUnlimited` and `ROLib` when installing via CKAN, which have been attributed to some speculated property of the exFAT filesystem (generally used for thumb drives):

![image](https://user-images.githubusercontent.com/1559108/189752103-e56f9615-5e5a-4cf8-8cbd-e07cff0467e9.png)

I suspect it's not _sorting_ by creation date per se (since why would Microsoft have bothered to do that, just for exFAT?), but rather just returning the files in disk order, which would correspond to the order in which they were created on exFAT. If that's the case, then "normal" listing behavior for other filesystems may _also_ be disk order (simpler/more consistent code in the kernel), but maybe the OS sorts the files alphanumerically **at time of creation**, since traditional hard drives don't have limits to the number of times they can be written the way flash drives do? In other words:

Filesystem | Speculated behavior at file creation
:-- | :--
NTFS | Append file to directory listing, sort the inodes by name for neatness
exFAT | Append file to directory listing, don't sort to reduce IO load on device

We're still looking for confirmation of this or any other similar explanation.

Regardless of how that search turns out, this is something I've thought about doing anyway, since it makes a big changeset more similar to a concatenation of the smaller changesets that it contains. In other words, if `B` depends on `A`, I could install `A` in one changeset and `B` in a later one, but I couldn't install `B` by itself first; so if I install both together in one changeset, it likewise makes sense for `A` to be installed before `B`.

## Changes

- `RelationshipResolver` now tracks multiple reasons per module
  - `RelationshipResolver.ReasonFor` is renamed `ReasonsFor` and returns a `List` instead of one value
  - Places using it are updated to search the list
  - Internal to `RelationshipResolver`, `Reasons.Add` is replaced by calling a new `AddReason` function that adds or appends to a `List`
  - The `RelationshipResolver` now adds a reason when we find that a dependency is satisfied by a mod already in the list, so all relationships will be represented
  - `RelationshipResolver.ReasonStringFor` was not in use and is removed
  - `RelationshipResolver.ModList` now returns its mods in an ordering based on dependencies instead of the random order of a `HashSet`'s keys (see below)
- `ModChange` now also tracks multiple reasons
  - `ModChange.Description` calls a new `SelectionReason.DescribeWith` function to merge all dependency reasons into one comma-delimited list
- The GUI changeset tab now shows mods in the order they will be installed rather than a custom order
  - The English text of "To satisfy dependency from" is shortened to "Dependency of" to make room for more modules
  - All of the reasons are shown, and the English header for that column is now plural

### The sorting algorithm

The goal is for a dependency to be installed before its depending mods, which implicitly includes indirect dependencies. This is not well suited to a traditional `.Sort()` call because given any two mods, you can't necessarily tell which one should go first without checking all of the intermediary dependency mods. So instead we use a procedural alrorithm based around an insertion sort.

First we sort the mods in ascending order of how many dependencies they have (so mods with no dependencies float to the top and are installed first), then alphanumerically by name (so the list doesn't look completely random on casual inspection).

Then we step through that list module by module and perform an insertion sort into what will be our final list. If the module we're inserting has an install reason indicating a dependency on any of the mods already in the final list, then we insert it before the first such dependency. Otherwise we add it to the end.

Circular dependencies complicate this; if `A` depends on `B` and `B` depends on `A`, then either ordering of those two mods would be acceptable. I don't know exactly what to do about that, so I'm just letting it pick whatever ordering it likes for those mods using the same logic as for everything else.

As a special case, user-requested mods are not sorted before non-user-requested mods, even if there is a dependency relationship, since we know they weren't pulled in as dependencies. This way you can see the ones you picked at the bottom, even if they have circular dependencies with other mods.

For confirmation that this puts `TexturesUnlimited` before `ROLib`:

![image](https://user-images.githubusercontent.com/1559108/189762954-9c4f16cb-5967-4802-84b7-7792bd294c04.png)
