### PR TITLE
Authors as clickable filter links, combine search links w/ ctrl or shift

### DIFF
--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -55,6 +55,22 @@ namespace CKAN.GUI
             Apply();
         }
 
+        /// <summary>
+        /// Merge the given searches with the currently active ones
+        /// </summary>
+        /// <param name="searches">New searches to add</param>
+        public void MergeSearches(List<ModSearch> searches)
+        {
+            // Merge inputs once for all editors
+            var merged = searches.Aggregate((search, newSearch) => search.MergedWith(newSearch));
+            foreach (var editor in editors)
+            {
+                // Combine all new with each existing (old AND new)
+                editor.Search = editor.Search?.MergedWith(merged) ?? merged;
+            }
+            Apply();
+        }
+
         private void AddSearchButton_Click(object sender, EventArgs e)
         {
             AddSearch().Focus();
@@ -87,6 +103,8 @@ namespace CKAN.GUI
             ResumeLayout(false);
             PerformLayout();
 
+            AddSearchButton.Top = editors[editors.Count - 1].Top;
+
             return ctl;
         }
 
@@ -107,6 +125,8 @@ namespace CKAN.GUI
                 Controls.Remove(which);
                 // Make sure the top label is always visible
                 editors[0].ShowLabel = true;
+
+                AddSearchButton.Top = editors[editors.Count - 1].Top;
 
                 Height = editors.Sum(ems => ems.Height);
             }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -20,6 +20,15 @@ namespace CKAN.GUI
             InitializeComponent();
 
             ToolTip.SetToolTip(InstallAllCheckbox, Properties.Resources.ManageModsInstallAllCheckboxTooltip);
+            FilterCompatibleButton.ToolTipText      = Properties.Resources.FilterLinkToolTip;
+            FilterInstalledButton.ToolTipText       = Properties.Resources.FilterLinkToolTip;
+            FilterInstalledUpdateButton.ToolTipText = Properties.Resources.FilterLinkToolTip;
+            FilterReplaceableButton.ToolTipText     = Properties.Resources.FilterLinkToolTip;
+            FilterCachedButton.ToolTipText          = Properties.Resources.FilterLinkToolTip;
+            FilterUncachedButton.ToolTipText        = Properties.Resources.FilterLinkToolTip;
+            FilterNewButton.ToolTipText             = Properties.Resources.FilterLinkToolTip;
+            FilterNotInstalledButton.ToolTipText    = Properties.Resources.FilterLinkToolTip;
+            FilterIncompatibleButton.ToolTipText    = Properties.Resources.FilterLinkToolTip;
 
             mainModList = new ModList(source => UpdateFilters());
             FilterToolButton.MouseHover += (sender, args) => FilterToolButton.ShowDropDown();
@@ -203,7 +212,8 @@ namespace CKAN.GUI
                     null, tagFilterButton_Click
                 )
                 {
-                    Tag = kvp.Value
+                    Tag         = kvp.Value,
+                    ToolTipText = Properties.Resources.FilterLinkToolTip,
                 });
             }
             FilterTagsToolButton.DropDownItems.Add(untaggedFilterToolStripSeparator);
@@ -226,7 +236,8 @@ namespace CKAN.GUI
                     null, customFilterButton_Click
                 )
                 {
-                    Tag = mlbl
+                    Tag         = mlbl,
+                    ToolTipText = Properties.Resources.FilterLinkToolTip,
                 });
             }
         }
@@ -295,78 +306,98 @@ namespace CKAN.GUI
         private void tagFilterButton_Click(object sender, EventArgs e)
         {
             var clicked = sender as ToolStripMenuItem;
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Tag, clicked.Tag as ModuleTag, null));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.Tag, clicked.Tag as ModuleTag, null), merge);
         }
 
         private void customFilterButton_Click(object sender, EventArgs e)
         {
             var clicked = sender as ToolStripMenuItem;
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null, clicked.Tag as ModuleLabel));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null, clicked.Tag as ModuleLabel), merge);
         }
 
         private void FilterCompatibleButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Compatible));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.Compatible), merge);
         }
 
         private void FilterInstalledButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Installed));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.Installed), merge);
         }
 
         private void FilterInstalledUpdateButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.InstalledUpdateAvailable));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.InstalledUpdateAvailable), merge);
         }
 
         private void FilterReplaceableButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Replaceable));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.Replaceable), merge);
         }
 
         private void FilterCachedButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Cached));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.Cached), merge);
         }
 
         private void FilterUncachedButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Uncached));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.Uncached), merge);
         }
 
         private void FilterNewButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.NewInRepository));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.NewInRepository), merge);
         }
 
         private void FilterNotInstalledButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.NotInstalled));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.NotInstalled), merge);
         }
 
         private void FilterIncompatibleButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Incompatible));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.Incompatible), merge);
         }
 
         private void FilterAllButton_Click(object sender, EventArgs e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.All));
+            var merge = (Control.ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.All), merge);
         }
 
         /// <summary>
         /// Called when the ModGrid filter (all, compatible, incompatible...) is changed.
         /// </summary>
         /// <param name="search">Search string</param>
-        public void Filter(SavedSearch search)
+        /// <param name="merge">If true, merge with current searches, else replace</param>
+        public void Filter(SavedSearch search, bool merge)
         {
             var searches = search.Values.Select(s => ModSearch.Parse(s,
-                Main.Instance.ManageMods.mainModList.ModuleLabels.LabelsFor(Main.Instance.CurrentInstance.Name).ToList()
+                mainModList.ModuleLabels.LabelsFor(Main.Instance.CurrentInstance.Name).ToList()
             )).ToList();
 
             Util.Invoke(ModGrid, () =>
             {
-                EditModSearches.SetSearches(searches);
+                if (merge)
+                {
+                    EditModSearches.MergeSearches(searches);
+                }
+                else
+                {
+                    EditModSearches.SetSearches(searches);
+                }
 
                 // Ask the configuration which columns to show.
                 foreach (DataGridViewColumn col in ModGrid.Columns)

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -30,6 +30,7 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(ModInfo));
+            this.ToolTip = new System.Windows.Forms.ToolTip();
             this.ModInfoTable = new System.Windows.Forms.TableLayoutPanel();
             this.MetadataModuleNameTextBox = new TransparentTextBox();
             this.MetadataTagsLabelsPanel = new System.Windows.Forms.FlowLayoutPanel();
@@ -45,6 +46,13 @@ namespace CKAN.GUI
             this.VersionsTabPage = new System.Windows.Forms.TabPage();
             this.Versions = new CKAN.GUI.Versions();
             this.SuspendLayout();
+            //
+            // ToolTip
+            //
+            this.ToolTip.AutoPopDelay = 10000;
+            this.ToolTip.InitialDelay = 250;
+            this.ToolTip.ReshowDelay = 250;
+            this.ToolTip.ShowAlways = true;
             //
             // ModInfoTable
             //
@@ -83,6 +91,7 @@ namespace CKAN.GUI
             //
             // MetadataTagsLabelsPanel
             //
+            this.MetadataTagsLabelsPanel.AutoSize = true;
             this.MetadataTagsLabelsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MetadataTagsLabelsPanel.Padding = new System.Windows.Forms.Padding(0);
             this.MetadataTagsLabelsPanel.Location = new System.Drawing.Point(0, 0);
@@ -150,6 +159,7 @@ namespace CKAN.GUI
             this.Metadata.Margin = new System.Windows.Forms.Padding(2);
             this.Metadata.Name = "Metadata";
             this.Metadata.TabIndex = 6;
+            this.Metadata.OnChangeFilter += Metadata_OnChangeFilter;
             //
             // RelationshipTabPage
             //
@@ -216,6 +226,7 @@ namespace CKAN.GUI
 
         #endregion
 
+        private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.TableLayoutPanel ModInfoTable;
         private TransparentTextBox MetadataModuleNameTextBox;
         private System.Windows.Forms.FlowLayoutPanel MetadataTagsLabelsPanel;

--- a/GUI/Controls/ModInfoTabs/Metadata.Designer.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.Designer.cs
@@ -30,6 +30,7 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(Metadata));
+            this.ToolTip = new System.Windows.Forms.ToolTip();
             this.MetadataTable = new System.Windows.Forms.TableLayoutPanel();
             this.IdentifierLabel = new System.Windows.Forms.Label();
             this.MetadataIdentifierTextBox = new TransparentTextBox();
@@ -41,11 +42,18 @@ namespace CKAN.GUI
             this.LicenseLabel = new System.Windows.Forms.Label();
             this.MetadataModuleVersionTextBox = new TransparentTextBox();
             this.MetadataModuleLicenseTextBox = new TransparentTextBox();
-            this.MetadataModuleAuthorTextBox = new TransparentTextBox();
+            this.AuthorsPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.VersionLabel = new System.Windows.Forms.Label();
             this.MetadataModuleReleaseStatusTextBox = new TransparentTextBox();
             this.MetadataModuleGameCompatibilityTextBox = new TransparentTextBox();
             this.SuspendLayout();
+            //
+            // ToolTip
+            //
+            this.ToolTip.AutoPopDelay = 10000;
+            this.ToolTip.InitialDelay = 250;
+            this.ToolTip.ReshowDelay = 250;
+            this.ToolTip.ShowAlways = true;
             //
             // MetadataTable
             //
@@ -54,18 +62,18 @@ namespace CKAN.GUI
             this.MetadataTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 90F));
             this.MetadataTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.MetadataTable.Controls.Add(this.VersionLabel, 0, 0);
-            this.MetadataTable.Controls.Add(this.LicenseLabel, 0, 1);
-            this.MetadataTable.Controls.Add(this.AuthorLabel, 0, 2);
-            this.MetadataTable.Controls.Add(this.ReleaseLabel, 0, 3);
-            this.MetadataTable.Controls.Add(this.GameCompatibilityLabel, 0, 4);
-            this.MetadataTable.Controls.Add(this.IdentifierLabel, 0, 5);
-            this.MetadataTable.Controls.Add(this.ReplacementLabel, 0, 6);
             this.MetadataTable.Controls.Add(this.MetadataModuleVersionTextBox, 1, 0);
+            this.MetadataTable.Controls.Add(this.LicenseLabel, 0, 1);
             this.MetadataTable.Controls.Add(this.MetadataModuleLicenseTextBox, 1, 1);
-            this.MetadataTable.Controls.Add(this.MetadataModuleAuthorTextBox, 1, 2);
+            this.MetadataTable.Controls.Add(this.AuthorLabel, 0, 2);
+            this.MetadataTable.Controls.Add(this.AuthorsPanel, 1, 2);
+            this.MetadataTable.Controls.Add(this.ReleaseLabel, 0, 3);
             this.MetadataTable.Controls.Add(this.MetadataModuleReleaseStatusTextBox, 1, 3);
+            this.MetadataTable.Controls.Add(this.GameCompatibilityLabel, 0, 4);
             this.MetadataTable.Controls.Add(this.MetadataModuleGameCompatibilityTextBox, 1, 4);
+            this.MetadataTable.Controls.Add(this.IdentifierLabel, 0, 5);
             this.MetadataTable.Controls.Add(this.MetadataIdentifierTextBox, 1, 5);
+            this.MetadataTable.Controls.Add(this.ReplacementLabel, 0, 6);
             this.MetadataTable.Controls.Add(this.ReplacementTextBox, 1, 6);
             this.MetadataTable.Dock = System.Windows.Forms.DockStyle.Top;
             this.MetadataTable.Location = new System.Drawing.Point(0, 0);
@@ -74,22 +82,13 @@ namespace CKAN.GUI
             this.MetadataTable.RowCount = 7;
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.MetadataTable.Size = new System.Drawing.Size(346, 255);
             this.MetadataTable.AutoSize = true;
-            /*
-            //this.MetadataTable.AutoScroll = true;
-            this.MetadataTable.HorizontalScroll.Enabled = false;
-            this.MetadataTable.HorizontalScroll.Visible = false;
-            this.MetadataTable.HorizontalScroll.Minimum = 0;
-            this.MetadataTable.HorizontalScroll.Maximum = 0;
-            this.MetadataTable.VerticalScroll.Enabled = true;
-            this.MetadataTable.VerticalScroll.Visible = true;
-            */
             this.MetadataTable.TabIndex = 0;
             //
             // IdentifierLabel
@@ -214,19 +213,15 @@ namespace CKAN.GUI
             this.MetadataModuleLicenseTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             resources.ApplyResources(this.MetadataModuleLicenseTextBox, "MetadataModuleLicenseTextBox");
             //
-            // MetadataModuleAuthorTextBox
+            // AuthorsPanel
             //
-            this.MetadataModuleAuthorTextBox.AutoSize = true;
-            this.MetadataModuleAuthorTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleAuthorTextBox.Location = new System.Drawing.Point(93, 60);
-            this.MetadataModuleAuthorTextBox.Name = "MetadataModuleAuthorTextBox";
-            this.MetadataModuleAuthorTextBox.Size = new System.Drawing.Size(250, 30);
-            this.MetadataModuleAuthorTextBox.TabIndex = 6;
-            this.MetadataModuleAuthorTextBox.ReadOnly = true;
-            this.MetadataModuleAuthorTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.MetadataModuleAuthorTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MetadataModuleAuthorTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            resources.ApplyResources(this.MetadataModuleAuthorTextBox, "MetadataModuleAuthorTextBox");
+            this.AuthorsPanel.AutoSize = true;
+            this.AuthorsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.AuthorsPanel.Margin = new System.Windows.Forms.Padding(this.AuthorsPanel.Margin.Left, 0, this.AuthorsPanel.Margin.Right, this.AuthorsPanel.Margin.Bottom);
+            this.AuthorsPanel.Padding = new System.Windows.Forms.Padding(0);
+            this.AuthorsPanel.Location = new System.Drawing.Point(0, 0);
+            this.AuthorsPanel.Name = "AuthorsPanel";
+            this.AuthorsPanel.Size = new System.Drawing.Size(500, 20);
             //
             // VersionLabel
             //
@@ -283,6 +278,7 @@ namespace CKAN.GUI
 
         #endregion
 
+        private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.TableLayoutPanel MetadataTable;
         private System.Windows.Forms.Label IdentifierLabel;
         private TransparentTextBox MetadataIdentifierTextBox;
@@ -294,7 +290,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.Label LicenseLabel;
         private TransparentTextBox MetadataModuleVersionTextBox;
         private TransparentTextBox MetadataModuleLicenseTextBox;
-        private TransparentTextBox MetadataModuleAuthorTextBox;
+        private System.Windows.Forms.FlowLayoutPanel AuthorsPanel;
         private System.Windows.Forms.Label VersionLabel;
         private TransparentTextBox MetadataModuleReleaseStatusTextBox;
         private TransparentTextBox MetadataModuleGameCompatibilityTextBox;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -491,7 +491,7 @@ namespace CKAN.GUI
                     ManageMods.mainModList.ModuleTags.Tags.GetOrDefault(configuration.TagFilter),
                     ManageMods.mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                         .FirstOrDefault(l => l.Name == configuration.CustomLabelFilter)
-                ));
+                ), false);
                 // Clear the old filter so it doesn't get pulled forward again
                 configuration.ActiveFilter = (int)GUIModFilter.All;
             }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -70,7 +70,7 @@ namespace CKAN.GUI
         public bool HasReplacement { get; private set; }
         public bool IsIncompatible { get; private set; }
         public bool IsAutodetected { get; private set; }
-        public string Authors { get; private set; }
+        public List<string> Authors => Mod.author ?? new List<string>();
         public string InstalledVersion { get; private set; }
         public DateTime? InstallDate { get; private set; }
         public string LatestVersion { get; private set; }
@@ -164,7 +164,6 @@ namespace CKAN.GUI
             Abstract      = mod.@abstract.Trim();
             Description   = mod.description?.Trim() ?? string.Empty;
             Abbrevation   = new string(Name.Split(' ').Where(s => s.Length > 0).Select(s => s[0]).ToArray());
-            Authors       = mod.author == null ? Properties.Resources.GUIModNSlashA : String.Join(",", mod.author);
 
             HasUpdate      = registry.HasUpdate(mod.identifier, current_game_version);
             HasReplacement = registry.GetReplacement(mod, current_game_version) != null;

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -365,8 +365,8 @@ namespace CKAN.GUI
                     Value = "-"
                 };
 
-            var name   = new DataGridViewTextBoxCell { Value = mod.Name   .Replace("&", "&&") };
-            var author = new DataGridViewTextBoxCell { Value = mod.Authors.Replace("&", "&&") };
+            var name   = new DataGridViewTextBoxCell { Value = mod.Name.Replace("&", "&&") };
+            var author = new DataGridViewTextBoxCell { Value = string.Join(", ", mod.Authors).Replace("&", "&&") };
 
             var installVersion = new DataGridViewTextBoxCell()
             {

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -1134,5 +1134,12 @@ namespace CKAN.GUI.Properties {
         public static string RelationshipTypeConflicts {
             get { return (string)(ResourceManager.GetObject("RelationshipTypeConflicts", resourceCulture)); }
         }
+
+        public static string AuthorSearchName {
+            get { return (string)(ResourceManager.GetObject("AuthorSearchName", resourceCulture)); }
+        }
+        public static string FilterLinkToolTip {
+            get { return (string)(ResourceManager.GetObject("FilterLinkToolTip", resourceCulture)); }
+        }
     }
 }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -453,4 +453,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="RelationshipTypeSuggests" xml:space="preserve"><value>Suggests</value></data>
   <data name="RelationshipTypeSupports" xml:space="preserve"><value>Supports</value></data>
   <data name="RelationshipTypeConflicts" xml:space="preserve"><value>Conflicts</value></data>
+  <data name="AuthorSearchName"><value>Mods by {0}</value></data>
+  <data name="FilterLinkToolTip"><value>Click to search
+Ctrl-click or Shift-click to combine with current search</value></data>
 </root>


### PR DESCRIPTION
## Motivation

Continuing recent efforts to improve mod info (see #3670), and remembering my quest to find FruitGoose's mods (see KSP-CKAN/NetKAN#9351), influenced by the "sticky" checkbox on the Relationships tab (see #3638), I thought it would be nice to be able to click author names in mod info to set the filter, like the tab/label links. And if we're going to have both tag/label links and author links, that raises the possibility of wanting to use them together somehow.

## Changes

- The authors field in mod info is now an autosized wrapping flow layout collection of links that can be clicked to search by that author, similar to the tag/label links
  - Since authors can contain characters that aren't allowed or don't work in searches, non-alphanumeric characters are removed before searching
  - Can be Ctrl- or Shift-clicked to merge with existing search instead of replacing
- Mod tag/label links are no longer oddly offset to the right by 2px
  - Can be Ctrl- or Shift-clicked to merge with existing search instead of replacing
- Filter dropdown menu options can be Ctrl- or Shift-clicked to merge with existing search instead of replacing
- The `[+]` button to add a filter moves up and down to align with the bottommost search, since you'd want to use it after populating that field

Merging two searches produces their **intersection** (AND logic). I think this makes sense because the user's typical goal is to narrow down the list of mods more and more until the desired mod is found, and using OR logic would expand the list instead. Similarly, if you already have multiple OR searches and choose to merge a new filter into it, the new filter is merged into **all** of those existing ones, to make sure mods not matching the new filter drop off.

Since Ctrl- and Shift-clicking are not discoverable, a tooltip calls it out in each place where it's available.

![image](https://user-images.githubusercontent.com/1559108/194403856-fbd3ddc4-6897-4ee3-a6f2-42e48cb09283.png)

![image](https://user-images.githubusercontent.com/1559108/194403836-ec064c56-8362-4d88-b4f7-ea75204b7109.png)

![image](https://user-images.githubusercontent.com/1559108/194403877-8c07c690-5390-4aa1-aa5d-a8bca8a79aa5.png)
