### PR TITLE
Fix modpack installation, install incompatible with confirmation

### DIFF
--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -591,5 +591,9 @@ namespace CKAN.Properties {
         internal static string SanityCheckerConflictsWith {
             get { return (string)(ResourceManager.GetObject("SanityCheckerConflictsWith", resourceCulture)); }
         }
+
+        internal static string ModpackName {
+            get { return (string)(ResourceManager.GetObject("ModpackName", resourceCulture)); }
+        }
     }
 }

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -308,4 +308,5 @@ Free up space on that device or change your settings to use another location.
   <data name="NetModuleCacheModuleResuming" xml:space="preserve"><value>{0} {1} ({2}, {3} remaining)</value></data>
   <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3} remaining)</value></data>
   <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve"><value> * Upgrade: {0} {1} to {2} ({3}, {4} remaining)</value></data>
+  <data name="ModpackName" xml:space="preserve"><value>installed-{0}</value></data>
 </root>

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -567,7 +567,10 @@ namespace CKAN
         private void Add(CkanModule module, SelectionReason reason)
         {
             if (module.IsMetapackage)
+            {
+                AddReason(module, reason);
                 return;
+            }
             if (module.IsDLC)
             {
                 throw new ModuleIsDLCKraken(module);
@@ -697,6 +700,12 @@ namespace CKAN
                             .Min();
                         log.DebugFormat("Parent found: {0}, {1}", index, module);
                         sortedDepsFirst.Insert(index, module);
+                    }
+                    catch (ArgumentException)
+                    {
+                        // ReasonsFor throws this for mods without reasons, just add it to the end
+                        log.DebugFormat("Reasons for parent not found: {0}", module);
+                        sortedDepsFirst.Add(module);
                     }
                     catch (InvalidOperationException)
                     {

--- a/Core/Versioning/GameVersion.cs
+++ b/Core/Versioning/GameVersion.cs
@@ -36,65 +36,59 @@ namespace CKAN.Versioning
         /// Gets the value of the major component of the version number for the current <see cref="GameVersion"/>
         /// object.
         /// </summary>
-        public int Major {  get { return _major; } }
+        public int Major => _major;
 
         /// <summary>
         /// Gets the value of the minor component of the version number for the current <see cref="GameVersion"/>
         /// object.
         /// </summary>
-        public int Minor { get { return _minor; } }
+        public int Minor => _minor;
 
         /// <summary>
         /// Gets the value of the patch component of the version number for the current <see cref="GameVersion"/>
         /// object.
         /// </summary>
-        public int Patch { get { return _patch; } }
+        public int Patch => _patch;
 
         /// <summary>
         /// Gets the value of the build component of the version number for the current <see cref="GameVersion"/>
         /// object.
         /// </summary>
-        public int Build { get { return _build; } }
+        public int Build => _build;
 
         /// <summary>
         /// Gets whether or not the major component of the version number for the current <see cref="GameVersion"/>
         /// object is defined.
         /// </summary>
-        public bool IsMajorDefined { get { return _major != Undefined; } }
+        public bool IsMajorDefined => _major != Undefined;
 
         /// <summary>
         /// Gets whether or not the minor component of the version number for the current <see cref="GameVersion"/>
         /// object is defined.
         /// </summary>
-        public bool IsMinorDefined { get { return _minor != Undefined; } }
+        public bool IsMinorDefined => _minor != Undefined;
 
         /// <summary>
         /// Gets whether or not the patch component of the version number for the current <see cref="GameVersion"/>
         /// object is defined.
         /// </summary>
-        public bool IsPatchDefined { get { return _patch != Undefined; } }
+        public bool IsPatchDefined => _patch != Undefined;
 
         /// <summary>
         /// Gets whether or not the build component of the version number for the current <see cref="GameVersion"/>
         /// object is defined.
         /// </summary>
-        public bool IsBuildDefined {  get { return _build != Undefined; } }
+        public bool IsBuildDefined => _build != Undefined;
 
         /// <summary>
         /// Indicates whether or not all components of the current <see cref="GameVersion"/> are defined.
         /// </summary>
-        public bool IsFullyDefined
-        {
-            get { return IsMajorDefined && IsMinorDefined && IsPatchDefined && IsBuildDefined; }
-        }
+        public bool IsFullyDefined => IsMajorDefined && IsMinorDefined && IsPatchDefined && IsBuildDefined;
 
         /// <summary>
         /// Indicates wheter or not all the components of the current <see cref="GameVersion"/> are undefined.
         /// </summary>
-        public bool IsAny
-        {
-            get { return !IsMajorDefined && !IsMinorDefined && !IsPatchDefined && !IsBuildDefined; }
-        }
+        public bool IsAny => !IsMajorDefined && !IsMinorDefined && !IsPatchDefined && !IsBuildDefined;
 
         /// <summary>
         /// Check whether a version is null or Any.
@@ -104,10 +98,7 @@ namespace CKAN.Versioning
         /// <returns>
         /// True if null or Any, false otherwise
         /// </returns>
-        public static bool IsNullOrAny(GameVersion v)
-        {
-            return v == null || v.IsAny;
-        }
+        public static bool IsNullOrAny(GameVersion v) => v == null || v.IsAny;
 
         /// <summary>
         /// Initialize a new instance of the <see cref="GameVersion"/> class with all components unspecified.
@@ -240,10 +231,7 @@ namespace CKAN.Versioning
         /// If the current <see cref="GameVersion"/> is totally undefined the return value will <c>null</c>.
         /// </para>
         /// </returns>
-        public override string ToString()
-        {
-            return _string;
-        }
+        public override string ToString() => _string;
 
         private static Dictionary<string, GameVersion> VersionsMax = new Dictionary<string, GameVersion>();
 
@@ -303,6 +291,13 @@ namespace CKAN.Versioning
         {
             return (int)Math.Pow(10, Math.Floor(Math.Log10(num + 1)) + 1) - 1;
         }
+
+        /// <summary>
+        /// Strip off the build number if it's defined
+        /// </summary>
+        /// <returns>A GameVersion equal to this but without a build number</returns>
+        public GameVersion WithoutBuild => IsBuildDefined ? new GameVersion(_major, _minor, _patch)
+                                                          : this;
 
         /// <summary>
         /// Converts the value of the current <see cref="GameVersion"/> to its equivalent
@@ -491,7 +486,7 @@ namespace CKAN.Versioning
         /// Raises a selection dialog for choosing a specific KSP version, if it is not fully defined yet.
         /// If a build number is specified but not known, it presents a list of all builds
         /// of the patch range.
-        /// Needs at least a Major and Minor (doesn't make sense else). 
+        /// Needs at least a Major and Minor (doesn't make sense else).
         /// </summary>
         /// <returns>A complete GameVersion object</returns>
         /// <param name="user">A IUser instance, to raise the corresponding dialog.</param>
@@ -526,7 +521,7 @@ namespace CKAN.Versioning
                         {
                             possibleVersions.Add(ver);
                         }
-                    } 
+                    }
                     // If we also have Patch -> compare it too.
                     else if (!IsBuildDefined)
                     {

--- a/Core/Versioning/GameVersionRange.cs
+++ b/Core/Versioning/GameVersionRange.cs
@@ -12,7 +12,7 @@ namespace CKAN.Versioning
             new GameVersionRange(GameVersionBound.Unbounded, GameVersionBound.Unbounded);
 
         public GameVersionBound Lower { get; private set; }
-        public GameVersionBound Upper { get; private set;  }
+        public GameVersionBound Upper { get; private set; }
 
         public GameVersionRange(GameVersionBound lower, GameVersionBound upper)
         {
@@ -31,10 +31,7 @@ namespace CKAN.Versioning
         public GameVersionRange(GameVersion lower, GameVersion upper)
             : this(lower?.ToVersionRange().Lower, upper?.ToVersionRange().Upper) { }
 
-        public override string ToString()
-        {
-            return _string;
-        }
+        public override string ToString() =>_string;
 
         public GameVersionRange IntersectWith(GameVersionRange other)
         {
@@ -64,10 +61,8 @@ namespace CKAN.Versioning
         }
 
         private static bool IsEmpty(GameVersionBound lower, GameVersionBound upper)
-        {
-            return upper.Value < lower.Value ||
+            => upper.Value < lower.Value ||
                 (lower.Value == upper.Value && (!lower.Inclusive || !upper.Inclusive));
-        }
 
         private static string DeriveString(GameVersionRange versionRange)
         {
@@ -89,11 +84,9 @@ namespace CKAN.Versioning
         }
 
         private static string SameVersionString(GameVersion v)
-        {
-            return v == null ? "???"
-                :  v.IsAny   ? "all versions"
-                :              v.ToString();
-        }
+            => v == null ? "???"
+             : v.IsAny   ? Properties.Resources.CkanModuleAllVersions
+             :             v.ToString();
 
         /// <summary>
         /// Generate a string describing a range of KSP versions.
@@ -105,15 +98,18 @@ namespace CKAN.Versioning
         /// Human readable string describing the versions.
         /// </returns>
         public static string VersionSpan(IGame game, GameVersion minKsp, GameVersion maxKsp)
-        {
-            return minKsp == maxKsp ? $"{game.ShortName} {SameVersionString(minKsp)}"
-                :  minKsp.IsAny
+            => minKsp == maxKsp
+                ? $"{game.ShortName} {SameVersionString(minKsp)}"
+                : minKsp.IsAny
                     ? string.Format(Properties.Resources.GameVersionRangeMinOnly, game.ShortName, maxKsp)
-                :  maxKsp.IsAny
-                    ? string.Format(Properties.Resources.GameVersionRangeMaxOnly, game.ShortName, minKsp)
-                :                     $"{game.ShortName} {minKsp}–{maxKsp}";
-        }
+                    : maxKsp.IsAny
+                        ? string.Format(Properties.Resources.GameVersionRangeMaxOnly, game.ShortName, minKsp)
+                        : $"{game.ShortName} {minKsp}–{maxKsp}";
 
+        public string ToSummaryString(IGame game)
+            => VersionSpan(game,
+                           Lower.AsInclusiveLower().WithoutBuild,
+                           Upper.AsInclusiveUpper().WithoutBuild);
     }
 
     public sealed partial class GameVersionRange : IEquatable<GameVersionRange>
@@ -140,14 +136,7 @@ namespace CKAN.Versioning
             }
         }
 
-        public static bool operator ==(GameVersionRange left, GameVersionRange right)
-        {
-            return Equals(left, right);
-        }
-
-        public static bool operator !=(GameVersionRange left, GameVersionRange right)
-        {
-            return !Equals(left, right);
-        }
+        public static bool operator ==(GameVersionRange left, GameVersionRange right) => Equals(left, right);
+        public static bool operator !=(GameVersionRange left, GameVersionRange right) => !Equals(left, right);
     }
 }

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -317,6 +317,18 @@ namespace CKAN.GUI
             }
             else if (TrySavePrompt(modpackExportOptions, out ExportOption selectedOption, out string filename))
             {
+                if (module.depends.Count == 0)
+                {
+                    module.depends = null;
+                }
+                if (module.recommends.Count == 0)
+                {
+                    module.recommends = null;
+                }
+                if (module.suggests.Count == 0)
+                {
+                    module.suggests = null;
+                }
                 CkanModule.ToFile(ApplyVersionsCheckbox(module), filename);
                 task?.SetResult(true);
             }

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -70,7 +70,9 @@ namespace CKAN.GUI
 
             return installable(installer, module, registry)
                 || Main.Instance.YesNoDialog(
-                    string.Format(Properties.Resources.AllModVersionsInstallPrompt, module.ToString()),
+                    string.Format(Properties.Resources.AllModVersionsInstallPrompt,
+                        module.ToString(),
+                        currentInstance.VersionCriteria().ToSummaryString(currentInstance.game)),
                     Properties.Resources.AllModVersionsInstallYes,
                     Properties.Resources.AllModVersionsInstallNo);
         }

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -85,6 +85,7 @@ namespace CKAN.GUI
                         {
                             AutoSize = true,
                             Text     = label,
+                            Margin   = new Padding(0, 8, 0, 0),
                         };
                         progressLabels.Add(label, newLb);
                         var newPb = new ProgressBar()

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -17,29 +17,30 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="registry">Reference to the registry</param>
         /// <param name="module">Module to install</param>
-        public void InstallModuleDriver(IRegistryQuerier registry, CkanModule module)
+        public void InstallModuleDriver(IRegistryQuerier registry, IEnumerable<CkanModule> modules)
         {
             try
             {
                 DisableMainWindow();
                 var userChangeSet = new List<ModChange>();
-                InstalledModule installed = registry.InstalledModule(module.identifier);
-                if (installed != null)
+                foreach (var module in modules)
                 {
-                    // Already installed, remove it first
-                    userChangeSet.Add(new ModChange(installed.Module, GUIModChangeType.Remove));
+                    InstalledModule installed = registry.InstalledModule(module.identifier);
+                    if (installed != null)
+                    {
+                        // Already installed, remove it first
+                        userChangeSet.Add(new ModChange(installed.Module, GUIModChangeType.Remove));
+                    }
+                    // Install the selected mod
+                    userChangeSet.Add(new ModChange(module, GUIModChangeType.Install));
                 }
-                // Install the selected mod
-                userChangeSet.Add(new ModChange(module, GUIModChangeType.Install));
                 if (userChangeSet.Count > 0)
                 {
                     // Resolve the provides relationships in the dependencies
                     Wait.StartWaiting(InstallMods, PostInstallMods, true,
                         new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                             userChangeSet,
-                            RelationshipResolver.DependsOnlyOpts()
-                        )
-                    );
+                            RelationshipResolver.DependsOnlyOpts()));
                 }
             }
             catch

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -501,6 +501,9 @@ namespace CKAN.GUI.Properties {
         internal static string AllModVersionsInstallPrompt {
             get { return (string)(ResourceManager.GetObject("AllModVersionsInstallPrompt", resourceCulture)); }
         }
+        internal static string ModpackInstallIncompatiblePrompt {
+            get { return (string)(ResourceManager.GetObject("ModpackInstallIncompatiblePrompt", resourceCulture)); }
+        }
         internal static string AllModVersionsInstallYes {
             get { return (string)(ResourceManager.GetObject("AllModVersionsInstallYes", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -214,9 +214,14 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="MainCorruptedRegistry" xml:space="preserve"><value>Corrupted registry archived to {0}: {1}
 
 This means that CKAN forgot about all your installed mods, but they are still in GameData. You can reinstall them by importing the {2} file.</value></data>
-  <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current game version and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
+  <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current compatible game versions ({1}) and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
 
 Do you really want to install it?</value></data>
+  <data name="ModpackInstallIncompatiblePrompt" xml:space="preserve"><value>Some of the selected mods (or their dependencies) are not supported on your current compatible game versions ({1}) and may not work at all. If you have any problems with them, you should NOT ask their maintainers for help.
+
+{0}
+
+Are you sure you want to install them? Cancelling will abort the entire installation.</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Install</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Cancel</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Update selected by user to version {0}.</value></data>

--- a/Tests/Core/Versioning/KspVersionRangeTests.cs
+++ b/Tests/Core/Versioning/KspVersionRangeTests.cs
@@ -628,7 +628,7 @@ namespace Tests.Core.Versioning
             // Act
             string s = GameVersionRange.VersionSpan(game, min, max);
             // Assert
-            Assert.AreEqual("KSP all versions", s);
+            Assert.AreEqual("KSP All versions", s);
         }
 
         [Test]


### PR DESCRIPTION
## Problems

- After #3667, trying to install modpacks doesn't work in dev builds anymore, because the relationship resolver's mod list property now tries to get the reason for each mod's _parent_, and mods from a modpack have a metapackage parent, which wouldn't have its reasons stored. An exception is thrown and not caught, so it fails messily. This definitely needs to be fixed before the next release.
- The default identifier for a modpack wasn't internationalized, but instead always had an English `installed-` prefix
- The "KSP all versions" string used in many places wasn't internationalized but instead always English

## Additional motivation

I felt like assembling my own modpack that I'm calling "Stock Plus," focused on enhancing the gameplay of the stock solar system and parts; if anyone is interested, I may be publishing it once this PR's changes are released. Working on this with the current dev build was how I discovered that modpack installation is broken.

A few mods that I really wanted are not marked compatible with KSP 1.10–1.12 (but they do work), which means I can still install them via the Versions tab by overriding a proper compatibility warning, but the options for adding them to a metapackage .ckan file are not satisfactory:

- Leave them as dependencies, which will prevent the modpack from being installed unless you add some really old game versions as compatible
- Change these mods to recommendations, which will simply hide them at install time

Either way, the incompatible mods that I want in my pack can't be installed via a modpack. I think we've had other modpack creators ask about this before, so it's potentially of general interest.

## Changes

- Now installing a modpack works again because the relationship resolver now saves the reason for metapackages (requested by user) even though they're excluded from the mod list
- Now the default identifier for a modpack is internationalized
- Now the "KSP all versions" string is internationalized using the already translated strings for `CkanModule.HighestCompatibleKSP`, and hence also changed capitalization to "KSP All versions" in English
- Now if some of a modpack's dependencies are incompatible, instead of erroring out, we alert the user and ask for confirmation, just like installing from the Versions tab (side note, the mods in this screenshot are **not** the affected mods from "Stock Plus"):
  ![image](https://user-images.githubusercontent.com/1559108/195952397-f3b053e9-50ba-4df3-84d8-face995731e4.png)
  This will make modpack installation more closely replicate the user experience of installing the same set of mods without a modpack.
- Now the Version tab's compatibility warning includes your currently configured compatible game versions, similar to the above warning. To make this work without updating the current translation strings, the new string is added with a later `string.Format` index, despite occurring earlier in the main string. For consistency, this same ordering is also used for the above warning.
- Now when you export a modpack, more properties are set, and some are set better:
  - `ksp_version_min` and `ksp_version_max` are set based on your current compatibility settings
  - The default unknown license is retrieved from `License.UnknownLicense` instead of hard coded in the registry manager
  - The `download_content_type` is set based on the `DefaultValue` attribute instead of hard coded in the registry manager
  - The `depends`, `recommends`, and `suggests` properties will now be omitted instead of `[]` if they are empty
- Now if you choose multiple .ckan files to install via File→Install from ckan..., all of the files are grouped together into one big changeset rather than being installed one at a time
- Now if you install a modpack via File→Install from ckan..., all of its dependencies are added to the changeset individually so their compatibility checks can be bypassed
- The labels for the per-mod progress bars are now better aligned with the progress bars (8px down)
