### PR TITLE
Make Netkan nested GameData check case insensitive

### DIFF
--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 using CKAN.NetKAN.Model;
@@ -39,7 +40,8 @@ namespace CKAN.NetKAN.Validators
 
                 // Make sure no paths include GameData other than at the start
                 var gamedatas = allFiles
-                    .Where(p => p.StartsWith("GameData") && p.LastIndexOf("/GameData/") > 0)
+                    .Where(p => p.StartsWith("GameData", StringComparison.InvariantCultureIgnoreCase)
+                         && p.LastIndexOf("/GameData/", StringComparison.InvariantCultureIgnoreCase) > 0)
                     .OrderBy(f => f)
                     .ToList();
                 if (gamedatas.Any())


### PR DESCRIPTION
## Problem

KSP-CKAN/NetKAN#9396 initially had an auto-generated netkan that installed to paths like `GameData/ESA_Rocket-0.1/Gamedata/Vega/AVUM.png`:

https://github.com/KSP-CKAN/NetKAN/actions/runs/3314556923/jobs/5473995107

No error was thrown because the ZIP contains `Gamedata` instead of `GameData`, even though this is just as wrong as it would be if the author had used the standard capitalization.

## Changes

Now the nested GameData check is case insensitive, courtesy of `StringComparison.InvariantCultureIgnoreCase`.

I'll self-review this since it's simple and low risk.
