### PR TITLE
Switch workflows from set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           VERSION=$(egrep '^\s*\#\#\s+v.*$' CHANGELOG.md | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-.*$//')
           if [[ $VERSION =~ [13579]$ ]]
           then
-            echo '::set-output name=odd_build::true'
+            echo 'odd_build=true' >> $GITHUB_OUTPUT
           fi
 
       - name: Installing build dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,13 +57,13 @@ jobs:
         id: release_data
         run: |
           URL=$(wget -qO- https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq '.[0].upload_url' | tr -d \")
-          echo "::set-output name=upload_url::$URL"
+          echo "upload_url=$URL" >> $GITHUB_OUTPUT
           VERSION=$(wget -qO- https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq '.[0].tag_name' | tr -d \"v)
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           RPM_VERSION=$(echo ${VERSION}.$(date +'%g%j') | sed -e 's/-/_/g')
-          echo "::set-output name=rpm_version::$RPM_VERSION"
+          echo "rpm_version=$RPM_VERSION" >> $GITHUB_OUTPUT
           DEB_VERSION=${VERSION}.$(date +'%g%j')
-          echo "::set-output name=deb_version::$DEB_VERSION"
+          echo "deb_version=$DEB_VERSION" >> $GITHUB_OUTPUT
       - name: Push deb to S3
         # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
## Motivation

Originally, the documented way to pass info from one GitHub workflow step to the next was to print this to stdout:

```
::set-output name=param_name::param_value
```

We used this in several places in CKAN's workflows (mainly dealing with the calculation of the version strings).

Recently GitHub decided they didn't like that anymore and added a warning message for it:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The replacement is to append `param_name=param_value` lines to the file specified by `$GITHUB_OUTPUT`:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

We have until June 2023 to migrate.

Noted thanks to KSP-CKAN/KSPMMCfgParser#16.

## Changes

Now the prescribed migration is done for the CKAN repo.

I'll self-review this.
