### PR TITLE
Red highlight for dependencies on missing DLC

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -607,21 +607,9 @@ namespace CKAN
             return this.identifier == identifier || provides.Contains(identifier);
         }
 
-        public bool IsMetapackage
-        {
-            get
-            {
-                return this.kind == "metapackage";
-            }
-        }
+        public bool IsMetapackage => kind == "metapackage";
 
-        public bool IsDLC
-        {
-            get
-            {
-                return this.kind == "dlc";
-            }
-        }
+        public bool IsDLC => kind == "dlc";
 
         protected bool Equals(CkanModule other)
         {

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -326,6 +326,7 @@ namespace CKAN.GUI
         private TreeNode indexedNode(IRegistryQuerier registry, CkanModule module, RelationshipType relationship, RelationshipDescriptor relDescr, GameVersionCriteria crit)
         {
             int icon = (int)relationship + 1;
+            bool missingDLC = module.IsDLC && !registry.InstalledDlc.ContainsKey(module.identifier);
             bool compatible = crit == null ? false
                 : registry.IdentifierCompatible(module.identifier, crit);
             string suffix = compatible ? ""
@@ -335,7 +336,9 @@ namespace CKAN.GUI
                 Name        = module.identifier,
                 ToolTipText = $"{relationship.Localize()} {relDescr}",
                 Tag         = module,
-                ForeColor   = compatible ? SystemColors.WindowText : Color.Red,
+                ForeColor   = (compatible && !missingDLC)
+                    ? SystemColors.WindowText
+                    : Color.Red,
             };
         }
 


### PR DESCRIPTION
## Problem

If a mod depends on a DLC that you don't have installed, the mod will be treated as incompatible with a red stop sign on the relationships tab due to the missing dependency (since CKAN can't install DLC even if there's a version of it that's compatible with your game version). But if you look at the relationships tab of mod info to try to figure out why it's incompatible, there's no indication that this is the reason:

![image](https://user-images.githubusercontent.com/1559108/200429906-7ad13d97-af16-4793-92d7-3e180d7c6dc0.png)

## Changes

Now if a mod depends on a DLC that isn't installed, the relationship will be highlighted red, just like for an incompatible dependency:

![image](https://user-images.githubusercontent.com/1559108/200430121-22d8d467-fd78-4547-8aa1-329463d577a8.png)
