### PR TITLE
Remove duplicate Install changes for upgrades

### DIFF
--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -126,6 +126,7 @@ namespace CKAN.GUI
         {
             var modules_to_install = new List<CkanModule>();
             var modules_to_remove = new HashSet<CkanModule>();
+            var upgrading = new HashSet<CkanModule>();
 
             foreach (var change in changeSet)
             {
@@ -134,7 +135,9 @@ namespace CKAN.GUI
                     case GUIModChangeType.None:
                         break;
                     case GUIModChangeType.Update:
-                        modules_to_install.Add((change as ModUpgrade)?.targetMod ?? change.Mod);
+                        var mod = (change as ModUpgrade)?.targetMod ?? change.Mod;
+                        modules_to_install.Add(mod);
+                        upgrading.Add(mod);
                         break;
                     case GUIModChangeType.Install:
                         modules_to_install.Add(change.Mod);
@@ -200,6 +203,8 @@ namespace CKAN.GUI
                 .Where(ch => !(ch.ChangeType is GUIModChangeType.Install))
                 .OrderBy(ch => ch.Mod.identifier)
                 .Union(resolver.ModList()
+                    // Changeset already contains Update changes for these
+                    .Except(upgrading)
                     .Where(m => !m.IsMetapackage)
                     .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonsFor(m))));
         }


### PR DESCRIPTION
## Problem

When you upgrade a module, the GUI changeset shows two entries for the same module, an Update step and an Install step.

![image](https://user-images.githubusercontent.com/1559108/201575234-929fcb11-db96-4d59-9230-6a558c9bafd6.png)

## Cause

I think these extra changes existed along, but were hidden in GUI by `CreateSortedModList` until #3667 simplified the changeset UI to show what's actually being done. The `!sortedChangeSet.Any(c => c.Mod.identifier == change.Mod.identifier` check would have prevented an Install change in the changeset from being added to the list in the UI if an Update was already present:

https://github.com/KSP-CKAN/CKAN/blob/32517ba0fdc6f3116c0817572cd5ae76dfcf307d/GUI/Controls/Changeset.cs#L133-L149

## Changes

Now the resolver's Install step is only added to the changeset if there isn't already an Update step for the same mod.
