### PR TITLE
Fix GUI freeze with non-empty changeset at startup

### DIFF
--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -42,12 +42,7 @@ namespace CKAN.GUI
         }
 
         public ListView.SelectedListViewItemCollection SelectedItems
-        {
-            get
-            {
-                return ChangesListView.SelectedItems;
-            }
-        }
+            => ChangesListView.SelectedItems;
 
         public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -112,19 +112,19 @@ namespace CKAN.GUI
 
         private void ChangeSetUpdated()
         {
-            if (ChangeSet != null && ChangeSet.Any())
+            Util.Invoke(this, () =>
             {
-                ApplyToolButton.Enabled = true;
-            }
-            else
-            {
-                ApplyToolButton.Enabled = false;
-                InstallAllCheckbox.Checked = true;
-            }
-            if (OnChangeSetChanged != null)
-            {
-                OnChangeSetChanged(ChangeSet);
-            }
+                if (ChangeSet != null && ChangeSet.Any())
+                {
+                    ApplyToolButton.Enabled = true;
+                }
+                else
+                {
+                    ApplyToolButton.Enabled = false;
+                    InstallAllCheckbox.Checked = true;
+                }
+                OnChangeSetChanged?.Invoke(ChangeSet);
+            });
         }
 
         private Dictionary<GUIMod, string> Conflicts

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -7,7 +7,7 @@ namespace CKAN.GUI
 {
     public partial class Main
     {
-        public void UpdateChangesDialog(List<ModChange> changeset)
+        private void UpdateChangesDialog(List<ModChange> changeset)
         {
             Changeset.LoadChangeset(
                 changeset,


### PR DESCRIPTION
## Problem

After KSP-CKAN/NetKAN#9438 and KSP-CKAN/CKAN-meta#3125, ZeroMiniAVC becomes auto-uninstallable (see #2753) for most users who have it. Unfortunately the client has problems with this.

The change set tab appears and the Apply changes button becomes enabled while the GUI is still responsive, but _clicking_ Apply changes or the change set tab froze the GUI. Multiple users have reported this on the forum and Discord.

Steps to reproduce:

1. Start CKAN
2. Install ToolbarController, ClickThroughBlocker, and ZeroMiniAVC
3. Mark ZeroMiniAVC as auto-installed
4. Close CKAN
5. Start CKAN
6. The change set tab appears and Apply changes is enabled, and using either one will freeze the GUI

## Cause

GUI properties on `Changeset` are being manipulated from a background thread, rather than WinForms's designated "GUI thread" (:vomiting_face:). This destabilizes that tab, so when we try to make it visible (by clicking the Changeset tab or the Apply changes button) or further manipulate it (by checking or unchecking the Install or auto-installed checkboxes for some mods), something in the runtime seizes up and stops responding during the call to `TabControl.SelectTab`, which never returns.

Without an auto-uninstallable mod, the change set is empty, so the tab isn't updated.

## Changes

Now `ManageMods.ChangeSetUpdated` is wrapped in a `Util.Invoke` call, since this is the outermost part of the relevant call stack that sets GUI properties (which were harmless at this level but still technically not allowed). This will allow the change set tab to be updated without being corrupted.

Fixes #3707.
