### PR TITLE
Fix Netkan check for Ships/Script spec_version

### DIFF
--- a/Netkan/Validators/InstallValidator.cs
+++ b/Netkan/Validators/InstallValidator.cs
@@ -1,4 +1,7 @@
+using System.Linq;
+
 using Newtonsoft.Json.Linq;
+
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 
@@ -30,7 +33,15 @@ namespace CKAN.NetKAN.Validators
                     {
                         throw new Kraken("spec_version v1.25+ required to install to Missions");
                     }
-                    if (metadata.SpecVersion < v1p29 && install_to.StartsWith("Ships/Script"))
+                    if (metadata.SpecVersion < v1p29 && (
+                        install_to.StartsWith("Ships/Script")
+                        || install_to.Equals("Ships") && (
+                            // find: .../Script, install_to: Ships
+                            ((string)stanza["find"])?.Split(new char[] {'/'})?.LastOrDefault() == "Script"
+                            // file: .../Script, install_to: Ships
+                            || ((string)stanza["file"])?.Split(new char[] {'/'})?.LastOrDefault() == "Script"
+                            // install_to: Ships, as: Script
+                            || (((string)stanza["as"])?.EndsWith("Script") ?? false))))
                     {
                         throw new Kraken("spec_version v1.29+ required to install to Ships/Script");
                     }


### PR DESCRIPTION
## Background

kOS scripts are installed to `Ships/Script`. We added support for this in #3180, including a Netkan validation check that the `spec_version` was `v1.29` or later, since earlier versions of CKAN wouldn't support it.

## Problem

The check only triggers for one specific case:

```yaml
install:
  - install_to: Ships/Script
```

There are other ways to install into that path:

```yaml
install:
  - file: some/path/Script
    install_to: Ships
```

```yaml
install:
  - find: some/path/Script
    install_to: Ships
```

```yaml
install:
  - file / find: whatever
    install_to: Ships
    as: Script
```

Remembered while reviewing KSP-CKAN/NetKAN#9443, which almost slipped by with a bad `spec_version` because of it.

## Changes

Now the Netkan validation checks for these other cases. It may still miss some things, but it's better than no check at all.
