### PR TITLE
Use changeset tab for reinstall

### DIFF
--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -17,6 +17,7 @@ namespace CKAN.GUI
 
         public void LoadChangeset(List<ModChange> changes, List<ModuleLabel> AlertLabels)
         {
+            changeset = changes;
             alertLabels = AlertLabels;
             ChangesListView.Items.Clear();
             if (changes != null)
@@ -46,7 +47,7 @@ namespace CKAN.GUI
 
         public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
 
-        public event Action OnConfirmChanges;
+        public event Action<List<ModChange>> OnConfirmChanges;
         public event Action<bool> OnCancelChanges;
 
         private void ChangesListView_SelectedIndexChanged(object sender, EventArgs e)
@@ -56,11 +57,12 @@ namespace CKAN.GUI
 
         private void ConfirmChangesButton_Click(object sender, EventArgs e)
         {
-            OnConfirmChanges?.Invoke();
+            OnConfirmChanges?.Invoke(changeset);
         }
 
         private void CancelChangesButton_Click(object sender, EventArgs e)
         {
+            changeset = null;
             OnCancelChanges?.Invoke(true);
         }
 
@@ -92,6 +94,7 @@ namespace CKAN.GUI
             };
         }
 
+        private List<ModChange>   changeset;
         private List<ModuleLabel> alertLabels;
     }
 }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -706,7 +706,7 @@ namespace CKAN.GUI
             if (changeset != null && changeset.Any())
             {
                 tabController.ShowTab("ChangesetTabPage", 1, false);
-                UpdateChangesDialog(changeset.ToList());
+                UpdateChangesDialog(changeset);
                 auditRecommendationsMenuItem.Enabled = false;
             }
             else
@@ -862,9 +862,8 @@ namespace CKAN.GUI
         // This is used by Reinstall
         private void ManageMods_StartChangeSet(List<ModChange> changeset)
         {
-            Wait.StartWaiting(InstallMods, PostInstallMods, true,
-                new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                    changeset, RelationshipResolver.DependsOnlyOpts()));
+            UpdateChangesDialog(changeset);
+            tabController.ShowTab("ChangesetTabPage", 1);
         }
 
         private void RefreshModList(Dictionary<string, bool> oldModules = null)

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -31,23 +31,20 @@ namespace CKAN.GUI
             tabController.ShowTab("ManageModsTabPage");
         }
 
-        private void Changeset_OnConfirmChanges()
+        private void Changeset_OnConfirmChanges(List<ModChange> changeset)
         {
             DisableMainWindow();
-
-            // Using the changeset passed in can cause issues with versions.
-            // An example is Mechjeb for FAR at 25/06/2015 with a 1.0.2 install.
-            // TODO Work out why this is.
             try
             {
                 Wait.StartWaiting(InstallMods, PostInstallMods, true,
                     new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
-                        ManageMods.mainModList
-                            .ComputeUserChangeSet(RegistryManager.Instance(CurrentInstance).registry, CurrentInstance.VersionCriteria())
+                        changeset
+                            .Where(change =>
+                                // Skip dependencies so auto-installed checkbox is set
+                                !(change.Reasons.Any(reason =>
+                                    reason is SelectionReason.Depends)))
                             .ToList(),
-                        RelationshipResolver.DependsOnlyOpts()
-                    )
-                );
+                        RelationshipResolver.DependsOnlyOpts()));
             }
             catch (InvalidOperationException)
             {


### PR DESCRIPTION
## Problem

1. Install `xScienceContinued` (which will also install three dependencies)
2. Right-click it and select "Reinstall"
3. Click Yes in the confirmation popup
4. Click Continue on the recommendations screen
5. Install flow fails:
   ![reinstall](https://user-images.githubusercontent.com/1630166/203775951-34cb4097-cf64-4c39-8ebd-48f696c928ce.png)

## Cause

The changeset passed to the install flow for reinstallation includes the dependencies, so they're added to the resolver once as dependencies and then again later as user-selected, which triggers an exception.

## Changes

- Now the reinstall option jumps to the changeset tab instead of popping up a confirmation dialog, so you can see what it's going to do
- Now the changeset tab saves the changeset it displays and passes it to the install flow upon confirmation, rather than re-calculating the changeset from the mod list
- Now the reinstall option generates a changeset that includes removing the depending/dependency mods but excludes installation of dependencies that will be pulled in automatically

After this, reinstallation succeeds for these mods. I also tried installing RP-1 express and re-installing some of it, and that worked as well. :crossed_fingers: 

Fixes #3725.
