### PR TITLE
Show conflicts in changeset

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -112,6 +112,7 @@ namespace CKAN.GUI
             this.menuStrip2.CanOverflow = true;
             this.menuStrip2.Location = new System.Drawing.Point(0, 0);
             this.menuStrip2.Name = "menuStrip2";
+            this.menuStrip2.ShowItemToolTips = true;
             this.menuStrip2.Size = new System.Drawing.Size(5876, 48);
             this.menuStrip2.TabStop = true;
             this.menuStrip2.TabIndex = 4;
@@ -149,6 +150,7 @@ namespace CKAN.GUI
             //
             // ApplyToolButton
             //
+            this.ApplyToolButton.AutoToolTip = false;
             this.ApplyToolButton.Image = global::CKAN.GUI.Properties.Resources.apply;
             this.ApplyToolButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.ApplyToolButton.Name = "ApplyToolButton";

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -701,12 +701,14 @@ namespace CKAN.GUI
             );
         }
 
-        private void ManageMods_OnChangeSetChanged(List<ModChange> changeset)
+        private void ManageMods_OnChangeSetChanged(List<ModChange> changeset, Dictionary<GUIMod, string> conflicts)
         {
             if (changeset != null && changeset.Any())
             {
                 tabController.ShowTab("ChangesetTabPage", 1, false);
-                UpdateChangesDialog(changeset);
+                UpdateChangesDialog(
+                    changeset,
+                    conflicts.ToDictionary(item => item.Key.ToCkanModule(), item => item.Value));
                 auditRecommendationsMenuItem.Enabled = false;
             }
             else
@@ -862,7 +864,7 @@ namespace CKAN.GUI
         // This is used by Reinstall
         private void ManageMods_StartChangeSet(List<ModChange> changeset)
         {
-            UpdateChangesDialog(changeset);
+            UpdateChangesDialog(changeset, null);
             tabController.ShowTab("ChangesetTabPage", 1);
         }
 

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -7,13 +7,14 @@ namespace CKAN.GUI
 {
     public partial class Main
     {
-        private void UpdateChangesDialog(List<ModChange> changeset)
+        private void UpdateChangesDialog(List<ModChange> changeset, Dictionary<CkanModule, string> conflicts)
         {
             Changeset.LoadChangeset(
                 changeset,
                 ManageMods.mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                     .Where(l => l.AlertOnInstall)
-                    .ToList());
+                    .ToList(),
+                conflicts);
         }
 
         private void Changeset_OnSelectedItemsChanged(ListView.SelectedListViewItemCollection items)
@@ -26,7 +27,7 @@ namespace CKAN.GUI
             if (reset)
             {
                 ManageMods.ClearChangeSet();
-                UpdateChangesDialog(null);
+                UpdateChangesDialog(null, null);
             }
             tabController.ShowTab("ManageModsTabPage");
         }

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -19,7 +19,7 @@ namespace Tests.GUI
     public class ModListTests
     {
         [Test]
-        public void ComputeChangeSetFromModList_WithEmptyList_HasEmptyChangeSet()
+        public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList(delegate { });
             Assert.That(item.ComputeUserChangeSet(null, null), Is.Empty);


### PR DESCRIPTION
## Background

When a user tries to install mods that conflict with one another or with an installed mod, the apply changes button is disabled and a description of the conflict appears in the leftward part of the status bar.

## Motivation

It has been fairly common recently for users to ask why the apply changes button is disabled; many or most users don't notice the text in the lower left until it's pointed out.

## Changes

Now when the changeset has conflicts, you can still click the apply changes button, but the conflicting mods are highlighted in red in the changeset, the conflict reasons take over the description column, and the apply button is disabled:

![image](https://user-images.githubusercontent.com/1559108/221464777-0252acbd-0284-4ab3-a14d-5b9f57ac9108.png)

Hopefully this will make it more discoverable.
