### PR TITLE
Leave user requested dependencies in changeset

### DIFF
--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -39,10 +39,8 @@ namespace CKAN.GUI
                 Wait.StartWaiting(InstallMods, PostInstallMods, true,
                     new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                         changeset
-                            .Where(change =>
-                                // Skip dependencies so auto-installed checkbox is set
-                                !(change.Reasons.Any(reason =>
-                                    reason is SelectionReason.Depends)))
+                            // Only pass along user requested mods, so auto-installed can be determined
+                            .Where(ch => ch.Reasons.Any(r => r is SelectionReason.UserRequested))
                             .ToList(),
                         RelationshipResolver.DependsOnlyOpts()));
             }


### PR DESCRIPTION
## Problem

1. Launch the [current master branch build of CKAN](https://ksp-ckan.s3-us-west-2.amazonaws.com/ckan.exe) (bug does not exist in latest release)
2. On a fresh game instance, check the three checkboxes to install these mods:
   - Parallax
   - Parallax - Stock Scatter Textures
   - Parallax - Stock Planet Textures
3. Click Apply changes
4. The install flow launches, but no mods are installed, and then the changeset is cleared :sob: 

Reported by @vega-star on Discord. Many thanks for trying out the dev build and contributing feedback in enough detail to pinpoint this bug!

## Cause

#3726 made it so that when you click to confirm a changeset, instead of recalculating the changeset from the mod grid as we did previously, it used the data from the same changeset object that the user just viewed and approved in the changeset tab. This allows us to use the changeset tab for changesets other than the one selected on the main mod list (such as reinstallation via the right click menu, which cannot otherwise be represented by the main mod list's checkboxes).

But if we just used the _exact_ same changeset, then the auto-installed flag would never be set, because dependencies are included alongside user requested mods. We need to exclude auto-installed mods from the changeset so the core code can determine that they are in fact auto-installed. #3726 did this by excluding any mod that was a dependency of another mod in the changeset. Turns out that was wrong, because it's possible to pick several mods that are all mutual dependencies, which results in passing an empty changeset to the install flow.

## Changes

Now instead of filtering _out_ dependencies, we pick the user-requested mods, which is what #3726 should have done in the first place.
