### PR TITLE
Fix auto-removal

### DIFF
--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -40,7 +40,9 @@ namespace CKAN.GUI
                     new KeyValuePair<List<ModChange>, RelationshipResolverOptions>(
                         changeset
                             // Only pass along user requested mods, so auto-installed can be determined
-                            .Where(ch => ch.Reasons.Any(r => r is SelectionReason.UserRequested))
+                            .Where(ch => ch.Reasons.Any(r => r is SelectionReason.UserRequested)
+                                // Include all removes and upgrades
+                                || ch.ChangeType != GUIModChangeType.Install)
                             .ToList(),
                         RelationshipResolver.DependsOnlyOpts()));
             }


### PR DESCRIPTION
## Problem

1. Install MiniAVC (or any other mod)
2. Check the checkbox for auto-installed
3. Click Apply changes
4. The changeset tab appears and shows the mod being removed
5. Click Continue
6. The install flow does nothing

## Cause

#3726 made it so that when you click to confirm a changeset, instead of recalculating the changeset from the mod grid as we did previously, it used the data from the same changeset object that the user just viewed and approved in the changeset tab. This allows us to use the changeset tab for changesets other than the one selected on the main mod list (such as reinstallation via the right click menu, which cannot otherwise be represented by the main mod list's checkboxes).

#3728 changed it to filter out non-user-requested changes. But this means auto-removals are filtered out of the changeset because their reason is not `SelectionReason.UserRequested` but rather `SelectionReason.NoLongerUsed`. They should be kept.

## Changes

Now all non-install changes are passed from the changeset tab to the install flow. Only non-user-requested installs are filtered out.

Fixes #3738.
