### PR TITLE
Attempt to fix .NET 4.5 compilation issue with VS 2022

### DIFF
--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -30,6 +30,10 @@
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">
@@ -52,17 +56,10 @@
       <InputAssemblies Include="fr-FR\$(AssemblyName).resources.dll" />
       <InputAssemblies Include="ru-RU\$(AssemblyName).resources.dll" />
     </ItemGroup>
-    <ILRepack OutputAssembly="AutoUpdater.exe"
-              MainAssembly="$(AssemblyName).exe"
-              InputAssemblies="@(InputAssemblies)"
-              OutputType="$(OutputType)"
-              WorkingDirectory="$(OutputPath)"
-              Internalize="true"
-              Parallel="true" />
+    <ILRepack OutputAssembly="AutoUpdater.exe" MainAssembly="$(AssemblyName).exe" InputAssemblies="@(InputAssemblies)" OutputType="$(OutputType)" WorkingDirectory="$(OutputPath)" Internalize="true" Parallel="true" />
     <ItemGroup>
       <Repacked Include="$(OutputPath)AutoUpdater.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(Repacked)"
-          DestinationFolder="..\_build\repack\$(Configuration)" />
+    <Copy SourceFiles="@(Repacked)" DestinationFolder="..\_build\repack\$(Configuration)" />
   </Target>
 </Project>

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
     <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="ReadLine" Version="1.2.0" />
   </ItemGroup>

--- a/ConsoleUI/CKAN-ConsoleUI.csproj
+++ b/ConsoleUI/CKAN-ConsoleUI.csproj
@@ -26,6 +26,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -43,7 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NJsonSchema" Version="10.0.27" />
   </ItemGroup>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -38,6 +38,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>CKAN-GUI</AssemblyName>
@@ -39,6 +39,10 @@
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="ini-parser" Version="3.4.0" />
     <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
@@ -250,7 +254,7 @@
       <DependentUpon>EditModSearchDetails.cs</DependentUpon>
     </Compile>
     <Compile Include="Controls\LeftRightRowPanel.cs">
-      <SubType>UserControl</SubType>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\ManageMods.cs">
       <SubType>UserControl</SubType>
@@ -967,7 +971,6 @@
     <EmbeddedResource Include="Localization\zh-CN\Metadata.zh-CN.resx">
       <DependentUpon>..\..\Controls\ModInfoTabs\Metadata.cs</DependentUpon>
     </EmbeddedResource>
-
     <EmbeddedResource Include="Localization\de-DE\Relationships.de-DE.resx">
       <DependentUpon>..\..\Controls\ModInfoTabs\Relationships.cs</DependentUpon>
     </EmbeddedResource>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="ini-parser" Version="3.4.0" />
-    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -38,18 +38,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.103.64" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.102.31" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.103.8" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.46" />
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="log4net" Version="2.0.10" />
-    <PackageReference Include="Namotion.Reflection" Version="1.0.7" />
+    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="Namotion.Reflection" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="YamlDotNet" Version="9.1.0" />
+    <PackageReference Include="YamlDotNet" Version="12.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -41,6 +41,10 @@
     <PackageReference Include="AWSSDK.Core" Version="3.3.103.64" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.102.31" />
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Namotion.Reflection" Version="1.0.7" />

--- a/README_NET45.md
+++ b/README_NET45.md
@@ -1,0 +1,13 @@
+### How to get this compiling on VS 2022 and later
+
+Visual Studio 2022 and later can't install the .NET 4.5 Developer Pack for working on these projects. Until migration is decided upon for .NET 4.7 and later, you may need to do the following to work with this project...
+
+1. ZIP up a backup copy of **C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5**
+
+2. Delete **C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5**
+
+3. **Copy C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1** or **v.4.5.2** to **C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5**
+
+4. Project should load normally.
+
+Reference: https://thomaslevesque.com/2021/11/12/building-a-project-that-target-net-45-in-visual-studio-2022/

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -42,6 +42,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Moq" Version="4.14.5" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -47,10 +47,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="log4net" Version="2.0.10" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="YamlDotNet" Version="9.1.0" />
+    <PackageReference Include="YamlDotNet" Version="12.3.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>


### PR DESCRIPTION
@HebaruSan Happy New Year! This is a follow-up to #3749; it attempts to correct compilation issues on Visual Studio 2022 by adding references to .NET 4.5 assemblies in the project files, minor dependency updates, and instructions on how to further "hack" the dev environment to accept these projects without triggering the dead Dev Pack download.
