### PR TITLE
Set git safe.directory in meta tester

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -5,6 +5,7 @@ RUN /bin/sed -i 's/^mozilla\/DST_Root_CA_X3.crt$/!mozilla\/DST_Root_CA_X3.crt/' 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools git build-essential python3-dev libffi-dev && \
     apt-get clean
+RUN git config --global --add safe.directory '*'
 RUN pip3 install 'git+https://github.com/KSP-CKAN/NetKAN-Infra#subdirectory=netkan'
 RUN pip3 install 'git+https://github.com/KSP-CKAN/xKAN-meta_testing'
 


### PR DESCRIPTION
## Problem

See KSP-CKAN/NetKAN#9527; the metadata tester is broken, but that attempt has not fixed the problem.

## Causes

Probing the docker image, I have slightly more confirmation now that this relates somehow to the permissions of the git repo (see the later comments in KSP-CKAN/NetKAN#9527).

However, there's a big gap in this explanation: **NOTHING CHANGED**. It's using the same old version of `git`, GitPython is probably the same, and our code is the same. For this to start happening when it did would imply that GitHub made some change to how Actions handle permissions right at the moment when we were rebuilding this docker image. So :shrug:.

## Changes

Now the Dockerfile for the meta tester sets git's `safe.directory` setting to `*`, which should allow our code to access the repo regardless of the mess that the GitHub Actions framework makes of the ownership or permissions.

I'll self-review this because it's low risk (the thing is already broken) and I want to test it right away.
