### PR TITLE
Fix mkbundle executable crash

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Transactions;
+using System.Diagnostics;
+
 using ChinhDo.Transactions.FileManager;
 using log4net;
 using Newtonsoft.Json;
@@ -241,9 +243,15 @@ namespace CKAN
 
             // Find the directory our executable is stored in.
             string exeDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            if (exeDir.Length == 0)
+            if (string.IsNullOrEmpty(exeDir))
             {
-                return null;
+                exeDir = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+                if (string.IsNullOrEmpty(exeDir))
+                {
+                    log.InfoFormat("Executing assembly path and main module path not found");
+                    return null;
+                }
+                log.InfoFormat("Executing assembly path not found, main module path is {0}", exeDir);
             }
 
             log.DebugFormat("Checking if {0} is in my exe dir: {1}",

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -241,6 +241,10 @@ namespace CKAN
 
             // Find the directory our executable is stored in.
             string exeDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+			if (exeDir.Length == 0)
+			{
+				return null;
+			}
 
             log.DebugFormat("Checking if {0} is in my exe dir: {1}",
                 game.ShortName, exeDir);

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -241,10 +241,10 @@ namespace CKAN
 
             // Find the directory our executable is stored in.
             string exeDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-			if (exeDir.Length == 0)
-			{
-				return null;
-			}
+            if (exeDir.Length == 0)
+            {
+                return null;
+            }
 
             log.DebugFormat("Checking if {0} is in my exe dir: {1}",
                 game.ShortName, exeDir);


### PR DESCRIPTION
In `CKAN.GameInstance.PortableDir (CKAN.Games.IGame game)`:

```cs
            // Find the directory our executable is stored in.
            string exeDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
````

An empty string would be assigned to `exeDir` when ckan is packaged
using mkbundle. This caused following method call
`game.GameInFolder(new DirectoryInfo(exeDir))` to crash with
`System.ArgumentException: The specified path is not of a legal form (empty).`

```
mkbundle --deps -o ckan --simple --machine-config /etc/mono/4.5/machine.config --config /etc/mono/config --simple ckan.exe
```