### PR TITLE
Clarify mod list saving options, add menu hotkeys

### DIFF
--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -123,27 +123,27 @@
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>File</value></data>
-  <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>Manage game instances</value></data>
-  <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Open game directory</value></data>
-  <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>Install from .ckan...</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list...</value></data>
-  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Export modpack...</value></data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Import downloaded mods...</value></data>
-  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Audit recommendations</value></data>
+  <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>&amp;File</value></data>
+  <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>&amp;Manage game instances</value></data>
+  <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Open game directory</value></data>
+  <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Install from .ckan...</value></data>
+  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list (cannot be re-imported)...</value></data>
+  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Export modpack (can be re-imported)...</value></data>
+  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
+  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Audit &amp;recommendations</value></data>
   <data name="ExitToolButton.Text" xml:space="preserve"><value>E&amp;xit</value></data>
-  <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>Settings</value></data>
-  <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN settings</value></data>
-  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN plugins</value></data>
-  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation filters</value></data>
-  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>Game command-line</value></data>
-  <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>Compatible game versions</value></data>
-  <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>Help</value></data>
-  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>User guide</value></data>
-  <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>Discord</value></data>
-  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN client</value></data>
-  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod metadata</value></data>
-  <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>About</value></data>
+  <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Settings</value></data>
+  <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;settings</value></data>
+  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;plugins</value></data>
+  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;filters</value></data>
+  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Game command-line</value></data>
+  <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Compatible game versions</value></data>
+  <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Help</value></data>
+  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>&amp;User guide</value></data>
+  <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Discord</value></data>
+  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN &amp;client</value></data>
+  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod &amp;metadata</value></data>
+  <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>&amp;About</value></data>
   <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Manage mods</value></data>
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Changeset</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Status log</value></data>
@@ -161,6 +161,6 @@
   <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Open Game Directory</value></data>
   <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Settings</value></data>
   <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quit</value></data>
-  <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play time...</value></data>
+  <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play &amp;time...</value></data>
   <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
 </root>


### PR DESCRIPTION
## Problem

If a user wants to install their current mod list on another computer or share it with friends, they might click File &rarr; Save installed mod list... to generate a text file with their list of mods. However, there is no way to use this file to install that same mod list somewhere else. (It's mainly useful for posting your mod list to the forum.)

Thanks to Discord user SpaceTrash67 for bringing this up.

## Cause

It's not easy to tell the difference between the menu options:

![image](https://user-images.githubusercontent.com/1559108/217111244-08c7bacc-efbb-4614-9d38-39baea2499e3.png)

In the given use case, the user would have to try to guess and maybe experiment with these options to learn what they do.

## Changes

Now the English versions of these menu options have a parenthetical clarification explaining whether the files they create can be re-imported, similar to what we did in #3400:

![image](https://user-images.githubusercontent.com/1559108/217110943-3c150490-05f0-4ffe-82e5-f90b67337efb.png)

Other locales would have to be updated subsequently by their individual translators.

I also added hotkeys to the menus and made the existing hotkeys more consistent; <kbd>i</kbd> should really install rather than import, since the latter is much less commonly used.
