### PR TITLE
Fix FIPS-mode exceptions on Windows for SHA256

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -711,7 +711,7 @@ namespace CKAN
         /// SHA256 hash, in all-caps hexadecimal format
         /// </returns>
         public string GetFileHashSha256(string filePath, IProgress<long> progress)
-            => GetFileHash<SHA256Managed>(filePath, "sha256", sha256Cache, progress);
+            => GetFileHash<SHA256CryptoServiceProvider>(filePath, "sha256", sha256Cache, progress);
 
         /// <summary>
         /// Calculate the hash of a file


### PR DESCRIPTION
## Background

FIPS stands for Federal Information Processing Standard, and it specifies a list of cryptographic algorithms that are considered secure enough for security:

- https://learn.microsoft.com/en-us/answers/questions/211279/sharepoint-2016-configuration-failed-this-implemen.html
- https://learn.microsoft.com/en-us/sharepoint/security-for-sharepoint-server/federal-information-processing-standard-security-standards
- https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/system-cryptography-use-fips-compliant-algorithms-for-encryption-hashing-and-signing
- https://docs.trendmicro.com/all/ent/sc/v3.0/en-US/cmcolh/t_fips.html

Windows has a setting to throw exceptions if an application tries to use one of its official crypto objects that isn't FIPS-compliant. (Of course, if you roll your own SHA1 function, it has no idea you've done that.)

CKAN uses hashes to detect corrupted downloads, not for security purposes.

## Problem

CKAN users with the FIPS setting enabled report this exception after downloading mods:

```
Unhandled exception:
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: This implementation is not part of the Windows Platform FIPS validated cryptographic algorithms.
   at System.Security.Cryptography.SHA256Managed..ctor()
   --- End of inner exception stack trace ---
   at System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean noCheck, Boolean& canBeCached, RuntimeMethodHandleInternal& ctor, Boolean& bNeedSecurityCheck)
   at System.RuntimeType.CreateInstanceSlow(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache, StackCrawlMark& stackMark)
   at System.Activator.CreateI
![ScreenShot_20230212113323](https://user-images.githubusercontent.com/10908465/218323959-7acdb83d-5aad-48c2-a8f3-038b49d2b0f0.png)
![image_2023-02-12_113428399](https://user-images.githubusercontent.com/10908465/218323964-03549ba4-4a64-4281-91a7-6cf624ac173f.png)
nstance[T]()
   at CKAN.NetFileCache.GetFileHash[T](String filePath, String hashSuffix, Dictionary`2 cache, IProgress`1 progress)
   at CKAN.NetFileCache.GetFileHashSha256(String filePath, IProgress`1 progress)
   at CKAN.NetModuleCache.Store(CkanModule module, String path, IProgress`1 progress, String description, Boolean move)
   at CKAN.NetAsyncModulesDownloader.ModuleDownloadComplete(Uri url, String filename, Exception error, String etag)
   at CKAN.NetAsyncDownloader.FileDownloadComplete(Int32 index, Exception error, Boolean canceled, String etag)
   at CKAN.NetAsyncDownloader.<>c__DisplayClass20_0.<DownloadModule>b__1(Object sender, AsyncCompletedEventArgs args, String etag)
   at System.Net.WebClient.OnDownloadFileCompleted(AsyncCompletedEventArgs e)
   at CKAN.ResumingWebClient.OnOpenReadCompleted(OpenReadCompletedEventArgs e)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch() 
```

## Causes

Apparently using `SHA1Managed` or `SHA256Managed` throws this exception if you have FIPS enabled.

This happened once before for SHA1, see #1497 and #1850. At that time the SHA1 code was fixed and the SHA256 code was not touched because the client wasn't using it (in #2243 the client began using SHA256 to validate downloads). Back then `SHA1Managed` was replaced by `SHA1Cng`, which #2820 later changed to `SHA1CryptoServiceProvider`.

https://github.com/KSP-CKAN/CKAN/blob/98f2836a5c144b9e5e73b6ee5c854c178ad80e4b/Core/Net/NetFileCache.cs#L702-L703

Since the exception is thrown for SHA256, which is calculated after SHA1, I take this to mean that `SHA1CryptoServiceProvider` works without upsetting FIPS.

## Changes

Now we use `SHA256CryptoServiceProvider`. This should suppress the FIPS exception.

Fixes #3773.
