### PR TITLE
Support cancellation of download checksums

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
+using System.Threading;
 using System.Security.Permissions;
 using System.Security.Cryptography;
 
@@ -699,8 +700,8 @@ namespace CKAN
         /// <returns>
         /// SHA1 hash, in all-caps hexadecimal format
         /// </returns>
-        public string GetFileHashSha1(string filePath, IProgress<long> progress)
-            => GetFileHash<SHA1CryptoServiceProvider>(filePath, "sha1", sha1Cache, progress);
+        public string GetFileHashSha1(string filePath, IProgress<long> progress, CancellationToken cancelToken = default(CancellationToken))
+            => GetFileHash<SHA1CryptoServiceProvider>(filePath, "sha1", sha1Cache, progress, cancelToken);
 
         /// <summary>
         /// Calculate the SHA256 hash of a file
@@ -710,8 +711,8 @@ namespace CKAN
         /// <returns>
         /// SHA256 hash, in all-caps hexadecimal format
         /// </returns>
-        public string GetFileHashSha256(string filePath, IProgress<long> progress)
-            => GetFileHash<SHA256CryptoServiceProvider>(filePath, "sha256", sha256Cache, progress);
+        public string GetFileHashSha256(string filePath, IProgress<long> progress, CancellationToken cancelToken = default(CancellationToken))
+            => GetFileHash<SHA256CryptoServiceProvider>(filePath, "sha256", sha256Cache, progress, cancelToken);
 
         /// <summary>
         /// Calculate the hash of a file
@@ -721,7 +722,7 @@ namespace CKAN
         /// <returns>
         /// Hash, in all-caps hexadecimal format
         /// </returns>
-        private string GetFileHash<T>(string filePath, string hashSuffix, Dictionary<string, string> cache, IProgress<long> progress)
+        private string GetFileHash<T>(string filePath, string hashSuffix, Dictionary<string, string> cache, IProgress<long> progress, CancellationToken cancelToken)
             where T: HashAlgorithm, new()
         {
             string hash = null;
@@ -742,7 +743,7 @@ namespace CKAN
                 using (BufferedStream bs     = new BufferedStream(fs))
                 using (T              hasher = new T())
                 {
-                    hash = BitConverter.ToString(hasher.ComputeHash(bs, progress)).Replace("-", "");
+                    hash = BitConverter.ToString(hasher.ComputeHash(bs, progress, cancelToken)).Replace("-", "");
                     cache.Add(filePath, hash);
                     if (Path.GetDirectoryName(hashFile) == Path.GetFullPath(cachePath))
                     {


### PR DESCRIPTION
## Problem

1. Choose to install a large mod on Windows (so the validation step will take long enough that you have to wait for it)
2. Apply changes
3. Wait till the download is finished and the ZIP is being validated (you'll see the progress bar's label change)
4. Click cancel during the validation step
5. Apply changes again
6. The file will re-validate, probably with its progress bar flickering back and forth; wait till it finishes
7. An exception is thrown:

```
Unhandled exception:
System.IO.IOException: The process cannot access the file 'C:\Users\danny\AppData\Local\CKAN\downloads\downloading\E4B2C9E4-Parallax-StockTextures-2.0.0.zip' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.File.InternalDelete(String path, Boolean checkHost)
   at CKAN.NetAsyncModulesDownloader.ModuleDownloadComplete(Uri url, String filename, Exception error, String etag)
   at CKAN.NetAsyncDownloader.FileDownloadComplete(Int32 index, Exception error, Boolean canceled, String etag)
   at CKAN.NetAsyncDownloader.<>c__DisplayClass20_0.<DownloadModule>b__1(Object sender, AsyncCompletedEventArgs args, String etag)
   at System.Net.WebClient.OnDownloadFileCompleted(AsyncCompletedEventArgs e)
   at CKAN.ResumingWebClient.OnOpenReadCompleted(OpenReadCompletedEventArgs e)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch() 
```

## Cause

The validation step doesn't support cancellation (even though we included it in the _low-level_ `ComputeHash` extension function in #3659), so when the second install attempt starts, the original validation is still happening, and another one starts up in parallel. Then one thread (probably the first one that the user tried to cancel) finishes and tries to copy the temp file to the cache and delete it. But the other thread is still validating the temp file, so the deletion attempt throws an exception (on Windows, which locks files that are in use).

## Changes

Now if the user clicks cancel while a mod is being validated, validation will stop before the file is copied to cache and deleted, so future install attempts can proceed without being blocked by another thread.

The file will be left in the in-progress download folder because there's most likely nothing wrong with it, and if there is something wrong, it will be caught in any future validation attempts.

Fixes #3777.

### Known limitations

`NetFileCache.ZipValid` can't be cancelled, because [`ZipFile.TestArchive` can't be cancelled](https://icsharpcode.github.io/SharpZipLib/help/api/ICSharpCode.SharpZipLib.Zip.ZipFile.html#ICSharpCode_SharpZipLib_Zip_ZipFile_TestArchive_System_Boolean_ICSharpCode_SharpZipLib_Zip_TestStrategy_ICSharpCode_SharpZipLib_Zip_ZipTestResultHandler_). So if the user tries to cancel while this is in progress, it will finish that step, and then the cancellation happens afterwards before the SHA1 check starts. This should still be fine since the deletion attempt will no longer occur.

(The SHA1 and SHA256 checks are both immediately cancellable.)
