### PR TITLE
Single word Polish translation for is:cached

### DIFF
--- a/GUI/Properties/Resources.pl-PL.resx
+++ b/GUI/Properties/Resources.pl-PL.resx
@@ -963,7 +963,7 @@ Czy chcesz zezwolić na to CKAN-owi? Jeśli klikniesz nie, nie zobaczysz tej wia
     <value>zainstalowane</value>
   </data>
   <data name="ModSearchCachedSuffix" xml:space="preserve">
-    <value>w-folderze-cache</value>
+    <value>pobrane</value>
   </data>
   <data name="ModSearchNewlyCompatibleSuffix" xml:space="preserve">
     <value>nowo-kompatybilne</value>


### PR DESCRIPTION
@Kalessin1 suggested a one-word Polish translation for `is:cached` here (after #3780 replaced the spaces of the previous translation with dashes):

https://forum.kerbalspaceprogram.com/index.php?/topic/197082-ckan-the-comprehensive-kerbal-archive-network-v1312-juno/&do=findComment&comment=4234435

Now this translation is used.
I'll self-review this minor l10n string change.
