### PR TITLE
Skip duplicate repo URLs during update

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -68,7 +68,6 @@ namespace CKAN.Extensions
             => source.Aggregate(TimeSpan.Zero,
                                 (a, b) => a + b);
 
-
         /// <summary>
         /// Select : SelectMany :: Zip : ZipMany
         /// </summary>
@@ -78,6 +77,15 @@ namespace CKAN.Extensions
         /// <returns>Flattened sequence of values from func applies to seq1 and seq2</returns>
         public static IEnumerable<V> ZipMany<T, U, V>(this IEnumerable<T> seq1, IEnumerable<U> seq2, Func<T, U, IEnumerable<V>> func)
             => seq1.Zip(seq2, func).SelectMany(seqs => seqs);
+
+        /// <summary>
+        /// Eliminate duplicate elements based on the value returned by a callback
+        /// </summary>
+        /// <param name="seq">Sequence of elements to check</param>
+        /// <param name="func">Function to return unique value per element</param>
+        /// <returns>Sequence where each element has a unique return value</returns>
+        public static IEnumerable<T> DistinctBy<T, U>(this IEnumerable<T> seq, Func<T, U> func)
+            => seq.GroupBy(func).Select(grp => grp.First());
 
     }
 

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -141,7 +141,7 @@ namespace CKAN
             // Create a handle for the tar stream
             using (TarInputStream tarStream = new TarInputStream(gzipStream, Encoding.UTF8))
             {
-                user.RaiseMessage("Loading modules from {0} repository...", repo.name);
+                user.RaiseMessage(Properties.Resources.NetRepoLoadingModulesFromRepo, repo.name);
                 TarEntry entry;
                 int prevPercent = 0;
                 while ((entry = tarStream.GetNextEntry()) != null)
@@ -152,7 +152,7 @@ namespace CKAN
                     {
                         downloadCounts = JsonConvert.DeserializeObject<SortedDictionary<string, int>>(
                             tarStreamString(tarStream, entry));
-                        user.RaiseMessage("Loaded download counts from {0} repository", repo.name);
+                        user.RaiseMessage(Properties.Resources.NetRepoLoadedDownloadCounts, repo.name);
                     }
                     else if (filename.EndsWith(".ckan"))
                     {
@@ -160,7 +160,9 @@ namespace CKAN
                         var percent = (int)(100 * inputStream.Position / inputStream.Length);
                         if (percent > prevPercent)
                         {
-                            user.RaiseProgress($"Loading modules from {repo.name} repository", percent);
+                            user.RaiseProgress(
+                                string.Format(Properties.Resources.NetRepoLoadingModulesFromRepo, repo.name),
+                                percent);
                             prevPercent = percent;
                         }
 
@@ -229,7 +231,9 @@ namespace CKAN
                         var percent = (int)(100 * index / zipfile.Count);
                         if (percent > prevPercent)
                         {
-                            user.RaiseProgress($"Loading modules from {repo.name} repository", percent);
+                            user.RaiseProgress(
+                                string.Format(Properties.Resources.NetRepoLoadingModulesFromRepo, repo.name),
+                                percent);
                         }
 
                         // Read each file into a string.

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -37,7 +37,9 @@ namespace CKAN
         /// </summary>
         public static RepoUpdateResult UpdateAllRepositories(RegistryManager registry_manager, GameInstance ksp, NetAsyncDownloader downloader, NetModuleCache cache, IUser user)
         {
-            var repos = registry_manager.registry.Repositories.Values.ToArray();
+            var repos = registry_manager.registry.Repositories.Values
+                .DistinctBy(r => r.uri)
+                .ToArray();
 
             // Get latest copy of the game versions data (remote build map)
             user.RaiseMessage(Properties.Resources.NetRepoUpdatingBuildMap);

--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -156,6 +156,12 @@ namespace CKAN.Properties {
         internal static string NetRepoInconsistenciesHeader {
             get { return (string)(ResourceManager.GetObject("NetRepoInconsistenciesHeader", resourceCulture)); }
         }
+        internal static string NetRepoLoadingModulesFromRepo {
+            get { return (string)(ResourceManager.GetObject("NetRepoLoadingModulesFromRepo", resourceCulture)); }
+        }
+        internal static string NetRepoLoadedDownloadCounts {
+            get { return (string)(ResourceManager.GetObject("NetRepoLoadedDownloadCounts", resourceCulture)); }
+        }
 
         internal static string JsonRelationshipConverterAnyOfCombined {
             get { return (string)(ResourceManager.GetObject("JsonRelationshipConverterAnyOfCombined", resourceCulture)); }

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -155,6 +155,8 @@ You should reinstall them in order to preserve consistency with the repository.
 
 Do you wish to reinstall now?</value></data>
   <data name="NetRepoInconsistenciesHeader" xml:space="preserve"><value>The following inconsistencies were found:</value></data>
+  <data name="NetRepoLoadingModulesFromRepo" xml:space="preserve"><value>Loading modules from {0} repository...</value></data>
+  <data name="NetRepoLoadedDownloadCounts" xml:space="preserve"><value>Loaded download counts from {0} repository</value></data>
   <data name="JsonRelationshipConverterAnyOfCombined" xml:space="preserve"><value>`any_of` should not be combined with `{0}`</value></data>
   <data name="RegistryFileConflict" xml:space="preserve"><value>{0} wishes to install {1}, but this file is registered to {2}</value></data>
   <data name="RegistryFileNotRemoved" xml:space="preserve"><value>{0} is registered to {1} but has not been removed!</value></data>


### PR DESCRIPTION
## Problem

A user reported this exception at start-up (partially translated from Chinese):

```
Unhandled exception:
System.ArgumentException: An item with the same key has already been added.
   在 System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   在 System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   在 CKAN.Repo.<>c__DisplayClass0_0.<UpdateAllRepositories>b__1(Uri url, String filename, Exception error, String etag)
   在 CKAN.NetAsyncDownloader.FileDownloadComplete(Int32 index, Exception error, Boolean canceled, String etag)
   在 CKAN.NetAsyncDownloader.<>c__DisplayClass20_0.<DownloadModule>b__1(Object sender, AsyncCompletedEventArgs args, String etag)
   在 System.Net.WebClient.OnDownloadFileCompleted(AsyncCompletedEventArgs e)
   在 CKAN.ResumingWebClient.OnOpenReadCompleted(OpenReadCompletedEventArgs e)
   在 System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   在 System.Threading.ThreadPoolWorkQueue.Dispatch() 
```

## Cause

This callback could throw that exception if you had multiple repos configured to use the same URL:

https://github.com/KSP-CKAN/CKAN/blob/8390a617db167e79255ed0da2a8416e3cb3b8e4c/Core/Net/Repo.cs#L56-L58

Doing that would not make sense, but apparently it happened anyway.

## Changes

Now we filter out repo entries with duplicate URLs early in the update process, so we'll only download them once and the exception will not be thrown.

Also some strings in repo updating that I forgot to internationalize in #3645 are now internationalized.

Fixes #3761.