### PR TITLE
Fix index -1 exception in Manage Instances

### DIFF
--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -79,8 +79,8 @@ namespace CKAN.GUI
             var allSameGame = _manager.Instances.Select(i => i.Value.game).Distinct().Count() <= 1;
             var hasPlayTime = _manager.Instances.Any(instance => (instance.Value.playTime?.Time ?? TimeSpan.Zero) > TimeSpan.Zero);
 
-            AddOrRemoveColumn(GameInstancesListView, Game, !allSameGame);
-            AddOrRemoveColumn(GameInstancesListView, GamePlayTime, hasPlayTime);
+            AddOrRemoveColumn(GameInstancesListView, Game, !allSameGame, GameInstallVersion.Index);
+            AddOrRemoveColumn(GameInstancesListView, GamePlayTime, hasPlayTime, GameInstallPath.Index);
 
             GameInstancesListView.Items.AddRange(_manager.Instances
                 .OrderByDescending(instance => instance.Value.Version())
@@ -95,11 +95,11 @@ namespace CKAN.GUI
             GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
         }
 
-        private void AddOrRemoveColumn(ListView listView, ColumnHeader column, bool condition)
+        private void AddOrRemoveColumn(ListView listView, ColumnHeader column, bool condition, int index)
         {
             if (condition && !listView.Columns.Contains(column))
             {
-                listView.Columns.Insert(column.Index, column);
+                listView.Columns.Insert(index, column);
             }
             else if (!condition && listView.Columns.Contains(column))
             {


### PR DESCRIPTION
## Problem

1. Open the manage game instances dialog
2. "Forget" all instances that have hours played (see #3543), if any; the Hours Played column will disappear if it was visible
3. Now add an instance that has hours played (again see #3543 for how to set this up), you'll get an exception and the instance list will fail to populate:

![image](https://user-images.githubusercontent.com/1559108/222597801-ce0111e2-a8f0-4478-b3bf-d32e8024b327.png)

![image](https://user-images.githubusercontent.com/1559108/222597807-6dd79194-e3fb-470a-b2d1-fbf4c944d2c3.png)

Noticed during dev of #3797 (in relation to the Game column instead), but I think I recall sporadic reports of this without those changes that I couldn't pin down at the time, so it seemed worth splitting into its own fix.

## Cause

The list view has two columns that are sometimes visible and sometimes hidden: Game and Hours Played. To hide them, we remove them from the list view. If they become visible again, we insert them using their `Column.Index` property, which unfortunately is `-1` for any column not already in the list:

- <https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.columnheader.index?view=netframework-4.7>

> If the [ColumnHeader](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.columnheader?view=netframework-4.7) is not contained within a [ListView](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.listview?view=netframework-4.7) control this property returns a value of -1.

Inserting the column with an index of `-1` throws an exception. This happens anytime a previously hidden column is supposed to become visible (including adding a KSP2 instance to a list of KSP1 instances in #3797).

## Changes

Now instead of using the column's own index property, the show/hide helper function has an index parameter, into which we pass the index of the _next_ column in the normal layout that is always visible. This makes the columns hide and reappear properly without exceptions.
