### PR TITLE
Cache path setting fixes

### DIFF
--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -28,6 +28,8 @@ namespace CKAN.Extensions
             return true;
         }
 
+        private static readonly char[] pathDelims = new char[] {Path.DirectorySeparatorChar};
+
         /// <summary>
         /// Check whether a given path is an ancestor of another
         /// </summary>
@@ -36,10 +38,8 @@ namespace CKAN.Extensions
         /// <returns>true if child is a descendant of parent, false otherwise</returns>
         public static bool IsAncestorOf(this DirectoryInfo parent, DirectoryInfo child)
             => StringArrayStartsWith(
-                child.FullName.Split(new char[] {Path.DirectorySeparatorChar},
-                                     StringSplitOptions.RemoveEmptyEntries),
-                parent.FullName.Split(new char[] {Path.DirectorySeparatorChar},
-                                      StringSplitOptions.RemoveEmptyEntries));
+                child.FullName.Split(pathDelims, StringSplitOptions.RemoveEmptyEntries),
+                parent.FullName.Split(pathDelims, StringSplitOptions.RemoveEmptyEntries));
 
         /// <summary>
         /// Extension method to fill in the gap of getting from a
@@ -51,7 +51,8 @@ namespace CKAN.Extensions
         /// <returns>The DriveInfo associated with this directory</returns>
         public static DriveInfo GetDrive(this DirectoryInfo dir)
             => DriveInfo.GetDrives()
-                        .Where(dr => dr.RootDirectory.IsAncestorOf(dir))
+                        .Where(dr => dr.RootDirectory == dir
+                                     || dr.RootDirectory.IsAncestorOf(dir))
                         .OrderByDescending(dr => dr.RootDirectory.FullName.Length)
                         .FirstOrDefault();
 

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -68,8 +68,8 @@ namespace CKAN
                     Properties.Resources.NetFileCacheCannotFind, cachePath));
             }
 
-            // Files go here while they're downloading
-            Directory.CreateDirectory(InProgressPath);
+            // Make sure we can access it
+            var bytesFree = new DirectoryInfo(cachePath)?.GetDrive()?.AvailableFreeSpace ?? 0;
 
             // Establish a watch on our cache. This means we can cache the directory contents,
             // and discard that cache if we spot changes.
@@ -107,14 +107,18 @@ namespace CKAN
             watcher.Dispose();
         }
 
+        // Files go here while they're downloading
         private string InProgressPath => Path.Combine(cachePath, "downloading");
 
         private string GetInProgressFileName(string hash, string description)
-            => Directory.EnumerateFiles(InProgressPath)
-                .Where(path => new FileInfo(path).Name.StartsWith(hash))
-                .FirstOrDefault()
-                // If not found, return the name to create
-                ?? Path.Combine(InProgressPath, $"{hash}-{description}");
+        {
+            Directory.CreateDirectory(InProgressPath);
+            return Directory.EnumerateFiles(InProgressPath)
+                            .Where(path => new FileInfo(path).Name.StartsWith(hash))
+                            .FirstOrDefault()
+                   // If not found, return the name to create
+                   ?? Path.Combine(InProgressPath, $"{hash}-{description}");
+        }
 
         public string GetInProgressFileName(Uri url, string description)
             => GetInProgressFileName(NetFileCache.CreateURLHash(url),
@@ -300,7 +304,7 @@ namespace CKAN
             numFiles = 0;
             numBytes = 0;
             GetSizeInfo(cachePath, ref numFiles, ref numBytes);
-            bytesFree = new DirectoryInfo(cachePath).GetDrive()?.AvailableFreeSpace ?? 0;
+            bytesFree = new DirectoryInfo(cachePath)?.GetDrive()?.AvailableFreeSpace ?? 0;
             foreach (var legacyDir in legacyDirs())
             {
                 GetSizeInfo(legacyDir, ref numFiles, ref numBytes);

--- a/GUI/Dialogs/SettingsDialog.resx
+++ b/GUI/Dialogs/SettingsDialog.resx
@@ -129,9 +129,9 @@
   <data name="NewAuthTokenButton.Text" xml:space="preserve"><value>New</value></data>
   <data name="DeleteAuthTokenButton.Text" xml:space="preserve"><value>Delete</value></data>
   <data name="CacheGroupBox.Text" xml:space="preserve"><value>Download Cache</value></data>
-  <data name="CacheSummary.Text" xml:space="preserve"><value>N files, M MB</value></data>
+  <data name="CacheSummary.Text" xml:space="preserve"><value>N files, M MiB</value></data>
   <data name="CacheLimitPreLabel.Text" xml:space="preserve"><value>Maximum cache size:</value></data>
-  <data name="CacheLimitPostLabel.Text" xml:space="preserve"><value>MB (empty for unlimited)</value></data>
+  <data name="CacheLimitPostLabel.Text" xml:space="preserve"><value>MiB (empty for unlimited)</value></data>
   <data name="ChangeCacheButton.Text" xml:space="preserve"><value>Change...</value></data>
   <data name="ClearCacheButton.Text" xml:space="preserve"><value>Purge</value></data>
   <data name="PurgeToLimitMenuItem.Text" xml:space="preserve"><value>Purge to limit</value></data>


### PR DESCRIPTION
## Problem

If you go to the settings and try to type a valid full path with drive letters into the cache path field, it silently gets "stuck" after the drive letter behind the scenes. Upon re-opening the settings the field is blank and can't be edited:

![image](https://user-images.githubusercontent.com/1559108/223281683-63028469-0717-4916-9742-86a50d0331a3.png)

The setting saved to disk is like:

```json
  "DownloadCacheDir": "E:",
```

Installing mods then fails with some strange text about a `System Volume Information` folder:

![image](https://user-images.githubusercontent.com/1559108/223281954-f87b0dd8-4a65-41f7-866e-a5784312deb3.png)

## Cause

`TrySetupCache` is supposed to determine whether a cache path is valid, but an exception was being thrown in `NetModuleCache.GetSizeInfo` when the path was `E:`, _after_ `TrySetupCache` succeeded, which corrupted the display and caused `updatingCache` to be `true` forever, which suppressed all further calls to update the setting while you typed the rest of the path.

Later, when we tried to use the cache during an install, `NetModuleCache.GetSizeInfo` again threw its exception and broke everything.

## Changes

- Now before we check whether the path segments match up, `GetDrive()` directly compares the given path to the drive's `RootDirectory` in the hopes of avoiding NREs for paths like `E:`
- Now `TrySetupCache` tries to check the free space associated with a cache path before changing the setting to it, to ensure it only ends up with valid values, which should make it fail for `E:`
- Now if we fail to initialize the cache at startup, we revert the cache path setting to its default and try again, to make sure we don't end up with an invalid cache object, to provide a recovery path for affected users
- Now instead of trying to change the cache setting with every keystroke, the settings window creates its own temporary cache object to validate the path, then tries to change the setting when the window is closed. If that fails, it'll display an error (again) and make you go back and fix it.
- Now we don't create the `downloading` folder until you actually _use_ a cache folder (previously if you typed a long path, we'd try creating it at each level because it was in `NetModuleCache`'s constructor)
- Now the English strings for the settings window say "MiB" instead of "MB" since that's technically more correct

Fixes #3801.

@navuek, there should be a test build that you can try here in a few minutes on the Checks tab under the Artifacts dropdown.
