### PR TITLE
Netkan warning when include_only doesn't match

### DIFF
--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 
+using log4net;
+
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.Extensions;
@@ -60,7 +62,26 @@ namespace CKAN.NetKAN.Validators
                     var badPaths = string.Join("\r\n", duplicates);
                     throw new Kraken($"Multiple files attempted to install to:\r\n{badPaths}");
                 }
+
+                // Not a perfect check (subject to false negatives)
+                // but better than nothing
+                if (mod.install != null)
+                {
+                    var unmatchedIncludeOnlys = mod.install
+                        .Where(stanza => stanza.include_only != null)
+                        .SelectMany(stanza => stanza.include_only)
+                        .Distinct()
+                        .Where(incl => !allFiles.Any(f => f.Contains(incl)))
+                        .ToList();
+                    if (unmatchedIncludeOnlys.Any())
+                    {
+                        log.WarnFormat("No matches for includes_only: {0}",
+                                       string.Join(", ", unmatchedIncludeOnlys));
+                    }
+                }
             }
         }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(InstallsFilesValidator));
     }
 }


### PR DESCRIPTION
## Problem

See KSP-CKAN/NetKAN#9614; a mod using `include_only` was changed to contain different filenames than we were trying to include, and there was no inflation error or warning.

```yaml
    include_only:
      - Assets
      - ASET_StckRplc_Mk1-2_Pod.cfg
      - RPM_ASET_StckRplc_Mk1-2_Pod_Patch.cfg
```

## Cause

A _different_ `include_only` list element (`Assets`) still matched, so there were still files being installed. (The other mods from that PR had no other `include_only` members, so they hit the "No files found" error).

## Changes

Now the `InstallsFilesValidator` prints a warning if any `include_only`  fails to match at least one installed file.

The logic isn't super sophisticated or water tight; it can miss things in very complex setups (e.g., if two stanzas have the same `include_only` and one has a match and the other doesn't, that file will count towards both). But it catches what we need it to:

```
NetKAN $ git checkout 30590d1fa
NetKAN $ netkan.exe NetKAN/MK12PodIVAReplacementbyASET.netkan
1976 [1] WARN CKAN.NetKAN.Validators.InstallsFilesValidator (null) - No matches for includes_only: ASET_StckRplc_Mk1-2_Pod.cfg, RPM_ASET_StckRplc_Mk1-2_Pod_Patch.cfg
2081 [1] WARN CKAN.NetKAN.Validators.ModuleManagerDependsValidator (null) - ModuleManager dependency may not be needed, no ModuleManager syntax found
```

I made this a warning instead of an error because `include_only` might conceivably be used to select things that _might_ be in a mod, so human judgment should be applied to determine whether changes are needed. (And also because it's not water tight, so a false positive should not block merging.)
