### PR TITLE
Make grid ampersand workaround platform specific

### DIFF
--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -373,8 +373,8 @@ namespace CKAN.GUI
                     Value = "-"
                 };
 
-            var name   = new DataGridViewTextBoxCell { Value = mod.Name.Replace("&", "&&") };
-            var author = new DataGridViewTextBoxCell { Value = string.Join(", ", mod.Authors).Replace("&", "&&") };
+            var name   = new DataGridViewTextBoxCell { Value = ToGridText(mod.Name)                       };
+            var author = new DataGridViewTextBoxCell { Value = ToGridText(string.Join(", ", mod.Authors)) };
 
             var installVersion = new DataGridViewTextBoxCell()
             {
@@ -403,7 +403,7 @@ namespace CKAN.GUI
             var installSize   = new DataGridViewTextBoxCell { Value = mod.InstallSize                 };
             var releaseDate   = new DataGridViewTextBoxCell { Value = mod.ToModule().release_date     };
             var installDate   = new DataGridViewTextBoxCell { Value = mod.InstallDate                 };
-            var desc          = new DataGridViewTextBoxCell { Value = mod.Abstract.Replace("&", "&&") };
+            var desc          = new DataGridViewTextBoxCell { Value = ToGridText(mod.Abstract)        };
 
             item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, downloadSize, installSize, releaseDate, installDate, downloadCount, desc);
 
@@ -413,6 +413,9 @@ namespace CKAN.GUI
 
             return item;
         }
+
+        private static string ToGridText(string text)
+            => Platform.IsMono ? text.Replace("&", "&&") : text;
 
         public Color GetRowBackground(GUIMod mod, bool conflicted, string instanceName)
         {


### PR DESCRIPTION
## Background

Originally, mod names, abstracts, and authors containing `&` characters would have them removed and the next character underlined on Mono:

![image](https://user-images.githubusercontent.com/1559108/224460910-1f961b86-ce97-418a-b6aa-8f80e4c8c1ff.png)

#3149 fixed that by escaping the ampersands, which is done by adding another one.

## Problem

Windows clients currently see `&&` in the grid:

![image](https://user-images.githubusercontent.com/1559108/224460899-99de2722-dbf7-48b3-9316-d408385cad4d.png)

## Cause

.NET is cross-platform in principle, but not quite "write once run anywhere" in practice. Whenever Mono deviates from how .NET does something, pain ensues for application developers. In this case, Mono treats `&` as a hotkey prefix character in the data grid view, but .NET treats it as just a normal character.

## Changes

Now we only double the ampersand on Mono. Windows gets the single ampersand and likes it:

![image](https://user-images.githubusercontent.com/1559108/224460879-3b287c9f-b057-46b1-b29f-b6ee926be8d7.png)

Fixes #3806.
