### PR TITLE
Default GAME env var to KSP in Inflator Dockerfile, fix redeploy

### DIFF
--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -5,6 +5,6 @@ RUN useradd -ms /bin/bash netkan
 USER netkan
 WORKDIR /home/netkan
 ADD netkan.exe .
-ENTRYPOINT /usr/bin/mono netkan.exe --game $GAME --queues $QUEUES \
+ENTRYPOINT /usr/bin/mono netkan.exe --game ${GAME:-KSP} --queues $QUEUES \
   --net-useragent 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)' \
   --github-token $GH_Token --gitlab-token "$GL_Token" --cachedir ckan_cache -v

--- a/build.cake
+++ b/build.cake
@@ -78,20 +78,23 @@ Task("docker-inflator")
     // Restart the Inflator
     var netkanImage = "kspckan/netkan";
     DockerPull(netkanImage);
-    DockerRun(new DockerContainerRunSettings()
+    var runSettings = new DockerContainerRunSettings()
+    {
+        Env = new string[]
         {
-            Env = new string[]
-            {
-                "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY",
-                "AWS_DEFAULT_REGION"
-            }
-        },
-        netkanImage,
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_DEFAULT_REGION"
+        }
+    };
+    DockerRun(runSettings, netkanImage,
         "redeploy-service",
         "--cluster",      "NetKANCluster",
-        "--service-name", "Inflator"
-    );
+        "--service-name", "InflatorKsp");
+    DockerRun(runSettings, netkanImage,
+        "redeploy-service",
+        "--cluster",      "NetKANCluster",
+        "--service-name", "InflatorKsp2");
 });
 
 Task("docker-metadata")


### PR DESCRIPTION
## Problem

If the `$GAME` environment variable isn't set, the Inflator won't start, as of #3797.

Also the `docker-inflator` Cake build target tries to redeploy the `Inflator` container, but that was renamed to `InflatorKsp` in KSP-CKAN/NetKAN-Infra#284. And the `InflatorKsp2` container isn't touched at all.

## Changes

- Now if it's not set, we fall back to a default value of `KSP` using `bash`'s `${ENVVAR:-defaultval}` syntax.
  - <https://stackoverflow.com/questions/2013547/assigning-default-values-to-shell-variables-with-a-single-command-in-bash>
- Now we redeploy `InflatorKsp` followed by `InflatorKsp2`
