### PR TITLE
Fix NRE on purging cache in GUI

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1042,7 +1042,7 @@ namespace CKAN.GUI
                     Main.Instance.Manager.Cache.Purge(mod);
                 }
                 selected.UpdateIsCached();
-                Main.Instance.UpdateModContentsTree(selected.ToCkanModule(), true);
+                Main.Instance.RefreshModContentsTree();
             }
         }
 

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -42,9 +42,9 @@ namespace CKAN.GUI
             get => selectedModule;
         }
 
-        public void UpdateModContentsTree(CkanModule module, bool force = false)
+        public void RefreshModContentsTree()
         {
-            Contents.UpdateModContentsTree(module, force);
+            Contents.Refresh();
         }
 
         public event Action<GUIMod>            OnDownloadClick;

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -23,15 +23,18 @@ namespace CKAN.GUI
                 if (value != selectedModule)
                 {
                     selectedModule = value;
-                    UpdateModContentsTree(selectedModule.ToModule());
+                    Util.Invoke(ContentsPreviewTree, () => _UpdateModContentsTree(selectedModule.ToModule()));
                 }
             }
             get => selectedModule;
         }
 
-        public void UpdateModContentsTree(CkanModule module, bool force = false)
+        public void Refresh()
         {
-            Util.Invoke(ContentsPreviewTree, () => _UpdateModContentsTree(module, force));
+            if (currentModContentsModule != null)
+            {
+                Util.Invoke(ContentsPreviewTree, () => _UpdateModContentsTree(currentModContentsModule, true));
+            }
         }
 
         public event Action<GUIMod> OnDownloadClick;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -264,7 +264,7 @@ namespace CKAN.GUI
                 }
 
                 // finally, clear the preview contents list
-                Main.Instance.UpdateModContentsTree(null, true);
+                Main.Instance.RefreshModContentsTree();
 
                 UpdateCacheInfo(config.DownloadCacheDir);
             }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -503,9 +503,9 @@ namespace CKAN.GUI
             }
         }
 
-        public void UpdateModContentsTree(CkanModule module, bool force = false)
+        public void RefreshModContentsTree()
         {
-            ModInfo.UpdateModContentsTree(module, force);
+            ModInfo.RefreshModContentsTree();
         }
 
         private void ExitToolButton_Click(object sender, EventArgs e)

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -88,7 +88,7 @@ namespace CKAN.GUI
             // Update mod list in case is:cached or not:cached filters are active
             RefreshModList();
             // User might have selected another row. Show current in tree.
-            UpdateModContentsTree(ModInfo.SelectedModule.ToCkanModule(), true);
+            RefreshModContentsTree();
         }
     }
 }


### PR DESCRIPTION
## Problem

If you use the purge all option in the GUI settings, an exception is thrown:

![image](https://user-images.githubusercontent.com/1559108/224505781-dc50a652-9993-4902-bb8e-56b89d354179.png)

## Causes

- The `Contents` tab has a poor public interface, with two ways to change the active mod, the `SelectedModule` property and `UpdateModContentsTree`
- `UpdateModContentsTree` has a `module` parameter, which is malsuited to this function's usage, which is simply to refresh the currently displayed mod after caching or purging, which requires calling code to do unnecessary work to retrieve and pass the currently shown mod
- `UpdateModContentsTree` assumes that its `CkanModule` parameter will never be `null`
- `SettingsDialog` passes that parameter as `null` after purging, to try to refresh the display in case a previously cached mod is shown, because it seemed like a natural way to request an operation on the same mod

## Changes

- Now the public interface of the `Contents` tab has _only_ `SelectedModule` for setting the mod, and `UpdateModContentsTree` is replaced by a new `Refresh` function for refreshing, which importantly does not have a module parameter and only re-uses the currently displayed one
- Similarly `Main.UpdateModContentsTree` and `ModInfo.UpdateModContentsTree` are replaced by zero-parameter functions `Main.RefreshModContentsTree` and `ModInfo.RefreshModContentsTree` calling `Contents.Refresh`
- Now all usages of `UpdateModContentsTree` are replaced by calls to `Refresh`, which eliminates the possibility of a null reference exception

Fixes #3809.

@GreenKeldeo, a few minutes after this is submitted, assuming there are no compile errors or failed tests, there should be a test build here under the Artifacts dropdown of the Contents tab, if you'd like try out the fix.
