### PR TITLE
Multi-game fakery

### DIFF
--- a/Cmdline/Properties/Resources.Designer.cs
+++ b/Cmdline/Properties/Resources.Designer.cs
@@ -282,6 +282,9 @@ namespace CKAN.CmdLine.Properties {
         internal static string InstanceFakeVersion {
             get { return (string)(ResourceManager.GetObject("InstanceFakeVersion", resourceCulture)); }
         }
+        internal static string InstanceFakeBadGame {
+            get { return (string)(ResourceManager.GetObject("InstanceFakeBadGame", resourceCulture)); }
+        }
         internal static string InstanceFakeBadGameVersion {
             get { return (string)(ResourceManager.GetObject("InstanceFakeBadGameVersion", resourceCulture)); }
         }

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -196,6 +196,7 @@ Try to add the new instance manually with "ckan instance add".
   <data name="InstanceFakeMakingHistory" xml:space="preserve"><value>Please check the Making History DLC version argument - Format it like Maj.Min.Patch - e.g. 1.1.0</value></data>
   <data name="InstanceFakeBreakingGround" xml:space="preserve"><value>Please check the Breaking Ground DLC version argument - Format it like Maj.Min.Patch - e.g. 1.1.0</value></data>
   <data name="InstanceFakeVersion" xml:space="preserve"><value>Please check the version argument - Format it like Maj.Min.Patch[.Build] - e.g. 1.6.0 or 1.2.2.1622</value></data>
+  <data name="InstanceFakeBadGame" xml:space="preserve"><value>No such game {0}!</value></data>
   <data name="InstanceFakeBadGameVersion" xml:space="preserve"><value>Couldn't find a valid game version for your input.
 Make sure to enter at least the version major and minor values in the form Maj.Min - e.g. 1.5</value></data>
   <data name="InstanceFakeCancelled" xml:space="preserve"><value>Selection cancelled! Please call 'ckan instance fake' again</value></data>

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -277,26 +277,22 @@ namespace CKAN
                     throw new BadInstallLocationKraken(Properties.Resources.GameInstanceFakeNotEmpty);
                 }
 
-                log.DebugFormat("Creating folder structure and text files at {0} for KSP version {1}", Path.GetFullPath(newPath), version.ToString());
+                log.DebugFormat("Creating folder structure and text files at {0} for {1} version {2}", Path.GetFullPath(newPath), game.ShortName, version.ToString());
 
                 // Create a KSP root directory, containing a GameData folder, a buildID.txt/buildID64.txt and a readme.txt
                 fileMgr.CreateDirectory(newPath);
-                fileMgr.CreateDirectory(Path.Combine(newPath, "GameData"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "Ships"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "Ships", "VAB"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "Ships", "SPH"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "Ships", "@thumbs"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "Ships", "@thumbs", "VAB"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "Ships", "@thumbs", "SPH"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "saves"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "saves", "scenarios"));
-                fileMgr.CreateDirectory(Path.Combine(newPath, "saves", "training"));
+                fileMgr.CreateDirectory(Path.Combine(newPath, game.PrimaryModDirectoryRelative));
+                game.RebuildSubdirectories(newPath);
 
                 // Don't write the buildID.txts if we have no build, otherwise it would be -1.
                 if (version.IsBuildDefined)
                 {
-                    fileMgr.WriteAllText(Path.Combine(newPath, "buildID.txt"), String.Format("build id = {0}", version.Build));
-                    fileMgr.WriteAllText(Path.Combine(newPath, "buildID64.txt"), String.Format("build id = {0}", version.Build));
+                    foreach (var b in game.BuildIDFiles)
+                    {
+                        fileMgr.WriteAllText(
+                            Path.Combine(newPath, b),
+                            String.Format("build id = {0}", version.Build));
+                    }
                 }
 
                 // Create the readme.txt WITHOUT build number.

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -24,7 +24,7 @@ namespace CKAN.Games
         string[] CreateableDirs { get; }
         bool     IsReservedDirectory(GameInstance inst, string path);
         bool     AllowInstallationIn(string name, out string path);
-        void     RebuildSubdirectories(GameInstance inst);
+        void     RebuildSubdirectories(string absGameRoot);
         string   DefaultCommandLine { get; }
         string[] AdjustCommandLine(string[] args, GameVersion installedVersion);
 

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -139,12 +139,22 @@ namespace CKAN.Games
             return allowedFolders.TryGetValue(name, out path);
         }
 
-        public void RebuildSubdirectories(GameInstance inst)
+        public void RebuildSubdirectories(string absGameRoot)
         {
-            string[] FoldersToCheck = { "Ships/VAB", "Ships/SPH", "Ships/@thumbs/VAB", "Ships/@thumbs/SPH" };
-            foreach (string sRelativePath in FoldersToCheck)
+            string[][] FoldersToCheck = {
+                new string[] { "Ships"                   },
+                new string[] { "Ships", "VAB"            },
+                new string[] { "Ships", "SPH"            },
+                new string[] { "Ships", "@thumbs"        },
+                new string[] { "Ships", "@thumbs", "VAB" },
+                new string[] { "Ships", "@thumbs", "SPH" },
+                new string[] { "saves"                   },
+                new string[] { "saves", "scenarios"      },
+                new string[] { "saves", "training"       },
+            };
+            foreach (string[] sRelativePath in FoldersToCheck)
             {
-                string sAbsolutePath = inst.ToAbsoluteGameDir(sRelativePath);
+                string sAbsolutePath = Path.Combine(absGameRoot, Path.Combine(sRelativePath));
                 if (!Directory.Exists(sAbsolutePath))
                     Directory.CreateDirectory(sAbsolutePath);
             }

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -131,8 +131,12 @@ namespace CKAN.Games
         public bool AllowInstallationIn(string name, out string path)
             => allowedFolders.TryGetValue(name, out path);
 
-        public void RebuildSubdirectories(GameInstance inst)
+        public void RebuildSubdirectories(string absGameRoot)
         {
+            const string dataDir = "KSP2_x64_Data";
+            var path = Path.Combine(absGameRoot, dataDir);
+            if (!Directory.Exists(path))
+                Directory.CreateDirectory(path);
         }
 
         public string DefaultCommandLine =>
@@ -178,7 +182,8 @@ namespace CKAN.Games
         public GameVersion DetectVersion(DirectoryInfo where)
             => GameVersion.Parse(
                 FileVersionInfo.GetVersionInfo(
-                    Path.Combine(where.FullName, "KSP2_x64.exe")).ProductVersion);
+                    Path.Combine(where.FullName, "KSP2_x64.exe")).ProductVersion
+                ?? versions.Last().ToString());
 
         public string CompatibleVersionsFile => "compatible_game_versions.json";
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -430,7 +430,7 @@ namespace CKAN.GUI
 
                 pluginController = new PluginController(pluginsPath);
 
-                CurrentInstance.game.RebuildSubdirectories(CurrentInstance);
+                CurrentInstance.game.RebuildSubdirectories(CurrentInstance.GameDir());
             }
 
             log.Info("GUI started");


### PR DESCRIPTION
## Motivation

As we advance toward the finish line of KSP2 support, we are getting closer to the point where we will need to be able to validate, review, and merge `KSP2-NetKAN` pull requests. This will require updating `xKAN-meta_testing` to support the new game. I started that and discovered that `ckan.exe` needs some more updates first.

## Problem

`ckan instance fake` is used by the validator to generate dummy game instances, but it currently can only do this for KSP1.

## Changes

- Now the `ckan instance fake` command has an optional `--game` argument that can be `KSP` (default) or `KSP2`, which determines the files and folders to be created to fake the instance according to the game. The metadata validator will eventually pass the value of a `$GAME` environment variable here to adapt itself to the right context.
- To accomplish this, remaining game-specific logic in `GameInstance.FakeInstance` is updated to use the `IGame game` parameter it already has
- `IGame.RebuildSubdirectories` now takes a path instead of a game instance so we can use it to create the game instance's files and folders _before_ instantiating the object
- `KerbalSpaceProgram2.RebuildSubdirectories` now creates the `KSP2_x64_Data` folder

This should allow us to generate fake KSP2 instances for the pull request validator.

### Known limitations

We can't generate a valid `KSP2_x64.exe` file on the fly, and this is how we get the game version!

To work around this, we just create it as if it's a `buildID.txt` file, and then if our attempt to get the version from that file fails, we fall back to using the most recent known version. This allows the fake instances to be added as valid, but for now they will not be able to represent exclusively older versions. Hopefully there will be a better way to get the game version eventually.
