### PR TITLE
Upgrade pip before installing NetKAN-Infra

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -6,6 +6,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools git build-essential python3-dev libffi-dev && \
     apt-get clean
 RUN git config --global --add safe.directory '*'
+RUN pip3 install --upgrade pip
 RUN pip3 install 'git+https://github.com/KSP-CKAN/NetKAN-Infra#subdirectory=netkan'
 RUN pip3 install 'git+https://github.com/KSP-CKAN/xKAN-meta_testing'
 


### PR DESCRIPTION
## Problem

https://github.com/KSP-CKAN/CKAN/actions/runs/4503992634/jobs/7928198047

The `deploy` workflow just started giving us weird compile errors involving Rust during the Dockerfile step that installs NetKAN-Infra. The error message suggests updating pip, which is reported to be at version 18.1, which was released on 2018-10-05.

The message says that newer pips might be able to install precompiled packages that older pips can't, so there's a chance that this could skip all those `bdist_wheel` commands that take a long time, speeding up the deploy.

## Changes

Now we try updating pip as suggested.
