### PR TITLE
Only update Versions tab when the mod changes

### DIFF
--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -124,12 +124,12 @@ namespace CKAN.GUI
                     {
                         visibleGuiModule.PropertyChanged += visibleGuiModule_PropertyChanged;
                     }
+
+                    if (value != null)
+                    {
+                        Refresh(value);
+                    }
                 }
-                if (value == null)
-                {
-                    return;
-                }
-                Refresh(value);
             }
         }
 


### PR DESCRIPTION
## Problem

If you switch to the Versions tab, then to another tab and back, the Versions tab fully refreshes itself, which it shouldn't do because it can take a long time (see #3638).

## Cause

The call to `Refresh` is unconditional and is only skipped if the mod is null.

## Changes

Now we don't refresh the versions list if it's already loaded for the same mod. There's already a code block checking if the mod is the same, so the call to `Refresh` is moved in there.
