### PR TITLE
Allow GUI users to delete registry lockfiles

### DIFF
--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -185,7 +185,7 @@ namespace CKAN.ConsoleUI {
                 } catch (RegistryInUseKraken k) {
 
                     ConsoleMessageDialog md = new ConsoleMessageDialog(
-                        string.Format(Properties.Resources.InstanceListLocked, k.lockfilePath),
+                        k.ToString(),
                         new List<string>() {
                             Properties.Resources.Cancel,
                             Properties.Resources.Force

--- a/ConsoleUI/Properties/Resources.Designer.cs
+++ b/ConsoleUI/Properties/Resources.Designer.cs
@@ -362,9 +362,6 @@ namespace CKAN.ConsoleUI.Properties {
         internal static string InstanceListLoadingError {
             get { return (string)(ResourceManager.GetObject("InstanceListLoadingError", resourceCulture)); }
         }
-        internal static string InstanceListLocked {
-            get { return (string)(ResourceManager.GetObject("InstanceListLocked", resourceCulture)); }
-        }
         internal static string InstanceListNoVersion {
             get { return (string)(ResourceManager.GetObject("InstanceListNoVersion", resourceCulture)); }
         }

--- a/ConsoleUI/Properties/Resources.fr-FR.resx
+++ b/ConsoleUI/Properties/Resources.fr-FR.resx
@@ -421,13 +421,6 @@
     <value>Erreur lors du chargement de {0} :
 {1}</value>
   </data>
-  <data name="InstanceListLocked" xml:space="preserve">
-    <value>Fichier verrou avec un ID de processus actif à {0}
-
-Cela veut probablement dire qu'une autre instance de CKAN s'occupe de cette instance. Vous pouvez supprimer ce fichier pour continuer, mais cela risque fortement de corrompre des données.
-
-Voulez-vous supprimez ce fichier verrou pour forcer l'accès ?</value>
-  </data>
   <data name="InstanceListNoVersion" xml:space="preserve">
     <value>&lt;AUCUNE&gt;</value>
   </data>

--- a/ConsoleUI/Properties/Resources.it-IT.resx
+++ b/ConsoleUI/Properties/Resources.it-IT.resx
@@ -421,13 +421,6 @@
     <value>Errore nel caricamento di {0}:
 {1}</value>
   </data>
-  <data name="InstanceListLocked" xml:space="preserve">
-    <value>File di blocco con ID di processo attivo trovato a {0}
-
-Ciò significa che probabilmente un'altra istanza di CKAN sta accedendo a questa istanza. Puoi eliminare il file per continuare, ma è molto probabile che i dati vengano danneggiati.
-
-Vuoi eliminare questo file di blocco per forzare l'accesso?</value>
-  </data>
   <data name="InstanceListNoVersion" xml:space="preserve">
     <value>&lt;NESSUNA&gt;</value>
   </data>
@@ -907,7 +900,7 @@ Se la disinstalli, CKAN non sarà in grado di reinstallarla.</value>
   <data name="ExitBody" xml:space="preserve">
     <value>STAI UTILIZZANDO {1}.
 
-Grazie per aver scaricato {0}. Ci auguriamo che tu ti diverta 
+Grazie per aver scaricato {0}. Ci auguriamo che tu ti diverta
 a usarlo come ci siamo divertiti noi a crearlo.
 
 Se hai pagato per {0}, cerca di ottenere il rimborso,

--- a/ConsoleUI/Properties/Resources.pl-PL.resx
+++ b/ConsoleUI/Properties/Resources.pl-PL.resx
@@ -421,13 +421,6 @@
     <value>Błąd ładowania {0}:
 {1}</value>
   </data>
-  <data name="InstanceListLocked" xml:space="preserve">
-    <value>Plik blokady znaleziony w {0}
-
-Oznacza to, że inna instancja CKAN prawdopodobnie ma dostęp do tej instalacji gry. Możesz usunąć plik, aby kontynuować, ale uszkodzenie danych jest bardzo prawdopodobne.
-
-Czy chcesz usunąć ten plik blokady, aby wymusić dostęp?</value>
-  </data>
   <data name="InstanceListNoVersion" xml:space="preserve">
     <value>&lt;BRAK&gt;</value>
   </data>

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -219,11 +219,6 @@
   <data name="InstanceListDefaultToggle" xml:space="preserve"><value>Default</value></data>
   <data name="InstanceListLoadingError" xml:space="preserve"><value>Error loading {0}:
 {1}</value></data>
-  <data name="InstanceListLocked" xml:space="preserve"><value>Lock file with live process ID found at {0}
-
-This means that another instance of CKAN probably is accessing this instance. You can delete the file to continue, but data corruption is very likely.
-
-Do you want to delete this lock file to force access?</value></data>
   <data name="InstanceListNoVersion" xml:space="preserve"><value>&lt;NONE&gt;</value></data>
   <data name="InstallTitle" xml:space="preserve"><value>Installing, Upgrading, and Removing Mods</value></data>
   <data name="InstallMessage" xml:space="preserve"><value>Calculating...</value></data>

--- a/ConsoleUI/Properties/Resources.ru-RU.resx
+++ b/ConsoleUI/Properties/Resources.ru-RU.resx
@@ -210,12 +210,6 @@
   <data name="InstanceListDefaultToggle" xml:space="preserve"><value>По умолчанию</value></data>
   <data name="InstanceListLoadingError" xml:space="preserve"><value>Ошибка загрузки «{0}»:
 {1}</value></data>
-  <data name="InstanceListLocked" xml:space="preserve"><value>Блокирующий файл с ID процесса найден в {0}
-
-Это может означать, что другой процесс CKAN работает с этой сборкой. 
-Вы можете удалить этот файл, но в таком случае вероятно повреждение данных.
-
-Хотите ли вы удалить блокирующий файл для получения доступа?</value></data>
   <data name="InstanceListNoVersion" xml:space="preserve"><value>&lt;НЕТ&gt;</value></data>
   <data name="InstallTitle" xml:space="preserve"><value>Установка, обновление и удаление модификаций</value></data>
   <data name="InstallMessage" xml:space="preserve"><value>Вычисление...</value></data>

--- a/Core/Properties/Resources.fr-FR.resx
+++ b/Core/Properties/Resources.fr-FR.resx
@@ -552,10 +552,11 @@ Consultez cette page pour obtenir de l'aide :
 Pensez à ajouter un jeton d'authentification pour augmenter la limite avant bridage.</value>
   </data>
   <data name="KrakenAlreadyRunning" xml:space="preserve">
-    <value>CKAN est déjà lancé pour cette instance !
+    <value>Fichier verrou avec un ID de processus actif à {0}
 
-Si vous êtes certain que ce n'est pas le cas, alors supprimez :
-"{0}"</value>
+Cela veut probablement dire qu'une autre instance de CKAN s'occupe de cette instance. Vous pouvez supprimer ce fichier pour continuer, mais cela risque fortement de corrompre des données.
+
+Voulez-vous supprimez ce fichier verrou pour forcer l'accès ?</value>
   </data>
   <data name="NotEnoughSpaceToDownload" xml:space="preserve">
     <value>Pas assez d'espace dans le dossier temporaire pour télécharger les modules !</value>

--- a/Core/Properties/Resources.it-IT.resx
+++ b/Core/Properties/Resources.it-IT.resx
@@ -552,10 +552,11 @@ Consulta questa pagina per aiuto:
 Prendi in considerazione l'aggiunta di un token di autenticazione per aumentare il limite prima del throttling.</value>
   </data>
   <data name="KrakenAlreadyRunning" xml:space="preserve">
-    <value>CKAN è già in esecuzione per questa istanza!
+    <value>File di blocco con ID di processo attivo trovato a {0}
 
-Se sei sicuro che non sia questo il caso, elimina:
-"{0}"</value>
+Ciò significa che probabilmente un'altra istanza di CKAN sta accedendo a questa istanza. Puoi eliminare il file per continuare, ma è molto probabile che i dati vengano danneggiati.
+
+Vuoi eliminare questo file di blocco per forzare l'accesso?</value>
   </data>
   <data name="NotEnoughSpaceToDownload" xml:space="preserve">
     <value>Spazio insufficiente nella cartella temporanea per scaricare i moduli!</value>

--- a/Core/Properties/Resources.pl-PL.resx
+++ b/Core/Properties/Resources.pl-PL.resx
@@ -552,10 +552,11 @@ Odwiedź tę stronę, aby uzyskać pomoc:
 Rozważ dodanie tokenu uwierzytelniającego, aby zwiększyć limit ograniczania.</value>
   </data>
   <data name="KrakenAlreadyRunning" xml:space="preserve">
-    <value>CKAN jest już uruchomiony z tą instalacją gry!
+    <value>Plik blokady znaleziony w {0}
 
-Jeśli jesteś pewien, że tak nie jest, to usuń:
-"{0}"</value>
+Oznacza to, że inna instancja CKAN prawdopodobnie ma dostęp do tej instalacji gry. Możesz usunąć plik, aby kontynuować, ale uszkodzenie danych jest bardzo prawdopodobne.
+
+Czy chcesz usunąć ten plik blokady, aby wymusić dostęp?</value>
   </data>
   <data name="NotEnoughSpaceToDownload" xml:space="preserve">
     <value>Za mało miejsca w folderze tymczasowym do pobrania modułów!</value>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -271,10 +271,12 @@ Consult this page for help:
   <data name="KrakenMissingCertificateNotUnix" xml:space="preserve"><value>Oh no! Our download failed with a certificate error!</value></data>
   <data name="KrakenDownloadThrottled" xml:space="preserve"><value>Download from {0} was throttled.
 Consider adding an authentication token to increase the throttling limit.</value></data>
-  <data name="KrakenAlreadyRunning" xml:space="preserve"><value>CKAN is already running for this instance!
+  <data name="KrakenAlreadyRunning" xml:space="preserve"><value>Lock file with live process ID found at:
+{0}
 
-If you're certain this is not the case, then delete:
-"{0}"</value></data>
+Another active CKAN process probably is accessing this game folder. Check your operating system's task manager application. If you are sure the lock file is stale, you may delete it to continue, but if it's not, then it's very likely that the two running CKANs will clash and corrupt your mod registry and game folder.
+
+Do you want to delete this lock file to force access?</value></data>
   <data name="NotEnoughSpaceToDownload" xml:space="preserve"><value>Not enough space in temp folder to download modules!</value></data>
   <data name="NotEnoughSpaceToCache" xml:space="preserve"><value>Not enough space in cache folder to store modules!</value></data>
   <data name="NotEnoughSpaceToInstall" xml:space="preserve"><value>Not enough space in game folder to install modules!</value></data>

--- a/Core/Properties/Resources.ru-RU.resx
+++ b/Core/Properties/Resources.ru-RU.resx
@@ -267,10 +267,12 @@ https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors</value></data>
   <data name="KrakenMissingCertificateNotUnix" xml:space="preserve"><value>О нет! Загрузка не завершена из-за ошибки сертификата!</value></data>
   <data name="KrakenDownloadThrottled" xml:space="preserve"><value>Загрузка из {0} была ограничена.
 Для увеличения квоты добавьте токен аутентификации.</value></data>
-  <data name="KrakenAlreadyRunning" xml:space="preserve"><value>CKAN уже запущен для этой сборки!
+  <data name="KrakenAlreadyRunning" xml:space="preserve"><value>Блокирующий файл с ID процесса найден в {0}
 
-Если вы уверены, что это не так, удалите:
-"{0}"</value></data>
+Это может означать, что другой процесс CKAN работает с этой сборкой.
+Вы можете удалить этот файл, но в таком случае вероятно повреждение данных.
+
+Хотите ли вы удалить блокирующий файл для получения доступа?</value></data>
   <data name="RelationshipResolverConflictsWith" xml:space="preserve"><value>{0} конфликтует с {1}</value></data>
   <data name="RelationshipResolverRequiredButResolver" xml:space="preserve"><value>Необходима {0}, но в ресольвере несовместимая версия</value></data>
   <data name="RelationshipResolverRequiredButInstalled" xml:space="preserve"><value>Необходима {0}, но установлена несовместимая версия</value></data>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -474,9 +474,8 @@ namespace CKAN
         }
 
         public override string ToString()
-        {
-            return String.Format(Properties.Resources.KrakenAlreadyRunning, lockfilePath);
-        }
+            => string.Format(Properties.Resources.KrakenAlreadyRunning,
+                             lockfilePath.Replace('/', Path.DirectorySeparatorChar));
     }
 
     /// <summary>

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -377,7 +377,7 @@ namespace CKAN.GUI
                 Filter = string.Join("|", exportOptions.Select(i => i.ToString()).ToArray()),
                 Title  = Properties.Resources.ExportInstalledModsDialogTitle
             };
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(Main.Instance) == DialogResult.OK)
             {
                 selectedOption = exportOptions[dlg.FilterIndex - 1];
                 filename       = dlg.FileName;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1122,7 +1122,9 @@ namespace CKAN.GUI
         {
             log.Info("Updating the mod list");
 
-            Main.Instance.Wait.AddLogMessage(Properties.Resources.MainModListLoadingRegistry);
+            Main.Instance.Wait.AddLogMessage(Properties.Resources.MainRepoScanning);
+            Main.Instance.CurrentInstance.Scan();
+
             GameVersionCriteria versionCriteria = Main.Instance.CurrentInstance.VersionCriteria();
             IRegistryQuerier registry = RegistryManager.Instance(Main.Instance.CurrentInstance).registry;
 

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -94,7 +94,7 @@ namespace CKAN.GUI
             LoadTab(ModInfoTabControl.SelectedTab.Name, SelectedModule);
         }
 
-        private GameInstanceManager manager => Main.Instance.manager;
+        private GameInstanceManager manager => Main.Instance.Manager;
 
         private int StringHeight(string text, Font font, int maxWidth)
             => (int)CreateGraphics().MeasureString(text, font, maxWidth).Height;

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -41,7 +41,7 @@ namespace CKAN.GUI
 
         private GUIMod              selectedModule;
         private CkanModule          currentModContentsModule;
-        private GameInstanceManager manager => Main.Instance.manager;
+        private GameInstanceManager manager => Main.Instance.Manager;
 
         private void ContentsPreviewTree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
         {

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -121,7 +121,7 @@ namespace CKAN.GUI
                 merge);
         }
 
-        private GameInstanceManager manager => Main.Instance.manager;
+        private GameInstanceManager manager => Main.Instance.Manager;
 
         private void LinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -73,7 +73,7 @@ namespace CKAN.GUI
         }
 
         private GUIMod              selectedModule;
-        private GameInstanceManager manager => Main.Instance.manager;
+        private GameInstanceManager manager => Main.Instance.Manager;
 
         private void DependsGraphTree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
         {

--- a/GUI/Dialogs/CloneFakeGameDialog.cs
+++ b/GUI/Dialogs/CloneFakeGameDialog.cs
@@ -74,7 +74,7 @@ namespace CKAN.GUI
             };
 
             // Show the FileDialog and let the user search for the game directory.
-            if (instanceDialog.ShowDialog() != DialogResult.OK || !File.Exists(instanceDialog.FileName))
+            if (instanceDialog.ShowDialog(this) != DialogResult.OK || !File.Exists(instanceDialog.FileName))
                 return;
 
             // Write the path to the textbox
@@ -327,7 +327,7 @@ namespace CKAN.GUI
 
         private void buttonPathBrowser_Click(object sender, EventArgs e)
         {
-            if (folderBrowserDialogNewPath.ShowDialog().Equals(DialogResult.OK))
+            if (folderBrowserDialogNewPath.ShowDialog(this).Equals(DialogResult.OK))
             {
                 textBoxNewPath.Text = folderBrowserDialogNewPath.SelectedPath;
             }

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -156,7 +156,7 @@ namespace CKAN.GUI
 
         private void AddToCKANMenuItem_Click(object sender, EventArgs e)
         {
-            if (_instanceDialog.ShowDialog() != DialogResult.OK
+            if (_instanceDialog.ShowDialog(this) != DialogResult.OK
                     || !File.Exists(_instanceDialog.FileName))
                 return;
 
@@ -187,7 +187,7 @@ namespace CKAN.GUI
         {
             var old_instance = Main.Instance.CurrentInstance;
 
-            var result = new CloneFakeGameDialog(_manager, _user).ShowDialog();
+            var result = new CloneFakeGameDialog(_manager, _user).ShowDialog(this);
             if (result == DialogResult.OK && !Equals(old_instance, Main.Instance.CurrentInstance))
             {
                 DialogResult = DialogResult.OK;

--- a/GUI/Dialogs/PluginsDialog.cs
+++ b/GUI/Dialogs/PluginsDialog.cs
@@ -118,7 +118,7 @@ namespace CKAN.GUI
 
         private void AddNewPluginButton_Click(object sender, EventArgs e)
         {
-            if (m_AddNewPluginDialog.ShowDialog() == DialogResult.OK)
+            if (m_AddNewPluginDialog.ShowDialog(this) == DialogResult.OK)
             {
                 var path = m_AddNewPluginDialog.FileName;
                 Main.Instance.pluginController.AddNewAssemblyToPluginsPath(path);

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -204,7 +204,7 @@ namespace CKAN.GUI
                 SelectedPath        = config.DownloadCacheDir,
                 ShowNewFolderButton = true
             };
-            DialogResult result = cacheChooser.ShowDialog();
+            DialogResult result = cacheChooser.ShowDialog(this);
             if (result == DialogResult.OK)
             {
                 UpdateCacheInfo(cacheChooser.SelectedPath);
@@ -309,7 +309,7 @@ namespace CKAN.GUI
         private void NewRepoButton_Click(object sender, EventArgs e)
         {
             var dialog = new NewRepoDialog();
-            if (dialog.ShowDialog() == DialogResult.OK)
+            if (dialog.ShowDialog(this) == DialogResult.OK)
             {
                 try
                 {
@@ -548,25 +548,21 @@ namespace CKAN.GUI
         private void CheckUpdateOnLaunchCheckbox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.CheckForUpdatesOnLaunch = CheckUpdateOnLaunchCheckbox.Checked;
-            Main.Instance.configuration.Save();
         }
 
         private void RefreshOnStartupCheckbox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.RefreshOnStartup = RefreshOnStartupCheckbox.Checked;
-            Main.Instance.configuration.Save();
         }
 
         private void HideEpochsCheckbox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.HideEpochs = HideEpochsCheckbox.Checked;
-            Main.Instance.configuration.Save();
         }
 
         private void HideVCheckbox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.HideV = HideVCheckbox.Checked;
-            Main.Instance.configuration.Save();
         }
 
         private void LanguageSelectionComboBox_SelectionChanged(object sender, EventArgs e)
@@ -577,20 +573,17 @@ namespace CKAN.GUI
         private void AutoSortUpdateCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.AutoSortByUpdate = AutoSortUpdateCheckBox.Checked;
-            Main.Instance.configuration.Save();
         }
 
         private void EnableTrayIconCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             MinimizeToTrayCheckBox.Enabled = Main.Instance.configuration.EnableTrayIcon = EnableTrayIconCheckBox.Checked;
-            Main.Instance.configuration.Save();
             Main.Instance.CheckTrayState();
         }
 
         private void MinimizeToTrayCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.MinimizeToTray = MinimizeToTrayCheckBox.Checked;
-            Main.Instance.configuration.Save();
             Main.Instance.CheckTrayState();
         }
 
@@ -609,7 +602,6 @@ namespace CKAN.GUI
         private void PauseRefreshCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             Main.Instance.configuration.RefreshPaused = PauseRefreshCheckBox.Checked;
-            Main.Instance.configuration.Save();
 
             if (Main.Instance.configuration.RefreshPaused)
                 Main.Instance.refreshTimer.Stop();

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -1,7 +1,11 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Forms;
+
 using CKAN.Versioning;
+
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
 
 namespace CKAN.GUI
 {
@@ -30,7 +34,7 @@ namespace CKAN.GUI
                         log.Debug("Found higher ckan version");
                         var release_notes = AutoUpdate.Instance.latestUpdate.ReleaseNotes;
                         var dialog = new NewUpdateDialog(latest_version.ToString(), release_notes);
-                        if (dialog.ShowDialog() == DialogResult.OK)
+                        if (dialog.ShowDialog(this) == DialogResult.OK)
                         {
                             UpdateCKAN();
                             return true;

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -3,6 +3,9 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Windows.Forms;
 
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
+
 namespace CKAN.GUI
 {
     public partial class Main

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -9,9 +9,14 @@ namespace CKAN.GUI
         private PluginsDialog pluginsDialog;
         private YesNoDialog yesNoDialog;
         private SelectionDialog selectionDialog;
+        public ControlFactory controlFactory;
 
         public void RecreateDialogs()
         {
+            if (controlFactory == null)
+            {
+                controlFactory = new ControlFactory();
+            }
             errorDialog = controlFactory.CreateControl<ErrorDialog>();
             pluginsDialog = controlFactory.CreateControl<PluginsDialog>();
             yesNoDialog = controlFactory.CreateControl<YesNoDialog>();

--- a/GUI/Main/MainExport.cs
+++ b/GUI/Main/MainExport.cs
@@ -4,8 +4,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+
 using CKAN.Exporters;
 using CKAN.Types;
+
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
 
 namespace CKAN.GUI
 {
@@ -65,7 +69,7 @@ namespace CKAN.GUI
                 Filter = string.Join("|", specialExportOptions.Select(i => i.ToString()).ToArray()),
                 Title  = Properties.Resources.ExportInstalledModsDialogTitle
             };
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (dlg.ShowDialog(this) == DialogResult.OK)
             {
                 var fileMode = File.Exists(dlg.FileName) ? FileMode.Truncate : FileMode.CreateNew;
                 using (var stream = new FileStream(dlg.FileName, fileMode))

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -3,6 +3,9 @@ using System.IO;
 using System.Collections.Generic;
 using System.Windows.Forms;
 
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
+
 namespace CKAN.GUI
 {
     public partial class Main
@@ -26,7 +29,7 @@ namespace CKAN.GUI
                 Filter           = Properties.Resources.MainImportFilter,
                 Multiselect      = true
             };
-            if (dlg.ShowDialog() == DialogResult.OK
+            if (dlg.ShowDialog(this) == DialogResult.OK
                     && dlg.FileNames.Length > 0)
             {
                 // Show WaitTabPage (status page) and lock it.

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -7,6 +7,9 @@ using System.Transactions;
 
 using CKAN.Extensions;
 
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
+
 namespace CKAN.GUI
 {
     using ModChanges = List<ModChange>;

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -3,8 +3,12 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Threading.Tasks;
 using System.Linq;
+
 using CKAN.Extensions;
 using CKAN.Versioning;
+
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
 
 namespace CKAN.GUI
 {

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -12,6 +12,9 @@ using Autofac;
 using CKAN.Versioning;
 using CKAN.Configuration;
 
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
+
 namespace CKAN.GUI
 {
     public partial class Main
@@ -208,7 +211,6 @@ namespace CKAN.GUI
                 {
                     configuration.RefreshOnStartup = false;
                 }
-                configuration.Save();
             }
         }
 

--- a/GUI/Main/MainTime.cs
+++ b/GUI/Main/MainTime.cs
@@ -2,6 +2,9 @@ using System;
 using System.Diagnostics;
 using System.Windows.Forms;
 
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
+
 namespace CKAN.GUI
 {
     public partial class Main

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -46,7 +46,6 @@ namespace CKAN.GUI
                 {
                     // Save the window state
                     configuration.IsWindowMaximised = WindowState == FormWindowState.Maximized;
-                    configuration.Save();
                 }
             }
             else

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Windows.Forms;
 
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
+
 namespace CKAN.GUI
 {
     public partial class Main

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -5,6 +5,8 @@ using System.Drawing;
 using System.IO;
 using System.Xml.Serialization;
 
+using CKAN.Games;
+
 namespace CKAN.GUI
 {
     [XmlRootAttribute("Configuration")]
@@ -100,14 +102,14 @@ namespace CKAN.GUI
             SaveConfiguration(this);
         }
 
-        public static GUIConfiguration LoadOrCreateConfiguration(string path)
+        public static GUIConfiguration LoadOrCreateConfiguration(string path, IGame game)
         {
             if (!File.Exists(path) || new FileInfo(path).Length == 0)
             {
                 var configuration = new GUIConfiguration
                 {
                     path = path,
-                    CommandLineArguments = Main.Instance.CurrentInstance.game.DefaultCommandLine
+                    CommandLineArguments = game.DefaultCommandLine
                 };
 
                 SaveConfiguration(configuration);

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -32,7 +32,12 @@ namespace CKAN.GUI
             }
             else
             {
-                new Main(args, manager, showConsole);
+                var main = new Main(args, manager);
+                if (!showConsole)
+                {
+                    Util.HideConsoleWindow();
+                }
+                Application.Run(main);
             }
         }
 

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -494,8 +494,17 @@ namespace CKAN.GUI.Properties {
         internal static string MainCantInstallDLC {
             get { return (string)(ResourceManager.GetObject("MainCantInstallDLC", resourceCulture)); }
         }
+        internal static string MainLoadingGameInstance {
+            get { return (string)(ResourceManager.GetObject("MainLoadingGameInstance", resourceCulture)); }
+        }
         internal static string MainCorruptedRegistry {
             get { return (string)(ResourceManager.GetObject("MainCorruptedRegistry", resourceCulture)); }
+        }
+        internal static string MainDeleteLockfileYes {
+            get { return (string)(ResourceManager.GetObject("MainDeleteLockfileYes", resourceCulture)); }
+        }
+        internal static string MainDeleteLockfileNo {
+            get { return (string)(ResourceManager.GetObject("MainDeleteLockfileNo", resourceCulture)); }
         }
 
         internal static string AllModVersionsInstallPrompt {

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -386,6 +386,8 @@ Essayez de déplacer {2} en dehors de {3} et redémarrez CKAN.</value>
 
 Cela veut dire que CKAN a oublié tous les mods que vous avez installé, mais ceux-ci sont toujours présents dans le dossier GameData. Vous pouvez les réinstaller en important le fichier {2}</value>
   </data>
+  <data name="MainDeleteLockfileYes" xml:space="preserve"><value>Forcer</value></data>
+  <data name="MainDeleteLockfileNo" xml:space="preserve"><value>Annuler</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve">
     <value>{0} n'est pas supporté par vos versions de jeu compatibles ({1}) et pourrait ne pas marcher du tout. Si vous avez des problèmes avec, vous NE devez PAS demander de l'aide à ses développeurs.
 

--- a/GUI/Properties/Resources.it-IT.resx
+++ b/GUI/Properties/Resources.it-IT.resx
@@ -386,6 +386,8 @@ Prova a spostare {2} da {3} e a riavviare CKAN.</value>
 
 Questo significa che CKAN si è dimenticato di tutte le tue mod installate, ma sono ancora presenti in GameData. Puoi reinstallarle importando il file {2}.</value>
   </data>
+  <data name="MainDeleteLockfileYes" xml:space="preserve"><value>Forza</value></data>
+  <data name="MainDeleteLockfileNo" xml:space="preserve"><value>Annulla</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve">
     <value>{0} non è supportato dalle versioni del gioco attualmente compatibili ({1}) e potrebbe non funzionare affatto. Se hai qualche problema, NON devi chiedere aiuto ai suoi manutentori.
 

--- a/GUI/Properties/Resources.pl-PL.resx
+++ b/GUI/Properties/Resources.pl-PL.resx
@@ -386,6 +386,8 @@ Spróbuj przenieść {2} z {3} i uruchomić ponownie CKAN.</value>
 
 Oznacza to, że CKAN zapomniał o wszystkich zainstalowanych modyfikacjach, ale wciąż znajdują się w GameData. Możesz je ponownie zainstalować importując plik {2}.</value>
   </data>
+  <data name="MainDeleteLockfileYes" xml:space="preserve"><value>Wymuś</value></data>
+  <data name="MainDeleteLockfileNo" xml:space="preserve"><value>Anuluj</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve">
     <value>{0} nie jest obsługiwany w bieżącej wersji gry i może w ogóle nie działać. Jeśli masz jakieś problemy z nim, NIE powinieneś poprosić twórców o pomoc.
 

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -211,9 +211,12 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Not found.</value></data>
   <data name="MainReinstallConfirm" xml:space="preserve"><value>Do you want to reinstall {0}?</value></data>
   <data name="MainCantInstallDLC" xml:space="preserve"><value>CKAN can't install expansion {0}!</value></data>
+  <data name="MainLoadingGameInstance" xml:space="preserve"><value>Loading game instance</value></data>
   <data name="MainCorruptedRegistry" xml:space="preserve"><value>Corrupted registry archived to {0}: {1}
 
 This means that CKAN forgot about all your installed mods, but they are still in GameData. You can reinstall them by importing the {2} file.</value></data>
+  <data name="MainDeleteLockfileYes" xml:space="preserve"><value>Force</value></data>
+  <data name="MainDeleteLockfileNo" xml:space="preserve"><value>Cancel</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current compatible game versions ({1}) and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
 
 Do you really want to install it?</value></data>

--- a/GUI/Properties/Resources.ru-RU.resx
+++ b/GUI/Properties/Resources.ru-RU.resx
@@ -185,6 +185,8 @@
   <data name="MainCorruptedRegistry" xml:space="preserve"><value>Повреждение реестра, архивированного в {0}: {1}
 
 Это означает, что CKAN «забыл» о всех установленных модификациях, но сами они продолжают находиться в GameData. Вы можете переустановить их, импортировав файлы {2}.</value></data>
+  <data name="MainDeleteLockfileYes" xml:space="preserve"><value>Принуд.</value></data>
+  <data name="MainDeleteLockfileNo" xml:space="preserve"><value>Отмена</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} не поддерживается установленной версией игры и может не заработать.
 
 Вы действительно хотите установить его?</value></data>

--- a/Tests/GUI/GUIConfiguration.cs
+++ b/Tests/GUI/GUIConfiguration.cs
@@ -1,8 +1,11 @@
 ﻿using System.IO;
-using CKAN;
-using CKAN.GUI;
+
 using NUnit.Framework;
 using Tests.Data;
+
+using CKAN;
+using CKAN.GUI;
+using CKAN.Games;
 
 namespace Tests.GUI
 {
@@ -33,7 +36,7 @@ namespace Tests.GUI
                 stream.Write("This is not a valid XML file.");
             }
 
-            Assert.Throws<Kraken>(() => GUIConfiguration.LoadOrCreateConfiguration(tempFile));
+            Assert.Throws<Kraken>(() => GUIConfiguration.LoadOrCreateConfiguration(tempFile, new KerbalSpaceProgram()));
         }
 
         [Test]
@@ -46,7 +49,7 @@ namespace Tests.GUI
                 stream.Write(TestData.ConfigurationFile());
             }
 
-            var result = GUIConfiguration.LoadOrCreateConfiguration(tempFile);
+            var result = GUIConfiguration.LoadOrCreateConfiguration(tempFile, new KerbalSpaceProgram());
 
             Assert.IsNotNull(result);
         }


### PR DESCRIPTION
## Motivation

ConsoleUI can do one thing that GUI can't:

![image](https://user-images.githubusercontent.com/1559108/233722625-ded4a4ec-72b0-4162-b802-6d05ceb4e9ac.png)

![image](https://user-images.githubusercontent.com/1559108/233722469-e922efc3-a50a-4e3a-bcf7-2f31bc00ca20.png)

It would be helpful if GUI users also had the option to delete the lockfile after an explanatory warning.

## Problems

- ConsoleUI's lockfile message confusingly says "instance" twice with different meanings
- The GUI window take a long time to appear at startup (for KSP1); as a rule, the app should be visible as early as possible so users can see it's running, and they should be able to tell what it's doing if it's busy.
- `Main`'s constructor was calling `Application.Run`, which is not good coding style; a constructor should just create the object (even under RAII), not trigger side effects such as _running the entire application_

## Cause

- GUI calls `Registry.Instance` before the window appears, which makes it load `registry.json` which is around 30 MiB nowadays and causes a substantial delay

## Changes

- ConsoleUI's lockfile message moved to `Core.RegistryInUseKraken.ToString` to be shared, and the English text is edited to be clearer (one "instance" is now "CKAN process" and the other is "game folder")
- Now GUI's lockfile error popup is replaced with a yes/no dialog with custom button captions (translations copied from ConsoleUI where available):
  ![image](https://user-images.githubusercontent.com/1559108/233722666-8f5dab02-860c-4bb2-a4fe-1d9b86a37e9a.png)
  If you click Cancel, the manage game instances popup will appear so you can pick a different game instance (if you have any others). If you click Force, it'll try to delete the lockfile and proceed with the chosen instance.
- Now the GUI window appears before `registry.json` is loaded, and a progress bar is shown while it loads
- The sometimes-slow `GameInstance.Scan` call is moved from startup to `UpdateModsList` with its own log message to keep the GUI responsive while it happens (since this was previously _between_ the two progress bar sections)
- We now pass the parent form to all the calls of `ShowDialog` that I was able to find, which is good practice in case we want to center the child dialogs on the parents
- `Main.manager` is now private and external users are switched to using the public `Main.Manager` instead, and various other members of `Main` are also made private or readonly
- All potentially slow actions are removed from `Main`'s constructor and from `OnLoad` and moved to `OnShown`, where they now occur within a `Wait.StartWaiting` block that shows a progress bar. The roles of these functions are now:
  - `Program.Main_`: Instantiate the main form, hide the console window, and run the application
  - Constructor: Just set up the basic core properties so `Main` can be loaded, such as the GUI events
  - `OnLoad`: Get the GUI configuration (without locking the instance!) so we can get the saved window geometry/layout before the window appears
  - `OnShown`: Load the registry once the window appears and prompt the user for various things
- GUI configuration is now only saved at exit and when we change instances rather than every time we change any setting
- `Main.tabController` and `Main.Instance` are now marked with the `[Obsolete]` attribute to generate code style warnings, and the `Main*.cs` file now all have `#pragma warning disable 0618` to suppress the warning when used by the same class

This will generally make GUI better behaved, since it will appear very soon after launch and tell the user what it's doing. And if the lockfile exists, users will have the option to delete it.

Fixes #3558.

### Deferred to later

We should also show a progress bar when the user changes instances via the manage game instances popup. I looked into that and it was more complicated than I could manage at this point due to conflicting usages of the progress bar tab.
