### PR TITLE
Add download link to staging PRs

### DIFF
--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -55,12 +55,12 @@ namespace CKAN.NetKAN.Transformers
                 new VersionEditTransformer(),
                 new ForcedVTransformer(),
                 new EpochTransformer(),
-                new StagingLinksTransformer(),
                 // This is the "default" VersionedOverrideTransformer for compatibility with overrides that don't
                 // specify a before or after property.
                 new VersionedOverrideTransformer(before: new string[] { null }, after: new string[] { null }),
                 new DownloadAttributeTransformer(http, fileService),
                 new InstallSizeTransformer(http, moduleService, game),
+                new StagingLinksTransformer(),
                 new GeneratedByTransformer(),
                 new OptimusPrimeTransformer(),
                 new StripNetkanMetadataTransformer(),

--- a/Netkan/Transformers/StagingLinksTransformer.cs
+++ b/Netkan/Transformers/StagingLinksTransformer.cs
@@ -40,6 +40,7 @@ namespace CKAN.NetKAN.Transformers
             // Blank lines to separate the table from the description
             table.AppendLine("Resource | URL");
             table.AppendLine(":-- | :--");
+            table.AppendLine($"download | <{metadata.Download}>");
             foreach (var prop in resourcesJson.Properties().OrderBy(prop => prop.Name))
             {
                 table.AppendLine($"{prop.Name} | <{prop.Value}>");


### PR DESCRIPTION
## Motivation

Dealing with KSP-CKAN/CKAN-meta#3183, KSP-CKAN/CKAN-meta#3184, KSP-CKAN/CKAN-meta#3185, KSP-CKAN/CKAN-meta#3186, and KSP-CKAN/CKAN-meta#3187 requires downloading the mod, but how to do this must be figured out by the PR reviewer (generally the answer is to click the spacedock or repository link and then click the download link on the host). This is inconvenient.

## Changes

- The `StagingLinksTransformer` now executes after `DownloadAttributeTransformer` and `InstallSizeTransformer`, which from reviewing #3454 I think should be fine
- Before it loops over the resources, `StagingLinksTransformer` adds a row containing `metadata.Download`
