### PR TITLE
Stop building on Mono 6.6 and earlier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mono: ['5.20', '6.4', '6.6', '6.8', 'latest']
+        mono: ['6.8', '6.10', '6.12', 'latest']
         configuration: [Debug, Release]
 
     container:


### PR DESCRIPTION
## Problem

Builds started failing on Mono 6.6 and earlier with #3558 (which itself made no relevant changes):

![image](https://user-images.githubusercontent.com/1559108/234433484-66b99a0b-f99b-4c96-902d-0625ee98299d.png)

## Cause

The Docker images for older Mono releases seem to point to Debian repos that no longer have the data for those versions ("stretch"). I don't think we can fix this; the images are now simply too old to be used.

<http://ftp.debian.org/debian/dists/>

## Changes

<https://www.mono-project.com/docs/about-mono/releases/>

- Mono 5.20 (April 2019), 6.4 (September 2019), and 6.6 (December 2019) are removed from the list of builds
- Mono 6.10 (May 2020) and 6.12 (November 2020) are added

This will allow our pull requests to build.