### PR TITLE
Installation history tab

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -122,20 +122,6 @@ namespace CKAN
                 User.RaiseMessage(Properties.Resources.GameInstanceCreatingDir, InstallHistoryDir());
                 txFileMgr.CreateDirectory(InstallHistoryDir());
             }
-
-            // Clear any temporary files we find. If the directory
-            // doesn't exist, then no sweat; FilesystemTransaction
-            // will auto-create it as needed.
-            // Create our temporary directories, or clear them if they
-            // already exist.
-            if (Directory.Exists(TempDir()))
-            {
-                var directory = new DirectoryInfo(TempDir());
-                foreach (FileInfo file in directory.GetFiles())
-                    txFileMgr.Delete(file.FullName);
-                foreach (DirectoryInfo subDirectory in directory.GetDirectories())
-                    txFileMgr.DeleteDirectory(subDirectory.FullName);
-            }
             log.InfoFormat("Initialised {0}", CkanDir());
         }
 
@@ -334,8 +320,6 @@ namespace CKAN
         public string InstallHistoryDir()
             => CKANPathUtils.NormalizePath(Path.Combine(CkanDir(), "history"));
 
-        public string TempDir()
-            => CKANPathUtils.NormalizePath(Path.Combine(CkanDir(), "temp"));
 
         public GameVersion Version()
         {

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -320,6 +320,10 @@ namespace CKAN
         public string InstallHistoryDir()
             => CKANPathUtils.NormalizePath(Path.Combine(CkanDir(), "history"));
 
+        public IOrderedEnumerable<FileInfo> InstallHistoryFiles()
+            => Directory.EnumerateFiles(InstallHistoryDir(), "*.ckan")
+                        .Select(f => new FileInfo(f))
+                        .OrderByDescending(fi => fi.CreationTime);
 
         public GameVersion Version()
         {

--- a/Core/HelpURLs.cs
+++ b/Core/HelpURLs.cs
@@ -18,6 +18,7 @@ namespace CKAN
         public const string Labels = "https://github.com/KSP-CKAN/CKAN/pull/2936";
         public const string PlayTime = "https://github.com/KSP-CKAN/CKAN/pull/3543";
         public const string DownloadsFailed = "https://github.com/KSP-CKAN/CKAN/pull/3635";
+        public const string UnmanagedFiles = "https://github.com/KSP-CKAN/CKAN/pull/3833";
 
         public const string Discord = "https://discord.gg/Mb4nXQD";
     }

--- a/Core/HelpURLs.cs
+++ b/Core/HelpURLs.cs
@@ -19,6 +19,7 @@ namespace CKAN
         public const string PlayTime = "https://github.com/KSP-CKAN/CKAN/pull/3543";
         public const string DownloadsFailed = "https://github.com/KSP-CKAN/CKAN/pull/3635";
         public const string UnmanagedFiles = "https://github.com/KSP-CKAN/CKAN/pull/3833";
+        public const string InstallationHistory = "https://github.com/KSP-CKAN/CKAN/pull/3834";
 
         public const string Discord = "https://discord.gg/Mb4nXQD";
     }

--- a/Core/Versioning/ModuleVersion.cs
+++ b/Core/Versioning/ModuleVersion.cs
@@ -86,9 +86,16 @@ namespace CKAN.Versioning
         /// The return value should not be considered safe for use in file paths.
         /// </remarks>
         public override string ToString()
-        {
-            return _string;
-        }
+            => _string;
+
+        public string ToString(bool hideEpoch, bool hideV)
+            => hideEpoch
+                ? hideV
+                    ? ModuleInstaller.StripEpoch(ModuleInstaller.StripV(_string))
+                    : ModuleInstaller.StripEpoch(_string)
+                : hideV
+                    ? ModuleInstaller.StripV(_string)
+                    : _string;
     }
 
     public partial class ModuleVersion : IEquatable<ModuleVersion>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -237,6 +237,12 @@
     <Compile Include="Controls\UnmanagedFiles.Designer.cs">
       <DependentUpon>UnmanagedFiles.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\InstallationHistory.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\InstallationHistory.Designer.cs">
+      <DependentUpon>InstallationHistory.cs</DependentUpon>
+    </Compile>
     <Compile Include="Controls\EditModSearches.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -338,6 +344,9 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Main\MainUnmanaged.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Main\MainHistory.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Main\MainWait.cs">
@@ -879,6 +888,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\UnmanagedFiles.resx">
       <DependentUpon>UnmanagedFiles.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Controls\InstallationHistory.resx">
+      <DependentUpon>InstallationHistory.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\PlayTime.resx">
       <DependentUpon>PlayTime.cs</DependentUpon>

--- a/GUI/Controls/InstallationHistory.Designer.cs
+++ b/GUI/Controls/InstallationHistory.Designer.cs
@@ -1,0 +1,238 @@
+namespace CKAN.GUI
+{
+    partial class InstallationHistory
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(InstallationHistory));
+            this.ToolTip = new System.Windows.Forms.ToolTip();
+            this.Toolbar = new System.Windows.Forms.MenuStrip();
+            this.InstallButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.Splitter = new System.Windows.Forms.SplitContainer();
+            this.HistoryListView = new ThemedListView();
+            this.TimestampColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.ModsListView = new ThemedListView();
+            this.NotInstalledGroup = new System.Windows.Forms.ListViewGroup();
+            this.InstalledGroup = new System.Windows.Forms.ListViewGroup();
+            this.NameColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.VersionColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.AuthorColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.DescriptionColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.SelectInstallMessage = new System.Windows.Forms.ListViewItem();
+            this.NoModsMessage = new System.Windows.Forms.ListViewItem();
+            this.BottomButtonPanel = new LeftRightRowPanel();
+            this.OKButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // Toolbar
+            //
+            this.Toolbar.AutoSize = false;
+            this.Toolbar.Dock = System.Windows.Forms.DockStyle.Top;
+            this.Toolbar.ImageScalingSize = new System.Drawing.Size(24, 24);
+            this.Toolbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.InstallButton});
+            this.Toolbar.CanOverflow = true;
+            this.Toolbar.Location = new System.Drawing.Point(0, 0);
+            this.Toolbar.Name = "Toolbar";
+            this.Toolbar.ShowItemToolTips = true;
+            this.Toolbar.Size = new System.Drawing.Size(5876, 48);
+            this.Toolbar.TabStop = true;
+            this.Toolbar.TabIndex = 0;
+            this.Toolbar.Text = "Toolbar";
+            //
+            // InstallButton
+            //
+            //this.InstallButton.Image = global::CKAN.GUI.Properties.Resources.install;
+            this.InstallButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.InstallButton.Name = "InstallButton";
+            this.InstallButton.Size = new System.Drawing.Size(114, 56);
+            this.InstallButton.Overflow = System.Windows.Forms.ToolStripItemOverflow.AsNeeded;
+            this.InstallButton.Click += new System.EventHandler(this.InstallButton_Click);
+            resources.ApplyResources(this.InstallButton, "InstallButton");
+            //
+            // Splitter
+            //
+            this.Splitter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Splitter.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.Splitter.IsSplitterFixed = true;
+            this.Splitter.Location = new System.Drawing.Point(5, 70);
+            this.Splitter.Margin = new System.Windows.Forms.Padding(0,0,0,0);
+            this.Splitter.Name = "Splitter";
+            this.Splitter.Size = new System.Drawing.Size(490, 385);
+            this.Splitter.SplitterDistance = 100;
+            this.Splitter.SplitterWidth = 10;
+            this.Splitter.TabIndex = 1;
+            //
+            // Splitter.Panel1
+            //
+            this.Splitter.Panel1.Controls.Add(this.HistoryListView);
+            this.Splitter.Panel1MinSize = 100;
+            //
+            // Splitter.Panel2
+            //
+            this.Splitter.Panel2.Controls.Add(this.ModsListView);
+            this.Splitter.Panel2MinSize = 400;
+            //
+            // HistoryListView
+            //
+            this.HistoryListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.TimestampColumn});
+            this.HistoryListView.CheckBoxes = false;
+            this.HistoryListView.FullRowSelect = true;
+            this.HistoryListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.HistoryListView.HideSelection = false;
+            this.HistoryListView.Location = new System.Drawing.Point(0, 0);
+            this.HistoryListView.MultiSelect = false;
+            this.HistoryListView.Name = "HistoryListView";
+            this.HistoryListView.Size = new System.Drawing.Size(230, 455);
+            this.HistoryListView.TabIndex = 2;
+            this.HistoryListView.UseCompatibleStateImageBehavior = false;
+            this.HistoryListView.View = System.Windows.Forms.View.Details;
+            this.HistoryListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.HistoryListView.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(HistoryListView_ItemSelectionChanged);
+            //
+            // TimestampColumn
+            //
+            this.TimestampColumn.Width = -1;
+            resources.ApplyResources(this.TimestampColumn, "TimestampColumn");
+            //
+            // ModsListView
+            //
+            this.ModsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.NameColumn,
+            this.VersionColumn,
+            this.AuthorColumn,
+            this.DescriptionColumn});
+            this.ModsListView.CheckBoxes = false;
+            this.ModsListView.FullRowSelect = true;
+            this.ModsListView.HideSelection = false;
+            this.ModsListView.Groups.Add(this.NotInstalledGroup);
+            this.ModsListView.Groups.Add(this.InstalledGroup);
+            this.ModsListView.Location = new System.Drawing.Point(0, 0);
+            this.ModsListView.MultiSelect = false;
+            this.ModsListView.Name = "ModsListView";
+            this.ModsListView.Size = new System.Drawing.Size(230, 455);
+            this.ModsListView.TabIndex = 2;
+            this.ModsListView.UseCompatibleStateImageBehavior = false;
+            this.ModsListView.View = System.Windows.Forms.View.Details;
+            this.ModsListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ModsListView.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(ModsListView_ItemSelectionChanged);
+            //
+            // NotInstalledGroup
+            //
+            this.NotInstalledGroup.Name = "NotInstalledGroup";
+            this.NotInstalledGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            resources.ApplyResources(this.NotInstalledGroup, "NotInstalledGroup");
+            //
+            // InstalledGroup
+            //
+            this.InstalledGroup.Name = "InstalledGroup";
+            this.InstalledGroup.HeaderAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            resources.ApplyResources(this.InstalledGroup, "InstalledGroup");
+            //
+            // NameColumn
+            //
+            this.NameColumn.Width = -1;
+            resources.ApplyResources(this.NameColumn, "NameColumn");
+            //
+            // VersionColumn
+            //
+            this.VersionColumn.Width = 70;
+            resources.ApplyResources(this.VersionColumn, "VersionColumn");
+            //
+            // AuthorColumn
+            //
+            this.AuthorColumn.Width = 120;
+            resources.ApplyResources(this.AuthorColumn, "AuthorColumn");
+            //
+            // DescriptionColumn
+            //
+            this.DescriptionColumn.Width = -1;
+            resources.ApplyResources(this.DescriptionColumn, "DescriptionColumn");
+            //
+            // SelectInstallMessage
+            //
+            resources.ApplyResources(this.SelectInstallMessage, "SelectInstallMessage");
+            //
+            // NoModsMessage
+            //
+            resources.ApplyResources(this.NoModsMessage, "NoModsMessage");
+            //
+            // BottomButtonPanel
+            //
+            this.BottomButtonPanel.RightControls.Add(this.OKButton);
+            this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.BottomButtonPanel.Name = "BottomButtonPanel";
+            //
+            // OKButton
+            //
+            this.OKButton.AutoSize = true;
+            this.OKButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.OKButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.OKButton.Name = "OKButton";
+            this.OKButton.Size = new System.Drawing.Size(112, 30);
+            this.OKButton.TabIndex = 2;
+            this.OKButton.Click += new System.EventHandler(this.OKButton_Click);
+            resources.ApplyResources(this.OKButton, "OKButton");
+            //
+            // InstallationHistory
+            //
+            this.Controls.Add(this.Splitter);
+            this.Controls.Add(this.Toolbar);
+            this.Controls.Add(this.BottomButtonPanel);
+            this.Name = "InstallationHistory";
+            this.Size = new System.Drawing.Size(500, 500);
+            resources.ApplyResources(this, "$this");
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ToolTip ToolTip;
+        private System.Windows.Forms.MenuStrip Toolbar;
+        private System.Windows.Forms.ToolStripMenuItem InstallButton;
+        private System.Windows.Forms.SplitContainer Splitter;
+        private System.Windows.Forms.ListView HistoryListView;
+        private System.Windows.Forms.ColumnHeader TimestampColumn;
+        private System.Windows.Forms.ListView ModsListView;
+        private System.Windows.Forms.ListViewGroup NotInstalledGroup;
+        private System.Windows.Forms.ListViewGroup InstalledGroup;
+        private System.Windows.Forms.ColumnHeader NameColumn;
+        private System.Windows.Forms.ColumnHeader VersionColumn;
+        private System.Windows.Forms.ColumnHeader AuthorColumn;
+        private System.Windows.Forms.ColumnHeader DescriptionColumn;
+        private System.Windows.Forms.ListViewItem SelectInstallMessage;
+        private System.Windows.Forms.ListViewItem NoModsMessage;
+        private LeftRightRowPanel BottomButtonPanel;
+        private System.Windows.Forms.Button OKButton;
+    }
+}

--- a/GUI/Controls/InstallationHistory.cs
+++ b/GUI/Controls/InstallationHistory.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using System.IO;
+using System.Threading.Tasks;
+
+using CKAN.Games;
+
+namespace CKAN.GUI
+{
+    public partial class InstallationHistory : UserControl
+    {
+        public InstallationHistory()
+        {
+            InitializeComponent();
+        }
+
+        public void LoadHistory(GameInstance inst, GUIConfiguration config)
+        {
+            this.inst     = inst;
+            this.registry = RegistryManager.Instance(inst).registry;
+            this.config   = config;
+            Util.Invoke(this, () =>
+            {
+                UseWaitCursor = true;
+                Task.Factory.StartNew(() =>
+                {
+                    var items = inst.InstallHistoryFiles()
+                                    .Select(fi => new ListViewItem(fi.CreationTime.ToString("g"))
+                                                  {
+                                                      Tag = fi
+                                                  })
+                                    .ToArray();
+                    Util.Invoke(this, () =>
+                    {
+                        HistoryListView.BeginUpdate();
+                        HistoryListView.Items.Clear();
+                        HistoryListView.Items.AddRange(items);
+                        HistoryListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+                        Splitter.Panel1MinSize = Splitter.SplitterDistance =
+                            TimestampColumn.Width
+                                + SystemInformation.VerticalScrollBarWidth
+                                + 4 * SystemInformation.BorderSize.Width;
+                        HistoryListView.EndUpdate();
+                        HistoryListView_ItemSelectionChanged(null, null);
+                        UseWaitCursor = false;
+                    });
+                });
+            });
+        }
+
+        /// <summary>
+        /// Invoked when the user selects a module
+        /// </summary>
+        public event Action<GUIMod> OnSelectedModuleChanged;
+
+        /// <summary>
+        /// Invoked when the user clicks the Install toolbar button
+        /// </summary>
+        public event Action<CkanModule[]> Install;
+
+        /// <summary>
+        /// Invoked when the user clicks OK
+        /// </summary>
+        public event Action Done;
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.InstallationHistory);
+        }
+
+        private void HistoryListView_ItemSelectionChanged(Object sender, ListViewItemSelectionChangedEventArgs e)
+        {
+            UseWaitCursor = true;
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    var path = HistoryListView.SelectedItems
+                                              .Cast<ListViewItem>()
+                                              .Select(lvi => lvi.Tag as FileInfo)
+                                              .First();
+                    var modRows = CkanModule.FromFile(path.FullName)
+                                            .depends
+                                            .Select(rel => rel as ModuleRelationshipDescriptor)
+                                            .Where(rel => rel != null)
+                                            .Select(ItemFromRelationship)
+                                            .Where(row => row != null)
+                                            .ToArray();
+                    Util.Invoke(this, () =>
+                    {
+                        ModsListView.BeginUpdate();
+                        ModsListView.Items.Clear();
+                        if (modRows.Length > 0)
+                        {
+                            if (!ModsListView.ShowGroups)
+                            {
+                                // Work around first group header not showing up on first click
+                                ModsListView.EndUpdate();
+                                ModsListView.ShowGroups = true;
+                                ModsListView.HeaderStyle = ColumnHeaderStyle.Clickable;
+                                ModsListView.BeginUpdate();
+                            }
+                            ModsListView.Items.AddRange(modRows);
+                        }
+                        else
+                        {
+                            ModsListView.ShowGroups = false;
+                            ModsListView.HeaderStyle = ColumnHeaderStyle.None;
+                            ModsListView.Items.Add(NoModsMessage);
+                        }
+                        // Don't auto-resize version or author columns
+                        ModsListView.AutoResizeColumn(NameColumn.Index,        ColumnHeaderAutoResizeStyle.ColumnContent);
+                        ModsListView.AutoResizeColumn(DescriptionColumn.Index, ColumnHeaderAutoResizeStyle.ColumnContent);
+                        ModsListView.EndUpdate();
+                        OnSelectedModuleChanged?.Invoke(null);
+                        UseWaitCursor = false;
+                    });
+                }
+                catch
+                {
+                    Util.Invoke(this, () =>
+                    {
+                        ModsListView.BeginUpdate();
+                        ModsListView.Items.Clear();
+                        ModsListView.ShowGroups = false;
+                        ModsListView.HeaderStyle = ColumnHeaderStyle.None;
+                        ModsListView.Items.Add(SelectInstallMessage);
+                        ModsListView.AutoResizeColumn(NameColumn.Index, ColumnHeaderAutoResizeStyle.ColumnContent);
+                        ModsListView.EndUpdate();
+                        UseWaitCursor = false;
+                    });
+                }
+            });
+        }
+
+        private ListViewItem ItemFromRelationship(ModuleRelationshipDescriptor rel)
+        {
+            var mod = registry.GetModuleByVersion(rel.name, rel.version)
+                      ?? SaneLatestAvail(rel.name);
+            return mod == null
+                ? new ListViewItem(new string[]
+                  {
+                      rel.name,
+                      rel.version.ToString(config.HideEpochs, config.HideV),
+                      "???",
+                      "???"
+                  })
+                  {
+                      Tag   = rel,
+                      Group = registry.IsInstalled(rel.name, false)
+                              ? InstalledGroup
+                              : NotInstalledGroup
+                  }
+                : mod.IsDLC
+                    // Never show DLC
+                    ? null
+                    : new ListViewItem(new string[]
+                      {
+                          mod.name,
+                          mod.version.ToString(config.HideEpochs, config.HideV),
+                          string.Join(", ", mod.author),
+                          mod.@abstract
+                      })
+                      {
+                          Tag   = mod,
+                          Group = registry.IsInstalled(mod.identifier, false)
+                                  ? InstalledGroup
+                                  : NotInstalledGroup
+                      };
+        }
+
+        // Registry.LatestAvailable without exceptions
+        private CkanModule SaneLatestAvail(string identifier)
+        {
+            try
+            {
+                return registry.LatestAvailable(identifier, inst.VersionCriteria());
+            }
+            catch
+            {
+                try
+                {
+                    return registry.LatestAvailable(identifier, null);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+        }
+
+        private void ModsListView_ItemSelectionChanged(Object sender, ListViewItemSelectionChangedEventArgs e)
+        {
+            var mod = ModsListView.SelectedItems
+                                  .Cast<ListViewItem>()
+                                  .Select(lvi => lvi.Tag as CkanModule)
+                                  .FirstOrDefault();
+            if (mod != null)
+            {
+                OnSelectedModuleChanged?.Invoke(new GUIMod(
+                    mod, registry, inst.VersionCriteria()));
+            }
+        }
+
+        private void InstallButton_Click(object sender, EventArgs e)
+        {
+            Install?.Invoke(ModsListView.Items
+                                        .Cast<ListViewItem>()
+                                        .Where(lvi => lvi.Group == NotInstalledGroup)
+                                        .Select(lvi => lvi.Tag as CkanModule)
+                                        .Where(mod => mod != null)
+                                        .ToArray());
+        }
+
+        private void OKButton_Click(object sender, EventArgs e)
+        {
+            Done?.Invoke();
+        }
+
+        private GameInstance     inst;
+        private Registry         registry;
+        private GUIConfiguration config;
+    }
+}

--- a/GUI/Controls/InstallationHistory.resx
+++ b/GUI/Controls/InstallationHistory.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -117,54 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>32</value>
-  </metadata>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>&amp;File</value></data>
-  <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>&amp;Manage game instances</value></data>
-  <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Open game directory</value></data>
-  <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Install from .ckan...</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list (cannot be re-imported)...</value></data>
-  <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Export modpack (can be re-imported)...</value></data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
-  <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Audit &amp;recommendations</value></data>
-  <data name="ExitToolButton.Text" xml:space="preserve"><value>E&amp;xit</value></data>
-  <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Settings</value></data>
-  <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;settings</value></data>
-  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;plugins</value></data>
-  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;filters</value></data>
-  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Game command-line</value></data>
-  <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Compatible game versions</value></data>
-  <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Help</value></data>
-  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>&amp;User guide</value></data>
-  <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Discord</value></data>
-  <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN &amp;client</value></data>
-  <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod &amp;metadata</value></data>
-  <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>&amp;About</value></data>
-  <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Manage Mods</value></data>
-  <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Changeset</value></data>
-  <data name="WaitTabPage.Text" xml:space="preserve"><value>Status Log</value></data>
-  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Choose Mods</value></data>
-  <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Choose Recommended, Suggested, or Supporting Mods</value></data>
-  <data name="PlayTimeTabPage.Text" xml:space="preserve"><value>Play Time</value></data>
-  <data name="DeleteDirectoriesTabPage.Text" xml:space="preserve"><value>Delete Directories</value></data>
-  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Edit Modpack</value></data>
-  <data name="UnmanagedFilesTabPage.Text" xml:space="preserve"><value>Unmanaged Files</value></data>
-  <data name="InstallationHistoryTabPage.Text" xml:space="preserve"><value>Installation History</value></data>
-  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
-  <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N available updates</value></data>
-  <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Refresh</value></data>
-  <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Pause</value></data>
-  <data name="openCKANToolStripMenuItem.Text" xml:space="preserve"><value>Open CKAN</value></data>
-  <data name="openGameToolStripMenuItem.Text" xml:space="preserve"><value>Launch Game</value></data>
-  <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Open Game Directory</value></data>
-  <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Settings</value></data>
-  <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quit</value></data>
-  <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play &amp;time...</value></data>
-  <data name="viewUnmanagedFilesStripMenuItem.Text" xml:space="preserve"><value>&amp;Unmanaged files...</value></data>
-  <data name="installationHistoryStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;history...</value></data>
-  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
+  <data name="TimestampColumn.Text" xml:space="preserve"><value>Timestamp</value></data>
+  <data name="NotInstalledGroup.Header" xml:space="preserve"><value>Not currently installed</value></data>
+  <data name="InstalledGroup.Header" xml:space="preserve"><value>Currently installed</value></data>
+  <data name="NameColumn.Text" xml:space="preserve"><value>Name</value></data>
+  <data name="VersionColumn.Text" xml:space="preserve"><value>Version</value></data>
+  <data name="AuthorColumn.Text" xml:space="preserve"><value>Authors</value></data>
+  <data name="DescriptionColumn.Text" xml:space="preserve"><value>Description</value></data>
+  <data name="SelectInstallMessage.Text" xml:space="preserve"><value>Click a timestamp at the left to see which mods were installed</value></data>
+  <data name="NoModsMessage.Text" xml:space="preserve"><value>No mods were installed</value></data>
+  <data name="InstallButton.Text" xml:space="preserve"><value>Install</value></data>
+  <data name="OKButton.Text" xml:space="preserve"><value>OK</value></data>
 </root>

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1133,20 +1133,20 @@ namespace CKAN.GUI
             gui_mods.UnionWith(
                 registry.InstalledModules
                     .Where(instMod => !instMod.Module.IsDLC)
-                    .Select(instMod => new GUIMod(instMod, registry, versionCriteria))
-            );
+                    .Select(instMod => new GUIMod(instMod, registry, versionCriteria, null,
+                        Main.Instance.configuration.HideEpochs, Main.Instance.configuration.HideV)));
             Main.Instance.Wait.AddLogMessage(Properties.Resources.MainModListLoadingAvailable);
             gui_mods.UnionWith(
                 registry.CompatibleModules(versionCriteria)
                     .Where(m => !m.IsDLC)
-                    .Select(m => new GUIMod(m, registry, versionCriteria))
-            );
+                    .Select(m => new GUIMod(m, registry, versionCriteria, null,
+                        Main.Instance.configuration.HideEpochs, Main.Instance.configuration.HideV)));
             Main.Instance.Wait.AddLogMessage(Properties.Resources.MainModListLoadingIncompatible);
             gui_mods.UnionWith(
                 registry.IncompatibleModules(versionCriteria)
                     .Where(m => !m.IsDLC)
-                    .Select(m => new GUIMod(m, registry, versionCriteria, true))
-            );
+                    .Select(m => new GUIMod(m, registry, versionCriteria, true,
+                        Main.Instance.configuration.HideEpochs, Main.Instance.configuration.HideV)));
 
             Main.Instance.Wait.AddLogMessage(Properties.Resources.MainModListPreservingNew);
             var toNotify = new HashSet<GUIMod>();
@@ -1187,7 +1187,7 @@ namespace CKAN.GUI
 
             Main.Instance.Wait.AddLogMessage(Properties.Resources.MainModListPopulatingList);
             // Update our mod listing
-            mainModList.ConstructModList(gui_mods.ToList(), Main.Instance.CurrentInstance.Name, ChangeSet, Main.Instance.configuration.HideEpochs, Main.Instance.configuration.HideV);
+            mainModList.ConstructModList(gui_mods.ToList(), Main.Instance.CurrentInstance.Name, ChangeSet);
             mainModList.Modules = new ReadOnlyCollection<GUIMod>(
                 mainModList.full_list_of_mod_rows.Values.Select(row => row.Tag as GUIMod).ToList());
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1641,8 +1641,7 @@ namespace CKAN.GUI
             try
             {
                 var gameVersion = inst.VersionCriteria();
-                var module_installer = new ModuleInstaller(inst, Main.Instance.Manager.Cache, Main.Instance.currentUser);
-                var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, module_installer, gameVersion);
+                var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, gameVersion);
                 full_change_set = tuple.Item1.ToList();
                 new_conflicts = tuple.Item2.ToDictionary(
                     item => new GUIMod(item.Key, registry, gameVersion),

--- a/GUI/Controls/UnmanagedFiles.cs
+++ b/GUI/Controls/UnmanagedFiles.cs
@@ -23,13 +23,21 @@ namespace CKAN.GUI
         {
             this.inst = inst;
             this.registry = RegistryManager.Instance(inst).registry;
-            Util.Invoke(GameFolderTree, _UpdateGameFolderTree);
+            Util.Invoke(this, _UpdateGameFolderTree);
         }
 
         /// <summary>
         /// Invoked when the user clicks OK
         /// </summary>
         public event Action Done;
+
+        /// <summary>
+        /// Open the user guide when the user presses F1
+        /// </summary>
+        protected override void OnHelpRequested(HelpEventArgs evt)
+        {
+            evt.Handled = Util.TryOpenWebPage(HelpURLs.UnmanagedFiles);
+        }
 
         private void _UpdateGameFolderTree()
         {

--- a/GUI/Controls/UnmanagedFiles.cs
+++ b/GUI/Controls/UnmanagedFiles.cs
@@ -7,6 +7,8 @@ using System.Windows.Forms;
 using System.IO;
 using System.Threading.Tasks;
 
+using CKAN.Games;
+
 namespace CKAN.GUI
 {
     public partial class UnmanagedFiles : UserControl
@@ -17,8 +19,10 @@ namespace CKAN.GUI
             GameFolderTree.TreeViewNodeSorter = new DirsFirstSorter();
         }
 
-        public void Refresh()
+        public void LoadFiles(GameInstance inst)
         {
+            this.inst = inst;
+            this.registry = RegistryManager.Instance(inst).registry;
             Util.Invoke(GameFolderTree, _UpdateGameFolderTree);
         }
 
@@ -26,8 +30,6 @@ namespace CKAN.GUI
         /// Invoked when the user clicks OK
         /// </summary>
         public event Action Done;
-
-        private GameInstanceManager manager => Main.Instance.Manager;
 
         private void _UpdateGameFolderTree()
         {
@@ -37,14 +39,13 @@ namespace CKAN.GUI
             GameFolderTree.Nodes.Clear();
             var rootNode = GameFolderTree.Nodes.Add(
                 "",
-                manager.CurrentInstance.GameDir().Replace('/', Path.DirectorySeparatorChar),
+                inst.GameDir().Replace('/', Path.DirectorySeparatorChar),
                 "folder", "folder");
 
             UseWaitCursor = true;
             Task.Factory.StartNew(() =>
             {
-                var registry = RegistryManager.Instance(manager.CurrentInstance).registry;
-                var paths = manager.CurrentInstance?.UnmanagedFiles(registry).ToArray()
+                var paths = inst?.UnmanagedFiles(registry).ToArray()
                     ?? new string[] { };
                 Util.Invoke(this, () =>
                 {
@@ -55,7 +56,7 @@ namespace CKAN.GUI
                     }
                     rootNode.Expand();
                     rootNode.EnsureVisible();
-                    ExpandDefaultModDir();
+                    ExpandDefaultModDir(inst.game);
                     // The nodes don't have children at first, so the sort needs to be re-applied after they're added
                     GameFolderTree.Sort();
                     GameFolderTree.EndUpdate();
@@ -68,9 +69,9 @@ namespace CKAN.GUI
             => Enumerable.Range(1, pathPieces.Length)
                          .Select(numPieces => string.Join("/", pathPieces.Take(numPieces)));
 
-        private void ExpandDefaultModDir()
+        private void ExpandDefaultModDir(IGame game)
         {
-            foreach (string path in ParentPaths(manager.CurrentInstance.game.PrimaryModDirectoryRelative.Split(new char[] {'/'})))
+            foreach (string path in ParentPaths(game.PrimaryModDirectoryRelative.Split(new char[] {'/'})))
             {
                 foreach (var node in GameFolderTree.Nodes.Find(path, true))
                 {
@@ -126,7 +127,7 @@ namespace CKAN.GUI
             GameFolderTree.BeginUpdate();
             GameFolderTree.CollapseAll();
             GameFolderTree.Nodes[0].Expand();
-            ExpandDefaultModDir();
+            ExpandDefaultModDir(inst.game);
             GameFolderTree.Nodes[0].EnsureVisible();
             GameFolderTree.EndUpdate();
             GameFolderTree.Focus();
@@ -141,9 +142,8 @@ namespace CKAN.GUI
         private void DeleteButton_Click(object sender, EventArgs e)
         {
             var relPath = GameFolderTree.SelectedNode?.Name;
-            var registry = RegistryManager.Instance(manager.CurrentInstance).registry;
-            var absPath = manager.CurrentInstance.ToAbsoluteGameDir(relPath);
-            if (manager.CurrentInstance.HasManagedFiles(registry, absPath))
+            var absPath = inst.ToAbsoluteGameDir(relPath);
+            if (inst.HasManagedFiles(registry, absPath))
             {
                 Main.Instance.ErrorDialog(Properties.Resources.FolderContainsManagedFiles, relPath);
             }
@@ -184,7 +184,7 @@ namespace CKAN.GUI
         {
             if (node != null)
             {
-                string location = manager.CurrentInstance.ToAbsoluteGameDir(node.Name);
+                string location = inst.ToAbsoluteGameDir(node.Name);
 
                 if (File.Exists(location))
                 {
@@ -203,6 +203,9 @@ namespace CKAN.GUI
                 Utilities.ProcessStartURL(location);
             }
         }
+
+        private GameInstance inst;
+        private Registry     registry;
     }
 
     internal class DirsFirstSorter : IComparer, IComparer<TreeNode>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -80,6 +80,8 @@
             this.PlayTime = new CKAN.GUI.PlayTime();
             this.UnmanagedFilesTabPage = new System.Windows.Forms.TabPage();
             this.UnmanagedFiles = new CKAN.GUI.UnmanagedFiles();
+            this.InstallationHistoryTabPage = new System.Windows.Forms.TabPage();
+            this.InstallationHistory = new CKAN.GUI.InstallationHistory();
             this.ChooseProvidedModsTabPage = new System.Windows.Forms.TabPage();
             this.ChooseProvidedMods = new CKAN.GUI.ChooseProvidedMods();
             this.minimizeNotifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
@@ -99,6 +101,7 @@
             this.quitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewPlayTimeStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewUnmanagedFilesStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.installationHistoryStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.DeleteDirectoriesTabPage = new System.Windows.Forms.TabPage();
             this.DeleteDirectories = new CKAN.GUI.DeleteDirectories();
             this.EditModpackTabPage = new System.Windows.Forms.TabPage();
@@ -119,6 +122,8 @@
             this.PlayTime.SuspendLayout();
             this.UnmanagedFilesTabPage.SuspendLayout();
             this.UnmanagedFiles.SuspendLayout();
+            this.InstallationHistoryTabPage.SuspendLayout();
+            this.InstallationHistory.SuspendLayout();
             this.minimizedContextMenuStrip.SuspendLayout();
             this.DeleteDirectoriesTabPage.SuspendLayout();
             this.EditModpackTabPage.SuspendLayout();
@@ -144,6 +149,7 @@
             this.manageGameInstancesMenuItem,
             this.openGameDirectoryToolStripMenuItem,
             this.toolStripSeparator1,
+            this.installationHistoryStripMenuItem,
             this.installFromckanToolStripMenuItem,
             this.importDownloadsToolStripMenuItem,
             this.toolStripSeparator2,
@@ -426,6 +432,7 @@
             this.MainTabControl.Controls.Add(this.ChooseRecommendedModsTabPage);
             this.MainTabControl.Controls.Add(this.PlayTimeTabPage);
             this.MainTabControl.Controls.Add(this.UnmanagedFilesTabPage);
+            this.MainTabControl.Controls.Add(this.InstallationHistoryTabPage);
             this.MainTabControl.Controls.Add(this.ChooseProvidedModsTabPage);
             this.MainTabControl.Controls.Add(this.DeleteDirectoriesTabPage);
             this.MainTabControl.Controls.Add(this.EditModpackTabPage);
@@ -583,6 +590,31 @@
             this.UnmanagedFiles.Size = new System.Drawing.Size(500, 500);
             this.UnmanagedFiles.TabIndex = 32;
             this.UnmanagedFiles.Done += UnmanagedFiles_Done;
+            //
+            // InstallationHistoryTabPage
+            //
+            this.InstallationHistoryTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.InstallationHistoryTabPage.Controls.Add(this.InstallationHistory);
+            this.InstallationHistoryTabPage.Location = new System.Drawing.Point(4, 29);
+            this.InstallationHistoryTabPage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.InstallationHistoryTabPage.Name = "InstallationHistoryTabPage";
+            this.InstallationHistoryTabPage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.InstallationHistoryTabPage.Size = new System.Drawing.Size(1536, 948);
+            this.InstallationHistoryTabPage.TabIndex = 24;
+            resources.ApplyResources(this.InstallationHistoryTabPage, "InstallationHistoryTabPage");
+            //
+            // InstallationHistory
+            //
+            this.InstallationHistory.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.InstallationHistory.Location = new System.Drawing.Point(0, 0);
+            this.InstallationHistory.Margin = new System.Windows.Forms.Padding(0,0,0,0);
+            this.InstallationHistory.Padding = new System.Windows.Forms.Padding(0,0,0,0);
+            this.InstallationHistory.Name = "InstallationHistory";
+            this.InstallationHistory.Size = new System.Drawing.Size(500, 500);
+            this.InstallationHistory.TabIndex = 32;
+            this.InstallationHistory.OnSelectedModuleChanged += InstallationHistory_OnSelectedModuleChanged;
+            this.InstallationHistory.Install += InstallationHistory_Install;
+            this.InstallationHistory.Done += InstallationHistory_Done;
             //
             // ChooseProvidedModsTabPage
             //
@@ -763,6 +795,13 @@
             this.viewUnmanagedFilesStripMenuItem.Click += new System.EventHandler(this.viewUnmanagedFilesStripMenuItem_Click);
             resources.ApplyResources(this.viewUnmanagedFilesStripMenuItem, "viewUnmanagedFilesStripMenuItem");
             //
+            // installationHistoryStripMenuItem
+            //
+            this.installationHistoryStripMenuItem.Name = "installationHistoryStripMenuItem";
+            this.installationHistoryStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.installationHistoryStripMenuItem.Click += new System.EventHandler(this.installationHistoryStripMenuItem_Click);
+            resources.ApplyResources(this.installationHistoryStripMenuItem, "installationHistoryStripMenuItem");
+            //
             // Main
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
@@ -807,6 +846,10 @@
             this.UnmanagedFilesTabPage.PerformLayout();
             this.UnmanagedFiles.ResumeLayout(false);
             this.UnmanagedFiles.PerformLayout();
+            this.InstallationHistoryTabPage.ResumeLayout(false);
+            this.InstallationHistoryTabPage.PerformLayout();
+            this.InstallationHistory.ResumeLayout(false);
+            this.InstallationHistory.PerformLayout();
             this.DeleteDirectoriesTabPage.ResumeLayout(false);
             this.DeleteDirectoriesTabPage.PerformLayout();
             this.EditModpackTabPage.ResumeLayout(false);
@@ -869,6 +912,8 @@
         private CKAN.GUI.PlayTime PlayTime;
         private System.Windows.Forms.TabPage UnmanagedFilesTabPage;
         private CKAN.GUI.UnmanagedFiles UnmanagedFiles;
+        private System.Windows.Forms.TabPage InstallationHistoryTabPage;
+        private CKAN.GUI.InstallationHistory InstallationHistory;
         private System.Windows.Forms.TabPage ChooseProvidedModsTabPage;
         private CKAN.GUI.ChooseProvidedMods ChooseProvidedMods;
         private System.Windows.Forms.TabPage DeleteDirectoriesTabPage;
@@ -892,5 +937,6 @@
         private System.Windows.Forms.ToolStripMenuItem quitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem viewPlayTimeStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem viewUnmanagedFilesStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem installationHistoryStripMenuItem;
     }
 }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -595,72 +595,76 @@ namespace CKAN.GUI
 
             if (open_file_dialog.ShowDialog(this) == DialogResult.OK)
             {
-                // We'll need to make some registry changes to do this.
-                RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
-                var crit = CurrentInstance.VersionCriteria();
+                InstallFromCkanFiles(open_file_dialog.FileNames);
+            }
+        }
 
-                var installed = registry_manager.registry.InstalledModules.Select(inst => inst.Module).ToList();
-                var toInstall = new List<CkanModule>();
+        private void InstallFromCkanFiles(string[] files)
+        {
+            // We'll need to make some registry changes to do this.
+            RegistryManager registry_manager = RegistryManager.Instance(CurrentInstance);
+            var crit = CurrentInstance.VersionCriteria();
 
-                foreach (string path in open_file_dialog.FileNames)
+            var installed = registry_manager.registry.InstalledModules.Select(inst => inst.Module).ToList();
+            var toInstall = new List<CkanModule>();
+            foreach (string path in files)
+            {
+                CkanModule module;
+
+                try
                 {
-                    CkanModule module;
-
-                    try
+                    module = CkanModule.FromFile(path);
+                    if (module.IsMetapackage && module.depends != null)
                     {
-                        module = CkanModule.FromFile(path);
-                        if (module.IsMetapackage && module.depends != null)
-                        {
-                            // Add metapackage dependencies to the changeset so we can skip compat checks for them
-                            toInstall.AddRange(module.depends
-                                .Where(rel => !rel.MatchesAny(installed, null, null))
-                                .Select(rel =>
-                                    // If there's a compatible match, return it
-                                    // Metapackages aren't intending to prompt users to choose providing mods
-                                    rel.ExactMatch(registry_manager.registry, crit, installed, toInstall)
-                                    // Otherwise look for incompatible
-                                    ?? rel.ExactMatch(registry_manager.registry, null, installed, toInstall))
-                                .Where(mod => mod != null));
-                        }
-                        toInstall.Add(module);
+                        // Add metapackage dependencies to the changeset so we can skip compat checks for them
+                        toInstall.AddRange(module.depends
+                            .Where(rel => !rel.MatchesAny(installed, null, null))
+                            .Select(rel =>
+                                // If there's a compatible match, return it
+                                // Metapackages aren't intending to prompt users to choose providing mods
+                                rel.ExactMatch(registry_manager.registry, crit, installed, toInstall)
+                                // Otherwise look for incompatible
+                                ?? rel.ExactMatch(registry_manager.registry, null, installed, toInstall))
+                            .Where(mod => mod != null));
                     }
-                    catch (Kraken kraken)
-                    {
-                        currentUser.RaiseError(kraken.InnerException == null
-                            ? kraken.Message
-                            : $"{kraken.Message}: {kraken.InnerException.Message}");
-
-                        continue;
-                    }
-                    catch (Exception ex)
-                    {
-                        currentUser.RaiseError(ex.Message);
-                        continue;
-                    }
-
-                    if (module.IsDLC)
-                    {
-                        currentUser.RaiseError(Properties.Resources.MainCantInstallDLC, module);
-                        continue;
-                    }
+                    toInstall.Add(module);
                 }
-                // Get all recursively incompatible module identifiers (quickly)
-                var allIncompat = registry_manager.registry.IncompatibleModules(crit)
-                    .Select(mod => mod.identifier)
-                    .ToHashSet();
-                // Get incompatible mods we're installing
-                var myIncompat = toInstall.Where(mod => allIncompat.Contains(mod.identifier)).ToList();
-                if (!myIncompat.Any()
-                    // Confirm installation of incompatible like the Versions tab does
-                    || Main.Instance.YesNoDialog(
-                        string.Format(Properties.Resources.ModpackInstallIncompatiblePrompt,
-                            string.Join(Environment.NewLine, myIncompat),
-                            crit.ToSummaryString(CurrentInstance.game)),
-                        Properties.Resources.AllModVersionsInstallYes,
-                        Properties.Resources.AllModVersionsInstallNo))
+                catch (Kraken kraken)
                 {
-                    InstallModuleDriver(registry_manager.registry, toInstall);
+                    currentUser.RaiseError(kraken.InnerException == null
+                        ? kraken.Message
+                        : $"{kraken.Message}: {kraken.InnerException.Message}");
+
+                    continue;
                 }
+                catch (Exception ex)
+                {
+                    currentUser.RaiseError(ex.Message);
+                    continue;
+                }
+
+                if (module.IsDLC)
+                {
+                    currentUser.RaiseError(Properties.Resources.MainCantInstallDLC, module);
+                    continue;
+                }
+            }
+            // Get all recursively incompatible module identifiers (quickly)
+            var allIncompat = registry_manager.registry.IncompatibleModules(crit)
+                .Select(mod => mod.identifier)
+                .ToHashSet();
+            // Get incompatible mods we're installing
+            var myIncompat = toInstall.Where(mod => allIncompat.Contains(mod.identifier)).ToList();
+            if (!myIncompat.Any()
+                // Confirm installation of incompatible like the Versions tab does
+                || Main.Instance.YesNoDialog(
+                    string.Format(Properties.Resources.ModpackInstallIncompatiblePrompt,
+                        string.Join(Environment.NewLine, myIncompat),
+                        crit.ToSummaryString(CurrentInstance.game)),
+                    Properties.Resources.AllModVersionsInstallYes,
+                    Properties.Resources.AllModVersionsInstallNo))
+            {
+                InstallModuleDriver(registry_manager.registry, toInstall);
             }
         }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -731,8 +731,9 @@ namespace CKAN.GUI
             ActiveModInfo = module == null ? null : new GUIMod(
                 module,
                 RegistryManager.Instance(CurrentInstance).registry,
-                CurrentInstance.VersionCriteria()
-            );
+                CurrentInstance.VersionCriteria(),
+                configuration.HideEpochs,
+                configuration.HideV);
         }
 
         private void ManageMods_OnChangeSetChanged(List<ModChange> changeset, Dictionary<GUIMod, string> conflicts)

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+using CKAN.Extensions;
+
+// Don't warn if we use our own obsolete properties
+#pragma warning disable 0618
+
+namespace CKAN.GUI
+{
+    public partial class Main
+    {
+        private void installationHistoryStripMenuItem_Click(object sender, EventArgs e)
+        {
+            InstallationHistory.LoadHistory(manager.CurrentInstance, configuration);
+            tabController.ShowTab("InstallationHistoryTabPage", 2);
+            DisableMainWindow();
+        }
+
+        private void InstallationHistory_Install(CkanModule[] modules)
+        {
+            InstallationHistory_Done();
+            var tuple = ManageMods.mainModList.ComputeFullChangeSetFromUserChangeSet(
+                RegistryManager.Instance(CurrentInstance).registry,
+                modules.Select(mod => new ModChange(mod, GUIModChangeType.Install))
+                       .ToHashSet(),
+                CurrentInstance.VersionCriteria());
+            UpdateChangesDialog(tuple.Item1.ToList(), tuple.Item2);
+            tabController.ShowTab("ChangesetTabPage", 1);
+        }
+
+        private void InstallationHistory_Done()
+        {
+            UpdateStatusBar();
+            tabController.ShowTab("ManageModsTabPage");
+            tabController.HideTab("InstallationHistoryTabPage");
+            EnableMainWindow();
+        }
+
+        private void InstallationHistory_OnSelectedModuleChanged(GUIMod m)
+        {
+            ActiveModInfo = m;
+        }
+
+    }
+}

--- a/GUI/Main/MainUnmanaged.cs
+++ b/GUI/Main/MainUnmanaged.cs
@@ -9,7 +9,7 @@ namespace CKAN.GUI
     {
         private void viewUnmanagedFilesStripMenuItem_Click(object sender, EventArgs e)
         {
-            UnmanagedFiles.Refresh();
+            UnmanagedFiles.LoadFiles(manager.CurrentInstance);
             tabController.ShowTab("UnmanagedFilesTabPage", 2);
             DisableMainWindow();
         }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -112,15 +112,11 @@ namespace CKAN.GUI
         /// otherwise false.
         /// </returns>
         public bool IsInstallable()
-        {
-            // Compatible mods are installable, but so are mods that are already installed
-            return !IsIncompatible || IsInstalled;
-        }
+           // Compatible mods are installable, but so are mods that are already installed
+           => !IsIncompatible || IsInstalled;
 
         public string Version
-        {
-            get { return IsInstalled ? InstalledVersion : LatestVersion; }
-        }
+            => IsInstalled ? InstalledVersion : LatestVersion;
 
         /// <summary>
         /// Initialize a GUIMod based on an InstalledModule
@@ -129,8 +125,8 @@ namespace CKAN.GUI
         /// <param name="registry">CKAN registry object for current game instance</param>
         /// <param name="current_game_version">Current game version</param>
         /// <param name="incompatible">If true, mark this module as incompatible</param>
-        public GUIMod(InstalledModule instMod, IRegistryQuerier registry, GameVersionCriteria current_game_version, bool? incompatible = null)
-            : this(instMod.Module, registry, current_game_version, incompatible)
+        public GUIMod(InstalledModule instMod, IRegistryQuerier registry, GameVersionCriteria current_game_version, bool? incompatible = null, bool hideEpochs = false, bool hideV = false)
+            : this(instMod.Module, registry, current_game_version, incompatible, hideEpochs, hideV)
         {
             IsInstalled      = true;
             IsInstallChecked = true;
@@ -139,7 +135,8 @@ namespace CKAN.GUI
                                ?? instMod.Module;
             IsAutoInstalled  = instMod.AutoInstalled;
             InstallDate      = instMod.InstallTime;
-            InstalledVersion = instMod.Module.version.ToString();
+
+            InstalledVersion = instMod.Module.version.ToString(hideEpochs, hideV);
             if (LatestVersion == null || LatestVersion.Equals("-"))
             {
                 LatestVersion = InstalledVersion;
@@ -155,8 +152,8 @@ namespace CKAN.GUI
         /// <param name="registry">CKAN registry object for current game instance</param>
         /// <param name="current_game_version">Current game version</param>
         /// <param name="incompatible">If true, mark this module as incompatible</param>
-        public GUIMod(CkanModule mod, IRegistryQuerier registry, GameVersionCriteria current_game_version, bool? incompatible = null)
-            : this(mod.identifier, registry, current_game_version, incompatible)
+        public GUIMod(CkanModule mod, IRegistryQuerier registry, GameVersionCriteria current_game_version, bool? incompatible = null, bool hideEpochs = false, bool hideV = false)
+            : this(mod.identifier, registry, current_game_version, incompatible, hideEpochs, hideV)
         {
             Mod           = mod;
             IsCKAN        = mod is CkanModule;
@@ -200,7 +197,7 @@ namespace CKAN.GUI
         /// <param name="registry">CKAN registry object for current game instance</param>
         /// <param name="current_game_version">Current game version</param>
         /// <param name="incompatible">If true, mark this module as incompatible</param>
-        public GUIMod(string identifier, IRegistryQuerier registry, GameVersionCriteria current_game_version, bool? incompatible = null)
+        public GUIMod(string identifier, IRegistryQuerier registry, GameVersionCriteria current_game_version, bool? incompatible = null, bool hideEpochs = false, bool hideV = false)
         {
             Identifier     = identifier;
             IsAutodetected = registry.IsAutodetected(identifier);
@@ -246,11 +243,11 @@ namespace CKAN.GUI
 
             if (latest_version != null)
             {
-                LatestVersion = latest_version.ToString();
+                LatestVersion = latest_version.ToString(hideEpochs, hideV);
             }
             else if (latest_available_for_any_ksp != null)
             {
-                LatestVersion = latest_available_for_any_ksp.version.ToString();
+                LatestVersion = latest_available_for_any_ksp.version.ToString(hideEpochs, hideV);
             }
             else
             {

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -292,22 +292,19 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="modules">A list of modules that may require updating</param>
         /// <param name="mc">Changes the user has made</param>
-        /// <param name="hideEpochs">If true, remove epochs from the displayed versions</param>
-        /// <param name="hideV">If true, strip 'v' prefix from versions</param>
         /// <returns>The mod list</returns>
         public IEnumerable<DataGridViewRow> ConstructModList(
-            IEnumerable<GUIMod> modules, string instanceName, IEnumerable<ModChange> mc = null,
-            bool hideEpochs = false, bool hideV = false)
+            IEnumerable<GUIMod> modules, string instanceName, IEnumerable<ModChange> mc = null)
         {
             List<ModChange> changes = mc?.ToList();
             full_list_of_mod_rows = modules.ToDictionary(
                 gm => gm.Identifier,
-                gm => MakeRow(gm, changes, instanceName, hideEpochs, hideV)
+                gm => MakeRow(gm, changes, instanceName)
             );
             return full_list_of_mod_rows.Values;
         }
 
-        private DataGridViewRow MakeRow(GUIMod mod, List<ModChange> changes, string instanceName, bool hideEpochs = false, bool hideV = false)
+        private DataGridViewRow MakeRow(GUIMod mod, List<ModChange> changes, string instanceName)
         {
             DataGridViewRow item = new DataGridViewRow() {Tag = mod};
 
@@ -378,23 +375,12 @@ namespace CKAN.GUI
 
             var installVersion = new DataGridViewTextBoxCell()
             {
-                Value = hideEpochs
-                    ? (hideV
-                        ? ModuleInstaller.StripEpoch(ModuleInstaller.StripV(mod.InstalledVersion ?? ""))
-                        : ModuleInstaller.StripEpoch(mod.InstalledVersion ?? ""))
-                    : (hideV
-                        ? ModuleInstaller.StripV(mod.InstalledVersion ?? "")
-                        : mod.InstalledVersion ?? "")
+                Value = mod.InstalledVersion
             };
 
             var latestVersion = new DataGridViewTextBoxCell()
             {
-                Value =
-                    hideEpochs ?
-                        (hideV ? ModuleInstaller.StripEpoch(ModuleInstaller.StripV(mod.LatestVersion))
-                        : ModuleInstaller.StripEpoch(mod.LatestVersion))
-                    : (hideV ? ModuleInstaller.StripV(mod.LatestVersion)
-                        : mod.LatestVersion)
+                Value = mod.LatestVersion
             };
 
             var downloadCount = new DataGridViewTextBoxCell { Value = $"{mod.DownloadCount:N0}"       };

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -125,11 +125,9 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="registry"></param>
         /// <param name="changeSet"></param>
-        /// <param name="installer">A module installer for the current game instance</param>
         /// <param name="version">The version of the current game instance</param>
         public Tuple<IEnumerable<ModChange>, Dictionary<CkanModule, string>> ComputeFullChangeSetFromUserChangeSet(
-            IRegistryQuerier registry, HashSet<ModChange> changeSet, ModuleInstaller installer,
-            GameVersionCriteria version)
+            IRegistryQuerier registry, HashSet<ModChange> changeSet, GameVersionCriteria version)
         {
             var modules_to_install = new List<CkanModule>();
             var modules_to_remove = new HashSet<CkanModule>();


### PR DESCRIPTION
## Motivation

Users often ask for a way to see what they have installed previously, and when we tell them this already exists in the `<GameRoot>/CKAN/history` folder, they then request an easier way to access those files.

## Changes

Now a new menu option opens an Installation History tab containing a list of all the timestamps for which there is a history entry in the `<GameRoot>/CKAN/history` folder:

![image](https://user-images.githubusercontent.com/1559108/235368859-712c3d51-318d-4b4e-8f82-9c982eb733ec.png)

![image](https://user-images.githubusercontent.com/1559108/235368891-f01ef2c7-1af7-49b4-b03a-5168dc86e7e1.png)

The OK button closes the tab and returns the user to Manage Mods.

If the user clicks an entry at the left, the mods that were installed at that point in time are listed on the right, split into a "Not currently installed" group at the top and a "Currently installed" group below that to make it easier to see the differences:

![image](https://user-images.githubusercontent.com/1559108/235369098-bebb62cc-9160-42b7-892d-df01badfc3ae.png)

The user can click a mod to open ModInfo:

![image](https://user-images.githubusercontent.com/1559108/235369103-61c24705-22b9-426c-ae5a-7d47e767d7b5.png)

If the user clicks the Install toolbar button, the currently displayed mods that aren't installed are put into the changeset, which the user can then install:

![image](https://user-images.githubusercontent.com/1559108/235369123-381b9ad1-a04d-4562-ac93-260206e06424.png)

If there are conflicts with already installed mods, these will be highlighted in the changeset and the user will not be able to continue:

![image](https://user-images.githubusercontent.com/1559108/235369162-c59bdf9d-c798-42eb-a49d-94a6b0054a47.png)

Fixes #3741.
