### PR TITLE
Show download errors for upgrades

### DIFF
--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -194,7 +194,9 @@ namespace CKAN.GUI
                     {
                         // Get full changeset (toInstall only includes user's selections, not dependencies)
                         var crit = CurrentInstance.VersionCriteria();
-                        var fullChangeset = new RelationshipResolver(toInstall, null, opts.Value, registry, crit).ModList().ToList();
+                        var fullChangeset = new RelationshipResolver(
+                            toInstall.Concat(toUpgrade), toUninstall, opts.Value, registry, crit
+                        ).ModList().ToList();
                         var dfd = new DownloadsFailedDialog(
                             Properties.Resources.ModDownloadsFailedMessage,
                             Properties.Resources.ModDownloadsFailedColHdr,
@@ -203,7 +205,7 @@ namespace CKAN.GUI
                                 fullChangeset.Where(m => m.download == kvp.Key.download).ToArray(),
                                 kvp.Value)),
                             (m1, m2) => (m1 as CkanModule)?.download == (m2 as CkanModule)?.download);
-                        Util.Invoke(this, () => dfd.ShowDialog(this));
+                        Util.Invoke(dfd, () => dfd.ShowDialog(this));
                         var skip = dfd.Wait()?.Select(m => m as CkanModule).ToArray();
                         var abort = dfd.Abort;
                         dfd.Dispose();


### PR DESCRIPTION
## Problem

If an upgrade's download fails, the failed downloads popup from #3635 appears, but empty:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/04bbec0f-8f29-4222-9d6c-677cf7d02be1)

This dead-ends any investigation of such problems.

[Originally reported by forum user jost.](https://forum.kerbalspaceprogram.com/index.php?/topic/197082-ckan-the-comprehensive-kerbal-archive-network-v1320-kepler-ksp-2-support/&do=findComment&comment=4283056)

## Cause

The rows of that table are built based on the mods in the changeset, but only the mods to install were included. The mods to upgrade were not, so if one of them had an error, it wouldn't be shown.

## Changes

Now the mods we're upgrading are also passed to the form, so the error appears as expected:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/317586d5-5544-4baa-afc0-17e3b5ebf892)

While investigating this, I found that the popup could cause CKAN to freeze before it opened, and that passing itself to `Util.Invoke` instead of a reference to the `Main` form fixed it, so that's included here as well.
