### PR TITLE
Set window title during startup

### DIFF
--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -166,6 +166,8 @@ namespace CKAN.GUI
 
             URLHandlers.RegisterURLHandler(configuration, currentUser);
 
+            Util.Invoke(this, () => Text = $"CKAN {Meta.GetVersion()}");
+
             try
             {
                 splitContainer1.SplitterDistance = configuration.PanelPosition;


### PR DESCRIPTION
## Problem

After #3829, the GUI window title is blank at startup:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/bf65448c-b6bb-4882-9c99-bc43e7a06aff)

It's set later, once the instance is loaded.

## Cause

The window title depends on the name, version, and path of the game instance, so it's currently not set while the instance is loading.

## Changes

Now we set an initial window title in `GUI.Main.OnLoad` containing the pieces that are not dependent on having the instance loaded:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/a0ec8e58-a0a5-4e81-aaad-ac5f16339b42)

The full title is still set later when the instance is loaded.
