### PR TITLE
Tooltip for auto-installed checkboxes

### DIFF
--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -337,7 +337,8 @@ namespace CKAN.GUI
             var autoInstalled = mod.IsInstalled && !mod.IsAutodetected
                 ? (DataGridViewCell) new DataGridViewCheckBoxCell()
                 {
-                    Value = mod.IsAutoInstalled
+                    Value = mod.IsAutoInstalled,
+                    ToolTipText = Properties.Resources.MainModListAutoInstalledToolTip,
                 }
                 : new DataGridViewTextBoxCell()
                 {

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -774,6 +774,9 @@ namespace CKAN.GUI.Properties {
         internal static string MainModListAutoDetected {
             get { return (string)(ResourceManager.GetObject("MainModListAutoDetected", resourceCulture)); }
         }
+        internal static string MainModListAutoInstalledToolTip {
+            get { return (string)(ResourceManager.GetObject("MainModListAutoInstalledToolTip", resourceCulture)); }
+        }
         internal static string MainModListUnknownFilter {
             get { return (string)(ResourceManager.GetObject("MainModListUnknownFilter", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -331,6 +331,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="MainModListAll" xml:space="preserve"><value>All ({0})</value></data>
   <data name="MainModListUpdatingTray" xml:space="preserve"><value>Updating tray...</value></data>
   <data name="MainModListAutoDetected" xml:space="preserve"><value>AD</value></data>
+  <data name="MainModListAutoInstalledToolTip" xml:space="preserve"><value>If checked, auto-uninstall this mod if everything that depends on it is removed</value></data>
   <data name="MainModListUnknownFilter" xml:space="preserve"><value>Unknown filter type {0} in IsModInFilter</value></data>
   <data name="MainRecommendationsTitle" xml:space="preserve"><value>Choose recommended, suggested, or supporting mods</value></data>
   <data name="MainRecommendationsNoneFound" xml:space="preserve"><value>No recommended, suggested, or supporting mods found.</value></data>


### PR DESCRIPTION
## Motivation

We somewhat frequently get questions about the Auto-installed column from #2753:

- #3146
- #3826
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/16763338-a250-40c9-99ad-a00bdc1a0738)
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/f6ac569e-1758-4e21-a409-d720207df0b7)
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/714692a9-5dc8-4517-84ed-263ee0e17b85)
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/4f829ef9-e0f2-4be8-b140-27e9746b0ce6)
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/9a307210-d76f-4f63-a290-557dc7d32248)
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/7ce5984c-2acc-4657-958e-d67239763c51)
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/66d1b587-e543-4932-8adf-39cd5d400dae)
- ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/c14cecd1-bdd9-4284-98b8-36241e8eaf79)

Apparently the purpose of this checkbox is not clear. But on the bright side, everyone seems to "get it" when provided a brief explanation.

## Changes

Now these checkboxes have a tooltip that explains what they're for:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/7f45fa11-4330-4a5c-b71e-b2d0c9d11f32)
