### PR TITLE
Clarify remote swinfo network errors

### DIFF
--- a/Netkan/Transformers/SpaceWarpInfoTransformer.cs
+++ b/Netkan/Transformers/SpaceWarpInfoTransformer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
@@ -54,14 +55,21 @@ namespace CKAN.NetKAN.Transformers
                         }
                         resourcesJson.SafeAdd("remote-swinfo", swinfo.version_check.OriginalString);
 
-                        var remoteInfo = modSvc.ParseSpaceWarpJson(
-                            githubApi?.DownloadText(swinfo.version_check)
-                            ?? httpSvc.DownloadText(swinfo.version_check));
-                        if (swinfo.version == remoteInfo?.version)
+                        try
                         {
-                            log.InfoFormat("Using remote swinfo.json file: {0}",
-                                           swinfo.version_check);
-                            swinfo = remoteInfo;
+                            var remoteInfo = modSvc.ParseSpaceWarpJson(
+                                githubApi?.DownloadText(swinfo.version_check)
+                                ?? httpSvc.DownloadText(swinfo.version_check));
+                            if (swinfo.version == remoteInfo?.version)
+                            {
+                                log.InfoFormat("Using remote swinfo.json file: {0}",
+                                               swinfo.version_check);
+                                swinfo = remoteInfo;
+                            }
+                        }
+                        catch (Exception exc)
+                        {
+                            throw new Kraken($"Error fetching remote swinfo {swinfo.version_check}: {exc.Message}");
                         }
                     }
 


### PR DESCRIPTION
## Background

#3817 added retrieval of remote `swinfo.json` files for KSP2 mods, which are very analogous to remote version files.

## Problem

If the `version_check` property contains a URL that's a broken link, the error message isn't clear. It's just a generic 404 error that could be coming from anywhere:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/1bbb3659-c519-4622-a7ed-0b0ab469f353)

## Changes

Now that exception is caught and replaced with one indicating the context in which the error occurred:

```
$ netkan.exe --game KSP2 NetKAN/ManeuverNodeController.netkan
2233 [1] FATAL CKAN.NetKAN.Program (null) - Error fetching remote swinfo https://raw.githubusercontent.com/schlosrat/ManeuverNodeController/master/maneuver_node_controller/swinfo.json: The remote server returned an error: (404) Not Found.
```

I might self-review this since it only affects the bot and would be nice to have soon-ish.
