### PR TITLE
fix: build with dotnet core on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,9 @@ jobs:
           key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Build ckan.exe and netkan.exe
-        run: ./build --configuration=${{ matrix.configuration}}
+        run: ./build ${{ matrix.configuration}}
       - name: Run tests
-        run: xvfb-run ./build test+only --configuration=${{ matrix.configuration }} --where="Category!=FlakyNetwork"
+        run: xvfb-run ./build ${{ matrix.configuration }} test+only --where="Category!=FlakyNetwork"
       - name: Run inflator container smoke test
         run: |
           cd _build
@@ -125,9 +125,9 @@ jobs:
           key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Build with .NET Core
-        run: ./build --configuration=${{ matrix.configuration }}
+        run: ./build ${{ matrix.configuration }}
       - name: Test with .NET Core
-        run: ./build test+only --configuration=${{ matrix.configuration }}
+        run: ./build ${{ matrix.configuration }} test+only
 
       - name: Send Discord Notification
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,15 +62,15 @@ jobs:
           key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Build ckan.exe and netkan.exe
-        run: ./build --configuration=Release
+        run: ./build Release
 
       - name: Build deb
         env:
           CODENAME: nightly
-        run: ./build deb --configuration=Release --exclusive
+        run: ./build Release deb --exclusive
         if: ${{ steps.check_version.outputs.odd_build }}
       - name: Build rpm
-        run: ./build rpm --configuration=Release --exclusive
+        run: ./build Release rpm --exclusive
         if: ${{ steps.check_version.outputs.odd_build }}
       - name: Import GPG key
         env:
@@ -83,17 +83,17 @@ jobs:
         env:
           CODENAME: nightly
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
-        run: ./build deb-sign --configuration=Release --exclusive
+        run: ./build Release deb-sign --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
       - name: Build rpm repository
         env:
           CODENAME: nightly
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
-        run: ./build rpm-repo --configuration=Release --exclusive
+        run: ./build Release rpm-repo --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
 
       - name: Run tests
-        run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
+        run: xvfb-run ./build Release test+only --where="Category!=FlakyNetwork"
 
       - name: Generate inflator Docker image and publish to Hub
         env:
@@ -105,7 +105,7 @@ jobs:
         if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD && env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          ./build docker-inflator --exclusive
+          ./build Release docker-inflator --exclusive
       - name: Generate metadata tester Docker image and publish to Hub
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -113,7 +113,7 @@ jobs:
         if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          ./build docker-metadata --exclusive
+          ./build Release docker-metadata --exclusive
 
       - name: Push ckan.exe and netkan.exe to S3
         # Send ckan.exe and netkan.exe to https://ksp-ckan.s3-us-west-2.amazonaws.com/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,18 @@ jobs:
         run: apt-get install -y xvfb
 
       - name: Build ckan.exe and netkan.exe
-        run: ./build --configuration=Release
+        run: ./build Release
       - name: Run tests
-        run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
+        run: xvfb-run ./build Release test+only --where="Category!=FlakyNetwork"
 
       - name: Build dmg
-        run: ./build osx --configuration=Release --exclusive
+        run: ./build Release osx --exclusive
       - name: Build deb
         env:
           CODENAME: stable
-        run: ./build deb --configuration=Release --exclusive
+        run: ./build Release deb --exclusive
       - name: Build rpm
-        run: ./build rpm --configuration=Release --exclusive
+        run: ./build Release rpm --exclusive
       - name: Import GPG key
         env:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
@@ -44,13 +44,13 @@ jobs:
         env:
           CODENAME: stable
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
-        run: ./build deb-sign --configuration=Release --exclusive
+        run: ./build Release deb-sign --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
       - name: Build rpm repository
         env:
           CODENAME: stable
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
-        run: ./build rpm-repo --configuration=Release --exclusive
+        run: ./build Release rpm-repo --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
 
       - name: Get release data

--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -45,7 +45,7 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+    <Exec Command="sh ../build Debug Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
   <Target Name="ILRepack" AfterTargets="Build">
     <ItemGroup>

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -68,6 +68,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+    <Exec Command="sh ../build Debug Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/ConsoleUI/CKAN-ConsoleUI.csproj
+++ b/ConsoleUI/CKAN-ConsoleUI.csproj
@@ -53,6 +53,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+    <Exec Command="sh ../build Debug Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -79,6 +79,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+    <Exec Command="sh ../build Debug Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,23 +7,23 @@
 #
 # To build the container:
 # $ docker build -t ckan .
-# 
+#
 # To use the container to update all mods:
 # $ docker run --rm -v ${KSPDIR}:/kspdir ckan
-# 
+#
 # To use the container to install MechJeb:
 # $ docker run --rm -v ${KSPDIR}:/kspdir ckan install MechJeb
-# 
+#
 # Both of the last two lines require that the ${KSPDIR} value be set.
-# 
+#
 # There is a docker-compose.yml supplied which will automatically do this for Linux users.
-# 
+#
 # To use the YAML file to build the container:
 # $ docker-compose build ckan
-# 
+#
 # To use the YAML file to update all mods:
 # $ docker-compose run --rm ckan
-# 
+#
 # To use the YAML file to install MechJeb
 # $ docker-compose run --rm ckan install MechJeb
 
@@ -56,7 +56,7 @@ COPY . /source
 WORKDIR /source
 ARG config
 ENV config ${config:-Release}
-RUN ./build --configuration=${config}
+RUN ./build Debug --configuration=${config}
 RUN mkdir /build
 RUN cp _build/repack/${config}/ckan.exe /build/ckan.exe
 ENTRYPOINT ["/root/entrypoint.sh"]

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -1439,6 +1439,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+    <Exec Command="sh ../build Debug Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -180,6 +180,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+    <Exec Command="sh ../build Debug Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -90,6 +90,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="BeforeBuild">
     <Exec Command="powershell ../build.ps1 Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Windows_NT'" />
-    <Exec Command="sh ../build Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
+    <Exec Command="sh ../build Debug Generate-GlobalAssemblyVersionInfo" Condition="!Exists('../_build/meta/GlobalAssemblyVersionInfo.cs') And '$(OS)' == 'Unix'" />
   </Target>
 </Project>

--- a/build
+++ b/build
@@ -1,14 +1,24 @@
 #!/bin/sh
 set -e
 
+configuration="Debug"
 arg0=""
 remainingArgs=""
 
+# .net framework not available on macos
+if [ "$(uname)" = "Darwin" ]; then
+    configuration="Debug_NetCore"
+fi
+
 if [ $# -gt 0 ]; then
-    arg0="$1"
+    configuration="$1"
 fi
 
 if [ $# -gt 1 ]; then
+    arg0="$2"
+fi
+
+if [ $# -gt 2 ]; then
     skippedFirst=false
     for i in "$@"; do
         if $skippedFirst; then
@@ -59,5 +69,5 @@ if $useExperimental; then
     cakeArgs="$cakeArgs --experimental"
 fi
 
-mono "$cakeExe" "$scriptFile" $cakeArgs $remainingArgs
+mono "$cakeExe" "$scriptFile" "--configuration=$configuration" $cakeArgs $remainingArgs
 exit $?

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -95,7 +95,7 @@ $(EXEDEST): $(EXESRC)
 	umask 0022 && cp $< $@
 
 $(EXESRC):
-	cd .. && ./build --configuration=$(CONFIGURATION)
+	cd .. && ./build $(CONFIGURATION)
 
 $(CONTROLDEST): $(CONTROLSRC) $(CHANGELOGSRC)
 	umask 0022 && mkdir -p $(shell dirname $@)

--- a/doc/building.md
+++ b/doc/building.md
@@ -105,13 +105,13 @@ After Cake is installed by NuGet, the bootstrapper scripts then parse the comman
 The bootstrapper scripts use the following command line:
 
 ```
-./build [<target>] [<cake-args>...]
+./build [<configuration>] [<target>] [<cake-args>...]
 ```
 
 Which is then used to execute Cake with the following command line:
 
 ```
-cake.exe build.cake [--target=<target>] [<cake-args>...]
+cake.exe build.cake --configuration=<configuration or "Debug"> [--target=<target>] [<cake-args>...]
 ```
 
 The first argument is the Cake script to execute. This is always `build.cake` and does not ever need to be changed. The
@@ -205,8 +205,8 @@ push. GitHub's operation is pretty simple:
 
 - A bunch of packages are installed to make the build work.
 - Some commands are executed to simulate a graphical environment for testing.
-- The solution is built using `./build --configuration=$BUILD_CONFIGURATION`
-- The solution is tested using `./build test+only --configuration=$BUILD_CONFIGURATION --exclude=FlakyNetwork`
+- The solution is built using `./build $BUILD_CONFIGURATION`
+- The solution is tested using `./build $BUILD_CONFIGURATION test+only --exclude=FlakyNetwork`
     - The `--exclude=FlakyNetwork` argument is used to not execute tests that rely upon a network connection and could
       thus behave nondeterministically (frustrating behavior for a CI system).
 - The built executables (`ckan.exe` and `netkan.exe`) are uploaded to Amazon S3 if the following conditions are met:

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -27,7 +27,7 @@ $(EXEDEST): $(EXESRC)
 	ln $< $@
 
 $(EXESRC):
-	cd .. && ./build --configuration=Release
+	cd .. && ./build Release
 
 $(SCRIPTDEST): $(SCRIPTSRC)
 	mkdir -p $(shell dirname $@)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -50,7 +50,7 @@ $(REPORPM): $(RPM) $(REPOFILE)
 	    --addsign $@
 
 $(EXESRC):
-	cd .. && ./build --configuration=$(CONFIGURATION)
+	cd .. && ./build $(CONFIGURATION)
 
 clean:
 	rm -r "$(TOPDIR)"


### PR DESCRIPTION
This pull request changes the build script to use Dotnet Core on macOS. Dotnet Framework (the default) is not available on Mac which causes build failures with a rather unintelligible error message.