### PR TITLE
Stop trying to check free space on Mono

### DIFF
--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -572,7 +572,7 @@ namespace CKAN
                 else
                 {
                     // Make sure we can access it
-                    var bytesFree = new DirectoryInfo(path).GetDrive().AvailableFreeSpace;
+                    var bytesFree = new DirectoryInfo(path).GetDrive()?.AvailableFreeSpace;
                     Cache = new NetModuleCache(this, path);
                     Configuration.DownloadCacheDir = path;
                 }

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -1277,7 +1277,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.ko-KR.resx">
-      <LogicalName>CKAN.Properties.Resources.ko-KR.resources</LogicalName>
+      <LogicalName>CKAN.GUI.Properties.Resources.ko-KR.resources</LogicalName>
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
## Problem

Mac and Linux users have reported spurious errors about free disk space when installing:

```
Not enough space in game folder to install modules!
Need to store 2.3 MiB to /Applications/ksp_osx, but only 0 B is available!     
Free up space on that device or change your settings to use another location.
```
![macspace](https://user-images.githubusercontent.com/40470811/215366870-dc604725-1580-46b4-bb08-db3b4e191093.png)


```
Not enough space in game folder to install modules!
Need to store 5.6 GiB to /home/storm/GOG Games/1.12.4-oldmods, but only 537.8 MiB is available!
Free up space on that device or change your settings to use another location.

[storm@defiant 1.12.4-oldmods]$ df -h .
Filesystem            Size  Used Avail Use% Mounted on
shuttlepod/GOG Games  3.5T   12G  3.5T   1% /home/storm/GOG Games
```

## Cause

Mono's `DriveInfo.GetDrives()` doesn't include mounted filesystems other than `/`, which makes it useless and unusable:

- https://github.com/mono/mono/blob/771947925a512a91e1ac88eb463ec845cafc2807/mcs/class/corlib/System.IO/DriveInfo.cs#L149-L159
- https://github.com/mono/mono/blob/771947925a512a91e1ac88eb463ec845cafc2807/mono/metadata/icall.c#L7342-L7404
- https://github.com/mono/mono/blob/771947925a512a91e1ac88eb463ec845cafc2807/mono/metadata/w32file-unix.c#L3986-L4256

I tested #3631 on a single partition system, which made it appear to work fine because `/` is hard-coded to be part of this list, but if you have more partitions mounted than that, only `/` will be checked, which can be wrong, and we have no way of detecting that it's wrong.

This can cause both false positives (user is told they don't have enough free space when they do) and false negatives (user is allowed to proceed with a nearly full disk and the install fails). So the free space check isn't reliable on Mono.

## Changes

Now our `DirectoryInfo.GetDrive()` extension method always returns `null` on Mono 😞, because finding a directory's drive can't be done on Mono (but _should_ be possible if Mono's code for this wasn't 💩). This will bypass the free space checks. Windows users will still be alerted before they fill up their disks, but Mac and Linux users will be back to installing without this guard rail, potentially filling their disks in the middle of downloading or installing.

I'm not going to bother trying to send a patch to Mono because they're not merging fixes anymore and because this code is probably so old that changing it would spook them. 👻

Fixes #3768.
Fixes #3848.

### Side fix

The localization DLL for Korean GUI strings has the same name as the one for Core, which causes this compile warning and probably breaks something in the UI somewhere:

```
WARN: Ignoring duplicate resource CKAN.Properties.Resources.ko-KR.resources
```

Now it's changed to `CKAN.GUI.Properties.Resources.ko-KR.resources`, consistent with all the other languages.
