### PR TITLE
Handle missing KSP2 exe

### DIFF
--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -180,10 +180,14 @@ namespace CKAN.Games
         public List<GameVersion> KnownVersions => versions;
 
         public GameVersion DetectVersion(DirectoryInfo where)
-            => GameVersion.Parse(
-                FileVersionInfo.GetVersionInfo(
-                    Path.Combine(where.FullName, "KSP2_x64.exe")).ProductVersion
-                ?? versions.Last().ToString());
+            => VersionFromFile(Path.Combine(where.FullName, "KSP2_x64.exe"));
+
+        private GameVersion VersionFromFile(string path)
+            => File.Exists(path)
+                ? GameVersion.Parse(
+                    FileVersionInfo.GetVersionInfo(path).ProductVersion
+                    ?? versions.Last().ToString())
+                : null;
 
         public string CompatibleVersionsFile => "compatible_game_versions.json";
 


### PR DESCRIPTION
## Problem

A user uninstalled KSP2 and reported this on Discord:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/41f33727-ba9a-462e-99ce-61d6a2bde7ad)

## Cause

`FileVersionInfo.GetVersionInfo` throws an exception when the file doesn't exist.

## Changes

Now we check `File.Exists` so the exception won't be thrown.
