### PR TITLE
More flexible SpaceWarp dependency checking

### DIFF
--- a/Netkan/Transformers/SpaceWarpInfoTransformer.cs
+++ b/Netkan/Transformers/SpaceWarpInfoTransformer.cs
@@ -87,9 +87,14 @@ namespace CKAN.NetKAN.Transformers
                     var moduleDeps = mod.depends.Select(r => (r as ModuleRelationshipDescriptor)?.name)
                                                 .Where(ident => ident != null)
                                                 .ToHashSet();
-                    var missingDeps = swinfo.dependencies.Select(dep => dep.id)
-                                                         .Except(moduleDeps)
-                                                         .ToList();
+                    var missingDeps = swinfo.dependencies
+                        .Select(dep => dep.id)
+                        .Where(depId => !moduleDeps.Contains(
+                            // Remove up to last period
+                            depId.Substring(depId.LastIndexOf('.') + 1),
+                            // Case insensitive
+                            StringComparer.InvariantCultureIgnoreCase))
+                        .ToList();
                     if (missingDeps.Any())
                     {
                         log.WarnFormat("Dependencies from swinfo.json missing from module: {0}",


### PR DESCRIPTION
## Motivations

Some KSP2 modules have started using a new format for the `dependencies` list in `swinfo.json`, and a few don't match the capitalization of the identifier in CKAN:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/1dfda902-e210-440b-b530-49ad5050dda6)

Currently we warn if the string doesn't match the identifier of any value in the `depends` list, so these will always warn even if you have `SpaceWarp` or `UITKforKSP2` in there.

## Changes

Now we remove characters up to and including the final `.`, then perform a case-insensitive comparison. This will produce fewer false positive warnings.

I might self-review this since it's just a Netkan warning.
