### PR TITLE
Linux network fixes

### DIFF
--- a/Core/Extensions/CryptoExtensions.cs
+++ b/Core/Extensions/CryptoExtensions.cs
@@ -35,6 +35,7 @@ namespace CKAN.Extensions
                 {
                     // Done!
                     hashAlgo.TransformFinalBlock(buffer, 0, bytesRead);
+                    progress.Report(100);
                     break;
                 }
                 else

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -70,9 +70,11 @@ namespace CKAN.Extensions
         public static void CopyTo(this Stream src, Stream dest, IProgress<long> progress, CancellationToken cancelToken = default(CancellationToken))
         {
             // CopyTo says its default buffer is 81920, but we want more than 1 update for a 100 KiB file
-            const int bufSize = 8192;
+            const int bufSize = 16384;
             var buffer = new byte[bufSize];
             long total = 0;
+            // Make sure we get an initial progress notification at the start
+            progress.Report(total);
             var lastProgressTime = DateTime.Now;
             while (true)
             {
@@ -91,6 +93,8 @@ namespace CKAN.Extensions
                     lastProgressTime = now;
                 }
             }
+            // Make sure we get a final progress notification after we're done
+            progress.Report(total);
         }
 
         private static readonly TimeSpan progressInterval = TimeSpan.FromMilliseconds(200);

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -141,6 +141,9 @@ namespace CKAN
                     }
                     // If there was an error in STORING, delete the file so we can try it from scratch later
                     File.Delete(filename);
+
+                    // Tell downloader there is a problem with this file
+                    throw;
                 }
                 catch (OperationCanceledException exc)
                 {

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -140,6 +140,7 @@ namespace CKAN
                                                                  bytesDownloaded, contentLength);
                                     }),
                                     cancelTokenSrc.Token);
+                                // Make sure caller knows we've finished
                                 DownloadProgress?.Invoke(100, contentLength, contentLength);
                                 cancelTokenSrc = null;
                             }


### PR DESCRIPTION
## Problems

- Users on Linux have reported that downloads and ZIP validation both sometimes "freeze", and eventually the whole install process comes to a halt. I have seen this when trying to install RP-1; usually a few smaller mods get stuck:
  ![ckan_mono_frozen_downloads](https://github.com/KSP-CKAN/CKAN/assets/1559108/d4121759-53cf-4da6-a57f-e1727148906e)
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/7b747a5f-0aa2-4047-b13e-d403656e85e5)
- If a downloaded ZIP fails to validate (such as for a file downloaded from taniwha.org), CKAN attempts to continue the installation, which wastes time because it will ultimately fail and be rolled back (reported by @UltraJohn on Discord)

## Causes

- Individual downloads and validations were not actually freezing; rather, they completed normally, and the files were moved to the main cache folder, but the *progress bars* reappeared after being completed, due to the final 100% completion progress update being reordered to occur before some of the earlier in-progress progress updates.
- The overall install was halting because once in a while, instead of starting the next queued download, CKAN was re-queueing it, because `shouldQueue` was `true` when it shouldn't have been, because `bytesLeft` wasn't `0` when it should have been in another completed download. This value gets set whenever a progress update is raised, so either the last one was missing, or it had wrong numbers.
- Exceptions thrown by ZIP validation were being caught and ignored after deleting the invalid file, so the installer thought everything was fine and kept going.
- The mutex guarding completed download processing was excessively broad and included ZIP validation, which can take on the order of a minute for large files, which is too long to hold a lock. This may have been causing issues since if one file completed while another was validating, the newly completed one would have to wait.

## Changes

- Now we have one more progress notification for completed downloads and validations, as well as explicitly setting `bytesLeft` to `0` in the completed download handler. This should prevent any problems with weird byte tracking.
- Now ZIP validation errors will be treated the same as network errors—saved and provided to calling code—including the ability to abort or retry, and the install won't proceed if they occur
- Now the mutex that guards processing of completed downloads is more granular (parts that don't access shared state are moved out of the `lock` block), to allow multiple concurrent ZIP validations to proceed without blocking one another.

After these changes, I'm able to download and install RP-1 in Linux, where before it would reliably get stuck.
