### PR TITLE
Include repo etags in transactions

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -72,16 +72,7 @@ namespace CKAN
                 .ToArray();
 
             // Loading done, commit etags
-            foreach (var kvp in savedEtags)
-            {
-                var repo = repos.Where(r => r.uri == kvp.Key).FirstOrDefault();
-                var etag = kvp.Value;
-                if (repo != null)
-                {
-                    log.DebugFormat("Setting etag for {0}: {1}", repo.name, etag);
-                    repo.last_server_etag = etag;
-                }
-            }
+            registry_manager.registry.SetETags(savedEtags);
 
             // Clean up temp files
             foreach (var f in files)

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -442,6 +442,29 @@ namespace CKAN
 
         #endregion
 
+        /// <summary>
+        /// Set the etag values of the repositories
+        /// Provided in the API so it can enlist us in the transaction
+        /// </summary>
+        /// <param name="savedEtags">Mapping from repo URLs to etags received from servers</param>
+        public void SetETags(Dictionary<Uri, string> savedEtags)
+        {
+            log.Debug("Setting repo etags");
+
+            // Make sure etags get reverted if the transaction fails
+            EnlistWithTransaction();
+
+            foreach (var kvp in savedEtags)
+            {
+                var etag = kvp.Value;
+                foreach (var repo in repositories.Values.Where(r => r.uri == kvp.Key))
+                {
+                    log.DebugFormat("Setting etag for {0}: {1}", repo.name, etag);
+                    repo.last_server_etag = etag;
+                }
+            }
+        }
+
         public void SetAllAvailable(IEnumerable<CkanModule> newAvail)
         {
             log.DebugFormat(


### PR DESCRIPTION
## Problem

In the course of investigating why available modules were missing in #3699, users shared their registries, which revealed that the server etags (see #2682) were getting out of sync with the available modules; users were ending up with old module lists but up-to-date etags. This meant that if they tried to Refresh immediately, it would say the list was already up to date, even though it wasn't.

## Cause

I found this very confusing for quite a long while. That data is all part of the `Registry` object; shouldn't it all be saved to `registry.json` together or not at all? No! There is one specific scenario in which they can get out of sync:

1. Metadata retrieved from network successfully
2. Etags updated
3. Module list updated
4. **Exception thrown while still inside transaction** (any exception would cause this, but in practice it was `ReinstallModuleKraken` from #3344)
5. Transaction handling reverts to the most recently saved copy of the registry, which happened at the start of step 3, _after_ the etags were updated but _before_ the modules were updated

## Changes

In #3828 we eliminated this exception, so this is already functionally fixed, but architecturally it's still important to make the data objects behave properly.

Now the etags are saved by a new `Registry.SetETags` function, which calls `EnlistWithTransaction` first, which will save off a copy of the registry with the **original** etags. This will ensure that if the registry is reverted in a transaction, the etags will accurately reflect the state of the available modules list.
