### PR TITLE
Default install_to to GameData/Mods for KSP2

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -446,9 +446,18 @@
                     "pattern"     : "^Missions"
                 },
                 {
+                    "description" : "KSP2 default mods folder",
+                    "enum"        : [ "GameData/Mods" ]
+                },
+                {
+                    "description" : "KSP2 default mods folder with subfolder",
+                    "type"        : "string",
+                    "pattern"     : "^GameData/Mods/"
+                },
+                {
                     "description" : "KSP2 BepInEx plugins folder",
                     "type"        : "string",
-                    "pattern"     : "BepInEx/plugins"
+                    "pattern"     : "^BepInEx/plugins$"
                 }
             ]
         },

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -96,7 +96,7 @@ namespace CKAN.Games
             return null;
         }
 
-        public string PrimaryModDirectoryRelative => "BepInEx/plugins";
+        public string PrimaryModDirectoryRelative => "GameData/Mods";
 
         public string PrimaryModDirectory(GameInstance inst)
             => CKANPathUtils.NormalizePath(
@@ -115,6 +115,8 @@ namespace CKAN.Games
 
         public string[] CreateableDirs => new string[]
         {
+            "GameData",
+            "GameData/Mods",
             "BepInEx",
             "BepInEx/plugins",
         };
@@ -200,6 +202,9 @@ namespace CKAN.Games
 
         public Uri RepositoryListURL => new Uri("https://raw.githubusercontent.com/KSP-CKAN/KSP2-CKAN-meta/main/repositories.json");
 
+        // Key: Allowed value of install_to
+        // Value: Relative path
+        // (PrimaryModDirectoryRelative is allowed implicitly)
         private readonly Dictionary<string, string> allowedFolders = new Dictionary<string, string>
         {
             { "BepInEx",         "BepInEx"         },

--- a/Spec.md
+++ b/Spec.md
@@ -295,7 +295,7 @@ In addition a destination directive *must* be provided:
 - `install_to`: The target location where the matched file or directory should be installed.
   -  Valid values for this entry for KSP1 mods are `GameData`, `Missions`(**v1.25**), `Ships`, `Ships/SPH`(**v1.12**), `Ships/VAB`(**v1.12**), `Ships/@thumbs/VAB`(**v1.16**), `Ships/@thumbs/SPH`(**v1.16**), `Ships/Script`(**v1.29**), `Tutorial`, `Scenarios` (**v1.14**),
   and `GameRoot` (which should be used sparingly, if at all).
-  -  Valid values for this entry for KSP2 mods are `GameRoot` and `BepInEx/plugins` (**v1.32**)
+  -  Valid values for this entry for KSP2 mods are `GameRoot`, `BepInEx/plugins` (**v1.32**), and `GameData/Mods` (**v1.33**)
   -  A path to a given subfolder location can be specified *only* under `GameData` (**v1.2**);
   for example: `GameData/MyMod/Plugins`. The client *must* check this path and abort the install
   if any attempts to traverse up directories are found (eg: `GameData/../Example`).


### PR DESCRIPTION
## Motivation

Currently all KSP2 mods install to `BepInEx/plugins`. However, once the official mod loader is completed, this is expected to change to `GameData/Mods`.

I was expecting to change this in a new client release when the official mod loader was released, but the modding ecosystem has already begun experimenting with using this path. See KSP-CKAN/KSP2-NetKAN#68 and KSP-CKAN/KSP2-NetKAN#70, and current versions of SpaceWarp supposedly already allow it, which means we are likely to see mods soon that require it to be installed properly.

## Changes

- Now `GameData/Mods` can be used in `install_to` for KSP2, including with subfolder paths
- `BepInEx/plugins` can still be used for KSP2, but no longer with subfolder paths (no current mods use subfolder paths)
- Now the value of `install_to` for the default KSP2 install stanza (the one used when the `install` property is not present) is `GameData/Mods`
- The spec and schema are updated to reflect these changes

FYI to @KSP-CKAN/wranglers and @cheese3660.

### Risks

- The default can only be changed safely if it's not being used. KSP-CKAN/KSP2-NetKAN#72 addressed this by ensuring that no KSP2 mods currently use the default install stanza.
- The completed official mod loader may or may not actually use this path. If they decide to change it before release (e.g., if they correctly decide that `GameData/Mods` makes less sense than simply `GameData`), then we'll have to do this all over again with the new path.
- Quantum and SpaceWarp are both attempting to make their support for this folder work the same as they expect the official loader to work, but it's still likely that there will be problems and incompatibilities down the line. Users will ask, why doesn't this (Quantum-compatible) mod work with the official loader, or SpaceWarp, etc.? We will probably have to point them to [the announcement](https://forum.kerbalspaceprogram.com/topic/197082-ckan-the-comprehensive-kerbal-archive-network-v1320-kepler-ksp-2-support/?do=findComment&comment=4270325):
  > The KSP2 modding scene is brand new and still quite volatile (much like the game itself), with major incompatible changes occurring without warning. You probably will have problems! Please be patient with mod authors and CKAN maintainers and understand what you're getting into.
