### PR TITLE
Fix exception at startup w/o default game inst

### DIFF
--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -255,13 +255,6 @@ namespace CKAN.GUI
                     } while (CurrentInstance == null);
                     // We can only reach this point if CurrentInstance is not null
                     // AND we acquired the lock for it successfully
-                    if (!configuration.CheckForUpdatesOnLaunchNoNag && AutoUpdate.CanUpdate)
-                    {
-                        log.Debug("Asking user if they wish for auto-updates");
-                        if (new AskUserForAutoUpdatesDialog().ShowDialog(this) == DialogResult.OK)
-                            configuration.CheckForUpdatesOnLaunch = true;
-                        configuration.CheckForUpdatesOnLaunchNoNag = true;
-                    }
                     evt.Result = true;
                 },
                 (sender, evt) =>
@@ -389,6 +382,14 @@ namespace CKAN.GUI
             configuration = GUIConfiguration.LoadOrCreateConfiguration(
                 Path.Combine(CurrentInstance.CkanDir(), "GUIConfig.xml"),
                 CurrentInstance.game);
+
+            if (!configuration.CheckForUpdatesOnLaunchNoNag && AutoUpdate.CanUpdate)
+            {
+                log.Debug("Asking user if they wish for auto-updates");
+                if (new AskUserForAutoUpdatesDialog().ShowDialog(this) == DialogResult.OK)
+                    configuration.CheckForUpdatesOnLaunch = true;
+                configuration.CheckForUpdatesOnLaunchNoNag = true;
+            }
 
             var pluginsPath = Path.Combine(CurrentInstance.CkanDir(), "Plugins");
             if (!Directory.Exists(pluginsPath))

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -99,7 +99,10 @@ namespace CKAN.GUI
 
         public void Save()
         {
-            SaveConfiguration(this);
+            if (!string.IsNullOrEmpty(path))
+            {
+                SaveConfiguration(this);
+            }
         }
 
         public static GUIConfiguration LoadOrCreateConfiguration(string path, IGame game)


### PR DESCRIPTION
## Problems

If you have multiple game instances and no default game instance, the Manage Game Instances window appears at startup. In v1.33.0, this exception is thrown after you select an instance:
 
```
System.ArgumentException: Empty path name is not legal.
   at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost)
   at System.IO.StreamWriter..ctor(String path)
   at CKAN.GUI.GUIConfiguration.SaveConfiguration(GUIConfiguration configuration)
   at CKAN.GUI.Main.CurrentInstanceUpdated(Boolean allowRepoUpdate)
   at System.ComponentModel.BackgroundWorker.OnRunWorkerCompleted(RunWorkerCompletedEventArgs e)
```

There's also a "Check for updates" prompt that will happen every time.

(Everything works fine if "Set as default" is checked for some instance.)

Initially reported by a Discord who prefers to remain anonymous, then [Poppa Wheelie on the forum](https://forum.kerbalspaceprogram.com/topic/197082-ckan-the-comprehensive-kerbal-archive-network-v1320-kepler-ksp-2-support/?do=findComment&comment=4304504).

## Causes

When you have no default instance, we use `GUIConfiguration`'s constructor to get the window geometry defaults from an instance of the class that doesn't correspond to a real file on disk, meaning its `path` field is null.

- `Main.CurrentInstanceUpdated` always saves the current `GUIConfiguration` object before loading the next one, but this causes an attempt to write to a null file path with the special instance described above
- The "Check for updates" prompt also uses the special `GUIConfiguration` instance, which can't save

## Changes

- Now `GUIConfiguration.Save` will abort if `GUIConfiguration.path` is null or empty, which will prevent the exception from occurring
- Now the "Check for updates" prompt is moved to `Main.CurrentInstanceUpdated`, where it will have a valid `GUIConfiguration` object and therefore always be able to save your choice

Fixes #3862.

We should do a hotfix release after this merged. I'm thinking v1.33.2, "Laplace" Δ.
