### PR TITLE
Fix deletion of unmanaged files

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -466,8 +466,9 @@ namespace CKAN
         /// <returns>true if any descendants of given path were installed by CKAN, false otherwise</returns>
         public bool HasManagedFiles(Registry registry, string absPath)
             => registry.FileOwner(ToRelativeGameDir(absPath)) != null
-               || Directory.EnumerateFileSystemEntries(absPath, "*", SearchOption.AllDirectories)
-                           .Any(f => registry.FileOwner(ToRelativeGameDir(f)) != null);
+               || (Directory.Exists(absPath)
+                   && Directory.EnumerateFileSystemEntries(absPath, "*", SearchOption.AllDirectories)
+                               .Any(f => registry.FileOwner(ToRelativeGameDir(f)) != null));
 
         public override string ToString()
             => string.Format(Properties.Resources.GameInstanceToString, game.ShortName, gameDir);

--- a/GUI/Main/MainUnmanaged.cs
+++ b/GUI/Main/MainUnmanaged.cs
@@ -9,7 +9,7 @@ namespace CKAN.GUI
     {
         private void viewUnmanagedFilesStripMenuItem_Click(object sender, EventArgs e)
         {
-            UnmanagedFiles.LoadFiles(manager.CurrentInstance);
+            UnmanagedFiles.LoadFiles(manager.CurrentInstance, currentUser);
             tabController.ShowTab("UnmanagedFilesTabPage", 2);
             DisableMainWindow();
         }


### PR DESCRIPTION
## Problem

If you open the Unmanaged Files tab from #3833 and try to delete a file, an exception is thrown:

```
System.IO.IOException: The directory name is invalid.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileSystemEnumerableIterator`1.CommonInit()
   at System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost)
   at System.IO.Directory.EnumerateFileSystemEntries(String path, String searchPattern, SearchOption searchOption)
   at CKAN.GameInstance.HasManagedFiles(Registry registry, String absPath)
   at CKAN.GUI.UnmanagedFiles.DeleteButton_Click(Object sender, EventArgs e)
   at System.Windows.Forms.ToolStripItem.RaiseEvent(Object key, EventArgs e)
   at System.Windows.Forms.ToolStripMenuItem.OnClick(EventArgs e)
   at System.Windows.Forms.ToolStripItem.HandleClick(EventArgs e)
   at System.Windows.Forms.ToolStripItem.HandleMouseUp(MouseEventArgs e)
   at System.Windows.Forms.ToolStrip.OnMouseUp(MouseEventArgs mea)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ToolStrip.WndProc(Message& m)
   at System.Windows.Forms.MenuStrip.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

(Deleting a directory works fine.)

## Cause

`GameInstance.HasManagedFiles` is passing its parameter to `Directory.EnumerateFileSystemEntries` even if it's a file. `Directory.EnumerateFileSystemEntries` hates that.

## Changes

- Now `GameInstance.HasManagedFiles` only calls `Directory.EnumerateFileSystemEntries` if the given path exists and is a directory.
- While fixing this I realized that `File.Delete` and `Directory.Delete` might throw exceptions if the user doesn't have access to the file. Now these will be caught and displayed.