### PR TITLE
Fix Netkan swinfo transformer null list error

### DIFF
--- a/Netkan/Transformers/SpaceWarpInfoTransformer.cs
+++ b/Netkan/Transformers/SpaceWarpInfoTransformer.cs
@@ -84,9 +84,10 @@ namespace CKAN.NetKAN.Transformers
                         log.InfoFormat("Found compatibility: {0}–{1}", minVer, maxVer);
                         ModuleService.ApplyVersions(json, null, minVer, maxVer);
                     }
-                    var moduleDeps = mod.depends.Select(r => (r as ModuleRelationshipDescriptor)?.name)
-                                                .Where(ident => ident != null)
-                                                .ToHashSet();
+                    var moduleDeps = (mod.depends?.Select(r => (r as ModuleRelationshipDescriptor)?.name)
+                                                  .Where(ident => ident != null)
+                                      ?? Enumerable.Empty<string>())
+                                      .ToHashSet();
                     var missingDeps = swinfo.dependencies
                         .Select(dep => dep.id)
                         .Where(depId => !moduleDeps.Contains(


### PR DESCRIPTION
## Problem

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/236cf317-df51-4351-89d0-469bddc89d45)

KSP-CKAN/KSP2-NetKAN#75

## Cause

If a module has no `depends` relationships, then `mod.depends` is null here, and `.Select` doesn't work:

https://github.com/KSP-CKAN/CKAN/blob/83b6e7deb0dba437947e5acda6ff78042d5293fe/Netkan/Transformers/SpaceWarpInfoTransformer.cs#L87-L89

This problem was masked by all previous mods with `swinfo.json` files having a dependency on SpaceWarp.

## Changes

Now if `CkanModule.depends` is null, we substitute the empty sequence.

Will self-review so that pull request can proceed.
