### PR TITLE
Add missing dependency to .deb package

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Version: @VERSION@
 Architecture: all
 Section: utils
 Priority: optional
-Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, liblog4net1.2-cil, libnewtonsoft-json5.0-cil, libmono-system-net-http-webrequest4.0-cil
+Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, liblog4net1.2-cil, libnewtonsoft-json5.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-servicemodel4.0a-cil
 Maintainer: The CKAN authors <debian@ksp-ckan.space>
 Description: KSP-CKAN official client.
  Official client for the Comprehensive Kerbal Archive Network (CKAN).


### PR DESCRIPTION
## Poblem

1. On Ubuntu, install the .deb without `mono-complete`
2. `ckan consoleui`
3. Press ctrl-R to refresh the mod list
4. `System.TypeLoadException: Could not load type of field 'CKAN.ConsoleUI.Toolkit.ConsoleTextBox:lines' (5) due to: Could not load file or assembly 'System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' or one of its dependencies.`

## Cause

`libmono-system-servicemodel4.0a-cil` is apparently required.

## Changes

Now that package is added as a dependency of our .deb package. This fixed the exception in my Ubuntu test system.

Fixes #3871.
