### PR TITLE
Add missing resource string for upgrading

### DIFF
--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -236,6 +236,7 @@ Overwrite?</value></data>
   <data name="ModuleInstallerRemoveAborted" xml:space="preserve"><value>Mod removal aborted at user request</value></data>
   <data name="ModuleInstallerRemovingMod" xml:space="preserve"><value>Removing {0}...</value></data>
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve"><value>About to upgrade:</value></data>
+  <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3} remaining)</value></data>
   <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3})</value></data>
   <data name="ModuleInstallerUpgradeInstallingCached" xml:space="preserve"><value> * Install: {0} {1} (cached)</value></data>
   <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve"><value> * Re-install: {0} {1}</value></data>


### PR DESCRIPTION
## Problem

I just noticed that the `ModuleInstallerUpgradeInstallingResuming` resource is declared (there's a property for it) and used but not defined (there's no actual text for it). This is used when you upgrade a module which has a new dependency that you don't have installed yet but which you have a partial download for sitting in your cache. (A quite rare scenario, which probably explains why we haven't had complaints about it yet.)

## Changes

Now the string is defined for the default locale as ` * Install: {0} {1} ({2}, {3} remaining)`.
