### PR TITLE
Repository management fixes

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -255,7 +255,7 @@ namespace CKAN.CmdLine
         /// <param name="percent">Progress in percent</param>
         public void RaiseProgress(string message, int percent)
         {
-            if (Regex.IsMatch(message, "download", RegexOptions.IgnoreCase))
+            if (Regex.IsMatch(message, Properties.Resources.UserProgressDownloadSubstring, RegexOptions.IgnoreCase))
             {
                 // In headless mode, only print a new message if the percent has changed,
                 // to reduce clutter in Jenkins for large downloads

--- a/Cmdline/Properties/Resources.Designer.cs
+++ b/Cmdline/Properties/Resources.Designer.cs
@@ -151,6 +151,9 @@ namespace CKAN.CmdLine.Properties {
         internal static string UserSelectionTooSmall {
             get { return (string)(ResourceManager.GetObject("UserSelectionTooSmall", resourceCulture)); }
         }
+        internal static string UserProgressDownloadSubstring {
+            get { return (string)(ResourceManager.GetObject("UserProgressDownloadSubstring", resourceCulture)); }
+        }
 
         internal static string AuthTokenHostHeader {
             get { return (string)(ResourceManager.GetObject("AuthTokenHostHeader", resourceCulture)); }
@@ -464,8 +467,14 @@ namespace CKAN.CmdLine.Properties {
         internal static string RepoAvailableFailed {
             get { return (string)(ResourceManager.GetObject("RepoAvailableFailed", resourceCulture)); }
         }
-        internal static string RepoListHeader {
-            get { return (string)(ResourceManager.GetObject("RepoListHeader", resourceCulture)); }
+        internal static string RepoListPriorityHeader {
+            get { return (string)(ResourceManager.GetObject("RepoListPriorityHeader", resourceCulture)); }
+        }
+        internal static string RepoListNameHeader {
+            get { return (string)(ResourceManager.GetObject("RepoListNameHeader", resourceCulture)); }
+        }
+        internal static string RepoListURLHeader {
+            get { return (string)(ResourceManager.GetObject("RepoListURLHeader", resourceCulture)); }
         }
         internal static string RepoAddNotFound {
             get { return (string)(ResourceManager.GetObject("RepoAddNotFound", resourceCulture)); }
@@ -473,8 +482,17 @@ namespace CKAN.CmdLine.Properties {
         internal static string RepoAddDuplicate {
             get { return (string)(ResourceManager.GetObject("RepoAddDuplicate", resourceCulture)); }
         }
+        internal static string RepoAddDuplicateURL {
+            get { return (string)(ResourceManager.GetObject("RepoAddDuplicateURL", resourceCulture)); }
+        }
         internal static string RepoAdded {
             get { return (string)(ResourceManager.GetObject("RepoAdded", resourceCulture)); }
+        }
+        internal static string RepoPriorityNotFound {
+            get { return (string)(ResourceManager.GetObject("RepoPriorityNotFound", resourceCulture)); }
+        }
+        internal static string RepoPriorityInvalid {
+            get { return (string)(ResourceManager.GetObject("RepoPriorityInvalid", resourceCulture)); }
         }
         internal static string RepoForgetNotFound {
             get { return (string)(ResourceManager.GetObject("RepoForgetNotFound", resourceCulture)); }

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -150,6 +150,7 @@ Update recommended!</value></data>
   <data name="UserSelectionNotNumber" xml:space="preserve"><value>The input is not a number</value></data>
   <data name="UserSelectionTooLarge" xml:space="preserve"><value>The number in the input is too large</value></data>
   <data name="UserSelectionTooSmall" xml:space="preserve"><value>The number in the input is too small</value></data>
+  <data name="UserProgressDownloadSubstring" xml:space="preserve"><value>download</value><comment>Progress update messages containing this will display a percentage and overwrite the same line on the screen</comment></data>
   <data name="AuthTokenHostHeader" xml:space="preserve"><value>Host</value></data>
   <data name="AuthTokenTokenHeader" xml:space="preserve"><value>Token</value></data>
   <data name="AuthTokenHelpSummary" xml:space="preserve"><value>Manage authentication tokens</value></data>
@@ -293,10 +294,15 @@ Try `ckan list` for a list of installed mods.</value></data>
   <data name="RepoUnknownCommand" xml:space="preserve"><value>Unknown command: repo {0}</value></data>
   <data name="RepoAvailableHeader" xml:space="preserve"><value>Listing all (canonical) available CKAN repositories:</value></data>
   <data name="RepoAvailableFailed" xml:space="preserve"><value>Couldn't fetch CKAN repositories master list from {0}</value></data>
-  <data name="RepoListHeader" xml:space="preserve"><value>Listing all known repositories:</value></data>
+  <data name="RepoListPriorityHeader" xml:space="preserve"><value>Priority</value></data>
+  <data name="RepoListNameHeader" xml:space="preserve"><value>Name</value></data>
+  <data name="RepoListURLHeader" xml:space="preserve"><value>URL</value></data>
   <data name="RepoAddNotFound" xml:space="preserve"><value>Name {0} not found in master list, please provide name and uri</value></data>
   <data name="RepoAddDuplicate" xml:space="preserve"><value>Repository with name "{0}" already exists, aborting</value></data>
+  <data name="RepoAddDuplicateURL" xml:space="preserve"><value>Repository with URL "{0}" already exists, aborting</value></data>
   <data name="RepoAdded" xml:space="preserve"><value>Added repository '{0}' - '{1}'</value></data>
+  <data name="RepoPriorityNotFound" xml:space="preserve"><value>Couldn't find repository with name "{0}", aborting</value></data>
+  <data name="RepoPriorityInvalid" xml:space="preserve"><value>Invalid priority: {0}, allowed values are 0 to {1}</value></data>
   <data name="RepoForgetNotFound" xml:space="preserve"><value>Couldn't find repository with name "{0}", aborting</value></data>
   <data name="RepoForgetRemoving" xml:space="preserve"><value>Removing insensitive match "{0}"</value></data>
   <data name="RepoForgetRemoved" xml:space="preserve"><value>Successfully removed "{0}"</value></data>

--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -39,6 +39,8 @@ namespace CKAN
         {
             var repos = registry_manager.registry.Repositories.Values
                 .DistinctBy(r => r.uri)
+                // Higher priority repo overwrites lower priority (SortedDictionary just sorts by name)
+                .OrderByDescending(r => r.priority)
                 .ToArray();
 
             // Get latest copy of the game versions data (remote build map)
@@ -203,7 +205,7 @@ namespace CKAN
             List<CkanModule> modules = new List<CkanModule>();
             using (var zipfile = new ZipFile(path))
             {
-                user.RaiseMessage("Loading modules from {0} repository...", repo.name);
+                user.RaiseMessage(Properties.Resources.NetRepoLoadingModulesFromRepo, repo.name);
                 int index = 0;
                 int prevPercent = 0;
                 foreach (ZipEntry entry in zipfile)

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -123,7 +123,7 @@
   <data name="NetInvalidLocation" xml:space="preserve"><value>Invalid URL in Location header: {0}</value></data>
   <data name="NetAsyncDownloaderDownloading" xml:space="preserve"><value>Downloading "{0}"</value></data>
   <data name="NetAsyncDownloaderCancelled" xml:space="preserve"><value>Download cancelled by user</value></data>
-  <data name="NetAsyncDownloaderProgress" xml:space="preserve"><value>{0}/sec - downloading - {1} left</value></data>
+  <data name="NetAsyncDownloaderProgress" xml:space="preserve"><value>{0}/sec - downloading - {1} left</value><comment>Should contain UserProgressDownloadSubstring from CmdLine</comment></data>
   <data name="NetAsyncDownloaderTryingFallback" xml:space="preserve"><value>Failed to download "{0}", trying fallback "{1}"</value></data>
   <data name="NetAsyncDownloaderValidating" xml:space="preserve"><value>Finished downloading {0}, validating and storing to cache...</value></data>
   <data name="NetFileCacheCannotFind" xml:space="preserve"><value>Cannot find cache directory: {0}</value></data>
@@ -149,7 +149,7 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="NetRepoNoModules" xml:space="preserve"><value>No modules found!</value></data>
   <data name="NetRepoFailedDownload" xml:space="preserve"><value>Failed to download {0}: {1}</value></data>
   <data name="NetRepoInconsistenciesHeader" xml:space="preserve"><value>The following inconsistencies were found:</value></data>
-  <data name="NetRepoLoadingModulesFromRepo" xml:space="preserve"><value>Loading modules from {0} repository...</value></data>
+  <data name="NetRepoLoadingModulesFromRepo" xml:space="preserve"><value>Loading modules from downloaded {0} repository...</value><comment>Should contain UserProgressDownloadSubstring from CmdLine</comment></data>
   <data name="NetRepoLoadedDownloadCounts" xml:space="preserve"><value>Loaded download counts from {0} repository</value></data>
   <data name="JsonRelationshipConverterAnyOfCombined" xml:space="preserve"><value>`any_of` should not be combined with `{0}`</value></data>
   <data name="RegistryFileConflict" xml:space="preserve"><value>{0} wishes to install {1}, but this file is registered to {2}</value></data>

--- a/GUI/Properties/Resources.Designer.cs
+++ b/GUI/Properties/Resources.Designer.cs
@@ -876,6 +876,18 @@ namespace CKAN.GUI.Properties {
         internal static string SettingsDialogDeleteConfirm {
             get { return (string)(ResourceManager.GetObject("SettingsDialogDeleteConfirm", resourceCulture)); }
         }
+        internal static string SettingsDialogRepoDeleteConfirm {
+            get { return (string)(ResourceManager.GetObject("SettingsDialogRepoDeleteConfirm", resourceCulture)); }
+        }
+        internal static string SettingsDialogRepoDeleteDelete {
+            get { return (string)(ResourceManager.GetObject("SettingsDialogRepoDeleteDelete", resourceCulture)); }
+        }
+        internal static string SettingsDialogRepoDeleteCancel {
+            get { return (string)(ResourceManager.GetObject("SettingsDialogRepoDeleteCancel", resourceCulture)); }
+        }
+        internal static string SettingsDialogRepoAddDuplicateURL {
+            get { return (string)(ResourceManager.GetObject("SettingsDialogRepoAddDuplicateURL", resourceCulture)); }
+        }
         internal static string SettingsDialogUpdateFailed {
             get { return (string)(ResourceManager.GetObject("SettingsDialogUpdateFailed", resourceCulture)); }
         }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -362,6 +362,10 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Invalid path: {0}</value></data>
   <data name="SettingsDialogCacheDescrip" xml:space="preserve"><value>Choose a folder for storing CKAN's mod downloads:</value></data>
   <data name="SettingsDialogDeleteConfirm" xml:space="preserve"><value>Do you really want to delete {0} cached files, freeing {1}?</value></data>
+  <data name="SettingsDialogRepoDeleteConfirm" xml:space="preserve"><value>Are you sure you want to delete the {0} repo? This can't be undone!</value></data>
+  <data name="SettingsDialogRepoDeleteDelete" xml:space="preserve"><value>Delete</value></data>
+  <data name="SettingsDialogRepoDeleteCancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="SettingsDialogRepoAddDuplicateURL" xml:space="preserve"><value>Repository with URL already in list: {0}</value></data>
   <data name="AddAuthTokenTitle" xml:space="preserve"><value>Add Authentication Token</value></data>
   <data name="AddAuthTokenHost" xml:space="preserve"><value>Host:</value></data>
   <data name="AddAuthTokenToken" xml:space="preserve"><value>Token:</value></data>


### PR DESCRIPTION
## Background

CKAN can be configured to retrieve module metadata from multiple sources, called "repositories." The vast majority of users only use one repository. Alternate repositories are typically used to allow users to opt-in to bleeding edge releases of specific mods (e.g. MechJeb2 and Kopernicus).

## Problems

- Updating the registry retrieves repositories in order of their names alphanumerically, regardless of the priorities
- The string `Loading modules from {0} repository...` was not internationalized

### CmdLine

- You can't edit the priorities from the command line
- `ckan repo list` uses a weird format different from the tabular output of most other commands
- Progress updates were hard-coded to show percentages only for strings containing the English word "download"
- The priority of newly added repositories isn't set, so it's easy to get multiple that are 0
- The string `Loading modules from {0} repository...` was displayed on many lines during updates

### GUI

- Newly added repos always have priority 0
- Adding, deleting, and changing the priority of a repository is weirdly slow because the registry is being saved

## Causes

This summary comment is false:

https://github.com/KSP-CKAN/CKAN/blob/2a5a94cc26c34673daff43c4cf48de9b58e00efc/Core/Registry/Registry.cs#L77-L86

`SortedDictionary` sorts only by the _key_ (in this case the name). (The specific sorting logic applied to the key can only be changed by passing an `IComparer` to the dictionary's constructor, which was never done here, but wouldn't have helped anyway if it had been since the priority is part of the value rather than the key). So `Registry.Repositories` has always only been sorted by name; the priority did nothing.

## Changes

- Now we sort the repositories by priority when we update the registry, so the priority will actually do something
- Now repository priorities are cleaned up at registry load to guarantee they start at 0 and don't repeat
- Now `Loading modules from {0} repository...` is internationalized

### CmdLine

- Now a new `ckan repo priority` command lets you set a repository's priority
- Now `ckan repo list` uses a tabular output format like other commands
- Now `ckan repo add` and `ckan repo default` set the priority of the new repository to the next available number
- Now `ckan repo add` will refuse to add multiple repositories with the same URL
- Now `ckan repo forget` adjusts the priorities of the remaining repositories after removing one to ensure they're unique and without duplicates or gaps
- Now the "download" substring for progress update percentage display is internationalized
- Now the string `Loading modules from {0} repository...` includes the word "download" so it will overwrite itself and show percentages

### GUI

- Now the columns in the settings window's repo grid are auto-sized to fit their contents
- Now there's a confirmation popup before we delete a repo, so if you click Delete by accident you aren't faced with a need to find an obscure URL to fix it
- Newly added repos have their priority set to the next available number
- Trying to add a new repo with the same URL as an existing repo raises an error
- Now while we save the registry after changing something repo-related, the hourglass cursor is shown and the UI remains responsive
- The code for managing repo priorities is simplified for easier maintenance (confusing duplicated state storing the list in multiple places is eliminated)
