### PR TITLE
Correctly print cmdline errors with braces

### DIFF
--- a/Cmdline/Action/AuthToken.cs
+++ b/Cmdline/Action/AuthToken.cs
@@ -110,7 +110,7 @@ namespace CKAN.CmdLine
             }
             else
             {
-                user.RaiseError("Invalid host name: {0}", opts.host);
+                user.RaiseError(Properties.Resources.AuthTokenInvalidHostName, opts.host);
             }
             return Exit.OK;
         }

--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -637,13 +637,13 @@ namespace CKAN.CmdLine
             catch (BadInstallLocationKraken kraken)
             {
                 // The folder exists and is not empty.
-                User.RaiseError(kraken.Message);
+                User.RaiseError("{0}", kraken.Message);
                 return badArgument();
             }
             catch (WrongGameVersionKraken kraken)
             {
                 // Thrown because the specified game instance is too old for one of the selected DLCs.
-                User.RaiseError(kraken.Message);
+                User.RaiseError("{0}", kraken.Message);
                 return badArgument();
             }
             catch (NotKSPDirKraken kraken)
@@ -651,7 +651,7 @@ namespace CKAN.CmdLine
                 // Something went wrong adding the new instance to the registry,
                 // most likely because the newly created directory is somehow not valid.
                 log.Error(kraken);
-                User.RaiseError(kraken.Message);
+                User.RaiseError("{0}", kraken.Message);
                 return error();
             }
             catch (InvalidKSPInstanceKraken)

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -88,9 +88,10 @@ namespace CKAN.CmdLine
                     }
                     catch (Kraken kraken)
                     {
-                        user.RaiseError(kraken.InnerException == null
-                            ? kraken.Message
-                            : $"{kraken.Message}: {kraken.InnerException.Message}");
+                        user.RaiseError("{0}",
+                            kraken.InnerException == null
+                                ? kraken.Message
+                                : $"{kraken.Message}: {kraken.InnerException.Message}");
                     }
                 }
 
@@ -142,7 +143,7 @@ namespace CKAN.CmdLine
                 }
                 catch (DependencyNotSatisfiedKraken ex)
                 {
-                    user.RaiseError(ex.Message);
+                    user.RaiseError("{0}", ex.Message);
                     user.RaiseMessage(Properties.Resources.InstallTryAgain);
                     return Exit.ERROR;
                 }
@@ -214,7 +215,7 @@ namespace CKAN.CmdLine
                 catch (InconsistentKraken ex)
                 {
                     // The prettiest Kraken formats itself for us.
-                    user.RaiseError(ex.InconsistenciesPretty);
+                    user.RaiseError("{0}", ex.InconsistenciesPretty);
                     user.RaiseMessage(Properties.Resources.InstallCancelled);
                     return Exit.ERROR;
                 }
@@ -226,12 +227,12 @@ namespace CKAN.CmdLine
                 catch (MissingCertificateKraken kraken)
                 {
                     // Another very pretty kraken.
-                    user.RaiseError(kraken.ToString());
+                    user.RaiseError("{0}", kraken.ToString());
                     return Exit.ERROR;
                 }
                 catch (DownloadThrottledKraken kraken)
                 {
-                    user.RaiseError(kraken.ToString());
+                    user.RaiseError("{0}", kraken.ToString());
                     user.RaiseMessage(Properties.Resources.InstallTryAuthToken, kraken.infoUrl);
                     return Exit.ERROR;
                 }
@@ -242,12 +243,12 @@ namespace CKAN.CmdLine
                 }
                 catch (ModuleDownloadErrorsKraken kraken)
                 {
-                    user.RaiseError(kraken.ToString());
+                    user.RaiseError("{0}", kraken.ToString());
                     return Exit.ERROR;
                 }
                 catch (DirectoryNotFoundKraken kraken)
                 {
-                    user.RaiseError(kraken.Message);
+                    user.RaiseError("{0}", kraken.Message);
                     return Exit.ERROR;
                 }
                 catch (ModuleIsDLCKraken kraken)

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -331,7 +331,7 @@ namespace CKAN.CmdLine
 
                 if (next_command == null)
                 {
-                    user.RaiseError(kraken.InconsistenciesPretty);
+                    user.RaiseError("{0}", kraken.InconsistenciesPretty);
                     user.RaiseError(Properties.Resources.ScanNotSaved);
                 }
                 else

--- a/Cmdline/Properties/Resources.Designer.cs
+++ b/Cmdline/Properties/Resources.Designer.cs
@@ -164,6 +164,9 @@ namespace CKAN.CmdLine.Properties {
         internal static string AuthTokenHelpSummary {
             get { return (string)(ResourceManager.GetObject("AuthTokenHelpSummary", resourceCulture)); }
         }
+        internal static string AuthTokenInvalidHostName {
+            get { return (string)(ResourceManager.GetObject("AuthTokenHelpSummary", resourceCulture)); }
+        }
 
         internal static string AvailableHeader {
             get { return (string)(ResourceManager.GetObject("AvailableHeader", resourceCulture)); }

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -154,6 +154,7 @@ Update recommended!</value></data>
   <data name="AuthTokenHostHeader" xml:space="preserve"><value>Host</value></data>
   <data name="AuthTokenTokenHeader" xml:space="preserve"><value>Token</value></data>
   <data name="AuthTokenHelpSummary" xml:space="preserve"><value>Manage authentication tokens</value></data>
+  <data name="AuthTokenInvalidHostName" xml:space="preserve"><value>Invalid host name: {0}</value></data>
   <data name="AvailableHeader" xml:space="preserve"><value>Modules compatible with {0} {1}</value></data>
   <data name="CacheHelpSummary" xml:space="preserve"><value>Manage the download cache path of CKAN</value></data>
   <data name="CacheSet" xml:space="preserve"><value>Download cache set to {0}</value></data>


### PR DESCRIPTION
## Problem

While I was testing some edge case `install` stanzas for @JonnyOThan, this metadata:

```json
    "install": {
        "file": "Astrogator",
        "install_to": "GameRoot/KSP_x64_Data"
    },
```

gave me this error:

```
$ ckan.exe install -c Astrogator-v1.0.0.ckan

Unhandled Exception: System.FormatException: Input string was not in a correct format.
   at System.Text.StringBuilder.FormatError()
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(IFormatProvider provider, String format, Object[] args)
   at System.IO.TextWriter.WriteLine(String format, Object[] arg)
   at System.IO.TextWriter.SyncTextWriter.WriteLine(String format, Object[] arg)
   at CKAN.CmdLine.ConsoleUser.RaiseError(String message, Object[] args)
   at CKAN.CmdLine.Install.RunCommand(GameInstance instance, Object raw_options)
   at CKAN.CmdLine.MainClass.RunSimpleAction(Options cmdline, CommonOptions options, String[] args, IUser user, GameInstanceManager manager)
   at CKAN.CmdLine.MainClass.Execute(GameInstanceManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

## Cause

The root cause is that my .ckan file was formatted wrong; the `install` property has to be an array, but mine was an object, so the attempt to deserialize failed.

However, the error message about that was not printed because there are places in CmdLine where a message string from an exception thrown by core code or third party libraries is passed as the first parameter of `IUser.RaiseError`, which always interprets that parameter as a format string (see #2111). If such a string contains `{` and `}` (as is particularly likely for JSON deserialization problems), these will be interpreted as parameter interpolation tokens and the string formatting will fail.

## Changes

- Now when we want to print an exception message, the first parameter is always `{0}`, to prevent the message from being interpreted as a format string. The original root cause error is printed:
  ```
  $ install -c Astrogator-v1.0.0.ckan
  JSON deserialization error: Cannot deserialize the current JSON object (e.g. {"name":"value"}) into type 'CKAN.ModuleInstallDescriptor[]' because the type requires a JSON array (e.g. [1,2,3]) to deserialize correctly.
  To fix this error either change the JSON to a JSON array (e.g. [1,2,3]) or change the deserialized type so that it is a normal .NET type (e.g. not a primitive type like integer, not a collection type like an array or List<T>) that can be deserialized from a JSON object. JsonObjectAttribute can also be added to the type to force it to deserialize from a JSON object.
  Path 'install', line 67, position 17.: Cannot deserialize the current JSON object (e.g. {"name":"value"}) into type 'CKAN.ModuleInstallDescriptor[]' because the type requires a JSON array (e.g. [1,2,3]) to deserialize correctly.
  To fix this error either change the JSON to a JSON array (e.g. [1,2,3]) or change the deserialized type so that it is a normal .NET type (e.g. not a primitive type like integer, not a collection type like an array or List<T>) that can be deserialized from a JSON object. JsonObjectAttribute can also be added to the type to force it to deserialize from a JSON object.
  Path 'install', line 67, position 17.
  Usage: ckan install [--with-suggests] [--with-all-suggests] [--no-recommends] [--headless] Mod [Mod2, ...]
  ```
- An untranslated error message is internationalized.
