### PR TITLE
Mod list fixes and improvements

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -346,6 +346,7 @@ namespace CKAN.GUI
             // Installed
             //
             this.Installed.Name = "Installed";
+            this.Installed.Frozen = true;
             this.Installed.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.Installed.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.Installed.Width = 50;
@@ -354,6 +355,7 @@ namespace CKAN.GUI
             // AutoInstalled
             //
             this.AutoInstalled.Name = "AutoInstalled";
+            this.AutoInstalled.Frozen = true;
             this.AutoInstalled.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.AutoInstalled.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.AutoInstalled.Width = 50;
@@ -362,6 +364,7 @@ namespace CKAN.GUI
             // UpdateCol
             //
             this.UpdateCol.Name = "UpdateCol";
+            this.UpdateCol.Frozen = true;
             this.UpdateCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.UpdateCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.UpdateCol.Width = 46;
@@ -370,6 +373,7 @@ namespace CKAN.GUI
             // ReplaceCol
             //
             this.ReplaceCol.Name = "ReplaceCol";
+            this.ReplaceCol.Frozen = true;
             this.ReplaceCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.ReplaceCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.ReplaceCol.Width = 46;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -420,7 +420,6 @@ namespace CKAN.GUI
                 }
                 else
                 {
-                    SetupDefaultSearch();
                     RefreshModList();
                 }
             }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -88,7 +88,8 @@ namespace CKAN.GUI
             // Update all mods that share the same ZIP
             var allGuiMods = ManageMods.AllGUIMods();
             foreach (var otherMod in module.ToModule().GetDownloadsGroup(
-                allGuiMods.Values.Select(guiMod => guiMod.ToModule())))
+                allGuiMods.Values.Select(guiMod => guiMod.ToModule())
+                                 .Where(mod => mod != null)))
             {
                 allGuiMods[otherMod.identifier].UpdateIsCached();
             }


### PR DESCRIPTION
## Problems

- If you have no mods installed, the Auto-installed column is still displayed even though it serves no purpose:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/143b2b00-c2e7-4c0d-99dd-209e61beb546)
- A Discord user confused himself by scrolling the mod list to the right and forgetting that the checkbox to install a mod had scrolled off the edge of the grid:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/ba313525-619b-4deb-84d7-457b06f23bfb)

## Causes

- This column's visibility was managed in multiple places, and they conflicted with one another; an older one was hiding the Auto-installed column while a newer one was unhiding it
- The checkbox columns are small but essential UI elements, so allowing them to scroll out of view has more disadvantages than advantages

## Motivation

We have a very old `TODO` item here:

https://github.com/KSP-CKAN/CKAN/blob/1a884fe056bbca120167d89cfaba61f833113537/GUI/Model/ModList.cs#L172

This is _not_ a very good place for it (it would be architecturally better for this class to be a pure data model, and this function could be called with a changeset that isn't meant to be applied to a grid), but the idea makes sense because showing users which mods will be removed could be helpful.

## Changes

- Now column visibility management is consolidated and cleaned up such that the Auto-installed column is hidden if no installed mods are visible:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/d210d311-0d3f-4c2d-be19-29575d366b73)
- Now the mod list's checkbox columns are frozen at the left, so they'll always be visible even if you scroll to the right:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/3363ed5e-8851-4353-8329-9e111c79ef5b)
- Now when your changeset includes removing some mods (including user-selected, removed due to missing dependencies, and removed due to no longer being needed), they will be shown with a ~~strikeout~~ font on the main mod list:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/856de2fe-4945-402d-b2af-76149771f165)
- Another `TODO` regarding `ModList.HandleTooManyProvides` is resolved by deleting that delegate definition, which is no longer in use
