### PR TITLE
Deduce primary branch name in merge script

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -153,17 +153,13 @@ namespace CKAN
         }
 
         // returns true if a url is already in the cache
-        public bool IsCached(Uri url)
-        {
-            return GetCachedFilename(url) != null;
-        }
+        public bool IsCached(Uri url) => GetCachedFilename(url) != null;
 
         // returns true if a url is already in the cache
         // returns the filename in the outFilename parameter
         public bool IsCached(Uri url, out string outFilename)
         {
             outFilename = GetCachedFilename(url);
-
             return outFilename != null;
         }
 
@@ -172,10 +168,7 @@ namespace CKAN
         /// validation tests. Prefer this over IsCached when working with
         /// zip files.
         /// </summary>
-        public bool IsCachedZip(Uri url)
-        {
-            return GetCachedZip(url) != null;
-        }
+        public bool IsCachedZip(Uri url) => GetCachedZip(url) != null;
 
         /// <summary>
         /// Returns true if a file matching the given URL is cached, but makes no
@@ -184,9 +177,7 @@ namespace CKAN
         /// Use IsCachedZip() for a slower but more reliable method.
         /// </summary>
         public bool IsMaybeCachedZip(Uri url, DateTime? remoteTimestamp = null)
-        {
-            return GetCachedFilename(url, remoteTimestamp) != null;
-        }
+            => GetCachedFilename(url, remoteTimestamp) != null;
 
         /// <summary>>
         /// Returns the filename of an already cached url or null otherwise
@@ -337,14 +328,12 @@ namespace CKAN
         }
 
         private HashSet<string> legacyDirs()
-        {
-            return manager?.Instances.Values
+            => manager?.Instances.Values
                 .Where(ksp => ksp.Valid)
                 .Select(ksp => ksp.DownloadCacheDir())
                 .Where(dir => Directory.Exists(dir))
                 .ToHashSet()
                 ?? new HashSet<string>();
-        }
 
         public void EnforceSizeLimit(long bytes, Registry registry)
         {

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -123,9 +123,7 @@ namespace CKAN
         /// SHA1 hash, in all-caps hexadecimal format
         /// </returns>
         public string GetFileHashSha1(string filePath, IProgress<long> progress, CancellationToken cancelToken = default(CancellationToken))
-        {
-            return cache.GetFileHashSha1(filePath, progress, cancelToken);
-        }
+            => cache.GetFileHashSha1(filePath, progress, cancelToken);
 
         /// <summary>
         /// Calculate the SHA256 hash of a file
@@ -136,9 +134,7 @@ namespace CKAN
         /// SHA256 hash, in all-caps hexadecimal format
         /// </returns>
         public string GetFileHashSha256(string filePath, IProgress<long> progress, CancellationToken cancelToken = default(CancellationToken))
-        {
-            return cache.GetFileHashSha256(filePath, progress, cancelToken);
-        }
+            => cache.GetFileHashSha256(filePath, progress, cancelToken);
 
         /// <summary>
         /// Try to add a file to the module cache.

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -89,30 +89,15 @@ namespace CKAN
         // registry format compatibility.
         [JsonProperty] private Dictionary<string, InstalledModuleFile> installed_files;
 
-        public IEnumerable<string> Files
-        {
-            get { return installed_files.Keys; }
-        }
-
-        public string identifier
-        {
-            get { return source_module.identifier; }
-        }
-
-        public CkanModule Module
-        {
-            get { return source_module; }
-        }
-
-        public DateTime InstallTime
-        {
-            get { return install_time; }
-        }
+        public IEnumerable<string> Files => installed_files.Keys;
+        public string identifier => source_module.identifier;
+        public CkanModule Module => source_module;
+        public DateTime InstallTime => install_time;
 
         public bool AutoInstalled
         {
-            get { return auto_installed;  }
-            set { 
+            get => auto_installed;
+            set {
                 if (Module.IsDLC)
                 {
                     throw new ModuleIsDLCKraken(Module);

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -47,14 +47,7 @@ namespace CKAN
         [JsonProperty] public readonly SortedDictionary<string, int> download_counts = new SortedDictionary<string, int>();
 
         public int? DownloadCount(string identifier)
-        {
-            int count;
-            if (download_counts.TryGetValue(identifier, out count))
-            {
-                return count;
-            }
-            return null;
-        }
+            => download_counts.TryGetValue(identifier, out int count) ? (int?)count : null;
 
         public void SetDownloadCounts(SortedDictionary<string, int> counts)
         {

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -17,10 +17,8 @@ namespace CKAN.GUI
         /// <summary>
         /// A GUIUser is obviously not headless. Returns false.
         /// </summary>
-        public bool Headless
-        {
-            get { return false; }
-        }
+        public bool Headless => false;
+
 
         /// <summary>
         /// Shows a small form with the question.
@@ -29,9 +27,7 @@ namespace CKAN.GUI
         /// <returns><c>true</c> if user pressed yes, <c>false</c> if no.</returns>
         /// <param name="question">Question.</param>
         public bool RaiseYesNoDialog(string question)
-        {
-            return main.YesNoDialog(question);
-        }
+            => main.YesNoDialog(question);
 
         /// <summary>
         /// Will show a small form with the message and a list to choose from.
@@ -40,9 +36,7 @@ namespace CKAN.GUI
         /// <param name="message">Message.</param>
         /// <param name="args">Array of offered options.</param>
         public int RaiseSelectionDialog(string message, params object[] args)
-        {
-            return main.SelectionDialog(message, args);
-        }
+            => main.SelectionDialog(message, args);
 
         /// <summary>
         /// Shows a message box containing the formatted error message.

--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -2,8 +2,10 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Globalization;
+
 using NUnit.Framework;
 using Tests.Data;
+
 using CKAN;
 
 namespace Tests.Core


### PR DESCRIPTION
## Motivation

The commit script currently assumes a `master` branch, but the latest recommendation is to prefer `main`, as with the KSP2 repos.

## Changes

- Now the name of the primary branch is retrieved from the repo's refs, similarly to KSP-CKAN/NetKAN-Infra#288, which removes one obstacle to renaming CKAN's `master`
- I accumulated various trivial C# style changes that didn't belong in other pull requests, which are now dumped here
