### PR TITLE
Multi-game labels

### DIFF
--- a/ConsoleUI/ExitScreen.cs
+++ b/ConsoleUI/ExitScreen.cs
@@ -48,7 +48,7 @@ namespace CKAN.ConsoleUI {
             Console.Clear();
 
             // Specially formatted snippets
-            var ckanPiece = new FancyLinePiece("CKAN", theme.ExitInnerBg, theme.ExitHighlightFg);
+            var ckanPiece = new FancyLinePiece(Meta.GetProductName(), theme.ExitInnerBg, theme.ExitHighlightFg);
             var ckanVersionPiece = new FancyLinePiece($"CKAN {Meta.GetVersion()}", theme.ExitInnerBg, theme.ExitHighlightFg);
             var releaseLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/releases/latest", theme.ExitInnerBg, theme.ExitLinkFg);
             var issuesLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/issues", theme.ExitInnerBg, theme.ExitLinkFg);

--- a/ConsoleUI/ExitScreen.cs
+++ b/ConsoleUI/ExitScreen.cs
@@ -43,7 +43,7 @@ namespace CKAN.ConsoleUI {
             }
             else
             {
-                Console.ResetColor();                
+                Console.ResetColor();
             }
             Console.Clear();
 

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -9,6 +9,13 @@ namespace CKAN
 {
     public static class CKANPathUtils
     {
+        /// <summary>
+        /// Path to save CKAN data shared across all game instances
+        /// </summary>
+        public static readonly string AppDataPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Meta.GetProductName());
+
         private static readonly ILog log = LogManager.GetLogger(typeof(CKANPathUtils));
 
         /// <summary>

--- a/Core/CompatibleGameVersions.cs
+++ b/Core/CompatibleGameVersions.cs
@@ -14,15 +14,10 @@ namespace CKAN
     public class CompatibleGameVersionsConverter : JsonPropertyNamesChangedConverter
     {
         protected override Dictionary<string, string> mapping
-        {
-            get
+            => new Dictionary<string, string>
             {
-                return new Dictionary<string, string>
-                {
-                    { "VersionOfKspWhenWritten", "GameVersionWhenWritten" },
-                    { "CompatibleKspVersions",   "Versions" }
-                };
-            }
-        }
+                { "VersionOfKspWhenWritten", "GameVersionWhenWritten" },
+                { "CompatibleKspVersions",   "Versions" }
+            };
     }
 }

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -51,17 +51,10 @@ namespace CKAN.Configuration
         // CKAN_CONFIG_FILE environment variable.
         public static readonly string defaultConfigFile =
             Environment.GetEnvironmentVariable("CKAN_CONFIG_FILE")
-            ?? Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "CKAN",
-                "config.json"
-            );
+            ?? Path.Combine(CKANPathUtils.AppDataPath, "config.json");
 
-        public static readonly string DefaultDownloadCacheDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "CKAN",
-            "downloads"
-        );
+        public static readonly string DefaultDownloadCacheDir =
+            Path.Combine(CKANPathUtils.AppDataPath, "downloads");
 
         // The actual config file state, and its location on the disk (we allow
         // the location to be changed for unit tests). Note that these are static

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -21,11 +21,8 @@ namespace CKAN.Configuration
         private const           string authTokenKey         = CKAN_KEY + @"\AuthTokens";
         private static readonly string authTokenKeyNoPrefix = StripPrefixKey(authTokenKey);
 
-        private static readonly string defaultDownloadCacheDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "CKAN",
-            "downloads"
-        );
+        private static readonly string defaultDownloadCacheDir =
+            Path.Combine(CKANPathUtils.AppDataPath, "downloads");
 
         public string DownloadCacheDir
         {

--- a/Core/Converters/JsonPropertyNamesChangedConverter.cs
+++ b/Core/Converters/JsonPropertyNamesChangedConverter.cs
@@ -2,24 +2,50 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace CKAN
 {
+    /// <summary>
+    /// Base class for a class-level converter that transfers values from
+    /// the old name for a property to its new name.
+    /// Inherit, then override the mapping property to specify the renamings.
+    /// </summary>
     public abstract class JsonPropertyNamesChangedConverter : JsonConverter
     {
+        /// <summary>
+        /// We don't want to make any changes during serialization
+        /// </summary>
         public override bool CanWrite => false;
+
+        /// <summary>
+        /// We don't want to make any changes during serialization
+        /// </summary>
+        /// <param name="writer">The object writing JSON to disk</param>
+        /// <param name="value">A value to be written for this class</param>
+        /// <param name="serializer">Generates output objects from tokens</param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }
 
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType.GetTypeInfo().IsClass;
-        }
+        /// <summary>
+        /// We only want to convert classes, not properties
+        /// </summary>
+        /// <param name="objectType">Type where this class been used as a JsonConverter</param>
+        /// <returns>true if it's a class, false otherwise</returns>
+        public override bool CanConvert(Type objectType) => objectType.GetTypeInfo().IsClass;
 
+        /// <summary>
+        /// Parse JSON to an object, renaming properties according to the mapping property
+        /// </summary>
+        /// <param name="reader">Object that provides tokens to be translated</param>
+        /// <param name="objectType">The output type to be populated</param>
+        /// <param name="existingValue">Not used</param>
+        /// <param name="serializer">Generates output objects from tokens</param>
+        /// <returns>Class object populated according to the renaming scheme</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             object instance = Activator.CreateInstance(objectType);
@@ -41,7 +67,10 @@ namespace CKAN
             return instance;
         }
 
-        // This is what you need to override in the child class
+        /// <summary>
+        /// This is what you need to override in your child class
+        /// </summary>
+        /// <value>Mapping from old names to new names</value>
         protected abstract Dictionary<string, string> mapping
         {
             get;

--- a/Core/Converters/JsonSingleOrArrayConverter.cs
+++ b/Core/Converters/JsonSingleOrArrayConverter.cs
@@ -41,9 +41,6 @@ namespace CKAN
         /// <returns>
         /// false
         /// </returns>
-        public override bool CanConvert(Type object_type)
-        {
-            return false;
-        }
+        public override bool CanConvert(Type object_type) => false;
     }
 }

--- a/Core/Converters/JsonToGamesDictionaryConverter.cs
+++ b/Core/Converters/JsonToGamesDictionaryConverter.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using System.Collections;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A property converter for making an old property game-specific.
+    /// Turns a String or Array value:
+    ///
+    ///     "myProperty": "a value",
+    ///     "myOtherProperty": [ "another value" ],
+    ///
+    /// into a Dictionary with the game names as keys and the original
+    /// value as each value:
+    ///
+    ///     "myProperty": {
+    ///         "KSP": "a value",
+    ///         "KSP2": "a value"
+    ///     },
+    ///     "myOtherProperty": {
+    ///         "KSP": [ "another value" ],
+    ///         "KSP2": [ "another value" ]
+    ///     },
+    ///
+    /// NOTE: Do NOT use with Object values because they can't
+    ///       be distinguished from an already converted value, and will
+    ///       just be deserialized as-is into your Dictionary!
+    ///
+    /// If the value is an empty array:
+    ///
+    ///     "myProperty": [],
+    ///
+    /// the Dictionary is left empty rather than creating multiple keys
+    /// with empty values:
+    ///
+    ///     "myProperty": {},
+    /// </summary>
+    public class JsonToGamesDictionaryConverter : JsonConverter
+    {
+        /// <summary>
+        /// Turn a tree of JSON tokens into a dictionary
+        /// </summary>
+        /// <param name="reader">Object that provides tokens to be translated</param>
+        /// <param name="objectType">The output type to be populated</param>
+        /// <param name="existingValue">Not used</param>
+        /// <param name="serializer">Generates output objects from tokens</param>
+        /// <returns>Dictionary of type matching the property where this converter was used, containing game-specific keys and values</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            if (token.Type == JTokenType.Object)
+            {
+                return token.ToObject(objectType);
+            }
+            var valueType = objectType.GetGenericArguments()[1];
+            var obj = (IDictionary)Activator.CreateInstance(objectType);
+            if (!IsTokenEmpty(token))
+            {
+                foreach (var gameName in GameInstanceManager.AllGameShortNames())
+                {
+                    // Make a new copy of the value for each game
+                    obj.Add(gameName, token.ToObject(valueType));
+                }
+            }
+            return obj;
+        }
+
+        /// <summary>
+        /// We don't want to make any changes during serialization
+        /// </summary>
+        public override bool CanWrite => false;
+
+        /// <summary>
+        /// We don't want to make any changes during serialization
+        /// </summary>
+        /// <param name="writer">The object writing JSON to disk</param>
+        /// <param name="value">A value to be written for this class</param>
+        /// <param name="serializer">Generates output objects from tokens</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// We *only* want to be triggered for types that have explicitly
+        /// set an attribute in their class saying they can be converted.
+        /// By returning false here, we declare we're not interested in participating
+        /// in any other conversions.
+        /// </summary>
+        /// <returns>
+        /// false
+        /// </returns>
+        public override bool CanConvert(Type object_type) => false;
+
+        private static bool IsTokenEmpty(JToken token)
+            => token.Type == JTokenType.Null
+                || (token.Type == JTokenType.Array && !token.HasValues);
+    }
+}

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -649,5 +649,12 @@ namespace CKAN
         public static IGame GameByShortName(string shortName)
             => knownGames.FirstOrDefault(g => g.ShortName == shortName);
 
+        /// <summary>
+        /// Return the short names of all known games
+        /// </summary>
+        /// <returns>Sequence of short name strings</returns>
+        public static IEnumerable<string> AllGameShortNames()
+            => knownGames.Select(g => g.ShortName);
+
     }
 }

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -612,9 +612,7 @@ namespace CKAN
         }
 
         public static bool IsGameInstanceDir(DirectoryInfo path)
-        {
-            return knownGames.Any(g => g.GameInFolder(path));
-        }
+            => knownGames.Any(g => g.GameInFolder(path));
 
         /// <summary>
         /// Tries to determine the game that is installed at the given path
@@ -643,6 +641,11 @@ namespace CKAN
             }
         }
 
+        /// <summary>
+        /// Return a game object based on its short name
+        /// </summary>
+        /// <param name="shortName">The short name to find</param>
+        /// <returns>A game object or null if none found</returns>
         public static IGame GameByShortName(string shortName)
             => knownGames.FirstOrDefault(g => g.ShortName == shortName);
 

--- a/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildMap.cs
+++ b/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildMap.cs
@@ -33,9 +33,8 @@ namespace CKAN.GameVersionProviders
         // TODO: Need a way for the client to configure this
         private static readonly Uri BuildMapUri =
             new Uri("https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/builds.json");
-        private static readonly string cachedBuildMapPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "CKAN", "builds-ksp.json");
+        private static readonly string cachedBuildMapPath =
+            Path.Combine(CKANPathUtils.AppDataPath, "builds-ksp.json");
 
         private static readonly ILog Log = LogManager.GetLogger(typeof(KspBuildMap));
 

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -151,9 +151,8 @@ namespace CKAN.Games
 
         private static readonly Uri BuildMapUri =
             new Uri("https://raw.githubusercontent.com/KSP-CKAN/KSP2-CKAN-meta/main/builds.json");
-        private static readonly string cachedBuildMapPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "CKAN", "builds-ksp2.json");
+        private static readonly string cachedBuildMapPath =
+            Path.Combine(CKANPathUtils.AppDataPath, "builds-ksp2.json");
 
         private List<GameVersion> versions = JsonConvert.DeserializeObject<List<GameVersion>>(
             File.Exists(cachedBuildMapPath)

--- a/Core/Meta.cs
+++ b/Core/Meta.cs
@@ -1,17 +1,27 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 
 namespace CKAN
 {
     public static class Meta
     {
+        /// <summary>
+        /// Programmatically generate the string "CKAN" from the assembly info attributes,
+        /// so we don't have to embed that string in many places
+        /// </summary>
+        /// <returns>"CKAN"</returns>
+        public static string GetProductName()
+            => Assembly.GetExecutingAssembly()
+                       .GetAssemblyAttribute<AssemblyProductAttribute>()
+                       .Product;
+
         public static string GetVersion(VersionFormat format = VersionFormat.Normal)
         {
-            var version = ((AssemblyInformationalVersionAttribute)
-                Assembly
-                    .GetExecutingAssembly()
-                    .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)[0]
-            ).InformationalVersion;
+            var version = Assembly
+                .GetExecutingAssembly()
+                .GetAssemblyAttribute<AssemblyInformationalVersionAttribute>()
+                .InformationalVersion;
 
             var dashIndex = version.IndexOf('-');
             var plusIndex = version.IndexOf('+');
@@ -38,5 +48,9 @@ namespace CKAN
 
             return "v" + version;
         }
+
+        private static T GetAssemblyAttribute<T>(this Assembly assembly)
+            => (T)assembly.GetCustomAttributes(typeof(T), false)
+                          .First();
     }
 }

--- a/Core/Registry/Tags/ModuleTagList.cs
+++ b/Core/Registry/Tags/ModuleTagList.cs
@@ -51,7 +51,7 @@ namespace CKAN
                 Untagged.Add(am.AllAvailable().First().identifier);
             }
         }
-        
+
         public static ModuleTagList Load(string path)
         {
             try

--- a/Core/Registry/Tags/ModuleTagList.cs
+++ b/Core/Registry/Tags/ModuleTagList.cs
@@ -17,11 +17,8 @@ namespace CKAN
         [JsonProperty("hidden_tags")]
         public HashSet<string> HiddenTags = new HashSet<string>();
 
-        public static readonly string DefaultPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "CKAN",
-            "tags.json"
-        );
+        public static readonly string DefaultPath =
+            Path.Combine(CKANPathUtils.AppDataPath, "tags.json");
 
         public void BuildTagIndexFor(AvailableModule am)
         {

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -86,7 +86,8 @@ namespace CKAN.GUI
         {
             var descr = change.Description;
             CkanModule m = change.Mod;
-            ModuleLabel warnLbl = alertLabels?.FirstOrDefault(l => l.ModuleIdentifiers.Contains(m.identifier));
+            ModuleLabel warnLbl = alertLabels?.FirstOrDefault(l =>
+                l.ContainsModule(Main.Instance.CurrentInstance.game, m.identifier));
             return new ListViewItem(new string[]
             {
                 change.NameAndStatus,

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -156,7 +156,7 @@ namespace CKAN.GUI
                     }
                 }
                 var labels = ModuleLabels?.LabelsFor(manager.CurrentInstance.Name)
-                    .Where(l => l.ModuleIdentifiers.Contains(mod.identifier))
+                    .Where(l => l.ContainsModule(Main.Instance.CurrentInstance.game, mod.identifier))
                     .OrderBy(l => l.Name);
                 if (labels != null)
                 {

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -52,9 +52,7 @@ namespace CKAN.GUI
         /// True if active, false otherwise
         /// </returns>
         public bool AppliesTo(string instanceName)
-        {
-            return InstanceName == null || InstanceName == instanceName;
-        }
+            => InstanceName == null || InstanceName == instanceName;
 
         /// <summary>
         /// Add a module to this label's group

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 namespace CKAN.GUI
 {
     [JsonObject(MemberSerialization.OptIn)]
+    [JsonConverter(typeof(ModuleIdentifiersRenamedConverter))]
     public class ModuleLabel
     {
         [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
@@ -41,7 +42,7 @@ namespace CKAN.GUI
         [DefaultValue(false)]
         public bool    HoldVersion;
 
-        [JsonProperty("module_identifiers", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("module_identifiers_by_game", NullValueHandling = NullValueHandling.Ignore)]
         public HashSet<string> ModuleIdentifiers = new HashSet<string>();
 
         /// <summary>
@@ -71,5 +72,17 @@ namespace CKAN.GUI
         {
             ModuleIdentifiers.Remove(identifier);
         }
+    }
+
+    /// <summary>
+    /// Protect old clients from trying to load a file they can't parse
+    /// </summary>
+    public class ModuleIdentifiersRenamedConverter : JsonPropertyNamesChangedConverter
+    {
+        protected override Dictionary<string, string> mapping
+            => new Dictionary<string, string>
+            {
+                { "module_identifiers", "module_identifiers_by_game" }
+            };
     }
 }

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -18,11 +18,8 @@ namespace CKAN.GUI
         public IEnumerable<ModuleLabel> LabelsFor(string instanceName)
             => Labels.Where(l => l.AppliesTo(instanceName));
 
-        public static readonly string DefaultPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "CKAN",
-            "labels.json"
-        );
+        public static readonly string DefaultPath =
+            Path.Combine(CKANPathUtils.AppDataPath, "labels.json");
 
         public static ModuleLabelList GetDefaultLabels()
             => new ModuleLabelList()

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Drawing;
 using System.Runtime.Serialization;
+
 using Newtonsoft.Json;
 
 namespace CKAN.GUI
@@ -15,9 +16,7 @@ namespace CKAN.GUI
         public ModuleLabel[] Labels = new ModuleLabel[] {};
 
         public IEnumerable<ModuleLabel> LabelsFor(string instanceName)
-        {
-            return Labels.Where(l => l.AppliesTo(instanceName));
-        }
+            => Labels.Where(l => l.AppliesTo(instanceName));
 
         public static readonly string DefaultPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -26,8 +25,7 @@ namespace CKAN.GUI
         );
 
         public static ModuleLabelList GetDefaultLabels()
-        {
-            return new ModuleLabelList()
+            => new ModuleLabelList()
             {
                 Labels = new ModuleLabel[]
                 {
@@ -50,7 +48,6 @@ namespace CKAN.GUI
                     }
                 }
             };
-        }
 
         public static ModuleLabelList Load(string path)
         {

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -113,7 +113,7 @@ namespace CKAN.GUI
                 {
                     Interval = 2
                 };
-                timer.Tick += (sender, e) => Thread.Yield();;
+                timer.Tick += (sender, e) => Thread.Yield();
                 timer.Start();
             }
 

--- a/GUI/Main/MainLabels.cs
+++ b/GUI/Main/MainLabels.cs
@@ -20,7 +20,7 @@ namespace CKAN.GUI
                 var toNotif = mods
                     .Where(m =>
                         notifLabs.Any(l =>
-                            l.ModuleIdentifiers.Contains(m.Identifier)))
+                            l.ContainsModule(CurrentInstance.game, m.Identifier)))
                     .Select(m => m.Name)
                     .Memoize();
                 if (toNotif.Any())
@@ -39,9 +39,9 @@ namespace CKAN.GUI
                 {
                     foreach (ModuleLabel l in ManageMods.mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                         .Where(l => l.RemoveOnChange
-                            && l.ModuleIdentifiers.Contains(mod.Identifier)))
+                            && l.ContainsModule(CurrentInstance.game, mod.Identifier)))
                     {
-                        l.Remove(mod.Identifier);
+                        l.Remove(CurrentInstance.game, mod.Identifier);
                     }
                 }
             });
@@ -50,17 +50,15 @@ namespace CKAN.GUI
         private void LabelsAfterInstall(CkanModule mod)
         {
             foreach (ModuleLabel l in ManageMods.mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
-                .Where(l => l.RemoveOnInstall && l.ModuleIdentifiers.Contains(mod.identifier)))
+                .Where(l => l.RemoveOnInstall && l.ContainsModule(CurrentInstance.game, mod.identifier)))
             {
-                l.Remove(mod.identifier);
+                l.Remove(CurrentInstance.game, mod.identifier);
             }
         }
 
         public bool LabelsHeld(string identifier)
-        {
-            return ManageMods.mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
-                .Any(l => l.HoldVersion && l.ModuleIdentifiers.Contains(identifier));
-        }
+            => ManageMods.mainModList.ModuleLabels.LabelsFor(CurrentInstance.Name)
+                .Any(l => l.HoldVersion && l.ContainsModule(CurrentInstance.game, identifier));
 
         #endregion
     }

--- a/GUI/Model/ModSearch.cs
+++ b/GUI/Model/ModSearch.cs
@@ -546,7 +546,8 @@ namespace CKAN.GUI
 
         private bool MatchesLabels(GUIMod mod)
             // Every label in Labels must contain this mod
-            => Labels.Count < 1 || Labels.All(lb => lb.ModuleIdentifiers.Contains(mod.Identifier));
+            => Labels.Count < 1 || Labels.All(lb =>
+                lb.ContainsModule(Main.Instance.CurrentInstance.game, mod.Identifier));
 
         private bool MatchesCompatible(GUIMod mod)
             => !Compatible.HasValue || Compatible.Value == !mod.IsIncompatible;

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -45,7 +45,8 @@ namespace Tests.GUI
                 var item = new ModList();
                 Assert.That(item.IsVisible(
                     new GUIMod(ckan_mod, registry, manager.CurrentInstance.VersionCriteria()),
-                    manager.CurrentInstance.Name
+                    manager.CurrentInstance.Name,
+                    manager.CurrentInstance.game
                 ));
 
                 manager.Dispose();
@@ -89,7 +90,8 @@ namespace Tests.GUI
                         new GUIMod(TestData.FireSpitterModule(), registry, manager.CurrentInstance.VersionCriteria()),
                         new GUIMod(TestData.kOS_014_module(), registry, manager.CurrentInstance.VersionCriteria())
                     },
-                    manager.CurrentInstance.Name
+                    manager.CurrentInstance.Name,
+                    manager.CurrentInstance.game
                 );
                 Assert.That(mod_list, Has.Count.EqualTo(2));
 
@@ -187,7 +189,7 @@ namespace Tests.GUI
                 .Select(mod => new GUIMod(mod.Value.Latest(), registry, instance.KSP.VersionCriteria()))
                 .ToList();
 
-            listGui.Rows.AddRange(modList.ConstructModList(modules, null).ToArray());
+            listGui.Rows.AddRange(modList.ConstructModList(modules, null, instance.KSP.game).ToArray());
             // The header row adds one to the count
             Assert.AreEqual(modules.Count + 1, listGui.Rows.Count);
 


### PR DESCRIPTION
## Problem

If you add a label to `ResonantOrbitCalculator` in KSP1, the different mod with the same identifier will also have that label added in KSP2, and vice versa. This is not ideal because these are two different mods, which you should be able to treat separately.

## Cause

The `labels.json` file just has one list of identifiers per label, with no distinctions between games, so when both games have a mod with the same identifier, they're treated as one mod.

## Changes

- Now `Meta.GetProductName()` provides a centralized way to get the string "CKAN", `CKANPathUtils.AppDataPath` uses it to provide a centralized way to get the path of the shared config folder, and code that uses either value is updated to use these properties (I did this initially because I was considering changing the path of the `labels.json` file, which I decided against, but this clean-up is still worth keeping)
- The property in the labels JSON file that formerly held a list of identifiers now holds an object with keys corresponding to game names and values corresponding to lists of identifiers:
  ```json
  "module_identifiers": {
      "KSP": [ "Mod1" ],
      "KSP2": [ "Mod2" ]
  }
  ```
  - For users who haven't added labels to mods before, these will start out empty and accumulate mods independently, without affecting the other game. For users who have already added some labels to mods, the existing list of mods will be copied to both games, so nothing in the UI will change immediately, but from that point forward the two lists will be maintained independently, so a mod can be removed from a label in one game without affecting the other game.
  - Since the old ckan.exe client is expecting this property to only be an array, it is renamed to `module_identifiers_by_game`. This means that you will lose all your label memberships if you temporarily switch back to an old client version, but at least it won't crash.

Fixes #3824.

## Considered and not done

Note that any mods that you have added to a label that are not actually available in that game (e.g., if you add `MechJeb2` to your Favorites for KSP1, then run these changes for the first time, then load a KSP2 instance) will be permanently stuck in those lists in the `labels.json` file behind the scenes (unless you edit it manually), since those mods can never appear in the mod list to be removed via the right click menu, and the mod counts in the label filter menu will be inflated by that amount.

I considered various options for trying to resolve this automatically, but none of them are safe. The problem is that there's no reliable way to determine the list of valid identifiers for a game, because users can add custom repos. For example, if someone adds the MechJeb2 dev build repo in one game instance, then the `MechJeb2-dev` module becomes available, and they could add it to a label. If they then later load a different game instance without that repo, it would be wrong to auto-remove that identifier just because we don't recognize it.
