### PR TITLE
Fix schema issue with install_to: GameData/Mods

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -432,7 +432,7 @@
         },
         "install_to" : {
             "description" : "Where file should be installed to. As of v1.2, GameData may take a path",
-            "oneOf" : [
+            "anyOf" : [
                 {
                     "description" : "Spec version 1 targets",
                     "enum"        : [ "GameData", "Ships", "GameRoot", "Tutorial", "Scenarios" ]

--- a/Tests/NetKAN/Validators/ObeysCKANSchemaValidatorTests.cs
+++ b/Tests/NetKAN/Validators/ObeysCKANSchemaValidatorTests.cs
@@ -52,6 +52,18 @@ namespace Tests.NetKAN.Validators
             );
         }
 
+        public void Validate_InstallToGameDataSlashmods_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(
+                () => TryModule(boringModule, null, "install",
+                                JArray.Parse(@"[
+                                    {
+                                        ""find"":       ""BetterPartsManager"",
+                                        ""install_to"": ""GameData/Mods""
+                                    }
+                                ]")));
+        }
+
         private void TryModule(string json, string removeProperty = null, string addProperty = null, JToken addPropertyValue = null)
         {
             // Arrange


### PR DESCRIPTION
## Problem

KSP-CKAN/KSP2-NetKAN#81

```yaml
install:
  - find: BetterPartsManager
    install_to: GameData/Mods
```

https://github.com/KSP-CKAN/KSP2-NetKAN/actions/runs/5930964431/job/16081829297

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/274884fb-7eed-43ea-bb69-0ebf0b0e366b)

## Cause

https://cswr.github.io/JsonSchema/spec/generic_keywords/

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/0bad146d-5066-455d-82c0-22e718d5e589)

`GameData/Mods` is _too correct_; it matches both of these:

https://github.com/KSP-CKAN/CKAN/blob/858d71fc389910fb3ce357d70fa2d4ea0de82218/CKAN.schema#L440-L444
https://github.com/KSP-CKAN/CKAN/blob/858d71fc389910fb3ce357d70fa2d4ea0de82218/CKAN.schema#L460-L463

And the tooling apparently doesn't like that. How this could ever possibly be useful is quite beyond me.

## Changes

I want to keep the explicit definition of the KSP2 default folder independent of what happens elsewhere in the list, so now the `install_to` part uses `anyOf` instead of `oneOf`, which will allow more than one match.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/878a562b-bca9-48ba-9037-d28f5231194b)

FYI to @NathanPeake.
