### PR TITLE
Alternate mod dirs for validation and manual installs

### DIFF
--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -17,7 +17,8 @@ namespace CKAN.Games
         string MacPath();
 
         // What do we contain?
-        string   PrimaryModDirectoryRelative { get; }
+        string   PrimaryModDirectoryRelative     { get; }
+        string[] AlternateModDirectoriesRelative { get; }
         string   PrimaryModDirectory(GameInstance inst);
         string[] StockFolders   { get; }
         string[] ReservedPaths  { get; }

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -92,6 +92,7 @@ namespace CKAN.Games
         }
 
         public string PrimaryModDirectoryRelative => "GameData";
+        public string[] AlternateModDirectoriesRelative => new string[] { };
 
         public string PrimaryModDirectory(GameInstance inst)
             => CKANPathUtils.NormalizePath(

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -97,6 +97,7 @@ namespace CKAN.Games
         }
 
         public string PrimaryModDirectoryRelative => "GameData/Mods";
+        public string[] AlternateModDirectoriesRelative => new string[] { "BepInEx/plugins" };
 
         public string PrimaryModDirectory(GameInstance inst)
             => CKANPathUtils.NormalizePath(


### PR DESCRIPTION
## Problem

In KSP-CKAN/KSP2-NetKAN#84, the validation script happily installed files to `BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace` and didn't complain:

https://github.com/KSP-CKAN/KSP2-NetKAN/actions/runs/5967777987/job/16190169201

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/8a18101e-3586-4d96-9416-2781f9256e70)

There's a "GameData within GameData" validator in Netkan that catches the equivalent issue for KSP1.

## Cause

The "GameData within GameData" check is hard-coded to use the string `GameData`.

## Changes

- Now `IGame.AlternateModDirectoriesRelative` defines an array of strings specifying alternative locations where mods can be installed
  - This contains `BepInEx/plugins` for KSP2 and nothing for KSP1
- Now we scan both the primary and alternate mod dirs for manually installed DLLs
- Now the "GameData within GameData" checks the primary and alternate mod dirs, which makes it work for the above case:

```
$ netkan.exe --game KSP2 NetKAN/QuestariaAereospace.netkan
88958 [1] WARN CKAN.NetKAN.Transformers.SpaceWarpInfoTransformer (null) - Dependencies from swinfo.json missing from module: lfo
90045 [1] FATAL CKAN.NetKAN.Program (null) - BepInEx/plugins directory found within BepInEx/plugins:
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/addressables/AddressablesLink/link.xml
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/addressables/catalog.json
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/addressables/settings.json
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/addressables/StandaloneWindows64/defaultlocalgroup_unitybuiltinshaders_7891cbe984cbeb1f2d1f8278873f00dc.bundle
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/addressables/StandaloneWindows64/questariaaerospace_assets_all_9f16c5859564ddf24dd943dd94e9b57a.bundle
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/assets/plumes/BE-4.json
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/assets/plumes/IQNTR.json
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/assets/plumes/IQparrotEngine.json
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/localizations/english.csv
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/QuestariaAerospace.dll
BepInEx/plugins/QuestariaAerospace/BepInEx/plugins/QuestariaAerospace/swinfo.json
```