### PR TITLE
Show recommendations of full changeset with opt-out

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -409,6 +409,10 @@
                             "choice_help_text": {
                                 "description" : "Optional help text shown when user has to choose among multiple modules",
                                 "type"        : "string"
+                            },
+                            "suppress_recommendations": {
+                                "description" : "If true, don't check this mod or its dependencies for recommendations or suggestions",
+                                "type"        : "boolean"
                             }
                         },
                         "required" : [ "name" ]

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1251,6 +1251,20 @@ namespace CKAN
             }
         }
 
+        private static readonly RelationshipResolverOptions RecommenderOptions = new RelationshipResolverOptions()
+        {
+            // Only look at depends
+            with_recommends = false,
+
+            // Don't throw anything
+            without_toomanyprovides_kraken = true,
+            without_enforce_consistency    = true,
+            proceed_with_inconsistencies   = true,
+
+            // Skip relationships with suppress_recommendations==true
+            get_recommenders = true,
+        };
+
         /// <summary>
         /// Looks for optional related modules that could be installed alongside the given modules
         /// </summary>
@@ -1268,22 +1282,24 @@ namespace CKAN
             Registry registry,
             out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
             out Dictionary<CkanModule, List<string>> suggestions,
-            out Dictionary<CkanModule, HashSet<string>> supporters
-        )
+            out Dictionary<CkanModule, HashSet<string>> supporters)
         {
-            Dictionary<CkanModule, List<string>> dependersIndex = getDependersIndex(sourceModules, registry, toInstall);
+            // Get all dependencies except where suppress_recommendations==true
+            var resolver = new RelationshipResolver(sourceModules, null, RecommenderOptions,
+                                                    registry, ksp.VersionCriteria());
+            var recommenders = resolver.ModList().ToList();
+
+            var dependersIndex = getDependersIndex(recommenders, registry, toInstall);
             var instList = toInstall.ToList();
             recommendations = new Dictionary<CkanModule, Tuple<bool, List<string>>>();
             suggestions = new Dictionary<CkanModule, List<string>>();
             supporters = new Dictionary<CkanModule, HashSet<string>>();
-            foreach (CkanModule mod in sourceModules.Where(m => m.recommends != null))
+            foreach (CkanModule mod in recommenders.Where(m => m.recommends != null))
             {
                 foreach (RelationshipDescriptor rel in mod.recommends)
                 {
                     List<CkanModule> providers = rel.LatestAvailableWithProvides(
-                        registry,
-                        ksp.VersionCriteria()
-                    );
+                        registry, ksp.VersionCriteria());
                     int i = 0;
                     foreach (CkanModule provider in providers)
                     {
@@ -1298,21 +1314,18 @@ namespace CKAN
                                 provider,
                                 new Tuple<bool, List<string>>(
                                     !provider.IsDLC && (i == 0 || provider.identifier == (rel as ModuleRelationshipDescriptor)?.name),
-                                    dependers)
-                            );
+                                    dependers));
                             ++i;
                         }
                     }
                 }
             }
-            foreach (CkanModule mod in sourceModules.Where(m => m.suggests != null))
+            foreach (CkanModule mod in recommenders.Where(m => m.suggests != null))
             {
                 foreach (RelationshipDescriptor rel in mod.suggests)
                 {
                     List<CkanModule> providers = rel.LatestAvailableWithProvides(
-                        registry,
-                        ksp.VersionCriteria()
-                    );
+                        registry, ksp.VersionCriteria());
                     foreach (CkanModule provider in providers)
                     {
                         if (!registry.IsInstalled(provider.identifier)
@@ -1331,7 +1344,7 @@ namespace CKAN
             // Find installable modules with "supports" relationships
             var candidates = registry.CompatibleModules(ksp.VersionCriteria())
                 .Where(mod => !registry.IsInstalled(mod.identifier)
-                    && !toInstall.Any(m => m.identifier == mod.identifier))
+                              && !toInstall.Any(m => m.identifier == mod.identifier))
                 .Where(m => m?.supports != null)
                 .Except(recommendations.Keys)
                 .Except(suggestions.Keys);
@@ -1340,7 +1353,7 @@ namespace CKAN
             {
                 foreach (RelationshipDescriptor rel in mod.supports)
                 {
-                    if (rel.MatchesAny(sourceModules, null, null))
+                    if (rel.MatchesAny(recommenders, null, null))
                     {
                         var name = (rel as ModuleRelationshipDescriptor)?.name;
                         if (!string.IsNullOrEmpty(name))
@@ -1357,11 +1370,11 @@ namespace CKAN
                     }
                 }
             }
-            supporters.RemoveWhere(kvp => !CanInstall(
-                RelationshipResolver.DependsOnlyOpts(),
-                instList.Concat(new List<CkanModule>() { kvp.Key }).ToList(),
-                registry
-            ));
+            supporters.RemoveWhere(kvp =>
+                !CanInstall(
+                    RelationshipResolver.DependsOnlyOpts(),
+                    instList.Concat(new List<CkanModule>() { kvp.Key }).ToList(),
+                    registry));
 
             return recommendations.Any() || suggestions.Any() || supporters.Any();
         }
@@ -1370,8 +1383,7 @@ namespace CKAN
         private Dictionary<CkanModule, List<string>> getDependersIndex(
             IEnumerable<CkanModule> sourceModules,
             IRegistryQuerier        registry,
-            List<CkanModule>        toExclude
-        )
+            List<CkanModule>        toExclude)
         {
             Dictionary<CkanModule, List<string>> dependersIndex = new Dictionary<CkanModule, List<string>>();
             foreach (CkanModule mod in sourceModules)
@@ -1383,9 +1395,7 @@ namespace CKAN
                         foreach (RelationshipDescriptor rel in relations)
                         {
                             List<CkanModule> providers = rel.LatestAvailableWithProvides(
-                                registry,
-                                ksp.VersionCriteria()
-                            );
+                                registry, ksp.VersionCriteria());
                             foreach (CkanModule provider in providers)
                             {
                                 if (!registry.IsInstalled(provider.identifier)

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -60,10 +60,15 @@ namespace CKAN
         /// </summary>
         public bool allow_incompatible = false;
 
-        public object Clone()
-        {
-            return MemberwiseClone();
-        }
+        /// <summary>
+        /// If true, get the list of mods that should be checked for
+        /// recommendations and suggestions.
+        /// Differs from normal resolution in that it stops when
+        /// ModuleRelationshipDescriptor.suppress_recommendations==true
+        /// </summary>
+        public bool get_recommenders = false;
+
+        public object Clone() => MemberwiseClone();
     }
 
     // TODO: RR currently conducts a depth-first resolution of requirements. While we do the
@@ -402,6 +407,12 @@ namespace CKAN
             foreach (RelationshipDescriptor descriptor in stanza)
             {
                 log.DebugFormat("Considering {0}", descriptor.ToString());
+
+                if (options.get_recommenders && descriptor.suppress_recommendations)
+                {
+                    log.DebugFormat("Skipping {0} because get_recommenders option is set");
+                    continue;
+                }
 
                 // If we already have this dependency covered,
                 // resolve its relationships if we haven't already.

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -109,8 +109,7 @@ namespace CKAN.GUI
                 registry,
                 out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
                 out Dictionary<CkanModule, List<string>> suggestions,
-                out Dictionary<CkanModule, HashSet<string>> supporters
-            ))
+                out Dictionary<CkanModule, HashSet<string>> supporters))
             {
                 tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
                 ChooseRecommendedMods.LoadRecommendations(

--- a/Spec.md
+++ b/Spec.md
@@ -565,6 +565,17 @@ depends:
     choice_help_text: Pick ModA if you prefer polka dots, ModB otherwise
 ```
 
+(**v1.34**) Clients implementing version `v1.34` or later of the spec *must* support
+the `suppress_recommendations` property in a relationship. If this property is `true`,
+then recommendations or suggestions will not be shown for the module satisfying this
+relationship or its (sole) dependencies.
+
+```yaml
+depends:
+  - name: OtherMod
+    suppress_recommendations: true
+```
+
 ##### depends
 
 A list of mods which are *required* for the current mod to operate.


### PR DESCRIPTION
## Motivation

Currently we show only the recommendations and suggestions for the mods the user selects. The recommendations and suggestions of dependencies aren't shown, even though the user stands to benefit from seeing them.

## Changes

- Now recommendations and suggestions are shown for the full changeset, including both user-selected mods and all of their dependencies, except...
- The KSP-RO folks don't want that for their modules, because the list would be very long and some of it might not be applicable to an RSS install, so modules can do this to opt out:
  ```yaml
  depends:
    - name: AMod
      suppress_recommendations: true
  ```
  With that in place, AMod would be pulled in as a dependency, but its recommendations and suggestions (and those of _its_ dependencies) won't be shown. This will allow the RP-1 install's listings to be kept shorter.

This is done with a new relationship resolver option, `get_recommenders`, which stops searching the relationship tree when `suppress_recommendations` is found.

Fixes #3838.

As a courtesy, before the next release, we should submit pull requests adding `suppress_recommendations` to the `depends` relationships of these metanetkans:

- <https://github.com/KSP-RO/RealSolarSystem/blob/master/RealSolarSystem.netkan>
- <https://github.com/KSP-RO/RealismOverhaul/blob/master/RealismOverhaul.netkan>
- <https://github.com/KSP-RO/RP-1/blob/master/RP-1.netkan>
- <https://github.com/KSP-RO/RP-0/blob/master/RP-0.netkan>
- <https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/blob/main/RP-1-ExpressInstall-Graphics-Low.netkan>
- <https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/blob/main/RP-1-ExpressInstall-Graphics-Medium.netkan>
- <https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/blob/main/RP-1-ExpressInstall-Graphics-High.netkan>

FYI to @NathanKell that this may be on its way.
