### PR TITLE
Fix archive.org fallback URLs for versions with spaces

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -126,10 +126,10 @@ namespace CKAN
 
         public string GetInProgressFileName(List<Uri> urls, string description)
         {
-            var filenames = urls.Select(url => GetInProgressFileName(NetFileCache.CreateURLHash(url), description))
-                                .ToArray();
-            return filenames.FirstOrDefault(filename => File.Exists(filename))
-                ?? filenames.FirstOrDefault();
+            var filenames = urls?.Select(url => GetInProgressFileName(NetFileCache.CreateURLHash(url), description))
+                                 .ToArray();
+            return filenames?.FirstOrDefault(filename => File.Exists(filename))
+                ?? filenames?.FirstOrDefault();
         }
 
         /// <summary>

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -94,7 +94,9 @@ namespace CKAN
         }
 
         public string GetInProgressFileName(CkanModule m)
-            => cache.GetInProgressFileName(m.download, m.StandardName());
+            => m.download == null
+                ? null
+                : cache.GetInProgressFileName(m.download, m.StandardName());
 
         private static string DescribeUncachedAvailability(CkanModule m, FileInfo fi)
             => fi.Exists

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -784,7 +784,7 @@ namespace CKAN
         {
             get
             {
-                string verStr = version.ToString().Replace(':', '-');
+                string verStr = version.ToString().Replace(' ', '_').Replace(':', '-');
                 // Some alternate registry repositories don't set download_hash
                 return (download_hash?.sha1 != null && license.All(l => l.Redistributable))
                     ? new Uri(


### PR DESCRIPTION
## Problems

- Spaces aren't allowed in archive.org bucket names, and recently a few mods have put spaces in their version strings, which broke the Mirrorer. To fix that, that KSP-CKAN/NetKAN-Infra#307 replaced those spaces with underscores. This allowed the mod to be mirrored, but the client doesn't perform the same substitution yet.
- In another branch, I have some code that generates `CkanModule`s with null `download` properties, and after switching back out of that branch, trying to install such a module threw a null reference exception

## Changes

- Now `Ckan.InternetArchiveDownload` replaces spaces with underscores, so the client will be able to find the fallback downloads of affected modules
- Now the `GetInProgressFileName` calls are more careful to avoid null references

I think I'll self-review this since it's so minor.
