### PR TITLE
Remove log4net, newtonsoft deps from deb package

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Version: @VERSION@
 Architecture: all
 Section: utils
 Priority: optional
-Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, liblog4net1.2-cil, libnewtonsoft-json5.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-servicemodel4.0a-cil
+Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-servicemodel4.0a-cil
 Maintainer: The CKAN authors <debian@ksp-ckan.space>
 Description: KSP-CKAN official client.
  Official client for the Comprehensive Kerbal Archive Network (CKAN).


### PR DESCRIPTION
## Problem

Trying to install the .deb on Debian 12 fails with a message indicating log4net is missing:

```
root@MartinPC:/home/martin/Downloads# apt install ckan
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 ckan : Depends: liblog4net1.2-cil but it is not installable
E: Unable to correct problems, you have held broken packages.
```

## Cause

The latest release of Debian seems to no longer include this package; "bookworm" doesn't show up in the package search listing:

https://packages.debian.org/search?searchon=names&keywords=liblog4net1.2-cil

However, our build process repacks log4net into `ckan.exe`, so we shouldn't need it to be installed in the OS:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/b7ae110b-ddf5-44eb-be75-8dd909b56088)

## Changes

Now log4net and newtonsoft are no longer listed as requirements for the .deb, because they are both repacked into the `ckan.exe` assembly. This should allow the .deb to be installed on Debian 12 and any other .deb-based OS that drops this package.

Fixes #3896.
