### PR TITLE
Shorten toolbar button labels

### DIFF
--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -117,10 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve"><value>Launch Game</value></data>
+  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve"><value>Play</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>Refresh</value></data>
-  <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>Add available updates</value></data>
-  <data name="ApplyToolButton.Text" xml:space="preserve"><value>Apply changes</value></data>
+  <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>Update all</value></data>
+  <data name="ApplyToolButton.Text" xml:space="preserve"><value>Apply</value></data>
   <data name="FilterToolButton.Text" xml:space="preserve"><value>Filters</value></data>
   <data name="FilterCompatibleButton.Text" xml:space="preserve"><value>Compatible</value></data>
   <data name="FilterInstalledButton.Text" xml:space="preserve"><value>Installed</value></data>


### PR DESCRIPTION
## Problem

On Discord, a Linux user with a 1024x768 monitor reported not being able to see the Filter dropdown button even with the GUI maximized:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/73bec58b-8e7d-4b8a-826e-e187599c1a86)

## Cause

Windows's toolbar has a dropdown feature to accommodate toolbar overflow, but Mono never implemented that.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/e5608607-0c18-49bc-93ff-400034b13b56)

## Changes

Now the following buttons' English titles are shortened to allow them to fit into a smaller space:

- Launch Game → Play
- Add available updates → Update all
- Apply changes → Apply

These should be clear enough to both new and existing users.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/75637e0c-89fd-4017-8624-d5cf599f44d0)
