### PR TITLE
Fix race condition for multiple very fast downloads

### DIFF
--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -168,7 +168,7 @@ namespace CKAN
             return targets.First().filename;
         }
 
-        public static void DownloadWithProgress(ICollection<DownloadTarget> downloadTargets, IUser user = null)
+        public static void DownloadWithProgress(IList<DownloadTarget> downloadTargets, IUser user = null)
         {
             var downloader = new NetAsyncDownloader(user ?? new NullUser());
             downloader.onOneCompleted += (url, filename, error, etag) =>

--- a/Tests/Core/Net/NetAsyncDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncDownloaderTests.cs
@@ -28,16 +28,22 @@ namespace Tests.Core.Net
             var target     = new CKAN.Net.DownloadTarget(new List<Uri> { new Uri(fromPath) },
                                                          Path.GetTempFileName());
             var targets    = new CKAN.Net.DownloadTarget[] { target };
-            var realSize   = new FileInfo(fromPath).Length;
+            var origSize   = new FileInfo(fromPath).Length;
 
             // Act
             try
             {
                 downloader.DownloadAndWait(targets);
+                var realSize = new FileInfo(target.filename).Length;
 
                 // Assert
-                Assert.IsTrue(File.Exists(target.filename));
-                Assert.AreEqual(realSize, target.size);
+                Assert.Multiple(() =>
+                {
+                    Assert.IsTrue(File.Exists(target.filename));
+                    Assert.AreEqual(origSize, realSize,    "Size on disk should match original");
+                    Assert.AreEqual(realSize, target.size, "Target size should match size on disk");
+                    Assert.AreEqual(origSize, target.size, "Target size should match original");
+                });
             }
             finally
             {
@@ -46,10 +52,19 @@ namespace Tests.Core.Net
         }
 
         [Test,
-            TestCase("DogeCoinFlag-1.01.zip",
+            TestCase("gh221.zip",
+                     "ModuleManager-2.5.1.zip",
+                     "ZipWithUnicodeChars.zip",
+                     "DogeCoinPlugin.zip",
+                     "DogeCoinFlag-1.01-corrupt.zip",
+                     "CKAN-meta-testkan.zip",
+                     "ZipWithBadChars.zip",
+                     "DogeCoinFlag-1.01-no-dir-entries.zip",
+                     "DogeTokenFlag-1.01.zip",
+                     "DogeCoinFlag-1.01.zip",
+                     "DogeCoinFlag-1.01-LZMA.zip",
                      "DogeCoinFlag-1.01-avc.zip",
-                     "DogeCoinFlag-extra-files.zip",
-                     "DogeCoinFlag-1.01-corrupt.zip"),
+                     "DogeCoinFlag-extra-files.zip"),
         ]
         public void DownloadAndWait_WithValidFileUrls_SetsTargetsSize(params string[] pathsWithinTestData)
         {
@@ -57,21 +72,28 @@ namespace Tests.Core.Net
             var downloader = new NetAsyncDownloader(new NullUser());
             var fromPaths  = pathsWithinTestData.Select(p => TestData.DataDir(p)).ToArray();
             var targets    = fromPaths.Select(p => new CKAN.Net.DownloadTarget(new List<Uri> { new Uri(p) },
-                                                                          Path.GetTempFileName()))
+                                                                               Path.GetTempFileName()))
                                       .ToArray();
-            var realSizes  = fromPaths.Select(p => new FileInfo(p).Length).ToArray();
+            var origSizes  = fromPaths.Select(p => new FileInfo(p).Length).ToArray();
 
             // Act
             try
             {
                 downloader.DownloadAndWait(targets);
+                var realSizes   = targets.Select(t => new FileInfo(t.filename).Length).ToArray();
+                var targetSizes = targets.Select(t => t.size).ToArray();
 
                 // Assert
-                foreach (var t in targets)
+                Assert.Multiple(() =>
                 {
-                    Assert.IsTrue(File.Exists(t.filename));
-                }
-                CollectionAssert.AreEquivalent(realSizes, targets.Select(t => t.size).ToArray());
+                    foreach (var t in targets)
+                    {
+                        Assert.IsTrue(File.Exists(t.filename));
+                    }
+                    CollectionAssert.AreEquivalent(origSizes, realSizes,   "Sizes on disk should match originals");
+                    CollectionAssert.AreEquivalent(realSizes, targetSizes, "Target sizes should match sizes on disk");
+                    CollectionAssert.AreEquivalent(origSizes, targetSizes, "Target sizes should match originals");
+                });
             }
             finally
             {
@@ -79,6 +101,115 @@ namespace Tests.Core.Net
                 {
                     File.Delete(t.filename);
                 }
+            }
+        }
+
+        [Test,
+            // Only one bad URL
+            TestCase("DoesNotExist.zip"),
+            // First URL is bad
+            TestCase("DoesNotExist.zip",
+                     "gh221.zip",
+                     "ModuleManager-2.5.1.zip",
+                     "ZipWithUnicodeChars.zip",
+                     "DogeCoinPlugin.zip",
+                     "DogeCoinFlag-1.01-corrupt.zip",
+                     "CKAN-meta-testkan.zip",
+                     "ZipWithBadChars.zip",
+                     "DogeCoinFlag-1.01-no-dir-entries.zip",
+                     "DogeTokenFlag-1.01.zip",
+                     "DogeCoinFlag-1.01.zip",
+                     "DogeCoinFlag-1.01-LZMA.zip",
+                     "DogeCoinFlag-1.01-avc.zip",
+                     "DogeCoinFlag-extra-files.zip"),
+            // Last URL is bad
+            TestCase("gh221.zip",
+                     "ModuleManager-2.5.1.zip",
+                     "ZipWithUnicodeChars.zip",
+                     "DogeCoinPlugin.zip",
+                     "DogeCoinFlag-1.01-corrupt.zip",
+                     "CKAN-meta-testkan.zip",
+                     "ZipWithBadChars.zip",
+                     "DogeCoinFlag-1.01-no-dir-entries.zip",
+                     "DoesNotExist.zip",
+                     "DogeTokenFlag-1.01.zip",
+                     "DogeCoinFlag-1.01.zip",
+                     "DogeCoinFlag-1.01-LZMA.zip",
+                     "DogeCoinFlag-1.01-avc.zip",
+                     "DogeCoinFlag-extra-files.zip"),
+            // A URL in the middle is bad
+            TestCase("gh221.zip",
+                     "ModuleManager-2.5.1.zip",
+                     "ZipWithUnicodeChars.zip",
+                     "DogeCoinPlugin.zip",
+                     "DogeCoinFlag-1.01-corrupt.zip",
+                     "CKAN-meta-testkan.zip",
+                     "ZipWithBadChars.zip",
+                     "DogeCoinFlag-1.01-no-dir-entries.zip",
+                     "DogeTokenFlag-1.01.zip",
+                     "DogeCoinFlag-1.01.zip",
+                     "DogeCoinFlag-1.01-LZMA.zip",
+                     "DogeCoinFlag-1.01-avc.zip",
+                     "DogeCoinFlag-extra-files.zip",
+                     "DoesNotExist.zip"),
+            // Every other URL is bad
+            TestCase("DoesNotExist.zip",
+                     "gh221.zip",
+                     "DoesNotExist.zip",
+                     "ModuleManager-2.5.1.zip",
+                     "DoesNotExist.zip",
+                     "ZipWithUnicodeChars.zip",
+                     "DoesNotExist.zip",
+                     "DogeCoinPlugin.zip",
+                     "DoesNotExist.zip",
+                     "DogeCoinFlag-1.01-corrupt.zip",
+                     "DoesNotExist.zip",
+                     "CKAN-meta-testkan.zip",
+                     "DoesNotExist.zip",
+                     "ZipWithBadChars.zip",
+                     "DoesNotExist.zip",
+                     "DogeCoinFlag-1.01-no-dir-entries.zip",
+                     "DoesNotExist.zip",
+                     "DogeTokenFlag-1.01.zip",
+                     "DoesNotExist.zip",
+                     "DogeCoinFlag-1.01.zip",
+                     "DoesNotExist.zip",
+                     "DogeCoinFlag-1.01-LZMA.zip",
+                     "DoesNotExist.zip",
+                     "DogeCoinFlag-1.01-avc.zip",
+                     "DoesNotExist.zip",
+                     "DogeCoinFlag-extra-files.zip",
+                     "DoesNotExist.zip"),
+        ]
+        public void DownloadAndWait_WithSomeInvalidUrls_ThrowsDownloadErrorsKraken(
+            params string[] pathsWithinTestData)
+        {
+            // Arrange
+            var downloader   = new NetAsyncDownloader(new NullUser());
+            var fromPaths    = pathsWithinTestData.Select(p => Path.GetFullPath(TestData.DataDir(p))).ToArray();
+            var targets      = fromPaths.Select(p => new CKAN.Net.DownloadTarget(new List<Uri> { new Uri(p) },
+                                                                                 Path.GetTempFileName()))
+                                        .ToArray();
+            var badIndices   = fromPaths.Select((p, i) => new Tuple<int, bool>(i, File.Exists(p)))
+                                        .Where(tuple => !tuple.Item2)
+                                        .Select(tuple => tuple.Item1)
+                                        .ToArray();
+            var validTargets = targets.Where((t, i) => !badIndices.Contains(i));
+
+            // Act / Assert
+            var exception = Assert.Throws<DownloadErrorsKraken>(() =>
+            {
+                downloader.DownloadAndWait(targets);
+            });
+            CollectionAssert.AreEquivalent(badIndices, exception.Exceptions.Select(kvp => kvp.Key).ToArray());
+            foreach (var kvp in exception.Exceptions)
+            {
+                var baseExc = kvp.Value.GetBaseException() as FileNotFoundException;
+                Assert.AreEqual(fromPaths[kvp.Key], baseExc.FileName);
+            }
+            foreach (var t in validTargets)
+            {
+                Assert.IsTrue(File.Exists(t.filename));
             }
         }
     }


### PR DESCRIPTION
## Problem

See #3906 for details; to sum up, one of the new `NetAsyncDownloader` tests from #3904 was failing in GitHub workflows but nowhere else.

When downloading multiple URLs, the `DownloadTarget.size` values were 0 for some of the files when `NetAsyncDownloader.DownloadAndWait` completed.

## Cause

This new test found a real, pre-existing problem for us! I'm really glad I didn't give in to the temptation to add `[Category("FlakyNetwork")]` and move on. 🎉

There's a race condition with multiple extremely fast downloads (the test is using `file://` URLs to avoid spurious failures caused by server glitches, so the files are already on disk and possibly cached in memory). At the start, the main thread loops over the requested URLs and starts a thread for each one. This sets up the `downloads` list with the currently executing downloads, and the `queuedDownloads` list with the downloads that are waiting their turn. When a thread completes, the sizes of the `downloads` and `queuedDownloads` lists are compared to `completed_downloads` to determine whether there are any other downloads in progress or waiting.

If at any time the active download threads manage to finish their work before all of the downloads are _started_, then they will be comparing the completed download count to _incomplete_ `downloads` and `queuedDownloads` lists! This results in the completion signal being sent early, and when the main thread returns to `DownloadAndWait`, it will skip waiting and signal completion with whatever was finished up to that point.

## Changes

- Now the downloader's main thread holds the `dlMutex` lock (which the other threads acquire before they check for completion) while it starts all the downloads. This ensures that by the time any downloader thread is able to check for completion, the `downloads` and `queuedDownloads` lists will be fully populated, which will prevent the completion notification from being triggered prematurely.
- The test now uses 13 files instead of 4, which made the problem start happening in my Ubuntu VM where it hadn't before (there seems to be a sensitivity to the number of downloads, with more downloads making the problem more likely).
- Now the test performs two additional checks: comparing the real downloaded file sizes that it observes on disk to the target sizes and the sizes of the original files.
- Since that test was so helpful, I decided to try adding one for failed downloads. In the process, I discovered that the index values in the failed downloads exception can be incorrect, so some further changes are made to clean that up (specifically, never queueing `file://` URLs and looking up the failed targets in the original input, which is now an `IList` instead of an `ICollection` because we need to call `IndexOf` on it).

Fixes #3906.
