### PR TITLE
Fix duplicate key exception in CompatibilitySorter

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -547,7 +547,11 @@ namespace CKAN
                     BuildProvidesIndex();
                 }
                 sorter = new CompatibilitySorter(
-                    versCrit, repoDataMgr?.GetAllAvailDicts(repositories.Values),
+                    versCrit,
+                    repoDataMgr?.GetAllAvailDicts(
+                        repositories.Values.OrderBy(r => r.priority)
+                                           // Break ties alphanumerically
+                                           .ThenBy(r => r.name)),
                     providers,
                     installed_modules, InstalledDlls.ToHashSet(), InstalledDlc);
             }

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -53,6 +53,11 @@ namespace CKAN
             Debug.Assert(module_version.Values.All(m => identifier.Equals(m.identifier)));
         }
 
+        public static AvailableModule Merge(IList<AvailableModule> availMods)
+            => availMods.Count == 1 ? availMods.First()
+                                    : new AvailableModule(availMods.First().identifier,
+                                                          availMods.Reverse().SelectMany(am => am.AllAvailable()));
+
         // The map of versions -> modules, that's what we're about!
         // First element is the oldest version, last is the newest.
         [JsonProperty]
@@ -71,7 +76,7 @@ namespace CKAN
         /// <summary>
         /// Record the given module version as being available.
         /// </summary>
-        public void Add(CkanModule module)
+        private void Add(CkanModule module)
         {
             if (!module.identifier.Equals(identifier))
                 throw new ArgumentException(
@@ -79,14 +84,6 @@ namespace CKAN
 
             log.DebugFormat("Adding to available module: {0}", module);
             module_version[module.version] = module;
-        }
-
-        /// <summary>
-        /// Remove the given version from our list of available.
-        /// </summary>
-        public void Remove(ModuleVersion version)
-        {
-            module_version.Remove(version);
         }
 
         /// <summary>

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -272,6 +272,7 @@ namespace CKAN
 
         private IEnumerable<RepositoryData> GetRepoDatas(IEnumerable<Repository> repos)
             => repos?.OrderBy(repo => repo.priority)
+                     .ThenBy(repo => repo.name)
                      .Select(repo => GetRepoData(repo))
                      .Where(data => data != null)
                ?? Enumerable.Empty<RepositoryData>();

--- a/Tests/Core/Registry/CompatibilitySorter.cs
+++ b/Tests/Core/Registry/CompatibilitySorter.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using CKAN;
+using CKAN.Versioning;
+using CKAN.Extensions;
+
+using Tests.Data;
+
+namespace Tests.Core.Registry
+{
+    [TestFixture]
+    public class CompatibilitySorterTests
+    {
+        [Test,
+            TestCase(new string[]
+                     {
+                         @"{
+                             ""spec_version"":    ""v1.4"",
+                             ""identifier"":      ""kOS-EVA"",
+                             ""name"":            ""kOS-EVA"",
+                             ""abstract"":        ""Addon for kOS that allows controlling a kerbal while on EVA"",
+                             ""version"":         ""0.2.0.0"",
+                             ""ksp_version_min"": ""1.8.0"",
+                             ""ksp_version_max"": ""1.12.99"",
+                             ""license"":         ""GPL-3.0"",
+                             ""download"":        ""https://github.com/"",
+                             ""depends"": [
+                                 { ""name"": ""Harmony2"" }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": ""v1.4"",
+                             ""identifier"":   ""Harmony2"",
+                             ""name"":         ""Harmony 2"",
+                             ""abstract"":     ""A library for patching, replacing and decorating .NET and Mono methods during runtime"",
+                             ""version"":      ""2.2.1.0"",
+                             ""ksp_version_min"": ""1.8.0"",
+                             ""ksp_version_max"": ""1.12.99"",
+                             ""license"":         ""MIT"",
+                             ""download"":        ""https://spacedockinfo/""
+                         }",
+                     },
+                     new string[]
+                     {
+                         @"{
+                             ""spec_version"":    ""v1.4"",
+                             ""identifier"":      ""kOS-EVA"",
+                             ""name"":            ""kOS-EVA"",
+                             ""abstract"":        ""Addon for kOS that allows controlling a kerbal while on EVA"",
+                             ""version"":         ""0.2.0.0"",
+                             ""ksp_version_min"": ""1.8.0"",
+                             ""ksp_version_max"": ""1.12.99"",
+                             ""license"":         ""GPL-3.0"",
+                             ""download"":        ""https://github.com/""
+                         }",
+                     },
+                     "kOS-EVA"),
+        ]
+        public void Constructor_OverlappingModules_HigherPriorityOverrides(string[] modules1,
+                                                                           string[] modules2,
+                                                                           string   identifier)
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var repo1 = new TemporaryRepository(0, modules1))
+            using (var repo2 = new TemporaryRepository(1, modules2))
+            using (var repoData = new TemporaryRepositoryData(user, repo1.repo,
+                                                                    repo2.repo))
+            {
+                var versCrit  = new GameVersionCriteria(GameVersion.Parse("1.12.5"));
+                var repos     = new Repository[] { repo1.repo, repo2.repo };
+                var providers = repoData.Manager
+                                        .GetAllAvailableModules(repos)
+                                        .GroupBy(am => am.AllAvailable().First().identifier)
+                                        .ToDictionary(grp => grp.Key,
+                                                      grp => grp.ToHashSet());
+                var installed = new Dictionary<string, InstalledModule>();
+                var dlls      = new HashSet<string>();
+                var dlcs      = new Dictionary<string, ModuleVersion>();
+                var highPrio  = repoData.Manager
+                                        .GetAvailableModules(Enumerable.Repeat<Repository>(repo1.repo, 1),
+                                                             identifier)
+                                        .First()
+                                        .Latest();
+
+                // Act
+                var sorter = new CompatibilitySorter(
+                    versCrit,
+                    repoData.Manager.GetAllAvailDicts(repos),
+                    providers, installed, dlls, dlcs);
+
+                // Assert
+                Assert.AreEqual(0, sorter.LatestIncompatible.Count);
+                Assert.AreEqual(2, sorter.LatestCompatible.Count);
+                Assert.AreEqual(CkanModule.ToJson(highPrio),
+                                CkanModule.ToJson(sorter.LatestCompatible.First(m => m.identifier == identifier)));
+            }
+        }
+    }
+}

--- a/Tests/Data/TemporaryRepository.cs
+++ b/Tests/Data/TemporaryRepository.cs
@@ -17,9 +17,10 @@ namespace Tests.Data
     /// </summary>
     public class TemporaryRepository : IDisposable
     {
-        public TemporaryRepository(params string[] fileContents)
+        public TemporaryRepository(int priority, params string[] fileContents)
         {
             path = Path.GetTempFileName();
+            repo = new Repository("temp", path, priority);
 
             using (var outputStream = File.OpenWrite(path))
             using (var gzipStream   = new GZipOutputStream(outputStream))
@@ -39,8 +40,12 @@ namespace Tests.Data
             }
         }
 
-        public Uri        uri  => new Uri(path);
-        public Repository repo => new Repository("temp", uri);
+        public TemporaryRepository(params string[] fileContents)
+            : this(0, fileContents)
+        { }
+
+        public          Uri        uri  => new Uri(path);
+        public readonly Repository repo;
 
         public void Dispose()
         {


### PR DESCRIPTION
## Problem

The metadata validator threw a duplicate key exception while checking KSP-CKAN/NetKAN#9800:

https://github.com/KSP-CKAN/NetKAN/actions/runs/6207962451/job/16853654203?pr=9800

```
  Unhandled Exception:
  System.ArgumentException: An item with the same key has already been added. Key: [kOS-EVA, CKAN.AvailableModule]
    at System.Collections.Generic.TreeSet`1[T].AddIfNotPresent (T item) [0x0001a] in <33b19a7ad5234d94abf4fd9b47566616>:0 
    at System.Collections.Generic.SortedSet`1[T].Add (T item) [0x00000] in <33b19a7ad5234d94abf4fd9b47566616>:0 
    at System.Collections.Generic.SortedDictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00020] in <33b19a7ad5234d94abf4fd9b47566616>:0 
    at CKAN.CompatibilitySorter.PartitionModules (System.Collections.Generic.IEnumerable`1[T] dicts, System.Collections.Generic.Dictionary`2[TKey,TValue] providers) [0x00114] in <f9f0ffbfa5e14bc18bf2f56116c5f6c1>:0 
    at CKAN.CompatibilitySorter..ctor (CKAN.Versioning.GameVersionCriteria crit, System.Collections.Generic.IEnumerable`1[T] available, System.Collections.Generic.Dictionary`2[TKey,TValue] providers, System.Collections.Generic.Dictionary`2[TKey,TValue] installed, System.Collections.Generic.HashSet`1[T] dlls, System.Collections.Generic.IDictionary`2[TKey,TValue] dlc) [0x0005b] in <f9f0ffbfa5e14bc18bf2f56116c5f6c1>:0 
```

## Cause

The `CompatibilitySorter` from #2963 was updated to handle multiple source repos in #3904, but multiple `AvailableModule`s with the same identifier weren't covered. This is essential for the metadata validator.

## Changes

- Now if the repositories contain multiple `AvailableModules` with the same identifier, the `CompatibilitySorter` merges them into one new `AvailableModule` containing the combined list of `CkanModule`s; if there are multiple `CkanModule`s with the same identifier and version, the module from the higher priority repo (defined as higher up in the list, so a lower number) takes precedence
- A test is added to exercise this case, which fails without the fix and passes with it
- `AvailableModule.Remove` wasn't being used and is deleted
  `AvailableModule.Add` is only being used internally so is now private

We may have to update the metadata validator after this to set the priority of the repositories to get the right modules to load; I think we were previously skating by on the coincidence that `default` comes before `local` alphabetically.
