### PR TITLE
Add test to check GUI thread safety

### DIFF
--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -104,20 +104,20 @@ namespace CKAN.CmdLine
 
     internal class RenameOptions : CommonOptions
     {
-        [GameInstancesAttribute]
+        [GameInstances]
         [ValueOption(0)] public string old_name { get; set; }
         [ValueOption(1)] public string new_name { get; set; }
     }
 
     internal class ForgetOptions : CommonOptions
     {
-        [GameInstancesAttribute]
+        [GameInstances]
         [ValueOption(0)] public string name { get; set; }
     }
 
     internal class DefaultOptions : CommonOptions
     {
-        [GameInstancesAttribute]
+        [GameInstances]
         [ValueOption(0)] public string name { get; set; }
     }
 

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -16,6 +16,7 @@ namespace CKAN.Extensions
         }
 
 #if NET45
+
         public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
         {
             if (source == null)
@@ -23,6 +24,10 @@ namespace CKAN.Extensions
 
             return new HashSet<T>(source);
         }
+
+        public static IEnumerable<T> Append<T>(this IEnumerable<T> source, T next)
+            => source.Concat(Enumerable.Repeat<T>(next, 1));
+
 #endif
 
         public static Dictionary<K, V> ToDictionary<K, V>(this IEnumerable<KeyValuePair<K, V>> pairs)

--- a/GUI/Attributes/ForbidGUICallsAttribute.cs
+++ b/GUI/Attributes/ForbidGUICallsAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace CKAN.GUI.Attributes
+{
+    /// <summary>
+    /// Tag background functions with this, and a test will check
+    /// that they're not calling GUI code without Util.Invoke.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Property
+                    | AttributeTargets.Method    | AttributeTargets.Delegate,
+                    Inherited = true, AllowMultiple = false)]
+    public class ForbidGUICallsAttribute : Attribute { }
+}

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\ForbidGUICallsAttribute.cs" />
     <Compile Include="Dialogs\AboutDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Windows.Forms;
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     public partial class ChooseProvidedMods : UserControl
@@ -13,6 +15,7 @@ namespace CKAN.GUI
             InitializeComponent();
         }
 
+        [ForbidGUICalls]
         public void LoadProviders(string message, List<CkanModule> modules, NetModuleCache cache)
         {
             Util.Invoke(this, () =>
@@ -36,6 +39,7 @@ namespace CKAN.GUI
             });
         }
 
+        [ForbidGUICalls]
         public CkanModule Wait()
         {
             task = new TaskCompletionSource<CkanModule>();

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -4,8 +4,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+
 using CKAN.Extensions;
 using CKAN.Versioning;
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -16,6 +18,7 @@ namespace CKAN.GUI
             InitializeComponent();
         }
 
+        [ForbidGUICalls]
         public void LoadRecommendations(
             IRegistryQuerier registry,
             List<CkanModule> toInstall, HashSet<CkanModule> toUninstall,
@@ -38,6 +41,7 @@ namespace CKAN.GUI
             });
         }
 
+        [ForbidGUICalls]
         public HashSet<CkanModule> Wait()
         {
             if (Platform.IsMono)

--- a/GUI/Controls/DeleteDirectories.cs
+++ b/GUI/Controls/DeleteDirectories.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Windows.Forms;
+
 using CKAN.Extensions;
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -21,6 +23,7 @@ namespace CKAN.GUI
         /// before the calling code switches to the tab.
         /// </summary>
         /// <param name="possibleConfigOnlyDirs">Directories that the user may want to delete</param>
+        [ForbidGUICalls]
         public void LoadDirs(GameInstance ksp, HashSet<string> possibleConfigOnlyDirs)
         {
             instance = ksp;
@@ -50,6 +53,7 @@ namespace CKAN.GUI
         /// <returns>
         /// true if user chose to delete, false otherwise
         /// </returns>
+        [ForbidGUICalls]
         public bool Wait(out HashSet<string> toDelete)
         {
             if (Platform.IsMono)

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -8,6 +8,7 @@ using Autofac;
 
 using CKAN.Versioning;
 using CKAN.Types;
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -33,6 +34,7 @@ namespace CKAN.GUI
             this.ToolTip.SetToolTip(ExportModpackButton,     Properties.Resources.EditModpackTooltipExport);
         }
 
+        [ForbidGUICalls]
         public void LoadModule(CkanModule module, IRegistryQuerier registry)
         {
             this.module = module;
@@ -64,6 +66,7 @@ namespace CKAN.GUI
 
         public event Action<ListView.SelectedListViewItemCollection> OnSelectedItemsChanged;
 
+        [ForbidGUICalls]
         public bool Wait(IUser user)
         {
             if (Platform.IsMono)

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -12,6 +12,7 @@ using log4net;
 
 using CKAN.Extensions;
 using CKAN.Versioning;
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -102,6 +103,7 @@ namespace CKAN.GUI
         private List<ModChange> ChangeSet
         {
             get => currentChangeSet;
+            [ForbidGUICalls]
             set
             {
                 var orig = currentChangeSet;
@@ -111,6 +113,7 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         private void ChangeSetUpdated()
         {
             Util.Invoke(this, () =>
@@ -149,12 +152,15 @@ namespace CKAN.GUI
         private Dictionary<GUIMod, string> Conflicts
         {
             get => conflicts;
+            [ForbidGUICalls]
             set
             {
                 var orig = conflicts;
                 conflicts = value;
                 if (orig != value)
-                    ConflictsUpdated(orig);
+                {
+                    Util.Invoke(this, () => ConflictsUpdated(orig));
+                }
             }
         }
 
@@ -1033,6 +1039,7 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         public Dictionary<string, GUIMod> AllGUIMods()
             => mainModList.Modules.ToDictionary(guiMod => guiMod.Identifier,
                                                 guiMod => guiMod);
@@ -1087,6 +1094,7 @@ namespace CKAN.GUI
             Util.Invoke(this, () => ModGrid.Focus());
         }
 
+        [ForbidGUICalls]
         public void UpdateFilters()
         {
             Util.Invoke(this, _UpdateFilters);
@@ -1135,11 +1143,13 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         public void Update(object sender, DoWorkEventArgs e)
         {
             e.Result = _UpdateModsList(e.Argument as Dictionary<string, bool>);
         }
 
+        [ForbidGUICalls]
         private bool _UpdateModsList(Dictionary<string, bool> old_modules = null)
         {
             log.Info("Updating the mod list");
@@ -1275,6 +1285,7 @@ namespace CKAN.GUI
             return true;
         }
 
+        [ForbidGUICalls]
         public void MarkModForInstall(string identifier, bool uncheck = false)
         {
             Util.Invoke(this, () => _MarkModForInstall(identifier, uncheck));
@@ -1649,6 +1660,7 @@ namespace CKAN.GUI
             Conflicts = null;
         }
 
+        [ForbidGUICalls]
         public void UpdateChangeSetAndConflicts(GameInstance inst, IRegistryQuerier registry)
         {
             if (freezeChangeSet)

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -10,6 +10,7 @@ using Autofac;
 
 using CKAN.Versioning;
 using CKAN.Extensions;
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -158,6 +159,7 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         private void ExpandOnePage(IRegistryQuerier registry, TreeNode parent, int start, int length)
         {
             // Should already have children, since the user is expanding it

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Autofac;
 
 using CKAN.Versioning;
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -88,6 +89,7 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         private bool installable(ModuleInstaller installer, CkanModule module, IRegistryQuerier registry)
         {
             return module.IsCompatible(Main.Instance.CurrentInstance.VersionCriteria())
@@ -199,6 +201,7 @@ namespace CKAN.GUI
             return items;
         }
 
+        [ForbidGUICalls]
         private void checkInstallable(ListViewItem[] items)
         {
             GameInstance     currentInstance = Main.Instance.Manager.CurrentInstance;

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -6,6 +6,8 @@ using System.Drawing;
 using System.Windows.Forms;
 using Timer = System.Windows.Forms.Timer;
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     public partial class Wait : UserControl
@@ -19,6 +21,8 @@ namespace CKAN.GUI
             bgWorker.RunWorkerCompleted += RunWorkerCompleted;
         }
 
+
+        [ForbidGUICalls]
         public void StartWaiting(Action<object, DoWorkEventArgs>             mainWork,
                                  Action<object, RunWorkerCompletedEventArgs> postWork,
                                  bool cancelable,
@@ -38,6 +42,7 @@ namespace CKAN.GUI
 
         public bool RetryEnabled
         {
+            [ForbidGUICalls]
             set
             {
                 Util.Invoke(this, () =>
@@ -58,6 +63,7 @@ namespace CKAN.GUI
 
         public bool ProgressIndeterminate
         {
+            [ForbidGUICalls]
             set
             {
                 Util.Invoke(this, () =>
@@ -217,6 +223,7 @@ namespace CKAN.GUI
             });
         }
 
+        [ForbidGUICalls]
         public void Reset(bool cancelable)
         {
             Util.Invoke(this, () =>
@@ -250,12 +257,14 @@ namespace CKAN.GUI
                 MessageTextBox.Text = "(" + message + ")");
         }
 
+        [ForbidGUICalls]
         private void ClearLog()
         {
             Util.Invoke(this, () =>
                 LogTextBox.Text = "");
         }
 
+        [ForbidGUICalls]
         public void AddLogMessage(string message)
         {
             Util.Invoke(this, () =>

--- a/GUI/Dialogs/DownloadsFailedDialog.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 
 using log4net;
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     /// <summary>
@@ -66,6 +68,7 @@ namespace CKAN.GUI
                 + BottomButtonPanel.Height);
         }
 
+        [ForbidGUICalls]
         public object[] Wait() => task.Task.Result;
 
         /// <summary>

--- a/GUI/Dialogs/ErrorDialog.cs
+++ b/GUI/Dialogs/ErrorDialog.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
+
 using log4net;
+
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -12,6 +15,7 @@ namespace CKAN.GUI
             InitializeComponent();
         }
 
+        [ForbidGUICalls]
         public void ShowErrorDialog(string text, params object[] args)
         {
             Util.Invoke(Main.Instance, () =>

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -16,6 +16,7 @@ using Autofac;
 
 using CKAN.Extensions;
 using CKAN.Versioning;
+using CKAN.GUI.Attributes;
 
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
@@ -972,6 +973,7 @@ namespace CKAN.GUI
                 oldModules);
         }
 
+        [ForbidGUICalls]
         private void EnableMainWindow()
         {
             Util.Invoke(this, () =>
@@ -988,6 +990,7 @@ namespace CKAN.GUI
             });
         }
 
+        [ForbidGUICalls]
         private void DisableMainWindow()
         {
             Util.Invoke(this, () =>

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Windows.Forms;
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     public partial class Main
@@ -23,6 +25,7 @@ namespace CKAN.GUI
             selectionDialog = controlFactory.CreateControl<SelectionDialog>();
         }
 
+        [ForbidGUICalls]
         public void AddStatusMessage(string text, params object[] args)
         {
             string msg = String.Format(text, args);
@@ -33,6 +36,7 @@ namespace CKAN.GUI
             Wait.AddLogMessage(msg);
         }
 
+        [ForbidGUICalls]
         public void ErrorDialog(string text, params object[] args)
         {
             errorDialog.ShowErrorDialog(String.Format(text, args));

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     public partial class Main
@@ -37,6 +39,7 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         private void CacheMod(object sender, DoWorkEventArgs e)
         {
             ResetProgress();
@@ -83,6 +86,7 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         private void UpdateCachedByDownloads(GUIMod module)
         {
             // Update all mods that share the same ZIP

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Transactions;
 
 using CKAN.Extensions;
+using CKAN.GUI.Attributes;
 
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
@@ -65,6 +66,7 @@ namespace CKAN.GUI
             }
         }
 
+        [ForbidGUICalls]
         private void InstallMods(object sender, DoWorkEventArgs e)
         {
             bool canceled = false;
@@ -222,7 +224,7 @@ namespace CKAN.GUI
                             toInstall.Concat(toUpgrade), toUninstall, options, registry, crit
                         ).ModList().ToList();
                         DownloadsFailedDialog dfd = null;
-                        Util.Invoke(dfd, () =>
+                        Util.Invoke(this, () =>
                         {
                             dfd = new DownloadsFailedDialog(
                                 Properties.Resources.ModDownloadsFailedMessage,
@@ -289,6 +291,7 @@ namespace CKAN.GUI
             e.Result = new InstallResult(true, changes);
         }
 
+        [ForbidGUICalls]
         private void HandlePossibleConfigOnlyDirs(Registry registry, HashSet<string> possibleConfigOnlyDirs)
         {
             if (possibleConfigOnlyDirs != null)

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 using CKAN.Extensions;
 using CKAN.Versioning;
+using CKAN.GUI.Attributes;
 
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
@@ -33,6 +34,7 @@ namespace CKAN.GUI
             ));
         }
 
+        [ForbidGUICalls]
         private void AuditRecommendations(IRegistryQuerier registry, GameVersionCriteria versionCriteria)
         {
             var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser);

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -13,6 +13,7 @@ using Autofac;
 using CKAN.Versioning;
 using CKAN.Configuration;
 using CKAN.Extensions;
+using CKAN.GUI.Attributes;
 
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
@@ -57,6 +58,7 @@ namespace CKAN.GUI
             ShowWaitDialog();
         }
 
+        [ForbidGUICalls]
         private void UpdateRepo(object sender, DoWorkEventArgs e)
         {
             (bool forceFullRefresh, bool refreshWithoutChanges) = (RepoArgument)e.Argument;

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Windows.Forms;
 
+using CKAN.GUI.Attributes;
+
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
 
@@ -8,6 +10,7 @@ namespace CKAN.GUI
 {
     public partial class Main
     {
+        [ForbidGUICalls]
         public void ShowWaitDialog()
         {
             Util.Invoke(this, () =>
@@ -69,6 +72,7 @@ namespace CKAN.GUI
             });
         }
 
+        [ForbidGUICalls]
         public void ResetProgress()
         {
             Wait.ProgressIndeterminate = true;

--- a/Tests/GUI/ThreadSafetyTests.cs
+++ b/Tests/GUI/ThreadSafetyTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+using Mono.Cecil;
+using MethodAttributes = Mono.Cecil.MethodAttributes;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+using CKAN.Extensions;
+using CKAN.GUI.Attributes;
+
+namespace Tests.GUI
+{
+    using MethodCall = List<MethodDefinition>;
+    using CallsDict  = Dictionary<MethodDefinition, List<MethodDefinition>>;
+
+    [TestFixture]
+    public class ThreadSafetyTests
+    {
+        [Test]
+        public void GUIAssemblyModule_MethodsWithForbidGUICalls_DontCallGUI()
+        {
+            // Arrange / Act
+            var mainModule = ModuleDefinition.ReadModule(Assembly.GetAssembly(typeof(CKAN.GUI.Main))
+                                                                 .Location);
+            var allMethods = mainModule.Types
+                                       .SelectMany(t => GetAllNestedTypes(t))
+                                       .SelectMany(t => t.Methods)
+                                       .ToArray();
+            var calls = allMethods.Where(hasForbidGUIAttribute)
+                                  .Select(meth => new MethodCall() { meth })
+                                  .Concat(allMethods.SelectMany(FindStartedTasks))
+                                  .SelectMany(GetAllCallsWithoutForbidGUI);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                foreach (var callStack in calls)
+                {
+                    Assert.IsFalse(unsafeCall(callStack.Last()),
+                                   $"Forbidden GUI call: {string.Join(" -> ", callStack.Select(SimpleName))}");
+                }
+            });
+        }
+
+        private IEnumerable<TypeDefinition> GetAllNestedTypes(TypeDefinition td)
+            => Enumerable.Repeat<TypeDefinition>(td, 1)
+                         .Concat(td.NestedTypes.SelectMany(nested => GetAllNestedTypes(nested)));
+
+        private IEnumerable<MethodCall> FindStartedTasks(MethodDefinition md)
+            => StartNewCalls(md).Select(FindStartNewArgument)
+                                .Select(taskArg => new MethodCall() { md, taskArg });
+
+        private IEnumerable<Instruction> StartNewCalls(MethodDefinition md)
+            => md.Body?.Instructions.Where(instr => callOpCodes.Contains(instr.OpCode.Name)
+                                                    && instr.Operand is MethodReference mr
+                                                    && isStartNew(mr))
+                      ?? Enumerable.Empty<Instruction>();
+
+        private bool isStartNew(MethodReference mr)
+            => (mr.DeclaringType.Namespace == "System.Threading.Tasks"
+                && mr.DeclaringType.Name   == "TaskFactory"
+                && mr.Name                 == "StartNew")
+               || (mr.DeclaringType.Namespace == "System.Threading.Tasks"
+                   && mr.DeclaringType.Name   == "Task"
+                   && mr.Name                 == "Run");
+
+        // The sequence to start a task seems to be:
+        // 1. ldftn the function to start
+        // 2. newobj a System.Action to hold it
+        // 3. callvirt StartNew
+        // ... so find the operand of the ldftn most immediately preceding the call
+        private MethodDefinition FindStartNewArgument(Instruction instr)
+            => instr.OpCode.Name == "ldftn" ? instr.Operand as MethodDefinition
+                                            : FindStartNewArgument(instr.Previous);
+
+        private IEnumerable<MethodCall> GetAllCallsWithoutForbidGUI(MethodCall initialStack)
+            => VisitMethodDefinition(initialStack, initialStack.Last(), new CallsDict(), hasForbidGUIAttribute, unsafeCall);
+
+        private string SimpleName(MethodDefinition md) => $"{md.DeclaringType.Name}.{md.Name}";
+
+        // https://gist.github.com/lnicola/b48db1a6ff3617bdac2a
+        private IEnumerable<MethodCall> VisitMethodDefinition(MethodCall                   fullStack,
+                                                              MethodDefinition             methDef,
+                                                              CallsDict                    calls,
+                                                              Func<MethodDefinition, bool> skip,
+                                                              Func<MethodDefinition, bool> stopAfter)
+        {
+            var called = calls[methDef] = methodsCalledBy(methDef).Distinct().ToList();
+            foreach (var calledMeth in called)
+            {
+                if (!calls.ContainsKey(calledMeth) && !skip(calledMeth))
+                {
+                    var newStack = fullStack.Append(calledMeth).ToList();
+                    yield return newStack;
+                    if (!stopAfter(calledMeth))
+                    {
+                        // yield from, please!
+                        foreach (var subcall in VisitMethodDefinition(newStack, calledMeth, calls, skip, stopAfter))
+                        {
+                            yield return subcall;
+                        }
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<MethodDefinition> methodsCalledBy(MethodDefinition methDef)
+            => methDef.Body
+                      .Instructions
+                      .Where(instr => callOpCodes.Contains(instr.OpCode.Name))
+                      .Select(instr => instr.Operand as MethodDefinition
+                                       ?? GetSetterDef(instr.Operand as MethodReference))
+                      .Where(calledMeth => calledMeth?.Body != null);
+
+        // Property setters are virtual and have references instead of definitions
+        private MethodDefinition GetSetterDef(MethodReference mr)
+            => (mr?.Name.StartsWith("set_") ?? false) ? mr.Resolve()
+                                                      : null;
+
+        private bool hasForbidGUIAttribute(MethodDefinition md)
+            => md.CustomAttributes.Any(attr => attr.AttributeType.Namespace == forbidAttrib.Namespace
+                                            && attr.AttributeType.Name      == forbidAttrib.Name);
+
+        private bool unsafeCall(MethodDefinition md)
+            // If it has [ForbidGUICalls], then treat as safe because it'll be checked on its own
+            => !hasForbidGUIAttribute(md)
+                // Adding an event handler is OK
+                && !md.IsAddOn
+                // Getting a property is OK
+                && !md.IsGetter
+                // Otherwise treat anything on a System.Windows.Forms object as unsafe
+                && unsafeType(md.DeclaringType);
+
+        // Any method on a type in WinForms or inheriting from anything in WinForms is presumed unsafe
+        private bool unsafeType(TypeDefinition t)
+            => t.Namespace == winformsNamespace
+                ? true
+                : (t.BaseType != null && unsafeType(t.BaseType.Resolve()));
+
+        private static readonly Type   forbidAttrib      = typeof(ForbidGUICallsAttribute);
+        private static readonly string winformsNamespace = typeof(Control).Namespace;
+
+        private static HashSet<string> callOpCodes = new HashSet<string>
+        {
+            // Constructors
+            "newobj",
+
+            // Normal function calls
+            "call",
+
+            // Virtual function calls (includes property setters)
+            "callvirt",
+        };
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -41,7 +41,7 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Moq" Version="4.14.5" />


### PR DESCRIPTION
## Background

WinForms is based on some of quite old Windows GUI libraries, from before multithreading was ubiquitous. The .NET implementation inherited a peculiar threading gotcha: All changes to the GUI must be made from the same "GUI thread", or the app will crash or freeze or worse.

## Motivation

If you look for ways to deal with this problem, mostly you'll find people recommending `Control.InvokeRequired`/`Control.Invoke`, which we already have in the form of `CKAN.GUI.Util.Invoke`. This is fine when you remember to use it correctly, but it's easy to forget, and when that happens, we get crashes or freezes or worse.

- https://jonskeet.uk/csharp/threads/winforms.html

A few people have created more elaborate systems that wrap the GUI objects in some kind of proxy class that calls `Invoke` as needed. These generally suffer from poor runtime performance if you use them heavily (since switching threads for every property access requires a lot of marshalling between threads) and awkward maintenance (defining an `interface` for _every_ GUI object you create, or creating your GUI objects with a third party facility like `AOPFactory.Create<MyForm>()`). And they still don't solve the problem of what happens if you forget to use them!

- https://osherove.com/blog/2007/5/19/easier-winform-ui-thread-safe-methods-with-dynamicproxy2-and.html
- https://www.codeproject.com/Articles/9597/Making-Windows-Forms-thread-safe

I have wanted for a long time to add a guardrail to catch thread-unsafe GUI code, but my search for a ready-made one never succeeded.

## Changes

Now CKAN is the home of the world's first and only static thread-safety checker for  WinForms. If you accidentally try to access a GUI object from a background thread, a new test will emit errors like this:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/6be7bb17-1f03-4daa-a4d5-31c62ee7bfd4)

This will finally provide a guardrail to prevent GUI threading problems. It's a static check that only runs as a unit test, so there is zero run time performance impact. In the future we can consider more aggressive refactoring of our GUI thread handling, confident that the test will catch any errors.

### How it works

The new test uses [`Mono.Cecil`](https://github.com/jbevain/cecil/tree/master/Mono.Cecil) to load and analyze the compiled GUI assembly instruction-by-instruction. Any function or lambda passed to `System.Threading.Tasks.Task.Factory.StartNew` or `System.Threading.Tasks.Task.Run` will be treated as a background thread, and any method or property setter of any class in (or inheriting from anything in) the `System.Windows.Forms` namespace will be treated as an unsafe GUI method. The test crawls the complete call tree of every background thread looking for calls to the GUI and throws if it finds one. Calling `Util.Invoke` breaks the chain and allows access to GUI within its argument function, as desired.

But, you exclaim, sometimes we _need_ to access properties or functions of one of our `Form`s or `UserControl`s from a background thread, and it's perfectly OK because those specific properties or functions don't actually do anything GUI-related! Right you are, and for such cases we can add the new `[ForbidGUICalls]` attribute to those functions, which does two things:

- Add the tagged function to the top-level list of function that the test checks for GUI calls, to ensure that the declaration of thread safety is in fact true
- Allow other GUI-forbidden functions to call them without triggering a test failure

The functions that our `BackgroundWorker`s run in the background are also marked with `[ForbidGUICalls]`.

In effect, everything the GUI calls in a background thread now has to be explicitly tagged as such, and nothing so tagged can interact directly with anything GUI-related, so we have achieved reliable thread-safety.
