### PR TITLE
Parallelize for performance, relationship resolver improvements

### DIFF
--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -45,10 +45,10 @@ namespace CKAN.CmdLine
                 else
                 {
                     log.InfoFormat("Importing {0} files", toImport.Count);
-                    var toInstall = new List<string>();
+                    var toInstall = new List<CkanModule>();
                     var installer = new ModuleInstaller(instance, manager.Cache, user);
                     var regMgr    = RegistryManager.Instance(instance, repoData);
-                    installer.ImportFiles(toImport, user, mod => toInstall.Add(mod.identifier), regMgr.registry, !opts.Headless);
+                    installer.ImportFiles(toImport, user, mod => toInstall.Add(mod), regMgr.registry, !opts.Headless);
                     HashSet<string> possibleConfigOnlyDirs = null;
                     if (toInstall.Count > 0)
                     {

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -52,11 +52,10 @@ namespace CKAN.CmdLine
                     HashSet<string> possibleConfigOnlyDirs = null;
                     if (toInstall.Count > 0)
                     {
-                        installer.InstallList(
-                            toInstall,
-                            new RelationshipResolverOptions(),
-                            regMgr,
-                            ref possibleConfigOnlyDirs);
+                        installer.InstallList(toInstall,
+                                              new RelationshipResolverOptions(),
+                                              regMgr,
+                                              ref possibleConfigOnlyDirs);
                     }
                     return Exit.OK;
                 }

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -221,8 +221,7 @@ namespace CKAN.CmdLine
                 }
                 catch (InconsistentKraken ex)
                 {
-                    // The prettiest Kraken formats itself for us.
-                    user.RaiseError("{0}", ex.InconsistenciesPretty);
+                    user.RaiseError("{0}", ex.Message);
                     user.RaiseMessage(Properties.Resources.InstallCancelled);
                     return Exit.ERROR;
                 }

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -136,7 +136,15 @@ namespace CKAN.CmdLine
                 {
                     HashSet<string> possibleConfigOnlyDirs = null;
                     var installer = new ModuleInstaller(instance, manager.Cache, user);
-                    installer.InstallList(modules, install_ops, regMgr, ref possibleConfigOnlyDirs);
+                    installer.InstallList(modules.Select(arg => CkanModule.FromIDandVersion(
+                                                                    regMgr.registry, arg,
+                                                                    options.allow_incompatible
+                                                                        ? null
+                                                                        : instance.VersionCriteria()))
+                                                 .ToList(),
+                                          install_ops,
+                                          regMgr,
+                                          ref possibleConfigOnlyDirs);
                     user.RaiseMessage("");
                     done = true;
                 }

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Collections.Generic;
 
 using log4net;
@@ -39,7 +40,9 @@ namespace CKAN.CmdLine
             if (!(options.porcelain) && exportFileType == null)
             {
                 user.RaiseMessage("");
-                user.RaiseMessage(Properties.Resources.ListGameFound, instance.game.ShortName, instance.GameDir());
+                user.RaiseMessage(Properties.Resources.ListGameFound,
+                                  instance.game.ShortName,
+                                  instance.GameDir().Replace('/', Path.DirectorySeparatorChar));
                 user.RaiseMessage("");
                 user.RaiseMessage(Properties.Resources.ListGameVersion, instance.game.ShortName, instance.Version());
                 user.RaiseMessage("");

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -134,7 +134,7 @@ namespace CKAN.CmdLine
             }
             catch (ModuleNotFoundKraken kraken)
             {
-                user.RaiseMessage(Properties.Resources.UpgradeNotFound, kraken.module);
+                user.RaiseMessage(Properties.Resources.UpgradeNotFound, $"{kraken.module} {kraken.version}");
                 return Exit.ERROR;
             }
             catch (InconsistentKraken kraken)
@@ -166,7 +166,7 @@ namespace CKAN.CmdLine
         /// <param name="user">IUser object for output</param>
         /// <param name="instance">Game instance to use</param>
         /// <param name="modules">List of modules to upgrade</param>
-        public void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance instance, bool ConfirmPrompt, List<CkanModule> modules)
+        private void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance instance, bool ConfirmPrompt, List<CkanModule> modules)
         {
             UpgradeModules(manager, user, instance, repoData,
                 (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs) =>
@@ -183,7 +183,7 @@ namespace CKAN.CmdLine
         /// <param name="user">IUser object for output</param>
         /// <param name="instance">Game instance to use</param>
         /// <param name="identsAndVersions">List of identifier[=version] to upgrade</param>
-        public void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance instance, List<string> identsAndVersions)
+        private void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance instance, List<string> identsAndVersions)
         {
             UpgradeModules(manager, user, instance, repoData,
                 (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs) =>

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -187,8 +187,15 @@ namespace CKAN.CmdLine
         {
             UpgradeModules(manager, user, instance, repoData,
                 (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs) =>
-                    installer.Upgrade(identsAndVersions, downloader,
-                        ref possibleConfigOnlyDirs, regMgr, true),
+                    installer.Upgrade(
+                        identsAndVersions.Select(arg => CkanModule.FromIDandVersion(
+                                                            regMgr.registry, arg,
+                                                            instance.VersionCriteria()))
+                                         .ToList(),
+                        downloader,
+                        ref possibleConfigOnlyDirs,
+                        regMgr,
+                        true),
                 m => identsAndVersions.Add(m.identifier)
             );
         }

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -323,7 +323,7 @@ namespace CKAN.CmdLine
 
                 if (next_command == null)
                 {
-                    user.RaiseError("{0}", kraken.InconsistenciesPretty);
+                    user.RaiseError("{0}", kraken.Message);
                     user.RaiseError(Properties.Resources.ScanNotSaved);
                 }
                 else

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Transactions;
 using System.Collections.Generic;
+using System.Linq;
 
 using CKAN.ConsoleUI.Toolkit;
 
@@ -76,7 +77,11 @@ namespace CKAN.ConsoleUI {
                             plan.Install.Clear();
                         }
                         if (plan.Upgrade.Count > 0) {
-                            inst.Upgrade(plan.Upgrade, dl, ref possibleConfigOnlyDirs, regMgr);
+                            inst.Upgrade(plan.Upgrade
+                                             .Select(ident => regMgr.registry.LatestAvailable(
+                                                                  ident, manager.CurrentInstance.VersionCriteria()))
+                                             .ToList(),
+                                         dl, ref possibleConfigOnlyDirs, regMgr);
                             plan.Upgrade.Clear();
                         }
                         if (plan.Replace.Count > 0) {

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -121,7 +121,7 @@ namespace CKAN.ConsoleUI {
                     } catch (MissingCertificateKraken ex) {
                         RaiseError(ex.ToString());
                     } catch (InconsistentKraken ex) {
-                        RaiseError(ex.InconsistenciesPretty);
+                        RaiseError(ex.Message);
                     } catch (TooManyModsProvideKraken ex) {
 
                         ConsoleChoiceDialog<CkanModule> ch = new ConsoleChoiceDialog<CkanModule>(

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -483,7 +483,7 @@ namespace CKAN.ConsoleUI {
                 regMgr.ScanUnmanagedFiles();
             } catch (InconsistentKraken ex) {
                 // Warn about inconsistent state
-                RaiseError(Properties.Resources.ModListScanBad, ex.InconsistenciesPretty);
+                RaiseError(Properties.Resources.ModListScanBad, ex.Message);
             }
             return true;
         }

--- a/ConsoleUI/Toolkit/Symbols.cs
+++ b/ConsoleUI/Toolkit/Symbols.cs
@@ -128,6 +128,14 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// and the letters in the splash screen ASCII art
         /// </summary>
         public static readonly char lowerHalfBlock = cp437c(0xdc);
+        /// <summary>
+        /// Full block used for most of a progress bar
+        /// </summary>
+        public static readonly char fullBlock = cp437c(0xdb);
+        /// <summary>
+        /// Left half block used for right edge of odd width progress bar
+        /// </summary>
+        public static readonly char leftHalfBlock = cp437c(0xdd);
 
         private static char   cp437c(byte num) { return dosCodePage.GetChars(new byte[] {num})[0]; }
         private static string cp437s(byte num) { return $"{cp437c(num)}";                          }

--- a/Core/Converters/JsonParallelDictionaryConverter.cs
+++ b/Core/Converters/JsonParallelDictionaryConverter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using CKAN.Extensions;
+
+namespace CKAN
+{
+    /// <summary>
+    /// A converter that loads a dictionary in parallel,
+    /// use with large collections of complex objects for a speed boost
+    /// </summary>
+    public class JsonParallelDictionaryConverter<V> : JsonConverter
+    {
+        public override object ReadJson(JsonReader     reader,
+                                        Type           objectType,
+                                        object         existingValue,
+                                        JsonSerializer serializer)
+            => ParseWithProgress(JObject.Load(reader)
+                                        .Properties()
+                                        .ToArray(),
+                                 serializer);
+
+        private object ParseWithProgress(JProperty[]    properties,
+                                         JsonSerializer serializer)
+            => Partitioner.Create(properties, true)
+                          .AsParallel()
+                          .WithMergeOptions(ParallelMergeOptions.NotBuffered)
+                          .Select(prop => new KeyValuePair<string, V>(
+                                              prop.Name,
+                                              prop.Value.ToObject<V>()))
+                          .WithProgress(properties.Length,
+                                        serializer.Context.Context as IProgress<int>)
+                          .ToDictionary();
+
+        public override bool CanWrite => false;
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        // Only convert when we're an explicit attribute
+        public override bool CanConvert(Type object_type) => false;
+    }
+}

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 
@@ -38,6 +39,9 @@ namespace CKAN.Extensions
         public static Dictionary<K, V> ToDictionary<K, V>(this ParallelQuery<KeyValuePair<K, V>> pairs)
             => pairs.ToDictionary(kvp => kvp.Key,
                                   kvp => kvp.Value);
+
+        public static ConcurrentDictionary<K, V> ToConcurrentDictionary<K, V>(this IEnumerable<KeyValuePair<K, V>> pairs)
+            => new ConcurrentDictionary<K, V>(pairs);
 
         // https://stackoverflow.com/a/55591477/2422988
         public static ParallelQuery<T> WithProgress<T>(this ParallelQuery<T> source,

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -141,6 +141,7 @@ namespace CKAN.Extensions
         }
 
 #if NET45
+
         /// <summary>
         /// Make pairs out of the elements of two sequences
         /// </summary>
@@ -149,7 +150,6 @@ namespace CKAN.Extensions
         /// <returns>Sequence of pairs of one element from seq1 and one from seq2</returns>
         public static IEnumerable<Tuple<T1, T2>> Zip<T1, T2>(this IEnumerable<T1> seq1, IEnumerable<T2> seq2)
             => seq1.Zip(seq2, (item1, item2) => new Tuple<T1, T2>(item1, item2));
-#endif
 
         /// <summary>
         /// Enable a `foreach` over a sequence of tuples
@@ -180,6 +180,24 @@ namespace CKAN.Extensions
         }
 
         /// <summary>
+        /// Enable a `foreach` over a sequence of tuples
+        /// </summary>
+        /// <param name="tuple">A tuple to deconstruct</param>
+        /// <param name="item1">Set to the first value from the tuple</param>
+        /// <param name="item2">Set to the second value from the tuple</param>
+        public static void Deconstruct<T1, T2, T3, T4>(this Tuple<T1, T2, T3, T4> tuple,
+                                                       out  T1                    item1,
+                                                       out  T2                    item2,
+                                                       out  T3                    item3,
+                                                       out  T4                    item4)
+        {
+            item1 = tuple.Item1;
+            item2 = tuple.Item2;
+            item3 = tuple.Item3;
+            item4 = tuple.Item4;
+        }
+
+        /// <summary>
         /// Enable a `foreach` over a sequence of key value pairs
         /// </summary>
         /// <param name="tuple">A tuple to deconstruct</param>
@@ -190,6 +208,9 @@ namespace CKAN.Extensions
             key = kvp.Key;
             val = kvp.Value;
         }
+
+#endif
+
     }
 
     /// <summary>

--- a/Core/Logging.cs
+++ b/Core/Logging.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using System.Diagnostics;
+
 using log4net;
 using log4net.Config;
 using log4net.Core;
@@ -40,5 +42,36 @@ namespace CKAN
                 }
             }
         }
+
+#if DEBUG
+
+        public static void WithTimeElapsed(Action<TimeSpan> elapsedCallback,
+                                           Action           toMeasure)
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+
+            toMeasure();
+
+            sw.Stop();
+            elapsedCallback(sw.Elapsed);
+        }
+
+        public static T WithTimeElapsed<T>(Action<TimeSpan> elapsedCallback,
+                                           Func<T>          toMeasure)
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+
+            T val = toMeasure();
+
+            sw.Stop();
+            elapsedCallback(sw.Elapsed);
+
+            return val;
+        }
+
+#endif
+
     }
 }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -102,7 +102,7 @@ namespace CKAN
                 filename = CkanModule.StandardName(module.identifier, module.version);
             }
 
-            string full_path = cache.GetCachedZip(module);
+            string full_path = cache.GetCachedFilename(module);
             if (full_path == null)
             {
                 return Download(module, filename, cache);
@@ -264,7 +264,7 @@ namespace CKAN
             }
 
             // Find ZIP in the cache if we don't already have it.
-            filename = filename ?? Cache.GetCachedZip(module);
+            filename = filename ?? Cache.GetCachedFilename(module);
 
             // If we *still* don't have a file, then kraken bitterly.
             if (filename == null)
@@ -1284,7 +1284,7 @@ namespace CKAN
         /// </summary>
         private void DownloadModules(IEnumerable<CkanModule> mods, IDownloader downloader)
         {
-            List<CkanModule> downloads = mods.Where(module => !Cache.IsCachedZip(module)).ToList();
+            List<CkanModule> downloads = mods.Where(module => !Cache.IsCached(module)).ToList();
 
             if (downloads.Count > 0)
             {

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -112,19 +112,6 @@ namespace CKAN
             return full_path;
         }
 
-        public void InstallList(List<string> modules, RelationshipResolverOptions options, RegistryManager registry_manager, ref HashSet<string> possibleConfigOnlyDirs, IDownloader downloader = null)
-        {
-            var resolver = new RelationshipResolver(modules, null, options, registry_manager.registry, ksp.VersionCriteria());
-            // Only pass the CkanModules of the parameters, so we can tell which are auto-installed,
-            // and relationships of metapackages, since metapackages aren't included in the RR modlist.
-            var list = resolver.ModList()
-                .Where(m => resolver.ReasonsFor(m).Any(reason =>
-                    reason is SelectionReason.UserRequested
-                    || (reason.Parent?.IsMetapackage ?? false)))
-                .ToList();
-            InstallList(list, options, registry_manager, ref possibleConfigOnlyDirs, downloader);
-        }
-
         /// <summary>
         ///     Installs all modules given a list of identifiers as a transaction. Resolves dependencies.
         ///     This *will* save the registry at the end of operation.
@@ -1038,26 +1025,6 @@ namespace CKAN
 
                 EnforceCacheSizeLimit(registry_manager.registry);
             }
-        }
-
-        /// <summary>
-        /// Upgrades the mods listed to the latest versions for the user's KSP.
-        /// Will *re-install* with warning even if an upgrade is not available.
-        /// Throws ModuleNotFoundKraken if module is not installed, or not available.
-        /// </summary>
-        public void Upgrade(IEnumerable<string> identifiers, IDownloader netAsyncDownloader, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool enforceConsistency = true)
-        {
-            // When upgrading, we are removing these mods first and install them again afterwards (but in different versions).
-            // So the list of identifiers of modulesToRemove and modulesToInstall is the same,
-            // RelationshipResolver take care of finding the right CkanModule for each identifier.
-            List<string> identifierList = identifiers.ToList();
-            var resolver = new RelationshipResolver(
-                identifierList,
-                identifierList,
-                RelationshipResolver.DependsOnlyOpts(),
-                registry_manager.registry, ksp.VersionCriteria()
-            );
-            Upgrade(resolver.ModList(), netAsyncDownloader, ref possibleConfigOnlyDirs, registry_manager, enforceConsistency);
         }
 
         /// <summary>

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1497,9 +1497,7 @@ namespace CKAN
                 }
                 else
                 {
-                    string problems = resolver.ConflictList.Values
-                        .Aggregate((a, b) => $"{a}, {b}");
-                    log.Debug($"Can't install {request}: {problems}");
+                    log.DebugFormat("Can't install {0}: {1}", request, string.Join("; ", resolver.ConflictDescriptions));
                     return false;
                 }
             }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -133,7 +133,12 @@ namespace CKAN
         /// Propagates a FileExistsKraken if we were going to overwrite a file.
         /// Propagates a CancelledActionKraken if the user cancelled the install.
         /// </summary>
-        public void InstallList(ICollection<CkanModule> modules, RelationshipResolverOptions options, RegistryManager registry_manager, ref HashSet<string> possibleConfigOnlyDirs, IDownloader downloader = null, bool ConfirmPrompt = true)
+        public void InstallList(ICollection<CkanModule>     modules,
+                                RelationshipResolverOptions options,
+                                RegistryManager             registry_manager,
+                                ref HashSet<string>         possibleConfigOnlyDirs,
+                                IDownloader                 downloader = null,
+                                bool                        ConfirmPrompt = true)
         {
             // TODO: Break this up into smaller pieces! It's huge!
             if (modules.Count == 0)
@@ -1060,7 +1065,13 @@ namespace CKAN
         /// Will *re-install* or *downgrade* (with a warning) as well as upgrade.
         /// Throws ModuleNotFoundKraken if a module is not installed.
         /// </summary>
-        public void Upgrade(IEnumerable<CkanModule> modules, IDownloader netAsyncDownloader, ref HashSet<string> possibleConfigOnlyDirs, RegistryManager registry_manager, bool enforceConsistency = true, bool resolveRelationships = false, bool ConfirmPrompt = true)
+        public void Upgrade(IEnumerable<CkanModule> modules,
+                            IDownloader             netAsyncDownloader,
+                            ref HashSet<string>     possibleConfigOnlyDirs,
+                            RegistryManager         registry_manager,
+                            bool                    enforceConsistency   = true,
+                            bool                    resolveRelationships = false,
+                            bool                    ConfirmPrompt        = true)
         {
             modules = modules.Memoize();
             var registry = registry_manager.registry;

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -157,7 +157,7 @@ namespace CKAN
             const int hashSha1Percent   = 20;
             const int hashSha256Percent = 20;
 
-            progress.Report(0);
+            progress?.Report(0);
             // Check file exists
             FileInfo fi = new FileInfo(path);
             if (!fi.Exists)

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Threading;
 using System.Security.Cryptography;
 
+using ICSharpCode.SharpZipLib.Zip;
+
 namespace CKAN
 {
     /// <summary>
@@ -16,6 +18,12 @@ namespace CKAN
     /// </summary>
     public class NetModuleCache : IDisposable
     {
+        static NetModuleCache()
+        {
+            // SharpZibLib 1.1.0 changed this to default to false, but we depend on it for international mods.
+            // https://github.com/icsharpcode/SharpZipLib/issues/591
+            ZipStrings.UseUnicode = true;
+        }
 
         /// <summary>
         /// Initialize the cache
@@ -66,18 +74,11 @@ namespace CKAN
             outFilename = null;
             return false;
         }
-        public bool IsCachedZip(CkanModule m)
-            => m.download?.Any(dlUri => cache.IsCachedZip(dlUri))
-                ?? false;
         public bool IsMaybeCachedZip(CkanModule m)
             => m.download?.Any(dlUri => cache.IsMaybeCachedZip(dlUri, m.release_date))
                 ?? false;
         public string GetCachedFilename(CkanModule m)
             => m.download?.Select(dlUri => cache.GetCachedFilename(dlUri, m.release_date))
-                          .Where(filename => filename != null)
-                          .FirstOrDefault();
-        public string GetCachedZip(CkanModule m)
-            => m.download?.Select(dlUri => cache.GetCachedZip(dlUri))
                           .Where(filename => filename != null)
                           .FirstOrDefault();
         public void GetSizeInfo(out int numFiles, out long numBytes, out long bytesFree)
@@ -172,8 +173,7 @@ namespace CKAN
             cancelToken.ThrowIfCancellationRequested();
 
             // Check valid CRC
-            string invalidReason;
-            if (!NetFileCache.ZipValid(path, out invalidReason, new Progress<long>(percent =>
+            if (!ZipValid(path, out string invalidReason, new Progress<long>(percent =>
                 progress?.Report(percent * zipValidPercent / 100))))
             {
                 throw new InvalidModuleFileKraken(module, path, string.Format(
@@ -214,6 +214,87 @@ namespace CKAN
             // Make sure completion is signalled so progress bars go away
             progress?.Report(100);
             return success;
+        }
+
+        /// <summary>
+        /// Check whether a ZIP file is valid
+        /// </summary>
+        /// <param name="filename">Path to zip file to check</param>
+        /// <param name="invalidReason">Description of problem with the file</param>
+        /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <returns>
+        /// True if valid, false otherwise. See invalidReason param for explanation.
+        /// </returns>
+        public static bool ZipValid(string filename, out string invalidReason, IProgress<long> progress)
+        {
+            try
+            {
+                if (filename != null)
+                {
+                    using (ZipFile zip = new ZipFile(filename))
+                    {
+                        string zipErr = null;
+                        // Limit progress updates to 100 per ZIP file
+                        long highestPercent = -1;
+                        // Perform CRC and other checks
+                        if (zip.TestArchive(true, TestStrategy.FindFirstError,
+                            (TestStatus st, string msg) =>
+                            {
+                                // This delegate is called as TestArchive proceeds through its
+                                // steps, both routine and abnormal.
+                                // The second parameter is non-null if an error occurred.
+                                if (st != null && !st.EntryValid && !string.IsNullOrEmpty(msg))
+                                {
+                                    // Capture the error string so we can return it
+                                    zipErr = string.Format(
+                                        Properties.Resources.NetFileCacheZipError,
+                                        st.Operation, st.Entry?.Name, msg);
+                                }
+                                else if (st.Entry != null && progress != null)
+                                {
+                                    // Report progress
+                                    var percent = 100 * st.Entry.ZipFileIndex / zip.Count;
+                                    if (percent > highestPercent)
+                                    {
+                                        progress.Report(percent);
+                                        highestPercent = percent;
+                                    }
+                                }
+                            }))
+                        {
+                            invalidReason = "";
+                            return true;
+                        }
+                        else
+                        {
+                            invalidReason = zipErr ?? Properties.Resources.NetFileCacheZipTestArchiveFalse;
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    invalidReason = Properties.Resources.NetFileCacheNullFileName;
+                    return false;
+                }
+            }
+            catch (ZipException ze)
+            {
+                // Save the errors someplace useful
+                invalidReason = ze.Message;
+                return false;
+            }
+            catch (ArgumentException ex)
+            {
+                invalidReason = ex.Message;
+                return false;
+            }
+            catch (NotSupportedException nse) when (Platform.IsMono)
+            {
+                // SharpZipLib throws this if your locale isn't installed on Mono
+                invalidReason = string.Format(Properties.Resources.NetFileCacheMonoNotSupported, nse.Message);
+                return false;
+            }
         }
 
         /// <summary>

--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -554,6 +554,9 @@ namespace CKAN.Properties {
         internal static string RelationshipResolverConflictsWith {
             get { return (string)(ResourceManager.GetObject("RelationshipResolverConflictsWith", resourceCulture)); }
         }
+        internal static string RelationshipResolverConflictingModDescription {
+            get { return (string)(ResourceManager.GetObject("RelationshipResolverConflictingModDescription", resourceCulture)); }
+        }
         internal static string RelationshipResolverRequiredButResolver {
             get { return (string)(ResourceManager.GetObject("RelationshipResolverRequiredButResolver", resourceCulture)); }
         }

--- a/Core/Properties/Resources.Designer.cs
+++ b/Core/Properties/Resources.Designer.cs
@@ -578,6 +578,9 @@ namespace CKAN.Properties {
         internal static string RelationshipResolverUserReason {
             get { return (string)(ResourceManager.GetObject("RelationshipResolverUserReason", resourceCulture)); }
         }
+        internal static string RelationshipResolverDependencyRemoved {
+            get { return (string)(ResourceManager.GetObject("RelationshipResolverDependencyRemoved", resourceCulture)); }
+        }
         internal static string RelationshipResolverNoLongerUsedReason {
             get { return (string)(ResourceManager.GetObject("RelationshipResolverNoLongerUsedReason", resourceCulture)); }
         }

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -296,6 +296,7 @@ Free up space on that device or change your settings to use another location.
   <data name="RelationshipResolverModNotInList" xml:space="preserve"><value>Mod {0} is not in the list</value></data>
   <data name="RelationshipResolverInstalledReason" xml:space="preserve"><value>Currently installed</value></data>
   <data name="RelationshipResolverUserReason" xml:space="preserve"><value>Requested by user</value></data>
+  <data name="RelationshipResolverDependencyRemoved" xml:space="preserve"><value>Dependency removed</value></data>
   <data name="RelationshipResolverNoLongerUsedReason" xml:space="preserve"><value>Auto-installed, depending modules removed</value></data>
   <data name="RelationshipResolverReplacementReason" xml:space="preserve"><value>Replacing {0}</value></data>
   <data name="RelationshipResolverSuggestedReason" xml:space="preserve"><value>Suggested by {0}</value></data>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -260,7 +260,7 @@ Please remove manually before trying to install it.</value></data>
   <data name="KrakenParentDependencyNotSatisfied" xml:space="preserve"><value>{0} dependency on {1} version {2} not satisfied</value></data>
   <data name="KrakenAny" xml:space="preserve"><value>(any)</value></data>
   <data name="KrakenProvidedByMoreThanOne" xml:space="preserve"><value>Module {0} is provided by more than one available module. Please choose one of the following:</value></data>
-  <data name="KrakenInconsistenciesHeader" xml:space="preserve"><value>The following inconsistencies were found:</value></data>
+  <data name="KrakenInconsistenciesHeader" xml:space="preserve"><value>Inconsistencies were found:</value></data>
   <data name="KrakenMissingDependency" xml:space="preserve"><value>{0} missing dependency {1}</value></data>
   <data name="KrakenConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="KrakenDownloadErrorsHeader" xml:space="preserve"><value>Uh oh, the following things went wrong when downloading...</value></data>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -288,6 +288,7 @@ Need to store {3} to {1}, but only {2} is available!
 Free up space on that device or change your settings to use another location.
 </value></data>
   <data name="RelationshipResolverConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
+  <data name="RelationshipResolverConflictingModDescription" xml:space="preserve"><value>{0} (needed for: {1})</value></data>
   <data name="RelationshipResolverRequiredButResolver" xml:space="preserve"><value>{0} required, but an incompatible version is in the resolver</value></data>
   <data name="RelationshipResolverRequiredButInstalled" xml:space="preserve"><value>{0} required, but an incompatible version is installed</value></data>
   <data name="RelationshipResolverAnUnmanaged" xml:space="preserve"><value>an unmanaged DLL or DLC</value></data>

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -362,7 +362,7 @@ namespace CKAN
             var autoInstIds  = autoInstMods.Select(im => im.Module.identifier).ToHashSet();
 
             // Need to get the full changeset for this to work as intended
-            RelationshipResolverOptions opts = RelationshipResolver.DependsOnlyOpts();
+            RelationshipResolverOptions opts = RelationshipResolverOptions.DependsOnlyOpts();
             opts.without_toomanyprovides_kraken = true;
             opts.without_enforce_consistency    = true;
             opts.proceed_with_inconsistencies   = true;

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -42,7 +42,11 @@ namespace CKAN
         /// If no ksp_version is provided, the latest module for *any* KSP version is returned.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
-        CkanModule LatestAvailable(string identifier, GameVersionCriteria ksp_version, RelationshipDescriptor relationship_descriptor = null);
+        CkanModule LatestAvailable(string                  identifier,
+                                   GameVersionCriteria     ksp_version,
+                                   RelationshipDescriptor  relationship_descriptor = null,
+                                   ICollection<CkanModule> installed = null,
+                                   ICollection<CkanModule> toInstall = null);
 
         /// <summary>
         /// Returns the max game version that is compatible with the given mod.
@@ -63,13 +67,11 @@ namespace CKAN
         /// Returns an empty list if nothing is available for our system, which includes if no such module exists.
         /// If no KSP version is provided, the latest module for *any* KSP version is given.
         /// </summary>
-        List<CkanModule> LatestAvailableWithProvides(
-            string identifier,
-            GameVersionCriteria ksp_version,
-            RelationshipDescriptor relationship_descriptor = null,
-            IEnumerable<CkanModule> installed = null,
-            IEnumerable<CkanModule> toInstall = null
-        );
+        List<CkanModule> LatestAvailableWithProvides(string                  identifier,
+                                                     GameVersionCriteria     ksp_version,
+                                                     RelationshipDescriptor  relationship_descriptor = null,
+                                                     ICollection<CkanModule> installed = null,
+                                                     ICollection<CkanModule> toInstall = null);
 
         /// <summary>
         /// Checks the sanity of the registry, to ensure that all dependencies are met,

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -16,10 +16,10 @@ namespace CKAN
     /// </summary>
     public interface IRegistryQuerier
     {
-        ReadOnlyDictionary<string, Repository> Repositories { get; }
-        IEnumerable<InstalledModule> InstalledModules { get; }
-        IEnumerable<string>          InstalledDlls    { get; }
-        IDictionary<string, ModuleVersion> InstalledDlc { get; }
+        ReadOnlyDictionary<string, Repository> Repositories     { get; }
+        IEnumerable<InstalledModule>           InstalledModules { get; }
+        IEnumerable<string>                    InstalledDlls    { get; }
+        IDictionary<string, ModuleVersion>     InstalledDlc     { get; }
 
         /// <summary>
         /// Returns a simple array of the latest compatible module for each identifier for
@@ -81,9 +81,9 @@ namespace CKAN
         /// <summary>
         /// Finds and returns all modules that could not exist without the listed modules installed, including themselves.
         /// </summary>
-        IEnumerable<string> FindReverseDependencies(
-            List<string> modulesToRemove, List<CkanModule> modulesToInstall = null, Func<RelationshipDescriptor, bool> satisfiedFilter = null
-        );
+        IEnumerable<string> FindReverseDependencies(List<string> modulesToRemove,
+                                                    List<CkanModule> modulesToInstall = null,
+                                                    Func<RelationshipDescriptor, bool> satisfiedFilter = null);
 
         /// <summary>
         /// Gets the installed version of a mod. Does not check for provided or autodetected mods.

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -146,10 +146,15 @@ namespace CKAN
         [OnDeserialized]
         private void DeSerialisationFixes(StreamingContext context)
         {
+            if (installed_files == null)
+            {
+                installed_files = new Dictionary<string, InstalledModuleFile>();
+            }
             if (Platform.IsWindows)
             {
                 // We need case insensitive path matching on Windows
-                installed_files = new Dictionary<string, InstalledModuleFile>(installed_files, StringComparer.OrdinalIgnoreCase);
+                installed_files = new Dictionary<string, InstalledModuleFile>(installed_files,
+                                                                              StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -38,10 +38,15 @@ namespace CKAN
         private SortedDictionary<string, Repository> repositories;
 
         // name => path
-        [JsonProperty] private  Dictionary<string, string>          installed_dlls;
-        [JsonProperty] private  Dictionary<string, InstalledModule> installed_modules;
+        [JsonProperty]
+        private Dictionary<string, string> installed_dlls;
+
+        [JsonProperty]
+        private Dictionary<string, InstalledModule> installed_modules;
+
         // filename (case insensitive on Windows) => module
-        [JsonProperty] private  Dictionary<string, string>          installed_files;
+        [JsonProperty]
+        private Dictionary<string, string> installed_files;
 
         /// <summary>
         /// Returns all the activated registries.
@@ -65,6 +70,7 @@ namespace CKAN
             InvalidateAvailableModCaches();
             repositories = value;
         }
+
         /// <summary>
         /// Wrapper around this.repositories.Clear() that invalidates
         /// available mod caches
@@ -789,11 +795,8 @@ namespace CKAN
             {
                 // For each AvailableModule, we want the latest one matching our constraints
                 return provs
-                    .Select(am => am.Latest(
-                        gameVersion,
-                        relationship_descriptor,
-                        installed ?? InstalledModules.Select(im => im.Module),
-                        toInstall))
+                    .Select(am => am.Latest(gameVersion, relationship_descriptor,
+                                            installed, toInstall))
                     .Where(m => m?.ProvidesList?.Contains(identifier) ?? false)
                     .ToList();
             }
@@ -1117,12 +1120,6 @@ namespace CKAN
             SanityChecker.EnforceConsistency(installed_modules.Select(pair => pair.Value.Module),
                                              installed_dlls.Keys, InstalledDlc);
         }
-
-        public List<string> GetSanityErrors()
-            => SanityChecker.ConsistencyErrors(installed_modules.Select(pair => pair.Value.Module),
-                                               installed_dlls.Keys,
-                                               InstalledDlc)
-                            .ToList();
 
         /// <summary>
         /// Finds and returns all modules that could not exist without the listed modules installed, including themselves.

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -609,10 +609,13 @@ namespace CKAN
         public CkanModule LatestAvailable(
             string identifier,
             GameVersionCriteria gameVersion,
-            RelationshipDescriptor relationshipDescriptor = null)
+            RelationshipDescriptor relationshipDescriptor = null,
+            ICollection<CkanModule> installed = null,
+            ICollection<CkanModule> toInstall = null)
         {
             log.DebugFormat("Finding latest available for {0}", identifier);
-            return getAvail(identifier)?.Select(am => am.Latest(gameVersion, relationshipDescriptor))
+            return getAvail(identifier)?.Select(am => am.Latest(gameVersion, relationshipDescriptor,
+                                                                installed, toInstall))
                                         .Where(m => m != null)
                                         .OrderByDescending(m => m.version)
                                         .FirstOrDefault();
@@ -793,8 +796,8 @@ namespace CKAN
             string                  identifier,
             GameVersionCriteria     gameVersion,
             RelationshipDescriptor  relationship_descriptor = null,
-            IEnumerable<CkanModule> installed = null,
-            IEnumerable<CkanModule> toInstall = null)
+            ICollection<CkanModule> installed = null,
+            ICollection<CkanModule> toInstall = null)
         {
             if (providers == null)
             {

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1181,9 +1181,9 @@ namespace CKAN
                     var brokenDeps = SanityChecker.FindUnsatisfiedDepends(hypothetical, dlls, dlc);
                     if (satisfiedFilter != null)
                     {
-                        brokenDeps.RemoveAll(kvp => satisfiedFilter(kvp.Value));
+                        brokenDeps.RemoveAll(kvp => satisfiedFilter(kvp.Item2));
                     }
-                    var brokenIdents = brokenDeps.Select(x => x.Key.identifier).ToHashSet();
+                    var brokenIdents = brokenDeps.Select(x => x.Item1.identifier).ToHashSet();
 
                     if (modulesToInstall != null)
                     {

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -712,9 +712,12 @@ namespace CKAN
         {
             get
             {
-                if (tags == null)
+                lock (tagMutex)
                 {
-                    BuildTagIndex();
+                    if (tags == null)
+                    {
+                        BuildTagIndex();
+                    }
                 }
                 return tags;
             }
@@ -725,13 +728,18 @@ namespace CKAN
         {
             get
             {
-                if (untagged == null)
+                lock (tagMutex)
                 {
-                    BuildTagIndex();
+                    if (untagged == null)
+                    {
+                        BuildTagIndex();
+                    }
                 }
                 return untagged;
             }
         }
+
+        private object tagMutex = new object();
 
         /// <summary>
         /// Assemble a mapping from tags to modules

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -42,6 +42,7 @@ namespace CKAN
         private Dictionary<string, string> installed_dlls;
 
         [JsonProperty]
+        [JsonConverter(typeof(JsonParallelDictionaryConverter<InstalledModule>))]
         private Dictionary<string, InstalledModule> installed_modules;
 
         // filename (case insensitive on Windows) => module

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -90,11 +90,11 @@ namespace CKAN
                 // automated tools do not care that no one picked a Scatterer config
                 if (gameInstance.User.Headless)
                 {
-                    log.InfoFormat("Loaded registry with inconsistencies:\r\n\r\n{0}", kraken.InconsistenciesPretty);
+                    log.InfoFormat("Loaded registry with inconsistencies:\r\n\r\n{0}", kraken.Message);
                 }
                 else
                 {
-                    log.ErrorFormat("Loaded registry with inconsistencies:\r\n\r\n{0}", kraken.InconsistenciesPretty);
+                    log.ErrorFormat("Loaded registry with inconsistencies:\r\n\r\n{0}", kraken.Message);
                 }
             }
         }

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -70,61 +70,6 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Attempts to convert the identifiers to CkanModules and then calls RelationshipResolver.ctor(IEnumerable{CkanModule}, IEnumerable{CkanModule}, Registry, GameVersion)"/>
-        /// </summary>
-        /// <param name="modulesToInstall">Identifiers of modules to install, will be converted to CkanModules using CkanModule.FromIDandVersion</param>
-        /// <param name="modulesToRemove">Identifiers of modules to remove, will be converted to CkanModules using Registry.InstalledModule</param>
-        /// <param name="options">Options for the RelationshipResolver</param>
-        /// <param name="registry">CKAN registry object for current game instance</param>
-        /// <param name="versionCrit">The current KSP version criteria to consider</param>
-        public RelationshipResolver(IEnumerable<string> modulesToInstall, IEnumerable<string> modulesToRemove, RelationshipResolverOptions options, IRegistryQuerier registry,
-            GameVersionCriteria versionCrit) :
-                this(
-                    modulesToInstall?.Select(mod => TranslateModule(mod, options, registry, versionCrit)),
-                    modulesToRemove?
-                        .Select(mod =>
-                        {
-                            var match = CkanModule.idAndVersionMatcher.Match(mod);
-                            return match.Success ? match.Groups["mod"].Value : mod;
-                        })
-                        .Where(identifier => registry.InstalledModule(identifier) != null)
-                        .Select(identifier => registry.InstalledModule(identifier).Module),
-                    options, registry, versionCrit)
-        {
-            // Does nothing, just calls the other overloaded constructor
-        }
-
-        /// <summary>
-        /// Translate mods from identifiers in its default or identifier=version format into CkanModules,
-        /// optionally falling back to incompatible modules if no compatibles could be found.
-        /// </summary>
-        /// <param name="name">The identifier or identifier=version of the module</param>
-        /// <param name="options">If options.allow_incompatible is set, fall back to searching incompatible modules if no compatible has been found</param>
-        /// <param name="registry">CKAN registry object for current game instance</param>
-        /// <param name="versionCrit">The current KSP version criteria to consider</param>
-        /// <returns>A CkanModule</returns>
-        private static CkanModule TranslateModule(string name, RelationshipResolverOptions options, IRegistryQuerier registry, GameVersionCriteria versionCrit)
-        {
-            if (options.allow_incompatible)
-            {
-                try
-                {
-                    return CkanModule.FromIDandVersion(registry, name, versionCrit);
-                }
-                catch (ModuleNotFoundKraken)
-                {
-                    // No versions found matching our game version, so
-                    // look for incompatible versions.
-                    return CkanModule.FromIDandVersion(registry, name, null);
-                }
-            }
-            else
-            {
-                return CkanModule.FromIDandVersion(registry, name, versionCrit);
-            }
-        }
-
-        /// <summary>
         /// Returns the default options for relationship resolution.
         /// </summary>
         public static RelationshipResolverOptions DefaultOpts()

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -776,6 +776,12 @@ namespace CKAN
                 => Properties.Resources.RelationshipResolverUserReason;
         }
 
+        public class DependencyRemoved : SelectionReason
+        {
+            public override string Reason
+                => Properties.Resources.RelationshipResolverDependencyRemoved;
+        }
+
         public class NoLongerUsed : SelectionReason
         {
             public override string Reason

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -603,17 +603,9 @@ namespace CKAN
         public bool IsConsistent => !conflicts.Any();
 
         public List<SelectionReason> ReasonsFor(CkanModule mod)
-        {
-            if (mod == null) throw new ArgumentNullException();
-            if (!reasons.ContainsKey(mod) && !ModList().Contains(mod))
-            {
-                throw new ArgumentException(string.Format(
-                    Properties.Resources.RelationshipResolverModNotInList,
-                    mod.identifier));
-            }
-
-            return reasons[mod];
-        }
+            => reasons.TryGetValue(mod, out List<SelectionReason> r)
+                ? r
+                : new List<SelectionReason>();
 
         /// <summary>
         /// Indicates whether a module should be considered auto-installed in this change set.

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using log4net;
-
 using CKAN.Extensions;
 using CKAN.Versioning;
 
@@ -13,47 +11,14 @@ namespace CKAN
     /// </summary>
     public static class SanityChecker
     {
-        private static readonly ILog log = LogManager.GetLogger(typeof(SanityChecker));
-
-        /// <summary>
-        ///     Checks the list of modules for consistency errors, returning a list of
-        ///     errors found. The list will be empty if everything is fine.
-        /// </summary>
-        public static ICollection<string> ConsistencyErrors(
-            IEnumerable<CkanModule> modules,
-            IEnumerable<string> dlls,
-            IDictionary<string, ModuleVersion> dlc)
-        {
-            List<KeyValuePair<CkanModule, RelationshipDescriptor>> unmetDepends;
-            List<KeyValuePair<CkanModule, RelationshipDescriptor>> conflicts;
-            var errors = new HashSet<string>();
-            if (!CheckConsistency(modules, dlls, dlc, out unmetDepends, out conflicts))
-            {
-                foreach (var kvp in unmetDepends)
-                {
-                    errors.Add(string.Format(
-                        Properties.Resources.SanityCheckerUnsatisfiedDependency,
-                        kvp.Key, kvp.Value));
-                }
-                foreach (var kvp in conflicts)
-                {
-                    errors.Add(string.Format(
-                        Properties.Resources.SanityCheckerConflictsWith,
-                        kvp.Key, kvp.Value));
-                }
-            }
-            return errors;
-        }
-
         /// <summary>
         /// Ensures all modules in the list provided can co-exist.
         /// Throws a BadRelationshipsKraken describing the problems otherwise.
         /// Does nothing if the modules can happily co-exist.
         /// </summary>
-        public static void EnforceConsistency(
-            IEnumerable<CkanModule> modules,
-            IEnumerable<string> dlls = null,
-            IDictionary<string, ModuleVersion> dlc = null)
+        public static void EnforceConsistency(IEnumerable<CkanModule>            modules,
+                                              IEnumerable<string>                dlls = null,
+                                              IDictionary<string, ModuleVersion> dlc  = null)
         {
             List<KeyValuePair<CkanModule, RelationshipDescriptor>> unmetDepends;
             List<KeyValuePair<CkanModule, RelationshipDescriptor>> conflicts;
@@ -65,16 +30,13 @@ namespace CKAN
 
         /// <summary>
         /// Returns true if the mods supplied can co-exist. This checks depends/pre-depends/conflicts only.
+        /// This is only used by tests!
         /// </summary>
-        public static bool IsConsistent(
-            IEnumerable<CkanModule> modules,
-            IEnumerable<string> dlls = null,
-            IDictionary<string, ModuleVersion> dlc = null)
-        {
-            List<KeyValuePair<CkanModule, RelationshipDescriptor>> unmetDepends;
-            List<KeyValuePair<CkanModule, RelationshipDescriptor>> conflicts;
-            return CheckConsistency(modules, dlls, dlc, out unmetDepends, out conflicts);
-        }
+        public static bool IsConsistent(IEnumerable<CkanModule>            modules,
+                                        IEnumerable<string>                dlls = null,
+                                        IDictionary<string, ModuleVersion> dlc  = null)
+            => CheckConsistency(modules, dlls, dlc,
+                                out var _, out var _);
 
         private static bool CheckConsistency(
             IEnumerable<CkanModule> modules,
@@ -147,24 +109,6 @@ namespace CKAN
             return confl;
         }
 
-        private sealed class ProvidesInfo
-        {
-            public string ProviderIdentifier     { get; }
-            public ModuleVersion ProviderVersion { get; }
-            public string ProvideeIdentifier     { get; }
-            public ModuleVersion ProvideeVersion { get; }
 
-            public ProvidesInfo(
-                string        providerIdentifier,
-                ModuleVersion providerVersion,
-                string        provideeIdentifier,
-                ModuleVersion provideeVersion)
-            {
-                ProviderIdentifier = providerIdentifier;
-                ProviderVersion    = providerVersion;
-                ProvideeIdentifier = provideeIdentifier;
-                ProvideeVersion    = provideeVersion;
-            }
-        }
     }
 }

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -102,8 +102,8 @@ namespace CKAN
         public CkanModule Latest(
             GameVersionCriteria     ksp_version  = null,
             RelationshipDescriptor  relationship = null,
-            IEnumerable<CkanModule> installed    = null,
-            IEnumerable<CkanModule> toInstall    = null)
+            ICollection<CkanModule> installed    = null,
+            ICollection<CkanModule> toInstall    = null)
         {
             IEnumerable<CkanModule> modules = module_version.Values.Reverse();
             if (relationship != null)
@@ -125,9 +125,8 @@ namespace CKAN
             return modules.FirstOrDefault();
         }
 
-        private static bool DependsAndConflictsOK(CkanModule module, IEnumerable<CkanModule> others)
+        private static bool DependsAndConflictsOK(CkanModule module, ICollection<CkanModule> others)
         {
-            others = others.Memoize();
             if (module.depends != null)
             {
                 foreach (RelationshipDescriptor rel in module.depends)
@@ -140,7 +139,7 @@ namespace CKAN
                     }
                 }
             }
-            var othersMinusSelf = others.Where(m => m.identifier != module.identifier).Memoize();
+            var othersMinusSelf = others.Where(m => m.identifier != module.identifier).ToList();
             if (module.conflicts != null)
             {
                 // Skip self-conflicts (but catch other modules providing self)

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -53,10 +53,15 @@ namespace CKAN
             Debug.Assert(module_version.Values.All(m => identifier.Equals(m.identifier)));
         }
 
-        public static AvailableModule Merge(IList<AvailableModule> availMods)
-            => availMods.Count == 1 ? availMods.First()
-                                    : new AvailableModule(availMods.First().identifier,
-                                                          availMods.Reverse().SelectMany(am => am.AllAvailable()));
+        /// <summary>
+        /// Generate a new AvailableModule given its CkanModules
+        /// </summary>
+        /// <param name="availMods">Sequence of mods to be contained, expected to be IGrouping&lt;&gt;, so it should support O(1) Count(), even though IEnumerable&lt;&gt; in general does not</param>
+        /// <returns></returns>
+        public static AvailableModule Merge(IEnumerable<AvailableModule> availMods)
+            => availMods.Count() == 1 ? availMods.First()
+                                      : new AvailableModule(availMods.First().identifier,
+                                                            availMods.Reverse().SelectMany(am => am.AllAvailable()));
 
         // The map of versions -> modules, that's what we're about!
         // First element is the oldest version, last is the newest.

--- a/Core/Repositories/ProgressImmediate.cs
+++ b/Core/Repositories/ProgressImmediate.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace CKAN
+{
+    public class ProgressImmediate<T> : IProgress<T>
+    {
+        public ProgressImmediate(Action<T> action)
+        {
+            this.action = action;
+        }
+
+        public void Report(T val)
+        {
+            action(val);
+        }
+
+        private readonly Action<T> action;
+    }
+}

--- a/Core/Repositories/ProgressScalePercentsByFileSize.cs
+++ b/Core/Repositories/ProgressScalePercentsByFileSize.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CKAN
+{
+    /// <summary>
+    /// Accepts progress updates in terms of percentage of one file within a group
+    /// and translates them into percentages across the whole operation.
+    /// </summary>
+    public class ProgressScalePercentsByFileSizes : IProgress<int>
+    {
+        /// <summary>
+        /// Initialize an percent-to-scaled-percent progress translator
+        /// </summary>
+        /// <param name="percentProgress">The upstream progress object expecting percentages</param>
+        /// <param name="sizes">Sequence of sizes of files in our group</param>
+        public ProgressScalePercentsByFileSizes(IProgress<int> percentProgress,
+                                                IEnumerable<long> sizes)
+        {
+            this.percentProgress = percentProgress;
+            this.sizes           = sizes.ToArray();
+            totalSize            = this.sizes.Sum();
+        }
+
+        /// <summary>
+        /// The IProgress member called when we advance within the current file
+        /// </summary>
+        /// <param name="currentFilePercent">How far into the current file we are</param>
+        public void Report(int currentFilePercent)
+        {
+            if (basePercent < 100 && currentIndex < sizes.Length)
+            {
+                var percent = basePercent + (int)(currentFilePercent * sizes[currentIndex] / totalSize);
+                // Only report each percentage once, to avoid spamming UI calls
+                if (percent > lastPercent)
+                {
+                    percentProgress?.Report(percent);
+                    lastPercent = percent;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Call this when you move on from one file to the next
+        /// </summary>
+        public void NextFile()
+        {
+            doneSize += sizes[currentIndex];
+            basePercent = (int)(100 * doneSize / totalSize);
+            ++currentIndex;
+            if (basePercent > lastPercent)
+            {
+                percentProgress?.Report(basePercent);
+                lastPercent = basePercent;
+            }
+        }
+
+        private IProgress<int> percentProgress;
+        private long[]         sizes;
+        private long           totalSize;
+        private long           doneSize     = 0;
+        private int            currentIndex = 0;
+        private int            basePercent  = 0;
+        private int            lastPercent  = -1;
+    }
+}

--- a/Core/Repositories/ReadProgressStream.cs
+++ b/Core/Repositories/ReadProgressStream.cs
@@ -20,11 +20,14 @@ namespace CKAN
         public override int Read(byte[] buffer, int offset, int count)
         {
             int amountRead = base.Read(buffer, offset, count);
-            long newProgress = Position;
-            if (newProgress > lastProgress)
+            if (progress != null)
             {
-                progress?.Report(newProgress);
-                lastProgress = newProgress;
+                long newProgress = Position;
+                if (newProgress > lastProgress)
+                {
+                    progress?.Report(newProgress);
+                    lastProgress = newProgress;
+                }
             }
             return amountRead;
         }

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -134,9 +134,10 @@ namespace CKAN
 
         private static RepositoryData FromTarGz(string path, IGame game, IProgress<long> progress)
         {
-            using (var inputStream = File.OpenRead(path))
-            using (var gzipStream  = new GZipInputStream(inputStream))
-            using (var tarStream   = new TarInputStream(gzipStream, Encoding.UTF8))
+            using (var inputStream    = File.OpenRead(path))
+            using (var progressStream = new ReadProgressStream(inputStream, progress))
+            using (var gzipStream     = new GZipInputStream(progressStream))
+            using (var tarStream      = new TarInputStream(gzipStream, Encoding.UTF8))
             {
                 var modules = new List<CkanModule>();
                 SortedDictionary<string, int> counts = null;
@@ -179,7 +180,9 @@ namespace CKAN
 
         private static RepositoryData FromZip(string path, IGame game, IProgress<long> progress)
         {
-            using (var zipfile = new ZipFile(path))
+            using (var inputStream = File.OpenRead(path))
+            using (var progressStream = new ReadProgressStream(inputStream, progress))
+            using (var zipfile = new ZipFile(progressStream))
             {
                 var modules = new List<CkanModule>();
                 SortedDictionary<string, int> counts = null;

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -100,7 +100,7 @@ namespace CKAN
                                                                                   new FileInfo(tuple.Item2).Length))
                                      .ToList();
             // Translate from file group offsets to percent
-            var progress = new ProgressFilesOffsetsToPercent(
+            var progress = new ProgressScalePercentsByFileSizes(
                 percentProgress, reposAndSizes.Select(tuple => tuple.Item2));
             foreach (var repo in reposAndSizes.Select(tuple => tuple.Item1))
             {
@@ -258,10 +258,11 @@ namespace CKAN
                 ? data
                 : LoadRepoData(repo, null);
 
-        private RepositoryData LoadRepoData(Repository repo, IProgress<long> progress)
+        private RepositoryData LoadRepoData(Repository repo, IProgress<int> progress)
         {
-            log.DebugFormat("Looking for data in {0}", GetRepoDataPath(repo));
-            var data = RepositoryData.FromJson(GetRepoDataPath(repo), progress);
+            var path = GetRepoDataPath(repo);
+            log.DebugFormat("Looking for data in {0}", path);
+            var data = RepositoryData.FromJson(path, progress);
             if (data != null)
             {
                 log.Debug("Found it! Adding...");

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Reflection;
 
 using Autofac;
 using log4net;
@@ -281,6 +282,11 @@ namespace CKAN
             // We don't have this passed in, so we'll ask the service locator
             // directly. Yuck.
             _comparator = ServiceLocator.Container.Resolve<IGameComparator>();
+            download_content_type = typeof(CkanModule).GetTypeInfo()
+                                                      .GetDeclaredField("download_content_type")
+                                                      .GetCustomAttribute<DefaultValueAttribute>()
+                                                      .Value
+                                                      .ToString();
         }
 
         /// <summary>

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -574,12 +574,6 @@ namespace CKAN
             => (realVers?.LastOrDefault(v => range.Contains(v))
                         ?? LatestCompatibleGameVersion());
 
-        /// <summary>
-        /// Returns true if this module provides the functionality requested.
-        /// </summary>
-        public bool DoesProvide(string identifier)
-            => this.identifier == identifier || provides.Contains(identifier);
-
         public bool IsMetapackage => kind == "metapackage";
 
         public bool IsDLC => kind == "dlc";

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 
 namespace CKAN
 {
+    using modRelList = List<Tuple<CkanModule, RelationshipDescriptor, CkanModule>>;
+
     /// <summary>
     /// Our application exceptions are called Krakens.
     /// </summary>
@@ -227,25 +229,23 @@ namespace CKAN
     public class BadRelationshipsKraken : InconsistentKraken
     {
         public BadRelationshipsKraken(
-            ICollection<KeyValuePair<CkanModule, RelationshipDescriptor>> depends,
-            ICollection<KeyValuePair<CkanModule, RelationshipDescriptor>> conflicts
+            modRelList depends,
+            modRelList conflicts
         ) : base(
-            (depends?.Select(dep => string.Format(Properties.Resources.KrakenMissingDependency, dep.Key, dep.Value))
+            (depends?.Select(dep => string.Format(Properties.Resources.KrakenMissingDependency, dep.Item1, dep.Item2))
                 ?? new string[] {}
             ).Concat(
-                conflicts?.Select(conf => string.Format(Properties.Resources.KrakenConflictsWith, conf.Key, conf.Value))
+                conflicts?.Select(conf => string.Format(Properties.Resources.KrakenConflictsWith, conf.Item1, conf.Item2))
                 ?? new string[] {}
             ).ToArray()
         )
         {
-            Depends   = depends?.ToList()
-                ?? new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();
-            Conflicts = conflicts?.ToList()
-                ?? new List<KeyValuePair<CkanModule, RelationshipDescriptor>>();
+            Depends   = depends   ?? new modRelList();
+            Conflicts = conflicts ?? new modRelList();
         }
 
-        public readonly List<KeyValuePair<CkanModule, RelationshipDescriptor>> Depends;
-        public readonly List<KeyValuePair<CkanModule, RelationshipDescriptor>> Conflicts;
+        public readonly modRelList Depends;
+        public readonly modRelList Conflicts;
     }
 
     /// <summary>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -199,35 +199,24 @@ namespace CKAN
     /// </summary>
     public class InconsistentKraken : Kraken
     {
-        public string InconsistenciesPretty
-        {
-            get
-            {
-                return String.Join(Environment.NewLine,
-                    new string[] { Properties.Resources.KrakenInconsistenciesHeader }
-                    .Concat(inconsistencies.Select(msg => $"* {msg}")));
-            }
-        }
-
         public InconsistentKraken(ICollection<string> inconsistencies, Exception innerException = null)
-            : base(null, innerException)
+            : base(string.Join(Environment.NewLine,
+                               new string[] { Properties.Resources.KrakenInconsistenciesHeader }
+                                   .Concat(inconsistencies.Select(msg => $"* {msg}"))),
+                   innerException)
         {
             this.inconsistencies = inconsistencies;
         }
 
         public InconsistentKraken(string inconsistency, Exception innerException = null)
-            : base(null, innerException)
-        {
-            inconsistencies = new List<string> { inconsistency };
-        }
+            : this(new List<string> { inconsistency }, innerException)
+        { }
 
         public string ShortDescription
             => string.Join("; ", inconsistencies);
 
         public override string ToString()
-        {
-            return InconsistenciesPretty + Environment.NewLine + Environment.NewLine + StackTrace;
-        }
+            => Message + Environment.NewLine + Environment.NewLine + StackTrace;
 
         private readonly ICollection<string> inconsistencies;
     }

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -12,7 +12,8 @@ namespace CKAN
     /// </summary>
     public class Kraken : Exception
     {
-        public Kraken(string reason = null, Exception innerException = null) : base(reason, innerException)
+        public Kraken(string reason = null, Exception innerException = null)
+            : base(reason, innerException)
         {
         }
     }
@@ -63,11 +64,8 @@ namespace CKAN
     /// </summary>
     public class BadInstallLocationKraken : Kraken
     {
-        // Okay C#, you really need a keyword in your class declaration that says we call our
-        // parent constructors by default. This sort of thing is unacceptable in a modern
-        // programming langauge.
-
-        public BadInstallLocationKraken(string reason = null, Exception innerException = null) : base(reason, innerException)
+        public BadInstallLocationKraken(string reason = null, Exception innerException = null)
+            : base(reason, innerException)
         {
         }
     }
@@ -77,11 +75,10 @@ namespace CKAN
         public readonly string module;
         public readonly string version;
 
-        // TODO: Is there a way to set the stringify version of this?
         public ModuleNotFoundKraken(string module, string version, string reason, Exception innerException = null)
-            : base(
-                reason ?? string.Format(Properties.Resources.KrakenDependencyNotSatisfied, module, version),
-                innerException)
+            : base(reason
+                   ?? string.Format(Properties.Resources.KrakenDependencyNotSatisfied, module, version),
+                   innerException)
         {
             this.module  = module;
             this.version = version;
@@ -112,11 +109,17 @@ namespace CKAN
         /// <param name="reason">Message parameter for base class</param>
         /// <param name="innerException">Originating exception parameter for base class</param>
         public DependencyNotSatisfiedKraken(CkanModule parentModule,
-            string module, string version = null, string reason = null, Exception innerException = null)
+                                            string     module,
+                                            string     version        = null,
+                                            string     reason         = null,
+                                            Exception  innerException = null)
             : base(module, version,
-                reason ?? string.Format(Properties.Resources.KrakenParentDependencyNotSatisfied,
-                    parentModule.identifier, module, version ?? Properties.Resources.KrakenAny),
-                innerException)
+                   reason ?? string.Format(
+                       Properties.Resources.KrakenParentDependencyNotSatisfied,
+                       parentModule.identifier,
+                       module,
+                       version ?? Properties.Resources.KrakenAny),
+                   innerException)
         {
             parent = parentModule;
         }
@@ -176,20 +179,17 @@ namespace CKAN
         public readonly string requested;
         public readonly string choice_help_text;
 
-        public TooManyModsProvideKraken(string requested, List<CkanModule> modules, string choice_help_text = null, Exception innerException = null)
-            : base(FormatMessage(requested, modules, choice_help_text), innerException)
+        public TooManyModsProvideKraken(string           requested,
+                                        List<CkanModule> modules,
+                                        string           choice_help_text = null,
+                                        Exception        innerException   = null)
+            : base(choice_help_text ?? string.Format(Properties.Resources.KrakenProvidedByMoreThanOne,
+                                                     requested),
+                   innerException)
         {
             this.requested        = requested;
             this.modules          = modules;
             this.choice_help_text = choice_help_text;
-        }
-
-        private static string FormatMessage(string requested, List<CkanModule> modules, string choice_help_text = null)
-        {
-            return choice_help_text
-                ?? string.Format(
-                    Properties.Resources.KrakenProvidedByMoreThanOne,
-                    requested);
         }
     }
 
@@ -199,8 +199,6 @@ namespace CKAN
     /// </summary>
     public class InconsistentKraken : Kraken
     {
-        public readonly ICollection<string> inconsistencies;
-
         public string InconsistenciesPretty
         {
             get
@@ -208,14 +206,6 @@ namespace CKAN
                 return String.Join(Environment.NewLine,
                     new string[] { Properties.Resources.KrakenInconsistenciesHeader }
                     .Concat(inconsistencies.Select(msg => $"* {msg}")));
-            }
-        }
-
-        public string ShortDescription
-        {
-            get
-            {
-                return String.Join("; ", inconsistencies);
             }
         }
 
@@ -231,10 +221,15 @@ namespace CKAN
             inconsistencies = new List<string> { inconsistency };
         }
 
+        public string ShortDescription
+            => string.Join("; ", inconsistencies);
+
         public override string ToString()
         {
             return InconsistenciesPretty + Environment.NewLine + Environment.NewLine + StackTrace;
         }
+
+        private readonly ICollection<string> inconsistencies;
     }
 
     /// <summary>
@@ -295,9 +290,9 @@ namespace CKAN
             = new List<KeyValuePair<int, Exception>>();
 
         public DownloadErrorsKraken(List<KeyValuePair<int, Exception>> errors)
-            : base(String.Join(Environment.NewLine,
-                new string[] { Properties.Resources.KrakenDownloadErrorsHeader, "" }
-                .Concat(errors.Select(e => e.Value.Message))))
+            : base(string.Join(Environment.NewLine,
+                               new string[] { Properties.Resources.KrakenDownloadErrorsHeader, "" }
+                               .Concat(errors.Select(e => e.Value.Message))))
         {
             Exceptions = new List<KeyValuePair<int, Exception>>(errors);
         }

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Runtime.CompilerServices;
+using System.Reflection;
 
 using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json;
@@ -109,6 +110,11 @@ namespace CKAN
         [JsonConstructor]
         private ModuleInstallDescriptor()
         {
+            install_to = typeof(ModuleInstallDescriptor).GetTypeInfo()
+                                                        .GetDeclaredField("install_to")
+                                                        .GetCustomAttribute<DefaultValueAttribute>()
+                                                        .Value
+                                                        .ToString();
         }
 
         /// <summary>

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -83,30 +83,12 @@ namespace CKAN
         /// <param name="other"></param>
         /// <returns>True if other_version is within the bounds</returns>
         public bool WithinBounds(ModuleVersion other)
-        {
             // UnmanagedModuleVersions with unknown versions always satisfy the bound
-            if (other is UnmanagedModuleVersion unmanagedModuleVersion && unmanagedModuleVersion.IsUnknownVersion)
-                return true;
-
-            if (version == null)
-            {
-                if (max_version == null && min_version == null)
-                    return true;
-
-                var minSat = min_version == null || min_version <= other;
-                var maxSat = max_version == null || max_version >= other;
-
-                if (minSat && maxSat)
-                    return true;
-            }
-            else
-            {
-                if (version.Equals(other))
-                    return true;
-            }
-
-            return false;
-        }
+            => (other is UnmanagedModuleVersion unmanagedModuleVersion
+                    && unmanagedModuleVersion.IsUnknownVersion)
+               || (version?.Equals(other)
+                          ?? ((min_version == null || min_version <= other)
+                              && (max_version == null || max_version >= other)));
 
         /// <summary>
         /// Check whether any of the modules in a given list match this descriptor.
@@ -189,14 +171,14 @@ namespace CKAN
                 .FirstOrDefault(mod => mod.identifier == name);
 
         public override bool Equals(RelationshipDescriptor other)
-        {
-            ModuleRelationshipDescriptor modRel = other as ModuleRelationshipDescriptor;
-            return modRel != null
-                && name        == modRel.name
-                && version     == modRel.version
-                && min_version == modRel.min_version
-                && max_version == modRel.max_version;
-        }
+            => Equals(other as ModuleRelationshipDescriptor);
+
+        protected bool Equals(ModuleRelationshipDescriptor other)
+            => other != null
+                && name        == other.name
+                && version     == other.version
+                && min_version == other.min_version
+                && max_version == other.max_version;
 
         public override bool ContainsAny(IEnumerable<string> identifiers)
             => identifiers.Contains(name);
@@ -237,7 +219,7 @@ namespace CKAN
             "name",
             "version",
             "min_version",
-            "max_version"
+            "max_version",
         };
 
         public override bool WithinBounds(CkanModule otherModule)
@@ -276,11 +258,11 @@ namespace CKAN
             => null;
 
         public override bool Equals(RelationshipDescriptor other)
-        {
-            AnyOfRelationshipDescriptor anyRel = other as AnyOfRelationshipDescriptor;
-            return anyRel != null
-                && (any_of?.SequenceEqual(anyRel.any_of) ?? anyRel.any_of == null);
-        }
+            => Equals(other as AnyOfRelationshipDescriptor);
+
+        protected bool Equals(AnyOfRelationshipDescriptor other)
+            => other != null
+                && (any_of?.SequenceEqual(other.any_of) ?? other.any_of == null);
 
         public override bool ContainsAny(IEnumerable<string> identifiers)
             => any_of?.Any(r => r.ContainsAny(identifiers)) ?? false;

--- a/GUI/Controls/ChooseRecommendedMods.Designer.cs
+++ b/GUI/Controls/ChooseRecommendedMods.Designer.cs
@@ -73,7 +73,6 @@
             this.RecommendedModsListView.UseCompatibleStateImageBehavior = false;
             this.RecommendedModsListView.View = System.Windows.Forms.View.Details;
             this.RecommendedModsListView.SelectedIndexChanged += new System.EventHandler(RecommendedModsListView_SelectedIndexChanged);
-            this.RecommendedModsListView.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(RecommendedModsListView_ItemChecked);
             this.RecommendedModsListView.Groups.Add(this.RecommendationsGroup);
             this.RecommendedModsListView.Groups.Add(this.SuggestionsGroup);
             this.RecommendedModsListView.Groups.Add(this.SupportedByGroup);

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -133,8 +133,7 @@ namespace CKAN.GUI
         };
 
         private Dictionary<CkanModule, String> FindConflicts()
-        {
-            return new RelationshipResolver(
+            => new RelationshipResolver(
                 RecommendedModsListView.CheckedItems.Cast<ListViewItem>()
                     .Select(item => item.Tag as CkanModule)
                     .Concat(toInstall)
@@ -142,14 +141,12 @@ namespace CKAN.GUI
                 toUninstall,
                 conflictOptions, registry, GameVersion
             ).ConflictList;
-        }
 
         private IEnumerable<ListViewItem> getRecSugRows(
             NetModuleCache cache,
             Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
             Dictionary<CkanModule, List<string>> suggestions,
-            Dictionary<CkanModule, HashSet<string>> supporters
-        )
+            Dictionary<CkanModule, HashSet<string>> supporters)
         {
             foreach (var kvp in recommendations)
             {

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -360,9 +360,7 @@ namespace CKAN.GUI
                 {
                     if (rels != null)
                     {
-                        foreach (var rel in rels
-                            .Select(rel => rel as ModuleRelationshipDescriptor)
-                            .Where(rel => rel != null))
+                        foreach (var rel in rels.OfType<ModuleRelationshipDescriptor>())
                         {
                             rel.version     = null;
                             rel.min_version = null;

--- a/GUI/Controls/InstallationHistory.cs
+++ b/GUI/Controls/InstallationHistory.cs
@@ -88,8 +88,7 @@ namespace CKAN.GUI
                                               .First();
                     var modRows = CkanModule.FromFile(path.FullName)
                                             .depends
-                                            .Select(rel => rel as ModuleRelationshipDescriptor)
-                                            .Where(rel => rel != null)
+                                            .OfType<ModuleRelationshipDescriptor>()
                                             .Select(ItemFromRelationship)
                                             .Where(row => row != null)
                                             .ToArray();
@@ -213,8 +212,8 @@ namespace CKAN.GUI
             Install?.Invoke(ModsListView.Items
                                         .Cast<ListViewItem>()
                                         .Where(lvi => lvi.Group == NotInstalledGroup)
-                                        .Select(lvi => lvi.Tag as CkanModule)
-                                        .Where(mod => mod != null)
+                                        .Select(lvi => lvi.Tag)
+                                        .OfType<CkanModule>()
                                         .ToArray());
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1685,7 +1685,12 @@ namespace CKAN.GUI
                     item => item.Value);
                 if (new_conflicts.Count > 0)
                 {
-                    Main.Instance.AddStatusMessage(string.Join(";", new_conflicts.Values));
+                    Main.Instance.AddStatusMessage(string.Join("; ", tuple.Item3));
+                }
+                else
+                {
+                    // Clear the conflict area if no conflicts
+                    Main.Instance.AddStatusMessage("");
                 }
             }
             catch (DependencyNotSatisfiedKraken k)

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1220,7 +1220,7 @@ namespace CKAN.GUI
                 // Copy the new mod flag from the old list.
                 var old_new_mods = new HashSet<GUIMod>(
                     mainModList.Modules.Where(m => m.IsNew));
-                foreach (var gui_mod in gui_mods.Where(m => old_new_mods.Contains(m)))
+                foreach (var gui_mod in gui_mods.Intersect(old_new_mods))
                 {
                     gui_mod.IsNew = true;
                 }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1121,13 +1121,10 @@ namespace CKAN.GUI
 
             var registry = RegistryManager.Instance(Main.Instance.CurrentInstance, repoData).registry;
             ModGrid.Rows.Clear();
-            foreach (var row in rows)
-            {
-                var mod = ((GUIMod) row.Tag);
-                var inst = Main.Instance.CurrentInstance;
-                row.Visible = mainModList.IsVisible(mod, inst.Name, inst.game, registry);
-            }
-
+            var instName = Main.Instance.CurrentInstance.Name;
+            var instGame = Main.Instance.CurrentInstance.game;
+            rows.AsParallel().ForAll(row =>
+                row.Visible = mainModList.IsVisible((GUIMod)row.Tag, instName, instGame, registry));
             ApplyHeaderGlyphs();
             ModGrid.Rows.AddRange(Sort(rows.Where(row => row.Visible)).ToArray());
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1681,7 +1681,9 @@ namespace CKAN.GUI
                 var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, gameVersion);
                 full_change_set = tuple.Item1.ToList();
                 new_conflicts = tuple.Item2.ToDictionary(
-                    item => new GUIMod(item.Key, repoData, registry, gameVersion),
+                    item => new GUIMod(item.Key, repoData, registry, gameVersion, null,
+                                       Main.Instance.configuration.HideEpochs,
+                                       Main.Instance.configuration.HideV),
                     item => item.Value);
                 if (new_conflicts.Count > 0)
                 {

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -296,9 +296,10 @@ namespace CKAN.GUI
             else
             {
                 // Several found or not same id, return a "provides" node
-                return providesNode(relDescr.ToString(), relationship,
-                    dependencyModules.Select(dep => indexedNode(registry, dep, relationship, relDescr, crit))
-                );
+                return providesNode(relDescr.ToString(),
+                                    relationship,
+                                    dependencyModules.Select(dep => indexedNode(
+                                        registry, dep, relationship, relDescr, crit)));
             }
         }
 

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -265,12 +265,11 @@ namespace CKAN.GUI
         private TreeNode findDependencyShallow(IRegistryQuerier registry, RelationshipDescriptor relDescr, RelationshipType relationship, GameVersionCriteria crit)
         {
             // Check if this dependency is installed
-            if (relDescr.MatchesAny(
-                registry.InstalledModules.Select(im => im.Module),
-                new HashSet<string>(registry.InstalledDlls),
-                // Maybe it's a DLC?
-                registry.InstalledDlc,
-                out CkanModule matched))
+            if (relDescr.MatchesAny(registry.InstalledModules.Select(im => im.Module).ToList(),
+                                    registry.InstalledDlls.ToHashSet(),
+                                    // Maybe it's a DLC?
+                                    registry.InstalledDlc,
+                                    out CkanModule matched))
             {
                 return matched != null
                     ? indexedNode(registry, matched, relationship, relDescr, crit)
@@ -281,7 +280,7 @@ namespace CKAN.GUI
             List<CkanModule> dependencyModules = relDescr.LatestAvailableWithProvides(
                 registry, crit,
                 // Ignore conflicts with installed mods
-                Enumerable.Empty<CkanModule>());
+                new List<CkanModule>());
             if (dependencyModules.Count == 0)
             {
                 // Nothing found, don't return a node

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -91,13 +91,10 @@ namespace CKAN.GUI
 
         [ForbidGUICalls]
         private bool installable(ModuleInstaller installer, CkanModule module, IRegistryQuerier registry)
-        {
-            return module.IsCompatible(Main.Instance.CurrentInstance.VersionCriteria())
-                && installer.CanInstall(
-                    RelationshipResolver.DependsOnlyOpts(),
-                    new List<CkanModule>() { module },
-                    registry);
-        }
+            => module.IsCompatible(Main.Instance.CurrentInstance.VersionCriteria())
+                && installer.CanInstall(RelationshipResolver.DependsOnlyOpts(),
+                                        new List<CkanModule>() { module },
+                                        registry);
 
         private bool allowInstall(CkanModule module)
         {

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -95,11 +95,20 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        private bool installable(ModuleInstaller installer, CkanModule module, IRegistryQuerier registry)
-            => module.IsCompatible(Main.Instance.CurrentInstance.VersionCriteria())
-                && installer.CanInstall(RelationshipResolver.DependsOnlyOpts(),
-                                        new List<CkanModule>() { module },
-                                        registry);
+        private static bool installable(ModuleInstaller     installer,
+                                        CkanModule          module,
+                                        IRegistryQuerier    registry)
+            => installable(installer, module, registry, Main.Instance.CurrentInstance.VersionCriteria());
+
+        [ForbidGUICalls]
+        private static bool installable(ModuleInstaller     installer,
+                                        CkanModule          module,
+                                        IRegistryQuerier    registry,
+                                        GameVersionCriteria crit)
+            => module.IsCompatible(crit)
+                && installer.CanInstall(new List<CkanModule>() { module },
+                                        RelationshipResolverOptions.DependsOnlyOpts(),
+                                        registry, crit);
 
         private bool allowInstall(CkanModule module)
         {

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -2,8 +2,10 @@ using System;
 using System.Linq;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Drawing;
 using System.Windows.Forms;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Autofac;
@@ -36,6 +38,8 @@ namespace CKAN.GUI
             {
                 if (!(visibleGuiModule?.Equals(value) ?? value?.Equals(visibleGuiModule) ?? true))
                 {
+                    // Stop background loading of row colors
+                    cancelTokenSrc?.Cancel();
                     // Listen for property changes (we only care about GUIMod.SelectedMod)
                     if (visibleGuiModule != null)
                     {
@@ -55,9 +59,10 @@ namespace CKAN.GUI
             }
         }
 
-        private RepositoryDataManager repoData;
-        private GUIMod                visibleGuiModule;
-        private bool                  ignoreItemCheck;
+        private RepositoryDataManager   repoData;
+        private GUIMod                  visibleGuiModule;
+        private bool                    ignoreItemCheck;
+        private CancellationTokenSource cancelTokenSrc;
 
         private void VersionsListView_ItemCheck(object sender, ItemCheckEventArgs e)
         {
@@ -201,51 +206,52 @@ namespace CKAN.GUI
         [ForbidGUICalls]
         private void checkInstallable(ListViewItem[] items)
         {
-            GameInstance     currentInstance = Main.Instance.Manager.CurrentInstance;
-            IRegistryQuerier registry        = RegistryManager.Instance(currentInstance, repoData).registry;
-            bool latestCompatibleVersionAlreadyFound = false;
-            var installer = new ModuleInstaller(
-                currentInstance,
-                Main.Instance.Manager.Cache,
-                Main.Instance.currentUser);
-            foreach (ListViewItem item in items)
-            {
-                if (item.ListView == null)
-                {
-                    // User switched to another mod, quit
-                    break;
-                }
-                if (installable(installer, item.Tag as CkanModule, registry))
-                {
-                    if (!latestCompatibleVersionAlreadyFound)
-                    {
-                        latestCompatibleVersionAlreadyFound = true;
-                        Util.Invoke(this, () =>
-                        {
-                            item.BackColor = Color.Green;
-                            item.ForeColor = Color.White;
-                        });
-                    }
-                    else
-                    {
-                        Util.Invoke(this, () =>
-                        {
-                            item.BackColor = Color.LightGreen;
-                        });
-                    }
-                }
-            }
-            Util.Invoke(this, () =>
-            {
-                UseWaitCursor = false;
-            });
+            var currentInstance = Main.Instance.Manager.CurrentInstance;
+            var registry        = RegistryManager.Instance(currentInstance, repoData).registry;
+            var installer       = new ModuleInstaller(currentInstance,
+                                                      Main.Instance.Manager.Cache,
+                                                      Main.Instance.currentUser);
+            ListViewItem latestCompatible = null;
+            // Load balance the items so they're processed roughly in-order instead of blocks
+            Partitioner.Create(items, true)
+                       // Distribute across cores
+                       .AsParallel()
+                       // Abort when they switch to another mod
+                       .WithCancellation(cancelTokenSrc.Token)
+                       // Return them as they're processed
+                       .WithMergeOptions(ParallelMergeOptions.NotBuffered)
+                       // Slow step to be performed across multiple cores
+                       .Where(item => installable(installer, item.Tag as CkanModule, registry))
+                       // Jump back to GUI thread for the updates for each compatible item
+                       .ForAll(item => Util.Invoke(this, () =>
+                       {
+                           if (latestCompatible == null || item.Index < latestCompatible.Index)
+                           {
+                               if (latestCompatible != null)
+                               {
+                                   // Revert color of previous best guess
+                                   latestCompatible.BackColor = Color.LightGreen;
+                                   latestCompatible.ForeColor = SystemColors.ControlText;
+                               }
+                               latestCompatible = item;
+                               item.BackColor = Color.Green;
+                               item.ForeColor = Color.White;
+                           }
+                           else
+                           {
+                               item.BackColor = Color.LightGreen;
+                           }
+                       }));
+            Util.Invoke(this, () => UseWaitCursor = false);
         }
 
         private void Refresh(GUIMod gmod)
         {
+            // checkInstallable needs this to stop background threads on switch to another mod
+            cancelTokenSrc     = new CancellationTokenSource();
             var startingModule = gmod;
             var items          = getItems(gmod, getVersions(gmod));
-            Util.Invoke(this, () =>
+            Util.AsyncInvoke(this, () =>
             {
                 VersionsListView.BeginUpdate();
                 VersionsListView.Items.Clear();

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -770,6 +770,7 @@ namespace CKAN.GUI
                 repoData,
                 RegistryManager.Instance(CurrentInstance, repoData).registry,
                 CurrentInstance.VersionCriteria(),
+                null,
                 configuration.HideEpochs,
                 configuration.HideV);
         }

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -47,7 +47,7 @@ namespace CKAN.GUI
                                               // Include all removes and upgrades
                                               || ch.ChangeType != GUIModChangeType.Install)
                                  .ToList(),
-                        RelationshipResolver.DependsOnlyOpts()));
+                        RelationshipResolverOptions.DependsOnlyOpts()));
             }
             catch (InvalidOperationException)
             {

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -41,7 +41,12 @@ namespace CKAN.GUI
 
         private void InstallationHistory_OnSelectedModuleChanged(CkanModule m)
         {
-            ActiveModInfo = new GUIMod(m, repoData, RegistryManager.Instance(CurrentInstance, repoData).registry, CurrentInstance.VersionCriteria());
+            ActiveModInfo = new GUIMod(m, repoData,
+                                       RegistryManager.Instance(CurrentInstance, repoData).registry,
+                                       CurrentInstance.VersionCriteria(),
+                                       null,
+                                       configuration.HideEpochs,
+                                       configuration.HideV);
         }
 
     }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -55,7 +55,7 @@ namespace CKAN.GUI
                     // Resolve the provides relationships in the dependencies
                     Wait.StartWaiting(InstallMods, PostInstallMods, true,
                         new InstallArgument(userChangeSet,
-                                            RelationshipResolver.DependsOnlyOpts()));
+                                            RelationshipResolverOptions.DependsOnlyOpts()));
                 }
             }
             catch

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -382,7 +382,7 @@ namespace CKAN.GUI
                         break;
 
                     case InconsistentKraken exc:
-                        currentUser.RaiseMessage(exc.InconsistenciesPretty);
+                        currentUser.RaiseMessage(exc.Message);
                         break;
 
                     case CancelledActionKraken exc:

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -60,7 +60,7 @@ namespace CKAN.GUI
                         new InstallArgument(
                             result.Select(mod => new ModChange(mod, GUIModChangeType.Install))
                                   .ToList(),
-                            RelationshipResolver.DependsOnlyOpts()));
+                            RelationshipResolverOptions.DependsOnlyOpts()));
                 }
             }
             else

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -147,7 +147,7 @@ namespace CKAN.GUI
                                   RegistryManager.Instance(CurrentInstance, repoData).registry,
                                   CurrentInstance.VersionCriteria())
                               .ToList(),
-                    RelationshipResolver.DependsOnlyOpts())
+                    RelationshipResolverOptions.DependsOnlyOpts())
             );
         }
         #endregion

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -133,9 +133,9 @@ namespace CKAN.GUI
                       RepositoryDataManager repoDataMgr,
                       IRegistryQuerier      registry,
                       GameVersionCriteria   current_game_version,
-                      bool? incompatible = null,
-                      bool  hideEpochs   = false,
-                      bool  hideV        = false)
+                      bool? incompatible,
+                      bool  hideEpochs,
+                      bool  hideV)
             : this(instMod.Module, repoDataMgr, registry, current_game_version, incompatible, hideEpochs, hideV)
         {
             IsInstalled      = true;
@@ -166,9 +166,9 @@ namespace CKAN.GUI
                       RepositoryDataManager repoDataMgr,
                       IRegistryQuerier      registry,
                       GameVersionCriteria   current_game_version,
-                      bool? incompatible = null,
-                      bool  hideEpochs   = false,
-                      bool  hideV        = false)
+                      bool? incompatible,
+                      bool  hideEpochs,
+                      bool  hideV)
             : this(mod.identifier, repoDataMgr, registry, current_game_version, incompatible, hideEpochs, hideV)
         {
             Mod           = mod;
@@ -210,9 +210,9 @@ namespace CKAN.GUI
                       RepositoryDataManager repoDataMgr,
                       IRegistryQuerier      registry,
                       GameVersionCriteria   current_game_version,
-                      bool? incompatible = null,
-                      bool  hideEpochs   = false,
-                      bool  hideV        = false)
+                      bool? incompatible,
+                      bool  hideEpochs,
+                      bool  hideV)
         {
             Identifier     = identifier;
             IsAutodetected = registry.IsAutodetected(identifier);

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -174,7 +174,8 @@ namespace CKAN.GUI
                     CkanModule module_by_version = registry.GetModuleByVersion(depMod.identifier,
                     depMod.version)
                         ?? registry.InstalledModule(dependent).Module;
-                    changeSet.Add(new ModChange(module_by_version, GUIModChangeType.Remove));
+                    changeSet.Add(new ModChange(module_by_version, GUIModChangeType.Remove,
+                                                new SelectionReason.DependencyRemoved()));
                     modules_to_remove.Add(module_by_version);
                 }
             }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -121,7 +121,7 @@ namespace CKAN.GUI
         /// <param name="registry"></param>
         /// <param name="changeSet"></param>
         /// <param name="version">The version of the current game instance</param>
-        public Tuple<IEnumerable<ModChange>, Dictionary<CkanModule, string>> ComputeFullChangeSetFromUserChangeSet(
+        public Tuple<IEnumerable<ModChange>, Dictionary<CkanModule, string>, List<string>> ComputeFullChangeSetFromUserChangeSet(
             IRegistryQuerier registry, HashSet<ModChange> changeSet, GameVersionCriteria version)
         {
             var modules_to_install = new List<CkanModule>();
@@ -192,7 +192,7 @@ namespace CKAN.GUI
                 conflictOptions, registry, version);
 
             // Replace Install entries in changeset with the ones from resolver to get all the reasons
-            return new Tuple<IEnumerable<ModChange>, Dictionary<CkanModule, string>>(
+            return new Tuple<IEnumerable<ModChange>, Dictionary<CkanModule, string>, List<string>>(
                 changeSet.Where(ch => !(ch.ChangeType is GUIModChangeType.Install))
                          .OrderBy(ch => ch.Mod.identifier)
                          .Union(resolver.ModList()
@@ -200,7 +200,8 @@ namespace CKAN.GUI
                                         .Except(upgrading)
                                         .Where(m => !m.IsMetapackage)
                                         .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonsFor(m)))),
-                resolver.ConflictList);
+                resolver.ConflictList,
+                resolver.ConflictDescriptions.ToList());
         }
 
         /// <summary>

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -272,9 +272,9 @@ namespace CKAN.GUI
         {
             Modules = modules;
             var changes = mc?.ToList();
-            full_list_of_mod_rows = Modules.ToDictionary(
-                gm => gm.Identifier,
-                gm => MakeRow(gm, changes, instanceName, game));
+            full_list_of_mod_rows = Modules.AsParallel()
+                                           .ToDictionary(gm => gm.Identifier,
+                                                         gm => MakeRow(gm, changes, instanceName, game));
             HasAnyInstalled = Modules.Any(m => m.IsInstalled);
             return full_list_of_mod_rows.Values;
         }

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
 
-namespace CKAN
+namespace CKAN.NetKAN
 {
     /// <summary>
     /// The commandline implementation of the IUser interface.

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -87,7 +87,7 @@ namespace CKAN.NetKAN.Services
                     case FileType.Zip:
                         extension = "zip";
                         string invalidReason;
-                        if (!NetFileCache.ZipValid(downloadedFile, out invalidReason, null))
+                        if (!NetModuleCache.ZipValid(downloadedFile, out invalidReason, null))
                         {
                             log.Debug($"{url} is not a valid ZIP file: {invalidReason}");
                             File.Delete(downloadedFile);

--- a/Netkan/Transformers/SpaceWarpInfoTransformer.cs
+++ b/Netkan/Transformers/SpaceWarpInfoTransformer.cs
@@ -84,8 +84,8 @@ namespace CKAN.NetKAN.Transformers
                         log.InfoFormat("Found compatibility: {0}–{1}", minVer, maxVer);
                         ModuleService.ApplyVersions(json, null, minVer, maxVer);
                     }
-                    var moduleDeps = (mod.depends?.Select(r => (r as ModuleRelationshipDescriptor)?.name)
-                                                  .Where(ident => ident != null)
+                    var moduleDeps = (mod.depends?.OfType<ModuleRelationshipDescriptor>()
+                                                  .Select(r => r.name)
                                       ?? Enumerable.Empty<string>())
                                       .ToHashSet();
                     var missingDeps = swinfo.dependencies

--- a/Tests/CapturingUser.cs
+++ b/Tests/CapturingUser.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+using CKAN;
+
+namespace Tests
+{
+    public class CapturingUser : IUser
+    {
+        public CapturingUser(bool                        headless,
+                             Func<string, bool>          yesNoAnswerer,
+                             Func<string, object[], int> selectionDialogAnswerer)
+        {
+            Headless                     = headless;
+            this.yesNoAnswerer           = yesNoAnswerer;
+            this.selectionDialogAnswerer = selectionDialogAnswerer;
+        }
+
+        public bool Headless { get; private set; }
+
+        public bool RaiseYesNoDialog(string question)
+        {
+            RaisedYesNoDialogQuestions.Add(question);
+            return yesNoAnswerer(question);
+        }
+
+        public int RaiseSelectionDialog(string message, params object[] args)
+        {
+            RaisedSelectionDialogs.Add(new Tuple<string, object[]>(message, args));
+            return selectionDialogAnswerer(message, args);
+        }
+
+        public void RaiseError(string message, params object[] args)
+        {
+            RaisedErrors.Add(string.Format(message, args));
+        }
+
+        public void RaiseProgress(string message, int percent)
+        {
+            RaisedProgresses.Add(new Tuple<string, int>(message, percent));
+        }
+
+        public void RaiseMessage(string message, params object[] args)
+        {
+            RaisedMessages.Add(string.Format(message, args));
+        }
+
+        public readonly List<string>                  RaisedYesNoDialogQuestions = new List<string>();
+        public readonly List<Tuple<string, object[]>> RaisedSelectionDialogs     = new List<Tuple<string, object[]>>();
+        public readonly List<string>                  RaisedErrors               = new List<string>();
+        public readonly List<Tuple<string, int>>      RaisedProgresses           = new List<Tuple<string, int>>();
+        public readonly List<string>                  RaisedMessages             = new List<string>();
+
+
+        private Func<string, bool>          yesNoAnswerer;
+        private Func<string, object[], int> selectionDialogAnswerer;
+    }
+}

--- a/Tests/CmdLine/InstallTests.cs
+++ b/Tests/CmdLine/InstallTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using CKAN;
+using CKAN.CmdLine;
+
+using Tests.Data;
+using Tests.Core.Configuration;
+
+namespace Tests.CmdLine
+{
+    [TestFixture]
+    public class InstallTests
+    {
+        [Test,
+            TestCase(new string[]
+                     {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""InstallableMod"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""InstallableMod"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""InstallableMod"",
+                             ""version"":      ""1.2.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }"
+                     },
+                     "InstallableMod",
+                     "1.1.0"),
+        ]
+        public void RunCommand_IdentifierEqualsVersionSyntax_InstallsCorrectVersion(
+            string[] modules,
+            string   identifier,
+            string   version)
+        {
+            // Arrange
+            var user = new CapturingUser(false, q => true, (msg, objs) => 0);
+            using (var inst     = new DisposableKSP())
+            using (var repo     = new TemporaryRepository(modules))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager  = new GameInstanceManager(user, config)
+                {
+                    CurrentInstance = inst.KSP,
+                })
+            {
+                var regMgr = RegistryManager.Instance(inst.KSP, repoData.Manager);
+                regMgr.registry.RepositoriesClear();
+                regMgr.registry.RepositoriesAdd(repo.repo);
+                var module = regMgr.registry.GetModuleByVersion(identifier, version);
+                manager.Cache.Store(module, TestData.DogeCoinFlagZip(), null);
+                var opts = new InstallOptions()
+                {
+                    modules = new List<string> { $"{identifier}={version}" },
+                };
+
+                // Act
+                ICommand cmd = new Install(manager, repoData.Manager, user);
+                cmd.RunCommand(inst.KSP, opts);
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                    CollectionAssert.AreEqual(Enumerable.Empty<string>(),
+                                              user.RaisedErrors);
+                    CollectionAssert.AreEqual(new CkanModule[] { module },
+                                              regMgr.registry.InstalledModules.Select(m => m.Module));
+                });
+            }
+        }
+    }
+}

--- a/Tests/CmdLine/ResourcesTests.cs
+++ b/Tests/CmdLine/ResourcesTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Resources;
 using System.Globalization;
+
 using NUnit.Framework;
 
 namespace Tests.CmdLine

--- a/Tests/CmdLine/UpgradeTests.cs
+++ b/Tests/CmdLine/UpgradeTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using CKAN;
+using CKAN.CmdLine;
+
+using Tests.Data;
+using Tests.Core.Configuration;
+
+namespace Tests.CmdLine
+{
+    [TestFixture]
+    public class UpgradeTests
+    {
+        [Test,
+            TestCase(new string[]
+                     {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""UpgradableMod"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""UpgradableMod"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""UpgradableMod"",
+                             ""version"":      ""1.2.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }"},
+                     "UpgradableMod",
+                     "1.0.0",
+                     "1.1.0"),
+        ]
+        public void RunCommand_IdentifierEqualsVersionSyntax_UpgradesToCorrectVersion(
+            string[] modules,
+            string   identifier,
+            string   fromVersion,
+            string   toVersion)
+        {
+            // Arrange
+            var user = new CapturingUser(false, q => true, (msg, objs) => 0);
+            using (var inst     = new DisposableKSP())
+            using (var repo     = new TemporaryRepository(modules))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager  = new GameInstanceManager(user, config)
+                {
+                    CurrentInstance = inst.KSP,
+                })
+            {
+                var regMgr = RegistryManager.Instance(inst.KSP, repoData.Manager);
+                regMgr.registry.RepositoriesClear();
+                regMgr.registry.RepositoriesAdd(repo.repo);
+                var fromModule = regMgr.registry.GetModuleByVersion(identifier, fromVersion);
+                var toModule   = regMgr.registry.GetModuleByVersion(identifier, toVersion);
+                regMgr.registry.RegisterModule(fromModule, Enumerable.Empty<string>(), inst.KSP, false);
+                manager.Cache.Store(toModule, TestData.DogeCoinFlagZip(), null);
+                var opts = new UpgradeOptions()
+                {
+                    modules = new List<string> { $"{identifier}={toVersion}" },
+                };
+
+                // Act
+                ICommand cmd = new Upgrade(manager, repoData.Manager, user);
+                cmd.RunCommand(inst.KSP, opts);
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                    CollectionAssert.AreEqual(Enumerable.Empty<string>(),
+                                              user.RaisedErrors);
+                    CollectionAssert.AreEqual(new CkanModule[] { toModule },
+                                              regMgr.registry.InstalledModules.Select(m => m.Module));
+                });
+            }
+        }
+    }
+}

--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -161,21 +161,21 @@ namespace Tests.Core
             // We could use any URL, but this one is awesome. <3
             Uri url = new Uri("http://kitte.nz/");
 
-            Assert.IsFalse(cache.IsCachedZip(url));
+            Assert.IsFalse(cache.IsCached(url));
 
             // Store a bad zip.
             cache.Store(url, TestData.DogeCoinFlagZipCorrupt());
 
-            // Make sure it's stored, but not valid as a zip
+            // Make sure it's stored
             Assert.IsTrue(cache.IsCached(url));
-            Assert.IsFalse(cache.IsCachedZip(url));
+            // Make sure it's not valid as a zip
+            Assert.IsFalse(NetModuleCache.ZipValid(cache.GetCachedFilename(url), out string invalidReason, null));
 
             // Store a good zip.
             cache.Store(url, TestData.DogeCoinFlagZip());
 
             // Make sure it's stored, and valid.
             Assert.IsTrue(cache.IsCached(url));
-            Assert.IsTrue(cache.IsCachedZip(url));
         }
 
         [Test]
@@ -189,7 +189,7 @@ namespace Tests.Core
             bool valid = false;
             string reason = "";
             Assert.DoesNotThrow(() =>
-                valid = NetFileCache.ZipValid(TestData.ZipWithBadChars, out reason, null));
+                valid = NetModuleCache.ZipValid(TestData.ZipWithBadChars, out reason, null));
 
             // The file is considered valid on Linux;
             // only check the reason if found invalid
@@ -212,7 +212,7 @@ namespace Tests.Core
             string reason = null;
 
             Assert.DoesNotThrow(() =>
-                valid = NetFileCache.ZipValid(TestData.ZipWithUnicodeChars, out reason, null));
+                valid = NetModuleCache.ZipValid(TestData.ZipWithUnicodeChars, out reason, null));
             Assert.IsTrue(valid, reason);
         }
 

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -65,7 +65,7 @@ namespace Tests.Core
             _manager.Cache.Store(_testModule, testModFile, new Progress<long>(bytes => {}));
             HashSet<string> possibleConfigOnlyDirs = null;
             _installer.InstallList(
-                new List<string>() { _testModule.identifier },
+                new List<CkanModule>() { _testModule },
                 new RelationshipResolverOptions(),
                 _registryManager,
                 ref possibleConfigOnlyDirs);

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -407,13 +407,13 @@ namespace Tests.Core
                 Assert.IsFalse(File.Exists(mod_file_path));
 
                 // Copy the zip file to the cache directory.
-                Assert.IsFalse(manager.Cache.IsCachedZip(TestData.DogeCoinFlag_101_module()));
+                Assert.IsFalse(manager.Cache.IsCached(TestData.DogeCoinFlag_101_module()));
 
                 string cache_path = manager.Cache.Store(TestData.DogeCoinFlag_101_module(),
                                                         TestData.DogeCoinFlagZip(),
                                                         new Progress<long>(bytes => {}));
 
-                Assert.IsTrue(manager.Cache.IsCachedZip(TestData.DogeCoinFlag_101_module()));
+                Assert.IsTrue(manager.Cache.IsCached(TestData.DogeCoinFlag_101_module()));
                 Assert.IsTrue(File.Exists(cache_path));
 
                 var registry = CKAN.RegistryManager.Instance(manager.CurrentInstance, repoData.Manager).registry;

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -423,7 +423,7 @@ namespace Tests.Core
                 Assert.AreEqual(1, registry.CompatibleModules(ksp.KSP.VersionCriteria()).Count());
 
                 // Attempt to install it.
-                List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
+                var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string> possibleConfigOnlyDirs = null;
                 new CKAN.ModuleInstaller(ksp.KSP, manager.Cache, nullUser)
@@ -433,47 +433,6 @@ namespace Tests.Core
                                  ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
-                Assert.IsTrue(File.Exists(mod_file_path));
-            }
-        }
-
-        [Test]
-        public void InstallList_IdentifierEqualsVersionSyntax_InstallsModule()
-        {
-            // Arrange
-            using (var ksp = new DisposableKSP())
-            using (var config = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-            using (var repo = new TemporaryRepository(TestData.DogeCoinFlag_101()))
-            using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var manager = new GameInstanceManager(nullUser, config)
-                {
-                    CurrentInstance = ksp.KSP
-                })
-            {
-                var registry = CKAN.RegistryManager.Instance(ksp.KSP, repoData.Manager).registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo.repo);
-
-                var inst = new CKAN.ModuleInstaller(ksp.KSP, manager.Cache, nullUser);
-
-                const string mod_file_name = "DogeCoinFlag/Flags/dogecoin.png";
-                string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);
-
-                var mod = registry.GetModuleByVersion("DogeCoinFlag", "1.01");
-                Assert.IsNotNull(mod, "DogeCoinFlag 1.01 should exist");
-                manager.Cache.Store(mod, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
-                List<string> modules = new List<string>()
-                {
-                    $"{mod.identifier}={mod.version}"
-                };
-
-                // Act
-                HashSet<string> possibleConfigOnlyDirs = null;
-                inst.InstallList(modules, new RelationshipResolverOptions(),
-                                 CKAN.RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
-                                 ref possibleConfigOnlyDirs);
-
-                // Assert
                 Assert.IsTrue(File.Exists(mod_file_path));
             }
         }
@@ -503,7 +462,7 @@ namespace Tests.Core
                                     TestData.DogeCoinFlagZip(),
                                     new Progress<long>(bytes => {}));
 
-                List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
+                var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string> possibleConfigOnlyDirs = null;
                 new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser)
@@ -516,7 +475,8 @@ namespace Tests.Core
 
                 // Attempt to uninstall it.
                 new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser)
-                    .UninstallList(modules, ref possibleConfigOnlyDirs,
+                    .UninstallList(modules.Select(m => m.identifier),
+                                   ref possibleConfigOnlyDirs,
                                    CKAN.RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
 
                 // Check that the module is not installed.
@@ -550,7 +510,7 @@ namespace Tests.Core
                                     TestData.DogeCoinFlagZip(),
                                     new Progress<long>(bytes => {}));
 
-                List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
+                var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string> possibleConfigOnlyDirs = null;
                 new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser)
@@ -566,7 +526,7 @@ namespace Tests.Core
                                     TestData.DogeCoinPluginZip(),
                                     new Progress<long>(bytes => {}));
 
-                modules.Add(TestData.DogeCoinPlugin_module().identifier);
+                modules.Add(TestData.DogeCoinPlugin_module());
 
                 new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser)
                     .InstallList(modules,
@@ -581,11 +541,11 @@ namespace Tests.Core
 
                 // Uninstall both mods.
 
-                modules.Add(TestData.DogeCoinFlag_101_module().identifier);
-                modules.Add(TestData.DogeCoinPlugin_module().identifier);
+                modules.Add(TestData.DogeCoinFlag_101_module());
+                modules.Add(TestData.DogeCoinPlugin_module());
 
                 new CKAN.ModuleInstaller(manager.CurrentInstance, manager.Cache, nullUser)
-                    .UninstallList(modules,
+                    .UninstallList(modules.Select(m => m.identifier),
                                    ref possibleConfigOnlyDirs,
                                    CKAN.RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
 
@@ -760,7 +720,7 @@ namespace Tests.Core
                                             new Progress<long>(bytes => {}));
 
                         // Attempt to install it.
-                        List<string> modules = new List<string> { TestData.DogeCoinFlag_101_module().identifier };
+                        var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                         HashSet<string> possibleConfigOnlyDirs = null;
                         new CKAN.ModuleInstaller(ksp.KSP, manager.Cache, nullUser)
@@ -1150,7 +1110,9 @@ namespace Tests.Core
                 }
 
                 // Act
-                installer.Upgrade(upgradeIdentifiers, downloader, ref possibleConfigOnlyDirs, regMgr, false);
+                installer.Upgrade(upgradeIdentifiers.Select(ident =>
+                                      registry.LatestAvailable(ident, inst.KSP.VersionCriteria())),
+                                  downloader, ref possibleConfigOnlyDirs, regMgr, false);
 
                 // Assert
                 CollectionAssert.AreEquivalent(correctRemainingIdentifiers,

--- a/Tests/Core/Net/NetAsyncDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncDownloaderTests.cs
@@ -201,16 +201,19 @@ namespace Tests.Core.Net
             {
                 downloader.DownloadAndWait(targets);
             });
-            CollectionAssert.AreEquivalent(badIndices, exception.Exceptions.Select(kvp => kvp.Key).ToArray());
-            foreach (var kvp in exception.Exceptions)
+            Assert.Multiple(() =>
             {
-                var baseExc = kvp.Value.GetBaseException() as FileNotFoundException;
-                Assert.AreEqual(fromPaths[kvp.Key], baseExc.FileName);
-            }
-            foreach (var t in validTargets)
-            {
-                Assert.IsTrue(File.Exists(t.filename));
-            }
+                CollectionAssert.AreEquivalent(badIndices, exception.Exceptions.Select(kvp => kvp.Key).ToArray());
+                foreach (var kvp in exception.Exceptions)
+                {
+                    var baseExc = kvp.Value.GetBaseException() as FileNotFoundException;
+                    Assert.AreEqual(fromPaths[kvp.Key], baseExc.FileName);
+                }
+                foreach (var t in validTargets)
+                {
+                    Assert.IsTrue(File.Exists(t.filename));
+                }
+            });
         }
     }
 }

--- a/Tests/Core/Net/NetAsyncModulesDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloaderTests.cs
@@ -171,8 +171,8 @@ namespace Tests.Core.Net
             // Download our module.
             async.DownloadModules(modules);
 
-            // Assert that we have it, and it passes zip validation.
-            Assert.IsTrue(cache.IsCachedZip(kOS));
+            // Assert that we have it (which meansit passed zip validation)
+            Assert.IsTrue(cache.IsCached(kOS));
         }
 
         [Test]
@@ -189,13 +189,13 @@ namespace Tests.Core.Net
             modules.Add(kOS);
             modules.Add(quick_revert);
 
-            Assert.IsFalse(cache.IsCachedZip(kOS));
-            Assert.IsFalse(cache.IsCachedZip(quick_revert));
+            Assert.IsFalse(cache.IsCached(kOS));
+            Assert.IsFalse(cache.IsCached(quick_revert));
 
             async.DownloadModules(modules);
 
-            Assert.IsTrue(cache.IsCachedZip(kOS));
-            Assert.IsTrue(cache.IsCachedZip(quick_revert));
+            Assert.IsTrue(cache.IsCached(kOS));
+            Assert.IsTrue(cache.IsCached(quick_revert));
         }
 
         [Test]
@@ -210,11 +210,11 @@ namespace Tests.Core.Net
 
             modules.Add(rAndS);
 
-            Assert.IsFalse(cache.IsCachedZip(rAndS), "Module not yet downloaded");
+            Assert.IsFalse(cache.IsCached(rAndS), "Module not yet downloaded");
 
             async.DownloadModules(modules);
 
-            Assert.IsTrue(cache.IsCachedZip(rAndS), "Module download successful");
+            Assert.IsTrue(cache.IsCached(rAndS), "Module download successful");
         }
 
     }

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -1051,10 +1051,12 @@ namespace Tests.Core.Relationships
                 modulesToRemove = new List<CkanModule>();
 
                 options.proceed_with_inconsistencies = false;
-                Assert.Throws<InconsistentKraken>(() =>
+                var exception = Assert.Throws<InconsistentKraken>(() =>
                 {
                     resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, null);
                 });
+                Assert.AreEqual($"{avp} conflicts with {eveDefaultConfig}",
+                                exception.ShortDescription);
 
                 // Scenario 2 - Try installing AVP, expect no exception for proceed_with_inconsistencies=true, but a conflict list
 
@@ -1064,7 +1066,10 @@ namespace Tests.Core.Relationships
                 {
                     resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, null);
                 });
-                CollectionAssert.AreEquivalent(new List<CkanModule> {avp, eveDefaultConfig}, resolver.ConflictList.Keys);
+                CollectionAssert.AreEquivalent(modulesToInstall,
+                                               resolver.ConflictList.Keys);
+                CollectionAssert.AreEquivalent(new List<string> {$"{avp} conflicts with {eveDefaultConfig}"},
+                                               resolver.ConflictList.Values);
 
                 // Scenario 3 - Try uninstalling eveDefaultConfig and installing avp, should work and result in no conflicts
 

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -23,7 +23,7 @@ namespace Tests.Core.Relationships
         [SetUp]
         public void Setup()
         {
-            options = RelationshipResolver.DefaultOpts();
+            options = RelationshipResolverOptions.DefaultOpts();
             generator = new RandomModuleGenerator(new Random(0451));
             //Sanity checker means even incorrect RelationshipResolver logic was passing
             options.without_enforce_consistency = true;
@@ -33,7 +33,7 @@ namespace Tests.Core.Relationships
         public void Constructor_WithoutModules_AlwaysReturns()
         {
             var registry = CKAN.Registry.Empty();
-            options = RelationshipResolver.DefaultOpts();
+            options = RelationshipResolverOptions.DefaultOpts();
             Assert.DoesNotThrow(() => new RelationshipResolver(new List<CkanModule>(),
                 null, options, registry, null));
         }
@@ -984,7 +984,7 @@ namespace Tests.Core.Relationships
                 CkanModule mod = generator.GeneratorRandomModule(depends: depends);
 
                 new RelationshipResolver(
-                    new CkanModule[] { mod }, null, RelationshipResolver.DefaultOpts(),
+                    new CkanModule[] { mod }, null, RelationshipResolverOptions.DefaultOpts(),
                     registry, new GameVersionCriteria(GameVersion.Parse("1.0.0")));
             }
         }

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -856,7 +856,7 @@ namespace Tests.Core.Relationships
         }
 
         [Test]
-        public void ReasonFor_WithModsNotInList_ThrowsArgumentException()
+        public void ReasonFor_WithModsNotInList_Empty()
         {
             var mod = generator.GeneratorRandomModule();
 
@@ -869,8 +869,8 @@ namespace Tests.Core.Relationships
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
 
                 var mod_not_in_resolver_list = generator.GeneratorRandomModule();
-                CollectionAssert.DoesNotContain(relationship_resolver.ModList(),mod_not_in_resolver_list);
-                Assert.Throws<ArgumentException>(() => relationship_resolver.ReasonsFor(mod_not_in_resolver_list));
+                CollectionAssert.DoesNotContain(relationship_resolver.ModList(), mod_not_in_resolver_list);
+                Assert.IsEmpty(relationship_resolver.ReasonsFor(mod_not_in_resolver_list));
             }
         }
 

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -996,7 +996,7 @@ namespace Tests.Core.Relationships
 
                 new RelationshipResolver(
                     new CkanModule[] { mod }, null, RelationshipResolver.DefaultOpts(),
-                    registry, new GameVersionCriteria (GameVersion.Parse("1.0.0")));
+                    registry, new GameVersionCriteria(GameVersion.Parse("1.0.0")));
             }
         }
 

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -34,7 +34,7 @@ namespace Tests.Core.Relationships
         {
             var registry = CKAN.Registry.Empty();
             options = RelationshipResolver.DefaultOpts();
-            Assert.DoesNotThrow(() => new RelationshipResolver(new List<string>(),
+            Assert.DoesNotThrow(() => new RelationshipResolver(new List<CkanModule>(),
                 null, options, registry, null));
         }
 
@@ -54,7 +54,7 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
 
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
 
@@ -83,7 +83,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -108,7 +108,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -133,7 +133,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -164,7 +164,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -189,7 +189,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -213,7 +213,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -237,7 +237,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -262,7 +262,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier, mod_b.identifier };
+                var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -295,22 +295,11 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_d.identifier };
+                var list = new List<CkanModule> { mod_d };
 
                 Assert.Throws<TooManyModsProvideKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
             }
-        }
-
-        [Test]
-        public void Constructor_WithMissingModules_Throws()
-        {
-            var mod_a = generator.GeneratorRandomModule();
-            var registry = CKAN.Registry.Empty();
-            var list = new List<string>() { mod_a.identifier };
-
-            Assert.Throws<ModuleNotFoundKraken>(() => new RelationshipResolver(
-                list, null, options, registry, null));
         }
 
         // Right now our RR always returns the modules it was provided. However
@@ -327,7 +316,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod_a.identifier };
+                var list = new List<CkanModule> { mod_a };
 
                 registry.Installed().Add(mod_a.identifier, mod_a.version);
 
@@ -353,7 +342,7 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 registry.Installed().Add(suggested.identifier, suggested.version);
-                var list = new List<string> { suggester.identifier };
+                var list = new List<CkanModule> { suggester };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
@@ -381,7 +370,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { suggester.identifier, mod.identifier };
+                var list = new List<CkanModule> { suggester, mod };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 CollectionAssert.DoesNotContain(relationship_resolver.ModList(), suggested);
@@ -408,7 +397,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier, conflicts_with_dependant.identifier };
+                var list = new List<CkanModule> { depender, conflicts_with_dependant };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -431,7 +420,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { suggester.identifier };
+                var list = new List<CkanModule> { suggester };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
@@ -462,7 +451,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { suggester.identifier };
+                var list = new List<CkanModule> { suggester };
 
                 options.with_all_suggests = true;
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
@@ -494,7 +483,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier };
+                var list = new List<CkanModule> { depender };
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
 
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
@@ -521,7 +510,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
 
                 Assert.Throws<DependencyNotSatisfiedKraken>(() =>
-                    new RelationshipResolver(new List<string> { depender.identifier },
+                    new RelationshipResolver(new List<CkanModule> { depender },
                                              null, options, registry, null));
             }
         }
@@ -547,7 +536,7 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
 
-                var list = new List<string> { depender.identifier };
+                var list = new List<CkanModule> { depender };
 
                 Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -571,11 +560,11 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string>() { depender.identifier };
+                var list = new List<CkanModule>() { depender };
 
                 Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
-                list.Add(dependant.identifier);
+                list.Add(dependant);
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
             }
@@ -598,7 +587,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier, dependant.identifier };
+                var list = new List<CkanModule> { depender, dependant };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -628,7 +617,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier, dependant.identifier };
+                var list = new List<CkanModule> { depender, dependant };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
                     list, null, options, registry, null));
@@ -656,7 +645,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier };
+                var list = new List<CkanModule> { depender };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
@@ -689,7 +678,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier };
+                var list = new List<CkanModule> { depender };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
@@ -722,7 +711,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier };
+                var list = new List<CkanModule> { depender };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
@@ -760,7 +749,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { depender.identifier };
+                var list = new List<CkanModule> { depender };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
@@ -876,7 +865,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod.identifier };
+                var list = new List<CkanModule> { mod };
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
 
                 var mod_not_in_resolver_list = generator.GeneratorRandomModule();
@@ -895,7 +884,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod.identifier };
+                var list = new List<CkanModule> { mod };
 
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
                 var reasons = relationship_resolver.ReasonsFor(mod);
@@ -917,7 +906,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod.identifier };
+                var list = new List<CkanModule> { mod };
 
                 options.with_all_suggests = true;
                 var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
@@ -954,7 +943,7 @@ namespace Tests.Core.Relationships
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<string> { mod.identifier };
+                var list = new List<CkanModule> { mod };
 
                 options.with_all_suggests = true;
                 options.with_recommends = true;

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -129,7 +129,7 @@ namespace Tests.Core.Relationships
             mods.Add(registry.LatestAvailable("CustomBiomes", null));
             Assert.Contains(
                 "CustomBiomesData",
-                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Value.ToString()).ToList(),
+                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Item2.ToString()).ToList(),
                 "Missing CustomBiomesData"
             );
 
@@ -141,7 +141,7 @@ namespace Tests.Core.Relationships
 
             Assert.Contains(
                 "CustomBiomes",
-                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Value.ToString()).ToList(),
+                CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc).Select(kvp => kvp.Item2.ToString()).ToList(),
                 "Missing CustomBiomes"
             );
         }

--- a/Tests/Data/TemporaryRepository.cs
+++ b/Tests/Data/TemporaryRepository.cs
@@ -11,7 +11,7 @@ using CKAN;
 namespace Tests.Data
 {
     /// <summary>
-    /// A disposable repository backed by an auto-created ZIP file
+    /// A disposable repository backed by an auto-created tar.gz file
     /// containing the given modules.
     /// Will be automatically cleaned up on falling out of using() scope.
     /// </summary>

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -32,7 +32,8 @@ namespace Tests.GUI
                 var registry = new Registry(repoData.Manager, repo.repo);
                 var ckan_mod = registry.GetModuleByVersion("kOS", "0.14");
 
-                var mod = new GUIMod(ckan_mod, repoData.Manager, registry, manager.CurrentInstance.VersionCriteria());
+                var mod = new GUIMod(ckan_mod, repoData.Manager, registry, manager.CurrentInstance.VersionCriteria(),
+                                     null, false, false);
                 Assert.False(mod.IsUpgradeChecked);
             }
         }
@@ -58,7 +59,8 @@ namespace Tests.GUI
 
                     registry.RegisterModule(old_version, Enumerable.Empty<string>(), null, false);
 
-                    var mod = new GUIMod(old_version, repoData.Manager, registry, tidy.KSP.VersionCriteria());
+                    var mod = new GUIMod(old_version, repoData.Manager, registry, tidy.KSP.VersionCriteria(),
+                                         null, false, false);
                     Assert.True(mod.HasUpdate);
                 }
             }
@@ -91,7 +93,8 @@ namespace Tests.GUI
                 CkanModule prevVersion = registry.GetModuleByVersion("OutOfOrderMod", "1.1.0");
 
                 // Act
-                GUIMod m = new GUIMod(mainVersion, repoData.Manager, registry, tidy.KSP.VersionCriteria(), false);
+                GUIMod m = new GUIMod(mainVersion, repoData.Manager, registry, tidy.KSP.VersionCriteria(),
+                                      null, false, false);
 
                 // Assert
                 Assert.AreEqual("1.4.2", m.GameCompatibilityVersion.ToString());

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -46,7 +46,8 @@ namespace Tests.GUI
 
                 var item = new ModList();
                 Assert.That(item.IsVisible(
-                    new GUIMod(ckan_mod, repoData.Manager, registry, manager.CurrentInstance.VersionCriteria()),
+                    new GUIMod(ckan_mod, repoData.Manager, registry, manager.CurrentInstance.VersionCriteria(),
+                               null, false, false),
                     manager.CurrentInstance.Name,
                     manager.CurrentInstance.game,
                     registry));
@@ -83,8 +84,10 @@ namespace Tests.GUI
                 var mod_list = main_mod_list.ConstructModList(
                     new List<GUIMod>
                     {
-                        new GUIMod(TestData.FireSpitterModule(), repoData.Manager, registry, manager.CurrentInstance.VersionCriteria()),
-                        new GUIMod(TestData.kOS_014_module(), repoData.Manager, registry, manager.CurrentInstance.VersionCriteria())
+                        new GUIMod(TestData.FireSpitterModule(), repoData.Manager, registry, manager.CurrentInstance.VersionCriteria(),
+                                   null, false, false),
+                        new GUIMod(TestData.kOS_014_module(), repoData.Manager, registry, manager.CurrentInstance.VersionCriteria(),
+                                   null, false, false)
                     },
                     manager.CurrentInstance.Name,
                     manager.CurrentInstance.game
@@ -182,7 +185,8 @@ namespace Tests.GUI
                 Assert.IsNotNull(modList);
 
                 var modules = repoData.Manager.GetAllAvailableModules(Enumerable.Repeat<Repository>(repo.repo, 1))
-                    .Select(mod => new GUIMod(mod.Latest(), repoData.Manager, registry, instance.KSP.VersionCriteria()))
+                    .Select(mod => new GUIMod(mod.Latest(), repoData.Manager, registry, instance.KSP.VersionCriteria(),
+                                              null, false, false))
                     .ToList();
 
                 listGui.Rows.AddRange(modList.ConstructModList(modules, null, instance.KSP.game).ToArray());


### PR DESCRIPTION
## Motivation

Somehow I found the documentation for Parallel LINQ and got excited:

- https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/introduction-to-plinq
- https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-create-and-execute-a-simple-plinq-query
- https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/understanding-speedup-in-plinq
- https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/custom-partitioners-for-plinq-and-tpl
- https://devblogs.microsoft.com/pfxteam/partitioning-in-plinq/
- https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/merge-options-in-plinq
- https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-specify-merge-options-in-plinq
- https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-write-a-custom-plinq-aggregate-function

Parallel processing is powerful but tricky, so it is nice to have a framework that takes care of the difficult parts for you. Some of the slower parts of CKAN happen to be what that documentation calls "delightfully parallel", so a survey of opportunities to apply PLINQ is in order.

## Problems

While working on this, I found several issues:

- CmdLine supports an `identifier=version` syntax for specifying , but even though neither ConsoleUI nor GUI nor NetKAN uses it, it's implemented in Core. This really belongs in CmdLine.
- `InconsistentKraken` uses a property called `InconsistenciesPretty` to return a text description of the problems it represents, meanwhile not even setting the `Exception.Message` property at all even though it serves the same purpose. When standard mechanisms like `Exception.Message` are available, we should use them rather than creating something redundant.
- `RelationshipResolver.ConflictList` included key-value pairs with the value set to null, which meant that when we tried to use it to generate a description of the conflicts, we got a spurious conflict with "an unmanaged DLL or DLC"
- If you select to install two mods that have conflicting dependencies, the mods' rows aren't highlighted. The conflict description text doesn't explain how the conflicting mods relate to your chosen mods, and it mentions each conflict twice, once as "A conflicts with B", followed by "B conflicts with A".
- If you select to install mods with conflicts, a description of the conflict appears in the status bar, but if you deselect them, it doesn't go away.
- If you choose to uninstall a mod that other mods depend on, it shows up in the changeset as "Requested by user", which is not strictly true.
- If you turn on the "Hide epochs" setting and then load recommendations for a changeset, then click a row to view the corresponding mod info, the Relationships tab will have a stop sign representing conflicts for every mod, because a parameter to `GUIMod` is missing and the `HideEpochs` setting is passed in the `incompatible` parameter.
- The new `suppress_recommendations` metadata property doesn't do anything for CmdLine. Arguably it should, especially given its behavior of automatically pulling in all recommendations by default.
- The recommendations tab unintentionally triggers the checkbox-changed event of its `ListView` for every row added while loading, running and re-running its conflicts check, which can take a long time for a large changeset. A similar problem happens when you click the checkbox at the lower-left; checkboxes are changed one by one, and conflicts are re-checked after _every_ such change.

## Changes

Each change is nicely split up into its own independent commit, which compiles and passes all tests.

- Since the first step in improving performance is always measurement, `Logging.WithTimeElapsed` is now a warpper around `System.Diagnostics.Stopwatch` for easily printing how long a particular piece of code takes to run. This was used to measure all parallelization changes to confirm that they improved performance.
  (The first thing I tried to parallelize was the test from #3914, which consistently ran **slower** instead. Figuring out the reasons for that was very helpful in getting familiar with PLINQ.)
- Now some of the loading of `Dictionary<string, T>` objects in `Registry` and `RepositoryData` is parallelized by a new `JsonParallelDictionaryConverter`. The actual loading from the file has to be done sequentially because of how disks work, but if we take a `JObject` as the output of that, we can turn the values of its properties into `AvailableModule` or `InstalledModule` objects in parallel. Preserving the progress bar updates during loading was tricky, but I ended up using a new `WithProgress` function to inject that capability into the PLINQ pipeline, and treating the `JObject` step and the parallelized step as about 50% each seemed to give the smoothest continuity.
- The Versions tab already used a background thread for loading its row colors, but it was only one thread and stil somewhat slow. Now it is fully parallelized courtesy of PLINQ.
- The `CompatibilitySorter` now performs its compatible-providers search, initial simple compatibility checks, and dependency checks in parallel.
- Creation of `GUIMod` objects from repo/registry data is now done in parallel
- Creation of grid rows from `GUIMod` objects is now done in parallel
- Filtering (setting `.Visible` property of) grid rows is now done in parallel
- The changeset sorting algorithm from #3667 is replaced with a more robust, less heuristic-based algorithm that's also faster thanks to being parallelized. To sum up, it treats the changeset as a graph (in the computer science sense) and assigns each mod in the changeset a number based on how many nodes (mods) can be visited by tracing a breadth-first search from dependency to depending mod, all the way to the user's original choices. This has many desirable properties, such as ensuring that dependencies always appear before their depending mods, putting ModuleManager at the very top, and handling dependency loops as well as they can be.
- Similar to the cached data deserialization, the loading of modules from `.tar.gz` files is also now parallelized. Again the file contents have to be loaded sequentially, but once that's done, we hand off to multiple threads to turn them into `CkanModule` objects.
- Now the recommendations tab loads much more quickly, partly due to being more parallelized and partly because it no longer checks every row for conflicts during loading.
- Since #2243 we have been validating ZIP files before storing them to the cache, but up till now we still validated cached ZIPs _again_ before installing. This takes quite a while for large ZIPs, and isn't necessary because ZIPs can't get into the cache without already being valid. It made some sense to leave it like this back then since people might still have had invalid files in the cache, but nowadays it's redundant. Now this extra re-validation is removed, which will speed up installs.
- Now all the supporting code for `identifier=syntax` is moved from Core to CmdLine. This relieves Core from the burden of providing it, and makes it easier to understand in the context where it applies. A test for the old code is removed, and tests for the new code are added.
- Now `InconsistentKraken.InconsistenciesPretty` is replaced by `Exception.Message`.
- Now `RelationshipResolver.ConflictList` returns the _user's choices_ as the keys of its pairs, so every mod that has a conflict or a conflicting dependency will be highlighted.
- Now `RelationshipResolver.ConflictDescriptions` is added to give a full, readable description of the conflicts.
  - Each conflict is shown once instead of twice.
  - When a conflicting mod is a dependency rather than chosen by the user, it has `(needed for: ModZ 1.1)` appended to it so the user can understand which mods brought the conflict into the changeset.
  - The conflict description disappears if you deselect the conflicting mods.
- Now if you remove a dependency, its depending mods say "Dependency removed" in the changeset
- Now the spurious stop signs in mod info are fixed, and the parameters that caused the confusion are no longer optional and so won't cause this again.
- Now dependencies with `suppress_recommendations` set to true in the metadata will also have their recommendations and suggestions skipped when installing via `ckan install modname`.
