### PR TITLE
Clean up Linux .desktop files

### DIFF
--- a/debian/ckan-cmdprompt.desktop
+++ b/debian/ckan-cmdprompt.desktop
@@ -2,7 +2,7 @@
 Name=CKAN Command Prompt
 Comment=Comprehensive Kerbal Archive Network Command Prompt
 Icon=/usr/share/icons/ckan.ico
-Categories=Game
+Categories=PackageManager;ConsoleOnly;
 Exec=/usr/bin/ckan prompt
 Terminal=true
 Type=Application

--- a/debian/ckan-cmdprompt.desktop
+++ b/debian/ckan-cmdprompt.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=CKAN Command Propmt
+Name=CKAN Command Prompt
 Comment=Comprehensive Kerbal Archive Network Command Prompt
 Icon=/usr/share/icons/ckan.ico
-Categories=Game;Utility
+Categories=Game
 Exec=/usr/bin/ckan prompt
 Terminal=true
 Type=Application

--- a/debian/ckan-consoleui.desktop
+++ b/debian/ckan-consoleui.desktop
@@ -2,7 +2,7 @@
 Name=CKAN Console UI
 Comment=Comprehensive Kerbal Archive Network Console UI
 Icon=/usr/share/icons/ckan.ico
-Categories=Game;Utility
+Categories=Game
 Exec=/usr/bin/ckan consoleui
 Terminal=true
 Type=Application

--- a/debian/ckan-consoleui.desktop
+++ b/debian/ckan-consoleui.desktop
@@ -2,7 +2,7 @@
 Name=CKAN Console UI
 Comment=Comprehensive Kerbal Archive Network Console UI
 Icon=/usr/share/icons/ckan.ico
-Categories=Game
+Categories=PackageManager;ConsoleOnly;
 Exec=/usr/bin/ckan consoleui
 Terminal=true
 Type=Application

--- a/debian/ckan.desktop
+++ b/debian/ckan.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=CKAN
-Comment=Comprehensive Kerbal Archive Network client
+Comment=Comprehensive Kerbal Archive Network Client
 Icon=/usr/share/icons/ckan.ico
-Categories=Game;Utility
+Categories=Game
 Exec=/usr/bin/ckan
 Terminal=false
 Type=Application

--- a/debian/ckan.desktop
+++ b/debian/ckan.desktop
@@ -2,7 +2,7 @@
 Name=CKAN
 Comment=Comprehensive Kerbal Archive Network Client
 Icon=/usr/share/icons/ckan.ico
-Categories=Game
+Categories=PackageManager;
 Exec=/usr/bin/ckan
 Terminal=false
 Type=Application


### PR DESCRIPTION
Fixed a typo in `debian/ckan-cmdprompt.desktop` ('propmt' -> 'prompt'), and remove all 3 .desktop files from `Utilities`.
If it's to go anywhere outside of `Games`, it would probably be better in `Database` or `Development`, I think.