### PR TITLE
Don't change language setting with scroll wheel

### DIFF
--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -563,6 +563,7 @@ namespace CKAN.GUI
             this.LanguageSelectionComboBox.TabIndex = 0;
             this.LanguageSelectionComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.LanguageSelectionComboBox.SelectionChangeCommitted += new System.EventHandler(this.LanguageSelectionComboBox_SelectionChanged);
+            this.LanguageSelectionComboBox.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.LanguageSelectionComboBox_MouseWheel);
             //
             // RefreshOnStartupCheckbox
             //

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -604,6 +604,15 @@ namespace CKAN.GUI
             Main.Instance.configuration.HideV = HideVCheckbox.Checked;
         }
 
+        private void LanguageSelectionComboBox_MouseWheel(object sender, MouseEventArgs e)
+        {
+            // Don't change values on scroll
+            if (e is HandledMouseEventArgs me)
+            {
+                me.Handled = true;
+            }
+        }
+
         private void LanguageSelectionComboBox_SelectionChanged(object sender, EventArgs e)
         {
             config.Language = LanguageSelectionComboBox.SelectedItem.ToString();


### PR DESCRIPTION
## Problem

For about 3 years now, we have had sporadic reports of the CKAN GUI using an unexpected language, initially Chinese, later French, occasionally other languages.

## Cause

Extensive, repeated audits of the code in search of bugs turned up a few leads that ultimately were dead ends. The code for defaulting the language initially, saving to/loading from disk, and the settings dialog are about as simple and robust as could be hoped, and we were not able to reproduce the problem with any imagined set of steps.

However, today a user shared a video that might explain what has been happening:

- [video](https://cdn.discordapp.com/attachments/601456752906469388/1175110199292469298/Settings_2023-11-17_17-26-29.mp4)

If the user thinks the dialog may be scrollable (many modern UIs hide the scrollbar until scrolling happens 😵‍💫), they may flick the mouse wheel to try to expose more settings. If the mouse cursor happens to be hovering over the language dropdown (a rare coincidence to be sure, but the reports of the problem have also been pretty rare), this changes its value, even without clicking it. This is the default behavior of comboboxes in WinForms, but it's unhelpful and surprising in this case.

## Changes

Now this dropdown has a handler for the `MouseWheel` event, which casts its `MouseEventArgs` argument to `HandledMouseEventArgs` in order to set `Handled = true`, which prevents the control from reacting to the mouse wheel. Appropriately, users will have to click to change the setting.

Yes, this is the documented way to access this API (!!):

https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.handledmouseeventargs?view=windowsdesktop-7.0#remarks

> HandledMouseEventArgs is not passed directly by MouseEventHandler when it handles the MouseWheel event. Rather, MouseEventHandler uses a MouseEventArgs, which you must cast to a HandledMouseEventArgs in order to cancel an occurrence of MouseWheel."

Fixes #3244. (Probably? We'll see if anyone reports it again after this fix goes public.)
