### PR TITLE
Modernize administrator and Mono version checks

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -7,7 +7,6 @@ using System;
 using System.Net;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -368,14 +367,5 @@ namespace CKAN.CmdLine
     public class NoGameInstanceKraken : Kraken
     {
         public NoGameInstanceKraken() { }
-    }
-
-    public class CmdLineUtil
-    {
-        public static uint GetUID()
-            => Platform.IsUnix || Platform.IsMac ? getuid() : 1;
-
-        [DllImport("libc")]
-        private static extern uint getuid();
     }
 }

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -127,11 +127,10 @@
   <data name="MainUnknownCommand" xml:space="preserve"><value>Unknown command, try --help</value></data>
   <data name="MainMissingInstance" xml:space="preserve"><value>I don't know where a game instance is installed.
 Use 'ckan instance help' for assistance in setting this.</value></data>
-  <data name="OptionsRootError" xml:space="preserve"><value>You are trying to run CKAN as root.
+  <data name="OptionsRootError" xml:space="preserve"><value>You are trying to run CKAN as an administrator user.
 This is a bad idea and there is absolutely no good reason to do it. Please run CKAN from a user account (or use --asroot if you are feeling brave).</value></data>
-  <data name="OptionsRootWarning" xml:space="preserve"><value>Warning: Running CKAN as root!</value></data>
-  <data name="OptionsMonoWarning" xml:space="preserve"><value>Warning. Detected mono runtime of {0} is less than the recommended version of {1}.
-Update recommended!</value></data>
+  <data name="OptionsRootWarning" xml:space="preserve"><value>Warning: CKAN is running as an administrator user!</value></data>
+  <data name="OptionsMonoWarning" xml:space="preserve"><value>Warning: Detected Mono {0}, recommended version is {1} or later!</value></data>
   <data name="OptionsInstanceAndGameDir" xml:space="preserve"><value>--instance and --gamedir can't be specified at the same time</value></data>
   <data name="OptionsInvalidInstance" xml:space="preserve"><value>Invalid game instance specified "{0}", use '--gamedir' to specify by path, or 'instance list' to see known game instances</value></data>
   <data name="InstanceNotInstance" xml:space="preserve"><value>Sorry, {0} does not appear to be a game instance</value></data>

--- a/Core/Extensions/RegexExtensions.cs
+++ b/Core/Extensions/RegexExtensions.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+
+namespace CKAN.Extensions
+{
+    public static class RegexExtensions
+    {
+        /// <summary>
+        /// Functional-friendly wrapper around Regex.Match
+        /// </summary>
+        /// <param name="regex">The regex to match</param>
+        /// <param name="value">The string to check</param>
+        /// <param name="match">Object representing the match, if any</param>
+        /// <returns>True if the regex matched the value, false otherwise</returns>
+        public static bool TryMatch(this Regex regex, string value, out Match match)
+        {
+            if (value == null)
+            {
+                // Nothing matches null
+                match = null;
+                return false;
+            }
+            match = regex.Match(value);
+            return match.Success;
+        }
+    }
+}

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 using log4net;


### PR DESCRIPTION
## Motivations

- CKAN has a check for whether the user is privileged and an `--asroot` flag to bypass this, but it's Linux-only. Windows users are just as likely to benefit from this guardrail. It's also implemented entirely within CmdLine, even though it could in principle apply more generally.
- There's a check that prints a warning if the user is on a version of Mono before 3.1.0, which duplicates platform-specific logic from Core in CmdLine, and I'm pretty sure you need a much newer version of Mono to run current CKAN
- `Platform.IsMonoFourOrLater` and `Platform.IsOnMonoFourOrLater` have been unused since #3041

## Changes

- Now the root user check is moved to `Platform.IsAdministrator()`
  - Now it has an `IsWindows` section that checks for administrator or system roles
  - Now the messages for the root user check are platform agnostic
  - I wanted to add an `--asadmin` alias for the `--asroot` flag, but I could not find a mechanism for that in the command line parser library, and I don't want to break existing scripts or shortcuts by changing it
- Now the duplicative Mono versioning logic from `Platform.IsOnMonoFourOrLater` and `CmdLine.Options.CheckMonoVersion` is moved to a `Platform.MonoVersion` field
  - Now the Mono warning is printed if they're on a version before 5.0.0 (stored in `Platform.RecommendedMonoVersion`), which is still pretty old but not as guaranteed ancient as 3.1.0
  - This uses a new `RegexExtensions.TryMatch` function to check a regex for a match and use its output within a functional-style expression
