### PR TITLE
Improve provides prompt usability, with bugfixes

### DIFF
--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -259,7 +259,9 @@ Please remove manually before trying to install it.</value></data>
   <data name="KrakenDependencyModuleNotFound" xml:space="preserve"><value>Module not found: {0} {1}</value></data>
   <data name="KrakenParentDependencyNotSatisfied" xml:space="preserve"><value>{0} dependency on {1} version {2} not satisfied</value></data>
   <data name="KrakenAny" xml:space="preserve"><value>(any)</value></data>
-  <data name="KrakenProvidedByMoreThanOne" xml:space="preserve"><value>Module {0} is provided by more than one available module. Please choose one of the following:</value></data>
+  <data name="KrakenProvidedByMoreThanOne" xml:space="preserve"><value>{1} requires {0}, which can be provided by multiple mods.
+
+Which {0} provider would you like to install?</value></data>
   <data name="KrakenInconsistenciesHeader" xml:space="preserve"><value>Inconsistencies were found:</value></data>
   <data name="KrakenMissingDependency" xml:space="preserve"><value>{0} missing dependency {1}</value></data>
   <data name="KrakenConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -326,14 +326,13 @@ namespace CKAN
                     // Oh no, too many to pick from!
                     if (options.without_toomanyprovides_kraken)
                     {
-                        if (options.get_recommenders)
+                        if (options.get_recommenders && !(reason is SelectionReason.Depends))
                         {
                             for (int i = 0; i < candidates.Count; ++i)
                             {
-                                var cand = candidates[i];
-                                Add(cand, reason is SelectionReason.Recommended rec
-                                              ? rec.WithIndex(i)
-                                              : reason);
+                                Add(candidates[i], reason is SelectionReason.Recommended rec
+                                                       ? rec.WithIndex(i)
+                                                       : reason);
                             }
                         }
                         continue;

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -347,15 +347,17 @@ namespace CKAN
                             .ToList();
                         if (provide.Count != 1)
                         {
-                            //We still have either nothing, or too many to pick from
-                            //Just throw the TMP now
-                            throw new TooManyModsProvideKraken(descriptor.ToString(), candidates, descriptor.choice_help_text);
+                            // We still have either nothing, or too many to pick from
+                            // Just throw the TMP now
+                            throw new TooManyModsProvideKraken(reason.Parent, descriptor.ToString(),
+                                                               candidates, descriptor.choice_help_text);
                         }
                         candidates[0] = provide.First();
                     }
                     else
                     {
-                        throw new TooManyModsProvideKraken(descriptor.ToString(), candidates, descriptor.choice_help_text);
+                        throw new TooManyModsProvideKraken(reason.Parent, descriptor.ToString(),
+                                                           candidates, descriptor.choice_help_text);
                     }
                 }
 

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -137,7 +137,7 @@ namespace CKAN
                     // If 'others' matches an identifier, it must also match the versions, else fail
                     if (rel.ContainsAny(others.Select(m => m.identifier)) && !rel.MatchesAny(others, null, null))
                     {
-                        log.DebugFormat("Unsatisfied dependency {0}, rejecting", rel);
+                        log.DebugFormat("Unsatisfied dependency {0}, rejecting {1}", rel, module);
                         return false;
                     }
                 }
@@ -151,7 +151,7 @@ namespace CKAN
                     // If any of the conflicts are present, fail
                     if (rel.MatchesAny(othersMinusSelf, null, null, out CkanModule matched))
                     {
-                        log.DebugFormat("Found conflict with {0}, rejecting", matched);
+                        log.DebugFormat("Found conflict with {0}, rejecting {1}", matched, module);
                         return false;
                     }
                 }
@@ -166,7 +166,7 @@ namespace CKAN
                     {
                         if (rel.MatchesAny(selfArray, null, null))
                         {
-                            log.DebugFormat("Found reverse conflict with {0}, rejecting", other);
+                            log.DebugFormat("Found reverse conflict with {0}, rejecting {1}", other, module);
                             return false;
                         }
                     }

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -176,18 +176,21 @@ namespace CKAN
 
     public class TooManyModsProvideKraken : Kraken
     {
+        public readonly CkanModule requester;
         public readonly List<CkanModule> modules;
         public readonly string requested;
         public readonly string choice_help_text;
 
-        public TooManyModsProvideKraken(string           requested,
+        public TooManyModsProvideKraken(CkanModule       requester,
+                                        string           requested,
                                         List<CkanModule> modules,
                                         string           choice_help_text = null,
                                         Exception        innerException   = null)
             : base(choice_help_text ?? string.Format(Properties.Resources.KrakenProvidedByMoreThanOne,
-                                                     requested),
+                                                     requested, requester.name),
                    innerException)
         {
+            this.requester        = requester;
             this.requested        = requested;
             this.modules          = modules;
             this.choice_help_text = choice_help_text;

--- a/GUI/Controls/ChooseProvidedMods.Designer.cs
+++ b/GUI/Controls/ChooseProvidedMods.Designer.cs
@@ -45,6 +45,7 @@ namespace CKAN.GUI
             this.ChooseProvidedModsLabel.Dock = System.Windows.Forms.DockStyle.Top;
             this.ChooseProvidedModsLabel.Location = new System.Drawing.Point(9, 18);
             this.ChooseProvidedModsLabel.Margin = new System.Windows.Forms.Padding(5,5,5,5);
+            this.ChooseProvidedModsLabel.Padding = new System.Windows.Forms.Padding(0, 10, 0, 10);
             this.ChooseProvidedModsLabel.Name = "ChooseProvidedModsLabel";
             this.ChooseProvidedModsLabel.Size = new System.Drawing.Size(490, 40);
             this.ChooseProvidedModsLabel.TabIndex = 0;

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -27,6 +27,8 @@ namespace CKAN.GUI
             Util.Invoke(this, () =>
             {
                 ChooseProvidedModsLabel.Text = message;
+                ChooseProvidedModsLabel.Height =
+                    Util.LabelStringHeight(CreateGraphics(), ChooseProvidedModsLabel);
 
                 ChooseProvidedModsListView.Items.Clear();
                 ChooseProvidedModsListView.Items.AddRange(modules
@@ -43,6 +45,12 @@ namespace CKAN.GUI
                 ChooseProvidedModsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
                 ChooseProvidedModsContinueButton.Enabled = false;
             });
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            ChooseProvidedModsLabel.Height = Util.LabelStringHeight(CreateGraphics(), ChooseProvidedModsLabel);
         }
 
         [ForbidGUICalls]

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -32,18 +32,19 @@ namespace CKAN.GUI
 
                 ChooseProvidedModsListView.Items.Clear();
                 ChooseProvidedModsListView.Items.AddRange(modules
-                    .Select(module => new ListViewItem(new string[]
+                    .Select((module, index) => new ListViewItem(new string[]
                     {
                         cache.DescribeAvailability(module),
                         module.@abstract
                     })
                     {
                         Tag     = module,
-                        Checked = false
+                        Checked = index == 0,
                     })
                     .ToArray());
                 ChooseProvidedModsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
-                ChooseProvidedModsContinueButton.Enabled = false;
+                ChooseProvidedModsContinueButton.Enabled =
+                    (ChooseProvidedModsListView.CheckedItems.Count > 0);
             });
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1193,6 +1193,9 @@ namespace CKAN.GUI
             Main.Instance.Wait.AddLogMessage(Properties.Resources.MainModListLoadingInstalled);
             var versionCriteria = Main.Instance.CurrentInstance.VersionCriteria();
 
+            var installed = registry.InstalledModules
+                                    .Select(im => im.Module)
+                                    .ToHashSet();
             var gui_mods = registry.InstalledModules
                                    .AsParallel()
                                    .Where(instMod => !instMod.Module.IsDLC)
@@ -1201,6 +1204,7 @@ namespace CKAN.GUI
                                                           Main.Instance.configuration.HideEpochs,
                                                           Main.Instance.configuration.HideV))
                                    .Concat(registry.CompatibleModules(versionCriteria)
+                                                   .Except(installed)
                                                    .AsParallel()
                                                    .Where(m => !m.IsDLC)
                                                    .Select(m => new GUIMod(
@@ -1208,6 +1212,7 @@ namespace CKAN.GUI
                                                                     Main.Instance.configuration.HideEpochs,
                                                                     Main.Instance.configuration.HideV)))
                                    .Concat(registry.IncompatibleModules(versionCriteria)
+                                                   .Except(installed)
                                                    .AsParallel()
                                                    .Where(m => !m.IsDLC)
                                                    .Select(m => new GUIMod(

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -271,6 +271,7 @@ namespace CKAN.GUI
                     {
                         // Prompt user to choose which mod to use
                         tabController.ShowTab("ChooseProvidedModsTabPage", 3);
+                        Util.Invoke(this, () => StatusProgress.Visible = false);
                         ChooseProvidedMods.LoadProviders(k.Message, k.modules, Manager.Cache);
                         tabController.SetTabLock(true);
                         CkanModule chosen = ChooseProvidedMods.Wait();
@@ -283,6 +284,7 @@ namespace CKAN.GUI
                             toInstall.Add(chosen);
                             // DON'T return so we can loop around and try the above InstallList call again
                             tabController.ShowTab("WaitTabPage");
+                            Util.Invoke(this, () => StatusProgress.Visible = true);
                         }
                         else
                         {


### PR DESCRIPTION
## Problems

- In current dev builds, an installed mod can show up as not installed in the mod list, which in turn can lead to unhandled exceptions if you try to "install" it, or even more confusing scenarios like a mod that looks like it isn't installed but can be upgraded (!)
- Also in current dev builds, installing Scatterer prompts regarding a recommendation for `BetterKerbol` via `TheKramsieChallengePlanetPack`, which doesn't make sense because you haven't selected to install that mod

Noticed while working on the below usability improvements for the provider choice prompt.

## Causes

- #3917 got too aggressive with parallelizing the mod list load. It generated two `GUIMod` object for each installed mod, one in the list of installed mods, and another in the list of compatible or incompatible mods. These were then merged together in parallel, which created a race condition that could cause the non-installed copy to take precedence over the installed one.
- #3917 also got too agressive in its optimization of #3892, checking _all_ of the provides choices and including their recommendations in the list

## Motivation

@JonnyOThan has reported that many users on the KSP Subreddit Discord struggle with the prompt to choose a providing mod:

![before screenshot](https://cdn.discordapp.com/attachments/601455398553387008/1179506793244786781/Desktop_Screenshot_2023.png?ex=657a084d&is=6567934d&hm=6a2947322c68c6ebe228903afa21d38707ac3b9bdd917a59c267787d06b00075&)

- The progress bar in the lower right makes it look like the window might still be busy when it's not
- The help text at the top doesn't explain why you landed here and is phrased in terms of "modules", which is programmer jargon rather than something a user would understand, and the "Please choose..." prompt is to the right of where they'd probably stop reading
- There's no easy way for a novice user to figure out the most common choice, since "Scatterer Sunflare" is almost at the bottom and its abstract doesn't call out that it's important
- 18 copies of the same abstract text for Kabrams

Apparently some people just sit there waiting for it to do something, before finally giving up and asking for help on the internet.

## Changes

- Now we exclude installed mods when generating `GUIMod`s for the compatible and incompatible mods, which allows these lists to be safely merged in parallel
- Now `RelationshipResolver` will only traverse all of the providers for recommendations and suggestions, so spurious recommendations-of-virtual-dependencies won't be pulled in
- Now the progress bar in the lower right is hidden while the user is selecting a provider
  (Side note, the test from #3914 prevented a bug here!)
- Now the default help text is phrased in terms the user is more likely to understand, with an explanation of which mod has the dependency and two line breaks before the part that presents the question they're supposed to answer
  (The custom help text from #3426 is not affected, so KSP-RO members can sleep comfortably.)
- Now the providing mods are sorted in descending order of download count (then by name), to make the most popular mods easy to find at the top of the list
- This might be controversial, but the top checkbox is now checked by default. Since that's the one with the highest download count, this will help novice users that just want to click "Continue" without reading anything while still allowing users with a preference to choose it.
- KSP-CKAN/NetKAN#9865 and KSP-CKAN/CKAN-meta#3211 have already improved the worst abstracts

After this, users should be able to get through this screen more easily.

![after screenshot](https://cdn.discordapp.com/attachments/601455398553387008/1180199309782827088/image.png?ex=657c8d42&is=656a1842&hm=cba823a4f296cdc75f462a837ff9ebf31f92392f54e83c281eee66a7f2ca8d49&)
