### PR TITLE
Better handling for DLC with missing readme.txt

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -964,10 +964,8 @@ namespace CKAN
                     installed_modules.Remove(identifier);
                 }
 
-                foreach (var kvp in dlcs)
+                foreach ((string identifier, ModuleVersion version) in dlcs)
                 {
-                    var identifier = kvp.Key;
-                    var version    = kvp.Value;
                     // Overwrite everything in case there are version differences
                     installed_modules[identifier] =
                         new InstalledModule(null,
@@ -980,7 +978,7 @@ namespace CKAN
                                     null,
                                     new List<string>() { "SQUAD" },
                                     new List<License>() { new License("restricted") },
-                                    version,
+                                    version ?? new UnmanagedModuleVersion(null),
                                     null,
                                     "dlc"),
                             Enumerable.Empty<string>(), false);

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -875,12 +875,7 @@ namespace CKAN
         public class Installed : SelectionReason
         {
             public override CkanModule Parent
-            {
-                get
-                {
-                    throw new Exception("Should never be called on Installed");
-                }
-            }
+                => throw new Exception("Should never be called on Installed");
 
             public override string ToString()
                 => Properties.Resources.RelationshipResolverInstalledReason;
@@ -889,12 +884,7 @@ namespace CKAN
         public class UserRequested : SelectionReason
         {
             public override CkanModule Parent
-            {
-                get
-                {
-                    throw new Exception("Should never be called on UserRequested");
-                }
-            }
+                => throw new Exception("Should never be called on UserRequested");
 
             public override string ToString()
                 => Properties.Resources.RelationshipResolverUserReason;

--- a/Tests/Core/Net/NetAsyncModulesDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloaderTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using log4net;
 using NUnit.Framework;
 
 using Tests.Data;
@@ -17,15 +16,12 @@ namespace Tests.Core.Net
     [TestFixture]
     public class NetAsyncModulesDownloaderTests
     {
-        private GameInstanceManager manager;
-        private RegistryManager registry_manager;
-        private CKAN.Registry            registry;
-        private DisposableKSP            ksp;
-        private IDownloader async;
-        private NetModuleCache           cache;
-        private TemporaryRepositoryData  repoData;
-
-        private static readonly ILog log = LogManager.GetLogger(typeof(NetAsyncModulesDownloaderTests));
+        private GameInstanceManager     manager;
+        private RegistryManager         registry_manager;
+        private CKAN.Registry           registry;
+        private DisposableKSP           ksp;
+        private NetModuleCache          cache;
+        private TemporaryRepositoryData repoData;
 
         [SetUp]
         public void Setup()
@@ -50,9 +46,6 @@ namespace Tests.Core.Net
             registry.Installed().Clear();
             // Make sure we have a registry we can use.
             registry.RepositoriesSet(repos);
-
-            // Ready our downloader.
-            async = new NetAsyncModulesDownloader(user, manager.Cache);
 
             // General shortcuts
             cache = manager.Cache;

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -184,6 +184,19 @@ namespace Tests.Core.Registry
         }
 
         [Test]
+        public void SetDLCs_NullVersion_DoesNotThrow()
+        {
+            var registry = CKAN.Registry.Empty();
+            Assert.DoesNotThrow(() =>
+            {
+                registry.SetDlcs(new Dictionary<string, ModuleVersion>
+                {
+                    { "MissingVersion", null },
+                });
+            }, "Missing readme.txt in a DLC shouldn't trigger an exception");
+        }
+
+        [Test]
         public void CompatibleModules_PastAndFutureCompatibility_ReturnsCurrentOnly()
         {
             // Arrange


### PR DESCRIPTION
## Problem

@JonnyOThan reported the following error with the current dev build:

```
Scanning for DLCs and manually installed modules...
MakingHistory-DLC missing required field version
Repository update failed!
```

## Cause

The DLC's folder was present, but its `readme.txt` file was absent. This caused its `CkanModule.version` property to be missing, which isn't allowed.

Originally this would have defaulted to `new UnmanagedModuleVersion(null)`, but this was lost in #3904's refactoring.

## Changes

Now we once again default to `new UnmanagedModuleVersion(null)`, as per previous releases. A new test exercises this case to make sure `Registry.SetDLCs` doesn't start throwing again.

I'll probably self-review this since it's small and a regression.
