### PR TITLE
Fix loading of legacy registry.json files

### DIFF
--- a/Core/Converters/JsonAlwaysEmptyObjectConverter.cs
+++ b/Core/Converters/JsonAlwaysEmptyObjectConverter.cs
@@ -12,7 +12,11 @@ namespace CKAN
     public class JsonAlwaysEmptyObjectConverter : JsonConverter
     {
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-            => Activator.CreateInstance(objectType);
+        {
+            // Read and discard this field's object (without this, loading stops!)
+            _ = JToken.Load(reader);
+            return Activator.CreateInstance(objectType);
+        }
 
         public override bool CanWrite => true;
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)


### PR DESCRIPTION
## Problem

If you install some mods with the current release of CKAN and then switch to the current dev build, it will show no mods installed.

Thanks to @JonnyOThan for reporting this on Discord.

## Cause

In #3904, we retired `Registry.available_modules` and `Registry.download_counts`. However, since the old client will crash if these are absent or null, we created a `JsonAlwaysEmptyObjectConverter` to ensure they're always saved as an empty JSON object (`{}`). This converter's deserialization function worked by simply creating an empty copy of the required type (`Dictionary<string, string>` in this case).

However, a `JsonConverter`'s `ReadJson` implementation **must** call `JToken.Load(reader)` to extract the current token from the input stream! We weren't doing that, and the parse was stopping right after that point, before `Registry.installed_modules` was deserialized. Maybe `Newtonsoft.Json` considers that an error condition?

This doesn't happen with a "new" registry because it doesn't call the converter when the JSON object is already empty (I think).

## Changes

Now `JsonAlwaysEmptyObjectConverter.ReadJson` calls `JToken.Load(reader)` and ignores its return value before it returns the empty dictionary.

I'll probably self-review this because it's small and a regression.
