### PR TITLE
Improve file deletion error while the game is running

### DIFF
--- a/ConsoleUI/Toolkit/ConsoleButton.cs
+++ b/ConsoleUI/Toolkit/ConsoleButton.cs
@@ -72,7 +72,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         {
             switch (k.Key) {
                 case ConsoleKey.Tab:
-                    Blur((k.Modifiers & ConsoleModifiers.Shift) == 0);
+                    Blur(!k.Modifiers.HasFlag(ConsoleModifiers.Shift));
                     break;
                 case ConsoleKey.Spacebar:
                 case ConsoleKey.Enter:

--- a/ConsoleUI/Toolkit/ConsoleField.cs
+++ b/ConsoleUI/Toolkit/ConsoleField.cs
@@ -107,7 +107,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                     }
                     break;
                 case ConsoleKey.Backspace:
-                    if ((k.Modifiers & ConsoleModifiers.Control) == 0) {
+                    if (!k.Modifiers.HasFlag(ConsoleModifiers.Control)) {
                         if (Position > 0) {
                             --Position;
                             Value = Value.Substring(0, Position) + Value.Substring(Position + 1);
@@ -121,9 +121,9 @@ namespace CKAN.ConsoleUI.Toolkit {
                     break;
                 case ConsoleKey.Delete:
                     if (Position < Value.Length) {
-                        Value = (k.Modifiers & ConsoleModifiers.Control) == 0
-                            ? Value.Substring(0, Position) + Value.Substring(Position + 1)
-                            : Value.Substring(0, Position);
+                        Value = k.Modifiers.HasFlag(ConsoleModifiers.Control)
+                            ? Value.Substring(0, Position)
+                            : Value.Substring(0, Position) + Value.Substring(Position + 1);
                         Changed();
                     }
                     break;
@@ -150,7 +150,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                     Position = Value.Length;
                     break;
                 case ConsoleKey.Tab:
-                    Blur((k.Modifiers & ConsoleModifiers.Shift) == 0);
+                    Blur(!k.Modifiers.HasFlag(ConsoleModifiers.Shift));
                     break;
                 default:
                     if (!char.IsControl(k.KeyChar)) {

--- a/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
@@ -196,9 +196,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         }
 
         private static bool isDir(FileSystemInfo fi)
-        {
-            return (fi.Attributes & FileAttributes.Directory) == FileAttributes.Directory;
-        }
+            => fi.Attributes.HasFlag(FileAttributes.Directory);
 
         /// <summary>
         /// Check whether two file system references are equal.

--- a/ConsoleUI/Toolkit/ConsoleListBox.cs
+++ b/ConsoleUI/Toolkit/ConsoleListBox.cs
@@ -242,14 +242,14 @@ namespace CKAN.ConsoleUI.Toolkit {
                     selectedRow = sortedFilteredData.Count - 1;
                     break;
                 case ConsoleKey.Tab:
-                    Blur((k.Modifiers & ConsoleModifiers.Shift) == 0);
+                    Blur(!k.Modifiers.HasFlag(ConsoleModifiers.Shift));
                     break;
                 default:
-                    // Go backwards if (k.Modifiers & ConsoleModifiers.Shift)
+                    // Go backwards if k.Modifiers.HasFlag(ConsoleModifiers.Shift)
                     if (!char.IsControl(k.KeyChar)
                             && (k.Modifiers | ConsoleModifiers.Shift) == ConsoleModifiers.Shift) {
 
-                        bool forward = (k.Modifiers & ConsoleModifiers.Shift) == 0;
+                        bool forward = !k.Modifiers.HasFlag(ConsoleModifiers.Shift);
                         Func<RowT, string> dfltRend = columns[defaultSortColumn].Renderer;
                         // Find first row after current, wrap
                         int startRow = forward

--- a/Core/Extensions/EnumExtensions.cs
+++ b/Core/Extensions/EnumExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Linq;
+
+namespace CKAN.Extensions
+{
+    public static class EnumExtensions
+    {
+
+        public static bool HasAnyFlag(this Enum val, params Enum[] flags)
+            => flags.Any(f => val.HasFlag(f));
+
+    }
+}

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -762,7 +762,7 @@ namespace CKAN
                         // explanation. – Kyle Trauberman Aug 30 '12 at 21:28
                         // (https://stackoverflow.com/questions/1395205/better-way-to-check-if-path-is-a-file-or-a-directory)
                         // This is the fastest way to do this test.
-                        if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
+                        if (attr.HasFlag(FileAttributes.Directory))
                         {
                             if (!directoriesToDelete.Contains(path))
                             {

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -153,7 +153,7 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="NetRepoLoadedDownloadCounts" xml:space="preserve"><value>Loaded download counts from {0} repository</value></data>
   <data name="JsonRelationshipConverterAnyOfCombined" xml:space="preserve"><value>`any_of` should not be combined with `{0}`</value></data>
   <data name="RegistryFileConflict" xml:space="preserve"><value>{0} wishes to install {1}, but this file is registered to {2}</value></data>
-  <data name="RegistryFileNotRemoved" xml:space="preserve"><value>{0} is registered to {1} but has not been removed!</value></data>
+  <data name="RegistryFileNotRemoved" xml:space="preserve"><value>Error unregistering {1}, file not removed: {0}</value></data>
   <data name="RegistryDefaultDLCAbstract" xml:space="preserve"><value>An official expansion pack</value></data>
   <data name="RegistryManagerDirectoryNotFound" xml:space="preserve"><value>Can't find a directory in {0}</value></data>
   <data name="RegistryManagerExportFilenamePrefix" xml:space="preserve"><value>installed</value></data>
@@ -263,6 +263,11 @@ Please remove manually before trying to install it.</value></data>
 
 Which {0} provider would you like to install?</value></data>
   <data name="KrakenInconsistenciesHeader" xml:space="preserve"><value>Inconsistencies were found:</value></data>
+  <data name="KrakenFailedToDeleteFiles" xml:space="preserve"><value>Unable to overwrite or delete files for {0}:
+
+{1}
+
+If the game is still running, close it and try again. Otherwise check the permissions.</value></data>
   <data name="KrakenMissingDependency" xml:space="preserve"><value>{0} missing dependency {1}</value></data>
   <data name="KrakenConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="KrakenDownloadErrorsHeader" xml:space="preserve"><value>Uh oh, the following things went wrong when downloading...</value></data>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Collections.Generic;
 
+using CKAN.Versioning;
+
 namespace CKAN
 {
     using modRelList = List<Tuple<CkanModule, RelationshipDescriptor, CkanModule>>;
@@ -223,6 +225,20 @@ namespace CKAN
             => Message + Environment.NewLine + Environment.NewLine + StackTrace;
 
         private readonly ICollection<string> inconsistencies;
+    }
+
+    public class FailedToDeleteFilesKraken : Kraken
+    {
+        public FailedToDeleteFilesKraken(string identifier, List<string> undeletableFiles)
+            : base(string.Format(Properties.Resources.KrakenFailedToDeleteFiles,
+                                 identifier,
+                                 string.Join(Environment.NewLine,
+                                             undeletableFiles.Select(f => f.Replace('/', Path.DirectorySeparatorChar)))))
+        {
+            this.undeletableFiles = undeletableFiles;
+        }
+
+        public readonly List<string> undeletableFiles;
     }
 
     /// <summary>
@@ -512,9 +528,9 @@ namespace CKAN
     /// </summary>
     public class WrongGameVersionKraken : Kraken
     {
-        public readonly Versioning.GameVersion version;
+        public readonly GameVersion version;
 
-        public WrongGameVersionKraken(Versioning.GameVersion version, string reason = null, Exception inner_exception = null)
+        public WrongGameVersionKraken(GameVersion version, string reason = null, Exception inner_exception = null)
             : base(reason, inner_exception)
         {
             this.version = version;

--- a/GUI/Controls/Changeset.Designer.cs
+++ b/GUI/Controls/Changeset.Designer.cs
@@ -34,6 +34,7 @@ namespace CKAN.GUI
             this.Mod = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ChangeType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.Reason = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.CloseTheGameLabel = new System.Windows.Forms.Label();
             this.BottomButtonPanel = new LeftRightRowPanel();
             this.ConfirmChangesButton = new System.Windows.Forms.Button();
             this.BackButton = new System.Windows.Forms.Button();
@@ -74,6 +75,19 @@ namespace CKAN.GUI
             //
             this.Reason.Width = 606;
             resources.ApplyResources(this.Reason, "Reason");
+            //
+            // CloseTheGameLabel
+            //
+            this.CloseTheGameLabel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.CloseTheGameLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 12, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Pixel);
+            this.CloseTheGameLabel.Location = new System.Drawing.Point(9, 18);
+            this.CloseTheGameLabel.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.CloseTheGameLabel.Padding = new System.Windows.Forms.Padding(0, 10, 0, 10);
+            this.CloseTheGameLabel.Name = "CloseTheGameLabel";
+            this.CloseTheGameLabel.Size = new System.Drawing.Size(490, 50);
+            this.CloseTheGameLabel.TabIndex = 0;
+            this.CloseTheGameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            resources.ApplyResources(this.CloseTheGameLabel, "CloseTheGameLabel");
             // 
             // BottomButtonPanel
             // 
@@ -123,9 +137,10 @@ namespace CKAN.GUI
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.Controls.Add(this.ChangesListView);
+            this.Controls.Add(this.CloseTheGameLabel);
             this.Controls.Add(this.BottomButtonPanel);
-            this.Margin = new System.Windows.Forms.Padding(0,0,0,0);
-            this.Padding = new System.Windows.Forms.Padding(0,0,0,0);
+            this.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
+            this.Padding = new System.Windows.Forms.Padding(0, 0, 0, 0);
             this.Name = "Changeset";
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
@@ -141,6 +156,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ColumnHeader Mod;
         private System.Windows.Forms.ColumnHeader ChangeType;
         private System.Windows.Forms.ColumnHeader Reason;
+        private System.Windows.Forms.Label CloseTheGameLabel;
         private LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Button BackButton;
         private System.Windows.Forms.Button CancelChangesButton;

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -30,7 +30,16 @@ namespace CKAN.GUI
             alertLabels    = AlertLabels;
             this.conflicts = conflicts;
             ConfirmChangesButton.Enabled = conflicts == null || !conflicts.Any();
+            CloseTheGameLabel.Visible = changeset != null
+                && changeset.Any(ch => DeletingChanges.Contains(ch.ChangeType));
         }
+
+        private static readonly HashSet<GUIModChangeType> DeletingChanges = new HashSet<GUIModChangeType>
+        {
+            GUIModChangeType.Remove,
+            GUIModChangeType.Update,
+            GUIModChangeType.Replace,
+        };
 
         protected override void OnVisibleChanged(EventArgs e)
         {

--- a/GUI/Controls/Changeset.resx
+++ b/GUI/Controls/Changeset.resx
@@ -120,6 +120,7 @@
   <data name="Mod.Text" xml:space="preserve"><value>Mod</value></data>
   <data name="ChangeType.Text" xml:space="preserve"><value>Change</value></data>
   <data name="Reason.Text" xml:space="preserve"><value>Reasons for action</value></data>
+  <data name="CloseTheGameLabel.Text" xml:space="preserve"><value>Note: To apply these changes, CKAN must overwrite or delete files. If the game is running, close it before continuing!</value></data>
   <data name="BackButton.Text" xml:space="preserve"><value>Back</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>Clear</value></data>
   <data name="ConfirmChangesButton.Text" xml:space="preserve"><value>Apply</value></data>

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -224,7 +224,7 @@ namespace CKAN.GUI
         private void RefreshToolButton_Click(object sender, EventArgs e)
         {
             // If user is holding Shift or Ctrl, force a full update
-            Main.Instance.UpdateRepo((ModifierKeys & (Keys.Control | Keys.Shift)) != 0);
+            Main.Instance.UpdateRepo(ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift));
         }
 
         #region Filter dropdown
@@ -345,74 +345,74 @@ namespace CKAN.GUI
         private void tagFilterButton_Click(object sender, EventArgs e)
         {
             var clicked = sender as ToolStripMenuItem;
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.Tag, clicked.Tag as ModuleTag, null), merge);
         }
 
         private void customFilterButton_Click(object sender, EventArgs e)
         {
             var clicked = sender as ToolStripMenuItem;
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null, clicked.Tag as ModuleLabel), merge);
         }
 
         private void FilterCompatibleButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.Compatible), merge);
         }
 
         private void FilterInstalledButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.Installed), merge);
         }
 
         private void FilterInstalledUpdateButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.InstalledUpdateAvailable), merge);
         }
 
         private void FilterReplaceableButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.Replaceable), merge);
         }
 
         private void FilterCachedButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.Cached), merge);
         }
 
         private void FilterUncachedButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.Uncached), merge);
         }
 
         private void FilterNewButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.NewInRepository), merge);
         }
 
         private void FilterNotInstalledButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.NotInstalled), merge);
         }
 
         private void FilterIncompatibleButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.Incompatible), merge);
         }
 
         private void FilterAllButton_Click(object sender, EventArgs e)
         {
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             Filter(ModList.FilterToSavedSearch(GUIModFilter.All), merge);
         }
 
@@ -579,7 +579,7 @@ namespace CKAN.GUI
             // Left click -> sort by new column / change sorting direction.
             if (e.Button == MouseButtons.Left)
             {
-                if ((ModifierKeys & Keys.Shift) == Keys.Shift)
+                if (ModifierKeys.HasFlag(Keys.Shift))
                 {
                     AddSort(ModGrid.Columns[e.ColumnIndex]);
                 }

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -9,6 +9,7 @@ using System.Runtime.Versioning;
 using Autofac;
 
 using CKAN.Versioning;
+using CKAN.Extensions;
 
 namespace CKAN.GUI
 {
@@ -204,7 +205,7 @@ namespace CKAN.GUI
         private void TagLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             var link = sender as LinkLabel;
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             OnChangeFilter?.Invoke(
                 ModList.FilterToSavedSearch(GUIModFilter.Tag, link.Tag as ModuleTag, null),
                 merge);
@@ -213,7 +214,7 @@ namespace CKAN.GUI
         private void LabelLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             var link = sender as LinkLabel;
-            var merge = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             OnChangeFilter?.Invoke(
                 ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null, link.Tag as ModuleLabel),
                 merge);

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Runtime.Versioning;
 #endif
 
+using CKAN.Extensions;
+
 namespace CKAN.GUI
 {
     #if NET5_0_OR_GREATER
@@ -119,7 +121,7 @@ namespace CKAN.GUI
         {
             var link   = sender as LinkLabel;
             var author = link.Text;
-            var merge  = (ModifierKeys & (Keys.Control | Keys.Shift)) != 0;
+            var merge  = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
             OnChangeFilter?.Invoke(
                 new SavedSearch()
                 {

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -111,7 +111,7 @@ namespace CKAN.GUI
                 ReverseRelationshipsCheckbox.CheckState == CheckState.Unchecked
                     // If user holds ctrl or shift, go to "sticky" indeterminate state,
                     // else normal checked
-                    ? (ModifierKeys & (Keys.Control | Keys.Shift)) != 0
+                    ? ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift)
                         ? CheckState.Indeterminate
                         : CheckState.Checked
                     : CheckState.Unchecked;


### PR DESCRIPTION
## Motivation

When you launch KSP1 on Windows, it locks either many or all of the mods' files. If you then try to uninstall those mods with CKAN while the game is still running, you get a hard to understand message that mentions the file but gives no information about why the problem happened or what you can do about it:

![before](https://cdn.discordapp.com/attachments/601455398553387008/1181720350162178099/image.png?ex=658215d6&is=656fa0d6&hm=90727ee22ef1df53515cf9c6cd0f1bf8db76583e6da5be9564247c60d26fa300&)

Brought up by @JonnyOThan on Discord.

## Changes

- Now the message is reformatted to be more understandable:
  > Unable to overwrite or delete files for MyMod:
  >
  > GameData\MyMod\MyMod.dll
  >
  > If the game is still running, close it and try again. Otherwise check the permissions.
  - The top line states simply that we were trying to delete files and could not
  - The bottom line says to close the game and check permissions
  - The file list is now relative to game root and uses local OS path separators (backslash on Windows)
- Now the changeset warns the user to close the game before applying changes that involve deletion:
  ![changeset after](https://cdn.discordapp.com/attachments/601455398553387008/1181746049707151431/image.png?ex=65822dc6&is=656fb8c6&hm=59251697600790c24ecc0b6d098efda0150f027150726be42df553090445d5fd&)
- At some point, .NET added an `Enum.HasFlag()` function for checking flag-style enums; previously you had to use bitwise AND and a comparison. Now we use the new function.
