### PR TITLE
Search by supports relationship and other search improvements

### DIFF
--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -45,7 +45,8 @@ namespace CKAN.Games
         string[]          BuildIDFiles { get; }
 
         // How to get metadata
-        Uri DefaultRepositoryURL { get; }
-        Uri RepositoryListURL    { get; }
+        Uri DefaultRepositoryURL  { get; }
+        Uri RepositoryListURL     { get; }
+        Uri MetadataBugtrackerURL { get; }
     }
 }

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -264,6 +264,8 @@ namespace CKAN.Games.KerbalSpaceProgram
 
         public Uri RepositoryListURL => new Uri("https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/repositories.json");
 
+        public Uri MetadataBugtrackerURL => new Uri("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
+
         private string Missions(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(inst.GameDir(), "Missions"));
 

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -218,6 +218,8 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public Uri RepositoryListURL => new Uri("https://raw.githubusercontent.com/KSP-CKAN/KSP2-CKAN-meta/main/repositories.json");
 
+        public Uri MetadataBugtrackerURL => new Uri("https://github.com/KSP-CKAN/KSP2-NetKAN/issues/new/choose");
+
         // Key: Allowed value of install_to
         // Value: Relative path
         // (PrimaryModDirectoryRelative is allowed implicitly)

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -178,7 +178,7 @@ namespace CKAN.GUI
             SearchDetails.Visible = expanded;
             if (SearchDetails.Visible)
             {
-                SearchDetails.FilterByNameTextBox.Focus();
+                SearchDetails.SetFocus();
                 if (Main.Instance != null)
                 {
                     Main.Instance.Move   += FormGeometryChanged;
@@ -207,41 +207,8 @@ namespace CKAN.GUI
         private void SearchToEditor()
         {
             suppressSearch = true;
-                SearchDetails.FilterByNameTextBox.Text        = currentSearch?.Name
-                                                                    ?? "";
-                SearchDetails.FilterByAuthorTextBox.Text      = currentSearch?.Authors.Aggregate("", CombinePieces)
-                                                                    ?? "";
-                SearchDetails.FilterByDescriptionTextBox.Text = currentSearch?.Description
-                                                                    ?? "";
-                SearchDetails.FilterByLanguageTextBox.Text    = currentSearch?.Localizations.Aggregate("", CombinePieces)
-                                                                    ?? "";
-                SearchDetails.FilterByDependsTextBox.Text     = currentSearch?.DependsOn.Aggregate("", CombinePieces)
-                                                                    ?? "";
-                SearchDetails.FilterByRecommendsTextBox.Text  = currentSearch?.Recommends.Aggregate("", CombinePieces)
-                                                                    ?? "";
-                SearchDetails.FilterByConflictsTextBox.Text   = currentSearch?.ConflictsWith.Aggregate("", CombinePieces)
-                                                                    ?? "";
-                SearchDetails.FilterBySuggestsTextBox.Text    = currentSearch?.Suggests.Aggregate("", CombinePieces)
-                                                                    ?? "";
-                SearchDetails.FilterByTagsTextBox.Text        = currentSearch?.TagNames.Aggregate("", CombinePieces)
-                                                                    ?? "";
-                SearchDetails.FilterByLabelsTextBox.Text      = currentSearch?.Labels
-                                                                    .Select(lb => lb.Name)
-                                                                    .Aggregate("", CombinePieces)
-                                                                    ?? "";
-
-                SearchDetails.CompatibleToggle.Value      = currentSearch?.Compatible;
-                SearchDetails.InstalledToggle.Value       = currentSearch?.Installed;
-                SearchDetails.CachedToggle.Value          = currentSearch?.Cached;
-                SearchDetails.NewlyCompatibleToggle.Value = currentSearch?.NewlyCompatible;
-                SearchDetails.UpgradeableToggle.Value     = currentSearch?.Upgradeable;
-                SearchDetails.ReplaceableToggle.Value     = currentSearch?.Replaceable;
+            SearchDetails.PopulateSearch(currentSearch);
             suppressSearch = false;
-        }
-
-        private static string CombinePieces(string joined, string piece)
-        {
-            return string.IsNullOrEmpty(joined) ? piece : $"{joined} {piece}";
         }
 
         private void SearchDetails_ApplySearch(object sender, EventArgs e)
@@ -251,29 +218,7 @@ namespace CKAN.GUI
                 return;
             }
 
-            var knownLabels = Main.Instance.ManageMods.mainModList.ModuleLabels.LabelsFor(Main.Instance.CurrentInstance.Name).ToList();
-
-            currentSearch = new ModSearch(
-                SearchDetails.FilterByNameTextBox.Text,
-                SearchDetails.FilterByAuthorTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                SearchDetails.FilterByDescriptionTextBox.Text,
-                SearchDetails.FilterByLanguageTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                SearchDetails.FilterByDependsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                SearchDetails.FilterByRecommendsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                SearchDetails.FilterBySuggestsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                SearchDetails.FilterByConflictsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                SearchDetails.FilterByTagsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                SearchDetails.FilterByLabelsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries)
-                    .Select(ln => knownLabels.FirstOrDefault(lb => lb.Name == ln))
-                    .Where(lb => lb != null)
-                    .ToList(),
-                SearchDetails.CompatibleToggle.Value,
-                SearchDetails.InstalledToggle.Value,
-                SearchDetails.CachedToggle.Value,
-                SearchDetails.NewlyCompatibleToggle.Value,
-                SearchDetails.UpgradeableToggle.Value,
-                SearchDetails.ReplaceableToggle.Value
-            );
+            currentSearch = SearchDetails.CurrentSearch();
             suppressSearch = true;
                 FilterCombinedTextBox.Text = currentSearch?.Combined ?? "";
             suppressSearch = false;

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -88,6 +88,29 @@ namespace CKAN.GUI
             }
         }
 
+        public void CloseSearch(Point screenCoords)
+        {
+            // Treat the entire main window as an uncheck button, and let
+            // the actual checkbox handle unchecking itself
+            var bounds = new Rectangle(ExpandButton.PointToScreen(new Point(0, 0)),
+                                       ExpandButton.Size);
+            if (!bounds.Contains(screenCoords))
+            {
+                ExpandButton.Checked = false;
+            }
+        }
+
+        public void ParentMoved()
+        {
+            FormGeometryChanged();
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            FormGeometryChanged();
+        }
+
         private bool suppressSearch = false;
         private ModSearch currentSearch = null;
 
@@ -174,25 +197,15 @@ namespace CKAN.GUI
 
         private void DoLayout(bool expanded)
         {
-            FormGeometryChanged(null, null);
+            FormGeometryChanged();
             SearchDetails.Visible = expanded;
             if (SearchDetails.Visible)
             {
                 SearchDetails.SetFocus();
-                if (Main.Instance != null)
-                {
-                    Main.Instance.Move   += FormGeometryChanged;
-                    Resize += FormGeometryChanged;
-                }
-            }
-            else if (Main.Instance != null)
-            {
-                Main.Instance.Move   -= FormGeometryChanged;
-                Resize -= FormGeometryChanged;
             }
         }
 
-        private void FormGeometryChanged(object sender, EventArgs e)
+        private void FormGeometryChanged()
         {
             SearchDetails.Location = PointToScreen(new Point(
                 FilterCombinedTextBox.Left,

--- a/GUI/Controls/EditModSearchDetails.Designer.cs
+++ b/GUI/Controls/EditModSearchDetails.Designer.cs
@@ -46,6 +46,8 @@ namespace CKAN.GUI
             this.FilterBySuggestsTextBox = new CKAN.GUI.HintTextBox();
             this.FilterByConflictsLabel = new System.Windows.Forms.Label();
             this.FilterByConflictsTextBox = new CKAN.GUI.HintTextBox();
+            this.FilterBySupportsLabel = new System.Windows.Forms.Label();
+            this.FilterBySupportsTextBox = new CKAN.GUI.HintTextBox();
             this.FilterByTagsLabel = new System.Windows.Forms.Label();
             this.FilterByTagsTextBox = new CKAN.GUI.HintTextBox();
             this.FilterByLabelsLabel = new System.Windows.Forms.Label();
@@ -256,11 +258,35 @@ namespace CKAN.GUI
             this.FilterByConflictsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
             resources.ApplyResources(this.FilterByConflictsTextBox, "FilterByConflictsTextBox");
             //
+            // FilterBySupportsLabel
+            //
+            this.FilterBySupportsLabel.AutoSize = true;
+            this.FilterBySupportsLabel.BackColor = System.Drawing.Color.Transparent;
+            this.FilterBySupportsLabel.Location = new System.Drawing.Point(6, 217);
+            this.FilterBySupportsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FilterBySupportsLabel.Name = "FilterBySupportsLabel";
+            this.FilterBySupportsLabel.Size = new System.Drawing.Size(149, 20);
+            this.FilterBySupportsLabel.TabIndex = 14;
+            resources.ApplyResources(this.FilterBySupportsLabel, "FilterBySupportsLabel");
+            //
+            // FilterBySupportsTextBox
+            //
+            this.FilterBySupportsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
+            this.FilterBySupportsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.FilterBySupportsTextBox.Location = new System.Drawing.Point(130, 215);
+            this.FilterBySupportsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.FilterBySupportsTextBox.Name = "FilterBySupportsTextBox";
+            this.FilterBySupportsTextBox.Size = new System.Drawing.Size(160, 26);
+            this.FilterBySupportsTextBox.TabIndex = 15;
+            this.FilterBySupportsTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
+            this.FilterBySupportsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FilterTextBox_KeyDown);
+            resources.ApplyResources(this.FilterBySupportsTextBox, "FilterBySupportsTextBox");
+            //
             // FilterByTagsLabel
             //
             this.FilterByTagsLabel.AutoSize = true;
             this.FilterByTagsLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByTagsLabel.Location = new System.Drawing.Point(6, 217);
+            this.FilterByTagsLabel.Location = new System.Drawing.Point(6, 243);
             this.FilterByTagsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.FilterByTagsLabel.Name = "FilterByTagsLabel";
             this.FilterByTagsLabel.Size = new System.Drawing.Size(149, 20);
@@ -271,7 +297,7 @@ namespace CKAN.GUI
             //
             this.FilterByTagsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByTagsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByTagsTextBox.Location = new System.Drawing.Point(130, 215);
+            this.FilterByTagsTextBox.Location = new System.Drawing.Point(130, 241);
             this.FilterByTagsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByTagsTextBox.Name = "FilterByTagsTextBox";
             this.FilterByTagsTextBox.Size = new System.Drawing.Size(160, 26);
@@ -284,7 +310,7 @@ namespace CKAN.GUI
             //
             this.FilterByLabelsLabel.AutoSize = true;
             this.FilterByLabelsLabel.BackColor = System.Drawing.Color.Transparent;
-            this.FilterByLabelsLabel.Location = new System.Drawing.Point(6, 243);
+            this.FilterByLabelsLabel.Location = new System.Drawing.Point(6, 269);
             this.FilterByLabelsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.FilterByLabelsLabel.Name = "FilterByLabelsLabel";
             this.FilterByLabelsLabel.Size = new System.Drawing.Size(149, 20);
@@ -295,7 +321,7 @@ namespace CKAN.GUI
             //
             this.FilterByLabelsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right));
             this.FilterByLabelsTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.FilterByLabelsTextBox.Location = new System.Drawing.Point(130, 241);
+            this.FilterByLabelsTextBox.Location = new System.Drawing.Point(130, 267);
             this.FilterByLabelsTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.FilterByLabelsTextBox.Name = "FilterByLabelsTextBox";
             this.FilterByLabelsTextBox.Size = new System.Drawing.Size(160, 26);
@@ -308,7 +334,7 @@ namespace CKAN.GUI
             //
             this.CompatibleLabel.AutoSize = true;
             this.CompatibleLabel.BackColor = System.Drawing.Color.Transparent;
-            this.CompatibleLabel.Location = new System.Drawing.Point(6, 269);
+            this.CompatibleLabel.Location = new System.Drawing.Point(6, 295);
             this.CompatibleLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.CompatibleLabel.Name = "CompatibleLabel";
             this.CompatibleLabel.Size = new System.Drawing.Size(149, 20);
@@ -317,14 +343,14 @@ namespace CKAN.GUI
             //
             // CompatibleToggle
             //
-            this.CompatibleToggle.Location = new System.Drawing.Point(130, 267);
+            this.CompatibleToggle.Location = new System.Drawing.Point(130, 293);
             this.CompatibleToggle.Changed += TriStateChanged;
             //
             // InstalledLabel
             //
             this.InstalledLabel.AutoSize = true;
             this.InstalledLabel.BackColor = System.Drawing.Color.Transparent;
-            this.InstalledLabel.Location = new System.Drawing.Point(6, 295);
+            this.InstalledLabel.Location = new System.Drawing.Point(6, 321);
             this.InstalledLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.InstalledLabel.Name = "InstalledLabel";
             this.InstalledLabel.Size = new System.Drawing.Size(149, 20);
@@ -333,14 +359,14 @@ namespace CKAN.GUI
             //
             // InstalledToggle
             //
-            this.InstalledToggle.Location = new System.Drawing.Point(130, 293);
+            this.InstalledToggle.Location = new System.Drawing.Point(130, 319);
             this.InstalledToggle.Changed += TriStateChanged;
             //
             // CachedLabel
             //
             this.CachedLabel.AutoSize = true;
             this.CachedLabel.BackColor = System.Drawing.Color.Transparent;
-            this.CachedLabel.Location = new System.Drawing.Point(6, 321);
+            this.CachedLabel.Location = new System.Drawing.Point(6, 347);
             this.CachedLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.CachedLabel.Name = "CachedLabel";
             this.CachedLabel.Size = new System.Drawing.Size(149, 20);
@@ -349,14 +375,14 @@ namespace CKAN.GUI
             //
             // CachedToggle
             //
-            this.CachedToggle.Location = new System.Drawing.Point(130, 319);
+            this.CachedToggle.Location = new System.Drawing.Point(130, 345);
             this.CachedToggle.Changed += TriStateChanged;
             //
             // NewlyCompatibleLabel
             //
             this.NewlyCompatibleLabel.AutoSize = true;
             this.NewlyCompatibleLabel.BackColor = System.Drawing.Color.Transparent;
-            this.NewlyCompatibleLabel.Location = new System.Drawing.Point(6, 347);
+            this.NewlyCompatibleLabel.Location = new System.Drawing.Point(6, 373);
             this.NewlyCompatibleLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.NewlyCompatibleLabel.Name = "NewlyCompatibleLabel";
             this.NewlyCompatibleLabel.Size = new System.Drawing.Size(149, 20);
@@ -365,14 +391,14 @@ namespace CKAN.GUI
             //
             // NewlyCompatibleToggle
             //
-            this.NewlyCompatibleToggle.Location = new System.Drawing.Point(130, 345);
+            this.NewlyCompatibleToggle.Location = new System.Drawing.Point(130, 371);
             this.NewlyCompatibleToggle.Changed += TriStateChanged;
             //
             // UpgradeableLabel
             //
             this.UpgradeableLabel.AutoSize = true;
             this.UpgradeableLabel.BackColor = System.Drawing.Color.Transparent;
-            this.UpgradeableLabel.Location = new System.Drawing.Point(6, 373);
+            this.UpgradeableLabel.Location = new System.Drawing.Point(6, 399);
             this.UpgradeableLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.UpgradeableLabel.Name = "UpgradeableLabel";
             this.UpgradeableLabel.Size = new System.Drawing.Size(149, 20);
@@ -381,14 +407,14 @@ namespace CKAN.GUI
             //
             // UpgradeableToggle
             //
-            this.UpgradeableToggle.Location = new System.Drawing.Point(130, 371);
+            this.UpgradeableToggle.Location = new System.Drawing.Point(130, 397);
             this.UpgradeableToggle.Changed += TriStateChanged;
             //
             // ReplaceableLabel
             //
             this.ReplaceableLabel.AutoSize = true;
             this.ReplaceableLabel.BackColor = System.Drawing.Color.Transparent;
-            this.ReplaceableLabel.Location = new System.Drawing.Point(6, 399);
+            this.ReplaceableLabel.Location = new System.Drawing.Point(6, 425);
             this.ReplaceableLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ReplaceableLabel.Name = "ReplaceableLabel";
             this.ReplaceableLabel.Size = new System.Drawing.Size(149, 20);
@@ -397,7 +423,7 @@ namespace CKAN.GUI
             //
             // ReplaceableToggle
             //
-            this.ReplaceableToggle.Location = new System.Drawing.Point(130, 397);
+            this.ReplaceableToggle.Location = new System.Drawing.Point(130, 423);
             this.ReplaceableToggle.Changed += TriStateChanged;
             //
             // EditModSearchDetails
@@ -421,6 +447,8 @@ namespace CKAN.GUI
             this.Controls.Add(this.FilterBySuggestsTextBox);
             this.Controls.Add(this.FilterByConflictsLabel);
             this.Controls.Add(this.FilterByConflictsTextBox);
+            this.Controls.Add(this.FilterBySupportsLabel);
+            this.Controls.Add(this.FilterBySupportsTextBox);
             this.Controls.Add(this.FilterByTagsLabel);
             this.Controls.Add(this.FilterByTagsTextBox);
             this.Controls.Add(this.FilterByLabelsLabel);
@@ -438,7 +466,7 @@ namespace CKAN.GUI
             this.Controls.Add(this.ReplaceableLabel);
             this.Controls.Add(this.ReplaceableToggle);
             this.Name = "EditModSearchDetails";
-            this.Size = new System.Drawing.Size(300, 434);
+            this.Size = new System.Drawing.Size(300, 460);
             resources.ApplyResources(this, "$this");
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -463,6 +491,8 @@ namespace CKAN.GUI
         private CKAN.GUI.HintTextBox FilterBySuggestsTextBox;
         private System.Windows.Forms.Label FilterByConflictsLabel;
         private CKAN.GUI.HintTextBox FilterByConflictsTextBox;
+        private System.Windows.Forms.Label FilterBySupportsLabel;
+        private CKAN.GUI.HintTextBox FilterBySupportsTextBox;
         private System.Windows.Forms.Label FilterByTagsLabel;
         private CKAN.GUI.HintTextBox FilterByTagsTextBox;
         private System.Windows.Forms.Label FilterByLabelsLabel;

--- a/GUI/Controls/EditModSearchDetails.Designer.cs
+++ b/GUI/Controls/EditModSearchDetails.Designer.cs
@@ -448,36 +448,36 @@ namespace CKAN.GUI
         #endregion
 
         private System.Windows.Forms.Label FilterByNameLabel;
-        internal CKAN.GUI.HintTextBox FilterByNameTextBox;
+        private CKAN.GUI.HintTextBox FilterByNameTextBox;
         private System.Windows.Forms.Label FilterByAuthorLabel;
-        internal CKAN.GUI.HintTextBox FilterByAuthorTextBox;
+        private CKAN.GUI.HintTextBox FilterByAuthorTextBox;
         private System.Windows.Forms.Label FilterByDescriptionLabel;
-        internal CKAN.GUI.HintTextBox FilterByDescriptionTextBox;
+        private CKAN.GUI.HintTextBox FilterByDescriptionTextBox;
         private System.Windows.Forms.Label FilterByLanguageLabel;
-        internal CKAN.GUI.HintTextBox FilterByLanguageTextBox;
+        private CKAN.GUI.HintTextBox FilterByLanguageTextBox;
         private System.Windows.Forms.Label FilterByDependsLabel;
-        internal CKAN.GUI.HintTextBox FilterByDependsTextBox;
+        private CKAN.GUI.HintTextBox FilterByDependsTextBox;
         private System.Windows.Forms.Label FilterByRecommendsLabel;
-        internal CKAN.GUI.HintTextBox FilterByRecommendsTextBox;
+        private CKAN.GUI.HintTextBox FilterByRecommendsTextBox;
         private System.Windows.Forms.Label FilterBySuggestsLabel;
-        internal CKAN.GUI.HintTextBox FilterBySuggestsTextBox;
+        private CKAN.GUI.HintTextBox FilterBySuggestsTextBox;
         private System.Windows.Forms.Label FilterByConflictsLabel;
-        internal CKAN.GUI.HintTextBox FilterByConflictsTextBox;
+        private CKAN.GUI.HintTextBox FilterByConflictsTextBox;
         private System.Windows.Forms.Label FilterByTagsLabel;
-        internal CKAN.GUI.HintTextBox FilterByTagsTextBox;
+        private CKAN.GUI.HintTextBox FilterByTagsTextBox;
         private System.Windows.Forms.Label FilterByLabelsLabel;
-        internal CKAN.GUI.HintTextBox FilterByLabelsTextBox;
+        private CKAN.GUI.HintTextBox FilterByLabelsTextBox;
         private System.Windows.Forms.Label CompatibleLabel;
-        internal CKAN.GUI.TriStateToggle CompatibleToggle;
+        private CKAN.GUI.TriStateToggle CompatibleToggle;
         private System.Windows.Forms.Label InstalledLabel;
-        internal CKAN.GUI.TriStateToggle InstalledToggle;
+        private CKAN.GUI.TriStateToggle InstalledToggle;
         private System.Windows.Forms.Label CachedLabel;
-        internal CKAN.GUI.TriStateToggle CachedToggle;
+        private CKAN.GUI.TriStateToggle CachedToggle;
         private System.Windows.Forms.Label NewlyCompatibleLabel;
-        internal CKAN.GUI.TriStateToggle NewlyCompatibleToggle;
+        private CKAN.GUI.TriStateToggle NewlyCompatibleToggle;
         private System.Windows.Forms.Label UpgradeableLabel;
-        internal CKAN.GUI.TriStateToggle UpgradeableToggle;
+        private CKAN.GUI.TriStateToggle UpgradeableToggle;
         private System.Windows.Forms.Label ReplaceableLabel;
-        internal CKAN.GUI.TriStateToggle ReplaceableToggle;
+        private CKAN.GUI.TriStateToggle ReplaceableToggle;
     }
 }

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -61,6 +61,7 @@ namespace CKAN.GUI
                 FilterByRecommendsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterBySuggestsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterByConflictsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterBySupportsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterByTagsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterByLabelsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries)
                                           .Select(ln => knownLabels.FirstOrDefault(lb => lb.Name == ln))
@@ -90,6 +91,8 @@ namespace CKAN.GUI
             FilterBySuggestsTextBox.Text    = search?.Suggests.Aggregate("", CombinePieces)
                                               ?? "";
             FilterByConflictsTextBox.Text   = search?.ConflictsWith.Aggregate("", CombinePieces)
+                                              ?? "";
+            FilterBySupportsTextBox.Text    = search?.Supports.Aggregate("", CombinePieces)
                                               ?? "";
             FilterByTagsTextBox.Text        = search?.TagNames.Aggregate("", CombinePieces)
                                               ?? "";

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -127,6 +127,8 @@ namespace CKAN.GUI
                 cp.Style   &= ~(int)WindowStyles.WS_VISIBLE;
                 // The window is a pop-up window. This style cannot be used with the WS_CHILD style.
                 cp.Style   |= unchecked((int)WindowStyles.WS_POPUP);
+                // The window should be placed above all non-topmost windows and should stay above them, even when the window is deactivated. To add or remove this style, use the SetWindowPos function.
+                cp.ExStyle |= (int)WindowExStyles.WS_EX_TOPMOST;
                 // The window is intended to be used as a floating toolbar. A tool window has a title bar that is shorter than a normal title bar, and the window title is drawn using a smaller font. A tool window does not appear in the taskbar or in the dialog that appears when the user presses ALT+TAB. If a tool window has a system menu, its icon is not displayed on the title bar. However, you can display the system menu by right-clicking or by typing ALT+SPACE.
                 cp.ExStyle |= (int)WindowExStyles.WS_EX_TOOLWINDOW;
                 // The window itself contains child windows that should take part in dialog box navigation. If this style is specified, the dialog manager recurses into children of this window when performing navigation operations such as handling the TAB key, an arrow key, or a keyboard mnemonic.
@@ -195,6 +197,7 @@ namespace CKAN.GUI
         // https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
         private enum WindowExStyles : uint
         {
+            WS_EX_TOPMOST       =        0x8,
             WS_EX_TOOLWINDOW    =       0x80,
             WS_EX_CONTROLPARENT =    0x10000,
             WS_EX_NOACTIVATE    = 0x08000000,

--- a/GUI/Controls/EditModSearchDetails.resx
+++ b/GUI/Controls/EditModSearchDetails.resx
@@ -125,6 +125,7 @@
   <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>Recommends:</value></data>
   <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>Suggests:</value></data>
   <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>Conflicts with:</value></data>
+  <data name="FilterBySupportsLabel.Text" xml:space="preserve"><value>Supports:</value></data>
   <data name="FilterByTagsLabel.Text" xml:space="preserve"><value>Tags:</value></data>
   <data name="FilterByLabelsLabel.Text" xml:space="preserve"><value>Labels:</value></data>
   <data name="CompatibleLabel.Text" xml:space="preserve"><value>Compatible:</value></data>

--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
@@ -38,6 +39,22 @@ namespace CKAN.GUI
         public void ExpandCollapse()
         {
             (ActiveControl as EditModSearch)?.ExpandCollapse();
+        }
+
+        public void CloseSearch(Point screenCoords)
+        {
+            foreach (var editor in editors)
+            {
+                editor.CloseSearch(screenCoords);
+            }
+        }
+
+        public void ParentMoved()
+        {
+            foreach (var editor in editors)
+            {
+                editor.ParentMoved();
+            }
         }
 
         public void SetSearches(List<ModSearch> searches)

--- a/GUI/Controls/EditModpack.Designer.cs
+++ b/GUI/Controls/EditModpack.Designer.cs
@@ -112,6 +112,8 @@ namespace CKAN.GUI
             this.IdentifierTextBox.Name = "IdentifierTextBox";
             this.IdentifierTextBox.Size = new System.Drawing.Size(250, 23);
             this.IdentifierTextBox.TabIndex = 1;
+            this.IdentifierTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.IdentifierTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.IdentifierTextBox, "IdentifierTextBox");
             // 
             // NameLabel
@@ -131,6 +133,8 @@ namespace CKAN.GUI
             this.NameTextBox.Name = "NameTextBox";
             this.NameTextBox.Size = new System.Drawing.Size(250, 23);
             this.NameTextBox.TabIndex = 3;
+            this.NameTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.NameTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.NameTextBox, "NameTextBox");
             // 
             // AbstractLabel
@@ -151,6 +155,8 @@ namespace CKAN.GUI
             this.AbstractTextBox.Name = "AbstractTextBox";
             this.AbstractTextBox.Size = new System.Drawing.Size(250, 50);
             this.AbstractTextBox.TabIndex = 5;
+            this.AbstractTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.AbstractTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.AbstractTextBox, "AbstractTextBox");
             // 
             // AuthorLabel
@@ -170,6 +176,8 @@ namespace CKAN.GUI
             this.AuthorTextBox.Name = "AbstractTextBox";
             this.AuthorTextBox.Size = new System.Drawing.Size(250, 23);
             this.AuthorTextBox.TabIndex = 5;
+            this.AuthorTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.AuthorTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.AuthorTextBox, "AuthorTextBox");
             // 
             // VersionLabel
@@ -189,6 +197,8 @@ namespace CKAN.GUI
             this.VersionTextBox.Name = "VersionTextBox";
             this.VersionTextBox.Size = new System.Drawing.Size(250, 23);
             this.VersionTextBox.TabIndex = 7;
+            this.VersionTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.VersionTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.VersionTextBox, "VersionTextBox");
             // 
             // GameVersionLabel

--- a/GUI/Controls/HintTextBox.Designer.cs
+++ b/GUI/Controls/HintTextBox.Designer.cs
@@ -43,6 +43,8 @@ namespace CKAN.GUI
             // 
             // HintTextBox
             // 
+            this.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.Controls.Add(ClearIcon);
             this.SizeChanged += new System.EventHandler(this.HintTextBox_SizeChanged);
             this.TextChanged += new System.EventHandler(this.HintTextBox_TextChanged);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1546,6 +1546,16 @@ namespace CKAN.GUI
                 ? null
                 : ModGrid.SelectedRows[0]?.Tag as GUIMod;
 
+        public void CloseSearch(Point screenCoords)
+        {
+            EditModSearches.CloseSearch(screenCoords);
+        }
+
+        public void ParentMoved()
+        {
+            EditModSearches.ParentMoved();
+        }
+
         #region Navigation History
 
         private void NavInit()

--- a/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
@@ -81,6 +81,8 @@ namespace CKAN.GUI
             //
             // textBoxClonePath
             //
+            this.textBoxClonePath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.textBoxClonePath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.textBoxClonePath.AllowDrop = true;
             this.textBoxClonePath.Location = new System.Drawing.Point(181, 49);
             this.textBoxClonePath.Name = "textBoxClonePath";
@@ -110,9 +112,13 @@ namespace CKAN.GUI
             //
             // textBoxNewName
             //
+            this.textBoxNewName.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.textBoxNewName.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.textBoxNewName.Location = new System.Drawing.Point(181, 79);
             this.textBoxNewName.Name = "textBoxNewName";
             this.textBoxNewName.Size = new System.Drawing.Size(218, 20);
+            this.textBoxNewName.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.textBoxNewName.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.textBoxNewName.TabIndex = 15;
             //
             // labelNewPath
@@ -126,6 +132,8 @@ namespace CKAN.GUI
             //
             // textBoxNewPath
             //
+            this.textBoxNewPath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.textBoxNewPath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.textBoxNewPath.Location = new System.Drawing.Point(181, 109);
             this.textBoxNewPath.Name = "textBoxNewPath";
             this.textBoxNewPath.Size = new System.Drawing.Size(158, 20);

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
@@ -132,6 +132,8 @@ namespace CKAN.GUI
             // addVersionToListTextBox
             //
             this.AddVersionToListTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.AddVersionToListTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.AddVersionToListTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.AddVersionToListTextBox.Location = new System.Drawing.Point(242, 211);
             this.AddVersionToListTextBox.Name = "addVersionToListTextBox";
             this.AddVersionToListTextBox.Size = new System.Drawing.Size(100, 15);

--- a/GUI/Dialogs/EditLabelsDialog.Designer.cs
+++ b/GUI/Dialogs/EditLabelsDialog.Designer.cs
@@ -175,6 +175,8 @@ namespace CKAN.GUI
             this.NameTextBox.Location = new System.Drawing.Point(118, 10);
             this.NameTextBox.Name = "NameTextBox";
             this.NameTextBox.Size = new System.Drawing.Size(125, 23);
+            this.NameTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.NameTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.NameTextBox, "NameTextBox");
             // 
             // ColorLabel

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
@@ -41,6 +41,8 @@ namespace CKAN.GUI
             this.AdditionalArguments.Location = new System.Drawing.Point(15, 25);
             this.AdditionalArguments.Name = "AdditionalArguments";
             this.AdditionalArguments.Size = new System.Drawing.Size(457, 20);
+            this.AdditionalArguments.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.AdditionalArguments.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.AdditionalArguments.TabIndex = 1;
             //
             // label1

--- a/GUI/Dialogs/NewRepoDialog.Designer.cs
+++ b/GUI/Dialogs/NewRepoDialog.Designer.cs
@@ -112,6 +112,8 @@ namespace CKAN.GUI
             this.RepoNameTextBox.Name = "RepoNameTextBox";
             this.RepoNameTextBox.Size = new System.Drawing.Size(110, 30);
             this.RepoNameTextBox.TabIndex = 11;
+            this.RepoNameTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.RepoNameTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.RepoNameTextBox.TextChanged += new System.EventHandler(this.RepoUrlTextBox_TextChanged);
             //
             // RepoUrlLabel
@@ -126,6 +128,8 @@ namespace CKAN.GUI
             // RepoUrlTextBox
             //
             this.RepoUrlTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.RepoUrlTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.RepoUrlTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.RepoUrlTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.RepoUrlTextBox.Location = new System.Drawing.Point(122, 22);
             this.RepoUrlTextBox.Name = "RepoUrlTextBox";

--- a/GUI/Dialogs/RenameInstanceDialog.Designer.cs
+++ b/GUI/Dialogs/RenameInstanceDialog.Designer.cs
@@ -41,6 +41,8 @@ namespace CKAN.GUI
             this.NameTextBox.Location = new System.Drawing.Point(13, 13);
             this.NameTextBox.Name = "NameTextBox";
             this.NameTextBox.Size = new System.Drawing.Size(294, 20);
+            this.NameTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.NameTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.NameTextBox.TabIndex = 0;
             //
             // OKButton

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -255,6 +255,8 @@ namespace CKAN.GUI
             //
             // CachePath
             //
+            this.CachePath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CachePath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.CachePath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.CachePath.Location = new System.Drawing.Point(12, 18);
             this.CachePath.Margin = new System.Windows.Forms.Padding(2);
@@ -283,6 +285,8 @@ namespace CKAN.GUI
             //
             // CacheLimit
             //
+            this.CacheLimit.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CacheLimit.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.CacheLimit.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.CacheLimit.Location = new System.Drawing.Point(117, 63);
             this.CacheLimit.Margin = new System.Windows.Forms.Padding(2);
@@ -499,6 +503,8 @@ namespace CKAN.GUI
             //
             // RefreshTextBox
             //
+            this.RefreshTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.RefreshTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.RefreshTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.RefreshTextBox.Location = new System.Drawing.Point(125, 64);
             this.RefreshTextBox.Name = "RefreshTextBox";

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -545,6 +545,33 @@ namespace CKAN.GUI
             base.OnFormClosing(e);
         }
 
+        // https://learn.microsoft.com/en-us/windows/win32/winmsg/window-notifications
+        private const int WM_PARENTNOTIFY = 0x210;
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+            if (Platform.IsWindows)
+            {
+                switch (m.Msg)
+                {
+                    // Windows sends us this when you click outside the search dropdown
+                    // Mono closes the dropdown automatically
+                    case WM_PARENTNOTIFY:
+                        ManageMods?.CloseSearch(
+                            PointToScreen(new Point(m.LParam.ToInt32() & 0xffff,
+                                                    m.LParam.ToInt32() >> 16)));
+                        break;
+                }
+            }
+        }
+
+        protected override void OnMove(EventArgs e)
+        {
+            base.OnMove(e);
+            ManageMods?.ParentMoved();
+        }
+
         private void SetupDefaultSearch()
         {
             var registry = RegistryManager.Instance(CurrentInstance, repoData).registry;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -885,7 +885,7 @@ namespace CKAN.GUI
 
         private void reportMetadataIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Utilities.ProcessStartURL("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
+            Utilities.ProcessStartURL(Manager.CurrentInstance.game.MetadataBugtrackerURL.ToString());
         }
 
         private void Main_Resize(object sender, EventArgs e)

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -33,7 +33,10 @@ namespace CKAN.GUI
             Util.Invoke(statusStrip1, () =>
                 StatusLabel.ToolTipText = StatusLabel.Text = msg.Replace("\r\n", " ").Replace("\n", " ")
             );
-            Wait.AddLogMessage(msg);
+            if (!string.IsNullOrEmpty(msg))
+            {
+                Wait.AddLogMessage(msg);
+            }
         }
 
         [ForbidGUICalls]

--- a/GUI/Model/ModSearch.cs
+++ b/GUI/Model/ModSearch.cs
@@ -32,6 +32,7 @@ namespace CKAN.GUI
         public ModSearch(
             string byName, List<string> byAuthors, string byDescription, List<string> localizations,
             List<string> depends, List<string> recommends, List<string> suggests, List<string> conflicts,
+            List<string> supports,
             List<string> tagNames, List<ModuleLabel> labels,
             bool? compatible, bool? installed, bool? cached, bool? newlyCompatible,
             bool? upgradeable, bool? replaceable,
@@ -48,6 +49,7 @@ namespace CKAN.GUI
             initStringList(Recommends,    recommends);
             initStringList(Suggests,      suggests);
             initStringList(ConflictsWith, conflicts);
+            initStringList(Supports,      supports);
 
             initStringList(TagNames, tagNames);
             if (labels?.Any() ?? false)
@@ -140,6 +142,11 @@ namespace CKAN.GUI
         public readonly List<string> ConflictsWith = new List<string>();
 
         /// <summary>
+        /// Identifier prefix to find in mod conflicts relationships
+        /// </summary>
+        public readonly List<string> Supports = new List<string>();
+
+        /// <summary>
         /// Full formatted search string
         /// </summary>
         public readonly string Combined;
@@ -163,7 +170,7 @@ namespace CKAN.GUI
             => new ModSearch(
                 // Can't search for spaces, so massage them like SearchableAuthors
                 "", authors.Select(a => CkanModule.nonAlphaNums.Replace(a, "")).ToList(), "", null,
-                null, null, null, null,
+                null, null, null, null, null,
                 null, null,
                 null, null, null, null,
                 null, null);
@@ -183,6 +190,7 @@ namespace CKAN.GUI
                 Recommends.Concat(other.Recommends).Distinct().ToList(),
                 Suggests.Concat(other.Suggests).Distinct().ToList(),
                 ConflictsWith.Concat(other.ConflictsWith).Distinct().ToList(),
+                Supports.Concat(other.Supports).Distinct().ToList(),
                 TagNames.Concat(other.TagNames).Distinct().ToList(),
                 Labels.Concat(other.Labels).Distinct().ToList(),
                 Compatible      ?? other.Compatible,
@@ -233,6 +241,10 @@ namespace CKAN.GUI
             foreach (var conf in ConflictsWith.Where(c => !string.IsNullOrEmpty(c)))
             {
                 pieces.Add(AddTermPrefix(Properties.Resources.ModSearchConflictsPrefix, conf));
+            }
+            foreach (var sup in Supports.Where(s => !string.IsNullOrEmpty(s)))
+            {
+                pieces.Add(AddTermPrefix(Properties.Resources.ModSearchSupportsPrefix, sup));
             }
             foreach (var tagName in TagNames)
             {
@@ -303,6 +315,7 @@ namespace CKAN.GUI
             var recommends = new List<string>();
             var suggests   = new List<string>();
             var conflicts  = new List<string>();
+            var supports   = new List<string>();
 
             List<string>      tagNames = new List<string>();
             List<ModuleLabel> labels   = new List<ModuleLabel>();
@@ -344,6 +357,10 @@ namespace CKAN.GUI
                 else if (TryPrefix(s, Properties.Resources.ModSearchConflictsPrefix, out string conf))
                 {
                     conflicts.Add(conf);
+                }
+                else if (TryPrefix(s, Properties.Resources.ModSearchSupportsPrefix, out string sup))
+                {
+                    supports.Add(sup);
                 }
                 else if (TryPrefix(s, Properties.Resources.ModSearchTagPrefix, out string tagName))
                 {
@@ -421,7 +438,7 @@ namespace CKAN.GUI
             }
             return new ModSearch(
                 byName, byAuthors, byDescription, byLocalizations,
-                depends, recommends, suggests, conflicts,
+                depends, recommends, suggests, conflicts, supports,
                 tagNames, labels,
                 compatible, installed, cached, newlyCompatible,
                 upgradeable, replaceable,
@@ -483,6 +500,7 @@ namespace CKAN.GUI
                 && MatchesRecommends(mod)
                 && MatchesSuggests(mod)
                 && MatchesConflicts(mod)
+                && MatchesSupports(mod)
                 && MatchesTags(mod)
                 && MatchesLabels(mod)
                 && MatchesCompatible(mod)
@@ -533,6 +551,8 @@ namespace CKAN.GUI
             => RelationshipMatch(mod.ToModule().suggests, Suggests);
         private bool MatchesConflicts(GUIMod mod)
             => RelationshipMatch(mod.ToModule().conflicts, ConflictsWith);
+        private bool MatchesSupports(GUIMod mod)
+            => RelationshipMatch(mod.ToModule().supports, Supports);
         private bool RelationshipMatch(List<RelationshipDescriptor> rels, List<string> toFind)
             => toFind.Count < 1
                 || (rels != null && toFind.All(searchRel =>
@@ -589,6 +609,7 @@ namespace CKAN.GUI
                 && Recommends.SequenceEqual(other.Recommends)
                 && Suggests.SequenceEqual(other.Suggests)
                 && ConflictsWith.SequenceEqual(other.ConflictsWith)
+                && Supports.SequenceEqual(other.Supports)
                 && TagNames.SequenceEqual(other.TagNames)
                 && Labels.SequenceEqual(other.Labels);
 

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -412,6 +412,7 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="ModSearchRecommendsPrefix" xml:space="preserve"><value>rec:</value></data>
   <data name="ModSearchSuggestsPrefix" xml:space="preserve"><value>sug:</value></data>
   <data name="ModSearchConflictsPrefix" xml:space="preserve"><value>conf:</value></data>
+  <data name="ModSearchSupportsPrefix" xml:space="preserve"><value>sup:</value></data>
   <data name="ModSearchTagPrefix" xml:space="preserve"><value>tag:</value></data>
   <data name="ModSearchLabelPrefix" xml:space="preserve"><value>label:</value></data>
   <data name="ModSearchYesPrefix" xml:space="preserve"><value>is:</value></data>


### PR DESCRIPTION
## Motivation

- The mod search can search all relationships except `supports`. @JonnyOThan suggested adding `supports`.

## Problems

- If you click the search dropdown button on Windows and then click it again, the dropdown disappears but you have to click the button two more times to get it to reappear. (On Mono this already works perfectly.)
- Ctrl+Backspace is a common hotkey for deleting whole words in a textbox (with a dubious history as a "rogue feature" starting with early Internet Explorer releases), but the CKAN GUI currently only supports it on Mono (where it's built in to the runtime)
- While working on the rest of this, I noticed that the "Help &rarr; Report an issue with mod metadata" link assumed the game was KSP1, even if you were working with a KSP2 instance

## Causes

- The search dropdown was set up to be a separate floating window, but clicking outside of it didn't make it invisible! Instead the main window was moved in front of it. The second click on Windows then toggled the button and officially hid the already non-visible dropdown, and the third click re-displayed it.

![before](https://cdn.discordapp.com/attachments/601455398553387008/1182091255673532487/image.png?ex=65836f45&is=6570fa45&hm=3590001dcde4b7be489e8719ff3e7d6cba38bc461a63e9a620f14cb917b5b98b&)

## Changes

- Now there's a Supports field in the search dropdown, corresponding to a `sup:` search prefix in the English locale
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/5a09380e-b4b6-4647-9b03-ce0be0b6d7bc)
- Now the search dropdown is properly set up as always-on-top, and we hide it when you click outside of it. A special case is needed when you click on the expand/collapse button again to avoid hiding it and then immediately re-displaying it. `Platform.IsWindows` is used because Windows and Mono differ drastically in how they handle this.
- Now Ctrl+Backspace works in our textboxes, using the de facto standard Windows API.
  Closes #3398.
- Now the mod metadata link is game-specific and opens KSP2-NetKAN for KSP2
