### PR TITLE
Prompt to delete dirs containing empty registered dirs

### DIFF
--- a/GUI/Controls/DeleteDirectories.Designer.cs
+++ b/GUI/Controls/DeleteDirectories.Designer.cs
@@ -54,7 +54,8 @@ namespace CKAN.GUI
             this.ExplanationLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 12, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Pixel);
             this.ExplanationLabel.Location = new System.Drawing.Point(5, 0);
             this.ExplanationLabel.Name = "ExplanationLabel";
-            this.ExplanationLabel.Padding = new System.Windows.Forms.Padding(5,5,5,5);
+            this.ExplanationLabel.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.ExplanationLabel.Padding = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.ExplanationLabel.Size = new System.Drawing.Size(490, 70);
             resources.ApplyResources(this.ExplanationLabel, "ExplanationLabel");
             // 


### PR DESCRIPTION
## Problem

1. Install TweakScale with the current dev build (problem reported not to happen with the released version)
2. Launch the game
3. Start or load a save
4. Launch a rocket
   This (or the previous step, not clear) should create a `GameData/TweakScale/Plugins/PluginData/Scale/config.xml` file
   ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/1e300589-61a3-47a0-a987-ecea10fade6e)
   (Don't ask me why this isn't just `GameData/TweakScale/PluginData/config.xml` instead.)
5. Close the game
6. Uninstall TweakScale
7. You're prompted to delete the `PluginData` folder, but not the `Plugins` or `Tweakscale` parent folders
   ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/f97ed632-17b5-4f5f-8ac6-6584ea85a5cb)
8. As you'd expect, clicking Delete Checked leaves the TweakScale folder there

## Cause

I think #3890's changes to the the deletion logic must have affected how subdirectories are treated, but I was more focused on understanding and fixing the current logic than on the details of the history.

## Changes

Now when we check whether to ask the user about deleting a directory, we ignore any subdirectories that are already in that list. This will add the `GameData/TweakScale` and `GameData/TweakScale/Plugins` folders to the list, and clicking Delete Checked will result in a clean GameData:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/b576b9ec-951d-4ff9-a748-c6dc85ac4ab2)

- [x] I'll adjust the auto sizing of the help label before merging, just forgot to take care of that before pushing

Fixes #3936.
