### PR TITLE
Fix two small typos in Resources.pt-BR.resx at line 182

### DIFF
--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -179,7 +179,7 @@ Tentando mover {2} de {3} e reiniciar o CKAN.</value></data>
   <data name="MainTSV" xml:space="preserve"><value>Arquivo separado por tabulação (*.tsv)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Não encontrado.</value></data>
   <data name="MainCantInstallDLC" xml:space="preserve"><value>O CKAN não pode instalar a expansão{0}!</value></data>
-  <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} não é suportado pela versão atual do seu jogo e pode não funcionar. Se você tiver qualquer problema com isso, você NÃO deve pedir ajuda aos colaboradores.
+  <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} não é suportado pela versão atual do seu jogo e pode não funcionar. Se você tiver qualquer problema com isso, você NÃO deve pedir ajuda aos mantenedores.
 
 Você quer realmente instalá-la?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Instalar</value></data>

--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -179,7 +179,7 @@ Tentando mover {2} de {3} e reiniciar o CKAN.</value></data>
   <data name="MainTSV" xml:space="preserve"><value>Arquivo separado por tabulação (*.tsv)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Não encontrado.</value></data>
   <data name="MainCantInstallDLC" xml:space="preserve"><value>O CKAN não pode instalar a expansão{0}!</value></data>
-  <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} não é suportado peça versão atual do seu jogo e mode não funcionar. Se você tiver qualquer problema com isso, você NÃO deve pedir ajuda aos mantenedores.
+  <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} não é suportado pela versão atual do seu jogo e pode não funcionar. Se você tiver qualquer problema com isso, você NÃO deve pedir ajuda aos colaboradores.
 
 Você quer realmente instalá-la?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Instalar</value></data>


### PR DESCRIPTION
Fixed small typos in line 182 (appears when the user tries to install a mod in a non-supported KSP version).

accidentaly discovered this when i was trying to install a mod, so here it is 👍