### PR TITLE
Protect upgradeable mods from being displayed as uninstalled

### DIFF
--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -153,7 +153,7 @@ namespace CKAN.Configuration
         public IEnumerable<string> GetAuthTokenHosts()
         {
             RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(authTokenKeyNoPrefix);
-            return key?.GetValueNames() ?? new string[0];
+            return key?.GetValueNames() ?? Array.Empty<string>();
         }
 
         public void SetAuthToken(string host, string token)

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -668,7 +668,7 @@ namespace CKAN
                     registry_manager.registry.FindRemovableAutoInstalled(
                         registry_manager.registry.InstalledModules
                             .Where(im => !revdep.Contains(im.identifier))
-                            .Concat(installing?.Select(m => new InstalledModule(null, m, new string[0], false)) ?? new InstalledModule[0])
+                            .Concat(installing?.Select(m => new InstalledModule(null, m, Array.Empty<string>(), false)) ?? Array.Empty<InstalledModule>())
                             .ToList(),
                         ksp.VersionCriteria())
                     .Select(im => im.identifier))
@@ -1160,7 +1160,7 @@ namespace CKAN
                     // Conjure the future state of the installed modules list after upgrading
                     registry.InstalledModules
                             .Where(im => !removingIdents.Contains(im.identifier))
-                            .Concat(modules.Select(m => new InstalledModule(null, m, new string[0], false)))
+                            .Concat(modules.Select(m => new InstalledModule(null, m, Array.Empty<string>(), false)))
                             .ToList(),
                     ksp.VersionCriteria())
                 .ToList();

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -304,7 +304,7 @@ namespace CKAN
                     // Nothing found, try again while simulating an empty mod list
                     // Necessary for e.g. proceed_with_inconsistencies, conflicts will still be caught below
                     candidates = descriptor
-                        .LatestAvailableWithProvides(registry, versionCrit, new CkanModule[0])
+                        .LatestAvailableWithProvides(registry, versionCrit, Array.Empty<CkanModule>())
                         .Where(mod => !modlist.ContainsKey(mod.identifier)
                                       && descriptor1.WithinBounds(mod)
                                       && MightBeInstallable(mod))

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -54,16 +54,16 @@ namespace CKAN.GUI
         private ModSearch CurrentSearch(List<ModuleLabel> knownLabels)
             => new ModSearch(
                 FilterByNameTextBox.Text,
-                FilterByAuthorTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterByAuthorTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterByDescriptionTextBox.Text,
-                FilterByLanguageTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterByDependsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterByRecommendsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterBySuggestsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterByConflictsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterBySupportsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterByTagsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterByLabelsTextBox.Text.Split(new char[0], StringSplitOptions.RemoveEmptyEntries)
+                FilterByLanguageTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterByDependsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterByRecommendsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterBySuggestsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterByConflictsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterBySupportsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterByTagsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
+                FilterByLabelsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries)
                                           .Select(ln => knownLabels.FirstOrDefault(lb => lb.Name == ln))
                                           .Where(lb => lb != null)
                                           .ToList(),

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1193,9 +1193,9 @@ namespace CKAN.GUI
             Main.Instance.Wait.AddLogMessage(Properties.Resources.MainModListLoadingInstalled);
             var versionCriteria = Main.Instance.CurrentInstance.VersionCriteria();
 
-            var installed = registry.InstalledModules
-                                    .Select(im => im.Module)
-                                    .ToHashSet();
+            var installedIdents = registry.InstalledModules
+                                          .Select(im => im.identifier)
+                                          .ToHashSet();
             var gui_mods = registry.InstalledModules
                                    .AsParallel()
                                    .Where(instMod => !instMod.Module.IsDLC)
@@ -1204,7 +1204,7 @@ namespace CKAN.GUI
                                                           Main.Instance.configuration.HideEpochs,
                                                           Main.Instance.configuration.HideV))
                                    .Concat(registry.CompatibleModules(versionCriteria)
-                                                   .Except(installed)
+                                                   .Where(m => !installedIdents.Contains(m.identifier))
                                                    .AsParallel()
                                                    .Where(m => !m.IsDLC)
                                                    .Select(m => new GUIMod(
@@ -1212,7 +1212,7 @@ namespace CKAN.GUI
                                                                     Main.Instance.configuration.HideEpochs,
                                                                     Main.Instance.configuration.HideV)))
                                    .Concat(registry.IncompatibleModules(versionCriteria)
-                                                   .Except(installed)
+                                                   .Where(m => !installedIdents.Contains(m.identifier))
                                                    .AsParallel()
                                                    .Where(m => !m.IsDLC)
                                                    .Select(m => new GUIMod(

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -232,7 +232,7 @@ namespace CKAN.GUI
                         ch.ChangeType == GUIModChangeType.Replace
                             ? registry.GetReplacement(ch.Mod, crit)?.ReplaceWith
                             : (ch as ModUpgrade)?.targetMod ?? ch.Mod,
-                        new string[0],
+                        Enumerable.Empty<string>(),
                         false)));
         }
 

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Transactions;
 using System.Collections.Generic;
@@ -9,7 +10,6 @@ using Tests.Data;
 
 using CKAN;
 using CKAN.Versioning;
-using System;
 
 namespace Tests.Core.Registry
 {

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -9,6 +9,7 @@ using Tests.Data;
 
 using CKAN;
 using CKAN.Versioning;
+using System;
 
 namespace Tests.Core.Registry
 {
@@ -315,8 +316,8 @@ namespace Tests.Core.Registry
                 CkanModule dependingMod = registry.GetModuleByVersion("DependingMod", "1.0");
 
                 GameInstance gameInst = gameInstWrapper.KSP;
-                registry.RegisterModule(olderDepMod,  new string[0], gameInst, false);
-                registry.RegisterModule(dependingMod, new string[0], gameInst, false);
+                registry.RegisterModule(olderDepMod,  Array.Empty<string>(), gameInst, false);
+                registry.RegisterModule(dependingMod, Array.Empty<string>(), gameInst, false);
                 GameVersionCriteria crit = new GameVersionCriteria(olderDepMod.ksp_version);
 
                 // Act

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -1036,8 +1036,8 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
 
                 // Start with eve and eveDefaultConfig installed
-                registry.RegisterModule(eve, new string[0], ksp.KSP, false);
-                registry.RegisterModule(eveDefaultConfig, new string[0], ksp.KSP, false);
+                registry.RegisterModule(eve, Array.Empty<string>(), ksp.KSP, false);
+                registry.RegisterModule(eveDefaultConfig, Array.Empty<string>(), ksp.KSP, false);
 
                 Assert.DoesNotThrow(() => registry.CheckSanity());
 


### PR DESCRIPTION
## Problem

The fix for installed mods showing up as not installed from #3934 was incomplete; it addressed installed mods that can't be upgraded, but the problem can still happen for installed mods that are upgradeable. If such a mod happens to load as uninstalled and you try to upgrade it, an exception is thrown:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/9b2ec2e7-9605-4d5a-8e0d-e2e51753477d)

Reported by @jan-bures on Discord.

## Cause

I used `.Except()` to filter installed mods out of the compatible and incompatible lists, but that only works when their `CkanModule.version` properties are the same. For an upgradeable mod, its version in the compatible list is newer than the installed verson, so `.Except()` doesn't filter it out, and we once again have a race condition.

## Changes

- Now we filter by identifier instead. (Unfortunately, `.ExceptBy()` is not available until .NET 6+).
- Also switched a bunch of `new type[0]` expressions to `Array.Empty<type>()` because this was recommended by VSCode at some point.

I'll self-review this since it's small and familiar, and so we can consider a quick hotfix release before KSP2 0.2.0.0 comes out.
