### PR TITLE
Restore conflict highlights in changeset

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -101,7 +101,7 @@ namespace CKAN.GUI
         public event Action<List<ModChange>, Dictionary<GUIMod, string>> OnChangeSetChanged;
         public event Action OnRegistryChanged;
 
-        public event Action<List<ModChange>> StartChangeSet;
+        public event Action<List<ModChange>, Dictionary<GUIMod, string>> StartChangeSet;
         public event Action<IEnumerable<GUIMod>> LabelsAfterUpdate;
 
         private List<ModChange> ChangeSet
@@ -523,7 +523,7 @@ namespace CKAN.GUI
 
         private void ApplyToolButton_Click(object sender, EventArgs e)
         {
-            StartChangeSet?.Invoke(currentChangeSet);
+            StartChangeSet?.Invoke(currentChangeSet, Conflicts);
         }
 
         public void MarkModForUpdate(string identifier, bool value)
@@ -1054,7 +1054,7 @@ namespace CKAN.GUI
                                                                module.version)
                                            ?? module,
                                    true)
-                });
+                }, null);
             }
         }
 
@@ -1672,8 +1672,8 @@ namespace CKAN.GUI
 
         public void InstanceUpdated()
         {
-            ChangeSet = null;
             Conflicts = null;
+            ChangeSet = null;
         }
 
         [ForbidGUICalls]

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -826,7 +826,8 @@ namespace CKAN.GUI
                 tabController.ShowTab("ChangesetTabPage", 1, false);
                 UpdateChangesDialog(
                     changeset,
-                    conflicts.ToDictionary(item => item.Key.ToCkanModule(), item => item.Value));
+                    conflicts.ToDictionary(item => item.Key.ToCkanModule(),
+                                           item => item.Value));
                 auditRecommendationsMenuItem.Enabled = false;
             }
             else
@@ -982,9 +983,11 @@ namespace CKAN.GUI
         }
 
         // This is used by Reinstall
-        private void ManageMods_StartChangeSet(List<ModChange> changeset)
+        private void ManageMods_StartChangeSet(List<ModChange> changeset, Dictionary<GUIMod, string> conflicts)
         {
-            UpdateChangesDialog(changeset, null);
+            UpdateChangesDialog(changeset,
+                                conflicts?.ToDictionary(item => item.Key.ToCkanModule(),
+                                                        item => item.Value));
             tabController.ShowTab("ChangesetTabPage", 1);
         }
 


### PR DESCRIPTION
## Problem

As of #3727, conflicts are supposed to be highlighted red in the changeset, but that's not working right now if you click the Apply button. (Clicking the changeset tab instead still works.)

## Cause

In #3890, the Apply button was refactored to re-use the `StartChangeSet` event (previously only used by the right click reinstall option) rather than the `GUI.Main.Instance` global singleton. But that event didn't handle conflicts, so they were passed as `null`, and the changeset tab never showed them.

## Changes

Now the conflicts are passed along.

Fixes #3946.

Definitely self-reviewing this one.
