### PR TITLE
Conflict highlight for selected row

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -632,7 +632,7 @@ namespace CKAN
         public IEnumerable<string> ConflictDescriptions
             => conflicts.Where(kvp => kvp.Value == null
                                       // Pick the pair with the least distantly selected one first
-                                      || totalDependers(kvp.Key) < totalDependers(kvp.Value))
+                                      || totalDependers(kvp.Key) <= totalDependers(kvp.Value))
                         .Select(kvp => string.Format(
                             Properties.Resources.RelationshipResolverConflictsWith,
                             conflictingModDescription(kvp.Key,   null),

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -290,6 +290,25 @@ namespace CKAN.GUI
             };
         }
 
+        public static Color BlendColors(Color[] colors)
+            => colors.Length <  1 ? Color.Empty
+             : colors.Length == 1 ? colors[0]
+             : colors.Aggregate((back, fore) => fore.AlphaBlendWith(1f / colors.Length, back));
+
+        public static Color AlphaBlendWith(this Color c1, float alpha, Color c2)
+            => AddColors(c1.MultiplyBy(alpha),
+                         c2.MultiplyBy(1f - alpha));
+
+        private static Color MultiplyBy(this Color c, float f)
+            => Color.FromArgb((int)(f * c.R),
+                              (int)(f * c.G),
+                              (int)(f * c.B));
+
+        private static Color AddColors(Color a, Color b)
+            => Color.FromArgb(a.R + b.R,
+                              a.G + b.G,
+                              a.B + b.B);
+
         /// <summary>
         /// Simple syntactic sugar around Graphics.MeasureString
         /// </summary>


### PR DESCRIPTION
## Problems / Motivations

- If you select to install two mods that conflict, their background color properties are set to a reddish color, but this is completely overridden by the blue row highlight color. If the other conflicting mod's row is off-screen, this usually meant that you couldn't see any red highlights at all.
- Conflict descriptions are missing from the status bar in some cases
- If you apply multiple labels to a mod, only one of their background colors is applied

## Causes

- `RelationshipResolver.ConflictDescriptions` only returned descriptions of conflicts for the mod with fewer indirectly-depending mods, intended to choose the conflict closest to what the user selected, but when these values were equal, neither would appear.

## Changes

- Now if two conflicting mods have equal numbers of indirectly-depending mods, both of their description conflicts are shown in the status bar
- Now if you select a row with a conflict, the red color is blended 75%/25% with the highlight color, producing a reddish purple color that can still be recognized as conflict-y:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/870bc6aa-2b2d-4420-9b31-e6f6af1b6099)
  The red conflict color has had its green and blue channels roughly halved to make this work a bit better.
- Similar to the above, a background color from a label is also blended 75%/25% with the highlight color so you can still tell a label has been applied while the row is highlighted
- Now if you apply multiple labels, their colors are blended together, and the labels menu shows the colors of the labels:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/246b9faf-95f5-4f73-b2d3-72cc8ac92b2a)

Fixes #3947.
