### PR TITLE
Fix uninstallation of manually deleted files and directories

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -771,6 +771,14 @@ namespace CKAN
                             file_transaction.Delete(absPath);
                         }
                     }
+                    catch (FileNotFoundException exc)
+                    {
+                        log.Debug("Ignoring missing file while deleting", exc);
+                    }
+                    catch (DirectoryNotFoundException exc)
+                    {
+                        log.Debug("Ignoring missing directory while deleting", exc);
+                    }
                     catch (IOException)
                     {
                         // "The specified file is in use."


### PR DESCRIPTION
## Problem

1. Install a mod with CKAN
2. Delete its files manually (this isn't a good idea, so don't do it normally, but it's how the bug is reproduced, so you have to do it this once)
3. Uninstall the mod in CKAN
4. This error is displayed:
   ![screenshot](https://private-user-images.githubusercontent.com/153859189/290634117-fc3e9351-fc01-436c-89b8-2838368d29b4.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDI1ODIzODYsIm5iZiI6MTcwMjU4MjA4NiwicGF0aCI6Ii8xNTM4NTkxODkvMjkwNjM0MTE3LWZjM2U5MzUxLWZjMDEtNDM2Yy04OWI4LTI4MzgzNjhkMjliNC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBSVdOSllBWDRDU1ZFSDUzQSUyRjIwMjMxMjE0JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDIzMTIxNFQxOTI4MDZaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT03MWZmMzEyNjk2NTA1NmUyY2Q1Y2IyYWY2ZDE0OGE4Y2UzYTNkNWY1MjBmZjk4MzBkYWMyNjAyY2YyODRmNjU4JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.JUUOBG8BHdmlC9tZLynd5-O8CsnVAAp_57APnAKqQpM)

## Cause

During development to improve the "inconsistencies were found / is registered to but has not been removed" message in #3938, I thought the missing-file case only needed to sneak past `File.Delete`, which explicitly says it won't throw an exception:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/d462f450-3e60-4865-81e8-25f957c8f9d2)

However, the underlying exception here is thrown elsewhere:

```
System.IO.DirectoryNotFoundException: Could not find a part of the path 'c:\program files (x86)\steam\SteamApps\common\Kerbal Space Program\GameData\AJE\RftS\Brown.dds'.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.File.GetAttributes(String path)
   at CKAN.ModuleInstaller.Uninstall(String identifier, HashSet`1& possibleConfigOnlyDirs, Registry registry)
```

The `File.GetAttributes` call is and always has been the first thing that happens when deleting files, so that's why this section of code was so aggressive in ignoring exceptions prior to #3938.

## Changes

Now if `DirectoryNotFoundException` or `FileNotFoundException` are thrown by `File.GetAttributes`, we log them as debug messages and ignore them. This allows uninstallation to finish for these mods. Exceptions thrown for other reasons, such as permissions or locked files, will still be collected into the error message from #3938.

Fixes #3954.
