### PR TITLE
Re-sort module properties after merging

### DIFF
--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -6,6 +6,7 @@ using YamlDotNet.RepresentationModel;
 
 using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
+using CKAN.NetKAN.Transformers;
 
 namespace CKAN.NetKAN.Model
 {
@@ -124,8 +125,9 @@ namespace CKAN.NetKAN.Model
 
         public static Metadata Merge(Metadata[] modules)
             => modules.Length == 1 ? modules[0]
-                                   : new Metadata(MergeJson(modules.Select(m => m._json)
-                                                                   .ToArray()));
+                                   : PropertySortTransformer.SortProperties(
+                                       new Metadata(MergeJson(modules.Select(m => m._json)
+                                                                     .ToArray())));
 
         private static JObject MergeJson(JObject[] jsons)
         {

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -62,8 +62,7 @@ namespace CKAN.NetKAN
                     );
                     inf.ValidateCkan(ckan);
                     Console.WriteLine(QueueHandler.serializeCkan(
-                        new PropertySortTransformer().Transform(ckan, null).First()
-                    ));
+                        PropertySortTransformer.SortProperties(ckan)));
                     return ExitOk;
                 }
 

--- a/Netkan/Transformers/PropertySortTransformer.cs
+++ b/Netkan/Transformers/PropertySortTransformer.cs
@@ -110,6 +110,10 @@ namespace CKAN.NetKAN.Transformers
             yield return new Metadata(sortedJson);
         }
 
+        public static Metadata SortProperties(Metadata metadata)
+            => new PropertySortTransformer().Transform(metadata, null)
+                                            .First();
+
         private static double GetPropertySortOrder(string propertyName)
             => PropertySortOrder.TryGetValue(propertyName, out int sortOrder)
                 ? sortOrder


### PR DESCRIPTION
## Problem

After merging KSP-CKAN/NetKAN#9882, I noticed `ksp_version` was appearing out of its normal ordering:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/5ad7705f-1257-4a08-9cfa-62e435bf3f1e)

## Cause

The GitHub module has no versioning info at all, whereas the one from SpaceDock has a game version, and otherwise they're identical, so the merge code is appending just that one property from the SpaceDock module onto the GitHub module after it's sorted.

## Changes

Now the merge logic reapplies sorting, so multi-host .ckans will have the same property ordering as single-host ones.
