### PR TITLE
Oops, `HttpClient` actually sucks

### DIFF
--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -24,7 +24,7 @@
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>IDE1006</NoWarn>
+    <NoWarn>IDE1006,NU1701</NoWarn>
     <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
   <ItemGroup>

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -266,34 +266,34 @@ namespace CKAN.Games.KerbalSpaceProgram
 
         public Uri MetadataBugtrackerURL => new Uri("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
 
-        private string Missions(GameInstance inst)
+        private static string Missions(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(inst.GameDir(), "Missions"));
 
-        private string Ships(GameInstance inst)
+        private static string Ships(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(inst.GameDir(), "Ships"));
 
-        private string ShipsVab(GameInstance inst)
+        private static string ShipsVab(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(Ships(inst), "VAB"));
 
-        private string ShipsSph(GameInstance inst)
+        private static string ShipsSph(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(Ships(inst), "SPH"));
 
-        private string ShipsThumbs(GameInstance inst)
+        private static string ShipsThumbs(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(Ships(inst), "@thumbs"));
 
-        private string ShipsThumbsSPH(GameInstance inst)
+        private static string ShipsThumbsSPH(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(ShipsThumbs(inst), "SPH"));
 
-        private string ShipsThumbsVAB(GameInstance inst)
+        private static string ShipsThumbsVAB(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(ShipsThumbs(inst), "VAB"));
 
-        private string ShipsScript(GameInstance inst)
+        private static string ShipsScript(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(Ships(inst), "Script"));
 
-        private string Tutorial(GameInstance inst)
+        private static string Tutorial(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(inst.GameDir(), "saves", "training"));
 
-        private string Scenarios(GameInstance inst)
+        private static string Scenarios(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(inst.GameDir(), "saves", "scenarios"));
 
         private readonly Dictionary<string, string> allowedFolders = new Dictionary<string, string>
@@ -343,7 +343,7 @@ namespace CKAN.Games.KerbalSpaceProgram
         /// <returns>
         /// args or args minus parameter
         /// </returns>
-        private string[] filterCmdLineArgs(string[] args, GameVersion installedVersion, GameVersionRange crashyKspRange, string parameter)
+        private static string[] filterCmdLineArgs(string[] args, GameVersion installedVersion, GameVersionRange crashyKspRange, string parameter)
         {
             var installedRange = installedVersion.ToVersionRange();
             if (crashyKspRange.IntersectWith(installedRange) != null

--- a/Core/Net/RedirectWebClient.cs
+++ b/Core/Net/RedirectWebClient.cs
@@ -1,7 +1,7 @@
-#if NETFRAMEWORK
-
 using System;
 using System.Net;
+
+#pragma warning disable SYSLIB0014
 
 namespace CKAN
 {
@@ -23,5 +23,3 @@ namespace CKAN
         }
     }
 }
-
-#endif

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -202,7 +202,22 @@ namespace CKAN.GUI
                         EnableMainWindow();
                         break;
 
+                    case AggregateException exc:
+                        foreach (var inner in exc.InnerExceptions
+                                                 .SelectMany(inner =>
+                                                     inner.TraverseNodes(ex => ex.InnerException)
+                                                          .Reverse()))
+                        {
+                            log.Error(inner.Message, inner);
+                            currentUser.RaiseMessage(inner.Message);
+                        }
+                        AddStatusMessage(Properties.Resources.MainRepoFailed);
+                        Wait.Finish();
+                        EnableMainWindow();
+                        break;
+
                     case Exception exc:
+                        log.Error(exc.Message, exc);
                         currentUser.RaiseMessage(exc.Message);
                         AddStatusMessage(Properties.Resources.MainRepoFailed);
                         Wait.Finish();

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -23,7 +23,7 @@
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>IDE1006</NoWarn>
+    <NoWarn>IDE1006,NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -18,7 +18,7 @@
     <Configurations>Debug;Release;NoGUI</Configurations>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
-    <NoWarn>IDE1006</NoWarn>
+    <NoWarn>IDE1006,NU1701</NoWarn>
     <TargetFrameworks>net48;net7.0;net7.0-windows</TargetFrameworks>
     <BaseTargetFramework>$(TargetFramework.Replace("-windows", ""))</BaseTargetFramework>
     <DefaultItemExcludes Condition=" '$(TargetFramework)' == 'net7.0' ">$(DefaultItemExcludes);AutoUpdate\**;GUI\**</DefaultItemExcludes>


### PR DESCRIPTION
## Background

Since #2682, CKAN has performed a `HEAD` request to get the ETag of each repo before retrieving the full data, to avoid re-downloading the same large metadata archive over and over. This makes the Refresh button finish very quickly if there haven't been any metadata changes since the last time you refreshed (it's basically the same as a browser cache). This was implemented with `WebRequest`, which is now obsolete according to this compiler warning:

https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0014

## Problem

After the release of CKAN v1.34.0, a few users reported that repo updates were sometimes hanging with the almost provocatively unhelpful message, "One or more errors occurred" (it turned out to be just one error :face_with_spiral_eyes:):

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/bd67b336-1b09-43b8-86ec-f904aad0575b)

Reported by @dandoesgithub and confirmed by @Falki-git, both of whom were very patient and generous with their time in helping to track down the cause. Thank you both!

## Cause

In #3932, I allowed myself to be seduced by the siren song of warning SYSLIB0014:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/9d5e140e-f138-4a35-8f66-0697080f2e52)

Seeing this as low-hanging fruit in my ongoing effort to modernize our code, I translated our `WebRequest` code for fetching ETags to use `HttpClient` instead, tested it, and it worked. Great, right? Apparently not.

That exception turned out to be an `AggregateException` with an `.InnerExceptions` property containing a `TaskCanceledException` with a `Message` of `A task was canceled`, which was extremely confusing because nothing was actually being cancelled (and because `AggregateException`'s documentation suggested that it's probably related to PLINQ, which it wasn't in this case). It turns out that `HttpClient` throws this when it _times out a request_, even though `TimeoutException` exists and would be a vastly superior way to indicate a timeout! :facepalm: A little more tracing determined that `HttpClient` was indeed throwing this in our ETag fetching code. Given a test build that used `WebRequest` instead, the same users reported no timeouts.

To recap, switching to `HttpClient` gave us two problems that we never had in the previous 4 years of `Net.CurrentETag`'s existence:

- A mysterious timeout that doesn't seem to reflect anything related to the client, server, or network, since `WebRequest` still works fine for these users
- A misleading and bizarre exception that seems almost intentionally hostile to the user and the programmer, which would be practically impossible to figure out if there were not lengthy discussion threads about it on the internet

Needless to say, this has not given us a great first impression of `HttpClient`. Upon looking deeper, it seems like `HttpClient` is not well designed or maintained. If you want to laugh until you cry and then cry until you laugh again, go watch its maintainers spend thirty screens and 29 months trying to figure out how to throw the right exception instead of the wrong exception in dotnet/runtime#21965. If something that simple takes them that much arguing and delaying (with a disappointing ultimate conclusion that still doesn't really address how confusing this is, as far as I can tell), then I'm not optimistic about the present or future of `HttpClient`. Any improvements that they do make will only be for current .NET versions, so as long as we still need to support .NET Framework (which will be until we figure out how to run WinForms on .NET7+ on Linux), we'd be stuck with the old, unimproved `HttpClient`.

## Changes

- Now the code that used `HttpClient` is rolled back to the previous state, using `WebRequest` and `WebClient`, with `#pragma warning disable SYSLIB0014` added to prevent that warning from appearing.
  If Microsoft ever forcibly sunsets their pre-`HttpClient` HTTP modules, we can consider migrating to a third party library.
- Some functions that weren't using instance state are now marked `static` care of VSCode suggestions
- The `NU1701` build warning is now suppressed because it doesn't seem to be reporting an actual problem

Fixes #3950.

### Considered and not done

At this point, we do not know _why_ `HttpClient` is timing out. Might it be possible for us to make it work properly through some currently unknown magic dance of setting properties differently, passing different parameters, etc.? Maybe. But debugging Microsoft's code is not a good use of (more) time that we could spend on fixes and enhancements when there is a perfectly viable fallback option that has already proven itself long-term stable in the wild.
