### PR TITLE
Usability improvements for adding game instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,7 @@ bld/
 *.nuget.props
 *.nuget.targets
 
+# Python won't let me install packages globally anymore
+/.venv/
+
 quotes.txt.dat

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -14,6 +14,7 @@ namespace CKAN.Games
         // Identification, used for display and saved/loaded in settings JSON
         // Must be unique!
         string ShortName { get; }
+        DateTime FirstReleaseDate { get; }
 
         // Where are we?
         bool   GameInFolder(DirectoryInfo where);
@@ -31,7 +32,7 @@ namespace CKAN.Games
         bool           IsReservedDirectory(GameInstance inst, string path);
         bool           AllowInstallationIn(string name, out string path);
         void           RebuildSubdirectories(string absGameRoot);
-        string         DefaultCommandLine { get; }
+        string         DefaultCommandLine(string path);
         string[]       AdjustCommandLine(string[] args, GameVersion installedVersion);
         IDlcDetector[] DlcDetectors { get; }
 
@@ -42,7 +43,7 @@ namespace CKAN.Games
         GameVersion[]     ParseBuildsJson(JToken json);
         GameVersion       DetectVersion(DirectoryInfo where);
         string            CompatibleVersionsFile { get; }
-        string[]          BuildIDFiles { get; }
+        string[]          InstanceAnchorFiles { get; }
 
         // How to get metadata
         Uri DefaultRepositoryURL  { get; }

--- a/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildIdVersionProvider.cs
+++ b/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildIdVersionProvider.cs
@@ -16,9 +16,9 @@ namespace CKAN.Games.KerbalSpaceProgram.GameVersionProviders
             _kspBuildMap = kspBuildMap;
         }
 
-        private static readonly string[] buildIDfilenames =
+        public static readonly string[] buildIDfilenames =
         {
-            "buildID.txt", "buildID64.txt"
+            "buildID64.txt", "buildID.txt"
         };
 
         public bool TryGetVersion(string directory, out GameVersion result)

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -17,10 +17,11 @@ namespace CKAN.Games.KerbalSpaceProgram2
     public class KerbalSpaceProgram2 : IGame
     {
         public string ShortName => "KSP2";
+        public DateTime FirstReleaseDate => new DateTime(2023, 2, 24);
 
         public bool GameInFolder(DirectoryInfo where)
-            => where.EnumerateFiles().Any(f => f.Name == "KSP2_x64.exe")
-                && where.EnumerateDirectories().Any(d => d.Name == "KSP2_x64_Data");
+            => InstanceAnchorFiles.Any(f => File.Exists(Path.Combine(where.FullName, f)))
+                && Directory.Exists(Path.Combine(where.FullName, "KSP2_x64_Data"));
 
         /// <summary>
         /// Finds the Steam KSP path. Returns null if the folder cannot be located.
@@ -147,10 +148,10 @@ namespace CKAN.Games.KerbalSpaceProgram2
             }
         }
 
-        public string DefaultCommandLine =>
-                  Platform.IsUnix ? "./KSP2.x86_64 -single-instance"
-                : Platform.IsMac  ? "./KSP2.app/Contents/MacOS/KSP"
-                :                   "KSP2_x64.exe -single-instance";
+        public string DefaultCommandLine(string path)
+            => Platform.IsUnix ? "./KSP2.x86_64 -single-instance"
+             : Platform.IsMac  ? "./KSP2.app/Contents/MacOS/KSP"
+             :                   "KSP2_x64.exe -single-instance";
 
         public string[] AdjustCommandLine(string[] args, GameVersion installedVersion)
             => args;
@@ -209,7 +210,7 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public string CompatibleVersionsFile => "compatible_game_versions.json";
 
-        public string[] BuildIDFiles => new string[]
+        public string[] InstanceAnchorFiles => new string[]
         {
             "KSP2_x64.exe",
         };

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -39,10 +39,8 @@ namespace CKAN.GUI
         /// "Build metadata files (buildID.txt;buildID64.txt)|buildID.txt;buildID64.txt"
         /// </returns>
         public static string GameFolderFilter(GameInstanceManager mgr)
-        {
-            return Properties.Resources.BuildIDFilterDescription
-                + "|" + string.Join(";", mgr.AllBuildIDFiles);
-        }
+        => Properties.Resources.GameProgramFileDescription
+            + "|" + string.Join(";", mgr.AllInstanceAnchorFiles);
 
         public bool HasSelections => GameInstancesListView.SelectedItems.Count > 0;
 
@@ -88,14 +86,16 @@ namespace CKAN.GUI
             AddOrRemoveColumn(GameInstancesListView, Game, !allSameGame, GameInstallVersion.Index);
             AddOrRemoveColumn(GameInstancesListView, GamePlayTime, hasPlayTime, GameInstallPath.Index);
 
-            GameInstancesListView.Items.AddRange(_manager.Instances
-                .OrderByDescending(instance => instance.Value.Version())
-                .Select(instance => new ListViewItem(rowItems(instance.Value, !allSameGame, hasPlayTime))
-                {
-                    Tag = instance.Key
-                })
-                .ToArray()
-            );
+            GameInstancesListView.Items.AddRange(
+                _manager.Instances.OrderByDescending(instance => instance.Value.game.FirstReleaseDate)
+                                  .ThenByDescending(instance => instance.Value.Version())
+                                  .ThenBy(instance => instance.Key)
+                                  .Select(instance => new ListViewItem(
+                                      rowItems(instance.Value, !allSameGame, hasPlayTime))
+                                  {
+                                      Tag = instance.Key
+                                  })
+                                  .ToArray());
 
             GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
             GameInstancesListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -114,7 +114,7 @@ namespace CKAN.GUI
                 var configuration = new GUIConfiguration
                 {
                     path = path,
-                    CommandLineArguments = game.DefaultCommandLine
+                    CommandLineArguments = game.DefaultCommandLine(path),
                 };
 
                 SaveConfiguration(configuration);

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -111,7 +111,7 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="CKANFileFilter" xml:space="preserve"><value>CKAN Metadaten (*.ckan)|*.ckan</value></data>
   <data name="ExportInstalledModsDialogTitle" xml:space="preserve"><value>Export der Modliste</value></data>
-  <data name="BuildIDFilterDescription" xml:space="preserve"><value>Build-Metadatendatei</value></data>
+  <data name="GameProgramFileDescription" xml:space="preserve"><value>Build-Metadatendatei</value></data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>Bitte gib einen Namen für die neue Instanz an.</value> </data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>Bitte gib einen Pfad für die neue Instanz an.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>Klone Instanz...</value></data>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -128,7 +128,7 @@
   <data name="AboutDialogLabel2Text" xml:space="preserve">
     <value>Version {0}</value>
   </data>
-  <data name="BuildIDFilterDescription" xml:space="preserve">
+  <data name="GameProgramFileDescription" xml:space="preserve">
     <value>Fichier de métadonnées/Build</value>
   </data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve">

--- a/GUI/Properties/Resources.it-IT.resx
+++ b/GUI/Properties/Resources.it-IT.resx
@@ -128,7 +128,7 @@
   <data name="AboutDialogLabel2Text" xml:space="preserve">
     <value>Versione {0}</value>
   </data>
-  <data name="BuildIDFilterDescription" xml:space="preserve">
+  <data name="GameProgramFileDescription" xml:space="preserve">
     <value>Generazione file metadati</value>
   </data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve">

--- a/GUI/Properties/Resources.ja-JP.resx
+++ b/GUI/Properties/Resources.ja-JP.resx
@@ -120,7 +120,7 @@
   <data name="CKANFileFilter" xml:space="preserve"><value>CKAN metadata (*.ckan)|*.ckan</value></data>
   <data name="ExportInstalledModsDialogTitle" xml:space="preserve"><value>Modリストのエクスポート</value></data>
   <data name="AboutDialogLabel2Text" xml:space="preserve"><value>バージョン {0}</value></data>
-  <data name="BuildIDFilterDescription" xml:space="preserve"><value>Build metadata file</value></data>
+  <data name="GameProgramFileDescription" xml:space="preserve"><value>Build metadata file</value></data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>新しいインスタンスの名前を入力してください。</value></data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>新しいインスタンスの場所を入力してください。</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>"インスタンスを複製中..."</value></data>

--- a/GUI/Properties/Resources.ko-KR.resx
+++ b/GUI/Properties/Resources.ko-KR.resx
@@ -120,7 +120,7 @@
   <data name="CKANFileFilter" xml:space="preserve"><value>CKAN 메타데이터 (*.ckan)|*.ckan</value></data>
   <data name="ExportInstalledModsDialogTitle" xml:space="preserve"><value>모드 리스트 내보내기</value></data>
   <data name="AboutDialogLabel2Text" xml:space="preserve"><value>버전 {0}</value></data>
-  <data name="BuildIDFilterDescription" xml:space="preserve"><value>메타데이터 파일 빌드</value></data>
+  <data name="GameProgramFileDescription" xml:space="preserve"><value>메타데이터 파일 빌드</value></data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>새로운 인스턴스의 이름을 입력해주세요.</value></data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>새로운 인스턴스의 경로를 입력해주세요.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>"인스턴스 복제 중..."</value></data>

--- a/GUI/Properties/Resources.pl-PL.resx
+++ b/GUI/Properties/Resources.pl-PL.resx
@@ -128,7 +128,7 @@
   <data name="AboutDialogLabel2Text" xml:space="preserve">
     <value>Wersja {0}</value>
   </data>
-  <data name="BuildIDFilterDescription" xml:space="preserve">
+  <data name="GameProgramFileDescription" xml:space="preserve">
     <value>Zbuduj plik metadanych</value>
   </data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve">

--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutDialogLabel2Text" xml:space="preserve"><value>Versão {0}</value></data>
-  <data name="BuildIDFilterDescription" xml:space="preserve"><value>Arquivo de metadados da Build</value></data>
+  <data name="GameProgramFileDescription" xml:space="preserve"><value>Arquivo de metadados da Build</value></data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>Por favor informe o nome da nova instância.</value></data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>Por favor informe o caminho da nova instância.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>"Clonando instância..."</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -122,7 +122,7 @@
   <data name="CKANFileFilter" xml:space="preserve"><value>CKAN metadata (*.ckan)|*.ckan</value></data>
   <data name="ExportInstalledModsDialogTitle" xml:space="preserve"><value>Export Mod List</value></data>
   <data name="AboutDialogLabel2Text" xml:space="preserve"><value>Version {0}</value></data>
-  <data name="BuildIDFilterDescription" xml:space="preserve"><value>Build metadata file</value></data>
+  <data name="GameProgramFileDescription" xml:space="preserve"><value>Game program file</value></data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>Please enter a name for the new instance.</value></data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>Please enter a path for the new instance.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>"Cloning instance..."</value></data>

--- a/GUI/Properties/Resources.ru-RU.resx
+++ b/GUI/Properties/Resources.ru-RU.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutDialogLabel2Text" xml:space="preserve"><value>Версия {0}</value></data>
-  <data name="BuildIDFilterDescription" xml:space="preserve"><value>Файл метаданных сборки</value></data>
+  <data name="GameProgramFileDescription" xml:space="preserve"><value>Файл метаданных сборки</value></data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>Введите название новой сборки.</value></data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>Введите путь к папке новой сборки.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>«Клонирование...»</value></data>

--- a/GUI/Properties/Resources.zh-CN.resx
+++ b/GUI/Properties/Resources.zh-CN.resx
@@ -120,7 +120,7 @@
   <data name="CKANFileFilter" xml:space="preserve"><value>CKAN元数据 (*.ckan)|*.ckan</value></data>
   <data name="ExportInstalledModsDialogTitle" xml:space="preserve"><value>导出Mod列表</value></data>
   <data name="AboutDialogLabel2Text" xml:space="preserve"><value>版本 {0}</value></data>
-  <data name="BuildIDFilterDescription" xml:space="preserve"><value>Build metadata file</value></data>
+  <data name="GameProgramFileDescription" xml:space="preserve"><value>Build metadata file</value></data>
   <data name="CloneFakeKspDialogEnterName" xml:space="preserve"><value>请输入新实例名称.</value></data>
   <data name="CloneFakeKspDialogEnterPath" xml:space="preserve"><value>请输入新实例路径.</value></data>
   <data name="CloneFakeKspDialogCloningInstance" xml:space="preserve"><value>"正在克隆实例..."</value></data>


### PR DESCRIPTION
## Motivations

- When you add a KSP1 instance in GUI, you have to pick `buildID.txt` or `buildID64.txt` in the file chooser. This has always been a bit confusing, because no user knows what this file is for or why we care about it. So far nobody seems to have been confused by having to pick the game EXE for KSP2.
  - It's also confusing that the file chooser says "Build metadata file," since no user knows what that means.
- The Manage Game Instances window sorts game instances by version without regard to which game it is, so KSP2 with its low version numbers always shows up before the beginning of KSP1.

## Problems

- Someday, KSP2 is probably going to start installing mods into a `GameData/Mods` folder. If/when this happens, current CKAN clients will detect those instances as KSP1 game folders.
- If you install a very old version of KSP1 (e.g., 1.0.5), it will only have a 32-bit executable, but our game command line defaults to the 64-bit executable, so the game won't run.

## Causes

- `KerbalSpaceProgram.GameInFolder` just checks for `GameData`, which may not always be a good way to differentiate between games.
- `KerbalSpaceProgram.DefaultCommandLine` just returns one string per platform, without checking whether it's valid.

## Changes

- Now you have to pick the game EXE for KSP1 as well. The allowed filenames are platform-specific and include current 64-bit and historical 32-bit versions.
  - This is only true for Windows and Linux. For Mac, you still have to choose `buildID64.txt` or `buildID.txt`, because the actual executable file is hidden away several layers deep inside an app bundle directory on Mac, but this is mostly irrelevant now that GUI doesn't run on Mac anymore.
  - The file chooser now says "Game program file" on English, which hopefully will be easier to understand than "Build metadata file". Other locales will have to wait for translation updates through the normal Crowdin process.
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/1e9a18eb-5a87-4acf-8195-cf036d14bddb)
- Now `IGame.FirstReleaseDate` tracks each game's initial release date, so we can sort KSP2 instances chronologically after KSP1.
- Now `KerbalSpaceProgram.GameInFolder` requires that at least one of the files in `KerbalSpaceProgram.InstanceAnchorFiles` (which has replaced `IGame.BuildIDFiles` and contains the platform-specific executable names) exists in the game folder, which will prevent `GameData` folders from confusing it.
- Now the default game command line for KSP1 depends on the files that are present in the game dir. If you have the old 32-bit EXE, then that will be used as the default, otherwise the 64-bit EXE will be used.

Fixes #3962.
