### PR TITLE
Pause after administrator error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -619,6 +619,7 @@ All notable changes to this project will be documented in this file.
 - [GUI] Fix 'ManageKspInstances' dialog logic (#2787 by: DasSkelett; reviewed: HebaruSan)
 
 ### Internal
+
 - [Build] Update packages (#2775 by: Olympic1; reviewed: DasSkelett, HebaruSan)
 - [Build] Fix fake/clone tests on Windows (#2778 by: HebaruSan; reviewed: DasSkelett)
 - [Reporting] Update issue templates (#2777 by: Olympic1; reviewed: DasSkelett, HebaruSan)
@@ -898,7 +899,6 @@ All notable changes to this project will be documented in this file.
 - [Netkan] Check zip validity in netkan (#2288 by: HebaruSan; reviewed: politas)
 - [Core] Replace colons with hyphens in archive URLs (#2290 by: HebaruSan; reviewed: techman83)
 - [Core] Force-allow TLS 1.2 on .NET 4.5 (#2297 by: HebaruSan; reviewed: politas)
-
 
 ## v1.24.0-PRE1 (McCandless)
 

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -235,6 +235,9 @@ namespace CKAN.CmdLine
                 if (!AsRoot)
                 {
                     user.RaiseError(Properties.Resources.OptionsRootError);
+                    user.RaiseMessage("");
+                    user.RaiseMessage(Properties.Resources.OptionsPressAnyKey);
+                    Console.ReadKey(true);
                     return Exit.ERROR;
                 }
                 else

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -127,8 +127,17 @@
   <data name="MainUnknownCommand" xml:space="preserve"><value>Unknown command, try --help</value></data>
   <data name="MainMissingInstance" xml:space="preserve"><value>I don't know where a game instance is installed.
 Use 'ckan instance help' for assistance in setting this.</value></data>
-  <data name="OptionsRootError" xml:space="preserve"><value>You are trying to run CKAN as an administrator user.
-This is a bad idea and there is absolutely no good reason to do it. Please run CKAN from a user account (or use --asroot if you are feeling brave).</value></data>
+  <data name="OptionsRootError" xml:space="preserve"><value>
+You are trying to run CKAN as an administrator user.
+This gives programs unlimited power to make unauthorized changes to any part of your system.
+We try our best to avoid bugs and malicious code, but you shouldn't trust us this much!
+
+Running as administrator can also cause filesystem permissions problems, since
+files installed by an administrator cannot be removed by a non-administrator.
+
+Run CKAN as a non-administrator user to protect your system from these risks.
+If you must run as an administrator, the `--asroot` parameter will bypass this check.</value></data>
+  <data name="OptionsPressAnyKey" xml:space="preserve"><value>Press any key to exit...</value></data>
   <data name="OptionsRootWarning" xml:space="preserve"><value>Warning: CKAN is running as an administrator user!</value></data>
   <data name="OptionsMonoWarning" xml:space="preserve"><value>Warning: Detected Mono {0}, recommended version is {1} or later!</value></data>
   <data name="OptionsInstanceAndGameDir" xml:space="preserve"><value>--instance and --gamedir can't be specified at the same time</value></data>


### PR DESCRIPTION
## Problem

Users attempting to run GUI as a Windows administrator have reported that the console window appears and disappears before they have a chance to see what it says (see #3956 and #3965).

## Changes

- Now we use a "Press any key to exit" prompt to keep the window visible and only close it after the user presses a key.
- The message now describes the risks involved in more detail.

This should allow users to understand what's happening and make an informed decision.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/96b3f898-c1dc-410d-82d1-3bc2505cd8fc)
