### PR TITLE
Install meta tester at system level again

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -35,10 +35,10 @@ RUN apt-get install -y --no-install-recommends \
 # Install the meta tester's Python code and its Infra dep
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip3 install --upgrade pip
-RUN pip3 install --user 'git+https://github.com/KSP-CKAN/NetKAN-Infra#subdirectory=netkan'
-RUN pip3 install --user 'git+https://github.com/KSP-CKAN/xKAN-meta_testing'
+RUN pip3 install 'git+https://github.com/KSP-CKAN/NetKAN-Infra#subdirectory=netkan'
+RUN pip3 install 'git+https://github.com/KSP-CKAN/xKAN-meta_testing'
 
-# Prune unused deps (`--user` is implicit for uninstall)
+# Prune unused deps
 RUN pip3 --no-input uninstall -y flask gunicorn werkzeug
 
 # The image we'll actually use
@@ -49,7 +49,7 @@ RUN apt-get clean \
     && rm -r /var/lib/apt/lists /var/log/dpkg.log /var/log/apt
 
 # Extract built Python packages from the build image
-COPY --from=build /root/.local /root/.local
+COPY --from=build /usr/local /usr/local
 
 # Install the .NET assemblies the meta tester uses
 ADD netkan.exe /usr/local/bin/.


### PR DESCRIPTION
## Problem

The meta tester is broken.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/c5638080-040f-4361-a672-27dfffdbadb0)

## Cause

In #3958 I added `--user` to the `pip3 install`, because I thought it would be cleaner than copying `/usr/local` from one image to the next. However, when it runs these images, GitHub sets `$HOME` to `/github/home`, which they map to a folder they control:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/794c3250-579d-4fea-b974-1c5925fb5b1c)

This takes `/root/.local/lib/python3.10`, which is where all our modules are installed, out of Python's module search path, which breaks everything. (It also makes for a very confusing problem because my `docker run` commands seemed to work fine until I spotted `HOME` in that long list of environment variables.)

## Changes

Now we install to `/usr/local` again and copy it forward. Impact on image size is negligible:

```
REPOSITORY                         TAG       IMAGE ID       CREATED             SIZE
meta_tester_testing                latest    7e633c3513db   11 minutes ago      376MB
```
