### PR TITLE
Generate schema compliant game versions from swinfo.json

### DIFF
--- a/Netkan/Transformers/SpaceWarpInfoTransformer.cs
+++ b/Netkan/Transformers/SpaceWarpInfoTransformer.cs
@@ -79,8 +79,10 @@ namespace CKAN.NetKAN.Transformers
                     if (GameVersion.TryParse(swinfo.ksp2_version.min, out GameVersion minVer)
                         || GameVersion.TryParse(swinfo.ksp2_version.max, out maxVer))
                     {
-                        log.InfoFormat("Found compatibility: {0}–{1}", minVer, maxVer);
-                        ModuleService.ApplyVersions(json, null, minVer, maxVer);
+                        log.InfoFormat("Found compatibility: {0}–{1}", minVer?.WithoutBuild,
+                                                                       maxVer?.WithoutBuild);
+                        ModuleService.ApplyVersions(json, null, minVer?.WithoutBuild,
+                                                                maxVer?.WithoutBuild);
                     }
                     var moduleDeps = (mod.depends?.OfType<ModuleRelationshipDescriptor>()
                                                   .Select(r => r.name)


### PR DESCRIPTION
## Problem

> NetKAN bot: New inflation error for SpaceWarp: Schema validation failed: #/ksp_version_min: PatternMismatch

## Cause

The schema supports 0.2.0 but not 0.2.0.0.

https://github.com/KSP-CKAN/CKAN/blob/3e8950af83b3e919efb1af4152deb79a8ae14c39/CKAN.schema#L380-L384

The `SpacedockTransformer` uses `GameVersion.WithoutBuild` to remove the 4th piece from the game version the user selects on SpaceDock:

https://github.com/KSP-CKAN/CKAN/blob/3e8950af83b3e919efb1af4152deb79a8ae14c39/Netkan/Transformers/SpacedockTransformer.cs#L79

But the `SpaceWarpInfoTransformer` does not do the same for the game versions in `swinfo.json`:

https://github.com/KSP-CKAN/CKAN/blob/3e8950af83b3e919efb1af4152deb79a8ae14c39/Netkan/Transformers/SpaceWarpInfoTransformer.cs#L78-L84

## Changes

Now game versions from `swinfo.json` are trimmed to conform to the schema.
