### PR TITLE
Fix cache timestamp comparisons

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -219,7 +219,7 @@ namespace CKAN
                 // Check local vs remote timestamps; if local is older, then it's invalid.
                 // null means we don't know the remote timestamp (so file is OK)
                 if (remoteTimestamp == null
-                    || remoteTimestamp < File.GetLastWriteTime(file).ToUniversalTime())
+                    || remoteTimestamp < File.GetLastWriteTimeUtc(file))
                 {
                     // File not too old, use it
                     log.Debug("Found good file, using it");

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -423,7 +423,11 @@ namespace CKAN
             // we had previously.
 
             lock (txMutex) {
-                var options = new JsonSerializerSettings {ObjectCreationHandling = ObjectCreationHandling.Replace};
+                var options = new JsonSerializerSettings
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                    ObjectCreationHandling = ObjectCreationHandling.Replace
+                };
 
                 JsonConvert.PopulateObject(transaction_backup, this, options);
 

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -307,6 +307,7 @@ namespace CKAN
             // after deserialisation.
             var settings = new JsonSerializerSettings
             {
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
                 Context = new StreamingContext(StreamingContextStates.Other, gameInstance)
             };
 

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -144,6 +144,7 @@ namespace CKAN
                 {
                     var settings = new JsonSerializerSettings()
                     {
+                        DateTimeZoneHandling = DateTimeZoneHandling.Utc,
                         Context = new StreamingContext(
                             StreamingContextStates.Other,
                             progress == null

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -341,7 +341,10 @@ namespace CKAN
             try
             {
                 // Use the json string to populate our object
-                JsonConvert.PopulateObject(json, this);
+                JsonConvert.PopulateObject(json, this, new JsonSerializerSettings
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                });
             }
             catch (JsonException ex)
             {

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -333,6 +333,7 @@ namespace CKAN.NetKAN.Services
         private const string SpaceWarpInfoFilename = "swinfo.json";
         private static readonly JsonSerializerSettings ignoreJsonErrors = new JsonSerializerSettings()
         {
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc,
             Error = (sender, e) => e.ErrorContext.Handled = true
         };
 


### PR DESCRIPTION
## Problem

If a user in the eastern hemisphere tries to install a version of a mod that was released in the past X hours, where X is the number of timezones east of Greenwich (so, 3 hours for UTC+3), it fails with this error:

```
About to upgrade:
 * Upgrade: Patch Manager 0.5.0 to 0.6.0 (spacedock.info, 247.0 KiB)
Downloading "https://spacedock.info/mod/3482/Patch%20Manager/download/0.6.0"
Finished downloading PatchManager 0.6.0, validating and storing to cache...
Trying to install PatchManager 0.6.0, but it's not downloaded or download is corrupted
Error during installation!
If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
```

## Cause

CKAN thinks the freshly downloaded file is older than the release date, which ordinarily means it needs to re-download the file because it was replaced on the server:

```
21312 [4] DEBUG CKAN.NetFileCache (null) - Checking cache for https://spacedock.info/mod/3482/Patch Manager/download/0.6.0
21313 [4] DEBUG CKAN.NetFileCache (null) - Rebuilding cache index
21315 [4] DEBUG CKAN.NetFileCache (null) - Found file C:\Users\SunMachine\AppData\Local\CKAN\downloads\3AFBD5A2-PatchManager-0.6.0.zip
21316 [4] DEBUG CKAN.NetFileCache (null) - Found stale file, deleting it
```

`CkanModule.release_date` is being affected by two serious design defects in different components:

- When `Newtonsoft.Json` (de-)serializes a UTC timestamp, such as `CkanModule.release_date`, it does not preserve the time zone as-is or convert it to UTC, as any reasonable programmer would expect. Instead, it converts to local time!! If you print it, it shows the correct time zone _offset_, so in theory it has all the info needed to recreate the original timestamp, except...
- `DateTime` has two modes, local and UTC (it is unable to represent a timestamp in any of the ~22 other time zones), and `<` and `>` comparison operators. When it compares a local timestamp to a UTC timestamp, it does **not** convert them to the same time zone, even though it has all the information it would need to do so!! Instead it just compares the raw numbers as if they were already in the same time zone. This means it gives wrong answers unless the calling code uses a mechanism like `.ToUniversalTime()` carefully and strategically to ensure consistency.

Together, these two very surprising choices in the runtime and libraries break this simple line of code for people east of Greenwich:

https://github.com/KSP-CKAN/CKAN/blob/9addf80bd67307366aac512c6ae5dd7b4ef2ad40/Core/Net/NetFileCache.cs#L221-L222

`remoteTimestamp` is a local timestamp (despite Netkan generating and saving it in UTC originally), so it will be treated as greater than an actually-equivalent-or-slightly-less UTC timestamp returned by `File.GetLastWriteTime(file).ToUniversalTime()` if the local hour is greater than the UTC hour, i.e. if the time zone offset is negative, i.e. if you're in the eastern hemisphere.

The western hemisphere has the opposite, far less obvious problem. There, remote timestamps are treated as _older_ than they really are by your distance from Greenwich, so if a mod author replaces a download, a user re-installing that mod will not get the latest changes if they first downloaded it just a few hours before the replacement.

## Changes

Now we set `JsonSerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc` to tell our JSON deserializers to convert timestamps to UTC so they can be used safely and sanely. The one in `CkanModule.FromJson` fixes loading freshly downloaded repo metadata, and the one in `RepositoryData.FromJson` handles loading cached repo metadata. The others are included just in case.

Fixes #3972.
