### PR TITLE
Fix compatible popup messing with max game version column

### DIFF
--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -213,20 +213,29 @@ namespace CKAN.Games.KerbalSpaceProgram
 
         private List<GameVersion> versions;
 
+        private readonly object versionMutex = new object();
+
         public List<GameVersion> KnownVersions
         {
             get
             {
-                // There's a lot of duplicate real versions with different build IDs,
-                // skip all those extra checks when we use these
                 if (versions == null)
                 {
-                    versions = ServiceLocator.Container
-                                             .Resolve<IKspBuildMap>()
-                                             .KnownVersions
-                                             .Select(v => v.WithoutBuild)
-                                             .Distinct()
-                                             .ToList();
+                    lock (versionMutex)
+                    {
+                        if (versions == null)
+                        {
+                            // There's a lot of duplicate real versions with different build IDs,
+                            // skip all those extra checks when we use these
+                            versions = ServiceLocator.Container
+                                                     .Resolve<IKspBuildMap>()
+                                                     .KnownVersions
+                                                     .Select(v => v.WithoutBuild)
+                                                     .Distinct()
+                                                     .OrderBy(v => v)
+                                                     .ToList();
+                        }
+                    }
                 }
                 return versions;
             }

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -183,7 +183,7 @@ namespace CKAN
         {
             // Cheat slightly for performance:
             // Find the CkanModule with the highest ksp_version_max,
-            // then get the real lastest compatible of just that one mod
+            // then get the real latest compatible of just that one mod
             GameVersion best    = null;
             CkanModule  bestMod = null;
             foreach (var mod in module_version.Values)

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -200,6 +200,12 @@ namespace CKAN.GUI
             if (GameCompatibilityVersion == null)
             {
                 GameCompatibilityVersion = mod.LatestCompatibleGameVersion();
+                if (GameCompatibilityVersion.IsAny)
+                {
+                    GameCompatibilityVersion = mod.LatestCompatibleRealGameVersion(
+                        Main.Instance?.Manager.CurrentInstance?.game.KnownVersions
+                        ?? new List<GameVersion>() {});
+                }
             }
 
             UpdateIsCached();


### PR DESCRIPTION
## Problem

If you open the compatible game versions dialog and click accept (whether or not you make any changes), the values in the max game version column change in strange and hard to understand ways.

## Cause

As of #3904, the max game versions column's behavior depends on the ordering of the global list of known game versions (e.g., in `KerbalSpaceProgram.KnownVersions` for KSP1), which it uses to find the latest real game version with which a mod is compatible. It's loaded in ascending order and is supposed to stay that way.

The compatible versions popup currently changes the sorting of this global list when it loads! So the next time you refresh the mod list, the versions are in descending order, so wrong versions are pulled out by the max game verison column.

## Changes

- Now the compatible versions dialog no longer re-sorts the main global singleton copy of the known game versions to suit its whims, which allows the max game version column to continue working correctly.
- During development of this, I discovered that `KerbalSpaceProgram.KnownVersions` can be initialized several times due to parallel loading. Now it uses a lock to load only once.
- A way for the column to say "any" is patched up to use the same real-version logic as it usually does.

Fixes #3973.
