### PR TITLE
Put auto-installed mods in ignored modpack group by default

### DIFF
--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -497,7 +497,7 @@ namespace CKAN
             };
 
             var rels = registry.InstalledModules
-                .Where(inst => !inst.Module.IsDLC && IsAvailable(inst))
+                .Where(inst => !inst.Module.IsDLC && !inst.AutoInstalled && IsAvailable(inst))
                 .OrderBy(inst => inst.identifier, StringComparer.OrdinalIgnoreCase)
                 .Select(with_versions ? (Func<InstalledModule, RelationshipDescriptor>) RelationshipWithVersion
                                       : RelationshipWithoutVersion)


### PR DESCRIPTION
## Motivation

Currently the export modpack option includes every installed module except DLC (and DarkKAN mods, but the less said of them the better).

By default, auto-installed mods are included, meaning that when you install that modpack, they won't be marked as auto-installed. We have received feedback expressing an interest in splitting these out so the auto-installed flag can be preserved.

## Changes

Now auto-installed mods are put in the Ignored group by default. Users who wish to preserve the auto-installed flag can export the default modpack as-is, and the same mods will be pulled in as dependencies when the modpack is installed. Users who wish to add some of those mods to the modpack may do so by moving them to another group as usual.

I think this was something I considered doing originally, but I wasn't happy about the idea of .ckan files not accurately reflecting your entire mod list. However, since `provides` mods will not be marked auto-installed by default, and because the user will still be able to choose to include auto-installed mods if they wish, I am convinced that the benefits outweight the risks.

Fixes #3975.
