### PR TITLE
Add links to hidden tags and labels below mod list

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -81,6 +81,7 @@ namespace CKAN.GUI
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.purgeContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hiddenTagsLabelsLinkList = new CKAN.GUI.TagsLabelsLinkList();
             this.menuStrip2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ModGrid)).BeginInit();
             this.ModListContextMenuStrip.SuspendLayout();
@@ -284,6 +285,16 @@ namespace CKAN.GUI
             this.NavForwardToolButton.Overflow = System.Windows.Forms.ToolStripItemOverflow.AsNeeded;
             this.NavForwardToolButton.Click += new System.EventHandler(this.NavForwardToolButton_Click);
             resources.ApplyResources(this.NavForwardToolButton, "NavForwardToolButton");
+            //
+            // InstallAllCheckbox
+            //
+            this.InstallAllCheckbox.Location = new System.Drawing.Point(18, 57);
+            this.InstallAllCheckbox.Size = new System.Drawing.Size(20, 20);
+            this.InstallAllCheckbox.Checked = true;
+            this.InstallAllCheckbox.CheckedChanged += new System.EventHandler(this.InstallAllCheckbox_CheckChanged);
+            this.InstallAllCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.InstallAllCheckbox.TabIndex = 11;
+            this.InstallAllCheckbox.TabStop = false;
             //
             // EditModSearches
             //
@@ -530,21 +541,22 @@ namespace CKAN.GUI
             this.ModListHeaderContextMenuStrip.ShowCheckMargin = true;
             this.ModListHeaderContextMenuStrip.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(ModListHeaderContextMenuStrip_ItemClicked);
             //
-            // InstallAllCheckbox
+            // hiddenTagsLabelsLinkList
             //
-            this.InstallAllCheckbox.Location = new System.Drawing.Point(18, 57);
-            this.InstallAllCheckbox.Size = new System.Drawing.Size(20, 20);
-            this.InstallAllCheckbox.Checked = true;
-            this.InstallAllCheckbox.CheckedChanged += new System.EventHandler(this.InstallAllCheckbox_CheckChanged);
-            this.InstallAllCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.InstallAllCheckbox.TabIndex = 11;
-            this.InstallAllCheckbox.TabStop = false;
+            this.hiddenTagsLabelsLinkList.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.hiddenTagsLabelsLinkList.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.hiddenTagsLabelsLinkList.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
+            this.hiddenTagsLabelsLinkList.Location = new System.Drawing.Point(0, 0);
+            this.hiddenTagsLabelsLinkList.Name = "hiddenTagsLabelsLinkList";
+            this.hiddenTagsLabelsLinkList.Size = new System.Drawing.Size(500, 20);
+            this.hiddenTagsLabelsLinkList.OnChangeFilter += hiddenTagsLabelsLinkList_OnChangeFilter;
             //
             // ManageMods
             //
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.Controls.Add(this.InstallAllCheckbox);
             this.Controls.Add(this.ModGrid);
+            this.Controls.Add(this.hiddenTagsLabelsLinkList);
             this.Controls.Add(this.EditModSearches);
             this.Controls.Add(this.menuStrip2);
             this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
@@ -565,6 +577,7 @@ namespace CKAN.GUI
 
         private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.MenuStrip menuStrip2;
+        private System.Windows.Forms.CheckBox InstallAllCheckbox;
         private System.Windows.Forms.ToolStripMenuItem launchGameToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem RefreshToolButton;
         private System.Windows.Forms.ToolStripMenuItem UpdateAllToolButton;
@@ -584,8 +597,8 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem FilterTagsToolButton;
         private System.Windows.Forms.ToolStripMenuItem NavBackwardToolButton;
         private System.Windows.Forms.ToolStripMenuItem NavForwardToolButton;
+        private CKAN.GUI.EditModSearches EditModSearches;
         public System.Windows.Forms.DataGridView ModGrid;
-        private System.Windows.Forms.CheckBox InstallAllCheckbox;
         private System.Windows.Forms.DataGridViewCheckBoxColumn Installed;
         private System.Windows.Forms.DataGridViewCheckBoxColumn AutoInstalled;
         private System.Windows.Forms.DataGridViewCheckBoxColumn UpdateCol;
@@ -613,6 +626,6 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem purgeContentsToolStripMenuItem;
-        private CKAN.GUI.EditModSearches EditModSearches;
+        private CKAN.GUI.TagsLabelsLinkList hiddenTagsLabelsLinkList;
     }
 }

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -30,13 +30,12 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(ModInfo));
-            this.ToolTip = new System.Windows.Forms.ToolTip();
             this.ModInfoTable = new System.Windows.Forms.TableLayoutPanel();
-            this.MetadataModuleNameTextBox = new TransparentTextBox();
-            this.MetadataTagsLabelsPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.MetadataModuleNameTextBox = new CKAN.GUI.TransparentTextBox();
+            this.tagsLabelsLinkList = new CKAN.GUI.TagsLabelsLinkList();
             this.MetadataModuleAbstractLabel = new System.Windows.Forms.Label();
-            this.MetadataModuleDescriptionTextBox = new TransparentTextBox();
-            this.ModInfoTabControl = new ThemedTabControl();
+            this.MetadataModuleDescriptionTextBox = new CKAN.GUI.TransparentTextBox();
+            this.ModInfoTabControl = new CKAN.GUI.ThemedTabControl();
             this.MetadataTabPage = new System.Windows.Forms.TabPage();
             this.Metadata = new CKAN.GUI.Metadata();
             this.RelationshipTabPage = new System.Windows.Forms.TabPage();
@@ -47,20 +46,13 @@ namespace CKAN.GUI
             this.Versions = new CKAN.GUI.Versions();
             this.SuspendLayout();
             //
-            // ToolTip
-            //
-            this.ToolTip.AutoPopDelay = 10000;
-            this.ToolTip.InitialDelay = 250;
-            this.ToolTip.ReshowDelay = 250;
-            this.ToolTip.ShowAlways = true;
-            //
             // ModInfoTable
             //
             this.ModInfoTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.ModInfoTable.ColumnCount = 1;
             this.ModInfoTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.ModInfoTable.Controls.Add(this.MetadataModuleNameTextBox, 0, 0);
-            this.ModInfoTable.Controls.Add(this.MetadataTagsLabelsPanel, 0, 1);
+            this.ModInfoTable.Controls.Add(this.tagsLabelsLinkList, 0, 1);
             this.ModInfoTable.Controls.Add(this.MetadataModuleAbstractLabel, 0, 2);
             this.ModInfoTable.Controls.Add(this.MetadataModuleDescriptionTextBox, 0, 3);
             this.ModInfoTable.Controls.Add(this.ModInfoTabControl, 0, 4);
@@ -89,14 +81,15 @@ namespace CKAN.GUI
             this.MetadataModuleNameTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             resources.ApplyResources(this.MetadataModuleNameTextBox, "MetadataModuleNameTextBox");
             //
-            // MetadataTagsLabelsPanel
+            // tagsLabelsLinkList
             //
-            this.MetadataTagsLabelsPanel.AutoSize = true;
-            this.MetadataTagsLabelsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataTagsLabelsPanel.Padding = new System.Windows.Forms.Padding(0);
-            this.MetadataTagsLabelsPanel.Location = new System.Drawing.Point(0, 0);
-            this.MetadataTagsLabelsPanel.Name = "MetadataTagsLabelsPanel";
-            this.MetadataTagsLabelsPanel.Size = new System.Drawing.Size(500, 20);
+            this.tagsLabelsLinkList.AutoSize = true;
+            this.tagsLabelsLinkList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tagsLabelsLinkList.Padding = new System.Windows.Forms.Padding(0);
+            this.tagsLabelsLinkList.Location = new System.Drawing.Point(0, 0);
+            this.tagsLabelsLinkList.Name = "tagsLabelsLinkList";
+            this.tagsLabelsLinkList.Size = new System.Drawing.Size(500, 20);
+            this.tagsLabelsLinkList.OnChangeFilter += tagsLabelsLinkList_OnChangeFilter;
             //
             // MetadataModuleAbstractLabel
             //
@@ -226,12 +219,11 @@ namespace CKAN.GUI
 
         #endregion
 
-        private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.TableLayoutPanel ModInfoTable;
-        private TransparentTextBox MetadataModuleNameTextBox;
-        private System.Windows.Forms.FlowLayoutPanel MetadataTagsLabelsPanel;
+        private CKAN.GUI.TransparentTextBox MetadataModuleNameTextBox;
+        private CKAN.GUI.TagsLabelsLinkList tagsLabelsLinkList;
         private System.Windows.Forms.Label MetadataModuleAbstractLabel;
-        private TransparentTextBox MetadataModuleDescriptionTextBox;
+        private CKAN.GUI.TransparentTextBox MetadataModuleDescriptionTextBox;
         private System.Windows.Forms.TabControl ModInfoTabControl;
         private System.Windows.Forms.TabPage MetadataTabPage;
         private CKAN.GUI.Metadata Metadata;

--- a/GUI/Controls/TagsLabelsLinkList.cs
+++ b/GUI/Controls/TagsLabelsLinkList.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
+using CKAN.Extensions;
+using CKAN.GUI.Attributes;
+
+namespace CKAN.GUI
+{
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
+    public partial class TagsLabelsLinkList : FlowLayoutPanel
+    {
+        [ForbidGUICalls]
+        public void UpdateTagsAndLabels(IEnumerable<ModuleTag>   tags,
+                                        IEnumerable<ModuleLabel> labels)
+        {
+            Util.Invoke(this, () =>
+            {
+                SuspendLayout();
+                Controls.Clear();
+                if (tags != null)
+                {
+                    foreach (ModuleTag tag in tags)
+                    {
+                        Controls.Add(TagLabelLink(
+                            tag.Name, tag,
+                            new LinkLabelLinkClickedEventHandler(TagLinkLabel_LinkClicked)));
+                    }
+                }
+                if (labels != null)
+                {
+                    foreach (ModuleLabel mlbl in labels)
+                    {
+                        Controls.Add(TagLabelLink(
+                            mlbl.Name, mlbl,
+                            new LinkLabelLinkClickedEventHandler(LabelLinkLabel_LinkClicked)));
+                    }
+                }
+                ResumeLayout();
+            });
+        }
+
+        public event Action<SavedSearch, bool> OnChangeFilter;
+
+        private static int LinkLabelBottom(LinkLabel lbl)
+            => lbl == null ? 0
+                           : lbl.Bottom + lbl.Margin.Bottom + lbl.Padding.Bottom;
+
+        public int TagsHeight
+            => LinkLabelBottom(Controls.OfType<LinkLabel>()
+                                       .LastOrDefault());
+
+        private LinkLabel TagLabelLink(string name,
+                                       object tag,
+                                       LinkLabelLinkClickedEventHandler onClick)
+        {
+            var link = new LinkLabel()
+            {
+                AutoSize     = true,
+                LinkColor    = SystemColors.GrayText,
+                LinkBehavior = LinkBehavior.HoverUnderline,
+                Margin       = new Padding(0, 2, 4, 2),
+                Text         = name,
+                Tag          = tag,
+            };
+            link.LinkClicked += onClick;
+            ToolTip.SetToolTip(link, Properties.Resources.FilterLinkToolTip);
+            return link;
+        }
+
+        private void TagLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            var link = sender as LinkLabel;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            OnChangeFilter?.Invoke(
+                ModList.FilterToSavedSearch(GUIModFilter.Tag,
+                                            link.Tag as ModuleTag, null),
+                merge);
+        }
+
+        private void LabelLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            var link = sender as LinkLabel;
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            OnChangeFilter?.Invoke(
+                ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null,
+                                            link.Tag as ModuleLabel),
+                merge);
+        }
+
+        private readonly ToolTip ToolTip = new ToolTip()
+        {
+            AutoPopDelay = 10000,
+            InitialDelay = 250,
+            ReshowDelay  = 250,
+            ShowAlways   = true,
+        };
+    }
+}

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -426,6 +426,9 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="EditModSearchTooltipExpandButton" xml:space="preserve"><value>Expand or collapse the detailed search fields (Ctrl-Shift-F)</value></data>
   <data name="EditModSearchesTooltipAddSearchButton" xml:space="preserve"><value>Combine a new search with your current searches</value></data>
   <data name="ManageModsInstallAllCheckboxTooltip" xml:space="preserve"><value>Uncheck to uninstall all mods, check to clear change set</value></data>
+  <data name="ManageModsHiddenLabels" xml:space="preserve"><value>Hidden labels:</value></data>
+  <data name="ManageModsHiddenTags" xml:space="preserve"><value>Hidden tags:</value></data>
+  <data name="ManageModsHiddenLabelsAndTags" xml:space="preserve"><value>Hidden labels and tags:</value></data>
   <data name="TotalPlayTime" xml:space="preserve"><value>Total play time: {0} hours</value></data>
   <data name="ChangeTypeNone" xml:space="preserve"><value>None</value></data>
   <data name="ChangeTypeInstall" xml:space="preserve"><value>Install</value></data>


### PR DESCRIPTION
## Motivation

The mod list header context menu provides the ability to hide all mods with particular tags, but it's easy to forget that you've done this afterwards. When people ask why some mods are missing in the support channels, it takes me a long time to remember that this feature exists.

## Changes

- Now if you hide a tag, a link to it will show up under the mod list to ensure that you can tell what happened (and that a screenshot will reveal it to anyone trying to provide support).
- Similarly, if you use a label to hide mods, a link to that label will show up in the same list.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/3da44d72-489a-44c3-98d9-17630b03f38e)
