### PR TITLE
Show tag-hiding menu on clicking hidden tag

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -549,7 +549,9 @@ namespace CKAN.GUI
             this.hiddenTagsLabelsLinkList.Location = new System.Drawing.Point(0, 0);
             this.hiddenTagsLabelsLinkList.Name = "hiddenTagsLabelsLinkList";
             this.hiddenTagsLabelsLinkList.Size = new System.Drawing.Size(500, 20);
-            this.hiddenTagsLabelsLinkList.OnChangeFilter += hiddenTagsLabelsLinkList_OnChangeFilter;
+            this.hiddenTagsLabelsLinkList.TagClicked += hiddenTagsLabelsLinkList_TagClicked;
+            this.hiddenTagsLabelsLinkList.LabelClicked += hiddenTagsLabelsLinkList_LabelClicked;
+            resources.ApplyResources(this.hiddenTagsLabelsLinkList, "hiddenTagsLabelsLinkList");
             //
             // ManageMods
             //

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -594,9 +594,24 @@ namespace CKAN.GUI
             // Right click -> Bring up context menu to change visibility of columns.
             else if (e.Button == MouseButtons.Right)
             {
-                // Start from scrap: clear the entire item list, then add all options again.
-                ModListHeaderContextMenuStrip.Items.Clear();
+                ShowHeaderContextMenu();
+            }
+        }
 
+        private void ShowHeaderContextMenu(bool columns = true,
+                                           bool tags    = true)
+        {
+            if (!columns && !tags)
+            {
+                // Don't show a blank menu
+                return;
+            }
+
+            // Start from scratch: clear the entire item list, then add all options again
+            ModListHeaderContextMenuStrip.Items.Clear();
+
+            if (columns)
+            {
                 // Add columns
                 ModListHeaderContextMenuStrip.Items.AddRange(
                     ModGrid.Columns.Cast<DataGridViewColumn>()
@@ -610,10 +625,16 @@ namespace CKAN.GUI
                     })
                     .ToArray()
                 );
+            }
 
+            if (columns && tags)
+            {
                 // Separator
                 ModListHeaderContextMenuStrip.Items.Add(new ToolStripSeparator());
+            }
 
+            if (tags)
+            {
                 // Add tags
                 var registry = RegistryManager.Instance(Main.Instance.CurrentInstance, repoData).registry;
                 ModListHeaderContextMenuStrip.Items.AddRange(
@@ -627,10 +648,10 @@ namespace CKAN.GUI
                     })
                     .ToArray()
                 );
-
-                // Show the context menu on cursor position.
-                ModListHeaderContextMenuStrip.Show(Cursor.Position);
             }
+
+            // Show the context menu on cursor position.
+            ModListHeaderContextMenuStrip.Show(Cursor.Position);
         }
 
         /// <summary>
@@ -1595,9 +1616,15 @@ namespace CKAN.GUI
             });
         }
 
-        private void hiddenTagsLabelsLinkList_OnChangeFilter(SavedSearch search, bool merge)
+        private void hiddenTagsLabelsLinkList_TagClicked(ModuleTag tag, bool merge)
         {
-            Filter(search, merge);
+            ShowHeaderContextMenu(columns: false);
+        }
+
+        private void hiddenTagsLabelsLinkList_LabelClicked(ModuleLabel label, bool merge)
+        {
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null, label),
+                   merge);
         }
 
         #endregion

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -136,6 +136,7 @@
   <data name="FilterLabelsToolButton.Text" xml:space="preserve"><value>Labels</value></data>
   <data name="NavBackwardToolButton.ToolTipText" xml:space="preserve"><value>Previous selected mod...</value></data>
   <data name="NavForwardToolButton.ToolTipText" xml:space="preserve"><value>Next selected mod...</value></data>
+  <data name="hiddenTagsLabelsLinkList.TagToolTipText" xml:space="preserve"><value>Click to show or hide tags</value></data>
   <data name="Installed.HeaderText" xml:space="preserve"><value>Installed</value></data>
   <data name="AutoInstalled.HeaderText" xml:space="preserve"><value>Auto-installed</value></data>
   <data name="UpdateCol.HeaderText" xml:space="preserve"><value>Update</value></data>

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -89,7 +89,8 @@ namespace CKAN.GUI
             this.tagsLabelsLinkList.Location = new System.Drawing.Point(0, 0);
             this.tagsLabelsLinkList.Name = "tagsLabelsLinkList";
             this.tagsLabelsLinkList.Size = new System.Drawing.Size(500, 20);
-            this.tagsLabelsLinkList.OnChangeFilter += tagsLabelsLinkList_OnChangeFilter;
+            this.tagsLabelsLinkList.TagClicked += tagsLabelsLinkList_TagClicked;
+            this.tagsLabelsLinkList.LabelClicked += tagsLabelsLinkList_LabelClicked;
             //
             // MetadataModuleAbstractLabel
             //

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -159,10 +159,16 @@ namespace CKAN.GUI
             });
         }
 
-        private void tagsLabelsLinkList_OnChangeFilter(SavedSearch search, bool merge)
-        {
-            OnChangeFilter?.Invoke(search, merge);
-        }
+
+        private void tagsLabelsLinkList_TagClicked(ModuleTag tag, bool merge)
+            => OnChangeFilter?.Invoke(ModList.FilterToSavedSearch(GUIModFilter.Tag,
+                                                                  tag, null),
+                                      merge);
+
+        private void tagsLabelsLinkList_LabelClicked(ModuleLabel label, bool merge)
+            => OnChangeFilter?.Invoke(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel,
+                                                                  null, label),
+                                      merge);
 
         private void Metadata_OnChangeFilter(SavedSearch search, bool merge)
         {

--- a/GUI/Controls/TagsLabelsLinkList.cs
+++ b/GUI/Controls/TagsLabelsLinkList.cs
@@ -30,7 +30,7 @@ namespace CKAN.GUI
                     foreach (ModuleTag tag in tags)
                     {
                         Controls.Add(TagLabelLink(
-                            tag.Name, tag,
+                            tag.Name, tag, tagToolTip,
                             new LinkLabelLinkClickedEventHandler(TagLinkLabel_LinkClicked)));
                     }
                 }
@@ -39,7 +39,7 @@ namespace CKAN.GUI
                     foreach (ModuleLabel mlbl in labels)
                     {
                         Controls.Add(TagLabelLink(
-                            mlbl.Name, mlbl,
+                            mlbl.Name, mlbl, Properties.Resources.FilterLinkToolTip,
                             new LinkLabelLinkClickedEventHandler(LabelLinkLabel_LinkClicked)));
                     }
                 }
@@ -47,7 +47,24 @@ namespace CKAN.GUI
             });
         }
 
-        public event Action<SavedSearch, bool> OnChangeFilter;
+        public string TagToolTipText
+        {
+            get => tagToolTip;
+            set
+            {
+                tagToolTip = value;
+                foreach (var lbl in Controls.OfType<LinkLabel>()
+                                            .Where(lbl => lbl.Tag is ModuleTag))
+                {
+                    ToolTip.SetToolTip(lbl, tagToolTip);
+                }
+            }
+        }
+
+        public event Action<ModuleTag,   bool> TagClicked;
+        public event Action<ModuleLabel, bool> LabelClicked;
+
+        private string tagToolTip = Properties.Resources.FilterLinkToolTip;
 
         private static int LinkLabelBottom(LinkLabel lbl)
             => lbl == null ? 0
@@ -59,6 +76,7 @@ namespace CKAN.GUI
 
         private LinkLabel TagLabelLink(string name,
                                        object tag,
+                                       string toolTip,
                                        LinkLabelLinkClickedEventHandler onClick)
         {
             var link = new LinkLabel()
@@ -71,7 +89,7 @@ namespace CKAN.GUI
                 Tag          = tag,
             };
             link.LinkClicked += onClick;
-            ToolTip.SetToolTip(link, Properties.Resources.FilterLinkToolTip);
+            ToolTip.SetToolTip(link, toolTip);
             return link;
         }
 
@@ -79,20 +97,14 @@ namespace CKAN.GUI
         {
             var link = sender as LinkLabel;
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            OnChangeFilter?.Invoke(
-                ModList.FilterToSavedSearch(GUIModFilter.Tag,
-                                            link.Tag as ModuleTag, null),
-                merge);
+            TagClicked?.Invoke(link.Tag as ModuleTag, merge);
         }
 
         private void LabelLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             var link = sender as LinkLabel;
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            OnChangeFilter?.Invoke(
-                ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null,
-                                            link.Tag as ModuleLabel),
-                merge);
+            LabelClicked?.Invoke(link.Tag as ModuleLabel, merge);
         }
 
         private readonly ToolTip ToolTip = new ToolTip()


### PR DESCRIPTION
## Motivation

#3979 added visible links so you can tell when you've hidden tags. Clicking them applies the filter for `tag:tagname`, which lets you see which mods are hidden, but doesn't help much for un-hiding them.

It would be more useful to be able to access the option to un-hide them easily.

## Changes

Clicking a hidden tag link now opens the context menu where you can hide and unhide them, excluding the column options. Clicking a hidden label still searches it, because you need to be able to remove mods from it one by one. The tooltip for tag links is changed to reflect the fact that it's not searching anymore.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/70b74890-852e-4a3e-b013-4ed821b3410a)
