### PR TITLE
Detect and use Windows KSP2 executable on Linux

### DIFF
--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -149,8 +149,7 @@ namespace CKAN.Games.KerbalSpaceProgram2
         }
 
         public string DefaultCommandLine(string path)
-            => Platform.IsUnix ? "./KSP2.x86_64 -single-instance"
-             : Platform.IsMac  ? "./KSP2.app/Contents/MacOS/KSP"
+            => Platform.IsMac  ? "./KSP2.app/Contents/MacOS/KSP"
              :                   "KSP2_x64.exe -single-instance";
 
         public string[] AdjustCommandLine(string[] args, GameVersion installedVersion)

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -149,8 +149,13 @@ namespace CKAN.Games.KerbalSpaceProgram2
         }
 
         public string DefaultCommandLine(string path)
-            => Platform.IsMac  ? "./KSP2.app/Contents/MacOS/KSP"
-             :                   "KSP2_x64.exe -single-instance";
+            => Platform.IsMac
+                ? "./KSP2.app/Contents/MacOS/KSP2"
+                : string.Format(Platform.IsUnix ? "./{0} -single-instance"
+                                                : "{0} -single-instance",
+                                InstanceAnchorFiles.FirstOrDefault(f =>
+                                    File.Exists(Path.Combine(path, f)))
+                                ?? InstanceAnchorFiles.First());
 
         public string[] AdjustCommandLine(string[] args, GameVersion installedVersion)
             => args;
@@ -209,10 +214,19 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public string CompatibleVersionsFile => "compatible_game_versions.json";
 
-        public string[] InstanceAnchorFiles => new string[]
-        {
-            "KSP2_x64.exe",
-        };
+        public string[] InstanceAnchorFiles =>
+            Platform.IsUnix
+                ? new string[]
+                {
+                    // Native Linux port, if/when it arrives
+                    "KSP2.x86_64",
+                    // Windows EXE via Proton on Linux
+                    "KSP2_x64.exe",
+                }
+                : new string[]
+                {
+                    "KSP2_x64.exe",
+                };
 
         public Uri DefaultRepositoryURL => new Uri("https://github.com/KSP-CKAN/KSP2-CKAN-meta/archive/main.tar.gz");
 


### PR DESCRIPTION
There is no official, unique KSP2 build for Linux. We can remove this reference to and assumption about the unsupported Unix platform.

This also has the positive indirect effect of treating the executable paths for Linux and Windows as identical (which appears to be the case for Proton installations).
