### PR TITLE
Save and load game version for fake KSP2 instances

### DIFF
--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -281,7 +281,8 @@ namespace CKAN
 
                 foreach (var anchor in game.InstanceAnchorFiles)
                 {
-                    fileMgr.WriteAllText(Path.Combine(newPath, anchor), "");
+                    fileMgr.WriteAllText(Path.Combine(newPath, anchor),
+                                         version.WithoutBuild.ToString());
                 }
 
                 // Don't write the buildID.txts if we have no build, otherwise it would be -1.
@@ -289,9 +290,8 @@ namespace CKAN
                 {
                     foreach (var b in KspBuildIdVersionProvider.buildIDfilenames)
                     {
-                        fileMgr.WriteAllText(
-                            Path.Combine(newPath, b),
-                            string.Format("build id = {0}", version.Build));
+                        fileMgr.WriteAllText(Path.Combine(newPath, b),
+                                             string.Format("build id = {0}", version.Build));
                     }
                 }
 

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -203,10 +203,13 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         private GameVersion VersionFromFile(string path)
             => File.Exists(path)
-                ? GameVersion.Parse(
-                    FileVersionInfo.GetVersionInfo(path).ProductVersion
-                    ?? versions.Last().ToString())
-                : null;
+                && GameVersion.TryParse(FileVersionInfo.GetVersionInfo(path).ProductVersion
+                                        // Fake instances have an EXE containing just the version string
+                                        ?? File.ReadAllText(path),
+                                        out GameVersion v)
+                    ? v
+                    // Fall back to the most recent version
+                    : KnownVersions.Last();
 
         public string CompatibleVersionsFile => "compatible_game_versions.json";
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -632,6 +632,7 @@ namespace CKAN
         {
             log.DebugFormat("Finding all available versions for {0}", identifier);
             return getAvail(identifier).SelectMany(am => am.AllAvailable())
+                                       .Distinct()
                                        .OrderByDescending(m => m.version);
         }
 


### PR DESCRIPTION
## Problems

Two problems came up during KSP-CKAN/KSP2-NetKAN#125:

- The meta tester always fails to install KSP2 mods that aren't compatible with the latest game version
- `ckan show --with-versions` lists multiple copies of the same version of a mod when the meta tester runs it

Initially I thought the former was caused by how the meta tester's Python code handles game version build numbers, but KSP-CKAN/xKAN-meta_testing#97 didn't fix it.

## Causes

- Currently a fake KSP2 instance is always treated as the current game version, because the game version isn't saved in a way that `KerbalSpaceProgram2.DetectVersion` can retrieve. That function uses `FileVersionInfo.GetVersionInfo(path).ProductVersion` to examine the game's executable, and we can't generate an executable on the fly. The game version we pass on the command line is saved to a `readme.txt` file but otherwise ignored.
- With the recent repo refactor, when a mod version exists in multiple repos (which is how the meta tester works), both copies are returned by `Registry.AvailableByIdentifier`

## Changes

- Now when we create a fake KSP2 instance, instead of creating `KSP_x64.exe` as an empty file, we save the game version in it
- Now if we fail to get the KSP2 game version from `FileVersionInfo.GetVersionInfo(path).ProductVersion`, we fall back to loading the text of the file as per the above point
- Now `Registry.AvailableByIdentifier` filters out duplicates
