### PR TITLE
Fix Audit Recommendations option

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1333,7 +1333,8 @@ namespace CKAN
                                         out Dictionary<CkanModule, HashSet<string>>           supporters)
         {
             var crit     = ksp.VersionCriteria();
-            var resolver = new RelationshipResolver(sourceModules, null,
+            var resolver = new RelationshipResolver(sourceModules.Where(m => !m.IsDLC),
+                                                    null,
                                                     RelationshipResolverOptions.KitchenSinkOpts(),
                                                     registry, crit);
             var recommenders = resolver.Dependencies().ToHashSet();


### PR DESCRIPTION
## Problem

If you have any DLCs installed in a KSP1 instance, the Audit Recommendations option doesn't work.

## Cause

As of #3892, `ModuleInstaller.FindRecommendations` uses `RelationshipResolver` to get the recommendations and suggestions for the full dependency tree of a given group of mods. (Previously it had a lot of its own duplicative logic that has been refactored to use the shared logic in `RelationshipResolver`.)

Audit Recommendations passes the list of installed modules, which includes DLCs, and `RelationshipResolver` throws `ModuleIsDLCKraken` when it finds a DLC in its input.

## Changes

Now `ModuleInstaller.FindRecommendations` filters DLCs out of the sequence of modules it passes to `RelationshipResolver`, so the exception is no longer thrown and Audit Recommendations works again.

We could have had `GUI.Main.AuditRecommendations` do this instead, but it seems more appropriate to enforce the constraint at the point where `RelationshipResolver` enters the picture.

Fixes #3987.
