### PR TITLE
Installation message usability improvements

### DIFF
--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using log4net;
 
 namespace CKAN.CmdLine
@@ -255,27 +254,31 @@ namespace CKAN.CmdLine
         /// <param name="percent">Progress in percent</param>
         public void RaiseProgress(string message, int percent)
         {
-            if (Regex.IsMatch(message, Properties.Resources.UserProgressDownloadSubstring, RegexOptions.IgnoreCase))
-            {
-                // In headless mode, only print a new message if the percent has changed,
-                // to reduce clutter in Jenkins for large downloads
-                if (!Headless || percent != previousPercent)
-                {
-                    // The \r at the front here causes download messages to *overwrite* each other.
-                    Console.Write("\r{0} - {1}%           ", message, percent);
-                    previousPercent = percent;
-                }
-            }
-            else
-            {
-                // The percent looks weird on non-download messages.
-                // The leading newline makes sure we don't end up with a mess from previous
-                // download messages.
-                GoToStartOfLine();
-                Console.Write("{0}", message);
-            }
-            // These messages leave the cursor at the end of a line of text
+            // The percent looks weird on non-download messages.
+            // The leading newline makes sure we don't end up with a mess from previous
+            // download messages.
+            GoToStartOfLine();
+            Console.Write("{0}", message);
+
+            // This message leaves the cursor at the end of a line of text
             atStartOfLine = false;
+        }
+
+        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        {
+            if (!Headless || percent != previousPercent)
+            {
+                GoToStartOfLine();
+                var fullMsg = string.Format(CKAN.Properties.Resources.NetAsyncDownloaderProgress,
+                                            CkanModule.FmtSize(bytesPerSecond),
+                                            CkanModule.FmtSize(bytesLeft));
+                // The \r at the front here causes download messages to *overwrite* each other.
+                Console.Write("\r{0} - {1}%           ", fullMsg, percent);
+                previousPercent = percent;
+
+                // This message leaves the cursor at the end of a line of text
+                atStartOfLine = false;
+            }
         }
 
         /// <summary>

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -205,6 +205,21 @@ namespace CKAN.ConsoleUI.Toolkit {
         }
 
         /// <summary>
+        /// Update a user visible progress bar
+        /// </summary>
+        /// <param name="percent">Value 0-100 representing the progress</param>
+        /// <param name="bytesPerSecond">Current download rate</param>
+        /// <param name="bytesLeft">Bytes remaining in the downloads</param>
+        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        {
+            var fullMsg = string.Format(CKAN.Properties.Resources.NetAsyncDownloaderProgress,
+                                        CkanModule.FmtSize(bytesPerSecond),
+                                        CkanModule.FmtSize(bytesLeft));
+            Progress(fullMsg, percent);
+            Draw(userTheme);
+        }
+
+        /// <summary>
         /// Forward a RaiseProgress request to child classes
         /// </summary>
         /// <param name="message">Message to be shown in progress bar</param>

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -700,10 +700,12 @@ namespace CKAN
                 foreach (string mod in goners)
                 {
                     int percent_complete = (step++ * 100) / goners.Count;
-                    User.RaiseProgress(
-                        string.Format(Properties.Resources.ModuleInstallerRemovingMod, mod),
-                        percent_complete);
-                    Uninstall(mod, ref possibleConfigOnlyDirs, registry_manager.registry);
+                    var registry = registry_manager.registry;
+                    User.RaiseProgress(string.Format(Properties.Resources.ModuleInstallerRemovingMod,
+                                                     registry.InstalledModule(mod)?.Module.ToString()
+                                                     ?? mod),
+                                       percent_complete);
+                    Uninstall(mod, ref possibleConfigOnlyDirs, registry);
                 }
 
                 // Enforce consistency if we're not installing anything,

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -138,8 +138,9 @@ namespace CKAN
                 CkanModule module = null;
                 try
                 {
-                    module = modules.First(m => m.download?.Any(dlUri => dlUri == url)
-                                                ?? false);
+                    module = modules.First(m => (m.download?.Any(dlUri => dlUri == url)
+                                                 ?? false)
+                                                || m.InternetArchiveDownload == url);
                     User.RaiseMessage(Properties.Resources.NetAsyncDownloaderValidating, module);
                     cache.Store(module, filename,
                         new Progress<long>(percent => StoreProgress?.Invoke(module, 100 - percent, 100)),

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -121,9 +121,9 @@
   <data name="NetDownloading" xml:space="preserve"><value>Downloading {0}</value></data>
   <data name="NetMissingCertFailed" xml:space="preserve"><value>Failed downloading {0}</value></data>
   <data name="NetInvalidLocation" xml:space="preserve"><value>Invalid URL in Location header: {0}</value></data>
-  <data name="NetAsyncDownloaderDownloading" xml:space="preserve"><value>Downloading "{0}"</value></data>
+  <data name="NetAsyncDownloaderDownloading" xml:space="preserve"><value>Downloading {0} ...</value></data>
   <data name="NetAsyncDownloaderCancelled" xml:space="preserve"><value>Download cancelled by user</value></data>
-  <data name="NetAsyncDownloaderProgress" xml:space="preserve"><value>{0}/sec - downloading - {1} left</value><comment>Should contain UserProgressDownloadSubstring from CmdLine</comment></data>
+  <data name="NetAsyncDownloaderProgress" xml:space="preserve"><value>{0}/sec - downloading - {1} left</value></data>
   <data name="NetAsyncDownloaderTryingFallback" xml:space="preserve"><value>Failed to download "{0}", trying fallback "{1}"</value></data>
   <data name="NetAsyncDownloaderValidating" xml:space="preserve"><value>Finished downloading {0}, validating and storing to cache...</value></data>
   <data name="NetFileCacheCannotFind" xml:space="preserve"><value>Cannot find cache directory: {0}</value></data>
@@ -209,11 +209,11 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="GameInstanceNoValidName" xml:space="preserve"><value>Could not return a valid name for the new instance</value></data>
   <data name="GameInstanceByPathName" xml:space="preserve"><value>custom</value></data>
   <data name="GameInstancePathNotFound" xml:space="preserve"><value>{0} does not exist</value></data>
-  <data name="ModuleInstallerDownloading" xml:space="preserve"><value>Downloading "{0}"</value></data>
+  <data name="ModuleInstallerDownloading" xml:space="preserve"><value>Downloading {0} ...</value></data>
   <data name="ModuleInstallerNothingToInstall" xml:space="preserve"><value>Nothing to install</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>About to install:</value></data>
   <data name="ModuleInstallerUserDeclined" xml:space="preserve"><value>User declined install list</value></data>
-  <data name="ModuleInstallerInstallingMod" xml:space="preserve"><value>Installing mod "{0}"</value></data>
+  <data name="ModuleInstallerInstallingMod" xml:space="preserve"><value>Installing {0}...</value></data>
   <data name="ModuleInstallerUpdatingRegistry" xml:space="preserve"><value>Updating registry</value></data>
   <data name="ModuleInstallerCommitting" xml:space="preserve"><value>Committing filesystem changes</value></data>
   <data name="ModuleInstallerRescanning" xml:space="preserve"><value>Rescanning {0}</value></data>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1305,10 +1305,11 @@ namespace CKAN
             => repoDataMgr.GetAllAvailableModules(repositories.Values)
                           // Pick all latest modules where download is not null
                           // Merge all the URLs into one sequence
-                          .SelectMany(availMod => availMod?.Latest()?.download
-                                                  ?? Enumerable.Empty<Uri>())
+                          .SelectMany(availMod => (availMod?.Latest()?.download
+                                                   ?? Enumerable.Empty<Uri>())
+                                                  .Append(availMod?.Latest()?.InternetArchiveDownload))
                           // Skip relative URLs because they don't have hosts
-                          .Where(dlUri => dlUri.IsAbsoluteUri)
+                          .Where(dlUri => dlUri?.IsAbsoluteUri ?? false)
                           // Group the URLs by host
                           .GroupBy(dlUri => dlUri.Host)
                           // Put most commonly used hosts first

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -172,7 +172,6 @@ namespace CKAN
                     targets.Select(t => new FileInfo(t.filename).Length));
                 foreach ((Repository repo, Net.DownloadTarget target) in toUpdate.Zip(targets))
                 {
-                    user.RaiseMessage(Properties.Resources.NetRepoLoadingModulesFromRepo, repo.name);
                     var file = target.filename;
                     msg = string.Format(Properties.Resources.NetRepoLoadingModulesFromRepo,
                                         repo.name);

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -21,6 +21,7 @@ namespace CKAN
         void RaiseError(string message, params object[] args);
 
         void RaiseProgress(string message, int percent);
+        void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft);
         void RaiseMessage(string message, params object[] args);
     }
 
@@ -56,6 +57,10 @@ namespace CKAN
         }
 
         public void RaiseProgress(string message, int percent)
+        {
+        }
+
+        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
         {
         }
 

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -68,6 +68,8 @@ namespace CKAN.GUI
         /// </summary>
         public event Action SurrenderFocus;
 
+        public event Action<string> ShowError;
+
         public ModSearch Search
         {
             get => currentSearch;
@@ -141,7 +143,7 @@ namespace CKAN.GUI
             }
             catch (Kraken k)
             {
-                Main.Instance?.AddStatusMessage(k.Message);
+                ShowError?.Invoke(k.Message);
             }
         }
 

--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -26,6 +26,7 @@ namespace CKAN.GUI
 
         public event Action                  SurrenderFocus;
         public event Action<List<ModSearch>> ApplySearches;
+        public event Action<string>          ShowError;
 
         public void Clear()
         {
@@ -113,6 +114,7 @@ namespace CKAN.GUI
             };
             ctl.ApplySearch    += EditModSearch_ApplySearch;
             ctl.SurrenderFocus += EditModSearch_SurrenderFocus;
+            ctl.ShowError      += error => ShowError?.Invoke(error);
 
             editors.Add(ctl);
             Controls.Add(ctl);

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -301,6 +301,7 @@ namespace CKAN.GUI
             this.EditModSearches.Dock = System.Windows.Forms.DockStyle.Top;
             this.EditModSearches.ApplySearches += EditModSearches_ApplySearches;
             this.EditModSearches.SurrenderFocus += EditModSearches_SurrenderFocus;
+            this.EditModSearches.ShowError += EditModSearches_ShowError;
             //
             // ModGrid
             //

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -267,6 +267,36 @@ namespace CKAN.GUI
                 MessageTextBox.Text = "(" + message + ")");
         }
 
+        public void SetMainProgress(string message, int percent)
+        {
+            Util.Invoke(this, () =>
+            {
+                MessageTextBox.Text = $"{message} - {percent}%";
+                ProgressIndeterminate = false;
+                ProgressValue = percent;
+                if (message != lastProgressMessage)
+                {
+                    AddLogMessage(message);
+                    lastProgressMessage = message;
+                }
+            });
+        }
+
+        public void SetMainProgress(int percent, long bytesPerSecond, long bytesLeft)
+        {
+            var fullMsg = string.Format(CKAN.Properties.Resources.NetAsyncDownloaderProgress,
+                                        CkanModule.FmtSize(bytesPerSecond),
+                                        CkanModule.FmtSize(bytesLeft));
+            Util.Invoke(this, () =>
+            {
+                MessageTextBox.Text = $"{fullMsg} - {percent}%";
+                ProgressIndeterminate = false;
+                ProgressValue = percent;
+            });
+        }
+
+        private string lastProgressMessage;
+
         [ForbidGUICalls]
         private void ClearLog()
         {
@@ -274,11 +304,9 @@ namespace CKAN.GUI
                 LogTextBox.Text = "");
         }
 
-        [ForbidGUICalls]
         public void AddLogMessage(string message)
         {
-            Util.Invoke(this, () =>
-                LogTextBox.AppendText(message + "\r\n"));
+            LogTextBox.AppendText(message + "\r\n");
         }
 
         private void RetryCurrentActionButton_Click(object sender, EventArgs e)

--- a/GUI/Dialogs/SelectionDialog.cs
+++ b/GUI/Dialogs/SelectionDialog.cs
@@ -4,6 +4,8 @@ using System.Windows.Forms;
 using System.Runtime.Versioning;
 #endif
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     #if NET5_0_OR_GREATER
@@ -25,6 +27,7 @@ namespace CKAN.GUI
         /// <returns>The selected index, -1 if canceled.</returns>
         /// <param name="message">Message.</param>
         /// <param name="args">Array of items to select from.</param>
+        [ForbidGUICalls]
         public int ShowSelectionDialog (string message, params object[] args)
         {
             int defaultSelection = -1;

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using System.Runtime.Versioning;
 #endif
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     #if NET5_0_OR_GREATER
@@ -20,6 +22,7 @@ namespace CKAN.GUI
             defaultNo  = NoButton.Text;
         }
 
+        [ForbidGUICalls]
         public DialogResult ShowYesNoDialog(Form parentForm, string text, string yesText = null, string noText = null)
         {
             task = new TaskCompletionSource<Tuple<DialogResult, bool>>();
@@ -33,6 +36,7 @@ namespace CKAN.GUI
             return task.Task.Result.Item1;
         }
 
+        [ForbidGUICalls]
         public Tuple<DialogResult, bool> ShowSuppressableYesNoDialog(Form parentForm, string text, string suppressText, string yesText = null, string noText = null)
         {
             task = new TaskCompletionSource<Tuple<DialogResult, bool>>();

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Windows.Forms;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
+
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -12,20 +16,27 @@ namespace CKAN.GUI
     #endif
     public class GUIUser : IUser
     {
-        public GUIUser(Main main, Wait wait)
+        public GUIUser(Main main,
+                       Wait wait,
+                       ToolStripStatusLabel statBarLabel,
+                       ToolStripProgressBar statBarProgBar)
         {
-            this.main = main;
-            this.wait = wait;
+            this.main           = main;
+            this.wait           = wait;
+            this.statBarLabel   = statBarLabel;
+            this.statBarProgBar = statBarProgBar;
         }
 
         private readonly Main main;
         private readonly Wait wait;
+        private readonly ToolStripStatusLabel statBarLabel;
+        private readonly ToolStripProgressBar statBarProgBar;
 
         /// <summary>
         /// A GUIUser is obviously not headless. Returns false.
         /// </summary>
+        [ForbidGUICalls]
         public bool Headless => false;
-
 
         /// <summary>
         /// Shows a small form with the question.
@@ -33,6 +44,7 @@ namespace CKAN.GUI
         /// </summary>
         /// <returns><c>true</c> if user pressed yes, <c>false</c> if no.</returns>
         /// <param name="question">Question.</param>
+        [ForbidGUICalls]
         public bool RaiseYesNoDialog(string question)
             => main.YesNoDialog(question);
 
@@ -42,6 +54,7 @@ namespace CKAN.GUI
         /// <returns>The index of the selection in the args array. 0-based!</returns>
         /// <param name="message">Message.</param>
         /// <param name="args">Array of offered options.</param>
+        [ForbidGUICalls]
         public int RaiseSelectionDialog(string message, params object[] args)
             => main.SelectionDialog(message, args);
 
@@ -50,6 +63,7 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="message">Message.</param>
         /// <param name="args">Arguments to format the message.</param>
+        [ForbidGUICalls]
         public void RaiseError(string message, params object[] args)
         {
             main.ErrorDialog(message, args);
@@ -60,10 +74,35 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="message">Message.</param>
         /// <param name="percent">Progress in percent.</param>
+        [ForbidGUICalls]
         public void RaiseProgress(string message, int percent)
         {
-            wait.SetDescription($"{message} - {percent}%");
-            main.SetProgress(percent);
+            Util.Invoke(main, () =>
+            {
+                statBarLabel.ToolTipText = message;
+                // No newlines in status bar
+                statBarLabel.Text = message.Replace("\r\n", " ")
+                                           .Replace("\n",   " ");
+                statBarProgBar.Value =
+                    Math.Max(statBarProgBar.Minimum,
+                        Math.Min(statBarProgBar.Maximum, percent));
+                statBarProgBar.Style = ProgressBarStyle.Continuous;
+                wait.SetMainProgress(message, percent);
+            });
+        }
+
+        [ForbidGUICalls]
+        public void RaiseProgress(int percent,
+                                  long bytesPerSecond, long bytesLeft)
+        {
+            Util.Invoke(main, () =>
+            {
+                wait.SetMainProgress(percent, bytesPerSecond, bytesLeft);
+                statBarProgBar.Value =
+                    Math.Max(statBarProgBar.Minimum,
+                        Math.Min(statBarProgBar.Maximum, percent));
+                statBarProgBar.Style = ProgressBarStyle.Continuous;
+            });
         }
 
         /// <summary>
@@ -72,9 +111,19 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="message">Message.</param>
         /// <param name="args">Arguments to fromat the message.</param>
+        [ForbidGUICalls]
         public void RaiseMessage(string message, params object[] args)
         {
-            main.AddStatusMessage(message, args);
+            var fullMsg = string.Format(message, args);
+            Util.Invoke(main, () =>
+            {
+                statBarLabel.ToolTipText = fullMsg;
+                // No newlines in status bar
+                statBarLabel.Text = fullMsg.Replace("\r\n", " ")
+                                           .Replace("\n",   " ");
+
+                wait.AddLogMessage(fullMsg);
+            });
         }
     }
 }

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -480,6 +480,9 @@ namespace CKAN.GUI
             this.ManageMods.OnRegistryChanged += ManageMods_OnRegistryChanged;
             this.ManageMods.LabelsAfterUpdate += ManageMods_LabelsAfterUpdate;
             this.ManageMods.StartChangeSet += ManageMods_StartChangeSet;
+            this.ManageMods.RaiseMessage += ManageMods_RaiseMessage;
+            this.ManageMods.RaiseError += ManageMods_RaiseError;
+            this.ManageMods.ClearStatusBar += ManageMods_ClearStatusBar;
             //
             // ChangesetTabPage
             //

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -32,7 +32,7 @@ namespace CKAN.GUI
         private static readonly ILog log = LogManager.GetLogger(typeof(Main));
 
         // Stuff we set in the constructor and never change
-        public readonly GUIUser currentUser;
+        public readonly IUser currentUser;
         public readonly GameInstanceManager Manager;
         public GameInstance CurrentInstance => Manager.CurrentInstance;
         private readonly RepositoryDataManager repoData;
@@ -133,10 +133,11 @@ namespace CKAN.GUI
             // Set the window name and class for X11
             if (Platform.IsX11)
             {
-                HandleCreated += (sender, e) => X11.SetWMClass("CKAN", "CKAN", Handle);
+                HandleCreated += (sender, e) => X11.SetWMClass(Meta.GetProductName(),
+                                                               Meta.GetProductName(), Handle);
             }
 
-            currentUser = new GUIUser(this, Wait);
+            currentUser = new GUIUser(this, Wait, StatusLabel, StatusProgress);
             if (mgr != null)
             {
                 // With a working GUI, assign a GUIUser to the GameInstanceManager to replace the ConsoleUser
@@ -224,7 +225,7 @@ namespace CKAN.GUI
             Wait.StartWaiting(
                 (sender, evt) =>
                 {
-                    Wait.AddLogMessage(Properties.Resources.MainModListLoadingRegistry);
+                    currentUser.RaiseMessage(Properties.Resources.MainModListLoadingRegistry);
                     // Make sure we have a lockable instance
                     do
                     {
@@ -840,6 +841,21 @@ namespace CKAN.GUI
         private void ManageMods_OnRegistryChanged()
         {
             needRegistrySave = true;
+        }
+
+        private void ManageMods_RaiseMessage(string message)
+        {
+            currentUser.RaiseMessage(message);
+        }
+
+        private void ManageMods_RaiseError(string error)
+        {
+            currentUser.RaiseError(error);
+        }
+
+        private void ManageMods_ClearStatusBar()
+        {
+            StatusLabel.ToolTipText = StatusLabel.Text = "";
         }
 
         private void MainTabControl_OnSelectedIndexChanged(object sender, EventArgs e)

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -56,7 +56,6 @@ namespace CKAN.GUI
         /// </summary>
         public void UpdateCKAN()
         {
-            ResetProgress();
             ShowWaitDialog();
             DisableMainWindow();
             tabController.RenameTab("WaitTabPage", Properties.Resources.MainUpgradingWaitTitle);

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -26,43 +26,26 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        public void AddStatusMessage(string text, params object[] args)
+        public void ErrorDialog(string text, params object[] args)
         {
-            string msg = string.Format(text, args);
-            // No newlines in status bar
-            Util.Invoke(statusStrip1, () =>
-                StatusLabel.ToolTipText = StatusLabel.Text = msg.Replace("\r\n", " ").Replace("\n", " ")
-            );
-            if (!string.IsNullOrEmpty(msg))
-            {
-                Wait.AddLogMessage(msg);
-            }
+            errorDialog.ShowErrorDialog(text, args);
         }
 
         [ForbidGUICalls]
-        public void ErrorDialog(string text, params object[] args)
-        {
-            errorDialog.ShowErrorDialog(string.Format(text, args));
-        }
-
         public bool YesNoDialog(string text, string yesText = null, string noText = null)
-        {
-            return yesNoDialog.ShowYesNoDialog(this, text, yesText, noText) == DialogResult.Yes;
-        }
+            => yesNoDialog.ShowYesNoDialog(this, text, yesText, noText) == DialogResult.Yes;
 
         /// <summary>
         /// Show a yes/no dialog with a "don't show again" checkbox
         /// </summary>
         /// <returns>A tuple of the dialog result and a bool indicating whether
         /// the suppress-checkbox has been checked (true)</returns>
+        [ForbidGUICalls]
         public Tuple<DialogResult, bool> SuppressableYesNoDialog(string text, string suppressText, string yesText = null, string noText = null)
-        {
-            return yesNoDialog.ShowSuppressableYesNoDialog(this, text, suppressText, yesText, noText);
-        }
+            => yesNoDialog.ShowSuppressableYesNoDialog(this, text, suppressText, yesText, noText);
 
+        [ForbidGUICalls]
         public int SelectionDialog(string message, params object[] args)
-        {
-            return selectionDialog.ShowSelectionDialog(message, args);
-        }
+            => selectionDialog.ShowSelectionDialog(message, args);
     }
 }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -43,8 +43,6 @@ namespace CKAN.GUI
         [ForbidGUICalls]
         private void CacheMod(object sender, DoWorkEventArgs e)
         {
-            ResetProgress();
-
             GUIMod gm = e.Argument as GUIMod;
             downloader = new NetAsyncModulesDownloader(currentUser, Manager.Cache);
             downloader.Progress      += Wait.SetModuleProgress;

--- a/GUI/Main/MainExport.cs
+++ b/GUI/Main/MainExport.cs
@@ -23,7 +23,7 @@ namespace CKAN.GUI
             // Background thread so GUI thread can work with the controls
             Task.Factory.StartNew(() =>
             {
-                AddStatusMessage("");
+                currentUser.RaiseMessage("");
                 tabController.ShowTab("EditModpackTabPage", 2);
                 DisableMainWindow();
                 var mgr = RegistryManager.Instance(CurrentInstance, repoData);

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -324,7 +324,7 @@ namespace CKAN.GUI
                                      .Any(relF => registry.FileOwner(relF) != null));
                 if (possibleConfigOnlyDirs.Count > 0)
                 {
-                    AddStatusMessage("");
+                    currentUser.RaiseMessage("");
                     tabController.ShowTab("DeleteDirectoriesTabPage", 4);
                     tabController.SetTabLock(true);
 
@@ -355,7 +355,8 @@ namespace CKAN.GUI
 
         private void OnModInstalled(CkanModule mod)
         {
-            AddStatusMessage(string.Format(Properties.Resources.MainInstallModSuccess, mod.name));
+            currentUser.RaiseMessage(string.Format(Properties.Resources.MainInstallModSuccess,
+                                     mod));
             LabelsAfterInstall(mod);
         }
 
@@ -477,7 +478,7 @@ namespace CKAN.GUI
             {
                 // The Result property throws if InstallMods threw (!!!)
                 (bool success, List<ModChange> changes) = (InstallResult)e.Result;
-                AddStatusMessage(Properties.Resources.MainInstallSuccess);
+                currentUser.RaiseMessage(Properties.Resources.MainInstallSuccess);
                 // Rebuilds the list of GUIMods
                 RefreshModList(false);
             }

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -21,7 +21,7 @@ namespace CKAN.GUI
 
         private void ChooseRecommendedMods_OnConflictFound(string message)
         {
-            AddStatusMessage(message);
+            currentUser.RaiseMessage(message);
         }
 
         private void auditRecommendationsMenuItem_Click(object sender, EventArgs e)

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -68,7 +68,7 @@ namespace CKAN.GUI
         {
             (bool forceFullRefresh, bool refreshWithoutChanges) = (RepoArgument)e.Argument;
             // Don't repeat this stuff if downloads fail
-            AddStatusMessage(Properties.Resources.MainRepoScanning);
+            currentUser.RaiseMessage(Properties.Resources.MainRepoScanning);
             log.Debug("Scanning before repo update");
             var regMgr = RegistryManager.Instance(CurrentInstance, repoData);
             bool scanChanged = regMgr.ScanUnmanagedFiles();
@@ -79,7 +79,6 @@ namespace CKAN.GUI
             // Load cached data with progress bars instead of without if not already loaded
             // (which happens if auto-update is enabled, otherwise this is a no-op).
             // We need the old data to alert the user of newly compatible modules after update.
-            AddStatusMessage(Properties.Resources.LoadingCachedRepoData);
             repoData.Prepopulate(
                 registry.Repositories.Values.ToList(),
                 new Progress<int>(p => currentUser.RaiseProgress(Properties.Resources.LoadingCachedRepoData, p)));
@@ -117,7 +116,7 @@ namespace CKAN.GUI
                             downloader.CancelDownload();
                         };
 
-                        AddStatusMessage(Properties.Resources.MainRepoUpdating);
+                        currentUser.RaiseMessage(Properties.Resources.MainRepoUpdating);
 
                         var updateResult = repoData.Update(repos, CurrentInstance.game,
                                                            forceFullRefresh, downloader, currentUser);
@@ -197,7 +196,7 @@ namespace CKAN.GUI
                             log.Error(exc.Message, exc);
                             currentUser.RaiseMessage(exc.Message);
                         }
-                        AddStatusMessage(Properties.Resources.MainRepoFailed);
+                        currentUser.RaiseMessage(Properties.Resources.MainRepoFailed);
                         Wait.Finish();
                         EnableMainWindow();
                         break;
@@ -211,7 +210,7 @@ namespace CKAN.GUI
                             log.Error(inner.Message, inner);
                             currentUser.RaiseMessage(inner.Message);
                         }
-                        AddStatusMessage(Properties.Resources.MainRepoFailed);
+                        currentUser.RaiseMessage(Properties.Resources.MainRepoFailed);
                         Wait.Finish();
                         EnableMainWindow();
                         break;
@@ -219,7 +218,7 @@ namespace CKAN.GUI
                     case Exception exc:
                         log.Error(exc.Message, exc);
                         currentUser.RaiseMessage(exc.Message);
-                        AddStatusMessage(Properties.Resources.MainRepoFailed);
+                        currentUser.RaiseMessage(Properties.Resources.MainRepoFailed);
                         Wait.Finish();
                         EnableMainWindow();
                         break;
@@ -234,7 +233,7 @@ namespace CKAN.GUI
                 switch (updateResult)
                 {
                     case RepositoryDataManager.UpdateResult.NoChanges:
-                        AddStatusMessage(Properties.Resources.MainRepoUpToDate);
+                        currentUser.RaiseMessage(Properties.Resources.MainRepoUpToDate);
                         // Reload rows if user added a cached repo repo
                         if (refreshWithoutChanges)
                         {
@@ -251,7 +250,7 @@ namespace CKAN.GUI
 
                     case RepositoryDataManager.UpdateResult.Updated:
                     default:
-                        AddStatusMessage(Properties.Resources.MainRepoSuccess);
+                        currentUser.RaiseMessage(Properties.Resources.MainRepoSuccess);
                         ShowRefreshQuestion();
                         UpgradeNotification();
                         RefreshModList(false, oldModules);

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
@@ -54,38 +53,14 @@ namespace CKAN.GUI
         {
             Util.Invoke(statusStrip1, () => {
                 StatusProgress.Visible = false;
-                AddStatusMessage(statusMsg);
+                currentUser.RaiseMessage(statusMsg);
             });
             Util.Invoke(WaitTabPage, () => {
                 RecreateDialogs();
                 Wait.Finish();
-                SetProgress(100);
             });
-            Wait.AddLogMessage(logMsg);
+            currentUser.RaiseMessage(logMsg);
             Wait.SetDescription(description);
-        }
-
-        public void SetProgress(int progress)
-        {
-            Wait.ProgressValue = progress;
-            Wait.ProgressIndeterminate = false;
-            Util.Invoke(statusStrip1, () =>
-            {
-                StatusProgress.Value =
-                    Math.Max(StatusProgress.Minimum,
-                        Math.Min(StatusProgress.Maximum, progress));
-                StatusProgress.Style = ProgressBarStyle.Continuous;
-            });
-        }
-
-        [ForbidGUICalls]
-        public void ResetProgress()
-        {
-            Wait.ProgressIndeterminate = true;
-            Util.Invoke(statusStrip1, () =>
-            {
-                StatusProgress.Style = ProgressBarStyle.Marquee;
-            });
         }
 
         public void Wait_OnRetry()

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -244,7 +244,7 @@ and try again.</value></data>
 Open settings now?</value></data>
   <data name="MainInstallOpenSettings" xml:space="preserve"><value>Open Settings</value></data>
   <data name="MainInstallNo" xml:space="preserve"><value>No</value></data>
-  <data name="MainInstallModSuccess" xml:space="preserve"><value>Module "{0}" successfully installed</value></data>
+  <data name="MainInstallModSuccess" xml:space="preserve"><value>Successfully installed {0}</value></data>
   <data name="MainInstallSuccess" xml:space="preserve"><value>Success!</value></data>
   <data name="MainInstallCancelTooLate" xml:space="preserve"><value>Cancellation too late, process complete!</value></data>
   <data name="MainInstallCancelAfterInstall" xml:space="preserve"><value>User canceled the process manually, but all mods already (un)installed/upgraded.</value></data>

--- a/Tests/CapturingUser.cs
+++ b/Tests/CapturingUser.cs
@@ -40,6 +40,12 @@ namespace Tests
             RaisedProgresses.Add(new Tuple<string, int>(message, percent));
         }
 
+        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        {
+            RaisedProgresses.Add(new Tuple<string, int>($"{bytesPerSecond} {bytesLeft}",
+                                                        percent));
+        }
+
         public void RaiseMessage(string message, params object[] args)
         {
             RaisedMessages.Add(string.Format(message, args));


### PR DESCRIPTION
## Problems

- When a download of a module with multiple explicit download URLs or an implicit archive.org fallback URL fails, the downloader does not begin downloading that mod's next URL (but it does start the next queued download from the host that just failed). When the last download succeeds or fails, the installation does not proceed if there were any failed downloads.
- If you use the Preferred Hosts window to make spacedock.info lower priority than `<ALL OTHER HOSTS>`, downloads of redistributable mods will succeed but not be stored to the cache, so the installation will fail
  - Related to this, `archive.org` isn't shown in the host list of that window for KSP2, even though there are redistributable mods archived there. This means that this host can't be prioritized above or below `<ALL OTHER HOSTS>`, and it's easy to forget it exists.

## Causes

- `NetAsyncDownloader.shouldQueue` can return true when it shouldn't, specifically for a download that has just failed and moved on to its next URL, because the same download itself is seen as an active download from the same host, even though it hasn't started yet. When this happens, we put that download in the pending queue instead of starting it, and we will probably never return to it.
- When a download completes, we search the installing modules for the completed URL to figure out which one it was so we can validate its hashes and store it into the cache. This fails for implicit archive.org URLs because they're not present in the `CkanModule.download` list, but rather in a separate `CkanModule.InternetArchiveDownload` property. Without a module, we can't validate or store to the cache.
- `Registry.GetAllHosts` also examines only `CkanModule.download` and not `CkanModule.InternetArchiveDownload`

## Motivations

- As of #3939, the GUI progress screen's text box no longer includes blank lines. This was done to suppress an annoying extraneous blank line in the middle of updating the mod list, but now we can't use blank lines for visual hierarchy when it _is_ appropriate. The purpose of that extraneous blank line was to clear any error messages from the status bar, which should be a distinct operation from adding a log message.
- The message log during installation is somewhat inconsistent and quirky
  - For some steps, the completion message appears in the log but the starting message only shows up in the progress bar label, so it can be difficult to tell what's happening or what happened previously and in what sequence
  - Quotes are put around URLs and mod names sometimes, a bit at random
  - For uninstalling mods, the identifier is shown rather than the name and version
  - The successfully-installed message prints the mod name without the version and puts it in the middle of the string rather than the end where it would be simpler to parse
- `GUIUser`'s message and progress functions are tightly coupled with code in `MainDialogs.cs` (which isn't really about dialogs), and there is ambiguity about which piece of that structure should own a given bit of functionality

## Changes

- Now `NetAsyncDownloader.shouldQueue` skips the same URL that it's being asked to assess, so it will return false if there are no _other_ active downloads from the same host, as intended
  Fixes #3983.
- Now we also check `CkanModule.InternetArchiveDownload` to find the module, so downloads from these URLs will be properly stored to cache
- Now instead of calling `IUser.RaiseMessage` with an empty string to clear the status bar, a new `MangageMods.ClearStatusBar` event is raised, in response to which `Main` clears the status bar
- Several calls to `Main.Instance.AddStatusMessage` now raise a `ManageMods.RaiseMessage` event instead because global variables are bad
- Now `Registry.GetAllHosts` examines `CkanModule.InternetArchiveDownload` in addition to `CkanModule.download`, so archive.org will appear for any game instance containing redistributable mods that have been uploaded to archive.org
- Now those message quirks are cleaned up
  - The strings on the progress bar are also added to the message log, with some duplicate filtering to avoid spamming a lot of messages. Progress updates specifically about downloads with byte counts are moved to a new separate `IUser` function to make it easier to exclude their spammy output from the log.
  - The quotes are removed
  - For uninstalling mods, the name and version are shown
  - The successfully-installed message prints the mod name and version at than the end
- The message and progress functions are removed from `MainDialogs.cs` and that functionality is now owned exclusively by `GUIUser`, which accepts new parameters related to the status bar in order to do its job
- The `[ForbidGUICalls]` attribute is added to every member of `GUIUser` to ensure thread safety. I think this wasn't done previously because polymorphism via the `IUser` interface inhibited #3914's test from analyzing this code fully. Something to return to.
