### PR TITLE
Resolve compatibility conflicts after multi-host merge

### DIFF
--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -7,6 +7,7 @@ using YamlDotNet.RepresentationModel;
 using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Transformers;
+using CKAN.NetKAN.Services;
 
 namespace CKAN.NetKAN.Model
 {
@@ -155,7 +156,12 @@ namespace CKAN.NetKAN.Model
                 }
                 first.Merge(other, mergeSettings);
             }
-            first[DownloadPropertyName] = JArray.FromObject(downloads);
+            // Merge game version compatibility
+            ModuleService.ApplyVersions(first, null, null, null);
+            // Only generate array if multiple URLs
+            first[DownloadPropertyName] = downloads.Length == 1
+                ? downloads.First()
+                : JArray.FromObject(downloads);
             return first;
         }
 


### PR DESCRIPTION
## Problems

- Multi-hosted mods on both GitHub and SpaceDock can have inflation errors saying
`ksp_version mixed with ksp_version_(min|max)`. KSP-CKAN/KSP2-NetKAN#125 had to use overrides to get around this:
  ```yaml
  x_netkan_override:
    - version: 1.2.3
      override:
        ksp_version_max: 0.1.2
  ```
- Between KSP-CKAN/KSP2-NetKAN#125 and KSP-CKAN/KSP2-NetKAN#127, `Inputbinder` had a `download` property containing an array with one element. This is odd and unnecessary.

## Cause

- SpaceDock adds a `ksp_version` / `ksp_version_max` based on the game version the uploader selects that isn't available on GitHub, so the GitHub branch of the netkan inflates with just `ksp_version_min`, while the SpaceDock branch has `ksp_version`, and the two branches are merged just by combining their JSON properties, which creates inconsistent metadata with both `ksp_version` and `ksp_version_min` set.
- `NetKAN.Model.Metadata.MergeJson` was generating an array regardless of how many download URLs it had. Single-host netkans weren't affected because that function is only called for multi-host.

## Changes

- Now after we merge the properties, `NetKAN.Services.ModuleService.ApplyVersions` (which is the logic we use elsewhere to combine compatibility from different sources) is used to reconcile these properties. This should make SpaceDock's compatibility carry through to the merged netkan without the need for overrides.
- Now if a merged module only has one download URL, the `download` property will be a string rather than an array

I'll remove the overrides from KSP-CKAN/KSP2-NetKAN#125 in a subsequent pull request.
