### PR TITLE
Suppress admin user check for URL handler registration

### DIFF
--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -57,7 +57,7 @@ namespace CKAN.GUI
                 {
                     try
                     {
-                       RegisterURLHandler_Win32();
+                        RegisterURLHandler_Win32();
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -69,14 +69,12 @@ namespace CKAN.GUI
                         if (user.RaiseYesNoDialog(Properties.Resources.URLHandlersPrompt))
                         {
                             // we need elevation to write to the registry
-                            ProcessStartInfo startInfo = new ProcessStartInfo(
-                                Assembly.GetEntryAssembly().Location)
+                            Process.Start(new ProcessStartInfo(Assembly.GetEntryAssembly().Location)
                             {
                                 // trigger a UAC prompt (if UAC is enabled)
                                 Verb      = "runas",
-                                Arguments = $"gui {UrlRegistrationArgument}"
-                            };
-                            Process.Start(startInfo);
+                                Arguments = $"gui --asroot {UrlRegistrationArgument}"
+                            });
                         }
                         else
                         {


### PR DESCRIPTION
## Problem

In [a recent forum thread](https://forum.kerbalspaceprogram.com/topic/222869-is-ckan-safe/), a user reported receiving the URL handler registration prompt:

> CKAN requires permission to add a handler for ckan:// URLs.
> 
> Do you want to allow CKAN to do this? If you click no you won't see this message again.

And after clicking Yes, the admin user error appeared in a new cmd window, while the main GUI process continued normally.

## Cause

The URL handler registration intentionally runs `ckan.exe gui registerUrl` as administrator, which trips the admin user check.

## Changes

Now the elevated command line to register the handler includes `--asroot` to bypass the admin check. This should allow it to finish normally.
