### PR TITLE
Fix null reference exception in swinfo transformer

### DIFF
--- a/Netkan/Transformers/SpaceWarpInfoTransformer.cs
+++ b/Netkan/Transformers/SpaceWarpInfoTransformer.cs
@@ -75,9 +75,9 @@ namespace CKAN.NetKAN.Transformers
                     json.SafeAdd("author",   swinfo.author);
                     json.SafeAdd("abstract", swinfo.description);
                     json.SafeAdd("version",  swinfo.version);
-                    GameVersion maxVer = null;
-                    if (GameVersion.TryParse(swinfo.ksp2_version.min, out GameVersion minVer)
-                        || GameVersion.TryParse(swinfo.ksp2_version.max, out maxVer))
+                    bool hasMin = GameVersion.TryParse(swinfo.ksp2_version?.min, out GameVersion minVer);
+                    bool hasMax = GameVersion.TryParse(swinfo.ksp2_version?.max, out GameVersion maxVer);
+                    if (hasMin || hasMax)
                     {
                         log.InfoFormat("Found compatibility: {0}–{1}", minVer?.WithoutBuild,
                                                                        maxVer?.WithoutBuild);


### PR DESCRIPTION
## Problem

QuestariaAerospace had an inflation error in its previous release, see KSP-CKAN/KSP2-NetKAN#144:

```
1780 [1] FATAL CKAN.NetKAN.Program (null) - Object reference not set to an instance of an object.
1847 [1] FATAL CKAN.NetKAN.Program (null) -    at CKAN.NetKAN.Transformers.SpaceWarpInfoTransformer.<Transform>d__3.MoveNext()
   at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at CKAN.NetKAN.Transformers.NetkanTransformer.Transform(Metadata metadata, TransformOptions opts)
   at CKAN.NetKAN.Processors.Inflator.<>c__DisplayClass1_0.<Inflate>b__0(Metadata netkan)
   at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
   at System.Linq.Lookup`2.Create[TSource](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.GroupedEnumerable`3.GetEnumerator()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at CKAN.NetKAN.Processors.Inflator.Inflate(String filename, Metadata[] netkans, TransformOptions opts)
   at CKAN.NetKAN.Program.Main(String[] args)
```

## Cause

The `ksp2_version` property was missing. This was due to an issue with KSP2UnityTools, but this is supposed to be allowed.

## Changes

- Now we access this property's properties with the `?.` null coalescing operator so it won't throw if null
- While looking into this, I had doubts about how short circuiting with `||` would affect parsing of min and max versions, so now we parse both in separate statements.
