### PR TITLE
Refactor Contents tab refreshing

### DIFF
--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -42,6 +42,9 @@ namespace CKAN
             cache = new NetFileCache(path);
         }
 
+        public event Action<CkanModule> ModStored;
+        public event Action<CkanModule> ModPurged;
+
         // Simple passthrough wrappers
         public void Dispose()
         {
@@ -50,6 +53,7 @@ namespace CKAN
         public void RemoveAll()
         {
             cache.RemoveAll();
+            ModPurged?.Invoke(null);
         }
         public void MoveFrom(string fromDir)
         {
@@ -215,6 +219,7 @@ namespace CKAN
             var success = cache.Store(module.download[0], path, description ?? module.StandardName(), move);
             // Make sure completion is signalled so progress bars go away
             progress?.Report(100);
+            ModStored?.Invoke(module);
             return success;
         }
 
@@ -318,6 +323,7 @@ namespace CKAN
                     }
                 }
             }
+            ModPurged?.Invoke(module);
             return true;
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1109,20 +1109,6 @@ namespace CKAN.GUI
                 {
                     Main.Instance.Manager.Cache.Purge(mod);
                 }
-
-                // Update all mods that share the same ZIP
-                var allGuiMods = AllGUIMods();
-                foreach (var otherMod in selected.ToModule().GetDownloadsGroup(
-                    allGuiMods.Values.Select(guiMod => guiMod.ToModule())
-                                     .Where(mod => mod != null)))
-                {
-                    allGuiMods[otherMod.identifier].UpdateIsCached();
-                }
-
-                // Reapply searches in case is:cached or not:cached is active
-                UpdateFilters();
-
-                Main.Instance.RefreshModContentsTree();
             }
         }
 

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -8,6 +8,7 @@ using System.Runtime.Versioning;
 using Autofac;
 
 using CKAN.Versioning;
+using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -45,6 +46,7 @@ namespace CKAN.GUI
             get => selectedModule;
         }
 
+        [ForbidGUICalls]
         public void RefreshModContentsTree()
         {
             Contents.RefreshModContentsTree();

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using System.Runtime.Versioning;
 #endif
 
+using CKAN.GUI.Attributes;
+
 namespace CKAN.GUI
 {
     #if NET5_0_OR_GREATER
@@ -35,6 +37,7 @@ namespace CKAN.GUI
             get => selectedModule;
         }
 
+        [ForbidGUICalls]
         public void RefreshModContentsTree()
         {
             if (currentModContentsModule != null)

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -294,18 +294,8 @@ namespace CKAN.GUI
 
             if (deleteConfirmationDialog.ShowYesNoDialog(this, confirmationText) == DialogResult.Yes)
             {
-                // tell the cache object to nuke itself
+                // Tell the cache object to nuke itself
                 Main.Instance.Manager.Cache.RemoveAll();
-
-                // forcibly tell all mod rows to re-check cache state
-                foreach (DataGridViewRow row in Main.Instance.ManageMods.ModGrid.Rows)
-                {
-                    var mod = row.Tag as GUIMod;
-                    mod?.UpdateIsCached();
-                }
-
-                // finally, clear the preview contents list
-                Main.Instance.RefreshModContentsTree();
 
                 UpdateCacheInfo(coreConfig.DownloadCacheDir);
             }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -151,6 +151,9 @@ namespace CKAN.GUI
                 Manager = new GameInstanceManager(currentUser);
             }
 
+            Manager.Cache.ModStored += OnModStoredOrPurged;
+            Manager.Cache.ModPurged += OnModStoredOrPurged;
+
             tabController = new TabController(MainTabControl);
             tabController.ShowTab("ManageModsTabPage");
 
@@ -593,11 +596,6 @@ namespace CKAN.GUI
             }
         }
 
-        public void RefreshModContentsTree()
-        {
-            ModInfo.RefreshModContentsTree();
-        }
-
         private void ExitToolButton_Click(object sender, EventArgs e)
         {
             Close();
@@ -785,7 +783,10 @@ namespace CKAN.GUI
 
         private void ManageMods_OnSelectedModuleChanged(GUIMod m)
         {
-            ActiveModInfo = m;
+            if (MainTabControl.SelectedTab == ManageModsTabPage)
+            {
+                ActiveModInfo = m;
+            }
         }
 
         private GUIMod ActiveModInfo


### PR DESCRIPTION
## Problem

The Contents tab refreshes and shows the mod contents if you download a mod via the Download button or right click menu, but not if it is downloaded during installation.

## Cause

Refreshing cache-related state (including the Contents tab) is handled (duplicatively) at the places where GUI stores or purges a mod, but when you install an uncached mod, it is downloaded and stored by `ModuleInstaller`, so GUI doesn't react.

This is a brittle approach because it has a many-to-many structure, where each place that deals with the cache must also handle all of the secondary consequences itself.

## Changes

- Now `NetModuleCache` has `ModStored` and `ModPurged` events that it fires whenever mods are stored or purged, including during mod installation. If **all** mods are purged, `ModPurged`'s module parameter will be null.
- The logic for reacting to cache changes is consolidated into one `GUI.Main.OnModStoredOrPurged` function, which is used to handle the new events, including during installation. Places that formerly triggered the refresh now no longer do, because they don't need to anymore.
- `UpdateCachedByDownloads` can now handle updating the full mod list's `IsCached` property when its parameter is `null`, for when the user clears the cache in the settings
- `ManageMods.OnSelectedModuleChanged` now no longer sets ModInfo's active mod when the Manage Mods tab is not active, for when `OnModStoredOrPurged` refilters the mod list in the background during installs, because this causes ModInfo to become visible when it shouldn't. It will still be set when the Manage Mods tab becomes active again.

Fixes #3998.
