### PR TITLE
Fix crash with DLC disabled by Steam

### DIFF
--- a/Core/Extensions/DictionaryExtensions.cs
+++ b/Core/Extensions/DictionaryExtensions.cs
@@ -10,7 +10,8 @@ namespace CKAN.Extensions
             => a == null ? b == null
                          : b != null && a.Count == b.Count
                            && a.Keys.All(k => b.ContainsKey(k))
-                           && b.Keys.All(k => a.ContainsKey(k) && a[k].Equals(b[k]));
+                           && b.Keys.All(k => a.ContainsKey(k)
+                                              && EqualityComparer<V>.Default.Equals(a[k], b[k]));
 
         public static V GetOrDefault<K, V>(this Dictionary<K, V> dict, K key)
         {


### PR DESCRIPTION
## Problem

If you disable a DLC in Steam:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/f983698f-a5e3-4d6b-b2dd-dba8b2bb9477)

... then CKAN throws an exception when it tries to refresh:

> Scanning for DLCs and manually installed modules...
> Object reference not set to an instance of an object.
> Repository update failed!

## Cause

Steam apparently deletes the _files_ for that DLC but leaves behind all the folders:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/2175110a-545d-4a4f-9c25-b3b75fa4775f)

This eventually makes our `DictionaryEquals` extension try to call `null.Equals()`:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.Extensions.DictionaryExtensions.<>c__DisplayClass0_0`2.<DictionaryEquals>b__1(K k)
   at System.Linq.Enumerable.All[TSource](IEnumerable`1 source, Func`2 predicate)
   at CKAN.Registry.SetDlcs(Dictionary`2 dlcs)
   at CKAN.RegistryManager.ScanUnmanagedFiles()
   at CKAN.GUI.Main.UpdateRepo(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

## Changes

- Now the `DictionaryEquals` extension uses `EqualityComparer<V>.Default.Equals` for better null handling
- Now the DLC detector returns `false` if the readme file doesn't exist, so DLCs disabled by Steam will be considered not installed

Fixes #4000.
