### PR TITLE
Fixes for installing .ckan files and DarkKAN mods

### DIFF
--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -230,11 +230,29 @@ namespace CKAN
         /// <returns>
         /// String describing range of compatible game versions.
         /// </returns>
-        public static string CompatibleGameVersions(this IRegistryQuerier querier, IGame game, string identifier)
+        public static string CompatibleGameVersions(this IRegistryQuerier querier,
+                                                    IGame                 game,
+                                                    string                identifier)
         {
-            List<CkanModule> releases = querier.AvailableByIdentifier(identifier).ToList();
-            if (releases != null && releases.Count > 0) {
-                CkanModule.GetMinMaxVersions(releases, out _, out _, out GameVersion minKsp, out GameVersion maxKsp);
+            List<CkanModule> releases = null;
+            try
+            {
+                releases = querier.AvailableByIdentifier(identifier)
+                                  .ToList();
+            }
+            catch
+            {
+                var instMod = querier.InstalledModule(identifier);
+                if (instMod != null)
+                {
+                    releases = Enumerable.Repeat(instMod.Module, 1)
+                                         .ToList();
+                }
+            }
+            if (releases != null && releases.Count > 0)
+            {
+                CkanModule.GetMinMaxVersions(releases, out _, out _,
+                                             out GameVersion minKsp, out GameVersion maxKsp);
                 return GameVersionRange.VersionSpan(game, minKsp, maxKsp);
             }
             return "";

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -740,7 +740,10 @@ namespace CKAN.GUI
                     Properties.Resources.AllModVersionsInstallYes,
                     Properties.Resources.AllModVersionsInstallNo))
             {
-                InstallModuleDriver(registry_manager.registry, toInstall);
+                UpdateChangesDialog(toInstall.Select(m => new ModChange(m, GUIModChangeType.Install))
+                                             .ToList(),
+                                    null);
+                tabController.ShowTab("ChangesetTabPage", 1);
             }
         }
 

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -51,11 +51,13 @@ namespace CKAN.GUI
         /// <param name="description">Message displayed above the DialogProgress bar</param>
         public void FailWaitDialog(string statusMsg, string logMsg, string description)
         {
-            Util.Invoke(statusStrip1, () => {
+            Util.Invoke(statusStrip1, () =>
+            {
                 StatusProgress.Visible = false;
                 currentUser.RaiseMessage(statusMsg);
             });
-            Util.Invoke(WaitTabPage, () => {
+            Util.Invoke(WaitTabPage, () =>
+            {
                 RecreateDialogs();
                 Wait.Finish();
             });
@@ -65,6 +67,7 @@ namespace CKAN.GUI
 
         public void Wait_OnRetry()
         {
+            EnableMainWindow();
             tabController.ShowTab("ChangesetTabPage", 1);
         }
 


### PR DESCRIPTION
## Problems

@JonnyOThan has been working with .ckan files for mods that aren't indexed yet and finding lots of bugs:

- `ckan install -c` currently doesn't work. If you use it with a module that's in one of your metadata repos, it'll try to install the version from the repo, and for mods that aren't there, it reports that it can't find the mod even though it's right there in the file.
- If you install from a .ckan file in GUI and it depends on an identifier that doesn't exist, you end up stuck with an hourglass cursor on the mod list with an error in the status bar, and some parts of the app window are disabled.
- If you install from a .ckan file in GUI and it fails, clicking Retry takes you to the change set tab, but it's empty, and trying to install again crashes.
- If you install some modules from .ckan files that aren't indexed in a metadata repo, the Relationships tab can throw exceptions when you try to look at it.

## Causes

- `ckan install -c` used to work by adding the module from the file into the registry's available modules list and then pretending that you had typed `identifier=version` for that module at the command line. That ceased to be a thing when available modules were divested from the registry, but the command wasn't updated to work with the newer systems.
- An exception was being thrown when `ModuleInstaller.FindRecommendations` tried to find all the dependencies of the changeset, since one of them doesn't exist, which happened after the cursor was set to hourglass and before the progress tab was activated.
- `IRegistryQuerier.CompatibleGameVersions` was using `AvailableByIdentifier` without catching the exceptions it can throw when the mod isn't in the available list.

## Changes

- Now `ckan install` is refactored to operate in terms of `CkanModule`s instead of strings, generated either by looking up the given identifiers in the available modules or by loading them from .ckan files.
- Now `ckan install`'s usage message includes the `-c` form and points out that it can handle URLs.
- Now if you install from a .ckan file in GUI, the first step is the changeset tab showing the modules from the files you selected (yes, multiple are allowed). This allows you to confirm what you're installing and also makes Retry work if there's a problem.
- Now if `ModuleInstaller.FindRecommendations` throws an exception during the install flow, we activate the progress tab so you can see the error and turn off the hourglass cursor
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/a6c5b5e3-a539-4ff5-983b-fee77b1ff31a)
- Now `IRegistryQuerier.CompatibleGameVersions` catches `AvailableByIdentifier`'s exceptions, tries to fall back to installed mods, and just returns the empty string if nothing is found at all

Fixes #4005.
