### PR TITLE
Sort mods satisfying the same recommendation by download count

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -814,6 +814,10 @@ namespace CKAN
                     .Select(am => am.Latest(gameVersion, relationship_descriptor,
                                             installed, toInstall))
                     .Where(m => m?.ProvidesList?.Contains(identifier) ?? false)
+                    // Put the most popular one on top
+                    .OrderByDescending(m => repoDataMgr.GetDownloadCount(Repositories.Values,
+                                                                         m.identifier)
+                                            ?? 0)
                     .ToList();
             }
             else


### PR DESCRIPTION
## Motivation

In #3934, we sorted the providing mods prompt by download count to make it easier for users to find the mods that they're most likely to want.

EnvironmentalVisualEnhancements recommends rather than depends on its config module, so when you install it, instead of the providing mods prompt, it uses the recommendations prompt, which is sorted by the related mod column and otherwise tries to reflect the ordering from the mods' relationships, but doesn't do any particular sorting within a group of mods satisfying a virtual module recommendation:

![image](https://github.com/KSP-CKAN/CKAN/assets/9804078/99835316-2c1e-4c1a-a73e-80a7a0ee8595)

## Changes

Now `Registry.LatestAvailableWithProvides`, which is used to satisfy virtual module recommendations, sorts its returned list by download count, which puts the most commonly used EVE configs at the top:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/1cc91482-6ad0-406e-9a89-4ab45cd227fa)

@JonnyOThan, does that list look right to you? I noticed a few spots where the download counts appear to be slightly out of order, but I'm not sure whether those are actual problems or just some harmless quirk elsewhere in the sorting logic.

Fixes #4004.
