### PR TITLE
Remove duplicate dev build prompts

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -63,12 +63,12 @@ namespace CKAN.CmdLine
                 }
                 var config = ServiceLocator.Container.Resolve<IConfiguration>();
                 var devBuild = options.dev_build
-                               || (!options.stable_release && config.DevBuilds);
+                               || (!options.stable_release && (config.DevBuilds ?? false));
                 if (devBuild != config.DevBuilds)
                 {
                     config.DevBuilds = devBuild;
                     user.RaiseMessage(
-                        config.DevBuilds
+                        config.DevBuilds ?? false
                             ? Properties.Resources.UpgradeSwitchingToDevBuilds
                             : Properties.Resources.UpgradeSwitchingToStableReleases);
                 }
@@ -77,7 +77,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     var upd = new AutoUpdate();
-                    var update = upd.GetUpdate(config.DevBuilds);
+                    var update = upd.GetUpdate(config.DevBuilds ?? false);
                     var latestVersion = update.Version;
                     var currentVersion = new ModuleVersion(Meta.GetVersion());
 
@@ -92,7 +92,7 @@ namespace CKAN.CmdLine
                         if (user.RaiseYesNoDialog(Properties.Resources.UpgradeProceed))
                         {
                             user.RaiseMessage(Properties.Resources.UpgradePleaseWait);
-                            upd.StartUpdateProcess(false, config.DevBuilds, user);
+                            upd.StartUpdateProcess(false, config.DevBuilds ?? false, user);
                         }
                     }
                     else

--- a/Core/Configuration/IConfiguration.cs
+++ b/Core/Configuration/IConfiguration.cs
@@ -68,6 +68,6 @@ namespace CKAN.Configuration
         /// <summary>
         /// true if user wants to use nightly builds from S3, false to use releases from GitHub
         /// </summary>
-        bool DevBuilds { get; set; }
+        bool? DevBuilds { get; set; }
     }
 }

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -29,7 +29,7 @@ namespace CKAN.Configuration
             public IDictionary<string, string> AuthTokens { get; set; } = new Dictionary<string, string>();
             public string[] GlobalInstallFilters { get; set; } = Array.Empty<string>();
             public string[] PreferredHosts { get; set; } = Array.Empty<string>();
-            public bool DevBuilds { get; set; }
+            public bool? DevBuilds { get; set; }
         }
 
         public class ConfigConverter : JsonPropertyNamesChangedConverter
@@ -324,7 +324,7 @@ namespace CKAN.Configuration
             }
         }
 
-        public bool DevBuilds
+        public bool? DevBuilds
         {
             get
             {

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -186,7 +186,7 @@ namespace CKAN.Configuration
         /// <summary>
         /// Not implemented because the Windows registry is deprecated
         /// </summary>
-        public bool DevBuilds { get; set; }
+        public bool? DevBuilds { get; set; }
 
         public static bool DoesRegistryConfigurationExist()
         {

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -65,7 +65,7 @@ namespace CKAN.GUI
             UpdateAutoUpdate();
 
             CheckUpdateOnLaunchCheckbox.Checked = guiConfig.CheckForUpdatesOnLaunch;
-            DevBuildsCheckbox.Checked = coreConfig.DevBuilds;
+            DevBuildsCheckbox.Checked = coreConfig.DevBuilds ?? false;
             RefreshOnStartupCheckbox.Checked = guiConfig.RefreshOnStartup;
             HideEpochsCheckbox.Checked = guiConfig.HideEpochs;
             HideVCheckbox.Checked = guiConfig.HideV;
@@ -84,7 +84,7 @@ namespace CKAN.GUI
             LocalVersionLabel.Text = Meta.GetVersion();
             try
             {
-                var latestVersion = updater.GetUpdate(coreConfig.DevBuilds)
+                var latestVersion = updater.GetUpdate(coreConfig.DevBuilds ?? false)
                                            .Version;
                 LatestVersionLabel.Text = latestVersion.ToString();
                 // Allow downgrading in case they want to stop using dev builds

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -27,12 +27,11 @@ namespace CKAN.GUI
                 guiConfig.CheckForUpdatesOnLaunchNoNag = true;
             }
 
-            if (!guiConfig.DevBuildsNoNag && guiConfig.CheckForUpdatesOnLaunch)
+            if (!coreConfig.DevBuilds.HasValue && guiConfig.CheckForUpdatesOnLaunch)
             {
                 coreConfig.DevBuilds = !YesNoDialog(Properties.Resources.MainReleasesOrDevBuildsPrompt,
                                                     Properties.Resources.MainReleasesOrDevBuildsYes,
                                                     Properties.Resources.MainReleasesOrDevBuildsNo);
-                guiConfig.DevBuildsNoNag = true;
             }
         }
 
@@ -51,7 +50,7 @@ namespace CKAN.GUI
                 {
                     log.Info("Making auto-update call");
                     var mainConfig = ServiceLocator.Container.Resolve<IConfiguration>();
-                    var update = updater.GetUpdate(mainConfig.DevBuilds);
+                    var update = updater.GetUpdate(mainConfig.DevBuilds ?? false);
                     var latestVersion = update.Version;
                     var currentVersion = new ModuleVersion(Meta.GetVersion());
 
@@ -87,12 +86,12 @@ namespace CKAN.GUI
             DisableMainWindow();
             tabController.RenameTab("WaitTabPage", Properties.Resources.MainUpgradingWaitTitle);
             var mainConfig = ServiceLocator.Container.Resolve<IConfiguration>();
-            var update = updater.GetUpdate(mainConfig.DevBuilds);
+            var update = updater.GetUpdate(mainConfig.DevBuilds ?? false);
             Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo,
                                 update.Version));
 
             log.Info("Start ckan update");
-            Wait.StartWaiting((sender, args) => updater.StartUpdateProcess(true, mainConfig.DevBuilds, currentUser),
+            Wait.StartWaiting((sender, args) => updater.StartUpdateProcess(true, mainConfig.DevBuilds ?? false, currentUser),
                               UpdateReady,
                               false,
                               null);

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -18,7 +18,6 @@ namespace CKAN.GUI
 
         public bool CheckForUpdatesOnLaunch = false;
         public bool CheckForUpdatesOnLaunchNoNag = false;
-        public bool DevBuildsNoNag = false;
 
         public bool EnableTrayIcon = false;
         public bool MinimizeToTray = false;

--- a/Tests/Core/Configuration/FakeConfiguration.cs
+++ b/Tests/Core/Configuration/FakeConfiguration.cs
@@ -151,7 +151,7 @@ namespace Tests.Core.Configuration
 
         public string[] PreferredHosts { get; set; } = Array.Empty<string>();
 
-        public bool DevBuilds { get; set; }
+        public bool? DevBuilds { get; set; }
 
         public void Dispose()
         {


### PR DESCRIPTION
## Problem

The dev builds prompt from #3997 shows up the first time you open any game instance.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/65fc87cf-b561-423e-9560-965fe5f0f51e)

## Cause

Since the prompt itself is part of GUI and most of the autoupdate prompting logic is governed by properties of the form `GUIConfiguration.*NoNag`, I created `GUIConfiguration.DevBuildsNoNag` to store whether the prompt had been shown. But this is stored per game instance, which means it will be false the first time you open any game instance, so the prompt will appear again.

## Changes

- Now `IConfiguration.DevBuilds` is a nullable bool, which means it can be true, false, or null (the default if it's absent from `config.json`)
  - When this value is used, null is treated as equivalent to false because we want stable releases to be the default
- Now `GUIConfiguration.DevBuildsNoNag` is removed and replaced by `IConfiguration.DevBuilds.HasValue`

This makes it possible to determine whether the user has ever been prompted regardless of the current game instance, so they'll only see the prompt one time.
