### PR TITLE
Alternate game command lines and Steam refactor

### DIFF
--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -558,7 +558,7 @@ namespace CKAN.CmdLine
             string path = options.path;
             GameVersion version;
             bool setDefault = options.setDefault;
-            IGame game = GameInstanceManager.GameByShortName(options.gameId);
+            IGame game = KnownGames.GameByShortName(options.gameId);
             if (game == null)
             {
                 User.RaiseMessage(Properties.Resources.InstanceFakeBadGame, options.gameId);

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -254,11 +254,15 @@ namespace CKAN.CmdLine
         /// <param name="percent">Progress in percent</param>
         public void RaiseProgress(string message, int percent)
         {
-            // The percent looks weird on non-download messages.
-            // The leading newline makes sure we don't end up with a mess from previous
-            // download messages.
-            GoToStartOfLine();
-            Console.Write("{0}", message);
+            if (message != lastProgressMessage)
+            {
+                // The percent looks weird on non-download messages.
+                // The leading newline makes sure we don't end up with a mess from previous
+                // download messages.
+                GoToStartOfLine();
+                Console.Write("{0}", message);
+                lastProgressMessage = message;
+            }
 
             // This message leaves the cursor at the end of a line of text
             atStartOfLine = false;
@@ -285,6 +289,8 @@ namespace CKAN.CmdLine
         /// Needed for <see cref="RaiseProgress(string, int)"/>
         /// </summary>
         private int previousPercent = -1;
+
+        private string lastProgressMessage = null;
 
         /// <summary>
         /// Writes a message to the console

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NJsonSchema" Version="10.9.0" />
+    <PackageReference Include="ValveKeyValue" Version="0.3.1.152" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="ChinhDo.Transactions.FileManager" Version="1.2.0" />

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 using log4net;
@@ -19,48 +18,6 @@ namespace CKAN
             Meta.GetProductName());
 
         private static readonly ILog log = LogManager.GetLogger(typeof(CKANPathUtils));
-
-        /// <summary>
-        /// Finds Steam on the current machine.
-        /// </summary>
-        /// <returns>The path to Steam, or null if not found</returns>
-        public static string SteamPath()
-        {
-            foreach (var steam in SteamPaths.Where(p => !string.IsNullOrEmpty(p)))
-            {
-                log.DebugFormat("Looking for Steam in {0}", steam);
-                if (Directory.Exists(steam))
-                {
-                    log.InfoFormat("Found Steam at {0}", steam);
-                    return steam;
-                }
-            }
-            log.Info("Steam not found on this system.");
-            return null;
-        }
-
-        private const string steamRegKey   = @"HKEY_CURRENT_USER\Software\Valve\Steam";
-        private const string steamRegValue = @"SteamPath";
-
-        private static string[] SteamPaths
-            => Platform.IsWindows ? new string[]
-            {
-                // First check the registry
-                (string)Microsoft.Win32.Registry.GetValue(steamRegKey, steamRegValue, null),
-            }
-            : Platform.IsUnix ? new string[]
-            {
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                             ".local", "share", "Steam"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                             ".steam", "steam"),
-            }
-            : Platform.IsMac ? new string[]
-            {
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                             "Library", "Application Support", "Steam"),
-            }
-            : Array.Empty<string>();
 
         /// <summary>
         /// Normalizes the path by replacing all \ with / and removing any trailing slash.

--- a/Core/Converters/JsonToGamesDictionaryConverter.cs
+++ b/Core/Converters/JsonToGamesDictionaryConverter.cs
@@ -4,6 +4,8 @@ using System.Collections;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+using CKAN.Games;
+
 namespace CKAN
 {
     /// <summary>
@@ -59,7 +61,7 @@ namespace CKAN
             var obj = (IDictionary)Activator.CreateInstance(objectType);
             if (!IsTokenEmpty(token))
             {
-                foreach (var gameName in GameInstanceManager.AllGameShortNames())
+                foreach (var gameName in KnownGames.AllGameShortNames())
                 {
                     // Make a new copy of the value for each game
                     obj.Add(gameName, token.ToObject(valueType));

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
+using System.Text.RegularExpressions;
 
 namespace CKAN.Extensions
 {
@@ -215,6 +216,16 @@ namespace CKAN.Extensions
             key = kvp.Key;
             val = kvp.Value;
         }
+
+        /// <summary>
+        /// Try matching a regex against a series of strings and return the Match objects
+        /// </summary>
+        /// <param name="source">Sequence of strings to scan</param>
+        /// <param name="pattern">Pattern to match</param>
+        /// <returns>Sequence of Match objects</returns>
+        public static IEnumerable<Match> WithMatches(this IEnumerable<string> source, Regex pattern)
+            => source.Select(val => pattern.TryMatch(val, out Match match) ? match : null)
+                     .Where(m => m != null);
 
     }
 

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -33,6 +33,7 @@ namespace CKAN
         public TimeLog playTime;
 
         public string Name { get; set; }
+
         /// <summary>
         /// Returns a file system safe version of the instance name that can be used within file names.
         /// </summary>
@@ -238,44 +239,6 @@ namespace CKAN
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Attempts to automatically find a KSP install on this system.
-        /// Returns the path to the install on success.
-        /// Throws a DirectoryNotFoundException on failure.
-        /// </summary>
-        public static string FindGameDir(IGame game)
-        {
-            // See if we can find KSP as part of a Steam install.
-            string gameSteamPath = game.SteamPath();
-            if (gameSteamPath != null)
-            {
-                if (game.GameInFolder(new DirectoryInfo(gameSteamPath)))
-                {
-                    return gameSteamPath;
-                }
-
-                log.DebugFormat("Have Steam, but {0} is not at \"{1}\".",
-                    game.ShortName, gameSteamPath);
-            }
-
-            // See if we can find a non-Steam Mac KSP install
-            string kspMacPath = game.MacPath();
-            if (kspMacPath != null)
-            {
-                if (game.GameInFolder(new DirectoryInfo(kspMacPath)))
-                {
-                    log.InfoFormat("Found a {0} install at {1}",
-                        game.ShortName, kspMacPath);
-                    return kspMacPath;
-                }
-                log.DebugFormat("Default Mac {0} folder exists at \"{1}\", but {0} is not installed there.",
-                    game.ShortName, kspMacPath);
-            }
-
-            // Oh noes! We can't find KSP!
-            throw new DirectoryNotFoundException();
         }
 
         /// <summary>

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -13,13 +13,12 @@ namespace CKAN.Games
     {
         // Identification, used for display and saved/loaded in settings JSON
         // Must be unique!
-        string ShortName { get; }
+        string   ShortName        { get; }
         DateTime FirstReleaseDate { get; }
 
         // Where are we?
-        bool   GameInFolder(DirectoryInfo where);
-        string SteamPath();
-        string MacPath();
+        bool          GameInFolder(DirectoryInfo where);
+        DirectoryInfo MacPath();
 
         // What do we contain?
         string         PrimaryModDirectoryRelative     { get; }
@@ -32,7 +31,7 @@ namespace CKAN.Games
         bool           IsReservedDirectory(GameInstance inst, string path);
         bool           AllowInstallationIn(string name, out string path);
         void           RebuildSubdirectories(string absGameRoot);
-        string         DefaultCommandLine(string path);
+        string[]       DefaultCommandLines(SteamLibrary steamLib, DirectoryInfo path);
         string[]       AdjustCommandLine(string[] args, GameVersion installedVersion);
         IDlcDetector[] DlcDetectors { get; }
 

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -26,67 +26,12 @@ namespace CKAN.Games.KerbalSpaceProgram
                 && Directory.Exists(Path.Combine(where.FullName, "GameData"));
 
         /// <summary>
-        /// Finds the Steam KSP path. Returns null if the folder cannot be located.
-        /// </summary>
-        /// <returns>The KSP path.</returns>
-        public string SteamPath()
-        {
-            // Attempt to get the Steam path.
-            string steamPath = CKANPathUtils.SteamPath();
-
-            if (steamPath == null)
-            {
-                return null;
-            }
-
-            // Default steam library
-            string installPath = KSPDirectory(steamPath);
-            if (installPath != null)
-            {
-                return installPath;
-            }
-
-            // Attempt to find through config file
-            string configPath = Path.Combine(steamPath, "config", "config.vdf");
-            if (File.Exists(configPath))
-            {
-                log.InfoFormat("Found Steam config file at {0}", configPath);
-                StreamReader reader = new StreamReader(configPath);
-                string line;
-                while ((line = reader.ReadLine()) != null)
-                {
-                    // Found Steam library
-                    if (line.Contains("BaseInstallFolder"))
-                    {
-                        // This assumes config file is valid, we just skip it if it looks funny.
-                        string[] split_line = line.Split('"');
-
-                        if (split_line.Length > 3)
-                        {
-                            log.DebugFormat("Found a Steam Libary Location at {0}", split_line[3]);
-
-                            installPath = KSPDirectory(split_line[3]);
-                            if (installPath != null)
-                            {
-                                log.InfoFormat("Found a KSP install at {0}", installPath);
-                                return installPath;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Could not locate the folder.
-            return null;
-        }
-
-        /// <summary>
         /// Get the default non-Steam path to KSP on macOS
         /// </summary>
         /// <returns>
         /// "/Applications/Kerbal Space Program" if it exists and we're on a Mac, else null
         /// </returns>
-        public string MacPath()
+        public DirectoryInfo MacPath()
         {
             if (Platform.IsMac)
             {
@@ -95,7 +40,8 @@ namespace CKAN.Games.KerbalSpaceProgram
                     Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
                     "Kerbal Space Program"
                 );
-                return Directory.Exists(installPath) ? installPath : null;
+                return Directory.Exists(installPath) ? new DirectoryInfo(installPath)
+                                                     : null;
             }
             return null;
         }
@@ -175,14 +121,18 @@ namespace CKAN.Games.KerbalSpaceProgram
             }
         }
 
-        public string DefaultCommandLine(string path)
-            => Platform.IsMac
-                ? "./KSP.app/Contents/MacOS/KSP"
-                : string.Format(Platform.IsUnix ? "./{0} -single-instance"
-                                                : "{0} -single-instance",
-                                InstanceAnchorFiles.FirstOrDefault(f =>
-                                    File.Exists(Path.Combine(path, f)))
-                                ?? InstanceAnchorFiles.First());
+        public string[] DefaultCommandLines(SteamLibrary steamLib, DirectoryInfo path)
+            => Enumerable.Repeat(Platform.IsMac
+                                     ? "./KSP.app/Contents/MacOS/KSP"
+                                     : string.Format(Platform.IsUnix ? "./{0} -single-instance"
+                                                                     : "{0} -single-instance",
+                                                     InstanceAnchorFiles.FirstOrDefault(f =>
+                                                         File.Exists(Path.Combine(path.FullName, f)))
+                                                     ?? InstanceAnchorFiles.First()),
+                                 1)
+                         .Concat(steamLib.GameAppURLs(path)
+                                         .Select(url => url.ToString()))
+                         .ToArray();
 
         public string[] AdjustCommandLine(string[] args, GameVersion installedVersion)
         {
@@ -324,28 +274,6 @@ namespace CKAN.Games.KerbalSpaceProgram
             { "Ships/@thumbs/SPH", "Ships/@thumbs/SPH" },
             { "Ships/Script",      "Ships/Script"      }
         };
-
-        /// <summary>
-        /// Finds the KSP path under a Steam Library. Returns null if the folder cannot be located.
-        /// </summary>
-        /// <param name="steamPath">Steam Library Path</param>
-        /// <returns>The KSP path.</returns>
-        private static string KSPDirectory(string steamPath)
-        {
-            // There are several possibilities for the path under Linux.
-            // Try with the uppercase version.
-            string installPath = Path.Combine(steamPath, "SteamApps", "common", "Kerbal Space Program");
-
-            if (Directory.Exists(installPath))
-            {
-                return installPath;
-            }
-
-            // Try with the lowercase version.
-            installPath = Path.Combine(steamPath, "steamapps", "common", "Kerbal Space Program");
-
-            return Directory.Exists(installPath) ? installPath : null;
-        }
 
         /// <summary>
         /// If the installed game version is in the given range,

--- a/Core/Games/KnownGames.cs
+++ b/Core/Games/KnownGames.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace CKAN.Games
+{
+    public static class KnownGames
+    {
+        public static readonly IGame[] knownGames = new IGame[]
+        {
+            new KerbalSpaceProgram.KerbalSpaceProgram(),
+            new KerbalSpaceProgram2.KerbalSpaceProgram2(),
+        };
+
+        /// <summary>
+        /// Return a game object based on its short name
+        /// </summary>
+        /// <param name="shortName">The short name to find</param>
+        /// <returns>A game object or null if none found</returns>
+        public static IGame GameByShortName(string shortName)
+            => knownGames.FirstOrDefault(g => g.ShortName == shortName);
+
+        /// <summary>
+        /// Return the short names of all known games
+        /// </summary>
+        /// <returns>Sequence of short name strings</returns>
+        public static IEnumerable<string> AllGameShortNames()
+            => knownGames.Select(g => g.ShortName);
+
+    }
+}

--- a/Core/SteamLibrary.cs
+++ b/Core/SteamLibrary.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+using log4net;
+using ValveKeyValue;
+
+namespace CKAN
+{
+    public class SteamLibrary
+    {
+        public SteamLibrary()
+        {
+            var libraryPath = SteamPaths.Where(p => !string.IsNullOrEmpty(p))
+                                        .FirstOrDefault(Directory.Exists);
+            if (libraryPath == null)
+            {
+                log.Info("Steam not found");
+                Games = Array.Empty<NonSteamGame>();
+            }
+            else
+            {
+                log.InfoFormat("Found Steam at {0}", libraryPath);
+                var txtParser     = KVSerializer.Create(KVSerializationFormat.KeyValues1Text);
+                var appPaths      = txtParser.Deserialize<List<LibraryFolder>>(
+                                                  File.OpenRead(Path.Combine(libraryPath,
+                                                                             "config",
+                                                                             "libraryfolders.vdf")))
+                                             .Select(lf => appRelPaths.Select(p => Path.Combine(lf.Path, p))
+                                                                      .FirstOrDefault(Directory.Exists))
+                                             .Where(p => p != null)
+                                             .ToArray();
+                var steamGames    = appPaths.SelectMany(p => LibraryPathGames(txtParser, p));
+                var binParser     = KVSerializer.Create(KVSerializationFormat.KeyValues1Binary);
+                var nonSteamGames = Directory.EnumerateDirectories(Path.Combine(libraryPath, "userdata"))
+                                             .Select(dirName => Path.Combine(dirName, "config"))
+                                             .Where(Directory.Exists)
+                                             .Select(dirName => Path.Combine(dirName, "shortcuts.vdf"))
+                                             .Where(File.Exists)
+                                             .SelectMany(p => ShortcutsFileGames(binParser, p));
+                Games = steamGames.Concat(nonSteamGames)
+                                  .ToArray();
+                log.DebugFormat("Games: {0}",
+                                string.Join(", ", Games.Select(g => $"{g.LaunchUrl} ({g.GameDir})")));
+            }
+        }
+
+        public IEnumerable<Uri> GameAppURLs(DirectoryInfo gameDir)
+            => Games.Where(g => gameDir.FullName.Equals(g.GameDir.FullName, compareOpt))
+                    .Select(g => g.LaunchUrl);
+
+        public readonly GameBase[] Games;
+
+        private static IEnumerable<GameBase> LibraryPathGames(KVSerializer acfParser,
+                                                              string       appPath)
+            => Directory.EnumerateFiles(appPath, "*.acf")
+                        .Select(acfFile => acfParser.Deserialize<SteamGame>(File.OpenRead(acfFile))
+                                                    .NormalizeDir(Path.Combine(appPath, "common")));
+
+        private static IEnumerable<GameBase> ShortcutsFileGames(KVSerializer vdfParser,
+                                                                string       path)
+            => vdfParser.Deserialize<List<NonSteamGame>>(File.OpenRead(path))
+                        .Select(nsg => nsg.NormalizeDir(path));
+
+        private const string registryKey   = @"HKEY_CURRENT_USER\Software\Valve\Steam";
+        private const string registryValue = @"SteamPath";
+        private static string[] SteamPaths
+            => Platform.IsWindows ? new string[]
+            {
+                // First check the registry
+                (string)Microsoft.Win32.Registry.GetValue(registryKey, registryValue, null),
+            }
+            : Platform.IsUnix ? new string[]
+            {
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                             ".local", "share", "Steam"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                             ".steam", "steam"),
+            }
+            : Platform.IsMac ? new string[]
+            {
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                             "Library", "Application Support", "Steam"),
+            }
+            : Array.Empty<string>();
+
+        private static readonly string[] appRelPaths = new string[] { "SteamApps", "steamapps" };
+
+        private static readonly StringComparison compareOpt
+            = Platform.IsWindows ? StringComparison.InvariantCultureIgnoreCase
+                                 : StringComparison.InvariantCulture;
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(SteamLibrary));
+    }
+
+    public class LibraryFolder
+    {
+        [KVProperty("path")] public string Path { get; set; }
+    }
+
+    public abstract class GameBase
+    {
+        public abstract string Name { get; set; }
+
+        [KVIgnore] public          DirectoryInfo GameDir   { get; set; }
+        [KVIgnore] public abstract Uri           LaunchUrl { get;      }
+
+        public abstract GameBase NormalizeDir(string appPath);
+    }
+
+    public class SteamGame : GameBase
+    {
+        [KVProperty("appid")]      public          ulong  AppId      { get; set; }
+        [KVProperty("name")]       public override string Name       { get; set; }
+        [KVProperty("installdir")] public          string InstallDir { get; set; }
+
+        [KVIgnore]
+        public override Uri LaunchUrl => new Uri($"steam://rungameid/{AppId}");
+
+        public override GameBase NormalizeDir(string commonPath)
+        {
+            GameDir = new DirectoryInfo(CKANPathUtils.NormalizePath(Path.Combine(commonPath, InstallDir)));
+            return this;
+        }
+    }
+
+    public class NonSteamGame : GameBase
+    {
+        [KVProperty("appid")]
+        public          int    AppId    { get; set; }
+        [KVProperty("AppName")]
+        public override string Name     { get; set; }
+        public          string Exe      { get; set; }
+        public          string StartDir { get; set; }
+
+        [KVIgnore]
+        private ulong UrlId => (unchecked((ulong)AppId) << 32) | 0x02000000;
+
+        [KVIgnore]
+        public override Uri LaunchUrl => new Uri($"steam://rungameid/{UrlId}");
+
+        public override GameBase NormalizeDir(string appPath)
+        {
+            GameDir = new DirectoryInfo(CKANPathUtils.NormalizePath(StartDir.Trim('"')));
+            return this;
+        }
+    }
+}

--- a/GUI/Controls/EditModSearchDetails.Designer.cs
+++ b/GUI/Controls/EditModSearchDetails.Designer.cs
@@ -344,7 +344,7 @@ namespace CKAN.GUI
             // CompatibleToggle
             //
             this.CompatibleToggle.Location = new System.Drawing.Point(130, 293);
-            this.CompatibleToggle.Changed += TriStateChanged;
+            this.CompatibleToggle.Changed += this.TriStateChanged;
             //
             // InstalledLabel
             //
@@ -360,7 +360,7 @@ namespace CKAN.GUI
             // InstalledToggle
             //
             this.InstalledToggle.Location = new System.Drawing.Point(130, 319);
-            this.InstalledToggle.Changed += TriStateChanged;
+            this.InstalledToggle.Changed += this.TriStateChanged;
             //
             // CachedLabel
             //
@@ -376,7 +376,7 @@ namespace CKAN.GUI
             // CachedToggle
             //
             this.CachedToggle.Location = new System.Drawing.Point(130, 345);
-            this.CachedToggle.Changed += TriStateChanged;
+            this.CachedToggle.Changed += this.TriStateChanged;
             //
             // NewlyCompatibleLabel
             //
@@ -392,7 +392,7 @@ namespace CKAN.GUI
             // NewlyCompatibleToggle
             //
             this.NewlyCompatibleToggle.Location = new System.Drawing.Point(130, 371);
-            this.NewlyCompatibleToggle.Changed += TriStateChanged;
+            this.NewlyCompatibleToggle.Changed += this.TriStateChanged;
             //
             // UpgradeableLabel
             //
@@ -408,7 +408,7 @@ namespace CKAN.GUI
             // UpgradeableToggle
             //
             this.UpgradeableToggle.Location = new System.Drawing.Point(130, 397);
-            this.UpgradeableToggle.Changed += TriStateChanged;
+            this.UpgradeableToggle.Changed += this.TriStateChanged;
             //
             // ReplaceableLabel
             //
@@ -424,7 +424,7 @@ namespace CKAN.GUI
             // ReplaceableToggle
             //
             this.ReplaceableToggle.Location = new System.Drawing.Point(130, 423);
-            this.ReplaceableToggle.Changed += TriStateChanged;
+            this.ReplaceableToggle.Changed += this.TriStateChanged;
             //
             // EditModSearchDetails
             //

--- a/GUI/Controls/HintTextBox.Designer.cs
+++ b/GUI/Controls/HintTextBox.Designer.cs
@@ -39,7 +39,7 @@ namespace CKAN.GUI
             this.ClearIcon.Image = global::CKAN.GUI.EmbeddedImages.textClear;
             this.ClearIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.ClearIcon.Size = new System.Drawing.Size(18, 18);
-            this.ClearIcon.Click += HintClearIcon_Click;
+            this.ClearIcon.Click += this.HintClearIcon_Click;
             // 
             // HintTextBox
             // 

--- a/GUI/Controls/LeftRightRowPanel.cs
+++ b/GUI/Controls/LeftRightRowPanel.cs
@@ -1,4 +1,5 @@
 using System.Windows.Forms;
+using System.Drawing;
 
 namespace CKAN.GUI
 {
@@ -30,6 +31,15 @@ namespace CKAN.GUI
                 // Right align the controls on the right
                 FlowDirection = FlowDirection.RightToLeft,
             };
+
+            // Let the outer control handle horizontal padding
+            LeftPanel.Margin = new Padding(0, LeftPanel.Margin.Top,
+                                           0, LeftPanel.Margin.Bottom);
+            RightPanel.Margin = new Padding(0, RightPanel.Margin.Top,
+                                            0, RightPanel.Margin.Bottom);
+
+            // Don't overwrite graphics drawn on parent
+            BackColor = LeftPanel.BackColor = RightPanel.BackColor = Color.Transparent;
 
             AutoSize = true;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -32,7 +32,9 @@ namespace CKAN.GUI
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(ManageMods));
             this.ToolTip = new System.Windows.Forms.ToolTip();
             this.menuStrip2 = new System.Windows.Forms.MenuStrip();
-            this.launchGameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.LaunchGameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.CommandLinesToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.EditCommandLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.RefreshToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.UpdateAllToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ApplyToolButton = new System.Windows.Forms.ToolStripMenuItem();
@@ -101,7 +103,7 @@ namespace CKAN.GUI
             this.menuStrip2.Dock = System.Windows.Forms.DockStyle.Top;
             this.menuStrip2.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.menuStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.launchGameToolStripMenuItem,
+            this.LaunchGameToolStripMenuItem,
             this.RefreshToolButton,
             this.UpdateAllToolButton,
             this.ApplyToolButton,
@@ -117,15 +119,23 @@ namespace CKAN.GUI
             this.menuStrip2.TabIndex = 4;
             this.menuStrip2.Text = "menuStrip2";
             //
-            // launchGameToolStripMenuItem
+            // LaunchGameToolStripMenuItem
             //
-            this.launchGameToolStripMenuItem.Image = global::CKAN.GUI.EmbeddedImages.ksp;
-            this.launchGameToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.launchGameToolStripMenuItem.Name = "launchGameToolStripMenuItem";
-            this.launchGameToolStripMenuItem.Size = new System.Drawing.Size(146, 56);
-            this.launchGameToolStripMenuItem.Overflow = System.Windows.Forms.ToolStripItemOverflow.AsNeeded;
-            this.launchGameToolStripMenuItem.Click += new System.EventHandler(this.launchGameToolStripMenuItem_Click);
-            resources.ApplyResources(this.launchGameToolStripMenuItem, "launchGameToolStripMenuItem");
+            this.LaunchGameToolStripMenuItem.MouseHover += new System.EventHandler(LaunchGameToolStripMenuItem_MouseHover);
+            this.LaunchGameToolStripMenuItem.Image = global::CKAN.GUI.EmbeddedImages.ksp;
+            this.LaunchGameToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.LaunchGameToolStripMenuItem.Name = "LaunchGameToolStripMenuItem";
+            this.LaunchGameToolStripMenuItem.Size = new System.Drawing.Size(146, 56);
+            this.LaunchGameToolStripMenuItem.Overflow = System.Windows.Forms.ToolStripItemOverflow.AsNeeded;
+            this.LaunchGameToolStripMenuItem.Click += new System.EventHandler(this.LaunchGameToolStripMenuItem_Click);
+            resources.ApplyResources(this.LaunchGameToolStripMenuItem, "LaunchGameToolStripMenuItem");
+            //
+            // EditCommandLinesToolStripMenuItem
+            //
+            this.EditCommandLinesToolStripMenuItem.Name = "EditCommandLinesToolStripMenuItem";
+            this.EditCommandLinesToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.EditCommandLinesToolStripMenuItem.Click += new System.EventHandler(this.EditCommandLinesToolStripMenuItem_Click);
+            resources.ApplyResources(this.EditCommandLinesToolStripMenuItem, "EditCommandLinesToolStripMenuItem");
             //
             // RefreshToolButton
             //
@@ -299,9 +309,9 @@ namespace CKAN.GUI
             // EditModSearches
             //
             this.EditModSearches.Dock = System.Windows.Forms.DockStyle.Top;
-            this.EditModSearches.ApplySearches += EditModSearches_ApplySearches;
-            this.EditModSearches.SurrenderFocus += EditModSearches_SurrenderFocus;
-            this.EditModSearches.ShowError += EditModSearches_ShowError;
+            this.EditModSearches.ApplySearches += this.EditModSearches_ApplySearches;
+            this.EditModSearches.SurrenderFocus += this.EditModSearches_SurrenderFocus;
+            this.EditModSearches.ShowError += this.EditModSearches_ShowError;
             //
             // ModGrid
             //
@@ -550,8 +560,8 @@ namespace CKAN.GUI
             this.hiddenTagsLabelsLinkList.Location = new System.Drawing.Point(0, 0);
             this.hiddenTagsLabelsLinkList.Name = "hiddenTagsLabelsLinkList";
             this.hiddenTagsLabelsLinkList.Size = new System.Drawing.Size(500, 20);
-            this.hiddenTagsLabelsLinkList.TagClicked += hiddenTagsLabelsLinkList_TagClicked;
-            this.hiddenTagsLabelsLinkList.LabelClicked += hiddenTagsLabelsLinkList_LabelClicked;
+            this.hiddenTagsLabelsLinkList.TagClicked += this.hiddenTagsLabelsLinkList_TagClicked;
+            this.hiddenTagsLabelsLinkList.LabelClicked += this.hiddenTagsLabelsLinkList_LabelClicked;
             resources.ApplyResources(this.hiddenTagsLabelsLinkList, "hiddenTagsLabelsLinkList");
             //
             // ManageMods
@@ -581,7 +591,9 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.MenuStrip menuStrip2;
         private System.Windows.Forms.CheckBox InstallAllCheckbox;
-        private System.Windows.Forms.ToolStripMenuItem launchGameToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem LaunchGameToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator CommandLinesToolStripSeparator;
+        private System.Windows.Forms.ToolStripMenuItem EditCommandLinesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem RefreshToolButton;
         private System.Windows.Forms.ToolStripMenuItem UpdateAllToolButton;
         private System.Windows.Forms.ToolStripMenuItem ApplyToolButton;

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -117,7 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve"><value>Play</value></data>
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve"><value>Play</value></data>
+  <data name="EditCommandLinesToolStripMenuItem.Text" xml:space="preserve"><value>Edit command lines...</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>Refresh</value></data>
   <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>Update all</value></data>
   <data name="ApplyToolButton.Text" xml:space="preserve"><value>Apply</value></data>

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -89,8 +89,8 @@ namespace CKAN.GUI
             this.tagsLabelsLinkList.Location = new System.Drawing.Point(0, 0);
             this.tagsLabelsLinkList.Name = "tagsLabelsLinkList";
             this.tagsLabelsLinkList.Size = new System.Drawing.Size(500, 20);
-            this.tagsLabelsLinkList.TagClicked += tagsLabelsLinkList_TagClicked;
-            this.tagsLabelsLinkList.LabelClicked += tagsLabelsLinkList_LabelClicked;
+            this.tagsLabelsLinkList.TagClicked += this.tagsLabelsLinkList_TagClicked;
+            this.tagsLabelsLinkList.LabelClicked += this.tagsLabelsLinkList_LabelClicked;
             //
             // MetadataModuleAbstractLabel
             //
@@ -153,7 +153,7 @@ namespace CKAN.GUI
             this.Metadata.Margin = new System.Windows.Forms.Padding(2);
             this.Metadata.Name = "Metadata";
             this.Metadata.TabIndex = 6;
-            this.Metadata.OnChangeFilter += Metadata_OnChangeFilter;
+            this.Metadata.OnChangeFilter += this.Metadata_OnChangeFilter;
             //
             // RelationshipTabPage
             //

--- a/GUI/Controls/PlayTime.Designer.cs
+++ b/GUI/Controls/PlayTime.Designer.cs
@@ -80,7 +80,7 @@ namespace CKAN.GUI
             this.PlayTimeGrid.Size = new System.Drawing.Size(1536, 837);
             this.PlayTimeGrid.StandardTab = false;
             this.PlayTimeGrid.TabIndex = 1;
-            this.PlayTimeGrid.CellValueChanged += PlayTimeGrid_CellValueChanged;
+            this.PlayTimeGrid.CellValueChanged += this.PlayTimeGrid_CellValueChanged;
             // 
             // NameColumn
             // 

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
@@ -30,67 +30,138 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(GameCommandLineOptionsDialog));
-            this.AdditionalArguments = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
+            this.CmdLineGrid = new System.Windows.Forms.DataGridView();
+            this.CmdLineColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.BottomButtonPanel = new CKAN.GUI.LeftRightRowPanel();
+            this.ResetToDefaultsButton = new System.Windows.Forms.Button();
+            this.AddButton = new System.Windows.Forms.Button();
             this.AcceptChangesButton = new System.Windows.Forms.Button();
             this.CancelChangesButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             //
-            // AdditionalArguments
+            // CmdLineGrid
             //
-            this.AdditionalArguments.Location = new System.Drawing.Point(15, 25);
-            this.AdditionalArguments.Name = "AdditionalArguments";
-            this.AdditionalArguments.Size = new System.Drawing.Size(457, 20);
-            this.AdditionalArguments.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.AdditionalArguments.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.AdditionalArguments.TabIndex = 1;
+            this.CmdLineGrid.AutoGenerateColumns = false;
+            this.CmdLineGrid.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.CmdLineGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.CmdLineGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnKeystrokeOrF2;
+            this.CmdLineGrid.AllowUserToAddRows = true;
+            this.CmdLineGrid.AllowUserToDeleteRows = true;
+            this.CmdLineGrid.AllowUserToResizeRows = false;
+            this.CmdLineGrid.BackgroundColor = System.Drawing.SystemColors.Window;
+            this.CmdLineGrid.EnableHeadersVisualStyles = false;
+            this.CmdLineGrid.ColumnHeadersDefaultCellStyle.Padding = new System.Windows.Forms.Padding(1, 3, 1, 3);
+            this.CmdLineGrid.ColumnHeadersDefaultCellStyle.BackColor = System.Drawing.SystemColors.Control;
+            this.CmdLineGrid.ColumnHeadersDefaultCellStyle.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.CmdLineGrid.ColumnHeadersDefaultCellStyle.SelectionBackColor = System.Drawing.SystemColors.Control;
+            this.CmdLineGrid.DefaultCellStyle.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.CmdLineGrid.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.SingleHorizontal;
+            this.CmdLineGrid.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Raised;
+            this.CmdLineGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.CmdLineGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.CmdLineColumn});
+            this.CmdLineGrid.Location = new System.Drawing.Point(12, 9);
+            this.CmdLineGrid.MultiSelect = false;
+            this.CmdLineGrid.Name = "CmdLineGrid";
+            this.CmdLineGrid.RowHeadersVisible = false;
+            this.CmdLineGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.CmdLineGrid.Size = new System.Drawing.Size(457, 20);
+            this.CmdLineGrid.StandardTab = false;
+            this.CmdLineGrid.TabIndex = 1;
+            this.CmdLineGrid.EditingControlShowing += this.CmdLineGrid_EditingControlShowing;
+            this.CmdLineGrid.UserDeletingRow += this.CmdLineGrid_UserDeletingRow;
             //
-            // label1
+            // CmdLineColumn
             //
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 9);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(60, 13);
-            this.label1.TabIndex = 2;
-            resources.ApplyResources(this.label1, "label1");
+            this.CmdLineColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.CmdLineColumn.Name = "CmdLineColumn";
+            this.CmdLineColumn.DataPropertyName = "CmdLine";
+            this.CmdLineColumn.ReadOnly = false;
+            this.CmdLineColumn.ValueType = typeof(string);
+            this.CmdLineColumn.Width = 250;
+            resources.ApplyResources(this.CmdLineColumn, "CmdLineColumn");
+            //
+            // BottomButtonPanel
+            //
+            this.BottomButtonPanel.LeftControls.Add(this.ResetToDefaultsButton);
+            this.BottomButtonPanel.LeftControls.Add(this.AddButton);
+            this.BottomButtonPanel.RightControls.Add(this.AcceptChangesButton);
+            this.BottomButtonPanel.RightControls.Add(this.CancelChangesButton);
+            this.BottomButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.BottomButtonPanel.Name = "BottomButtonPanel";
+            //
+            // ResetToDefaultsButton
+            //
+            this.ResetToDefaultsButton.AutoSize = true;
+            this.ResetToDefaultsButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.ResetToDefaultsButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ResetToDefaultsButton.Location = new System.Drawing.Point(316, 51);
+            this.ResetToDefaultsButton.Margin = new System.Windows.Forms.Padding(0, 4, 8, 4);
+            this.ResetToDefaultsButton.Name = "ResetToDefaultsButton";
+            this.ResetToDefaultsButton.Size = new System.Drawing.Size(75, 23);
+            this.ResetToDefaultsButton.TabIndex = 2;
+            this.ResetToDefaultsButton.UseVisualStyleBackColor = true;
+            this.ResetToDefaultsButton.Click += this.ResetToDefaultsButton_Click;
+            resources.ApplyResources(this.ResetToDefaultsButton, "ResetToDefaultsButton");
+            //
+            // AddButton
+            //
+            this.AddButton.AutoSize = true;
+            this.AddButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.AddButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.AddButton.Location = new System.Drawing.Point(316, 51);
+            this.AddButton.Margin = new System.Windows.Forms.Padding(0, 4, 8, 4);
+            this.AddButton.Name = "AddButton";
+            this.AddButton.Size = new System.Drawing.Size(75, 23);
+            this.AddButton.TabIndex = 2;
+            this.AddButton.UseVisualStyleBackColor = true;
+            this.AddButton.Visible = false;
+            this.AddButton.Click += this.AddButton_Click;
+            resources.ApplyResources(this.AddButton, "AddButton");
+            //
+            // CancelChangesButton
+            //
+            this.CancelChangesButton.AutoSize = true;
+            this.CancelChangesButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.CancelChangesButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CancelChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.CancelChangesButton.Location = new System.Drawing.Point(316, 51);
+            this.CancelChangesButton.Margin = new System.Windows.Forms.Padding(8, 4, 0, 4);
+            this.CancelChangesButton.Name = "CancelChangesButton";
+            this.CancelChangesButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelChangesButton.TabIndex = 2;
+            this.CancelChangesButton.UseVisualStyleBackColor = true;
+            resources.ApplyResources(this.CancelChangesButton, "CancelChangesButton");
             //
             // AcceptChangesButton
             //
+            this.AcceptChangesButton.AutoSize = true;
+            this.AcceptChangesButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.AcceptChangesButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.AcceptChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.AcceptChangesButton.Location = new System.Drawing.Point(397, 51);
+            this.AcceptChangesButton.Margin = new System.Windows.Forms.Padding(8, 4, 0, 4);
             this.AcceptChangesButton.Name = "AcceptChangesButton";
             this.AcceptChangesButton.Size = new System.Drawing.Size(75, 23);
             this.AcceptChangesButton.TabIndex = 3;
             this.AcceptChangesButton.UseVisualStyleBackColor = true;
+            this.AcceptChangesButton.Click += this.AcceptChangesButton_Click;
             resources.ApplyResources(this.AcceptChangesButton, "AcceptChangesButton");
-            //
-            // CancelChangesButton
-            //
-            this.CancelChangesButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelChangesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelChangesButton.Location = new System.Drawing.Point(316, 51);
-            this.CancelChangesButton.Name = "CancelChangesButton";
-            this.CancelChangesButton.Size = new System.Drawing.Size(75, 23);
-            this.CancelChangesButton.TabIndex = 4;
-            this.CancelChangesButton.UseVisualStyleBackColor = true;
-            resources.ApplyResources(this.CancelChangesButton, "CancelChangesButton");
             //
             // GameCommandLineOptionsDialog
             //
-            this.AcceptButton = this.AcceptChangesButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.CancelChangesButton;
-            this.ClientSize = new System.Drawing.Size(481, 112);
+            this.ClientSize = new System.Drawing.Size(320, 180);
             this.ControlBox = false;
-            this.Controls.Add(this.CancelChangesButton);
-            this.Controls.Add(this.AcceptChangesButton);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.AdditionalArguments);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Controls.Add(this.CmdLineGrid);
+            this.Controls.Add(this.BottomButtonPanel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.Icon = EmbeddedImages.AppIcon;
+            this.MinimumSize = new System.Drawing.Size(320, 180);
             this.Name = "GameCommandLineOptionsDialog";
+            this.Padding = new System.Windows.Forms.Padding(8, 8, 8, 0);
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -99,9 +170,12 @@ namespace CKAN.GUI
 
         #endregion
 
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.DataGridView CmdLineGrid;
+        private System.Windows.Forms.DataGridViewTextBoxColumn CmdLineColumn;
+        private CKAN.GUI.LeftRightRowPanel BottomButtonPanel;
+        private System.Windows.Forms.Button ResetToDefaultsButton;
+        private System.Windows.Forms.Button AddButton;
         private System.Windows.Forms.Button AcceptChangesButton;
         private System.Windows.Forms.Button CancelChangesButton;
-        public System.Windows.Forms.TextBox AdditionalArguments;
     }
 }

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.cs
@@ -1,26 +1,116 @@
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace CKAN.GUI
 {
-
     public partial class GameCommandLineOptionsDialog : Form
     {
         public GameCommandLineOptionsDialog()
         {
             InitializeComponent();
-
-            StartPosition = FormStartPosition.CenterScreen;
+            if (Platform.IsMono)
+            {
+                // Mono's DataGridView has showstopper bugs with AllowUserToAddRows,
+                // so use an Add button instead
+                CmdLineGrid.AllowUserToAddRows = false;
+                AddButton.Visible = true;
+            }
         }
 
-        public DialogResult ShowGameCommandLineOptionsDialog(string arguments)
+        public DialogResult ShowGameCommandLineOptionsDialog(IWin32Window parent,
+                                                             List<string> cmdLines,
+                                                             string[] defaults)
         {
-            AdditionalArguments.Text = arguments;
-            return ShowDialog();
+            rows = cmdLines.Select(cmdLine => new CmdLineRow(cmdLine))
+                           .ToList();
+            CmdLineGrid.DataSource = new BindingList<CmdLineRow>(rows)
+                                     {
+                                         AllowEdit   = true,
+                                         AllowRemove = true,
+                                     };
+            this.defaults = defaults;
+            return ShowDialog(parent);
         }
 
-        public string GetResult()
+        protected override void OnShown(EventArgs e)
         {
-            return AdditionalArguments.Text;
+            base.OnShown(e);
+            // Edit the top cell immediately for convenience
+            CmdLineGrid.BeginEdit(false);
         }
+
+        public List<string> Results => rows.Select(row => row.CmdLine)
+                                           .Where(str => !string.IsNullOrEmpty(str))
+                                           .ToList();
+
+        private void CmdLineGrid_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
+        {
+            // Don't auto-select the text when the user clicks on it
+            if (e.Control is DataGridViewTextBoxEditingControl tbec)
+            {
+                BeginInvoke(new Action(() =>
+                {
+                    tbec.SelectionLength = 0;
+                }));
+            }
+        }
+
+        private void CmdLineGrid_UserDeletingRow(object sender, DataGridViewRowCancelEventArgs e)
+        {
+            // You can't delete the last row
+            if (rows.Count == 1)
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private void ResetToDefaultsButton_Click(object sender, EventArgs e)
+        {
+            rows = defaults.Select(cmdLine => new CmdLineRow(cmdLine))
+                           .ToList();
+            CmdLineGrid.DataSource = new BindingList<CmdLineRow>(rows)
+                                     {
+                                         AllowEdit   = true,
+                                         AllowRemove = true,
+                                     };
+        }
+
+        private void AddButton_Click(object sender, EventArgs e)
+        {
+            (CmdLineGrid.DataSource as BindingList<CmdLineRow>)?.AddNew();
+            CmdLineGrid.CurrentCell = CmdLineGrid.Rows[CmdLineGrid.RowCount - 1].Cells[0];
+            CmdLineGrid.BeginEdit(false);
+        }
+
+        private void AcceptChangesButton_Click(object sender, EventArgs e)
+        {
+            if (Results.Count < 1)
+            {
+                // Don't accept an empty grid (shouldn't happen because of row deletion limit above)
+                DialogResult = DialogResult.None;
+            }
+        }
+
+        private string[]         defaults;
+        private List<CmdLineRow> rows;
+    }
+
+    public class CmdLineRow
+    {
+        // Called when the user clicks on an empty row
+        public CmdLineRow()
+        {
+            CmdLine = "";
+        }
+
+        public CmdLineRow(string cmdLine)
+        {
+            CmdLine = cmdLine;
+        }
+
+        public string CmdLine { get; set; }
     }
 }

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.resx
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.resx
@@ -117,8 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve"><value>Arguments:</value></data>
-  <data name="AcceptChangesButton.Text" xml:space="preserve"><value>OK</value></data>
-  <data name="CancelChangesButton.Text" xml:space="preserve"><value>Cancel</value></data>
-  <data name="$this.Text" xml:space="preserve"><value>Command-line arguments</value></data>
+  <data name="CmdLineColumn.HeaderText" xml:space="preserve"><value>Command lines</value></data>
+  <data name="ResetToDefaultsButton.Text" xml:space="preserve"><value>&amp;Reset</value></data>
+  <data name="AddButton.Text" xml:space="preserve"><value>Add</value></data>
+  <data name="AcceptChangesButton.Text" xml:space="preserve"><value>&amp;Accept</value></data>
+  <data name="CancelChangesButton.Text" xml:space="preserve"><value>&amp;Cancel</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Game command lines</value></data>
 </root>

--- a/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
@@ -46,6 +46,7 @@ namespace CKAN.GUI
             this.InstanceListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.openDirectoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AddToCKANMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ImportFromSteamMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.CloneGameInstanceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.RenameButton = new System.Windows.Forms.Button();
             this.SetAsDefaultCheckbox = new System.Windows.Forms.CheckBox();
@@ -149,6 +150,7 @@ namespace CKAN.GUI
             //
             this.AddNewMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.AddToCKANMenuItem,
+            this.ImportFromSteamMenuItem,
             this.CloneGameInstanceMenuItem});
             this.AddNewMenu.Name = "AddNewMenu";
             this.AddNewMenu.Size = new System.Drawing.Size(222, 48);
@@ -159,6 +161,13 @@ namespace CKAN.GUI
             this.AddToCKANMenuItem.Size = new System.Drawing.Size(216, 22);
             this.AddToCKANMenuItem.Click += new System.EventHandler(this.AddToCKANMenuItem_Click);
             resources.ApplyResources(this.AddToCKANMenuItem, "AddToCKANMenuItem");
+            //
+            // ImportFromSteamMenuItem
+            //
+            this.ImportFromSteamMenuItem.Name = "ImportFromSteamMenuItem";
+            this.ImportFromSteamMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.ImportFromSteamMenuItem.Click += new System.EventHandler(this.ImportFromSteamMenuItem_Click);
+            resources.ApplyResources(this.ImportFromSteamMenuItem, "ImportFromSteamMenuItem");
             //
             // CloneGameInstanceMenuItem
             //
@@ -246,6 +255,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ContextMenuStrip InstanceListContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem openDirectoryMenuItem;
         private System.Windows.Forms.ToolStripMenuItem AddToCKANMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ImportFromSteamMenuItem;
         private System.Windows.Forms.ToolStripMenuItem CloneGameInstanceMenuItem;
         private System.Windows.Forms.Button RenameButton;
         private System.Windows.Forms.CheckBox SetAsDefaultCheckbox;

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -61,7 +61,7 @@ namespace CKAN.GUI
 
             if (!_manager.Instances.Any())
             {
-                _manager.FindAndRegisterDefaultInstance();
+                _manager.FindAndRegisterDefaultInstances();
             }
 
             // Set the renderer for the AddNewMenu
@@ -193,6 +193,20 @@ namespace CKAN.GUI
             {
                 _user.RaiseError(exc.Message);
             }
+        }
+
+        private void ImportFromSteamMenuItem_Click(object sender, EventArgs e)
+        {
+            var currentDirs = _manager.Instances.Values
+                                                .Select(inst => inst.GameDir())
+                                                .ToHashSet();
+            var toAdd = _manager.FindDefaultInstances()
+                                .Where(inst => !currentDirs.Contains(inst.GameDir()));
+            foreach (var inst in toAdd)
+            {
+                _manager.AddInstance(inst);
+            }
+            UpdateInstancesList();
         }
 
         private void CloneGameInstanceMenuItem_Click(object sender, EventArgs e)
@@ -343,6 +357,7 @@ namespace CKAN.GUI
         {
             RenameButton.Enabled = SelectButton.Enabled = SetAsDefaultCheckbox.Enabled = CloneGameInstanceMenuItem.Enabled = HasSelections;
             ForgetButton.Enabled = HasSelections && (string)GameInstancesListView.SelectedItems[0].Tag != _manager.CurrentInstance?.Name;
+            ImportFromSteamMenuItem.Enabled = _manager.SteamLibrary.Games.Length > 0;
         }
     }
 }

--- a/GUI/Dialogs/ManageGameInstancesDialog.resx
+++ b/GUI/Dialogs/ManageGameInstancesDialog.resx
@@ -115,6 +115,8 @@
   <data name="SelectButton.Text" xml:space="preserve"><value>Select</value></data>
   <data name="AddNewButton.Text" xml:space="preserve"><value>New game instance</value></data>
   <data name="AddToCKANMenuItem.Text" xml:space="preserve"><value>Add instance to CKAN</value></data>
+  <data name="ImportFromSteamMenuItem.Text" xml:space="preserve"><value>Import from Steam</value></data>
+  <data name="ImportFromSteamMenuItem.TooltipText" xml:space="preserve"><value>Scan your Steam library for recognized game directories and add them as instances</value></data>
   <data name="CloneGameInstanceMenuItem.Text" xml:space="preserve"><value>Clone instance</value></data>
   <data name="RenameButton.Text" xml:space="preserve"><value>Rename</value></data>
   <data name="SetAsDefaultCheckbox.Text" xml:space="preserve"><value>Set as default</value></data>

--- a/GUI/Localization/de-DE/ManageMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ManageMods.de-DE.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve"><value>Spiel starten</value></data>
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve"><value>Spiel starten</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>Aktualisieren</value></data>
   <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>Verfügbare Updates auswählen</value></data>
   <data name="ApplyToolButton.Text" xml:space="preserve"><value>Annehmen</value></data>

--- a/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
+++ b/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>Lancer le Jeu</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/it-IT/ManageMods.it-IT.resx
+++ b/GUI/Localization/it-IT/ManageMods.it-IT.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>Avvia Gioco</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/ja-JP/ManageMods.ja-JP.resx
+++ b/GUI/Localization/ja-JP/ManageMods.ja-JP.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>ゲームを起動</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/ko-KR/ManageMods.ko-KR.resx
+++ b/GUI/Localization/ko-KR/ManageMods.ko-KR.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>게임 실행</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/nl-NL/ManageMods.nl-NL.resx
+++ b/GUI/Localization/nl-NL/ManageMods.nl-NL.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>Spel Starten</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/pl-PL/ManageMods.pl-PL.resx
+++ b/GUI/Localization/pl-PL/ManageMods.pl-PL.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>Uruchom grę</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/pt-BR/ManageMods.pt-BR.resx
+++ b/GUI/Localization/pt-BR/ManageMods.pt-BR.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>Abrir Jogo</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/ru-RU/ManageMods.ru-RU.resx
+++ b/GUI/Localization/ru-RU/ManageMods.ru-RU.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve">
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve">
     <value>Запустить игру</value>
   </data>
   <data name="RefreshToolButton.Text" xml:space="preserve">

--- a/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
+++ b/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="launchGameToolStripMenuItem.Text" xml:space="preserve"><value>启动游戏</value></data>
+  <data name="LaunchGameToolStripMenuItem.Text" xml:space="preserve"><value>启动游戏</value></data>
   <data name="RefreshToolButton.Text" xml:space="preserve"><value>刷新</value></data>
   <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>添加可用更新</value></data>
   <data name="ApplyToolButton.Text" xml:space="preserve"><value>应用更改</value></data>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -400,7 +400,7 @@ namespace CKAN.GUI
             this.ModInfo.Name = "ModInfo";
             this.ModInfo.Size = new System.Drawing.Size(360, 836);
             this.ModInfo.TabIndex = 34;
-            this.ModInfo.OnDownloadClick += ModInfo_OnDownloadClick;
+            this.ModInfo.OnDownloadClick += this.ModInfo_OnDownloadClick;
             //
             // StatusLabel
             //
@@ -475,14 +475,16 @@ namespace CKAN.GUI
             this.ManageMods.Name = "ManageMods";
             this.ManageMods.Size = new System.Drawing.Size(500, 500);
             this.ManageMods.TabIndex = 4;
-            this.ManageMods.OnSelectedModuleChanged += ManageMods_OnSelectedModuleChanged;
-            this.ManageMods.OnChangeSetChanged += ManageMods_OnChangeSetChanged;
-            this.ManageMods.OnRegistryChanged += ManageMods_OnRegistryChanged;
-            this.ManageMods.LabelsAfterUpdate += ManageMods_LabelsAfterUpdate;
-            this.ManageMods.StartChangeSet += ManageMods_StartChangeSet;
-            this.ManageMods.RaiseMessage += ManageMods_RaiseMessage;
-            this.ManageMods.RaiseError += ManageMods_RaiseError;
-            this.ManageMods.ClearStatusBar += ManageMods_ClearStatusBar;
+            this.ManageMods.OnSelectedModuleChanged += this.ManageMods_OnSelectedModuleChanged;
+            this.ManageMods.OnChangeSetChanged += this.ManageMods_OnChangeSetChanged;
+            this.ManageMods.OnRegistryChanged += this.ManageMods_OnRegistryChanged;
+            this.ManageMods.LabelsAfterUpdate += this.ManageMods_LabelsAfterUpdate;
+            this.ManageMods.StartChangeSet += this.ManageMods_StartChangeSet;
+            this.ManageMods.RaiseMessage += this.ManageMods_RaiseMessage;
+            this.ManageMods.RaiseError += this.ManageMods_RaiseError;
+            this.ManageMods.ClearStatusBar += this.ManageMods_ClearStatusBar;
+            this.ManageMods.LaunchGame += this.LaunchGame;
+            this.ManageMods.EditCommandLines += this.EditCommandLines;
             //
             // ChangesetTabPage
             //
@@ -505,9 +507,9 @@ namespace CKAN.GUI
             this.Changeset.Name = "Changeset";
             this.Changeset.Size = new System.Drawing.Size(500, 500);
             this.Changeset.TabIndex = 32;
-            this.Changeset.OnSelectedItemsChanged += Changeset_OnSelectedItemsChanged;
-            this.Changeset.OnConfirmChanges += Changeset_OnConfirmChanges;
-            this.Changeset.OnCancelChanges += Changeset_OnCancelChanges;
+            this.Changeset.OnSelectedItemsChanged += this.Changeset_OnSelectedItemsChanged;
+            this.Changeset.OnConfirmChanges += this.Changeset_OnConfirmChanges;
+            this.Changeset.OnCancelChanges += this.Changeset_OnCancelChanges;
             //
             // WaitTabPage
             //
@@ -530,8 +532,8 @@ namespace CKAN.GUI
             this.Wait.Name = "Wait";
             this.Wait.Size = new System.Drawing.Size(500, 500);
             this.Wait.TabIndex = 32;
-            this.Wait.OnRetry += Wait_OnRetry;
-            this.Wait.OnOk += Wait_OnOk;
+            this.Wait.OnRetry += this.Wait_OnRetry;
+            this.Wait.OnOk += this.Wait_OnOk;
             //
             // ChooseRecommendedModsTabPage
             //
@@ -578,7 +580,7 @@ namespace CKAN.GUI
             this.PlayTime.Name = "PlayTime";
             this.PlayTime.Size = new System.Drawing.Size(500, 500);
             this.PlayTime.TabIndex = 32;
-            this.PlayTime.Done += PlayTime_Done;
+            this.PlayTime.Done += this.PlayTime_Done;
             //
             // UnmanagedFilesTabPage
             //
@@ -601,7 +603,7 @@ namespace CKAN.GUI
             this.UnmanagedFiles.Name = "UnmanagedFiles";
             this.UnmanagedFiles.Size = new System.Drawing.Size(500, 500);
             this.UnmanagedFiles.TabIndex = 32;
-            this.UnmanagedFiles.Done += UnmanagedFiles_Done;
+            this.UnmanagedFiles.Done += this.UnmanagedFiles_Done;
             //
             // InstallationHistoryTabPage
             //
@@ -624,9 +626,9 @@ namespace CKAN.GUI
             this.InstallationHistory.Name = "InstallationHistory";
             this.InstallationHistory.Size = new System.Drawing.Size(500, 500);
             this.InstallationHistory.TabIndex = 32;
-            this.InstallationHistory.OnSelectedModuleChanged += InstallationHistory_OnSelectedModuleChanged;
-            this.InstallationHistory.Install += InstallationHistory_Install;
-            this.InstallationHistory.Done += InstallationHistory_Done;
+            this.InstallationHistory.OnSelectedModuleChanged += this.InstallationHistory_OnSelectedModuleChanged;
+            this.InstallationHistory.Install += this.InstallationHistory_Install;
+            this.InstallationHistory.Done += this.InstallationHistory_Done;
             //
             // ChooseProvidedModsTabPage
             //

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -134,7 +134,7 @@
   <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;plugins</value></data>
   <data name="preferredHostsToolStripMenuItem.Text" xml:space="preserve"><value>Preferred &amp;hosts</value></data>
   <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;filters</value></data>
-  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Game command-line</value></data>
+  <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Game command lines</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Compatible game versions</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Help</value></data>
   <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>&amp;User guide</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -432,6 +432,8 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="ModSearchReplaceableSuffix" xml:space="preserve"><value>replaceable</value></data>
   <data name="EditModSearchTooltipExpandButton" xml:space="preserve"><value>Expand or collapse the detailed search fields (Ctrl-Shift-F)</value></data>
   <data name="EditModSearchesTooltipAddSearchButton" xml:space="preserve"><value>Combine a new search with your current searches</value></data>
+  <data name="ManageModsSteamPlayTimeYesTooltip" xml:space="preserve"><value>(will count play time in Steam)</value></data>
+  <data name="ManageModsSteamPlayTimeNoTooltip" xml:space="preserve"><value>(will NOT count play time in Steam)</value></data>
   <data name="ManageModsInstallAllCheckboxTooltip" xml:space="preserve"><value>Uncheck to uninstall all mods, check to clear change set</value></data>
   <data name="ManageModsHiddenLabels" xml:space="preserve"><value>Hidden labels:</value></data>
   <data name="ManageModsHiddenTags" xml:space="preserve"><value>Hidden tags:</value></data>

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -20,7 +20,6 @@ namespace CKAN.NetKAN.Processors
         {
             log.Debug("Initializing inflator");
             cache = FindCache(
-                new GameInstanceManager(new ConsoleUser(false)),
                 ServiceLocator.Container.Resolve<IConfiguration>(),
                 cacheDir);
 
@@ -80,7 +79,7 @@ namespace CKAN.NetKAN.Processors
             ckanValidator.Validate(ckan);
         }
 
-        private static NetFileCache FindCache(GameInstanceManager kspManager, IConfiguration cfg, string cacheDir)
+        private static NetFileCache FindCache(IConfiguration cfg, string cacheDir)
         {
             if (cacheDir != null)
             {
@@ -92,7 +91,7 @@ namespace CKAN.NetKAN.Processors
             {
                 log.InfoFormat("Using main CKAN meta-cache at {0}", cfg.DownloadCacheDir);
                 // Create a new file cache in the same location so NetKAN can download pure URLs not sourced from CkanModules
-                return new NetFileCache(kspManager, cfg.DownloadCacheDir);
+                return new NetFileCache(null, cfg.DownloadCacheDir);
             }
             catch
             {

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -11,6 +11,7 @@ using log4net.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+using CKAN.Games;
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Processors;
@@ -48,7 +49,7 @@ namespace CKAN.NetKAN
                     return ExitOk;
                 }
 
-                var game = GameInstanceManager.GameByShortName(Options.Game);
+                var game = KnownGames.GameByShortName(Options.Game);
 
                 if (!string.IsNullOrEmpty(Options.ValidateCkan))
                 {

--- a/Tests/GUI/GUIConfiguration.cs
+++ b/Tests/GUI/GUIConfiguration.cs
@@ -1,10 +1,10 @@
 using System.IO;
+using System.Collections.Generic;
 
 using NUnit.Framework;
 
 using CKAN;
 using CKAN.GUI;
-using CKAN.Games.KerbalSpaceProgram;
 
 using Tests.Data;
 
@@ -37,7 +37,7 @@ namespace Tests.GUI
                 stream.Write("This is not a valid XML file.");
             }
 
-            Assert.Throws<Kraken>(() => GUIConfiguration.LoadOrCreateConfiguration(tempFile, new KerbalSpaceProgram()));
+            Assert.Throws<Kraken>(() => GUIConfiguration.LoadOrCreateConfiguration(tempFile, new List<string>()));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace Tests.GUI
                 stream.Write(TestData.ConfigurationFile());
             }
 
-            var result = GUIConfiguration.LoadOrCreateConfiguration(tempFile, new KerbalSpaceProgram());
+            var result = GUIConfiguration.LoadOrCreateConfiguration(tempFile, new List<string>());
 
             Assert.IsNotNull(result);
         }


### PR DESCRIPTION
## Background 

If you're a Steam user, you can add extra game instances to Steam using this menu item:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/93596c66-fe8b-49ec-b4a5-9912b20e55f7)

## Motivations

- @linuxgurugamer wants to be able to configure an alternate command line that runs the game with a debugger
- @k0smonaut was surprised that launching the game through CKAN didn't make Steam count play time. This is because simply launching `KSP_x64.exe` or `KSP2_x64.exe` doesn't launch it through Steam. To count play time in Steam, you have to launch the game with Steam, which can be done either by clicking in Steam or with a `steam://rungameid/` URL.

## Changes

- Now all of our disparate Steam handling code is refactored into a single `SteamLibrary` class that uses the newly referenced `ValveKeyValue` MIT-licensed library to retrieve Steam's full list of games from its data files
- Now on the first run, instead of scanning each of your configured Steam library folders for one hard coded directory name per game, we check for each supported game in each Steam game folder, including non-Steam games, so if you have multiple game instances added as non-Steam games, they'll all be found
  - The instance names will be pulled from the names Steam uses for each game instead of "Auto KSP" or "Auto KSP2"
  - We now retrieve the library folders from `config/libraryfolders.vdf` instead of `config/config.vdf` because @Olympic1's additional folder was listed in the former but not the latter
  - Since this scan checks that the game is actually installed, it will make us somewhat more robust in the face of unusual situations like `SteamApps/common/Kerbal Space Program` existing but being empty, which would have caused problems under the old logic but would correctly be ignored now
  - There is also a new "Import from Steam" option in the "Add new game instance" dropdown that will perform the same scan and add any instances it finds that aren't already in your list, to make it easy to "catch up" in case users add non-Steam games to Steam after running CKAN
    ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/4e290dde-5b4e-4cce-b620-778ba276e1da)
- Now `IGame.DefaultCommandLine` is replaced by `IGame.DefaultCommandLines`, which uses the `SteamLibrary` class to find the URL for each game when available in addition to the direct EXE file option
- Now the command line setting is a list instead of a single value. When you first run a version of the CKAN client with these changes, your currently configured command line will be pulled forward into this setting, with the default command lines pulled in afterwards. A new "Reset to defaults" button is available in case you want to revert to the default command line settings.
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/88ac931d-5867-46ee-82e7-fdc992c479bd)
- Now the Play button has a dropdown menu showing all of your configured command lines and some help text indicating whether each one will count play time in Steam if you have Steam, followed by an edit option to make it easier to find the command line settings
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/1a17f04c-ecc8-4b3b-8534-008e81086dc2)

Side fixes:

 - `ckan update` won't spam "Loading modules from downloaded default repository..." anymore
 - The GUI mod list will no longer preserve which row was selected when switching from one instance to another, because it's distracting to jump halfway down the list and not know why

Fixes #2706.
Fixes #4003 (in that it explicitly tells the user whether Steam will count play time and makes the `steam://` URL option discoverable).
