### PR TITLE
Improve netkan relationship error message

### DIFF
--- a/Netkan/Validators/ObeysCKANSchemaValidator.cs
+++ b/Netkan/Validators/ObeysCKANSchemaValidator.cs
@@ -11,9 +11,7 @@ namespace CKAN.NetKAN.Validators
             var errors = CKANSchema.schema.Validate(metadata.Json());
             if (errors.Any())
             {
-                string msg = errors
-                    .Select(err => $"{err.Path}: {err.Kind}")
-                    .Aggregate((a, b) => $"{a}\r\n{b}");
+                var msg = string.Join(", ", errors.Select(err => $"{err.Path}: {err.Kind}"));
                 throw new Kraken($"Schema validation failed: {msg}");
             }
         }

--- a/Netkan/Validators/RelationshipsValidator.cs
+++ b/Netkan/Validators/RelationshipsValidator.cs
@@ -1,7 +1,9 @@
+using System.Linq;
+
 using Newtonsoft.Json.Linq;
+
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
-using System.Linq;
 
 namespace CKAN.NetKAN.Validators
 {
@@ -18,7 +20,7 @@ namespace CKAN.NetKAN.Validators
                     {
                         throw new Kraken("spec_version v1.2+ required for 'supports'");
                     }
-                    foreach (JObject rel in json[relName].Cast<JObject>())
+                    foreach (var rel in json[relName].Children<JObject>())
                     {
                         if (rel.ContainsKey("any_of"))
                         {
@@ -65,7 +67,6 @@ namespace CKAN.NetKAN.Validators
                     }
                 }
             }
-
         }
 
         private static readonly string[] relProps = new string[]


### PR DESCRIPTION
## Problem

This metadata fragment:

```yaml
depends:
  - BDArmoryForRunwayProject
```

... produces an obscure inflation error:

```
362 [1] FATAL CKAN.NetKAN.Program (null) - Specified cast is not valid.
```

This example is from KSP-CKAN/NetKAN#9909.

## Cause

An exception is thrown on this line of `RelationshipsValidator`:

```csharp
                    foreach (JObject rel in json[relName].Cast<JObject>())
```

There are four main ways to loop over the children of a JSON array property:

- `.Cast<T>()`, which is a generic Linq function and throws an exception if any element isn't a `T` ("BDArmoryForRunwayProject" is a `JValue`, not a `JObject`)
- `.OfType<T>()`, which is a generic Linq function and ignores any element that isn't a `T` instead of throwing
- `.Children<T>()`, which is a `Newtonsoft.Json` function and equivalent to `.OfType<T>()`
- `.Children()`, which is a `Newtonsoft.Json` function and equivalent to `.Children<JToken>()`

We're using the wrong option from this list.

## Changes

- Now we use `.Children<Jobject>()`, which will examine all the object children and skip the rest. If any of the others are invalid, the schema validator will catch them.
- The schema validator now outputs all on one line so the GitHub action can parse it better
  ```
  $ netkan.exe NetKAN/kOS-KerbalEngineer.netkan
  1717 [1] FATAL CKAN.NetKAN.Program (null) - Schema validation failed: #/depends[0]: ArrayItemNotValid, #/depends[1]: ArrayItemNotValid, #/depends[2]: ArrayItemNotValid, #/supports[0]: ArrayItemNotValid, #/supports[1]: ArrayItemNotValid
  ```
