### PR TITLE
Further improve netkan relationship error message

### DIFF
--- a/Netkan/Validators/RelationshipsValidator.cs
+++ b/Netkan/Validators/RelationshipsValidator.cs
@@ -1,5 +1,4 @@
-using System.Linq;
-
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 using CKAN.Versioning;
@@ -20,49 +19,64 @@ namespace CKAN.NetKAN.Validators
                     {
                         throw new Kraken("spec_version v1.2+ required for 'supports'");
                     }
-                    foreach (var rel in json[relName].Children<JObject>())
+                    foreach (var relToken in json[relName].Children())
                     {
-                        if (rel.ContainsKey("any_of"))
+                        switch (relToken)
                         {
-                            if (metadata.SpecVersion < v1p26)
-                            {
-                                throw new Kraken("spec_version v1.26+ required for 'any_of'");
-                            }
-                            foreach (string forbiddenPropertyName in AnyOfRelationshipDescriptor.ForbiddenPropertyNames)
-                            {
-                                if (rel.ContainsKey(forbiddenPropertyName))
+                            case JObject rel:
+                                if (rel.ContainsKey("any_of"))
                                 {
-                                    throw new Kraken($"{forbiddenPropertyName} is not valid in the same relationship as 'any_of'");
+                                    if (metadata.SpecVersion < v1p26)
+                                    {
+                                        throw new Kraken("spec_version v1.26+ required for 'any_of'");
+                                    }
+                                    foreach (string forbiddenPropertyName in AnyOfRelationshipDescriptor.ForbiddenPropertyNames)
+                                    {
+                                        if (rel.ContainsKey(forbiddenPropertyName))
+                                        {
+                                            throw new Kraken($"{forbiddenPropertyName} is not valid in the same relationship as 'any_of'");
+                                        }
+                                    }
+                                    if (rel.ContainsKey("choice_help_text") && metadata.SpecVersion < v1p31)
+                                    {
+                                        throw new Kraken("spec_version v1.31+ required for choice_help_text in same relationship as 'any_of'");
+                                    }
+                                    foreach (var optToken in rel["any_of"].Children())
+                                    {
+                                        switch (optToken)
+                                        {
+                                            case JObject opt:
+                                                string name = (string)opt["name"];
+                                                if (!Identifier.ValidIdentifierPattern.IsMatch(name))
+                                                {
+                                                    throw new Kraken($"{name} in {relName} 'any_of' is not a valid CKAN identifier");
+                                                }
+                                                break;
+                                            default:
+                                                throw new Kraken($"{relName} 'any_of' elements should be {JTokenType.Object}, found {optToken.Type}: {optToken.ToString(Formatting.None)}");
+                                        }
+                                    }
                                 }
-                            }
-                            if (rel.ContainsKey("choice_help_text") && metadata.SpecVersion < v1p31)
-                            {
-                                throw new Kraken("spec_version v1.31+ required for choice_help_text in same relationship as 'any_of'");
-                            }
-                            foreach (JObject opt in rel["any_of"].Cast<JObject>())
-                            {
-                                string name = (string)opt["name"];
-                                if (!Identifier.ValidIdentifierPattern.IsMatch(name))
+                                else
                                 {
-                                    throw new Kraken($"{name} in {relName} 'any_of' is not a valid CKAN identifier");
+                                    string name = (string)rel["name"];
+                                    if (!Identifier.ValidIdentifierPattern.IsMatch(name))
+                                    {
+                                        throw new Kraken($"{name} in {relName} is not a valid CKAN identifier");
+                                    }
+                                    if (rel.ContainsKey("version_min"))
+                                    {
+                                        throw new Kraken($"'version_min' found in relationship, the correct form is 'min_version'");
+                                    }
+                                    if (rel.ContainsKey("version_max"))
+                                    {
+                                        throw new Kraken($"'version_max' found in relationship, the correct form is 'max_version'");
+                                    }
                                 }
-                            }
-                        }
-                        else
-                        {
-                            string name = (string)rel["name"];
-                            if (!Identifier.ValidIdentifierPattern.IsMatch(name))
-                            {
-                                throw new Kraken($"{name} in {relName} is not a valid CKAN identifier");
-                            }
-                            if (rel.ContainsKey("version_min"))
-                            {
-                                throw new Kraken($"'version_min' found in relationship, the correct form is 'min_version'");
-                            }
-                            if (rel.ContainsKey("version_max"))
-                            {
-                                throw new Kraken($"'version_max' found in relationship, the correct form is 'max_version'");
-                            }
+                                break;
+
+                            default:
+                                throw new Kraken($"{relName} elements should be {JTokenType.Object}, found {relToken.Type}: {relToken.ToString(Formatting.None)}");
                         }
                     }
                 }


### PR DESCRIPTION
## Motivation

#4020 replaced the very unclear "Specified cast is not valid" message with a proper schema validation error. On further consideration, the schema error still isn't clear enough, because it doesn't explain _why_ the array item is not valid.

```
1717 [1] FATAL CKAN.NetKAN.Program (null) - Schema validation failed: #/depends[0]: ArrayItemNotValid, #/depends[1]: ArrayItemNotValid, #/depends[2]: ArrayItemNotValid, #/supports[0]: ArrayItemNotValid, #/supports[1]: ArrayItemNotValid
```

## Changes

Now the `RelationshipsValidator` explicitly checks the type of the elements of relationships arrays and prints a message that hopefully will be clearer:

```
$ netkan.exe NetKAN/kOS-KerbalEngineer.netkan
507 [1] FATAL CKAN.NetKAN.Program (null) - depends elements should be Object, found String: "KerbalEngineerRedux"
```
