### PR TITLE
Better version specific relationships at install and upgrade

### DIFF
--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -202,7 +202,7 @@ namespace CKAN.CmdLine
             CKAN.GameInstance inst = MainClass.GetGameInstance(manager);
             var registry = RegistryManager.Instance(inst, repoData).registry;
             return registry.Installed(false, false)
-                           .Select(kvp => kvp.Key)
+                           .Keys
                            .Where(ident => ident.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
                                            && !registry.GetInstalledVersion(ident).IsDLC)
                            .ToArray();
@@ -214,7 +214,7 @@ namespace CKAN.CmdLine
 
         private string[] GetGameInstances(string prefix)
             => manager.Instances
-                      .Select(kvp => kvp.Key)
+                      .Keys
                       .Where(ident => ident.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
                       .ToArray();
 

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -193,9 +193,14 @@ namespace CKAN.CmdLine
         /// <param name="user">IUser object for output</param>
         /// <param name="instance">Game instance to use</param>
         /// <param name="modules">List of modules to upgrade</param>
-        private void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance instance, bool ConfirmPrompt, List<CkanModule> modules)
+        private void UpgradeModules(GameInstanceManager manager,
+                                    IUser               user,
+                                    CKAN.GameInstance   instance,
+                                    bool                ConfirmPrompt,
+                                    List<CkanModule>    modules)
         {
-            UpgradeModules(manager, user, instance, repoData,
+            UpgradeModules(
+                manager, user, instance, repoData,
                 (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs) =>
                     installer.Upgrade(modules, downloader,
                         ref possibleConfigOnlyDirs, regMgr, true, true, ConfirmPrompt),
@@ -210,9 +215,13 @@ namespace CKAN.CmdLine
         /// <param name="user">IUser object for output</param>
         /// <param name="instance">Game instance to use</param>
         /// <param name="identsAndVersions">List of identifier[=version] to upgrade</param>
-        private void UpgradeModules(GameInstanceManager manager, IUser user, CKAN.GameInstance instance, List<string> identsAndVersions)
+        private void UpgradeModules(GameInstanceManager manager,
+                                    IUser               user,
+                                    CKAN.GameInstance   instance,
+                                    List<string>        identsAndVersions)
         {
-            UpgradeModules(manager, user, instance, repoData,
+            UpgradeModules(
+                manager, user, instance, repoData,
                 (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string> possibleConfigOnlyDirs) =>
                     installer.Upgrade(
                         identsAndVersions.Select(arg => CkanModule.FromIDandVersion(
@@ -241,11 +250,12 @@ namespace CKAN.CmdLine
         /// <param name="instance">Game instance to use</param>
         /// <param name="attemptUpgradeCallback">Function to call to try to perform the actual upgrade, may throw TooManyModsProvideKraken</param>
         /// <param name="addUserChoiceCallback">Function to call when the user has requested a new module added to the change set in response to TooManyModsProvideKraken</param>
-        private void UpgradeModules(
-            GameInstanceManager manager, IUser user, CKAN.GameInstance instance,
-            RepositoryDataManager repoData,
-            AttemptUpgradeAction attemptUpgradeCallback,
-            Action<CkanModule> addUserChoiceCallback)
+        private void UpgradeModules(GameInstanceManager   manager,
+                                    IUser                 user,
+                                    CKAN.GameInstance     instance,
+                                    RepositoryDataManager repoData,
+                                    AttemptUpgradeAction  attemptUpgradeCallback,
+                                    Action<CkanModule>    addUserChoiceCallback)
         {
             using (TransactionScope transact = CkanTransaction.CreateTransactionScope()) {
                 var installer  = new ModuleInstaller(instance, manager.Cache, user);

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -372,6 +372,8 @@ Try `ckan list` for a list of installed mods.</value></data>
   <data name="UpgradeAlreadyHaveLatest" xml:space="preserve"><value>You already have the latest version</value></data>
   <data name="UpgradeAborted" xml:space="preserve"><value>Upgrade aborted: {0}</value></data>
   <data name="UpgradeNotFound" xml:space="preserve"><value>Module {0} not found</value></data>
+  <data name="UpgradeAlreadyUpToDate" xml:space="preserve"><value>Module {0} is already up to date</value></data>
+  <data name="UpgradeAllUpToDate" xml:space="preserve"><value>All modules are up to date</value></data>
   <data name="UpgradeDLC" xml:space="preserve"><value>CKAN can't upgrade expansion '{0}' for you</value></data>
   <data name="UpgradeDLCStorePage" xml:space="preserve"><value>To upgrade this expansion, download any updates from the store page from which you purchased it:
 {0}</value></data>

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -48,13 +48,14 @@ namespace CKAN.ConsoleUI {
                         // Reset this so we stop unless an exception sets it to true
                         retry = false;
 
-                        RegistryManager regMgr = RegistryManager.Instance(manager.CurrentInstance, repoData);
+                        var regMgr   = RegistryManager.Instance(manager.CurrentInstance, repoData);
+                        var registry = regMgr.registry;
 
                         // GUI prompts user to choose recs/sugs,
                         // CmdLine assumes recs and ignores sugs
                         if (plan.Install.Count > 0) {
                             // Track previously rejected optional dependencies and don't prompt for them again.
-                            DependencyScreen ds = new DependencyScreen(manager, regMgr.registry, plan, rejected, debug);
+                            DependencyScreen ds = new DependencyScreen(manager, registry, plan, rejected, debug);
                             if (ds.HaveOptions()) {
                                 LaunchSubScreen(theme, ds);
                             }

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -266,6 +266,9 @@ namespace CKAN.ConsoleUI {
                 const int lblW = 16;
                 int nameW = midL - 2 - lblW - 2 - 1;
                 int depsH = (h - 2) * numDeps / (numDeps + numConfs);
+                var upgradeableGroups = registry
+                                        .CheckUpgradeable(manager.CurrentInstance.VersionCriteria(),
+                                                          new HashSet<string>());
 
                 AddObject(new ConsoleFrame(
                     1, top, midL, top + h - 1,
@@ -290,7 +293,8 @@ namespace CKAN.ConsoleUI {
                     foreach (RelationshipDescriptor rd in mod.depends) {
                         tb.AddLine(ScreenObject.TruncateLength(
                             // Show install status
-                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.ToString()))
+                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.ToString(),
+                                                                         upgradeableGroups[true]))
                                 + rd.ToString(),
                             nameW
                         ));
@@ -315,7 +319,8 @@ namespace CKAN.ConsoleUI {
                     foreach (RelationshipDescriptor rd in mod.conflicts) {
                         tb.AddLine(ScreenObject.TruncateLength(
                             // Show install status
-                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.ToString()))
+                            ModListScreen.StatusSymbol(plan.GetModStatus(manager, registry, rd.ToString(),
+                                                                         upgradeableGroups[true]))
                             + rd.ToString(),
                             nameW
                         ));

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -594,7 +594,7 @@ namespace CKAN
                                 .Concat(WellKnownDlcScan())
                                 .ToDictionary());
 
-        private IEnumerable<KeyValuePair<string, ModuleVersion>> TestDlcScan(string dlcDir)
+        private static IEnumerable<KeyValuePair<string, ModuleVersion>> TestDlcScan(string dlcDir)
             => (Directory.Exists(dlcDir)
                        ? Directory.EnumerateFiles(dlcDir, "*.dlc",
                                                   SearchOption.TopDirectoryOnly)

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -171,6 +171,20 @@ namespace CKAN
                         }
                     }
                 }
+                // And check reverse depends for version limits
+                if (other.depends != null)
+                {
+                    foreach (RelationshipDescriptor rel in other.depends)
+                    {
+                        // If 'others' matches an identifier, it must also match the versions, else fail
+                        if (rel.ContainsAny(Enumerable.Repeat(module.identifier, 1))
+                            && !rel.MatchesAny(selfArray, null, null))
+                        {
+                            log.DebugFormat("Unmatched reverse dependency from {0}, rejecting", other);
+                            return false;
+                        }
+                    }
+                }
             }
             return true;
         }

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -468,19 +468,9 @@ namespace CKAN
                     throw new ModuleNotFoundKraken(ident, version,
                         string.Format(Properties.Resources.CkanModuleNotAvailable, ident, version));
                 }
+                return module;
             }
-            else
-            {
-                module = registry.LatestAvailable(mod, ksp_version)
-                      ?? registry.InstalledModule(mod)?.Module;
-
-                if (module == null)
-                {
-                    throw new ModuleNotFoundKraken(mod, null,
-                        string.Format(Properties.Resources.CkanModuleNotInstalledOrAvailable, mod));
-                }
-            }
-            return module;
+            return null;
         }
 
         public static readonly Regex idAndVersionMatcher =

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -382,7 +382,7 @@ namespace CKAN.GUI
                 Filter = string.Join("|", exportOptions.Select(i => i.ToString()).ToArray()),
                 Title  = Properties.Resources.ExportInstalledModsDialogTitle
             };
-            if (dlg.ShowDialog(Main.Instance) == DialogResult.OK)
+            if (dlg.ShowDialog(ParentForm) == DialogResult.OK)
             {
                 selectedOption = exportOptions[dlg.FilterIndex - 1];
                 filename       = dlg.FileName;

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -21,6 +21,7 @@ namespace CKAN.GUI
         {
             InitializeComponent();
             Contents.OnDownloadClick += gmod => OnDownloadClick?.Invoke(gmod);
+            Relationships.ModuleDoubleClicked += mod => ModuleDoubleClicked?.Invoke(mod);
         }
 
         public GUIMod SelectedModule
@@ -54,6 +55,7 @@ namespace CKAN.GUI
 
         public event Action<GUIMod>            OnDownloadClick;
         public event Action<SavedSearch, bool> OnChangeFilter;
+        public event Action<CkanModule>        ModuleDoubleClicked;
 
         protected override void OnResize(EventArgs e)
         {

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -27,7 +27,6 @@ namespace CKAN.GUI
         {
             set
             {
-                var module = value?.ToModule();
                 if (value != selectedModule)
                 {
                     selectedModule = value;
@@ -93,7 +92,7 @@ namespace CKAN.GUI
                 ContentsPreviewTree.Enabled = true;
                 ContentsPreviewTree.Nodes.Clear();
                 var rootNode = ContentsPreviewTree.Nodes.Add("", module.ToString(), "folderZip", "folderZip");
-                if (!Main.Instance.Manager.Cache.IsMaybeCachedZip(module))
+                if (!manager.Cache.IsMaybeCachedZip(module))
                 {
                     NotCachedLabel.Text = Properties.Resources.ModInfoNotCached;
                     ContentsDownloadButton.Enabled = true;
@@ -103,7 +102,7 @@ namespace CKAN.GUI
                 else
                 {
                     rootNode.Text = Path.GetFileName(
-                        Main.Instance.Manager.Cache.GetCachedFilename(module));
+                        manager.Cache.GetCachedFilename(module));
                     NotCachedLabel.Text = Properties.Resources.ModInfoCached;
                     ContentsDownloadButton.Enabled = false;
                     ContentsOpenButton.Enabled = true;
@@ -114,7 +113,7 @@ namespace CKAN.GUI
                     {
                         var paths = new ModuleInstaller(
                                 manager.CurrentInstance,
-                                Main.Instance.Manager.Cache,
+                                manager.Cache,
                                 Main.Instance.currentUser)
                             .GetModuleContentsList(module)
                             // Load fully in bg

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -76,6 +76,8 @@ namespace CKAN.GUI
             get => selectedModule;
         }
 
+        public event Action<CkanModule> ModuleDoubleClicked;
+
         private void UpdateModDependencyGraph(CkanModule module)
         {
             Util.Invoke(DependsGraphTree, () => _UpdateModDependencyGraph(module));
@@ -87,7 +89,10 @@ namespace CKAN.GUI
 
         private void DependsGraphTree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
         {
-            Main.Instance.ManageMods.ResetFilterAndSelectModOnList(e.Node.Name);
+            if (e.Node.Tag is CkanModule module)
+            {
+                ModuleDoubleClicked?.Invoke(module);
+            }
         }
 
         private bool ImMyOwnGrandpa(TreeNode node)

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -64,6 +64,10 @@ namespace CKAN.GUI
             }
         }
 
+        private GameInstance        currentInstance => Main.Instance.CurrentInstance;
+        private GameInstanceManager manager         => Main.Instance.Manager;
+        private IUser               user            => Main.Instance.currentUser;
+
         private readonly RepositoryDataManager repoData;
         private GUIMod                  visibleGuiModule;
         private bool                    ignoreItemCheck;
@@ -100,10 +104,10 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        private static bool installable(ModuleInstaller     installer,
-                                        CkanModule          module,
-                                        IRegistryQuerier    registry)
-            => installable(installer, module, registry, Main.Instance.CurrentInstance.VersionCriteria());
+        private bool installable(ModuleInstaller     installer,
+                                 CkanModule          module,
+                                 IRegistryQuerier    registry)
+            => installable(installer, module, registry, currentInstance.VersionCriteria());
 
         [ForbidGUICalls]
         private static bool installable(ModuleInstaller     installer,
@@ -117,12 +121,8 @@ namespace CKAN.GUI
 
         private bool allowInstall(CkanModule module)
         {
-            GameInstance currentInstance = Main.Instance.Manager.CurrentInstance;
             IRegistryQuerier registry = RegistryManager.Instance(currentInstance, repoData).registry;
-            var installer = new ModuleInstaller(
-                currentInstance,
-                Main.Instance.Manager.Cache,
-                Main.Instance.currentUser);
+            var installer = new ModuleInstaller(currentInstance, manager.Cache, user);
 
             return installable(installer, module, registry)
                 || Main.Instance.YesNoDialog(
@@ -157,7 +157,6 @@ namespace CKAN.GUI
 
         private List<CkanModule> getVersions(GUIMod gmod)
         {
-            GameInstance currentInstance = Main.Instance.Manager.CurrentInstance;
             IRegistryQuerier registry = RegistryManager.Instance(currentInstance, repoData).registry;
 
             // Can't be functional because AvailableByIdentifier throws exceptions
@@ -183,7 +182,6 @@ namespace CKAN.GUI
 
         private ListViewItem[] getItems(GUIMod gmod, List<CkanModule> versions)
         {
-            GameInstance     currentInstance  = Main.Instance.Manager.CurrentInstance;
             IRegistryQuerier registry         = RegistryManager.Instance(currentInstance, repoData).registry;
             ModuleVersion    installedVersion = registry.InstalledVersion(gmod.Identifier);
 
@@ -220,11 +218,8 @@ namespace CKAN.GUI
         [ForbidGUICalls]
         private void checkInstallable(ListViewItem[] items)
         {
-            var currentInstance = Main.Instance.Manager.CurrentInstance;
-            var registry        = RegistryManager.Instance(currentInstance, repoData).registry;
-            var installer       = new ModuleInstaller(currentInstance,
-                                                      Main.Instance.Manager.Cache,
-                                                      Main.Instance.currentUser);
+            var registry  = RegistryManager.Instance(currentInstance, repoData).registry;
+            var installer = new ModuleInstaller(currentInstance, manager.Cache, user);
             ListViewItem latestCompatible = null;
             // Load balance the items so they're processed roughly in-order instead of blocks
             Partitioner.Create(items, true)

--- a/GUI/Dialogs/ErrorDialog.cs
+++ b/GUI/Dialogs/ErrorDialog.cs
@@ -22,9 +22,9 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        public void ShowErrorDialog(string text, params object[] args)
+        public void ShowErrorDialog(Main mainForm, string text, params object[] args)
         {
-            Util.Invoke(Main.Instance, () =>
+            Util.Invoke(this, () =>
             {
                 log.ErrorFormat(text, args);
                 // Append to previous text, if any
@@ -45,17 +45,12 @@ namespace CKAN.GUI
                                                     ErrorMessage.Width - 4)));
                 if (!Visible)
                 {
-                    StartPosition = Main.Instance.actuallyVisible
+                    StartPosition = mainForm.actuallyVisible
                         ? FormStartPosition.CenterParent
                         : FormStartPosition.CenterScreen;
-                    ShowDialog(Main.Instance);
+                    ShowDialog(mainForm);
                 }
             });
-        }
-
-        public void HideErrorDialog()
-        {
-            Util.Invoke(this, () => Close());
         }
 
         private void DismissButton_Click(object sender, EventArgs e)

--- a/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
@@ -250,7 +250,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ColumnHeader GamePlayTime;
         private System.Windows.Forms.ColumnHeader GameInstallPath;
         private System.Windows.Forms.Button SelectButton;
-        private DropdownMenuButton AddNewButton;
+        private CKAN.GUI.DropdownMenuButton AddNewButton;
         private System.Windows.Forms.ContextMenuStrip AddNewMenu;
         private System.Windows.Forms.ContextMenuStrip InstanceListContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem openDirectoryMenuItem;

--- a/GUI/Dialogs/PluginsDialog.cs
+++ b/GUI/Dialogs/PluginsDialog.cs
@@ -17,6 +17,8 @@ namespace CKAN.GUI
             StartPosition = FormStartPosition.CenterScreen;
         }
 
+        private PluginController pluginController => Main.Instance.pluginController;
+
         private readonly OpenFileDialog m_AddNewPluginDialog = new OpenFileDialog();
 
         private void PluginsDialog_Load(object sender, EventArgs e)
@@ -35,7 +37,7 @@ namespace CKAN.GUI
 
         private void RefreshActivePlugins()
         {
-            var activePlugins = Main.Instance.pluginController.ActivePlugins;
+            var activePlugins = pluginController.ActivePlugins;
 
             ActivePluginsListBox.Items.Clear();
             foreach (var plugin in activePlugins)
@@ -46,7 +48,7 @@ namespace CKAN.GUI
 
         private void RefreshDormantPlugins()
         {
-            var dormantPlugins = Main.Instance.pluginController.DormantPlugins;
+            var dormantPlugins = pluginController.DormantPlugins;
 
             DormantPluginsListBox.Items.Clear();
             foreach (var plugin in dormantPlugins)
@@ -70,7 +72,7 @@ namespace CKAN.GUI
             }
 
             var plugin = (IGUIPlugin) ActivePluginsListBox.SelectedItem;
-            Main.Instance.pluginController.DeactivatePlugin(plugin);
+            pluginController.DeactivatePlugin(plugin);
             RefreshActivePlugins();
             RefreshDormantPlugins();
         }
@@ -83,8 +85,8 @@ namespace CKAN.GUI
             }
 
             var plugin = (IGUIPlugin)ActivePluginsListBox.SelectedItem;
-            Main.Instance.pluginController.DeactivatePlugin(plugin);
-            Main.Instance.pluginController.ActivatePlugin(plugin);
+            pluginController.DeactivatePlugin(plugin);
+            pluginController.ActivatePlugin(plugin);
             RefreshActivePlugins();
             RefreshDormantPlugins();
         }
@@ -104,7 +106,7 @@ namespace CKAN.GUI
             }
 
             var plugin = (IGUIPlugin)DormantPluginsListBox.SelectedItem;
-            Main.Instance.pluginController.ActivatePlugin(plugin);
+            pluginController.ActivatePlugin(plugin);
             RefreshActivePlugins();
             RefreshDormantPlugins();
         }
@@ -117,7 +119,7 @@ namespace CKAN.GUI
             }
 
             var plugin = (IGUIPlugin)DormantPluginsListBox.SelectedItem;
-            Main.Instance.pluginController.UnloadPlugin(plugin);
+            pluginController.UnloadPlugin(plugin);
             RefreshActivePlugins();
             RefreshDormantPlugins();
         }
@@ -127,7 +129,7 @@ namespace CKAN.GUI
             if (m_AddNewPluginDialog.ShowDialog(this) == DialogResult.OK)
             {
                 var path = m_AddNewPluginDialog.FileName;
-                Main.Instance.pluginController.AddNewAssemblyToPluginsPath(path);
+                pluginController.AddNewAssemblyToPluginsPath(path);
                 RefreshDormantPlugins();
             }
         }

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -25,6 +25,8 @@ namespace CKAN.GUI
         public bool RepositoryRemoved { get; private set; } = false;
         public bool RepositoryMoved   { get; private set; } = false;
 
+        private GameInstanceManager manager => Main.Instance.Manager;
+
         private readonly IConfiguration   coreConfig;
         private readonly GUIConfiguration guiConfig;
         private readonly RegistryManager  regMgr;
@@ -103,7 +105,7 @@ namespace CKAN.GUI
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
             if (CachePath.Text != coreConfig.DownloadCacheDir
-                && !Main.Instance.Manager.TrySetupCache(CachePath.Text, out string failReason))
+                && !manager.TrySetupCache(CachePath.Text, out string failReason))
             {
                 user.RaiseError(Properties.Resources.SettingsDialogSummaryInvalid, failReason);
                 e.Cancel = true;
@@ -260,13 +262,13 @@ namespace CKAN.GUI
             {
                 // Switch main cache since user seems committed to this path
                 if (CachePath.Text != coreConfig.DownloadCacheDir
-                    && !Main.Instance.Manager.TrySetupCache(CachePath.Text, out string failReason))
+                    && !manager.TrySetupCache(CachePath.Text, out string failReason))
                 {
                     user.RaiseError(Properties.Resources.SettingsDialogSummaryInvalid, failReason);
                     return;
                 }
 
-                Main.Instance.Manager.Cache.EnforceSizeLimit(
+                manager.Cache.EnforceSizeLimit(
                     coreConfig.CacheSizeLimit.Value,
                     regMgr.registry);
                 UpdateCacheInfo(coreConfig.DownloadCacheDir);
@@ -277,13 +279,13 @@ namespace CKAN.GUI
         {
             // Switch main cache since user seems committed to this path
             if (CachePath.Text != coreConfig.DownloadCacheDir
-                && !Main.Instance.Manager.TrySetupCache(CachePath.Text, out string failReason))
+                && !manager.TrySetupCache(CachePath.Text, out string failReason))
             {
                 user.RaiseError(Properties.Resources.SettingsDialogSummaryInvalid, failReason);
                 return;
             }
 
-            Main.Instance.Manager.Cache.GetSizeInfo(
+            manager.Cache.GetSizeInfo(
                 out int cacheFileCount, out long cacheSize, out _);
 
             YesNoDialog deleteConfirmationDialog = new YesNoDialog();
@@ -295,7 +297,7 @@ namespace CKAN.GUI
             if (deleteConfirmationDialog.ShowYesNoDialog(this, confirmationText) == DialogResult.Yes)
             {
                 // Tell the cache object to nuke itself
-                Main.Instance.Manager.Cache.RemoveAll();
+                manager.Cache.RemoveAll();
 
                 UpdateCacheInfo(coreConfig.DownloadCacheDir);
             }

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Linq;
 
 using Newtonsoft.Json;
 
@@ -79,6 +80,11 @@ namespace CKAN.GUI
         /// </returns>
         public bool AppliesTo(string instanceName)
             => InstanceName == null || InstanceName == instanceName;
+
+        public IEnumerable<string> IdentifiersFor(IGame game)
+            => ModuleIdentifiers.TryGetValue(game.ShortName, out HashSet<string> idents)
+                ? idents
+                : Enumerable.Empty<string>();
 
         /// <summary>
         /// Add a module to this label's group

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -79,5 +79,10 @@ namespace CKAN.GUI
                 return false;
             }
         }
+
+        public IEnumerable<string> HeldIdentifiers(GameInstance inst)
+            => LabelsFor(inst.Name).Where(l => l.HoldVersion)
+                                   .SelectMany(l => l.IdentifiersFor(inst.game))
+                                   .Distinct();
     }
 }

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -482,6 +482,7 @@ namespace CKAN.GUI
             this.ManageMods.StartChangeSet += this.ManageMods_StartChangeSet;
             this.ManageMods.RaiseMessage += this.ManageMods_RaiseMessage;
             this.ManageMods.RaiseError += this.ManageMods_RaiseError;
+            this.ManageMods.SetStatusBar += this.ManageMods_SetStatusBar;
             this.ManageMods.ClearStatusBar += this.ManageMods_ClearStatusBar;
             this.ManageMods.LaunchGame += this.LaunchGame;
             this.ManageMods.EditCommandLines += this.EditCommandLines;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -101,6 +101,7 @@ namespace CKAN.GUI
             InitializeComponent();
             // React when the user clicks a tag or filter link in mod info
             ModInfo.OnChangeFilter += ManageMods.Filter;
+            ModInfo.ModuleDoubleClicked += ManageMods.ResetFilterAndSelectModOnList;
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
 
             Instance = this;
@@ -256,7 +257,8 @@ namespace CKAN.GUI
                                 if (!string.IsNullOrEmpty(regMgr.previousCorruptedMessage)
                                     && !string.IsNullOrEmpty(regMgr.previousCorruptedPath))
                                 {
-                                    errorDialog.ShowErrorDialog(Properties.Resources.MainCorruptedRegistry,
+                                    errorDialog.ShowErrorDialog(this,
+                                        Properties.Resources.MainCorruptedRegistry,
                                         regMgr.previousCorruptedPath, regMgr.previousCorruptedMessage,
                                         Path.Combine(Path.GetDirectoryName(regMgr.previousCorruptedPath) ?? "", regMgr.LatestInstalledExportFilename()));
                                     regMgr.previousCorruptedMessage = null;
@@ -405,7 +407,8 @@ namespace CKAN.GUI
             if (!string.IsNullOrEmpty(regMgr.previousCorruptedMessage)
                 && !string.IsNullOrEmpty(regMgr.previousCorruptedPath))
             {
-                errorDialog.ShowErrorDialog(Properties.Resources.MainCorruptedRegistry,
+                errorDialog.ShowErrorDialog(this,
+                    Properties.Resources.MainCorruptedRegistry,
                     regMgr.previousCorruptedPath, regMgr.previousCorruptedMessage,
                     Path.Combine(Path.GetDirectoryName(regMgr.previousCorruptedPath) ?? "", regMgr.LatestInstalledExportFilename()));
                 regMgr.previousCorruptedMessage = null;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -446,7 +446,6 @@ namespace CKAN.GUI
                 // If not allowing, don't do anything
                 if (repoUpdateNeeded)
                 {
-                    ManageMods.ModGrid.Rows.Clear();
                     UpdateRepo(refreshWithoutChanges: true);
                 }
                 else
@@ -877,6 +876,11 @@ namespace CKAN.GUI
         private void ManageMods_RaiseError(string error)
         {
             currentUser.RaiseError(error);
+        }
+
+        private void ManageMods_SetStatusBar(string message)
+        {
+            StatusLabel.ToolTipText = StatusLabel.Text = message;
         }
 
         private void ManageMods_ClearStatusBar()

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -28,7 +28,7 @@ namespace CKAN.GUI
         [ForbidGUICalls]
         public void ErrorDialog(string text, params object[] args)
         {
-            errorDialog.ShowErrorDialog(text, args);
+            errorDialog.ShowErrorDialog(this, text, args);
         }
 
         [ForbidGUICalls]

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -146,10 +146,7 @@ namespace CKAN.GUI
             // Install
             Wait.StartWaiting(InstallMods, PostInstallMods, true,
                 new InstallArgument(
-                    ManageMods.mainModList
-                              .ComputeUserChangeSet(
-                                  RegistryManager.Instance(CurrentInstance, repoData).registry,
-                                  CurrentInstance.VersionCriteria())
+                    ManageMods.ComputeUserChangeSet()
                               .ToList(),
                     RelationshipResolverOptions.DependsOnlyOpts())
             );

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -24,6 +24,9 @@ namespace CKAN.GUI
         public  CkanModule      LatestAvailableMod  { get; private set; }
         public  InstalledModule InstalledMod        { get; private set; }
 
+        private GameInstance        currentInstance => Main.Instance?.CurrentInstance;
+        private GameInstanceManager manager         => Main.Instance?.Manager;
+
         /// <summary>
         /// The module of the checkbox that is checked in the MainAllModVersions list if any,
         /// null otherwise.
@@ -50,10 +53,9 @@ namespace CKAN.GUI
                     }
                     Main.Instance.ManageMods.MarkModForInstall(Identifier, selectedMod == null);
 
-                    var inst = Main.Instance.CurrentInstance;
                     Main.Instance.ManageMods.UpdateChangeSetAndConflicts(
-                        inst,
-                        RegistryManager.Instance(inst,
+                        currentInstance,
+                        RegistryManager.Instance(currentInstance,
                             ServiceLocator.Container.Resolve<RepositoryDataManager>()).registry);
 
                     OnPropertyChanged();
@@ -204,7 +206,7 @@ namespace CKAN.GUI
                 if (GameCompatibilityVersion.IsAny)
                 {
                     GameCompatibilityVersion = mod.LatestCompatibleRealGameVersion(
-                        Main.Instance?.Manager.CurrentInstance?.game.KnownVersions
+                        manager.CurrentInstance?.game.KnownVersions
                         ?? new List<GameVersion>() {});
                 }
             }
@@ -269,7 +271,7 @@ namespace CKAN.GUI
             if (LatestAvailableMod != null)
             {
                 GameCompatibilityVersion = registry.LatestCompatibleGameVersion(
-                    Main.Instance?.Manager.CurrentInstance?.game.KnownVersions ?? new List<GameVersion>() {},
+                    currentInstance?.game.KnownVersions ?? new List<GameVersion>() {},
                     identifier);
             }
 
@@ -294,12 +296,12 @@ namespace CKAN.GUI
         /// </summary>
         public void UpdateIsCached()
         {
-            if (Main.Instance?.Manager?.Cache == null || Mod?.download == null)
+            if (manager?.Cache == null || Mod?.download == null)
             {
                 return;
             }
 
-            IsCached = Main.Instance.Manager.Cache.IsMaybeCachedZip(Mod);
+            IsCached = manager.Cache.IsMaybeCachedZip(Mod);
         }
 
         /// <summary>

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -157,7 +157,7 @@ namespace CKAN.GUI
         /// <summary>
         /// The target version for upgrading
         /// </summary>
-        public readonly CkanModule targetMod;
+        public CkanModule targetMod;
 
         private bool IsReinstall
             => targetMod.identifier == Mod.identifier

--- a/Tests/CmdLine/UpgradeTests.cs
+++ b/Tests/CmdLine/UpgradeTests.cs
@@ -100,5 +100,538 @@ namespace Tests.CmdLine
                 });
             }
         }
+
+        [Test,
+            TestCase("No mods, do nothing without crashing",
+                     new string[] { },
+                     new string[] { },
+                     new string[] { },
+                     new string[] { }),
+            TestCase("No mods, do nothing (--all) without crashing",
+                     new string[] { },
+                     new string[] { },
+                     null,
+                     new string[] { }),
+            TestCase("Enforce version requirements of identifier=version specified mod",
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.0.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Depender""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Dependency""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.1.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Depender""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Dependency""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.2.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.2.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Depender""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.2.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Dependency""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] { "Depender=1.1.0", "Dependency" },
+                     new string[] { "1.1.0", "1.1.0" }),
+            // Installed and latest version of the depender has a version specific depends,
+            // the current installed dependency is old, and we upgrade to an intermediate version
+            // instead of the absolute latest
+            // (lamont-granquist's use case with identifiers)
+            TestCase("Should upgrade-with-identifiers to intermediate version when installed dependency blocks latest",
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.1.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.2.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] { "Dependency" },
+                     new string[] { "1.0.0", "1.1.0" }),
+            // Installed and latest version of the depender has a version specific depends,
+            // the current installed dependency is old, and we upgrade to an intermediate version
+            // instead of the absolute latest
+            // (lamont-granquist's use case with --all)
+            TestCase("Should upgrade-all to intermediate version when installed dependency blocks latest",
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.1.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.2.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     null,
+                     new string[] { "1.0.0", "1.1.0" }),
+            // Depender stops any upgrades at all (with identifiers)
+            // (could be broken by naive fix for lamont-granquist's use case)
+            TestCase("Depender stops any upgrades-with-identifiers at all",
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.0.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] { "Dependency" },
+                     new string[] { "1.0.0", "1.0.0" }),
+            // Depender stops any upgrades at all (--all)
+            // (could be broken by naive fix for lamont-granquist's use case)
+            TestCase("Depender stops any upgrades-all at all",
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.0.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     null,
+                     new string[] { "1.0.0", "1.0.0" }),
+            // Depender blocks latest dependency, but the latest available depender
+            // doesn't have that limitation, and we upgrade both to latest
+            // (could be broken by naive fix for lamont-granquist's use case)
+            TestCase("Upgrade-with-identifiers both to bypass current version limitation",
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.0.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Depender""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Dependency""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] { "Depender", "Dependency" },
+                     new string[] { "1.1.0", "1.1.0" }),
+            // Depender blocks latest dependency, but the latest available depender
+            // doesn't have that limitation, and we upgrade both to latest
+            // (could be broken by naive fix for lamont-granquist's use case)
+            TestCase("Upgrade-all both to bypass current version limitation",
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""depends"": [
+                                 {
+                                     ""name"":        ""Dependency"",
+                                     ""max_version"": ""1.0.0""
+                                 }
+                             ],
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.0.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData""
+                                 }
+                             ]
+                         }",
+                     },
+                     new string[] {
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Depender"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Depender""
+                                 }
+                             ]
+                         }",
+                         @"{
+                             ""spec_version"": 1,
+                             ""identifier"":   ""Dependency"",
+                             ""version"":      ""1.1.0"",
+                             ""download"":     ""https://github.com/"",
+                             ""install"": [
+                                 {
+                                     ""find"": ""DogeCoinFlag"",
+                                     ""install_to"": ""GameData/Dependency""
+                                 }
+                             ]
+                         }",
+                     },
+                     null,
+                     new string[] { "1.1.0", "1.1.0" }),
+        ]
+        public void RunCommand_VersionDependsUpgrade_UpgradesCorrectly(string   description,
+                                                                       string[] instModules,
+                                                                       string[] addlModules,
+                                                                       string[] upgradeIdentifiers,
+                                                                       string[] versionsAfter)
+        {
+            // Arrange
+            var user = new CapturingUser(false, q => true, (msg, objs) => 0);
+            using (var inst     = new DisposableKSP())
+            using (var repo     = new TemporaryRepository(instModules.Concat(addlModules)
+                                                                     .ToArray()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager  = new GameInstanceManager(user, config)
+                {
+                    CurrentInstance = inst.KSP,
+                })
+            {
+                var regMgr = RegistryManager.Instance(inst.KSP, repoData.Manager);
+                regMgr.registry.RepositoriesClear();
+                regMgr.registry.RepositoriesAdd(repo.repo);
+
+                // Register installed mods
+                var instMods = instModules.Select(CkanModule.FromJson)
+                                          .ToArray();
+                foreach (var fromModule in instMods)
+                {
+                    regMgr.registry.RegisterModule(fromModule,
+                                                   Enumerable.Empty<string>(),
+                                                   inst.KSP, false);
+                }
+                // Pre-store mods that might be installed
+                foreach (var toModule in addlModules.Select(CkanModule.FromJson))
+                {
+                    manager.Cache.Store(toModule, TestData.DogeCoinFlagZip(), null);
+                }
+                // Simulate passing `--all`
+                var opts = upgradeIdentifiers != null
+                    ? new UpgradeOptions()
+                    {
+                        modules = upgradeIdentifiers.ToList(),
+                    }
+                    : new UpgradeOptions()
+                    {
+                        modules     = new List<string>() {},
+                        upgrade_all = true,
+                    };
+
+                // Act
+                ICommand cmd = new Upgrade(manager, repoData.Manager, user);
+                cmd.RunCommand(inst.KSP, opts);
+
+                // Assert
+                CollectionAssert.AreEqual(versionsAfter,
+                                          instMods.Select(m => regMgr.registry
+                                                                     .GetInstalledVersion(m.identifier)
+                                                                     .version
+                                                                     .ToString())
+                                                  .ToArray(),
+                                          description);
+
+            }
+        }
     }
 }

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -19,7 +19,7 @@ namespace Tests.Core.Registry
         private string repoDataDir;
 
         private static readonly GameVersionCriteria v0_24_2 = new GameVersionCriteria(GameVersion.Parse("0.24.2"));
-        private static readonly GameVersionCriteria v0_25_0 = new GameVersionCriteria (GameVersion.Parse("0.25.0"));
+        private static readonly GameVersionCriteria v0_25_0 = new GameVersionCriteria(GameVersion.Parse("0.25.0"));
 
         [SetUp]
         public void Setup()

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -268,7 +268,7 @@ namespace Tests.Core.Registry
                 GameVersionCriteria crit = new GameVersionCriteria(mod.ksp_version);
 
                 // Act
-                bool has = registry.HasUpdate(mod.identifier, crit);
+                bool has = registry.HasUpdate(mod.identifier, crit, out _);
 
                 // Assert
                 Assert.IsTrue(has, "Can't upgrade manually installed DLL");
@@ -321,7 +321,10 @@ namespace Tests.Core.Registry
                 GameVersionCriteria crit = new GameVersionCriteria(olderDepMod.ksp_version);
 
                 // Act
-                bool has = registry.HasUpdate(olderDepMod.identifier, crit);
+                bool has = registry.HasUpdate(olderDepMod.identifier, crit, out _,
+                                              registry.InstalledModules
+                                                      .Select(im => im.Module)
+                                                      .ToList());
 
                 // Assert
                 Assert.IsFalse(has, "Upgrade allowed that would break another mod's dependency");

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
@@ -39,12 +40,12 @@ namespace Tests.GUI
 
                 var mod = new GUIMod(ckan_mod, repoData.Manager, registry, manager.CurrentInstance.VersionCriteria(),
                                      null, false, false);
-                Assert.False(mod.IsUpgradeChecked);
+                Assert.True(mod.SelectedMod == mod.InstalledMod?.Module);
             }
         }
 
         [Test]
-        public void HasUpdateReturnsTrueWhenUpdateAvailable()
+        public void HasUpdate_UpdateAvailable_ReturnsTrue()
         {
             var user = new NullUser();
             using (var tidy = new DisposableKSP())
@@ -63,9 +64,14 @@ namespace Tests.GUI
                     var registry = new Registry(repoData.Manager, repo.repo);
 
                     registry.RegisterModule(old_version, Enumerable.Empty<string>(), null, false);
+                    var upgradeableGroups = registry.CheckUpgradeable(tidy.KSP.VersionCriteria(),
+                                                                      new HashSet<string>());
 
                     var mod = new GUIMod(old_version, repoData.Manager, registry, tidy.KSP.VersionCriteria(),
-                                         null, false, false);
+                                         null, false, false)
+                    {
+                        HasUpdate = upgradeableGroups[true].Any(m => m.identifier == old_version.identifier),
+                    };
                     Assert.True(mod.HasUpdate);
                 }
             }

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -27,7 +27,7 @@ namespace Tests.GUI
         public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList();
-            Assert.That(item.ComputeUserChangeSet(null, null), Is.Empty);
+            Assert.That(item.ComputeUserChangeSet(null, null, null), Is.Empty);
         }
 
         [Test]
@@ -201,16 +201,16 @@ namespace Tests.GUI
 
                 // Mark the mod for install, after completion we will get an exception
                 var otherModule = modules.First(mod => mod.Identifier.Contains("kOS"));
-                otherModule.IsInstallChecked = true;
+                otherModule.SelectedMod = otherModule.LatestAvailableMod;
 
-                Assert.IsTrue(otherModule.IsInstallChecked);
+                Assert.IsTrue(otherModule.SelectedMod == otherModule.LatestAvailableMod);
                 Assert.IsFalse(otherModule.IsInstalled);
 
                 Assert.DoesNotThrow(() =>
                 {
                     // Install the "other" module
                     installer.InstallList(
-                        modList.ComputeUserChangeSet(null, null).Select(change => change.Mod).ToList(),
+                        modList.ComputeUserChangeSet(null, null, null).Select(change => change.Mod).ToList(),
                         new RelationshipResolverOptions(),
                         registryManager,
                         ref possibleConfigOnlyDirs,

--- a/Tests/GUI/ThreadSafetyTests.cs
+++ b/Tests/GUI/ThreadSafetyTests.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using NUnit.Framework;
+
 using CKAN.GUI.Attributes;
 
 namespace Tests.GUI


### PR DESCRIPTION
I've been sitting on these changes for a while because I wasn't quite happy with the implementation, but I think it's about as good as it's going to get for now, and I want to get it off my plate to focus on other issues.

## Problem

If you install a mod that has a version-specific dependency on an older version of another mod, CKAN will appear to treat that other mod as upgradeable, but the upgrade will fail if attempted. Intermediate versions that could satisfy all requirements will not be discovered automatically, but may be selected manually by the user.

E.g., `RP-0` recently did this:

```yaml
depends:
  - name: RealismOverhaul
    max_version: v15.99.0.0
```

Versions after that are meant to be used only with `RP-1`. But `RealismOverhaul` will still show up as upgradeable, and trying to upgrade it will fail.

## Cause

- `AvailableModule.DependsAndConflictsOK` doesn't check version requirements of other modules that depend on the given module
- In general, mod upgradeability is treated as a property of the individual mod, when it really needs to be a collective property of groups of mods that are installed or being installed.

## Changes

- Now reverse dependencies of installed mods are considered when looking for available versions
- `IRegistryQuerier.HasUpdate` now accepts a list of other modules that are used to limit the compatible versions of the given mod
- A new function `IRegistryQuerier.CheckUpgradeable` is created to provide more complex upgrading logic; it first finds the latest available versions of all installed mods, then uses their relationship constraints to roll back one after another until a consistent changeset is generated. This function is now used by:
  - GUI's upgrade checkboxes, via setting `GUIMod.HasUpdate` from outside `GUIMod`
  - The changeset is updated based on what upgrades are actually allowed
  - `ckan upgrade --all`
  - `ckan list`'s status characters
- Mods with a "held" label are treated as not upgradeable, so they're excluded from that initial step of looking for the latest versions. When you add or remove labels or edit a label, we recalculate which upgrade checkboxes are shown.
- Several tests are added to ensure `ckan upgrade` works as intended

Fixes #3849.
Fixes #3945.
