### PR TITLE
Prompt for client upgrade when newer spec is found

### DIFF
--- a/Core/Meta.cs
+++ b/Core/Meta.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Reflection;
 
+using CKAN.Versioning;
+
 namespace CKAN
 {
     public static class Meta
@@ -16,6 +18,8 @@ namespace CKAN
                        .GetAssemblyAttribute<AssemblyProductAttribute>()
                        .Product;
 
+        public static readonly ModuleVersion ReleaseVersion = new ModuleVersion(GetVersion());
+
         public static string GetVersion(VersionFormat format = VersionFormat.Normal)
         {
             var version = Assembly
@@ -25,8 +29,6 @@ namespace CKAN
 
             switch (format)
             {
-                case VersionFormat.Short:
-                    return $"v{version.UpToCharacters(shortDelimiters)}";
                 case VersionFormat.Normal:
                     return "v" + Assembly.GetExecutingAssembly()
                                          .GetAssemblyAttribute<AssemblyFileVersionAttribute>()
@@ -37,15 +39,6 @@ namespace CKAN
                     throw new ArgumentOutOfRangeException(nameof(format), format, null);
             }
         }
-
-        private static readonly char[] shortDelimiters = new char[] { '-', '+' };
-
-        private static string UpToCharacters(this string orig, char[] what)
-            => orig.UpToIndex(orig.IndexOfAny(what));
-
-        private static string UpToIndex(this string orig, int index)
-            => index == -1 ? orig
-                           : orig.Substring(0, index);
 
         private static T GetAssemblyAttribute<T>(this Assembly assembly)
             => (T)assembly.GetCustomAttributes(typeof(T), false)

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -116,6 +116,7 @@ namespace CKAN
             Failed,
             Updated,
             NoChanges,
+            OutdatedClient,
         }
 
         /// <summary>
@@ -218,7 +219,9 @@ namespace CKAN
                 downloader.onOneCompleted -= setETag;
             }
 
-            return UpdateResult.Updated;
+            return repositoriesData.Values.Any(repoData => repoData.UnsupportedSpec)
+                ? UpdateResult.OutdatedClient
+                : UpdateResult.Updated;
         }
 
         /// <summary>

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -700,12 +700,7 @@ namespace CKAN
         /// Returns true if we support at least spec_version of the CKAN spec.
         /// </summary>
         internal static bool IsSpecSupported(ModuleVersion spec_version)
-        {
-            // This could be a read-only state variable; do we have those in C#?
-            ModuleVersion release = new ModuleVersion(Meta.GetVersion(VersionFormat.Short));
-
-            return release == null || release.IsGreaterThan(spec_version);
-        }
+            => Meta.ReleaseVersion.IsGreaterThan(spec_version);
 
         /// <summary>
         /// Returns true if we support the CKAN spec used by this module.

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -293,7 +293,7 @@ namespace CKAN
                 }
                 else
                 {
-                    throw new UnsupportedKraken(Properties.Resources.ModuleInstallDescriptorRequireFileFind);
+                    throw new Kraken(Properties.Resources.ModuleInstallDescriptorRequireFileFind);
                 }
             }
         }

--- a/Core/VersionFormat.cs
+++ b/Core/VersionFormat.cs
@@ -2,7 +2,6 @@ namespace CKAN
 {
     public enum VersionFormat
     {
-        Short,
         Normal,
         Full
     }

--- a/GUI/Dialogs/NewUpdateDialog.Designer.cs
+++ b/GUI/Dialogs/NewUpdateDialog.Designer.cs
@@ -99,7 +99,7 @@ namespace CKAN.GUI
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.ClientSize = new System.Drawing.Size(426, 310);
             this.Controls.Add(this.CancelUpdateButton);
             this.Controls.Add(this.InstallUpdateButton);

--- a/GUI/Dialogs/NewUpdateDialog.resx
+++ b/GUI/Dialogs/NewUpdateDialog.resx
@@ -118,7 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label1.Text" xml:space="preserve"><value>Version:</value></data>
-  <data name="VersionLabel.Text" xml:space="preserve"><value>v0.0.0</value></data>
   <data name="InstallUpdateButton.Text" xml:space="preserve"><value>Install</value></data>
   <data name="CancelUpdateButton.Text" xml:space="preserve"><value>Not now</value></data>
   <data name="$this.Text" xml:space="preserve"><value>A new version of CKAN is available</value></data>

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -585,7 +585,7 @@ namespace CKAN.GUI
 
         private void InstallUpdateButton_Click(object sender, EventArgs e)
         {
-            if (AutoUpdate.CanUpdate)
+            if (Main.Instance.CheckForCKANUpdate())
             {
                 Hide();
                 Main.Instance.UpdateCKAN();

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -419,7 +419,12 @@ namespace CKAN.GUI
                                             .Resolve<IConfiguration>(),
                               configuration);
 
-            bool autoUpdating = CheckForCKANUpdate();
+            bool autoUpdating = configuration.CheckForUpdatesOnLaunch
+                                && CheckForCKANUpdate();
+            if (autoUpdating)
+            {
+                UpdateCKAN();
+            }
 
             var pluginsPath = Path.Combine(CurrentInstance.CkanDir(), "Plugins");
             if (!Directory.Exists(pluginsPath))

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -42,9 +42,9 @@ namespace CKAN.GUI
         /// <returns>
         /// true if update found, false otherwise.
         /// </returns>
-        private bool CheckForCKANUpdate()
+        public bool CheckForCKANUpdate()
         {
-            if (configuration.CheckForUpdatesOnLaunch && AutoUpdate.CanUpdate)
+            if (AutoUpdate.CanUpdate)
             {
                 try
                 {
@@ -52,16 +52,14 @@ namespace CKAN.GUI
                     var mainConfig = ServiceLocator.Container.Resolve<IConfiguration>();
                     var update = updater.GetUpdate(mainConfig.DevBuilds ?? false);
                     var latestVersion = update.Version;
-                    var currentVersion = new ModuleVersion(Meta.GetVersion());
 
-                    if (latestVersion.IsGreaterThan(currentVersion))
+                    if (latestVersion.IsGreaterThan(Meta.ReleaseVersion))
                     {
-                        log.Debug("Found higher ckan version");
+                        log.DebugFormat("Found higher CKAN version: {0}", latestVersion);
                         var releaseNotes = update.ReleaseNotes;
                         var dialog = new NewUpdateDialog(latestVersion.ToString(), releaseNotes);
                         if (dialog.ShowDialog(this) == DialogResult.OK)
                         {
-                            UpdateCKAN();
                             return true;
                         }
                     }
@@ -90,7 +88,7 @@ namespace CKAN.GUI
             Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo,
                                 update.Version));
 
-            log.Info("Start ckan update");
+            log.Info("Starting CKAN update");
             Wait.StartWaiting((sender, args) => updater.StartUpdateProcess(true, mainConfig.DevBuilds ?? false, currentUser),
                               UpdateReady,
                               false,

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -248,6 +248,22 @@ namespace CKAN.GUI
                         }
                         break;
 
+
+                    case RepositoryDataManager.UpdateResult.OutdatedClient:
+                        currentUser.RaiseMessage(Properties.Resources.MainRepoOutdatedClient);
+                        if (CheckForCKANUpdate())
+                        {
+                            UpdateCKAN();
+                        }
+                        else
+                        {
+                            // No update available or user said no. Proceed as normal.
+                            ShowRefreshQuestion();
+                            UpgradeNotification();
+                            RefreshModList(false, oldModules);
+                        }
+                        break;
+
                     case RepositoryDataManager.UpdateResult.Updated:
                     default:
                         currentUser.RaiseMessage(Properties.Resources.MainRepoSuccess);

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -323,6 +323,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="MainRepoUpToDate" xml:space="preserve"><value>Repositories already up to date.</value></data>
   <data name="MainRepoFailed" xml:space="preserve"><value>Repository update failed!</value></data>
   <data name="MainRepoSuccess" xml:space="preserve"><value>Repositories successfully updated.</value></data>
+  <data name="MainRepoOutdatedClient" xml:space="preserve"><value>Repositories updated, but found modules that require a new version of CKAN. Checking for updates...</value></data>
   <data name="MainRepoAutoRefreshPrompt" xml:space="preserve"><value>Would you like CKAN to refresh the modlist every time it is loaded? (You can always manually refresh using the button up top.)</value></data>
   <data name="MainRepoBalloonTipDetails" xml:space="preserve"><value>{0} update(s) available</value></data>
   <data name="MainRepoBalloonTipTooltip" xml:space="preserve"><value>Click to upgrade</value></data>

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("CKAN")]
 [assembly: AssemblyCompany("CKAN Contributors")]
-[assembly: AssemblyCopyright("Copyright © 2014–2023")]
+[assembly: AssemblyCopyright("Copyright © 2014–2024")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]


### PR DESCRIPTION
## Motivation

- The `CkanModule.spec_version` property allows us to handle backwards incompatible changes to metadata; if it is greater than your client version for a module, then that module is hidden. When this happens, it is not apparent to the user, and users sometimes ask us or mod authors why a mod version is missing.
- If you configure CKAN to check for automated updates, you'll see the popup that shows the changelog, but if you update only via the button in the settings, you never get to see the changelog

## Changes

- Now if you update your repositories and they contain one or more modules with an unsupported spec version, we print a message along those lines to the log, check for a client update, and prompt the user to update if one is found:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/02252c2b-c14a-498a-9c91-9fd734990129)
- Now that popup opens centered on the main window instead of centered on the screen
- Now if you click to install an update from the settings window, that popup appears first so you can see the changelog
- While working on this, I found that `CkanModule.IsSpecSupported` retrieves the version from the executing assembly and parses it _every single time_, which is probably a small amount of wasted work, but might add up over a thousand-plus modules. This is now replaced by a public static variable that's only parsed once.

Fixes #3994.
