### PR TITLE
Fix exception on clicking Play before dropdown appears

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -554,8 +554,6 @@ namespace CKAN.GUI
         private void LaunchGameToolStripMenuItem_MouseHover(object sender, EventArgs e)
         {
             var cmdLines = Main.Instance.configuration.CommandLines;
-            LaunchGameToolStripMenuItem.Tag =
-                LaunchGameToolStripMenuItem.ToolTipText = cmdLines.First();
             LaunchGameToolStripMenuItem.DropDownItems.Clear();
             LaunchGameToolStripMenuItem.DropDownItems.AddRange(
                 cmdLines.Select(cmdLine => (ToolStripItem)

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -937,11 +937,15 @@ namespace CKAN.GUI
 
         private void openGameToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            LaunchGame(configuration.CommandLines.First());
+            LaunchGame();
         }
 
-        private void LaunchGame(string command)
+        private void LaunchGame(string command = null)
         {
+            if (string.IsNullOrEmpty(command))
+            {
+                command = configuration.CommandLines.First();
+            }
             var split = command.Split(' ');
             if (split.Length == 0)
             {


### PR DESCRIPTION
## Problem

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/f3594c4e-2d8e-4bd0-a948-42ab3b9a665c)

## Cause

`Main.LaunchGame` implicitly assumes its string argument will not be null.

`ManageMods.LaunchGameToolStripMenuItem_Click` passes `menuItem?.Tag as string`, which implicitly assumes the menu item's `Tag` will always be set.

The tag is set in `LaunchGameToolStripMenuItem_MouseHover`, which is executed when you hover the button, but _after a short delay_. If you click before the delay is over, the tag is null.

## Changes

Now `Main.LaunchGame` allows a null argument and defaults to the first configured command line.
