### PR TITLE
Show repo ETag and parsing errors in Failed Downloads

### DIFF
--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -51,10 +51,19 @@ namespace CKAN
             WebRequest req = WebRequest.Create(url);
             #pragma warning restore SYSLIB0014
             req.Method = "HEAD";
-            HttpWebResponse resp = (HttpWebResponse)req.GetResponse();
-            string val = resp.Headers["ETag"]?.Replace("\"", "");
-            resp.Close();
-            return val;
+            try
+            {
+                HttpWebResponse resp = (HttpWebResponse)req.GetResponse();
+                string val = resp.Headers["ETag"]?.Replace("\"", "");
+                resp.Close();
+                return val;
+            }
+            catch (WebException exc)
+            {
+                // Let the calling code keep going to get the actual problem
+                log.Debug($"Failed to get ETag from {url}", exc);
+                return null;
+            }
         }
 
         /// <summary>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -151,6 +151,7 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="NetRepoInconsistenciesHeader" xml:space="preserve"><value>The following inconsistencies were found:</value></data>
   <data name="NetRepoLoadingModulesFromRepo" xml:space="preserve"><value>Loading modules from downloaded {0} repository...</value><comment>Should contain UserProgressDownloadSubstring from CmdLine</comment></data>
   <data name="NetRepoLoadedDownloadCounts" xml:space="preserve"><value>Loaded download counts from {0} repository</value></data>
+  <data name="NetRepoNotATarGz" xml:space="preserve"><value>Not a .tar.gz or .zip, cannot process: {0}</value></data>
   <data name="JsonRelationshipConverterAnyOfCombined" xml:space="preserve"><value>`any_of` should not be combined with `{0}`</value></data>
   <data name="RegistryFileConflict" xml:space="preserve"><value>{0} wishes to install {1}, but this file is registered to {2}</value></data>
   <data name="RegistryFileNotRemoved" xml:space="preserve"><value>Error unregistering {1}, file not removed: {0}</value></data>

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -187,7 +187,7 @@ namespace CKAN
             {
                 case FileType.TarGz: return FromTarGz(path, game, progress);
                 case FileType.Zip:   return FromZip(path, game, progress);
-                default: throw new UnsupportedKraken($"Not a .tar.gz or .zip, cannot process: {path}");
+                default: throw new UnsupportedKraken(string.Format(Properties.Resources.NetRepoNotATarGz, path));
             }
         }
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -303,6 +303,14 @@ namespace CKAN
         {
             Exceptions = new List<KeyValuePair<int, Exception>>(errors);
         }
+
+        public DownloadErrorsKraken(int index, Exception exc)
+        {
+            Exceptions = new List<KeyValuePair<int, Exception>>
+            {
+                new KeyValuePair<int, Exception>(index, exc),
+            };
+        }
     }
 
     /// <summary>

--- a/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
@@ -168,6 +168,7 @@ namespace CKAN.GUI
             this.Icon = EmbeddedImages.AppIcon;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.Padding = new System.Windows.Forms.Padding(8, 8, 8, 0);
             this.HelpButton = true;
             this.Name = "DownloadsFailedDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;


### PR DESCRIPTION
## Problems

- If you set up a custom repo of someone's ZIP on a server and then it is later removed, the 404 error will be reported in the message log instead of the Failed Downloads popup:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/9804078/6ba617d3-ae79-456e-997f-97fe6d29bb7a)
- If you set up a custom repo that points to a file that isn't a ZIP or .tar.gz, the error appears in the message log instead of the Failed Downloads popup:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/9804078/974a1cb3-ba93-42b6-82aa-a620d60ae6d6)

## Causes

- If a previously working repo is removed, `Net.CurrentETag` throws an exception when we try to get the latest ETag
- If a downloaded repo file is in the wrong format, `UnsupportedKraken` is thrown when `RepositoryDataManager.Update` calls `RepositoryData.FromDownload`

The Failed Downloads popup depends on `DownloadErrorsKraken`, which isn't thrown in either case.

## Changes

- Now both classes of errors are redirected into `DownloadErrorsKraken` exceptions, so they show up in the Failed Downloads popup:
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/c1fabebe-8fb5-469d-8a7d-63de004a31e5)
  ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/a7f5f0e3-fe91-4689-98b7-76086f519594)
- The Failed Downloads popup now has horizontal padding so the grid view doesn't abut the edge of the window
- The string reporting the format problem wasn't internationalized and now has been

Fixes #4027.
