### PR TITLE
Ability to clear auto-installed flag from changeset tab

### DIFF
--- a/GUI/Controls/Changeset.Designer.cs
+++ b/GUI/Controls/Changeset.Designer.cs
@@ -30,10 +30,11 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(Changeset));
-            this.ChangesListView = new ThemedListView();
-            this.Mod = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.ChangeType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.Reason = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.ChangesGrid = new System.Windows.Forms.DataGridView();
+            this.ModColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ChangeTypeColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ReasonsColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DeleteColumn = new System.Windows.Forms.DataGridViewImageColumn();
             this.CloseTheGameLabel = new System.Windows.Forms.Label();
             this.BottomButtonPanel = new CKAN.GUI.LeftRightRowPanel();
             this.ConfirmChangesButton = new System.Windows.Forms.Button();
@@ -42,39 +43,78 @@ namespace CKAN.GUI
             this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
-            // ChangesListView
+            // ChangesGrid
             //
-            this.ChangesListView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ChangesListView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.ChangesListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.Mod,
-            this.ChangeType,
-            this.Reason});
-            this.ChangesListView.FullRowSelect = true;
-            this.ChangesListView.Location = new System.Drawing.Point(-2, 0);
-            this.ChangesListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ChangesListView.Name = "ChangesListView";
-            this.ChangesListView.Size = new System.Drawing.Size(1532, 886);
-            this.ChangesListView.ShowItemToolTips = true;
-            this.ChangesListView.TabIndex = 0;
-            this.ChangesListView.UseCompatibleStateImageBehavior = false;
-            this.ChangesListView.View = System.Windows.Forms.View.Details;
-            this.ChangesListView.SelectedIndexChanged += new System.EventHandler(ChangesListView_SelectedIndexChanged);
+            this.ChangesGrid.AllowUserToResizeColumns = true;
+            this.ChangesGrid.AllowUserToOrderColumns = true;
+            this.ChangesGrid.AllowUserToResizeRows = false;
+            this.ChangesGrid.AutoGenerateColumns = false;
+            this.ChangesGrid.BackgroundColor = System.Drawing.SystemColors.Window;
+            this.ChangesGrid.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.ChangesGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ChangesGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.ModColumn,
+            this.ChangeTypeColumn,
+            this.ReasonsColumn,
+            this.DeleteColumn});
+            this.ChangesGrid.ColumnHeadersDefaultCellStyle.Padding = new System.Windows.Forms.Padding(1, 3, 1, 3);
+            this.ChangesGrid.ColumnHeadersDefaultCellStyle.BackColor = System.Drawing.SystemColors.Control;
+            this.ChangesGrid.ColumnHeadersDefaultCellStyle.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.ChangesGrid.ColumnHeadersDefaultCellStyle.SelectionBackColor = System.Drawing.SystemColors.Control;
+            this.ChangesGrid.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Raised;
+            this.ChangesGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.ChangesGrid.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
+            this.ChangesGrid.DefaultCellStyle.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.ChangesGrid.EnableHeadersVisualStyles = false;
+            this.ChangesGrid.Location = new System.Drawing.Point(-2, 0);
+            this.ChangesGrid.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.ChangesGrid.MultiSelect = false;
+            this.ChangesGrid.Name = "ChangesGrid";
+            this.ChangesGrid.RowHeadersVisible = false;
+            this.ChangesGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.ChangesGrid.ShowCellToolTips = true;
+            this.ChangesGrid.Size = new System.Drawing.Size(1532, 886);
+            this.ChangesGrid.TabIndex = 0;
+            this.ChangesGrid.TabStop = false;
+            this.ChangesGrid.SelectionChanged += new System.EventHandler(this.ChangesGrid_SelectionChanged);
+            this.ChangesGrid.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.ChangesGrid_DataBindingComplete);
+            this.ChangesGrid.CellClick += this.ChangesGrid_CellClick;
             //
-            // Mod
+            // ModColumn
             //
-            this.Mod.Width = 332;
-            resources.ApplyResources(this.Mod, "Mod");
+            this.ModColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            this.ModColumn.Width = 332;
+            this.ModColumn.ValueType = typeof(string);
+            this.ModColumn.DataPropertyName = "Mod";
+            this.ModColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            resources.ApplyResources(this.ModColumn, "ModColumn");
             //
-            // ChangeType
+            // ChangeTypeColumn
             //
-            this.ChangeType.Width = 111;
-            resources.ApplyResources(this.ChangeType, "ChangeType");
+            this.ReasonsColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            this.ChangeTypeColumn.Width = 111;
+            this.ChangeTypeColumn.ValueType = typeof(string);
+            this.ChangeTypeColumn.DataPropertyName = "ChangeType";
+            this.ChangeTypeColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            resources.ApplyResources(this.ChangeTypeColumn, "ChangeTypeColumn");
             //
-            // Reason
+            // ReasonsColumn
             //
-            this.Reason.Width = 606;
-            resources.ApplyResources(this.Reason, "Reason");
+            this.ReasonsColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.ReasonsColumn.Width = 606;
+            this.ReasonsColumn.ValueType = typeof(string);
+            this.ReasonsColumn.DataPropertyName = "Reasons";
+            this.ReasonsColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            resources.ApplyResources(this.ReasonsColumn, "ReasonsColumn");
+            //
+            // DeleteColumn
+            //
+            this.DeleteColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            this.DeleteColumn.Width = 200;
+            this.DeleteColumn.ValueType = typeof(System.Drawing.Bitmap);
+            this.DeleteColumn.DataPropertyName = "DeleteImage";
+            this.DeleteColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            resources.ApplyResources(this.DeleteColumn, "DeleteColumn");
             //
             // CloseTheGameLabel
             //
@@ -88,9 +128,9 @@ namespace CKAN.GUI
             this.CloseTheGameLabel.TabIndex = 0;
             this.CloseTheGameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             resources.ApplyResources(this.CloseTheGameLabel, "CloseTheGameLabel");
-            // 
+            //
             // BottomButtonPanel
-            // 
+            //
             this.BottomButtonPanel.RightControls.Add(this.ConfirmChangesButton);
             this.BottomButtonPanel.RightControls.Add(this.CancelChangesButton);
             this.BottomButtonPanel.RightControls.Add(this.BackButton);
@@ -132,11 +172,11 @@ namespace CKAN.GUI
             this.ConfirmChangesButton.TabIndex = 2;
             this.ConfirmChangesButton.Click += new System.EventHandler(this.ConfirmChangesButton_Click);
             resources.ApplyResources(this.ConfirmChangesButton, "ConfirmChangesButton");
-            // 
+            //
             // Changeset
-            // 
+            //
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.Controls.Add(this.ChangesListView);
+            this.Controls.Add(this.ChangesGrid);
             this.Controls.Add(this.CloseTheGameLabel);
             this.Controls.Add(this.BottomButtonPanel);
             this.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
@@ -152,10 +192,11 @@ namespace CKAN.GUI
 
         #endregion
 
-        private System.Windows.Forms.ListView ChangesListView;
-        private System.Windows.Forms.ColumnHeader Mod;
-        private System.Windows.Forms.ColumnHeader ChangeType;
-        private System.Windows.Forms.ColumnHeader Reason;
+        private System.Windows.Forms.DataGridView ChangesGrid;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ModColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ChangeTypeColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ReasonsColumn;
+        private System.Windows.Forms.DataGridViewImageColumn DeleteColumn;
         private System.Windows.Forms.Label CloseTheGameLabel;
         private CKAN.GUI.LeftRightRowPanel BottomButtonPanel;
         private System.Windows.Forms.Button BackButton;

--- a/GUI/Controls/Changeset.resx
+++ b/GUI/Controls/Changeset.resx
@@ -117,9 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve"><value>Mod</value></data>
-  <data name="ChangeType.Text" xml:space="preserve"><value>Change</value></data>
-  <data name="Reason.Text" xml:space="preserve"><value>Reasons for action</value></data>
+  <data name="ModColumn.HeaderText" xml:space="preserve"><value>Mod</value></data>
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve"><value>Change</value></data>
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve"><value>Reasons for action</value></data>
+  <data name="DeleteColumn.HeaderText" xml:space="preserve"><value>Skip?</value></data>
   <data name="CloseTheGameLabel.Text" xml:space="preserve"><value>Note: To apply these changes, CKAN must overwrite or delete files. If the game is running, close it before continuing!</value></data>
   <data name="BackButton.Text" xml:space="preserve"><value>Back</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>Clear</value></data>

--- a/GUI/Dialogs/YesNoDialog.Designer.cs
+++ b/GUI/Dialogs/YesNoDialog.Designer.cs
@@ -126,7 +126,7 @@ namespace CKAN.GUI
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.Icon = EmbeddedImages.AppIcon;
             this.Name = "YesNoDialog";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
             this.panel1.ResumeLayout(false);
             this.BottomButtonPanel.ResumeLayout(false);

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -67,6 +67,7 @@ namespace CKAN.GUI
                 ClientSize.Width,
                 Math.Min(maxHeight, height)
             );
+            ActiveControl = YesButton;
         }
 
         private void SetupSuppressable(string text, string yesText, string noText, string suppressText)

--- a/GUI/Localization/de-DE/Changeset.de-DE.resx
+++ b/GUI/Localization/de-DE/Changeset.de-DE.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ChangeType.Text" xml:space="preserve"><value>Änderung</value></data>
-  <data name="Reason.Text" xml:space="preserve"><value>Grund</value></data>
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve"><value>Änderung</value></data>
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve"><value>Grund</value></data>
   <data name="BackButton.Text" xml:space="preserve"><value>Zurück</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>Löschen</value></data>
   <data name="ConfirmChangesButton.Text" xml:space="preserve"><value>Annehmen</value></data>

--- a/GUI/Localization/fr-FR/Changeset.fr-FR.resx
+++ b/GUI/Localization/fr-FR/Changeset.fr-FR.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>Mod</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>Changement</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>Raison de l'action</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/it-IT/Changeset.it-IT.resx
+++ b/GUI/Localization/it-IT/Changeset.it-IT.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>Mod</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>Modifica</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>Motivi dell’azione</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/ja-JP/Changeset.ja-JP.resx
+++ b/GUI/Localization/ja-JP/Changeset.ja-JP.resx
@@ -117,9 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve"><value>Mod</value></data>
-  <data name="ChangeType.Text" xml:space="preserve"><value>変更</value></data>
-  <data name="Reason.Text" xml:space="preserve"><value>変更の理由</value></data>
+  <data name="ModColumn.HeaderText" xml:space="preserve"><value>Mod</value></data>
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve"><value>変更</value></data>
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve"><value>変更の理由</value></data>
   <data name="BackButton.Text" xml:space="preserve"><value>戻る</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>取消</value></data>
   <data name="ConfirmChangesButton.Text" xml:space="preserve"><value>適用</value></data>

--- a/GUI/Localization/ko-KR/Changeset.ko-KR.resx
+++ b/GUI/Localization/ko-KR/Changeset.ko-KR.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>모드</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>변경</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>변경 이유</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/nl-NL/Changeset.nl-NL.resx
+++ b/GUI/Localization/nl-NL/Changeset.nl-NL.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>Mod</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>Wijziging</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>Redenen voor actie</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/pl-PL/Changeset.pl-PL.resx
+++ b/GUI/Localization/pl-PL/Changeset.pl-PL.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>Mod</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>Zmień</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>Powód działania</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/pt-BR/Changeset.pt-BR.resx
+++ b/GUI/Localization/pt-BR/Changeset.pt-BR.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>Mod</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>Mudança</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>Razão para a ação</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/ru-RU/Changeset.ru-RU.resx
+++ b/GUI/Localization/ru-RU/Changeset.ru-RU.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>Модификация</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>Действие</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>Причина действия</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/tr-TR/Changeset.tr-TR.resx
+++ b/GUI/Localization/tr-TR/Changeset.tr-TR.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve">
+  <data name="ModColumn.HeaderText" xml:space="preserve">
     <value>Mod</value>
   </data>
-  <data name="ChangeType.Text" xml:space="preserve">
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve">
     <value>Değişim</value>
   </data>
-  <data name="Reason.Text" xml:space="preserve">
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve">
     <value>İşlem için sebepler</value>
   </data>
   <data name="BackButton.Text" xml:space="preserve">

--- a/GUI/Localization/zh-CN/Changeset.zh-CN.resx
+++ b/GUI/Localization/zh-CN/Changeset.zh-CN.resx
@@ -117,9 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Mod.Text" xml:space="preserve"><value>Mod</value></data>
-  <data name="ChangeType.Text" xml:space="preserve"><value>更改</value></data>
-  <data name="Reason.Text" xml:space="preserve"><value>操作理由</value></data>
+  <data name="ModColumn.HeaderText" xml:space="preserve"><value>Mod</value></data>
+  <data name="ChangeTypeColumn.HeaderText" xml:space="preserve"><value>更改</value></data>
+  <data name="ReasonsColumn.HeaderText" xml:space="preserve"><value>操作理由</value></data>
  <data name="BackButton.Text" xml:space="preserve"><value>返回</value></data>
   <data name="CancelChangesButton.Text" xml:space="preserve"><value>取消更改</value></data>
   <data name="ConfirmChangesButton.Text" xml:space="preserve"><value>应用</value></data>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -508,6 +508,7 @@ namespace CKAN.GUI
             this.Changeset.Size = new System.Drawing.Size(500, 500);
             this.Changeset.TabIndex = 32;
             this.Changeset.OnSelectedItemsChanged += this.Changeset_OnSelectedItemsChanged;
+            this.Changeset.OnRemoveItem += ManageMods.RemoveChangesetItem;
             this.Changeset.OnConfirmChanges += this.Changeset_OnConfirmChanges;
             this.Changeset.OnCancelChanges += this.Changeset_OnCancelChanges;
             //

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -826,10 +826,8 @@ namespace CKAN.GUI
             }
         }
 
-        private void ShowSelectionModInfo(ListView.SelectedListViewItemCollection selection)
+        private void ShowSelectionModInfo(CkanModule module)
         {
-            CkanModule module = (CkanModule)selection?.Cast<ListViewItem>().FirstOrDefault()?.Tag;
-
             ActiveModInfo = module == null ? null : new GUIMod(
                 module,
                 repoData,
@@ -838,6 +836,11 @@ namespace CKAN.GUI
                 null,
                 configuration.HideEpochs,
                 configuration.HideV);
+        }
+
+        private void ShowSelectionModInfo(ListView.SelectedListViewItemCollection selection)
+        {
+            ShowSelectionModInfo(selection?.Cast<ListViewItem>().FirstOrDefault()?.Tag as CkanModule);
         }
 
         private void ManageMods_OnChangeSetChanged(List<ModChange> changeset, Dictionary<GUIMod, string> conflicts)
@@ -888,7 +891,7 @@ namespace CKAN.GUI
                     break;
 
                 case "ChangesetTabPage":
-                    ShowSelectionModInfo(Changeset.SelectedItems);
+                    ShowSelectionModInfo(Changeset.SelectedItem);
                     break;
 
                 case "ChooseRecommendedModsTabPage":
@@ -900,7 +903,7 @@ namespace CKAN.GUI
                     break;
 
                 default:
-                    ShowSelectionModInfo(null);
+                    ShowSelectionModInfo((CkanModule)null);
                     break;
             }
         }

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Windows.Forms;
 
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
@@ -20,9 +19,12 @@ namespace CKAN.GUI
                 conflicts);
         }
 
-        private void Changeset_OnSelectedItemsChanged(ListView.SelectedListViewItemCollection items)
+        private void Changeset_OnSelectedItemsChanged(CkanModule item)
         {
-            ShowSelectionModInfo(items);
+            if (MainTabControl.SelectedTab == ChangesetTabPage)
+            {
+                ShowSelectionModInfo(item);
+            }
         }
 
         private void Changeset_OnCancelChanges(bool reset)

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -43,12 +43,6 @@ namespace CKAN.GUI
     public class ModChange
     {
         public CkanModule        Mod        { get; private set; }
-        /// <summary>
-        /// For changes involving another version in addition to the main one,
-        /// this is that other version.
-        /// When upgrading, the target version.
-        /// Otherwise not used.
-        /// </summary>
         public GUIModChangeType  ChangeType { get; private set; }
         public SelectionReason[] Reasons    { get; private set; }
 
@@ -57,6 +51,16 @@ namespace CKAN.GUI
         /// false otherwise
         /// </summary>
         public readonly bool IsAutoRemoval;
+
+        /// <summary>
+        /// true if this change is user requested and no other changes depend on it, false otherwise.
+        /// </summary>
+        public readonly bool IsUserRequested;
+
+        /// <summary>
+        /// true if this change can be removed from a changeset, false otherwise
+        /// </summary>
+        public bool IsRemovable => IsAutoRemoval || IsUserRequested;
 
         // If we don't have a Reason, the user probably wanted to install it
         public ModChange(CkanModule mod, GUIModChangeType changeType)
@@ -74,7 +78,8 @@ namespace CKAN.GUI
             Mod        = mod;
             ChangeType = changeType;
             Reasons    = reasons.ToArray();
-            IsAutoRemoval = Reasons.All(r => r is SelectionReason.NoLongerUsed);
+            IsAutoRemoval   = Reasons.All(r => r is SelectionReason.NoLongerUsed);
+            IsUserRequested = Reasons.All(r => r is SelectionReason.UserRequested);
         }
 
         public override bool Equals(object obj)
@@ -149,6 +154,9 @@ namespace CKAN.GUI
                 : string.Format(Properties.Resources.MainChangesetUpdateSelected,
                                 targetMod.version);
 
+        /// <summary>
+        /// The target version for upgrading
+        /// </summary>
         public readonly CkanModule targetMod;
 
         private bool IsReinstall

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -377,6 +377,17 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Save</value></data>
   <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Discard</value></data>
   <data name="MainChangesetWarningInstallingModuleWithLabel" xml:space="preserve"><value>WARNING: INSTALLING MODULE WITH LABEL {0} ({1})</value></data>
+  <data name="ChangesetDeleteTooltip" xml:space="preserve"><value>Don't {0} {1}</value></data>
+  <data name="ChangesetConfirmRemoveAutoRemoval" xml:space="preserve"><value>{0} is being removed because it was installed as a dependency of another mod, which is being removed.
+
+Are you sure you want to keep it?</value></data>
+  <data name="ChangesetConfirmRemoveAutoRemovalYes" xml:space="preserve"><value>Keep</value></data>
+  <data name="ChangesetConfirmRemoveAutoRemovalNo" xml:space="preserve"><value>Cancel</value></data>
+  <data name="ChangesetConfirmRemoveUserRequested" xml:space="preserve"><value>You had chosen to {0} {1}.
+
+Are you sure you want to skip this change?</value></data>
+  <data name="ChangesetConfirmRemoveUserRequestedYes" xml:space="preserve"><value>Skip</value></data>
+  <data name="ChangesetConfirmRemoveUserRequestedNo" xml:space="preserve"><value>Cancel</value></data>
   <data name="EditLabelsToolTipName" xml:space="preserve"><value>The label will appear in the Labels menu under this name, must be unique per install</value></data>
   <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Rows for modules with this label will be drawn with this background color</value></data>
   <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>The instance for which this label is available, leave blank for all</value></data>


### PR DESCRIPTION
## Motivation

The Changeset tab is shown when you choose to install, upgrade, or uninstall mods and then click Apply. If there is something in the list that you don't want, the only way to fix it is to click Back, then scroll or search through the mod list to find the affected mods, then make whatever change would undo the change, then click Apply again. This is cumbersome, especially for auto-installed mods, since the user may not know the full details of how to mark them as not auto-installed.

## Changes

- Now the Changeset tab list has a "Skip?" column at the right
- Changes that would be simple to remove from the changeset (independent from other changes) have an "X" icon in this column with a tooltip like "Don't Install MyMod 1.0.0"
- Changes that are not simple to remove (other changes depend on them) have no such icon
- If you click an X icon, a confirmation popup asks you if you really want to remove that change from the changeset
- If you cancel in the popup, the change stays in the changeset
- If you confirm the removal, the change is removed and the changeset is recalculated
- A bug is fixed where clicking the Clear button would mark many auto-installed modules as not auto-installed

Thanks to @JonnyOThan for providing in-depth UI feedback and saving us from ambiguous checkboxes.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/64140027-2b68-4abe-b8b8-c1517125cf37)

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/2773e6bc-ea66-487e-b69e-831f9e3a8d24)

Fixes #4012.
