### PR TITLE
Get KSP2 version from game assembly

### DIFF
--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NJsonSchema" Version="10.9.0" />
     <PackageReference Include="ValveKeyValue" Version="0.3.1.152" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <PackageReference Include="ChinhDo.Transactions.FileManager" Version="1.2.0" />


### PR DESCRIPTION
## Motivation

Based on how KSP1 works, if/when KSP2 is released for Linux someday, it will have a Linux executable called `KSP2.x86_64` instead of a Windows executable called `KSP2_x64.exe`.

Since KSP2 has no equivalent of KSP1's `buildID.txt` or `readme.txt` files, we currently get the game version from the Windows executable's assembly properties. This will no longer be viable once there is a Linux release, and so far there is no sign that the KSP2 devs have heard our pleas to create a `buildID.txt` equivalent.

## Changes

Now we get the KSP2 game version by using Mono.Cecil to retrieve the `VersionID.VERSION_TEXT` string constant from `<GameRoot>/KSP2_x64_Data/Managed/Assembly-CSharp.dll` (the main assembly for the game). If this doesn't work, we fall back to the previous method of looking for the EXE's properties.

Thanks to @cheese3660 for showing us where to find this value. 👍 

Caveats:

- This string has five dot-delimited numeric pieces, but our `GameVersion` type only allows 4, so we have to use `.Take(4)` to drop the last piece (which is a build ID)
- Again going by the KSP1 example, the `KSP2_x64_Data` folder path will probably become `KSP2_Data` on Linux. At this point I have opted not to overly future-proof this due to the uncertainty of whether that will actually be the case and the complexity of handling multiple folder paths here. If it turns out that we do need this when a Linux port happens, we can tackle it at that point.

Fixes #3990.
