### PR TITLE
Properly clear AD upgrades from changeset

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -678,11 +678,9 @@ namespace CKAN
         private readonly Dictionary<string, CkanModule> modlist = new Dictionary<string, CkanModule>();
         private readonly List<CkanModule> user_requested_mods = new List<CkanModule>();
 
-        //TODO As the conflict detection gets more advanced there is a greater need to have messages in here
-        // as recreating them from reasons is no longer possible.
         private readonly List<ModPair> conflicts = new List<ModPair>();
         private readonly Dictionary<CkanModule, List<SelectionReason>> reasons =
-            new Dictionary<CkanModule, List<SelectionReason>>(new NameComparer());
+            new Dictionary<CkanModule, List<SelectionReason>>();
 
         private readonly IRegistryQuerier            registry;
         private readonly GameVersionCriteria         versionCrit;

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -154,7 +154,7 @@ namespace CKAN.GUI
             this.UpdateAllToolButton.Name = "UpdateAllToolButton";
             this.UpdateAllToolButton.Size = new System.Drawing.Size(232, 56);
             this.UpdateAllToolButton.Overflow = System.Windows.Forms.ToolStripItemOverflow.AsNeeded;
-            this.UpdateAllToolButton.Click += new System.EventHandler(this.MarkAllUpdatesToolButton_Click);
+            this.UpdateAllToolButton.Click += new System.EventHandler(this.UpdateAllToolButton_Click);
             resources.ApplyResources(this.UpdateAllToolButton, "UpdateAllToolButton");
             //
             // ApplyToolButton

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -32,7 +32,6 @@ namespace CKAN.GUI
             if (reset)
             {
                 ManageMods.ClearChangeSet();
-                UpdateChangesDialog(null, null);
             }
             tabController.ShowTab("ManageModsTabPage");
         }


### PR DESCRIPTION
## Problems

- If you choose to upgrade an AD mod and then use the install-all checkbox to clear the changeset, the AD upgrade will only be fully removed if the mod matches the current search filters (and is therefore visible or could be made visible with scrolling). Otherwise the row's checkbox will be cleared but the install of the mod will remain in the changeset.
- If you choose to upgrade an AD mod to have CKAN take ownership of it, the changeset removal icon from #4033 will appear but not work for that entry.
- If you use the Versions tab to replace one version of a mod with a different version, the changeset tab will say "Currently installed" for the new instead of the old version, and the changeset removal icon from #4033 won't appear for that entry.
- The install-all checkbox at the upper left above the Install column is supposed to uninstall all mods when unchecked, leaving the user with a clean empty install, but it doesn't void pending upgrades of AD mods, even though they would cause files to be installed rather than removed.

## Causes

- When an upgrading AD row is visible, `GUIMod.SetUpgradeChecked` is called twice, once to clear the checkbox and once to _react_ to the changing of the checkbox. (I hate this and desperately want to change it, but I don't think I would be able to account for all the complexities well enough to avoid breaking something.) The first call sets `GUIMod.SelectedMod` (the property that drives the changeset) to its current value again, which is incorrect, and the second call sets it to null, which is correct. (There are complex interactions with the Versions tab here in order to ensure that switching to the latest version of a mod is always equivalent to upgrading and vice versa.)
  When such a row is invisible, the second call does not occur because `ManageMods.ModGrid_CellValueChanged` is not called by the grid.
- An upgrade of an AD mod uses the upgrade checkbox in the grid, but internally it is represented as an Install action because there's no previous version to remove, so the changeset removal functionality was only clearing the Install checkbox, not Upgrade.
- `RelationshipResolver.reasons` was using `NameComparer`, which makes it match keys only based on identifier and therefore could return the wrong reasons for a module.
- When the install-all checkbox code was written, it wasn't possible to upgrade a mod that wasn't installed, so it didn't consider that case.

## Changes

- Now the first call to `GUIMod.SetUpgradeChecked` sets `GUIMod.SelectedMod` to null, properly removing the AD upgrade from the changeset.
- Now `ManageMods.RemoveChangesetItem` unchecks the Upgrade checkbox for an Install action of an AD mod, so you can remove these actions from a changeset.
- Now `RelationshipResolver.reasons` uses the normal comparer, which uses both identifier and version, so the right reason will be used for each version.
- Now the install-all checkbox also unchecks the upgrade checkbox for AD mods.
- Now the existing incipient `ManageMods.freezeChangeSet` mechanism to skip redundant refreshes of the changeset tab is refactored into a `WithFrozenChangeset` function, which is now used by the following to improve response times:
  - The Update all button
  - The Install-all checkbox in the upper left above the Install column
  - The Clear button on the progress tab (which also no longer separately calls `UpdateChangesDialog`)

Fixes #4035.
