### PR TITLE
Build nuget package, support netstandard2.0 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Run tests
         run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
 
+      - name: Publish ckan.dll to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        if: env.NUGET_API_KEY
+        run: |
+          curl -o nuget.exe -L 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
+          mono nuget.exe push _build/out/CKAN/Release/bin/*.nupkg ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate
+
       - name: Build dmg
         run: ./build osx --configuration=Release --exclusive
       - name: Build deb

--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -20,6 +20,7 @@
     <ApplicationIcon>..\assets\ckan.ico</ApplicationIcon>
     <TargetFrameworks>net48;net7.0-windows</TargetFrameworks>
     <UseWindowsForms Condition=" '$(TargetFramework)' == 'net7.0-windows' ">true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -18,31 +18,42 @@
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
     <NoWarn>IDE1006</NoWarn>
-    <TargetFrameworks>net48;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net48;net7.0</TargetFrameworks>
     <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>CKAN</PackageId>
+    <Title>Comprehensive Kerbal Archive Network</Title>
+    <Description>Manages mods for KSP1 and KPS2</Description>
+    <Version>$([System.Text.RegularExpressions.Regex]::Replace(
+                   $([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)\..\CHANGELOG.md")),
+                   "^.*?##\s+v(\S+).*$", "$1",
+                   System.Text.RegularExpressions.RegexOptions.Singleline))</Version>
+    <PackageVersion>$(Version)</PackageVersion>
+    <Authors>The CKAN Authors</Authors>
+    <Copyright>Copyright © CKAN Authors 2014–2024</Copyright>
+    <PackageTags>KerbalSpaceProgram Mods</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/KSP-CKAN/CKAN</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/KSP-CKAN/CKAN</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="TxFileManager.NETStandard" Version="2.0.0" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NJsonSchema" Version="10.9.0" />
     <PackageReference Include="ValveKeyValue" Version="0.3.1.152" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-    <PackageReference Include="ChinhDo.Transactions.FileManager" Version="1.2.0" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
-    <PackageReference Include="TxFileManager.NETStandard" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">
@@ -53,6 +64,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\"/>
     <EmbeddedResource Include="builds-ksp.json" />
     <EmbeddedResource Include="builds-ksp2.json" />
     <EmbeddedResource Include="..\CKAN.schema">

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -15,15 +15,42 @@ namespace CKAN.Extensions
                 ? throw new ArgumentNullException(nameof(source))
                 : source is ICollection<T> collection ? collection : source.ToArray();
 
-#if NET45
+#if NET45 || NETSTANDARD2_0
 
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
+        #if NET45
+        public
+        #elif NETSTANDARD2_0
+        internal
+        #endif
+        static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
         {
             if (source == null)
+            {
                 throw new ArgumentNullException(nameof(source));
+            }
 
             return new HashSet<T>(source);
         }
+
+        #if NET45
+        public
+        #elif NETSTANDARD2_0
+        internal
+        #endif
+        static HashSet<T> ToHashSet<T>(this IEnumerable<T>  source,
+                                              IEqualityComparer<T> comparer)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return new HashSet<T>(source, comparer);
+        }
+
+#endif
+
+#if NET45
 
         public static IEnumerable<T> Append<T>(this IEnumerable<T> source, T next)
             => source.Concat(Enumerable.Repeat<T>(next, 1));
@@ -115,7 +142,7 @@ namespace CKAN.Extensions
         public static IEnumerable<V> ZipMany<T, U, V>(this IEnumerable<T> seq1, IEnumerable<U> seq2, Func<T, U, IEnumerable<V>> func)
             => seq1.Zip(seq2, func).SelectMany(seqs => seqs);
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
 
         /// <summary>
         /// Eliminate duplicate elements based on the value returned by a callback
@@ -142,7 +169,7 @@ namespace CKAN.Extensions
             }
         }
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD2_0
 
         /// <summary>
         /// Make pairs out of the elements of two sequences

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -7,6 +7,9 @@ using log4net;
 
 using CKAN.Versioning;
 using CKAN.Games;
+#if NETSTANDARD2_0
+using CKAN.Extensions;
+#endif
 
 namespace CKAN
 {

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using CKAN.Versioning;
+#if NETSTANDARD2_0
+using CKAN.Extensions;
+#endif
 
 namespace CKAN
 {

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -14,6 +14,9 @@ using Newtonsoft.Json;
 
 using CKAN.Versioning;
 using CKAN.Games;
+#if NETSTANDARD2_0
+using CKAN.Extensions;
+#endif
 
 namespace CKAN
 {

--- a/Core/Types/License.cs
+++ b/Core/Types/License.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 
 using Newtonsoft.Json;
 
+#if NETSTANDARD2_0
+using CKAN.Extensions;
+#endif
+
 namespace CKAN
 {
     /// <summary>

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -21,6 +21,7 @@
     <TargetFrameworks>net48;net7.0-windows</TargetFrameworks>
     <BaseTargetFramework>$(TargetFramework.Replace("-windows", ""))</BaseTargetFramework>
     <UseWindowsForms Condition=" '$(TargetFramework)' == 'net7.0-windows' ">true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It provides strong assurances that mods are installed in the way prescribed by t
 for the correct version of Kerbal Space Program, alongside their dependencies, and without any conflicting mods.
 
 CKAN is great for players _and_ for authors:
+
 - players can find new content and install it with just a few clicks;
 - modders don't have to worry about misinstall problems or outdated versions;
 

--- a/Tests/Core/Registry/CompatibilitySorter.cs
+++ b/Tests/Core/Registry/CompatibilitySorter.cs
@@ -5,7 +5,9 @@ using NUnit.Framework;
 
 using CKAN;
 using CKAN.Versioning;
+#if NET45
 using CKAN.Extensions;
+#endif
 
 using Tests.Data;
 


### PR DESCRIPTION
## Motivation

@cheese3660 and @jan-bures have expressed an interest in using some functionality from CKAN in a future update of the KSP2 mod [SpaceWarp](https://github.com/SpaceWarpDev/SpaceWarp). Currently this would require them to compile it themselves, which is not very convenient or maintainable.

This dovetails with a longstanding aspiration to make CKAN's core DLL available on Nuget for mods.

## Changes

- Now the core DLL has a third target framework, `netstandard2.0`, because it is better for mods
- Now the core DLL has properties to autogenerate a `.nupkg` file containing DLLs for `net48`, `net7.0`, and `netstandard2.0`
- Now the Cake build script is updated to perform a separate all-platforms build for the core DLL on Linux, which is required for the `.nupkg` file to be created (Windows already handles it in the single build-everything pass that we're already doing)
- Now once we define `NUGET_API_KEY` in this repo's secrets, it will be used to upload the generated `.nupkg` file to Nuget when we make a release

Fixes #1031.
Fixes #1037.
Fixes #1588.

### Important note

We have no established commitment to follow SemVer with respect to the core DLL's public types. The only current versioning rule is that we increment the minor version when we change [the metadata spec](https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md)/[schema](https://github.com/KSP-CKAN/CKAN/blob/master/CKAN.schema) in ways that older clients can't support, and the patch version otherwise (which is always even for stable releases and odd for dev builds).

We might choose to make such a commitment in the future, but be aware that for now, if you use this DLL, any public stuff might change from one version to the next, so you should only update its dependency version if you are prepared to fix an unknown number of compile errors.
