### PR TITLE
Support Windows KSP1 instances on Linux

### DIFF
--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -222,7 +222,9 @@ namespace CKAN.Games.KerbalSpaceProgram
         public string[] InstanceAnchorFiles =>
             // KSP.app is a directory :(
               Platform.IsMac     ? new string[] { "buildID64.txt", "buildID.txt" }
-            : Platform.IsUnix    ? new string[] { "KSP.x86_64",    "KSP.x86" }
+            : Platform.IsUnix    ? new string[] { "KSP.x86_64",    "KSP.x86",
+                                                  // Windows EXEs via Proton on Linux
+                                                  "KSP_x64.exe",   "KSP.exe" }
             :                      new string[] { "KSP_x64.exe",   "KSP.exe" };
 
         public Uri DefaultRepositoryURL => new Uri("https://github.com/KSP-CKAN/CKAN-meta/archive/master.tar.gz");


### PR DESCRIPTION
## Background

Originally, CKAN looked for `buildID.txt` and `buildID64.txt` to identify KSP1 instances. For KSP2, no equivalent file exists (but luckily we won't need it anymore, see #4034), so we look for the game executable instead.

It was fairly common for confused KSP1 users to ask how to add an instance, because they didn't know what `buildID.txt` was and so clicking it was a non-obvious action. Meanwhile, nobody seemed the least bit confused by choosing the KSP2 executable. So in #3964 we changed the prompting for KSP1 to also use the executable, which seems to have succeeded in improving usability so far.

Later, a Linux user submitted #3984 to _run_ the KSP2 Windows executable from Linux, which apparently can work thanks to Proton, which somehow can reach out from inside however Steam installs it to launch EXE files similar to how Mono does (I'm still not sure about the details of this).

## Motivation

Some KSP1 users on Linux also prefer to run via Proton, because it performs better for them, or because DirectX makes some graphics-heavy mods like Parallax work better than they do on OpenGL. Currently such users have to create a `KSP.x86_64` file to be able to add such an instance to CKAN, which is a very non-obvious workaround, and they also have to configure the command line manually.

## Changes

Now CKAN will look for Windows KSP1 executables in addition to the Linux ones when running on Linux. This applies both to adding the instance and to launching the game. Whichever executable is present in the folder will be treated as the right one to run, as per #3964.

Fixes #4036.
Fixes #4038.
Fixes #4041.
