### PR TITLE
De-over-parallelize Versions tab

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -68,6 +68,11 @@ namespace CKAN.Extensions
         public static ConcurrentDictionary<K, V> ToConcurrentDictionary<K, V>(this IEnumerable<KeyValuePair<K, V>> pairs)
             => new ConcurrentDictionary<K, V>(pairs);
 
+        public static IEnumerable<T> AsParallelIf<T>(this IEnumerable<T> source,
+                                                     bool                parallel)
+            => parallel ? source.AsParallel()
+                        : source;
+
         // https://stackoverflow.com/a/55591477/2422988
         public static ParallelQuery<T> WithProgress<T>(this ParallelQuery<T> source,
                                                        long                  totalCount,

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1399,7 +1399,7 @@ namespace CKAN
                                          .Where(m => m != null);
                 var resolver = new RelationshipResolver(toInstall, installed, opts, registry, crit);
 
-                var resolverModList = resolver.ModList().ToList();
+                var resolverModList = resolver.ModList(false).ToList();
                 if (resolverModList.Count >= toInstall.Count(m => !m.IsMetapackage))
                 {
                     // We can install with no further dependencies

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -519,10 +519,10 @@ namespace CKAN
         /// Returns a list of all modules to install to satisfy the changes required.
         /// Each mod is after its dependencies and before its reverse dependencies.
         /// </summary>
-        public IEnumerable<CkanModule> ModList()
+        public IEnumerable<CkanModule> ModList(bool parallel = true)
             => modlist.Values
                       .Distinct()
-                      .AsParallel()
+                      .AsParallelIf(parallel)
                       // Put user choices at the bottom; .OrderBy(bool) -> false first
                       .OrderBy(m => ReasonsFor(m).Any(r => r is SelectionReason.UserRequested))
                       // Put dependencies before dependers
@@ -539,8 +539,8 @@ namespace CKAN
                 || r is SelectionReason.Recommended
                 || r is SelectionReason.Suggested;
 
-        private IEnumerable<T> BreadthFirstSearch<T>(IEnumerable<T>                      startingGroup,
-                                                     Func<T, HashSet<T>, IEnumerable<T>> getNextGroup)
+        private static IEnumerable<T> BreadthFirstSearch<T>(IEnumerable<T>                      startingGroup,
+                                                            Func<T, HashSet<T>, IEnumerable<T>> getNextGroup)
         {
             var found    = startingGroup.ToHashSet();
             var toSearch = new Queue<T>(found);

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -339,7 +339,7 @@ namespace CKAN
         /// <summary>
         /// Inflates a CKAN object from a JSON string.
         /// </summary>
-        public CkanModule(string json, IGameComparator comparator)
+        public CkanModule(string json, IGameComparator comparator = null)
         {
             try
             {
@@ -355,7 +355,7 @@ namespace CKAN
                     string.Format(Properties.Resources.CkanModuleDeserialisationError, ex.Message),
                     ex);
             }
-            _comparator = comparator;
+            _comparator = comparator ?? ServiceLocator.Container.Resolve<IGameComparator>();
             CheckHealth();
             CalculateSearchables();
         }
@@ -510,18 +510,12 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Generates a CKAN.META object from a string.
+        /// Generates a CkanModule object from a string.
         /// Also validates that all required fields are present.
         /// Throws a BadMetaDataKraken if any fields are missing.
         /// </summary>
         public static CkanModule FromJson(string json)
-        {
-            log.Debug("Inflating comparator object");
-            IGameComparator comparator = ServiceLocator.Container.Resolve<IGameComparator>();
-
-            log.Debug("Building CkanModule");
-            return new CkanModule(json, comparator);
-        }
+            => new CkanModule(json);
 
         #endregion
 

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -241,6 +241,7 @@ namespace CKAN.GUI
                        {
                            if (latestCompatible == null || item.Index < latestCompatible.Index)
                            {
+                               VersionsListView.BeginUpdate();
                                if (latestCompatible != null)
                                {
                                    // Revert color of previous best guess
@@ -250,6 +251,7 @@ namespace CKAN.GUI
                                latestCompatible = item;
                                item.BackColor = Color.Green;
                                item.ForeColor = Color.White;
+                               VersionsListView.EndUpdate();
                            }
                            else
                            {


### PR DESCRIPTION
## Problems

- The Versions tab sometimes has a delay when loading; it might sit for several seconds before starting to set the background colors of compatible rows to green.
- An extreme consequence of this can be observed by opening the Versions tab before typing a search for a mod (e.g., "ksp community fixes"): the whole app appears to hang while waiting for the Versions tab to update.

## Cause

We appear to have a case of [over-parallelization](https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/potential-pitfalls-with-plinq#avoid-over-parallelization). `RelationshipResolver.ModList` is parallel (for speeding up very large changesets), and `Versions.checkInstallable` _calls it_ in parallel (via `ModuleInstaller.CanInstall`; that's what feeds the `ToList` call highlighted above).

When parallel calls are nested, I think the outer one sets up some thread pooling and marshalling and so on to distribute load to your N CPUs, and then the inner calls each do the same thing, so you effectively have threads competing for N\*N CPUs, which is N\*(N-1) more than you have.

## Changes

- Now `EnumerableExtensions.AsParallelIf` is added to create a way to make a PLINQ call parallel only if its parameter is true
- Now `RelationshipResolver.ModList` has a `parallel` parameter (defaulting to true to keep it parallel for the situations where it's helpful) and passes it to `AsParallelIf`
- Now `ModuleInstaller.CanInstall` tells `ModList` not to load in parallel

This follows the recommendation of the above link to keep the outer loop parallel while making the inner loop non-parallel, and it makes the Versions tab load much quicker now.

It's unfortunate that we have to hard-code whether a specific call should be parallel instead of just writing optimal queries and letting the framework sort out the parallelization, but that's where we are. Ideally we would create our own way to toggle it automatically, but this will work for now, and we can revisit it later if we think of a better solution.

Side changes:

- `CkanModule.FromJson` and `CkanModule`'s constructor now initialize the `_comparator` field in a simpler way
- The Versions tab now uses `BeginUpdate`/`EndUpdate` to minimize flickering of the listview while setting multiple row colors in a row

Fixes #4046.
