### PR TITLE
Use better console hiding API

### DIFF
--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -55,17 +55,14 @@ namespace CKAN.GUI
 
         // hides the console window on windows
         // useful when running the GUI
-        [DllImport("kernel32.dll")]
-        private static extern IntPtr GetConsoleWindow();
-
-        [DllImport("user32.dll")]
-        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+        [DllImport("kernel32.dll", SetLastError=true)]
+        private static extern int FreeConsole();
 
         public static void HideConsoleWindow()
         {
             if (Platform.IsWindows)
             {
-                ShowWindow(GetConsoleWindow(), 0);
+                FreeConsole();
             }
         }
 


### PR DESCRIPTION
## Background

Windows 11 recently introduced a new virtual terminal to replace the Windows console. It behaves much more like standard Unix terminals:

- <https://learn.microsoft.com/en-us/windows/console/classic-vs-vt>

## Problems

- If you open a console (old style) in Windows and then run ckan.exe without the `--show-console` flag (and none of the CmdLine commands like `list` or `install`), your console windows closes. This is not typical behavior for a command that you launch from a console and can be very surprising.
- If you double click ckan.exe in Windows 11, the virtual terminal stays open the entire time you're using the GUI

## Causes

Since ckan.exe is both a console application and a GUI application, Windows always automatically opens a console for it at launch. This is not desirable when running in GUI mode, so the GUI closes its console by finding it with `GetConsoleWindow` and then hiding it with `ShowWindow`.

- This approach is too aggressive because it doesn't care whether that console is still in use by other applications
- The new virtual terminal doesn't support `GetConsoleWindow`, so the whole approach breaks down anyway

## Changes

Now we use [`FreeConsole`](https://learn.microsoft.com/en-us/windows/console/freeconsole) instead of `ShowWindow` and `GetConsoleWindow`. This API just _detaches_ the current process from its console or terminal, so it won't aggressively close consoles that are still in use by other processes (such as a shell), but will auto-close any terminal that is _only_ associated with ckan.exe. It is also supported by the new virtual terminals (see microsoft/terminal#14544), so console hiding should now work on Win11.

Fixes #3902.
