### PR TITLE
Trigger progress updates for frozen downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ bld/
 # Don't ignore the root bin folder
 !/bin/
 
+.config/
+.mypy_cache/
+
 # NuGet Packages
 *.nupkg
 # The packages folder can be ignored because of Package Restore

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -139,6 +139,7 @@ namespace CKAN
                                         DownloadProgress?.Invoke((int)(100 * bytesDownloaded / contentLength),
                                                                  bytesDownloaded, contentLength);
                                     }),
+                                    TimeSpan.FromSeconds(5),
                                     cancelTokenSrc.Token);
                                 // Make sure caller knows we've finished
                                 DownloadProgress?.Invoke(100, contentLength, contentLength);


### PR DESCRIPTION
## Motivation

Sometimes CKAN is able to connect to a host, but the download times out without sending any data (it seems like SpaceDock does this every few weeks). Since our system for progress updates depends on traffic received, this means that no progress updates are sent. And since these progress updates drive the progress bars on the progress tab, and since they are ignored unless 3 seconds have already passed since the download group started, I'm pretty sure it's possible for such a frozen download to never show up as an empty progress bar.

## Changes

- Now a frozen download will trigger progress updates every 5 seconds, even if no data is coming through. This will ensure that progress bars will appear for such downloads in the progress tab, so the user can see what's happening.
- A couple of stray folders that I found in my working copy are added to the `.gitignore` for convenience
