### PR TITLE
Fix NRE on trying to update all when there's nothing to update

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -154,17 +154,17 @@ namespace CKAN.GUI
                 var removing = changeIdentifiersOfType(GUIModChangeType.Remove)
                                .Except(changeIdentifiersOfType(GUIModChangeType.Install))
                                .ToHashSet();
-                foreach (var kvp in mainModList.full_list_of_mod_rows)
+                foreach ((string ident, DataGridViewRow row) in mainModList.full_list_of_mod_rows)
                 {
-                    if (removing.Contains(kvp.Key))
+                    if (removing.Contains(ident))
                     {
                         // Set strikeout font for rows being uninstalled
-                        kvp.Value.DefaultCellStyle.Font = uninstallingFont;
+                        row.DefaultCellStyle.Font = uninstallingFont;
                     }
-                    else if (kvp.Value.DefaultCellStyle.Font != null)
+                    else if (row.DefaultCellStyle.Font != null)
                     {
                         // Clear strikeout font for rows not being uninstalled
-                        kvp.Value.DefaultCellStyle.Font = null;
+                        row.DefaultCellStyle.Font = null;
                     }
                 }
             });

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -43,7 +43,7 @@ namespace CKAN.GUI
     public class ModList
     {
         //identifier, row
-        internal Dictionary<string, DataGridViewRow> full_list_of_mod_rows;
+        internal Dictionary<string, DataGridViewRow> full_list_of_mod_rows = new Dictionary<string, DataGridViewRow>();
 
         public event Action ModFiltersUpdated;
         public IReadOnlyCollection<GUIMod> Modules { get; private set; } =


### PR DESCRIPTION
## Problem

1. Set up a repo with an invalid URL as your only repo
2. Close CKAN
3. Start CKAN
4. The failed downloads window will appear. Click abort.
5. Now you have an empty mod list
   (The above steps are just one specific way that I've found to get to this point. It may or may not be how other users might get here, but the below problem happens regardless of the specific path taken.)
6. Click Update all even though there are no mods to update
7. An NRE is thrown

## Cause

`ManageMods.mainModList.full_list_of_mod_rows` is null when the grid is empty, and `ManageMods.MarkAllUpdates` accesses its `.Values` property.

## Changes

- Now `ManageMods.mainModList.full_list_of_mod_rows` is set to an empty dictionary on initialization, so it can always be accessed safely, and clicking the button with an empty list will do nothing.
- A `foreach` loop in `ManageMods.ChangeSetUpdated` now uses a deconstructor to get the key and value separately instead of a `kvp` variable to represent the key value pair. This isn't needed to fix anything, but it's nice for readability.

Fixes #4053.
