### PR TITLE
Proportional, granular progress updates for installing

### DIFF
--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -65,10 +65,8 @@ namespace CKAN.ConsoleUI {
 
                         HashSet<string> possibleConfigOnlyDirs = null;
 
-                        ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this)
-                        {
-                            onReportModInstalled = OnModInstalled
-                        };
+                        ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this);
+                        inst.onReportModInstalled += OnModInstalled;
                         if (plan.Remove.Count > 0) {
                             inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr, true, new List<CkanModule>(plan.Install));
                             plan.Remove.Clear();
@@ -103,9 +101,9 @@ namespace CKAN.ConsoleUI {
                         }
 
                         trans.Complete();
+                        inst.onReportModInstalled -= OnModInstalled;
                         // Don't let the installer re-use old screen references
                         inst.User = null;
-                        inst.onReportModInstalled = null;
 
                     } catch (CancelledActionKraken) {
                         // Don't need to tell the user they just cancelled out.

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -115,6 +115,12 @@ namespace CKAN.Extensions
                     lastProgressTime = now;
                 }
             }
+            if (timer != null)
+            {
+                timer.Stop();
+                timer.Close();
+                timer = null;
+            }
             // Make sure we get a final progress notification after we're done
             progress.Report(total);
         }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -829,10 +829,10 @@ namespace CKAN
         /// Register the supplied module as having been installed, thereby keeping
         /// track of its metadata and files.
         /// </summary>
-        public void RegisterModule(CkanModule          mod,
-                                   IEnumerable<string> absoluteFiles,
-                                   GameInstance        inst,
-                                   bool                autoInstalled)
+        public void RegisterModule(CkanModule   mod,
+                                   List<string> absoluteFiles,
+                                   GameInstance inst,
+                                   bool         autoInstalled)
         {
             log.DebugFormat("Registering module {0}", mod);
             EnlistWithTransaction();

--- a/Core/Repositories/ProgressFilesOffsetsToPercent.cs
+++ b/Core/Repositories/ProgressFilesOffsetsToPercent.cs
@@ -29,12 +29,15 @@ namespace CKAN
         /// <param name="currentFileOffset">How far into the current file we are</param>
         public void Report(long currentFileOffset)
         {
-            var percent = basePercent + (int)(100 * currentFileOffset / totalSize);
-            // Only report each percentage once, to avoid spamming UI calls
-            if (percent > lastPercent)
+            if (totalSize > 0)
             {
-                percentProgress.Report(percent);
-                lastPercent = percent;
+                var percent = basePercent + (int)(100 * currentFileOffset / totalSize);
+                // Only report each percentage once, to avoid spamming UI calls
+                if (percent > lastPercent)
+                {
+                    percentProgress.Report(percent);
+                    lastPercent = percent;
+                }
             }
         }
 
@@ -44,7 +47,10 @@ namespace CKAN
         public void NextFile()
         {
             doneSize += sizes[currentIndex];
-            basePercent = (int)(100 * doneSize / totalSize);
+            if (totalSize > 0)
+            {
+                basePercent = (int)(100 * doneSize / totalSize);
+            }
             ++currentIndex;
             if (basePercent > lastPercent)
             {

--- a/Core/Repositories/ProgressScalePercentsByFileSize.cs
+++ b/Core/Repositories/ProgressScalePercentsByFileSize.cs
@@ -29,7 +29,7 @@ namespace CKAN
         /// <param name="currentFilePercent">How far into the current file we are</param>
         public void Report(int currentFilePercent)
         {
-            if (basePercent < 100 && currentIndex < sizes.Length)
+            if (basePercent < 100 && currentIndex < sizes.Length && totalSize > 0)
             {
                 var percent = basePercent + (int)(currentFilePercent * sizes[currentIndex] / totalSize);
                 // Only report each percentage once, to avoid spamming UI calls
@@ -47,7 +47,10 @@ namespace CKAN
         public void NextFile()
         {
             doneSize += sizes[currentIndex];
-            basePercent = (int)(100 * doneSize / totalSize);
+            if (totalSize > 0)
+            {
+                basePercent = (int)(100 * doneSize / totalSize);
+            }
             ++currentIndex;
             if (basePercent > lastPercent)
             {

--- a/Tests/CmdLine/UpgradeTests.cs
+++ b/Tests/CmdLine/UpgradeTests.cs
@@ -79,7 +79,7 @@ namespace Tests.CmdLine
                 regMgr.registry.RepositoriesAdd(repo.repo);
                 var fromModule = regMgr.registry.GetModuleByVersion(identifier, fromVersion);
                 var toModule   = regMgr.registry.GetModuleByVersion(identifier, toVersion);
-                regMgr.registry.RegisterModule(fromModule, Enumerable.Empty<string>(), inst.KSP, false);
+                regMgr.registry.RegisterModule(fromModule, new List<string>(), inst.KSP, false);
                 manager.Cache.Store(toModule, TestData.DogeCoinFlagZip(), null);
                 var opts = new UpgradeOptions()
                 {
@@ -598,7 +598,7 @@ namespace Tests.CmdLine
                 foreach (var fromModule in instMods)
                 {
                     regMgr.registry.RegisterModule(fromModule,
-                                                   Enumerable.Empty<string>(),
+                                                   new List<string>(),
                                                    inst.KSP, false);
                 }
                 // Pre-store mods that might be installed

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -319,7 +319,7 @@ namespace Tests.Core
 
                 Assert.Throws<FileExistsKraken>(delegate
                 {
-                    ModuleInstaller.CopyZipEntry(zipfile, entry, tmpfile, false);
+                    ModuleInstaller.CopyZipEntry(zipfile, entry, tmpfile, false, null);
                 });
 
                 // Cleanup
@@ -357,7 +357,7 @@ namespace Tests.Core
 
             // We have to delete our temporary file, as CZE refuses to overwrite; huzzah!
             File.Delete(tmpfile);
-            ModuleInstaller.CopyZipEntry(zipfile, entry, tmpfile, false);
+            ModuleInstaller.CopyZipEntry(zipfile, entry, tmpfile, false, null);
 
             return tmpfile;
         }
@@ -662,7 +662,7 @@ namespace Tests.Core
                 var registry = RegistryManager.Instance(inst.KSP, repoData.Manager).registry;
                 // Make files to be registered to another mod
                 var absFiles = registeredFiles.Select(f => inst.KSP.ToAbsoluteGameDir(f))
-                                              .ToArray();
+                                              .ToList();
                 foreach (var absPath in absFiles)
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(absPath));
@@ -874,7 +874,7 @@ namespace Tests.Core
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache);
 
                 // Act
-                registry.RegisterModule(replaced, Enumerable.Empty<string>(), inst.KSP, false);
+                registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
                 manager.Cache.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 var replacement = querier.GetReplacement(replaced.identifier,
                                                          new GameVersionCriteria(new GameVersion(1, 12)));
@@ -940,7 +940,7 @@ namespace Tests.Core
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache);
 
                 // Act
-                registry.RegisterModule(replaced, Enumerable.Empty<string>(), inst.KSP, false);
+                registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
                 manager.Cache.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 var replacement = querier.GetReplacement(replaced.identifier,
                                                          new GameVersionCriteria(new GameVersion(1, 11)));
@@ -1006,14 +1006,14 @@ namespace Tests.Core
                 foreach (var m in regularMods)
                 {
                     registry.RegisterModule(CkanModule.FromJson(m),
-                                            Enumerable.Empty<string>(),
+                                            new List<string>(),
                                             inst.KSP,
                                             false);
                 }
                 foreach (var m in autoInstMods)
                 {
                     registry.RegisterModule(CkanModule.FromJson(m),
-                                            Enumerable.Empty<string>(),
+                                            new List<string>(),
                                             inst.KSP,
                                             true);
                 }
@@ -1098,7 +1098,7 @@ namespace Tests.Core
                     if (!querier.IsInstalled(module.identifier, false))
                     {
                         registry.RegisterModule(module,
-                                                Enumerable.Empty<string>(),
+                                                new List<string>(),
                                                 inst.KSP,
                                                 false);
                     }
@@ -1106,7 +1106,7 @@ namespace Tests.Core
                 foreach (var m in autoInstMods)
                 {
                     registry.RegisterModule(CkanModule.FromJson(m),
-                                            Enumerable.Empty<string>(),
+                                            new List<string>(),
                                             inst.KSP,
                                             true);
                 }

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Transactions;
 using System.Collections.Generic;
@@ -316,8 +315,8 @@ namespace Tests.Core.Registry
                 CkanModule dependingMod = registry.GetModuleByVersion("DependingMod", "1.0");
 
                 GameInstance gameInst = gameInstWrapper.KSP;
-                registry.RegisterModule(olderDepMod,  Array.Empty<string>(), gameInst, false);
-                registry.RegisterModule(dependingMod, Array.Empty<string>(), gameInst, false);
+                registry.RegisterModule(olderDepMod,  new List<string>(), gameInst, false);
+                registry.RegisterModule(dependingMod, new List<string>(), gameInst, false);
                 GameVersionCriteria crit = new GameVersionCriteria(olderDepMod.ksp_version);
 
                 // Act
@@ -420,7 +419,7 @@ namespace Tests.Core.Registry
             using (var tScope = new TransactionScope())
             {
                 reg = CKAN.Registry.Empty();
-                reg.RegisterModule(module, Enumerable.Empty<string>(),
+                reg.RegisterModule(module, new List<string>(),
                                    gameInstWrapper.KSP, false);
 
                 CollectionAssert.AreEqual(
@@ -451,7 +450,7 @@ namespace Tests.Core.Registry
             using (var gameInstWrapper = new DisposableKSP())
             using (var tScope = new TransactionScope())
             {
-                registry.RegisterModule(module, Enumerable.Empty<string>(),
+                registry.RegisterModule(module, new List<string>(),
                                         gameInstWrapper.KSP, false);
 
                 CollectionAssert.AreEqual(
@@ -481,7 +480,7 @@ namespace Tests.Core.Registry
                                  ""version"":      ""1.0"",
                                  ""download"":     ""https://github.com/""
                              }");
-                registry.RegisterModule(module, Enumerable.Empty<string>(),
+                registry.RegisterModule(module, new List<string>(),
                                         gameInstWrapper.KSP, false);
 
                 CollectionAssert.AreEqual(
@@ -515,7 +514,7 @@ namespace Tests.Core.Registry
                                  ""version"":      ""1.0"",
                                  ""download"":     ""https://github.com/""
                              }");
-                registry.RegisterModule(module, Enumerable.Empty<string>(),
+                registry.RegisterModule(module, new List<string>(),
                                         gameInstWrapper.KSP, false);
 
                 using (var tScope2 = new TransactionScope(TransactionScopeOption.RequiresNew))
@@ -528,7 +527,7 @@ namespace Tests.Core.Registry
                                           ""version"":      ""1.0"",
                                           ""download"":     ""https://github.com/""
                                       }");
-                        registry.RegisterModule(module2, Enumerable.Empty<string>(),
+                        registry.RegisterModule(module2, new List<string>(),
                                                 gameInstWrapper.KSP, false);
                     });
                     tScope2.Complete();
@@ -553,7 +552,7 @@ namespace Tests.Core.Registry
                                  ""version"":      ""1.0"",
                                  ""download"":     ""https://github.com/""
                              }");
-                registry.RegisterModule(module, Enumerable.Empty<string>(),
+                registry.RegisterModule(module, new List<string>(),
                                         gameInstWrapper.KSP, false);
 
                 using (var tScope2 = new TransactionScope())
@@ -566,7 +565,7 @@ namespace Tests.Core.Registry
                                           ""version"":      ""1.0"",
                                           ""download"":     ""https://github.com/""
                                       }");
-                        registry.RegisterModule(module2, Enumerable.Empty<string>(),
+                        registry.RegisterModule(module2, new List<string>(),
                                                 gameInstWrapper.KSP, false);
                     });
                     tScope2.Complete();

--- a/Tests/Core/Registry/RegistryManager.cs
+++ b/Tests/Core/Registry/RegistryManager.cs
@@ -199,7 +199,7 @@ namespace Tests.Core.Registry
                 var regMgr   = RegistryManager.Instance(gameInst, repoData.Manager);
                 var registry = regMgr.registry;
                 var absReg   = registered.Select(p => gameInst.ToAbsoluteGameDir(p))
-                                                .ToArray();
+                                                .ToList();
                 var absUnreg = unregistered.Select(p => gameInst.ToAbsoluteGameDir(p))
                                                   .ToArray();
 

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -312,7 +312,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { mod_a };
 
-                registry.RegisterModule(mod_a, Array.Empty<string>(), null, false);
+                registry.RegisterModule(mod_a, new List<string>(), null, false);
 
                 var relationship_resolver = new RelationshipResolver(
                     list, null, options, registry, null);
@@ -1036,8 +1036,8 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
 
                 // Start with eve and eveDefaultConfig installed
-                registry.RegisterModule(eve, Array.Empty<string>(), ksp.KSP, false);
-                registry.RegisterModule(eveDefaultConfig, Array.Empty<string>(), ksp.KSP, false);
+                registry.RegisterModule(eve, new List<string>(), ksp.KSP, false);
+                registry.RegisterModule(eveDefaultConfig, new List<string>(), ksp.KSP, false);
 
                 Assert.DoesNotThrow(() => registry.CheckSanity());
 

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -63,7 +63,7 @@ namespace Tests.GUI
                 {
                     var registry = new Registry(repoData.Manager, repo.repo);
 
-                    registry.RegisterModule(old_version, Enumerable.Empty<string>(), null, false);
+                    registry.RegisterModule(old_version, new List<string>(), null, false);
                     var upgradeableGroups = registry.CheckUpgradeable(tidy.KSP.VersionCriteria(),
                                                                       new HashSet<string>());
 

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -161,7 +161,7 @@ namespace Tests.GUI
 
                 // Install module and set it as pre-installed
                 manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
-                registry.RegisterModule(anyVersionModule, Array.Empty<string>(), instance.KSP, false);
+                registry.RegisterModule(anyVersionModule, new List<string>(), instance.KSP, false);
 
                 HashSet<string> possibleConfigOnlyDirs = null;
                 installer.InstallList(


### PR DESCRIPTION
## Motivation

- There are no UI updates while a mod is being installed, which can take a long time for a very large mod and may make it look like the GUI is frozen
- The progress bar for installing mods treats tiny mods and huge mods as an equal percentage of the install, which makes it useless for estimating how complete the install actually is
- The mod installation progress bar counts up from 0% to 60% for the actual unzipping, and then the remaining 40% reflects saving the registry (which became a lot faster in #3904) and completing the transaction (which is basically instantaneous), which likewise makes the progress bar less reflective of overall completion

## Changes

- Now we generate at least one progress update per file being unzipped, and another progress update every 200 milliseconds after that for large files, so large mods will have many gradual updates to the progress bar, and you'll be able to tell that it's still installing
- Now installation progress updates are scaled proportionally to the number of bytes installed, so the progress bar will reflect how far along you are in the overall install
- Now mod installation is given 85% of the progress bar, with saving the registry and finishing the transaction relegated to the remaining 15%

Fixes #4014.

### Side fixes

- The timer from #4052 was continuing to run and generate spurious updates after downloads completed. Now it's properly destroyed.
- `ModuleInstaller.onReportModInstalled` is now a proper `event`, and its type is `Action<CkanModule>` instead of a custom delegate
- `ModuleInstaller.InstallModule` formerly returned `IEnumerable<string>`, which isn't a great idea for a collection that's going to be passed to other functions because `IEnumerable<>` often involves lazy evaluation, which may cause performance problems if evaluated multiple times. Now it's a `List<string>`.
- `ModuleInstaller.ksp` is renamed to `instance`
