### PR TITLE
Fix outdated client message when up to date

### DIFF
--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -288,7 +288,10 @@ namespace CKAN
                                              subtotal.Item2 ?? item.Item2,
                                              subtotal.Item3 ?? item.Item3,
                                              subtotal.Item4 ?? item.Item4,
-                                             subtotal.Item5 || item.Item1 == null),
+                                             subtotal.Item5 || (item.Item1 == null
+                                                                && item.Item2 == null
+                                                                && item.Item3 == null
+                                                                && item.Item4 == null)),
                                  (total, subtotal)
                                      => new ArchiveList(total.Item1.Concat(subtotal.Item1).ToList(),
                                                         total.Item2 ?? subtotal.Item2,

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -418,33 +418,28 @@ namespace CKAN.GUI
             configuration?.Save();
             configuration = GUIConfigForInstance(Manager.SteamLibrary, CurrentInstance);
 
-            AutoUpdatePrompts(ServiceLocator.Container
-                                            .Resolve<IConfiguration>(),
-                              configuration);
-
-            bool autoUpdating = configuration.CheckForUpdatesOnLaunch
-                                && CheckForCKANUpdate();
-            if (autoUpdating)
-            {
-                UpdateCKAN();
-            }
-
             var pluginsPath = Path.Combine(CurrentInstance.CkanDir(), "Plugins");
             if (!Directory.Exists(pluginsPath))
             {
                 Directory.CreateDirectory(pluginsPath);
             }
-
             pluginController = new PluginController(pluginsPath, true);
 
             CurrentInstance.game.RebuildSubdirectories(CurrentInstance.GameDir());
 
             ManageMods.InstanceUpdated();
-            bool repoUpdateNeeded = configuration.RefreshOnStartup;
-            if (!autoUpdating)
+
+            AutoUpdatePrompts(ServiceLocator.Container
+                                            .Resolve<IConfiguration>(),
+                              configuration);
+
+            if (configuration.CheckForUpdatesOnLaunch && CheckForCKANUpdate())
             {
-                // If not allowing, don't do anything
-                if (repoUpdateNeeded)
+                UpdateCKAN();
+            }
+            else
+            {
+                if (configuration.RefreshOnStartup)
                 {
                     UpdateRepo(refreshWithoutChanges: true);
                 }

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -85,7 +85,7 @@ namespace CKAN.GUI
             var mainConfig = ServiceLocator.Container.Resolve<IConfiguration>();
             var update = updater.GetUpdate(mainConfig.DevBuilds ?? false);
             Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo,
-                                update.Version));
+                                              update.Version));
 
             log.Info("Starting CKAN update");
             Wait.StartWaiting((sender, args) => updater.StartUpdateProcess(true, mainConfig.DevBuilds ?? false, currentUser),


### PR DESCRIPTION
## Problem

The new "Repositories updated, but found modules that require a new version of CKAN. Checking for updates..." message appears on every update, regardless of whether your client is outdated.

## Cause

In #4026 we treated an `ArchiveEntry` tuple as indicating an unsupported spec version if its first item was null, but this is also expected for `download_counts.json`, `builds.json`, and `repositories.json`. The correct indicator is when **all** of the first four items are null.

## Changes

Now we check whether all of the first four items in the tuple are null.
