### PR TITLE
Launch wiki when Windows users select dev updates

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -66,6 +66,12 @@ namespace CKAN.CmdLine
                                || (!options.stable_release && (config.DevBuilds ?? false));
                 if (devBuild != config.DevBuilds)
                 {
+                    if (!config.DevBuilds.HasValue && devBuild && Platform.IsWindows)
+                    {
+                        // Tell Windows users about malware scanner's false positives
+                        // and how to disable it, if they feel safe doing it
+                        Utilities.ProcessStartURL(HelpURLs.WindowsDevBuilds);
+                    }
                     config.DevBuilds = devBuild;
                     user.RaiseMessage(
                         config.DevBuilds ?? false

--- a/Core/HelpURLs.cs
+++ b/Core/HelpURLs.cs
@@ -11,6 +11,7 @@ namespace CKAN
         public const string ModPacks = "https://github.com/KSP-CKAN/CKAN/wiki/Sharing-a-modlist-%28metapackages%29";
         public const string AuthTokens = "https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-GitHub-API-authtoken";
         public const string CertificateErrors = "https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors";
+        public const string WindowsDevBuilds = "https://github.com/KSP-CKAN/CKAN/wiki/Using-dev-builds-on-Windows";
 
         public const string CloneFakeInstances = "https://github.com/KSP-CKAN/CKAN/pull/2627";
         public const string DeleteDirectories = "https://github.com/KSP-CKAN/CKAN/pull/2962";

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -31,6 +31,12 @@ namespace CKAN.GUI
                 coreConfig.DevBuilds = !YesNoDialog(Properties.Resources.MainReleasesOrDevBuildsPrompt,
                                                     Properties.Resources.MainReleasesOrDevBuildsYes,
                                                     Properties.Resources.MainReleasesOrDevBuildsNo);
+                if (coreConfig.DevBuilds.Value && Platform.IsWindows)
+                {
+                    // Tell Windows users about malware scanner's false positives
+                    // and how to disable it, if they feel safe doing it
+                    Utilities.ProcessStartURL(HelpURLs.WindowsDevBuilds);
+                }
             }
         }
 


### PR DESCRIPTION
## Motivation

Before #3997's dev builds functionality gets released, we need to do something about Windows' malware scanner's high false positive rate. It has always been a problem (in that it falsely flags ckan.exe as malware), but for full releases we (or interested users) can submit it for manual review and whitelisting. Dev builds are generated too frequently for that too be feasible.

## Changes

- A wiki has been created to explain how to configure Windows' malware scanner to stop raising these false positives (or how to switch back to the full releases if you want to keep using the malware scanner):
  <https://github.com/KSP-CKAN/CKAN/wiki/Using-dev-builds-on-Windows>
- Now when a Windows user clicks "Use dev builds" in the popup from #3997 (or runs `ckan upgrade ckan --dev-build` for the first time), we auto-open that page in a browser, so the user can read about the problem and decide how they want to handle it. This should at least take a big bite out of the problem of users' ckan.exe dev builds getting deleted by surprise. And for those who miss it the first time, we can send them the URL again when they come to complain on Discord.

Fixes #4040 (since it addresses the malware scanner problem, and the specific suggestion given doesn't seem to be workable).
