### PR TITLE
Add downloads column for ConsoleUI

### DIFF
--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -57,6 +57,14 @@ namespace CKAN.ConsoleUI {
                         Width    = 20,
                         Renderer = m => registry.LatestCompatibleGameVersion(game.KnownVersions, m.identifier)?.ToString() ?? "",
                         Comparer = (a, b) => registry.LatestCompatibleGameVersion(game.KnownVersions, a.identifier).CompareTo(registry.LatestCompatibleGameVersion(game.KnownVersions, b.identifier))
+                    }, new ConsoleListBoxColumn<CkanModule>() {
+                        Header   = Properties.Resources.ModListDownloadsHeader,
+                        Width    = 12,
+                        Renderer = m => repoData.GetDownloadCount(registry.Repositories.Values, m.identifier)
+                                                ?.ToString()
+                                                ?? "",
+                        Comparer = (a, b) => (repoData.GetDownloadCount(registry.Repositories.Values, a.identifier) ?? 0)
+                                             .CompareTo(repoData.GetDownloadCount(registry.Repositories.Values, b.identifier) ?? 0),
                     }
                 },
                 1, 0, ListSortDirection.Descending,

--- a/ConsoleUI/Properties/Resources.fr-FR.resx
+++ b/ConsoleUI/Properties/Resources.fr-FR.resx
@@ -663,6 +663,9 @@ Si vous le retirez, CKAN ne pourra pas le réinstaller.</value>
   <data name="ModListMaxGameVersionHeader" xml:space="preserve">
     <value>Version de jeu max</value>
   </data>
+  <data name="ModListDownloadsHeader" xml:space="preserve">
+    <value>Nombre de téléchargements</value>
+  </data>
   <data name="ModListSearchFocusedGhostText" xml:space="preserve">
     <value>&lt;Taper pour faire une recherche&gt;</value>
   </data>

--- a/ConsoleUI/Properties/Resources.it-IT.resx
+++ b/ConsoleUI/Properties/Resources.it-IT.resx
@@ -663,6 +663,9 @@ Se la disinstalli, CKAN non sarà in grado di reinstallarla.</value>
   <data name="ModListMaxGameVersionHeader" xml:space="preserve">
     <value>Versione massima del gioco</value>
   </data>
+  <data name="ModListDownloadsHeader" xml:space="preserve">
+    <value>Download</value>
+  </data>
   <data name="ModListSearchFocusedGhostText" xml:space="preserve">
     <value>&lt;Digita per cercare&gt;</value>
   </data>

--- a/ConsoleUI/Properties/Resources.pl-PL.resx
+++ b/ConsoleUI/Properties/Resources.pl-PL.resx
@@ -663,6 +663,9 @@ Jeśli go odinstalujesz, CKAN nie będzie mógł go ponownie zainstalować.</val
   <data name="ModListMaxGameVersionHeader" xml:space="preserve">
     <value>Maksymalna wersja gry</value>
   </data>
+  <data name="ModListDownloadsHeader" xml:space="preserve">
+    <value>Ilość pobrań</value>
+  </data>
   <data name="ModListSearchFocusedGhostText" xml:space="preserve">
     <value>&lt;Wyszukaj&gt;</value>
   </data>

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -305,6 +305,7 @@ If you uninstall it, CKAN will not be able to re-install it.</value></data>
   <data name="ModListNameHeader" xml:space="preserve"><value>Name</value></data>
   <data name="ModListVersionHeader" xml:space="preserve"><value>Version</value></data>
   <data name="ModListMaxGameVersionHeader" xml:space="preserve"><value>Max game version</value></data>
+  <data name="ModListDownloadsHeader" xml:space="preserve"><value>Downloads</value></data>
   <data name="ModListSearchFocusedGhostText" xml:space="preserve"><value>&lt;Type to search&gt;</value></data>
   <data name="ModListSearchUnfocusedGhostText" xml:space="preserve"><value>&lt;Ctrl+F to search&gt;</value></data>
   <data name="ModListCount" xml:space="preserve"><value>{0} mods</value></data>

--- a/ConsoleUI/Properties/Resources.ru-RU.resx
+++ b/ConsoleUI/Properties/Resources.ru-RU.resx
@@ -663,6 +663,9 @@
   <data name="ModListMaxGameVersionHeader" xml:space="preserve">
     <value>Макс.вер.</value>
   </data>
+  <data name="ModListDownloadsHeader" xml:space="preserve">
+    <value>Загрузки</value>
+  </data>
   <data name="ModListSearchFocusedGhostText" xml:space="preserve">
     <value>&lt;Введите текст для поиска...&gt;</value>
   </data>


### PR DESCRIPTION
## Motivation

We track the download counts for mods, but currently they're only shown in GUI. A Mac user has requested to be able to see them in ConsoleUI.

## Changes

Now a Downloads column is added at the right side of the mod list, containing the download counts. The column header translations are copied from the Downloads column in GUI.

Fixes #4047.
