### PR TITLE
Play game option for ConsoleUI

### DIFF
--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -147,6 +147,7 @@ namespace CKAN.ConsoleUI {
             AddObject(searchBox);
             AddObject(moduleList);
 
+            AddBinding(Keys.CtrlP, (object sender, ConsoleTheme theme) => PlayGame());
             AddBinding(Keys.CtrlQ, (object sender, ConsoleTheme theme) => false);
             AddBinding(Keys.AltX,  (object sender, ConsoleTheme theme) => false);
             AddBinding(Keys.F1,    (object sender, ConsoleTheme theme) => Help(theme));
@@ -279,6 +280,22 @@ namespace CKAN.ConsoleUI {
             ));
 
             List<ConsoleMenuOption> opts = new List<ConsoleMenuOption>() {
+                new ConsoleMenuOption(Properties.Resources.ModListPlayMenu, "",
+                                      Properties.Resources.ModListPlayMenuTip,
+                                      true, null, null, null, true,
+                                      () => new ConsolePopupMenu(
+                                                manager.CurrentInstance
+                                                       .game
+                                                       .DefaultCommandLines(manager.SteamLibrary,
+                                                                            new DirectoryInfo(manager.CurrentInstance.GameDir()))
+                                                       .Select((cmd, i) => new ConsoleMenuOption(
+                                                                               cmd,
+                                                                               i == 0 ? $"{Properties.Resources.Ctrl}+P"
+                                                                                      : "",
+                                                                               cmd, true,
+                                                                               th => PlayGame(cmd)))
+                                                       .ToList())),
+                null,
                 new ConsoleMenuOption(Properties.Resources.ModListSortMenu, "",
                     Properties.Resources.ModListSortMenuTip,
                     true, null, null, moduleList.SortMenu()),
@@ -430,6 +447,19 @@ namespace CKAN.ConsoleUI {
         private int daysSinceUpdated(string filename)
         {
             return (DateTime.Now - File.GetLastWriteTime(filename)).Days;
+        }
+
+        private bool PlayGame()
+            => PlayGame(manager.CurrentInstance
+                               .game
+                               .DefaultCommandLines(manager.SteamLibrary,
+                                                    new DirectoryInfo(manager.CurrentInstance.GameDir()))
+                               .FirstOrDefault());
+
+        private bool PlayGame(string commandLine)
+        {
+            manager.CurrentInstance.PlayGame(commandLine);
+            return true;
         }
 
         private bool UpdateRegistry(ConsoleTheme theme, bool showNewModsPrompt = true)

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -319,6 +319,8 @@ If you uninstall it, CKAN will not be able to re-install it.</value></data>
   <data name="ModListApplyChangesTip" xml:space="preserve"><value>Apply changes</value></data>
   <data name="ModListUpdatedDayAgo" xml:space="preserve"><value>Updated at least {0} day ago</value></data>
   <data name="ModListUpdatedDaysAgo" xml:space="preserve"><value>Updated at least {0} days ago</value></data>
+  <data name="ModListPlayMenu" xml:space="preserve"><value>Play game</value></data>
+  <data name="ModListPlayMenuTip" xml:space="preserve"><value>Launch the game</value></data>
   <data name="ModListSortMenu" xml:space="preserve"><value>Sort...</value></data>
   <data name="ModListSortMenuTip" xml:space="preserve"><value>Change the sorting of the list of mods</value></data>
   <data name="ModListRefreshMenu" xml:space="preserve"><value>Refresh mod list</value></data>

--- a/ConsoleUI/Toolkit/ConsolePopupMenu.cs
+++ b/ConsoleUI/Toolkit/ConsolePopupMenu.cs
@@ -21,7 +21,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                     int len = opt.Caption.Length + (
                         string.IsNullOrEmpty(opt.Key) ? 0 : 2 + opt.Key.Length
                     ) + (
-                        opt.SubMenu     != null ? 3 :
+                        opt.SubMenu     != null || opt.SubMenuFunc != null ? 3 :
                         opt.RadioActive != null ? 4 :
                         0
                     );
@@ -66,7 +66,8 @@ namespace CKAN.ConsoleUI.Toolkit {
                         if (options[selectedOption].OnExec != null) {
                             val = options[selectedOption].OnExec(theme);
                         }
-                        options[selectedOption].SubMenu?.Run(
+                        (options[selectedOption].SubMenu ?? (options[selectedOption].SubMenuFunc?.Invoke()))
+                            ?.Run(
                                 theme,
                                 right - 2,
                                 top + selectedOption + 2);
@@ -153,7 +154,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         }
 
         private string AnnotatedCaption(ConsoleMenuOption opt)
-            => opt.SubMenu != null
+            => opt.SubMenu != null || opt.SubMenuFunc != null
                 ? opt.Caption.PadRight(longestLength - 1) + submenuIndicator
                 : opt.RadioActive != null
                     ? opt.RadioActive()
@@ -184,9 +185,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="radio">If set, this option is a radio button, and this function returns its value</param>
         /// <param name="submenu">Submenu to open for this option</param>
         /// <param name="enabled">true if this option should be drawn normally and allowed for selection, false to draw it grayed out and not allow selection</param>
+        /// <param name="submenuFunc">Function to generate submenu to open for this option</param>
         public ConsoleMenuOption(string cap, string key, string tt, bool close,
                 Func<ConsoleTheme, bool> exec = null, Func<bool> radio = null, ConsolePopupMenu submenu = null,
-                bool enabled = true)
+                bool enabled = true, Func<ConsolePopupMenu> submenuFunc = null)
         {
             Caption     = cap;
             Key         = key;
@@ -196,6 +198,7 @@ namespace CKAN.ConsoleUI.Toolkit {
             SubMenu     = submenu;
             RadioActive = radio;
             Enabled     = enabled;
+            SubMenuFunc = submenuFunc;
         }
 
         /// <summary>
@@ -226,6 +229,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Submenu to open for this option
         /// </summary>
         public readonly ConsolePopupMenu SubMenu;
+        /// <summary>
+        /// Function to generate submenu to open for this option
+        /// </summary>
+        public readonly Func<ConsolePopupMenu> SubMenuFunc;
         /// <summary>
         /// Function to call to check whether this option is enabled
         /// </summary>

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -177,6 +177,13 @@ namespace CKAN.ConsoleUI.Toolkit {
         );
 
         /// <summary>
+        /// Representation of Ctrl+P for key bindings
+        /// </summary>
+        public static readonly ConsoleKeyInfo CtrlP = new ConsoleKeyInfo(
+            (char)16, ConsoleKey.P, false, false, true
+        );
+
+        /// <summary>
         /// Representation of Ctrl+Q for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlQ = new ConsoleKeyInfo(

--- a/Core/Properties/Resources.fr-FR.resx
+++ b/Core/Properties/Resources.fr-FR.resx
@@ -393,6 +393,9 @@ Installez le paquet `mono-complete` ou un équivalent pour votre système d'expl
   <data name="GameInstancePathNotFound" xml:space="preserve">
     <value>{0} n'existe pas</value>
   </data>
+  <data name="GameInstancePlayGameFailed" xml:space="preserve"><value>Impossible de lancer le jeu.
+
+{0}</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve">
     <value>Téléchargement de {0} ...</value>
   </data>
@@ -582,7 +585,7 @@ Pensez à ajouter un jeton d'authentification pour augmenter la limite avant bri
   <data name="KrakenAlreadyRunning" xml:space="preserve">
     <value>Fichier verrou avec un ID de processus actif à {0}
 
-Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu. 
+Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu.
 
 Voulez-vous supprimez ce fichier verrou pour forcer l'accès ?</value>
   </data>

--- a/Core/Properties/Resources.it-IT.resx
+++ b/Core/Properties/Resources.it-IT.resx
@@ -390,6 +390,9 @@ Installa il pacchetto `mono-complete` o un pacchetto equivalente per il tuo sist
   <data name="GameInstancePathNotFound" xml:space="preserve">
     <value>{0} non esiste</value>
   </data>
+  <data name="GameInstancePlayGameFailed" xml:space="preserve"><value>Impossibile avviare il gioco.
+
+{0}</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve">
     <value>Download di "{0}"</value>
   </data>

--- a/Core/Properties/Resources.pl-PL.resx
+++ b/Core/Properties/Resources.pl-PL.resx
@@ -380,6 +380,9 @@ Zainstaluj pakiet `mono-complete` lub pasujący do twojego systemu operacyjnego.
   <data name="GameInstancePathNotFound" xml:space="preserve">
     <value>{0} nie istnieje</value>
   </data>
+  <data name="GameInstancePlayGameFailed" xml:space="preserve"><value>Nie można uruchomić gry.
+
+{0}</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve">
     <value>Pobieranie "{0}"</value>
   </data>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -210,6 +210,9 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="GameInstanceNoValidName" xml:space="preserve"><value>Could not return a valid name for the new instance</value></data>
   <data name="GameInstanceByPathName" xml:space="preserve"><value>custom</value></data>
   <data name="GameInstancePathNotFound" xml:space="preserve"><value>{0} does not exist</value></data>
+  <data name="GameInstancePlayGameFailed" xml:space="preserve"><value>Couldn't start game.
+
+{0}</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve"><value>Downloading {0} ...</value></data>
   <data name="ModuleInstallerNothingToInstall" xml:space="preserve"><value>Nothing to install</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>About to install:</value></data>

--- a/Core/Properties/Resources.ru-RU.resx
+++ b/Core/Properties/Resources.ru-RU.resx
@@ -204,6 +204,9 @@
   <data name="GameInstanceNoValidName" xml:space="preserve"><value>Не удалось вернуть корректное имя для новой сборки</value></data>
   <data name="GameInstanceByPathName" xml:space="preserve"><value>своя</value></data>
   <data name="GameInstancePathNotFound" xml:space="preserve"><value>{0} не существует</value></data>
+  <data name="GameInstancePlayGameFailed" xml:space="preserve"><value>Не удалось запустить игру.
+
+{0}</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve"><value>Загружается «{0}»</value></data>
   <data name="ModuleInstallerNothingToInstall" xml:space="preserve"><value>Нечего устанавливать</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>Будут установлены:</value></data>

--- a/Core/Properties/Resources.zh-CN.resx
+++ b/Core/Properties/Resources.zh-CN.resx
@@ -393,6 +393,9 @@
   <data name="GameInstancePathNotFound" xml:space="preserve">
     <value>{0} 不存在</value>
   </data>
+  <data name="GameInstancePlayGameFailed" xml:space="preserve"><value>无法启动游戏.
+
+{0}</value></data>
   <data name="ModuleInstallerDownloading" xml:space="preserve">
     <value>正在下载 "{0}"</value>
   </data>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -171,11 +171,6 @@ Versuche {2} aus {3} zu verschieben und CKAN neu zu starten.</value></data>
   </data>
   <data name="MainLaunch" xml:space="preserve"><value>Starten</value></data>
   <data name="MainLaunchDontShow" xml:space="preserve"><value>Für diese Mods und {0} {1} nicht mehr anzeigen</value></data>
-  <data name="MainLaunchFailed" xml:space="preserve">
-    <value>Das Spiel konnte nicht gestartet werden.
-
-{0}</value>
-  </data>
   <data name="MainModPack" xml:space="preserve"><value>CKAN Modpack (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Klartext (*.txt)</value></data>
   <data name="MainNotFound" xml:space="preserve"><value>Nicht gefunden.</value></data>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -285,11 +285,6 @@ Quelle version souhaitez-vous utiliser ?
   <data name="MainLaunch" xml:space="preserve">
     <value>Lancement</value>
   </data>
-  <data name="MainLaunchFailed" xml:space="preserve">
-    <value>Impossible de lancer le jeu.
-
-{0}</value>
-  </data>
   <data name="MainModPack" xml:space="preserve">
     <value>Modpack CKAN (*.ckan)</value>
   </data>

--- a/GUI/Properties/Resources.it-IT.resx
+++ b/GUI/Properties/Resources.it-IT.resx
@@ -271,11 +271,6 @@ Prova a spostare {2} da {3} e a riavviare CKAN.</value>
   <data name="MainLaunch" xml:space="preserve">
     <value>Avvia</value>
   </data>
-  <data name="MainLaunchFailed" xml:space="preserve">
-    <value>Impossibile avviare il gioco.
-
-{0}</value>
-  </data>
   <data name="MainModPack" xml:space="preserve">
     <value>Modpack CKAN (*.ckan)</value>
   </data>

--- a/GUI/Properties/Resources.ja-JP.resx
+++ b/GUI/Properties/Resources.ja-JP.resx
@@ -170,9 +170,6 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
 
 {0}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>起動</value></data>
-  <data name="MainLaunchFailed" xml:space="preserve"><value>起動に失敗しました。
-
-{0}</value></data>
   <data name="MainModPack" xml:space="preserve"><value>CKAN Modパック (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>平文 (*.txt)</value></data>
   <data name="MainMarkdown" xml:space="preserve"><value>Markdown (*.md)</value></data>

--- a/GUI/Properties/Resources.ko-KR.resx
+++ b/GUI/Properties/Resources.ko-KR.resx
@@ -171,9 +171,6 @@
 {0}</value></data>
   <data name="MainLaunchDontShow" xml:space="preserve"><value>이 모드들에 관해서는 다시 보여주지 않기 {0} {1}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>실행</value></data>
-  <data name="MainLaunchFailed" xml:space="preserve"><value>게임을 실행할 수 없었어요.
-
-{0}</value></data>
   <data name="MainModPack" xml:space="preserve"><value>CKAN 모드팩 (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>일반 텍스트(*.txt)</value></data>
   <data name="MainMarkdown" xml:space="preserve"><value>마크다운 (*.md)</value></data>

--- a/GUI/Properties/Resources.pl-PL.resx
+++ b/GUI/Properties/Resources.pl-PL.resx
@@ -271,11 +271,6 @@ Spróbuj przenieść {2} z {3} i uruchomić ponownie CKAN.</value>
   <data name="MainLaunch" xml:space="preserve">
     <value>Uruchom</value>
   </data>
-  <data name="MainLaunchFailed" xml:space="preserve">
-    <value>Nie można uruchomić gry.
-
-{0}</value>
-  </data>
   <data name="MainModPack" xml:space="preserve">
     <value>CKAN modpack (*.ckan)</value>
   </data>

--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -168,9 +168,6 @@ Tentando mover {2} de {3} e reiniciar o CKAN.</value></data>
 
 {0}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>Inicializar</value></data>
-  <data name="MainLaunchFailed" xml:space="preserve"><value>Não é possivel inicializar o jogo.
-
-{0}</value></data>
   <data name="MainModPack" xml:space="preserve"><value>Lista de mods do CKAN (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Texto plano (*.txt)</value></data>
   <data name="MainMarkdown" xml:space="preserve"><value>Markdown (*.md)</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -180,9 +180,6 @@ Which build would you like to use?
 {0}</value></data>
   <data name="MainLaunchDontShow" xml:space="preserve"><value>Don't show this again for these mods on {0} {1}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>Launch</value></data>
-  <data name="MainLaunchFailed" xml:space="preserve"><value>Couldn't start game.
-
-{0}</value></data>
   <data name="MainModPack" xml:space="preserve"><value>CKAN modpack (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Plain text (*.txt)</value></data>
   <data name="MainMarkdown" xml:space="preserve"><value>Markdown (*.md)</value></data>

--- a/GUI/Properties/Resources.ru-RU.resx
+++ b/GUI/Properties/Resources.ru-RU.resx
@@ -168,9 +168,6 @@
 
 {0}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>Запустить</value></data>
-  <data name="MainLaunchFailed" xml:space="preserve"><value>Не удалось запустить игру.
-
-{0}</value></data>
   <data name="MainModPack" xml:space="preserve"><value>Пакет модификаций CKAN (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Текст (*.txt)</value></data>
   <data name="MainMarkdown" xml:space="preserve"><value>Markdown (*.md)</value></data>

--- a/GUI/Properties/Resources.zh-CN.resx
+++ b/GUI/Properties/Resources.zh-CN.resx
@@ -169,9 +169,6 @@
 
 {0}</value></data>
   <data name="MainLaunch" xml:space="preserve"><value>启动</value></data>
-  <data name="MainLaunchFailed" xml:space="preserve"><value>无法启动游戏.
-
-{0}</value></data>
   <data name="MainModPack" xml:space="preserve"><value>CKAN modpack (*.ckan)</value></data>
   <data name="MainPlainText" xml:space="preserve"><value>Plain text (*.txt)</value></data>
   <data name="MainMarkdown" xml:space="preserve"><value>Markdown (*.md)</value></data>


### PR DESCRIPTION
## Motivation

Currently only GUI can launch the game. A user has requested to be able to do this for ConsoleUI as well.

## Changes

Now the ConsoleUI main menu has a new "Play game" submenu that lists all the default game command lines from #4010:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/9e94fdf9-9343-499f-bfd1-b40198cd3814)

The first item in this list shows a "Ctrl+P" hotkey that you can press outside of the menu to launch the game in one step.

Currently neither the specific command lines nor the one to use for the hotkey are configurable, in line with ConsoleUI generally being streamlined. If someone needs more complicated functionality, we can return to this.

Fixes #3534.
