### PR TITLE
ConsoleUI prompt to delete non-empty folders after uninstall

### DIFF
--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -43,7 +43,7 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("");
                 user.RaiseMessage(Properties.Resources.ListGameFound,
                                   instance.game.ShortName,
-                                  instance.GameDir().Replace('/', Path.DirectorySeparatorChar));
+                                  Platform.FormatPath(instance.GameDir()));
                 user.RaiseMessage("");
                 user.RaiseMessage(Properties.Resources.ListGameVersion, instance.game.ShortName, instance.Version());
                 user.RaiseMessage("");

--- a/ConsoleUI/AuthTokenListScreen.cs
+++ b/ConsoleUI/AuthTokenListScreen.cs
@@ -39,7 +39,7 @@ namespace CKAN.ConsoleUI {
                     },
                     new ConsoleListBoxColumn<string>() {
                         Header   = Properties.Resources.AuthTokenListTokenHeader,
-                        Width    = 50,
+                        Width    = null,
                         Renderer = (string s) => {
                             return ServiceLocator.Container.Resolve<IConfiguration>().TryGetAuthToken(s, out string token)
                                 ? token

--- a/ConsoleUI/CompatibleVersionDialog.cs
+++ b/ConsoleUI/CompatibleVersionDialog.cs
@@ -30,7 +30,7 @@ namespace CKAN.ConsoleUI {
                 new List<ConsoleListBoxColumn<GameVersion>>() {
                     new ConsoleListBoxColumn<GameVersion>() {
                         Header   = Properties.Resources.CompatibleVersionsListHeader,
-                        Width    = r - l - 5,
+                        Width    = null,
                         Renderer = v => v.ToString(),
                         Comparer = (v1, v2) => v1.CompareTo(v2)
                     }

--- a/ConsoleUI/DeleteDirectoriesScreen.cs
+++ b/ConsoleUI/DeleteDirectoriesScreen.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Linq;
+using System.IO;
+using System.Collections.Generic;
+
+using CKAN.ConsoleUI.Toolkit;
+
+namespace CKAN.ConsoleUI {
+    /// <summary>
+    /// Screen prompting user to delete game-created folders
+    /// </summary>
+    public class DeleteDirectoriesScreen : ConsoleScreen {
+
+        /// <summary>
+        /// Initialize the screen
+        /// </summary>
+        /// <param name="inst">Game instance</param>
+        /// <param name="possibleConfigOnlyDirs">Deletable stuff the user should see</param>
+        public DeleteDirectoriesScreen(GameInstance    inst,
+                                       HashSet<string> possibleConfigOnlyDirs)
+        {
+            instance = inst;
+            toDelete = possibleConfigOnlyDirs.ToHashSet();
+
+            var tb = new ConsoleTextBox(1, 2, -1, 4, false);
+            tb.AddLine(Properties.Resources.DeleteDirectoriesHelpLabel);
+            AddObject(tb);
+
+            var listWidth = (Console.WindowWidth - 4) / 2;
+
+            directories = new ConsoleListBox<string>(
+                1, 6, listWidth - 1, -2,
+                possibleConfigOnlyDirs.OrderBy(d => d).ToList(),
+                new List<ConsoleListBoxColumn<string>>() {
+                    new ConsoleListBoxColumn<string>() {
+                        Header   = "",
+                        Width    = 1,
+                        Renderer = s => toDelete.Contains(s) ? Symbols.checkmark : "",
+                    },
+                    new ConsoleListBoxColumn<string>() {
+                        Header   = Properties.Resources.DeleteDirectoriesFoldersHeader,
+                        Width    = null,
+                        // The data model holds absolute paths, but the UI shows relative
+                        Renderer = p => Platform.FormatPath(instance.ToRelativeGameDir(p)),
+                    },
+                },
+                0, -1);
+            directories.AddTip("D", Properties.Resources.DeleteDirectoriesDeleteDirTip,
+                               () => !toDelete.Contains(directories.Selection));
+            directories.AddBinding(Keys.D, (object sender, ConsoleTheme theme) => {
+                toDelete.Add(directories.Selection);
+                return true;
+            });
+            directories.AddTip("K", Properties.Resources.DeleteDirectoriesKeepDirTip,
+                               () => toDelete.Contains(directories.Selection));
+            directories.AddBinding(Keys.K, (object sender, ConsoleTheme theme) => {
+                toDelete.Remove(directories.Selection);
+                return true;
+            });
+            directories.SelectionChanged += PopulateFiles;
+            AddObject(directories);
+
+            files = new ConsoleListBox<string>(
+                listWidth + 1, 6, -1, -2,
+                new List<string>() { "" },
+                new List<ConsoleListBoxColumn<string>>() {
+                    new ConsoleListBoxColumn<string>() {
+                        Header   = Properties.Resources.DeleteDirectoriesFilesHeader,
+                        Width    = null,
+                        Renderer = p => Platform.FormatPath(CKANPathUtils.ToRelative(p, directories.Selection)),
+                    },
+                },
+                0, -1);
+            AddObject(files);
+
+            AddTip(Properties.Resources.Esc,
+                   Properties.Resources.DeleteDirectoriesCancelTip);
+            AddBinding(Keys.Escape,
+                       // Discard changes
+                       (object sender, ConsoleTheme theme) => false);
+
+            AddTip("F9", Properties.Resources.DeleteDirectoriesApplyTip);
+            AddBinding(Keys.F9, (object sender, ConsoleTheme theme) => {
+                foreach (var d in toDelete) {
+                    try {
+                        Directory.Delete(d, true);
+                    } catch {
+                    }
+                }
+                return false;
+            });
+
+            PopulateFiles();
+        }
+
+        private void PopulateFiles()
+        {
+            files.SetData(
+                Directory.EnumerateFileSystemEntries(directories.Selection,
+                                                     "*",
+                                                     SearchOption.AllDirectories)
+                         .OrderBy(f => f)
+                         .ToList(),
+                true);
+        }
+
+        /// <summary>
+        /// Put CKAN 1.25.5 in top left corner
+        /// </summary>
+        protected override string LeftHeader() => $"CKAN {Meta.GetVersion()}";
+
+        /// <summary>
+        /// Show the Delete Directories header
+        /// </summary>
+        protected override string CenterHeader() => Properties.Resources.DeleteDirectoriesHeader;
+
+        private readonly GameInstance           instance;
+        private readonly HashSet<string>        toDelete;
+        private readonly ConsoleListBox<string> directories;
+        private readonly ConsoleListBox<string> files;
+    }
+}

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -53,7 +53,7 @@ namespace CKAN.ConsoleUI {
                     },
                     new ConsoleListBoxColumn<Dependency>() {
                         Header   = Properties.Resources.RecommendationsNameHeader,
-                        Width    = 36,
+                        Width    = null,
                         Renderer = (Dependency d) => d.module.ToString()
                     },
                     new ConsoleListBoxColumn<Dependency>() {

--- a/ConsoleUI/GameInstanceEditScreen.cs
+++ b/ConsoleUI/GameInstanceEditScreen.cs
@@ -66,7 +66,7 @@ namespace CKAN.ConsoleUI {
                         }, new ConsoleListBoxColumn<Repository>() {
                             Header   = Properties.Resources.InstanceEditRepoURLHeader,
                             Renderer = r => r.uri.ToString(),
-                            Width    = 50
+                            Width    = null
                         }
                     },
                     1, 0, ListSortDirection.Ascending

--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -52,7 +52,7 @@ namespace CKAN.ConsoleUI {
                         Comparer = (a, b) => a.Version()?.CompareTo(b.Version() ?? GameVersion.Any) ?? 1
                     }, new ConsoleListBoxColumn<GameInstance>() {
                         Header   = Properties.Resources.InstanceListPathHeader,
-                        Width    = 70,
+                        Width    = null,
                         Renderer = k => k.GameDir()
                     }
                 },
@@ -229,7 +229,7 @@ namespace CKAN.ConsoleUI {
 
                     ConsoleMessageDialog errd = new ConsoleMessageDialog(
                         string.Format(Properties.Resources.InstanceListLoadingError,
-                                      Path.Combine(ksp.CkanDir(), "registry.json").Replace('/', Path.DirectorySeparatorChar),
+                                      Platform.FormatPath(Path.Combine(ksp.CkanDir(), "registry.json")),
                                       e.ToString()),
                         new List<string>() { Properties.Resources.OK }
                     );

--- a/ConsoleUI/InstallFiltersScreen.cs
+++ b/ConsoleUI/InstallFiltersScreen.cs
@@ -50,7 +50,7 @@ namespace CKAN.ConsoleUI {
                 new List<ConsoleListBoxColumn<string>>() {
                     new ConsoleListBoxColumn<string>() {
                         Header   = Properties.Resources.FiltersGlobalHeader,
-                        Width    = 40,
+                        Width    = null,
                         Renderer = f => f,
                     }
                 },
@@ -73,7 +73,7 @@ namespace CKAN.ConsoleUI {
                 new List<ConsoleListBoxColumn<string>>() {
                     new ConsoleListBoxColumn<string>() {
                         Header   = Properties.Resources.FiltersInstanceHeader,
-                        Width    = 40,
+                        Width    = null,
                         Renderer = f => f,
                     }
                 },

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -45,7 +45,7 @@ namespace CKAN.ConsoleUI {
                         Renderer = StatusSymbol
                     }, new ConsoleListBoxColumn<CkanModule>() {
                         Header   = Properties.Resources.ModListNameHeader,
-                        Width    = 44,
+                        Width    = null,
                         Renderer = m => m.name ?? ""
                     }, new ConsoleListBoxColumn<CkanModule>() {
                         Header   = Properties.Resources.ModListVersionHeader,
@@ -639,8 +639,11 @@ namespace CKAN.ConsoleUI {
 
         private bool ApplyChanges(ConsoleTheme theme)
         {
-            LaunchSubScreen(theme, new InstallScreen(manager, repoData, plan, debug));
-            RefreshList(theme);
+            if (plan.NonEmpty())
+            {
+                LaunchSubScreen(theme, new InstallScreen(manager, repoData, plan, debug));
+                RefreshList(theme);
+            }
             return true;
         }
 

--- a/ConsoleUI/Properties/Resources.fr-FR.resx
+++ b/ConsoleUI/Properties/Resources.fr-FR.resx
@@ -466,6 +466,12 @@ Veuillez désinstaller manuellement le mod auquel ce fichier appartient pour pou
   <data name="InstallModInstalled" xml:space="preserve">
     <value>{0} installé avec succès {1} {2}</value>
   </data>
+  <data name="DeleteDirectoriesHeader" xml:space="preserve"><value>Supprimer les Dossiers</value></data>
+  <data name="DeleteDirectoriesHelpLabel" xml:space="preserve"><value>Attention, il reste certains dossiers, parce que CKAN ne sait pas s'il peut supprimer les fichiers restants. Garder ces dossiers peut casser d'autres mods ! Si vous n'avez pas besoin de ces fichiers, il est recommandé de les supprimer.</value></data>
+  <data name="DeleteDirectoriesFoldersHeader" xml:space="preserve"><value>Dossiers</value></data>
+  <data name="DeleteDirectoriesFilesHeader" xml:space="preserve"><value>Contenu du Dossier</value></data>
+  <data name="DeleteDirectoriesCancelTip" xml:space="preserve"><value>Tout Garder</value></data>
+  <data name="DeleteDirectoriesApplyTip" xml:space="preserve"><value>Supprimer Coché</value></data>
   <data name="ModInfoTitle" xml:space="preserve">
     <value>Détails du Mod</value>
   </data>

--- a/ConsoleUI/Properties/Resources.it-IT.resx
+++ b/ConsoleUI/Properties/Resources.it-IT.resx
@@ -466,6 +466,13 @@ Modificaew i token di autenticazione adesso?</value>
   <data name="InstallModInstalled" xml:space="preserve">
     <value>{0} installato con successo {1} {2}</value>
   </data>
+  <data name="DeleteDirectoriesHeader" xml:space="preserve"><value>Elimina Cartelle</value></data>
+  <data name="DeleteDirectoriesHelpLabel" xml:space="preserve"><value>Le directory sottostanti sono dei residui rimasti a seguito della rimozione di alcune mod. Contengono file che non sono stati installati da CKAN (probabilmente generati da una mod o installati manualmente). CKAN non elimina automaticamente i file che non ha installato, ma puoi scegliere di rimuoverli se ti sembra sicuro farlo (scelta consigliata).
+Nota che se decidi di non rimuovere una cartella, ModuleManager potrebbe pensare erroneamente che il mod sia ancora installato.</value></data>
+  <data name="DeleteDirectoriesFoldersHeader" xml:space="preserve"><value>Cartelle</value></data>
+  <data name="DeleteDirectoriesFilesHeader" xml:space="preserve"><value>Contenuto Cartella</value></data>
+  <data name="DeleteDirectoriesCancelTip" xml:space="preserve"><value>Mantieni Tutte</value></data>
+  <data name="DeleteDirectoriesApplyTip" xml:space="preserve"><value>Elimina Selezionata</value></data>
   <data name="ModInfoTitle" xml:space="preserve">
     <value>Dettagli Mod</value>
   </data>

--- a/ConsoleUI/Properties/Resources.pl-PL.resx
+++ b/ConsoleUI/Properties/Resources.pl-PL.resx
@@ -466,6 +466,13 @@ Edytować tokeny uwierzytelniania?</value>
   <data name="InstallModInstalled" xml:space="preserve">
     <value>{0} pomyślnie zainstalowano {1} {2}</value>
   </data>
+  <data name="DeleteDirectoriesHeader" xml:space="preserve"><value>Usuń foldery</value></data>
+  <data name="DeleteDirectoriesHelpLabel" xml:space="preserve"><value>Poniższe foldery są pozostałościami po usuniętych modach. Zawierają pliki które nie były pobierane przez CKAN (prawdopodobnie wygenerowane przez moda bądź zainstalowane ręcznie). CKAN nie usuwa plików których nie instalował ale możesz sam je usunąć jeśli uważasz że to bezpieczne (zalecane)
+Uważaj bo jeśli nie usuniesz folderu, ModuleManager może myśleć że mod jest nadal zainstalowany.</value></data>
+  <data name="DeleteDirectoriesFoldersHeader" xml:space="preserve"><value>Foldery</value></data>
+  <data name="DeleteDirectoriesFilesHeader" xml:space="preserve"><value>Zawartość folderu</value></data>
+  <data name="DeleteDirectoriesCancelTip" xml:space="preserve"><value>Zachowaj wszystko</value></data>
+  <data name="DeleteDirectoriesApplyTip" xml:space="preserve"><value>Usuń zaznaczone</value></data>
   <data name="ModInfoTitle" xml:space="preserve">
     <value>Szczegóły modyfikacji</value>
   </data>

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -238,6 +238,14 @@ Edit authentication tokens now?</value></data>
 {1}</value></data>
   <data name="InstallNotInstalled" xml:space="preserve"><value>{0} is not installed, can't remove</value></data>
   <data name="InstallModInstalled" xml:space="preserve"><value>{0} Successfully installed {1} {2}</value></data>
+  <data name="DeleteDirectoriesHeader" xml:space="preserve"><value>Delete Directories</value></data>
+  <data name="DeleteDirectoriesHelpLabel" xml:space="preserve"><value>Warning, some folders have been left behind because CKAN does not know whether it is safe to delete their remaining files. Keeping these folders may break other mods! If you do not need these files, deleting them is recommended.</value></data>
+  <data name="DeleteDirectoriesFoldersHeader" xml:space="preserve"><value>Directories</value></data>
+  <data name="DeleteDirectoriesFilesHeader" xml:space="preserve"><value>Directory Contents</value></data>
+  <data name="DeleteDirectoriesDeleteDirTip" xml:space="preserve"><value>Delete folder</value></data>
+  <data name="DeleteDirectoriesKeepDirTip" xml:space="preserve"><value>Keep folder</value></data>
+  <data name="DeleteDirectoriesCancelTip" xml:space="preserve"><value>Keep all</value></data>
+  <data name="DeleteDirectoriesApplyTip" xml:space="preserve"><value>Delete checked</value></data>
   <data name="ModInfoTitle" xml:space="preserve"><value>Mod Details</value></data>
   <data name="ModInfoMenuTip" xml:space="preserve"><value>Links</value></data>
   <data name="ModInfoAuthors" xml:space="preserve"><value>By {0}</value></data>

--- a/ConsoleUI/Properties/Resources.ru-RU.resx
+++ b/ConsoleUI/Properties/Resources.ru-RU.resx
@@ -466,6 +466,13 @@
   <data name="InstallModInstalled" xml:space="preserve">
     <value>{0} Успешно установлен {1} {2}</value>
   </data>
+  <data name="DeleteDirectoriesHeader" xml:space="preserve"><value>Удаление папок</value></data>
+  <data name="DeleteDirectoriesHelpLabel" xml:space="preserve"><value>Следующие папки остались после удаления модификаций. Они содержат файлы, не установленные CKAN (сгенерированные модификациями или установленные вручную). CKAN не удаляет сторонние файлы автоматически, однако вы можете удалить их вручную, если это безопасно.
+Обратите внимание, что если папки не будут удалены, ModuleManager может неверно посчитать, что модификации установлены.</value></data>
+  <data name="DeleteDirectoriesFoldersHeader" xml:space="preserve"><value>Папки</value></data>
+  <data name="DeleteDirectoriesFilesHeader" xml:space="preserve"><value>Содержимое папок</value></data>
+  <data name="DeleteDirectoriesCancelTip" xml:space="preserve"><value>Оставить всё</value></data>
+  <data name="DeleteDirectoriesApplyTip" xml:space="preserve"><value>Удалить отмеченное</value></data>
   <data name="ModInfoTitle" xml:space="preserve">
     <value>О модификации</value>
   </data>

--- a/ConsoleUI/Toolkit/ConsoleChoiceDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleChoiceDialog.cs
@@ -51,7 +51,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                 new List<ConsoleListBoxColumn<ChoiceT>>() {
                     new ConsoleListBoxColumn<ChoiceT>() {
                         Header   = hdr,
-                        Width    = w - 6,
+                        Width    = null,
                         Renderer = renderer,
                         Comparer = comparer
                     }

--- a/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
@@ -64,7 +64,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                         Renderer = getRowSymbol
                     }, new ConsoleListBoxColumn<FileSystemInfo>() {
                         Header   = Properties.Resources.FileSelectNameHeader,
-                        Width    = 36,
+                        Width    = null,
                         Renderer = getRowName,
                         Comparer = compareNames
                     }, new ConsoleListBoxColumn<FileSystemInfo>() {

--- a/ConsoleUI/Toolkit/ConsoleTextBox.cs
+++ b/ConsoleUI/Toolkit/ConsoleTextBox.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace CKAN.ConsoleUI.Toolkit {
 
     /// <summary>
-    /// Object displaying a long screen in a big box
+    /// Object displaying a long string in a big box
     /// </summary>
     public class ConsoleTextBox : ScreenObject {
 

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -241,6 +241,13 @@ namespace CKAN.ConsoleUI.Toolkit {
         );
 
         /// <summary>
+        /// Representation of letter 'k' for key bindings
+        /// </summary>
+        public static readonly ConsoleKeyInfo K = new ConsoleKeyInfo(
+            'k', ConsoleKey.K, false, false, false
+        );
+
+        /// <summary>
         /// Representation of letter 'n' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo N = new ConsoleKeyInfo(

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -655,7 +655,8 @@ namespace CKAN
                 default:
                     // Prompt user to choose
                     int selection = user.RaiseSelectionDialog(
-                        $"Please select the game that is installed at {path.FullName.Replace('/', Path.DirectorySeparatorChar)}",
+                        string.Format(Properties.Resources.GameInstanceManagerSelectGamePrompt,
+                                      Platform.FormatPath(path.FullName)),
                         matchingGames.Select(g => g.ShortName).ToArray());
                     return selection >= 0 ? matchingGames[selection] : null;
             }

--- a/Core/Platform.cs
+++ b/Core/Platform.cs
@@ -69,6 +69,9 @@ namespace CKAN
             IsWindows ? StringComparison.OrdinalIgnoreCase
                       : StringComparison.Ordinal;
 
+        public static string FormatPath(string p)
+            => p.Replace('/', Path.DirectorySeparatorChar);
+
         public static bool IsAdministrator()
         {
             if (File.Exists("/.dockerenv"))

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -203,6 +203,7 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="GameInstanceToString" xml:space="preserve"><value>{0} Install: {1}</value></data>
   <data name="GameInstanceManagerPortable" xml:space="preserve"><value>portable</value></data>
   <data name="GameInstanceManagerAuto" xml:space="preserve"><value>Auto {0}</value></data>
+  <data name="GameInstanceManagerSelectGamePrompt" xml:space="preserve"><value>Please select the game that is installed at {0}</value></data>
   <data name="GameInstanceCloneInvalid" xml:space="preserve"><value>The specified instance is not a valid {0} instance</value></data>
   <data name="GameInstanceFakeBadVersion" xml:space="preserve"><value>The specified {0} version is not a known version: {1}</value></data>
   <data name="GameInstanceFakeNotEmpty" xml:space="preserve"><value>The specified folder already exists and is not empty</value></data>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -233,7 +233,7 @@ namespace CKAN
             : base(string.Format(Properties.Resources.KrakenFailedToDeleteFiles,
                                  identifier,
                                  string.Join(Environment.NewLine,
-                                             undeletableFiles.Select(f => f.Replace('/', Path.DirectorySeparatorChar)))))
+                                             undeletableFiles.Select(Platform.FormatPath))))
         {
             this.undeletableFiles = undeletableFiles;
         }
@@ -482,7 +482,7 @@ namespace CKAN
 
         public override string ToString()
             => string.Format(Properties.Resources.KrakenAlreadyRunning,
-                             lockfilePath.Replace('/', Path.DirectorySeparatorChar));
+                             Platform.FormatPath(lockfilePath));
     }
 
     /// <summary>

--- a/GUI/Controls/DeleteDirectories.cs
+++ b/GUI/Controls/DeleteDirectories.cs
@@ -34,7 +34,7 @@ namespace CKAN.GUI
             instance = ksp;
             var items = possibleConfigOnlyDirs
                 .OrderBy(d => d)
-                .Select(d => new ListViewItem(instance.ToRelativeGameDir(d).Replace('/', Path.DirectorySeparatorChar))
+                .Select(d => new ListViewItem(Platform.FormatPath(instance.ToRelativeGameDir(d)))
                     {
                         Tag     = d,
                         Checked = true
@@ -112,7 +112,7 @@ namespace CKAN.GUI
                             lvi.Tag as string,
                             "*",
                             SearchOption.AllDirectories)
-                        .Select(f => new ListViewItem(instance.ToRelativeGameDir(f).Replace('/', Path.DirectorySeparatorChar))))
+                        .Select(f => new ListViewItem(Platform.FormatPath(CKANPathUtils.ToRelative(f, lvi.Tag as string)))))
                     .ToArray());
             if (DirectoriesListView.SelectedItems.Count == 0)
             {

--- a/GUI/Controls/UnmanagedFiles.cs
+++ b/GUI/Controls/UnmanagedFiles.cs
@@ -56,7 +56,7 @@ namespace CKAN.GUI
             GameFolderTree.Nodes.Clear();
             var rootNode = GameFolderTree.Nodes.Add(
                 "",
-                inst.GameDir().Replace('/', Path.DirectorySeparatorChar),
+                Platform.FormatPath(inst.GameDir()),
                 "folder", "folder");
 
             UseWaitCursor = true;
@@ -167,7 +167,7 @@ namespace CKAN.GUI
             }
             else if (!string.IsNullOrEmpty(relPath) && Main.Instance.YesNoDialog(
                 string.Format(Properties.Resources.DeleteUnmanagedFileConfirmation,
-                    relPath.Replace('/', Path.DirectorySeparatorChar)),
+                              Platform.FormatPath(relPath)),
                 Properties.Resources.DeleteUnmanagedFileDelete,
                 Properties.Resources.DeleteUnmanagedFileCancel))
             {

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -56,7 +56,7 @@ namespace CKAN.GUI
             string sel = comboBoxKnownInstance.SelectedItem as string;
             textBoxClonePath.Text = string.IsNullOrEmpty(sel)
                 ? ""
-                : manager.Instances[sel].GameDir().Replace('/', Path.DirectorySeparatorChar);
+                : Platform.FormatPath(manager.Instances[sel].GameDir());
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace CKAN.GUI
             try
             {
                 if (!manager.Instances.TryGetValue(comboBoxKnownInstance.SelectedItem as string, out GameInstance instanceToClone)
-                    || existingPath != instanceToClone.GameDir().Replace('/', Path.DirectorySeparatorChar))
+                    || existingPath != Platform.FormatPath(instanceToClone.GameDir()))
                 {
                     IGame sourceGame = manager.DetermineGame(new DirectoryInfo(existingPath), user);
                     if (sourceGame == null)
@@ -154,13 +154,15 @@ namespace CKAN.GUI
             }
             catch (NotKSPDirKraken kraken)
             {
-                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogInstanceNotValid, kraken.path.Replace('/', Path.DirectorySeparatorChar)));
+                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogInstanceNotValid,
+                                Platform.FormatPath(kraken.path)));
                 reactivateDialog();
                 return;
             }
             catch (PathErrorKraken kraken)
             {
-                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogDestinationNotEmpty, kraken.path.Replace('/', Path.DirectorySeparatorChar)));
+                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogDestinationNotEmpty,
+                                Platform.FormatPath(kraken.path)));
                 reactivateDialog();
                 return;
             }

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.cs
@@ -38,7 +38,7 @@ namespace CKAN.GUI
             var compatibleVersions = inst.GetCompatibleVersions();
 
             GameVersionLabel.Text  = inst.Version()?.ToString() ?? Properties.Resources.CompatibleGameVersionsDialogNone;
-            GameLocationLabel.Text = inst.GameDir().Replace('/', Path.DirectorySeparatorChar);
+            GameLocationLabel.Text = Platform.FormatPath(inst.GameDir());
             var knownVersions = inst.game.KnownVersions;
             var majorVersionsList = CreateMajorVersionsList(knownVersions);
             var compatibleVersionsLeftOthers = compatibleVersions.Except(knownVersions)

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -136,7 +136,7 @@ namespace CKAN.GUI
                 list.Add(instance.playTime?.ToString() ?? "");
             }
 
-            list.Add(instance.GameDir().Replace('/', Path.DirectorySeparatorChar));
+            list.Add(Platform.FormatPath(instance.GameDir()));
             return list.ToArray();
         }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -393,7 +393,7 @@ namespace CKAN.GUI
 
             Util.Invoke(this, () =>
             {
-                Text = $"CKAN {Meta.GetVersion()} - {CurrentInstance.game.ShortName} {CurrentInstance.Version()}    --    {CurrentInstance.GameDir().Replace('/', Path.DirectorySeparatorChar)}";
+                Text = $"CKAN {Meta.GetVersion()} - {CurrentInstance.game.ShortName} {CurrentInstance.Version()}    --    {Platform.FormatPath(CurrentInstance.GameDir())}";
                 UpdateStatusBar();
             });
 

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -334,7 +334,7 @@ namespace CKAN.GUI
                                      .Any(relF => registry.FileOwner(relF) != null));
                 if (possibleConfigOnlyDirs.Count > 0)
                 {
-                    currentUser.RaiseMessage("");
+                    Util.Invoke(this, () => StatusLabel.ToolTipText = StatusLabel.Text = "");
                     tabController.ShowTab("DeleteDirectoriesTabPage", 4);
                     tabController.SetTabLock(true);
 


### PR DESCRIPTION
## Motivation

#2962 added a prompt in GUI to ask the user whether to delete folders that contain only files not created by CKAN after uninstalling a mod, because such folders can make ModuleManager `:NEEDS[]` clauses behave as if a mod is installed when it's not.

Currently this isn't available in ConsoleUI, even though the concern about leftover folders and ModuleManager still applies.

## Changes

Now ConsoleUI presents a screen after uninstallation to ask about these directories as well, if any are found:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/c4eb42f0-9d0f-47a2-b1bc-03995896e916)

(The `GameData/Squad` and `GameData/SquadExpansion` folders would never be included here in practice. I was just using them for testing.)

Fixes #3484.
