### PR TITLE
Treat mods with missing files as upgradeable/reinstallable

### DIFF
--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -54,7 +54,7 @@ namespace CKAN.CmdLine
             {
                 var installed = new SortedDictionary<string, ModuleVersion>(registry.Installed());
                 var upgradeable = registry
-                                  .CheckUpgradeable(instance.VersionCriteria(), new HashSet<string>())
+                                  .CheckUpgradeable(instance, new HashSet<string>())
                                   [true]
                                   .Select(m => m.identifier)
                                   .ToHashSet();

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -121,7 +121,7 @@ namespace CKAN.CmdLine
                 if (options.upgrade_all)
                 {
                     var to_upgrade = registry
-                                     .CheckUpgradeable(instance.VersionCriteria(), new HashSet<string>())
+                                     .CheckUpgradeable(instance, new HashSet<string>())
                                      [true];
                     if (to_upgrade.Count == 0)
                     {
@@ -225,7 +225,7 @@ namespace CKAN.CmdLine
                                                     .ToList();
                     // Modules allowed by THOSE modules' relationships
                     var upgradeable = registry
-                                      .CheckUpgradeable(crit, heldIdents, limiters)
+                                      .CheckUpgradeable(instance, heldIdents, limiters)
                                       [true]
                                       .ToDictionary(m => m.identifier,
                                                     m => m);

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -88,7 +88,7 @@ namespace CKAN.ConsoleUI {
                         }
                         if (plan.Upgrade.Count > 0) {
                             var upgGroups = registry
-                                            .CheckUpgradeable(manager.CurrentInstance.VersionCriteria(),
+                                            .CheckUpgradeable(manager.CurrentInstance,
                                                               // Hold identifiers not chosen for upgrading
                                                               registry.Installed(false)
                                                                       .Keys

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -267,7 +267,7 @@ namespace CKAN.ConsoleUI {
                 int nameW = midL - 2 - lblW - 2 - 1;
                 int depsH = (h - 2) * numDeps / (numDeps + numConfs);
                 var upgradeableGroups = registry
-                                        .CheckUpgradeable(manager.CurrentInstance.VersionCriteria(),
+                                        .CheckUpgradeable(manager.CurrentInstance,
                                                           new HashSet<string>());
 
                 AddObject(new ConsoleFrame(

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -607,7 +607,7 @@ namespace CKAN.ConsoleUI {
                     }
                 }
                 upgradeableGroups = registry
-                                    .CheckUpgradeable(crit, new HashSet<string>());
+                                    .CheckUpgradeable(manager.CurrentInstance, new HashSet<string>());
             }
             return allMods;
         }

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
 using System.Runtime.Serialization;
 
 using Newtonsoft.Json;
@@ -12,51 +11,9 @@ namespace CKAN
     [JsonObject(MemberSerialization.OptIn)]
     public class InstalledModuleFile
     {
-
-        // TODO: This class should also record file paths as well.
-        // It's just sha1 now for registry compatibility.
-
-        [JsonProperty("sha1_sum", NullValueHandling = NullValueHandling.Ignore)]
-        private readonly string sha1_sum;
-
-        public string Sha1 => sha1_sum;
-
-        public InstalledModuleFile(string path, GameInstance ksp)
-        {
-            string absolute_path = ksp.ToAbsoluteGameDir(path);
-            // TODO: What is the net performance cost of calculating this? Big files are not quick to hash!
-            sha1_sum = Sha1Sum(absolute_path);
-        }
-
-        // We need this because otherwise JSON.net tries to pass in
-        // our sha1's as paths, and things go wrong.
         [JsonConstructor]
-        private InstalledModuleFile()
+        public InstalledModuleFile()
         {
-        }
-
-        /// <summary>
-        /// Returns the sha1 sum of the given filename.
-        /// Returns null if passed a directory.
-        /// Throws an exception on failure to access the file.
-        /// </summary>
-        private static string Sha1Sum(string path)
-        {
-            if (Directory.Exists(path))
-            {
-                return null;
-            }
-
-            SHA1 hasher = SHA1.Create();
-
-            // Even if we throw an exception, the using block here makes sure
-            // we close our file.
-            using (var fh = File.OpenRead(path))
-            {
-                string sha1 = BitConverter.ToString(hasher.ComputeHash(fh));
-                fh.Close();
-                return sha1;
-            }
         }
     }
 
@@ -127,7 +84,7 @@ namespace CKAN
                     }
 
                     // IMF needs a KSP object so it can compute the SHA1.
-                    installed_files[file] = new InstalledModuleFile(file, ksp);
+                    installed_files[file] = new InstalledModuleFile();
                 }
             }
         }

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -40,7 +40,6 @@ namespace CKAN.GUI
                 changes?.Select(ch => new ChangesetRow(ch, AlertLabels, conflicts))
                         .ToList()
                        ?? new List<ChangesetRow>());
-            ChangesGrid.AutoResizeColumns();
         }
 
         public CkanModule SelectedItem => SelectedRow?.Change.Mod;
@@ -70,6 +69,7 @@ namespace CKAN.GUI
                     }
                 }
             }
+            ChangesGrid.AutoResizeColumns();
         }
 
         private void ChangesGrid_CellClick(object sender, DataGridViewCellEventArgs e)
@@ -101,8 +101,13 @@ namespace CKAN.GUI
 
         private void ChangesGrid_SelectionChanged(object sender, EventArgs e)
         {
+            if (ChangesGrid.SelectedRows.Count > 0 && !Visible)
+            {
+                // Suppress selection while inactive
+                ChangesGrid.ClearSelection();
+            }
             // Don't pop up mod info when they click the X icons
-            if (ChangesGrid.CurrentCell?.OwningColumn is DataGridViewTextBoxColumn)
+            else if (ChangesGrid.CurrentCell?.OwningColumn is DataGridViewTextBoxColumn)
             {
                 OnSelectedItemsChanged?.Invoke(SelectedRow?.Change.Mod);
             }

--- a/GUI/Controls/ChooseRecommendedMods.Designer.cs
+++ b/GUI/Controls/ChooseRecommendedMods.Designer.cs
@@ -58,7 +58,6 @@ namespace CKAN.GUI
             this.Toolbar.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.Toolbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.UncheckAllButton,
-            this.AlwaysUncheckAllButton,
             this.UncheckCheckSeparator,
             this.CheckAllButton,
             this.CheckRecommendationsButton});

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -889,6 +889,13 @@ namespace CKAN.GUI
                                             ? gmod.SelectedMod
                                             : gmod.LatestAvailableMod
                                         : gmod.InstalledMod?.Module;
+
+                                    if (nowChecked && gmod.SelectedMod == gmod.LatestAvailableMod)
+                                    {
+                                        // Reinstall, force update without change
+                                        UpdateChangeSetAndConflicts(currentInstance,
+                                            RegistryManager.Instance(currentInstance, repoData).registry);
+                                    }
                                     break;
                                 case "AutoInstalled":
                                     gmod.SetAutoInstallChecked(row, AutoInstalled);
@@ -1837,7 +1844,7 @@ namespace CKAN.GUI
             => mainModList.ComputeUserChangeSet(
                   RegistryManager.Instance(currentInstance, repoData).registry,
                   currentInstance.VersionCriteria(),
-                  ReplaceCol);
+                  UpdateCol, ReplaceCol);
 
         [ForbidGUICalls]
         public void UpdateChangeSetAndConflicts(GameInstance inst, IRegistryQuerier registry)
@@ -1852,7 +1859,7 @@ namespace CKAN.GUI
             Dictionary<GUIMod, string> new_conflicts = null;
 
             var gameVersion = inst.VersionCriteria();
-            var user_change_set = mainModList.ComputeUserChangeSet(registry, gameVersion, ReplaceCol);
+            var user_change_set = mainModList.ComputeUserChangeSet(registry, gameVersion, UpdateCol, ReplaceCol);
             try
             {
                 // Set the target versions of upgrading mods based on what's actually allowed

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -885,7 +885,8 @@ namespace CKAN.GUI
                                 case "UpdateCol":
                                     gmod.SelectedMod = nowChecked
                                         ? gmod.SelectedMod != null
-                                          && gmod.InstalledMod.Module.version < gmod.SelectedMod.version
+                                          && (gmod.InstalledMod == null
+                                              || gmod.InstalledMod.Module.version < gmod.SelectedMod.version)
                                             ? gmod.SelectedMod
                                             : gmod.LatestAvailableMod
                                         : gmod.InstalledMod?.Module;
@@ -929,9 +930,9 @@ namespace CKAN.GUI
                             }
                             if (row.Cells[UpdateCol.Index] is DataGridViewCheckBoxCell upgCell)
                             {
-                                bool newVal = gmod.InstalledMod != null
-                                              && gmod.SelectedMod != null
-                                              && gmod.InstalledMod.Module.version < gmod.SelectedMod.version;
+                                bool newVal = gmod.SelectedMod != null
+                                              && (gmod.InstalledMod == null
+                                                  || gmod.InstalledMod.Module.version < gmod.SelectedMod.version);
                                 if ((bool)upgCell.Value != newVal)
                                 {
                                     upgCell.Value = newVal;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -334,16 +334,16 @@ namespace CKAN.GUI
             {
                 mlbl.Remove(currentInstance.game, module.Identifier);
             }
-            if (mlbl.HoldVersion)
-            {
-                UpdateAllToolButton.Enabled = mainModList.Modules.Any(mod =>
-                    mod.HasUpdate && !Main.Instance.LabelsHeld(mod.Identifier));
-            }
             var registry = RegistryManager.Instance(currentInstance, repoData).registry;
             mainModList.ReapplyLabels(module, Conflicts?.ContainsKey(module) ?? false,
                                       currentInstance.Name, currentInstance.game, registry);
             mainModList.ModuleLabels.Save(ModuleLabelList.DefaultPath);
             UpdateHiddenTagsAndLabels();
+            if (mlbl.HoldVersion)
+            {
+                UpdateCol.Visible = UpdateAllToolButton.Enabled =
+                    mainModList.ResetHasUpdate(currentInstance, registry, ChangeSet, ModGrid.Rows);
+            }
         }
 
         private void editLabelsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -359,6 +359,8 @@ namespace CKAN.GUI
                                           currentInstance.Name, currentInstance.game, registry);
             }
             UpdateHiddenTagsAndLabels();
+            UpdateCol.Visible = UpdateAllToolButton.Enabled =
+                mainModList.ResetHasUpdate(currentInstance, registry, ChangeSet, ModGrid.Rows);
         }
 
         #endregion
@@ -1433,7 +1435,7 @@ namespace CKAN.GUI
             // After the update / replacement, they are hidden again.
             Util.Invoke(ModGrid, () =>
             {
-                UpdateCol.Visible  = mainModList.Modules.Any(mod => mod.HasUpdate);
+                UpdateCol.Visible  = has_unheld_updates;
                 ReplaceCol.Visible = mainModList.Modules.Any(mod => mod.IsInstalled && mod.HasReplacement);
             });
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1857,6 +1857,7 @@ namespace CKAN.GUI
             => mainModList.ComputeUserChangeSet(
                   RegistryManager.Instance(currentInstance, repoData).registry,
                   currentInstance.VersionCriteria(),
+                  currentInstance,
                   UpdateCol, ReplaceCol);
 
         [ForbidGUICalls]
@@ -1872,7 +1873,7 @@ namespace CKAN.GUI
             Dictionary<GUIMod, string> new_conflicts = null;
 
             var gameVersion = inst.VersionCriteria();
-            var user_change_set = mainModList.ComputeUserChangeSet(registry, gameVersion, UpdateCol, ReplaceCol);
+            var user_change_set = mainModList.ComputeUserChangeSet(registry, gameVersion, inst, UpdateCol, ReplaceCol);
             try
             {
                 // Set the target versions of upgrading mods based on what's actually allowed

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -980,6 +980,12 @@ namespace CKAN.GUI
                                 checkCell.Value = false;
                             }
                             break;
+                        case GUIModChangeType.Update:
+                            if (row.Cells[UpdateCol.Index] is DataGridViewCheckBoxCell updateCell)
+                            {
+                                updateCell.Value = false;
+                            }
+                            break;
                     }
                 }
                 UpdateChangeSetAndConflicts(
@@ -1043,6 +1049,10 @@ namespace CKAN.GUI
                     if (row.Cells[ReplaceCol.Index] is DataGridViewCheckBoxCell checkCell)
                     {
                         checkCell.Value = false;
+                    }
+                    if (row.Cells[UpdateCol.Index] is DataGridViewCheckBoxCell updateCell)
+                    {
+                        updateCell.Value = false;
                     }
                 }
                 // Marking a mod as AutoInstalled can immediately queue it for removal if there is no dependent mod.

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -85,7 +85,7 @@ namespace CKAN.GUI
             this.InstallationHistory = new CKAN.GUI.InstallationHistory();
             this.ChooseProvidedModsTabPage = new System.Windows.Forms.TabPage();
             this.ChooseProvidedMods = new CKAN.GUI.ChooseProvidedMods();
-            this.minimizeNotifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
+            this.minimizeNotifyIcon = new System.Windows.Forms.NotifyIcon();
             this.minimizedContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.updatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -547,6 +547,10 @@ namespace CKAN.GUI
                 }
             }
 
+            // Remove the tray icon
+            minimizeNotifyIcon.Visible = false;
+            minimizeNotifyIcon.Dispose();
+
             base.OnFormClosing(e);
         }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -304,16 +304,16 @@ namespace CKAN.GUI
         /// <returns>The CkanModule associated with this GUIMod or null if there is none</returns>
         public CkanModule ToModule() => Mod;
 
-        public IEnumerable<ModChange> GetModChanges(bool replaceChecked)
+        public IEnumerable<ModChange> GetModChanges(bool upgradeChecked, bool replaceChecked)
         {
             if (replaceChecked)
             {
                 yield return new ModChange(Mod, GUIModChangeType.Replace);
             }
             else if (!(SelectedMod?.Equals(InstalledMod?.Module)
-                  ?? InstalledMod?.Module.Equals(SelectedMod)
-                  // Both null
-                  ?? true))
+                       ?? InstalledMod?.Module?.Equals(SelectedMod)
+                       // Both null
+                       ?? true))
             {
                 if (InstalledMod != null && SelectedMod == LatestAvailableMod)
                 {
@@ -333,6 +333,14 @@ namespace CKAN.GUI
                         yield return new ModChange(SelectedMod, GUIModChangeType.Install);
                     }
                 }
+            }
+            else if (upgradeChecked)
+            {
+                // Reinstall
+                yield return new ModUpgrade(Mod,
+                                            GUIModChangeType.Update,
+                                            SelectedMod,
+                                            false);
             }
         }
 

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -558,14 +558,20 @@ namespace CKAN.GUI
                                          ModuleLabels.HeldIdentifiers(inst)
                                                      .ToHashSet())
                        .SelectMany(kvp => kvp.Value
-                                             .Where(mod => !registry.IsAutodetected(mod.identifier))
-                                             .Select(mod => new GUIMod(registry.InstalledModule(mod.identifier),
-                                                                       repoData, registry,
-                                                                       versionCriteria, null,
-                                                                       hideEpochs, hideV)
-                                                            {
-                                                                HasUpdate = kvp.Key,
-                                                            }))
+                                             .Select(mod => registry.IsAutodetected(mod.identifier)
+                                                            ? new GUIMod(mod, repoData, registry,
+                                                                         versionCriteria, null,
+                                                                         hideEpochs, hideV)
+                                                              {
+                                                                  HasUpdate = kvp.Key,
+                                                              }
+                                                            : new GUIMod(registry.InstalledModule(mod.identifier),
+                                                                         repoData, registry,
+                                                                         versionCriteria, null,
+                                                                         hideEpochs, hideV)
+                                                              {
+                                                                  HasUpdate = kvp.Key,
+                                                              }))
                        .Concat(registry.CompatibleModules(versionCriteria)
                                        .Where(m => !installedIdents.Contains(m.identifier))
                                        .AsParallel()

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -435,6 +435,7 @@ namespace CKAN.GUI
 
         public HashSet<ModChange> ComputeUserChangeSet(IRegistryQuerier    registry,
                                                        GameVersionCriteria crit,
+                                                       GameInstance        instance,
                                                        DataGridViewColumn  upgradeCol,
                                                        DataGridViewColumn  replaceCol)
         {
@@ -454,7 +455,7 @@ namespace CKAN.GUI
                                          .ToArray();
                 if (upgrades.Length > 0)
                 {
-                    var upgradeable = registry.CheckUpgradeable(crit,
+                    var upgradeable = registry.CheckUpgradeable(instance,
                                                                 // Hold identifiers not chosen for upgrading
                                                                 registry.Installed(false)
                                                                         .Select(kvp => kvp.Key)
@@ -503,7 +504,7 @@ namespace CKAN.GUI
                                    List<ModChange>           ChangeSet,
                                    DataGridViewRowCollection rows)
         {
-            var upgGroups = registry.CheckUpgradeable(inst.VersionCriteria(),
+            var upgGroups = registry.CheckUpgradeable(inst,
                                                       ModuleLabels.HeldIdentifiers(inst)
                                                                   .ToHashSet());
             var dlls = registry.InstalledDlls.ToList();
@@ -571,7 +572,7 @@ namespace CKAN.GUI
                                                HashSet<string>       installedIdents,
                                                bool                  hideEpochs,
                                                bool                  hideV)
-            => registry.CheckUpgradeable(versionCriteria,
+            => registry.CheckUpgradeable(inst,
                                          ModuleLabels.HeldIdentifiers(inst)
                                                      .ToHashSet())
                        .SelectMany(kvp => kvp.Value

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -256,6 +256,7 @@ namespace Tests.Core.Registry
                 var mod = registry.GetModuleByVersion("AutoDetectedMod", "1.0");
 
                 GameInstance gameInst = gameInstWrapper.KSP;
+                gameInst.SetCompatibleVersions(new List<GameVersion> { mod.ksp_version });
                 registry.SetDlls(new Dictionary<string, string>()
                 {
                     {
@@ -264,10 +265,9 @@ namespace Tests.Core.Registry
                                                                 "GameData", $"{mod.identifier}.dll"))
                     }
                 });
-                GameVersionCriteria crit = new GameVersionCriteria(mod.ksp_version);
 
                 // Act
-                bool has = registry.HasUpdate(mod.identifier, crit, out _);
+                bool has = registry.HasUpdate(mod.identifier, gameInst, out _);
 
                 // Assert
                 Assert.IsTrue(has, "Can't upgrade manually installed DLL");
@@ -320,7 +320,7 @@ namespace Tests.Core.Registry
                 GameVersionCriteria crit = new GameVersionCriteria(olderDepMod.ksp_version);
 
                 // Act
-                bool has = registry.HasUpdate(olderDepMod.identifier, crit, out _,
+                bool has = registry.HasUpdate(olderDepMod.identifier, gameInst, out _,
                                               registry.InstalledModules
                                                       .Select(im => im.Module)
                                                       .ToList());

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -64,7 +64,7 @@ namespace Tests.GUI
                     var registry = new Registry(repoData.Manager, repo.repo);
 
                     registry.RegisterModule(old_version, new List<string>(), null, false);
-                    var upgradeableGroups = registry.CheckUpgradeable(tidy.KSP.VersionCriteria(),
+                    var upgradeableGroups = registry.CheckUpgradeable(tidy.KSP,
                                                                       new HashSet<string>());
 
                     var mod = new GUIMod(old_version, repoData.Manager, registry, tidy.KSP.VersionCriteria(),

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -27,7 +27,7 @@ namespace Tests.GUI
         public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList();
-            Assert.That(item.ComputeUserChangeSet(null, null, null), Is.Empty);
+            Assert.That(item.ComputeUserChangeSet(null, null, null, null), Is.Empty);
         }
 
         [Test]
@@ -210,7 +210,7 @@ namespace Tests.GUI
                 {
                     // Install the "other" module
                     installer.InstallList(
-                        modList.ComputeUserChangeSet(null, null, null).Select(change => change.Mod).ToList(),
+                        modList.ComputeUserChangeSet(null, null, null, null).Select(change => change.Mod).ToList(),
                         new RelationshipResolverOptions(),
                         registryManager,
                         ref possibleConfigOnlyDirs,

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -27,7 +27,7 @@ namespace Tests.GUI
         public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList();
-            Assert.That(item.ComputeUserChangeSet(null, null, null, null), Is.Empty);
+            Assert.That(item.ComputeUserChangeSet(null, null, null, null, null), Is.Empty);
         }
 
         [Test]
@@ -210,7 +210,7 @@ namespace Tests.GUI
                 {
                     // Install the "other" module
                     installer.InstallList(
-                        modList.ComputeUserChangeSet(null, null, null, null).Select(change => change.Mod).ToList(),
+                        modList.ComputeUserChangeSet(null, null, null, null, null).Select(change => change.Mod).ToList(),
                         new RelationshipResolverOptions(),
                         registryManager,
                         ref possibleConfigOnlyDirs,

--- a/build.cake
+++ b/build.cake
@@ -227,6 +227,7 @@ Task("Build")
             // Use Mono to build for net48 since dotnet can't use WinForms on Linux
             MSBuild(solution,
                     settings => settings.SetConfiguration(configuration)
+                                        .SetMaxCpuCount(0)
                                         .WithProperty("TargetFramework",
                                                       buildNetFramework));
             // Use dotnet to build the stuff Mono can't build


### PR DESCRIPTION
## Motivation

Users supposedly sometimes install a mod in CKAN, then delete the files manually in GameData, then install depending mods in CKAN and complain that they don't work. We need to detect missing files and guide the user into restoring them.

It was suggested to create some kind of "clean-up" button, but I don't think users who expect to be able to delete CKAN-installed mods manually without causing problems would know to use something like that. We need something automatic and pro-active.

## Problems

While working on the above, I discovered that (as expected) the major data model refactoring in #4023 broke a lot of things:

- Checking checkboxes on Mono wasn't updating the changeset or enabling the Apply button
- The changeset always displays mod info
- Metadata changes were no longer causing the upgrade checkbox to appear, and/or if you checked it, the changeset wasn't updated and the Apply button wasn't enabled
- Manually installed mods no longer appeared as upgradeable
- If you add an upgradeable mod to a Held label, its upgrade checkbox remains, the upgrade column remains visible, and the Update all button stays enabled
- If your changeset included reinstall actions, the X icon from #4033 to remove these steps from your changeset appeared but didn't work

## Causes

- I think we were trying to perform GUI updates in a background thread via `guiModule_PropertyChanged`, and `ModGrid.RefreshEdit` was freezing on Mono.
- The new grid always auto-selects its first row, which is treated as if the user clicked on it to see mod info
- As of the transition to tracking the user's changes solely via `GUIMod.SelectedMod`, there's no longer a way to represent reinstallation in `GUIMod`.
- `ModList.GetGUIMods` left manually installed mods to be handled by the `registry.CompatibleModules` check, which has no mechanism for setting `GUIMod.HasUpdate`, which drives the checkbox
- I wrote `ModList.ResetHasUpdate` to re-run the `CheckUpgradeable` logic and update the UI appropriately, but I think the _usage_ of it got lost in the shuffle of rebasing and conflict resolution.
- The logic for removing things from the changeset had special handling for the replace checkbox but not the upgrade checkbox

## Changes

- Now if you install a mod with CKAN and delete any of its files, the upgrade checkbox will appear for that mod, and checking it will add a reinstall action to the changeset for that mod, similar to how changed metadata is handled after #3828.
  Fixes #4017.
- Now `guiModule_PropertyChanged` uses `Util.Invoke` to access GUI properties and only calls `ModGrid.RefreshEdit` on Windows. Some adjustments are also made to `ModGrid_CellValueChanged` to address a problem where multiple checkboxes on the Version tab could become checked if you tried to install historical versions.
- Now we try to clear the selection more aggressively to suit Mono's quirks. It's not quite working 100%, but it's closer and sometimes seems to work.
- Now the state of the upgrade checkbox is passed through to `GUIMod.GetModChanges`, which uses it to add reinstallation actions to the changeset as appropriate
- Upgradeable manually installed mods are now handled in the `registry.CheckUpgradeable` section and have `GUIMod.HasUpdate` set appropriately. Some adjustments are also made to ensure the checkbox actually works when checked.
- Now `ModList.ResetHasUpdate` is called when there are changes related to Held labels, which make the checkboxes appear and disappear appropriately, show/hide the upgrade column, and enable/disable the Upgrade all button.
- Now reinstalls can be removed from the changeset as expected

Other small stuff:

- `./build` on Linux was emitting a message about using the `-m` parameter to MSBuild to enable parallelization. Now we do that.
- GUI on Linux was throwing an exception at exit related to failure to dispose the tray icon due to closed file handles or somesuch.
  Now it's fixed by hiding and disposing the tray icon ourselves in the main form's `OnClosing` rather than letting `this.components` handle it for us.
- When we install files, we calculate the SHA1sum of each one and save it to the registry and then never do anything with it (this goes back to the earliest commits that I was able to find). This is colossally wasteful of CPU time, since some files we install are quite large and therefore costly to hash.
  Now this is removed. We can put it back if we decide to add actual functionality that needs it.
- The "always uncheck all" button from #4025 was being added redundantly to both the "uncheck all" button's dropdown and the main toolbar.
  Now it's only in the dropdown.
