### PR TITLE
Omit duplicate inflation warnings in queue

### DIFF
--- a/Netkan/QueueAppender.cs
+++ b/Netkan/QueueAppender.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+
 using log4net.Core;
 using log4net.Appender;
 
@@ -10,9 +11,13 @@ namespace CKAN.NetKAN
 
         protected override void Append(LoggingEvent evt)
         {
-            Warnings.Add(evt.RenderedMessage);
+            // Skip duplicate messages for better multi-kref handling
+            if (!Warnings.Contains(evt.RenderedMessage))
+            {
+                Warnings.Add(evt.RenderedMessage);
+            }
         }
 
-        public List<string> Warnings = new List<string>();
+        public readonly List<string> Warnings = new List<string>();
     }
 }


### PR DESCRIPTION
## Motivation

Currently, inflation warnings for multi-hosted modules are duplicated.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/c550cdfe-2348-499c-a128-54743e44e27f)

## Changes

Now we filter duplicates, so each message will only appear once. This should produce a nice cascade of de-duplication in Discord and the status page.
