### PR TITLE
Tolerate null repo URLs

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -555,7 +555,7 @@ namespace CKAN
         {
             using (SHA1 sha1 = SHA1.Create())
             {
-                byte[] hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(url.ToString()));
+                byte[] hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(url?.ToString() ?? ""));
 
                 return BitConverter.ToString(hash).Replace("-", "").Substring(0, 8);
             }

--- a/Core/Repositories/Repository.cs
+++ b/Core/Repositories/Repository.cs
@@ -49,7 +49,7 @@ namespace CKAN
             => other != null && uri == other.uri;
 
         public override int GetHashCode()
-            => uri.GetHashCode();
+            => uri?.GetHashCode() ?? 0;
 
         public override string ToString()
             => string.Format("{0} ({1}, {2})", name, priority, uri);

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -140,7 +140,8 @@ namespace CKAN
 
             // Check if any ETags have changed, quit if not
             user.RaiseProgress(Properties.Resources.NetRepoCheckingForUpdates, 0);
-            var toUpdate = repos.DefaultIfEmpty(new Repository("default", game.DefaultRepositoryURL))
+            var toUpdate = repos.DefaultIfEmpty(new Repository($"{game.ShortName}-{Repository.default_ckan_repo_name}",
+                                                               game.DefaultRepositoryURL))
                                 .DistinctBy(r => r.uri)
                                 .Where(r => r.uri != null
                                             && (r.uri.IsFile

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -91,7 +91,7 @@ namespace CKAN
         public void Prepopulate(List<Repository> repos, IProgress<int> percentProgress)
         {
             // Look up the sizes of repos that have uncached files
-            var reposAndSizes = repos.Where(r => !repositoriesData.ContainsKey(r))
+            var reposAndSizes = repos.Where(r => r.uri != null && !repositoriesData.ContainsKey(r))
                                      .Select(r => new Tuple<Repository, string>(r, GetRepoDataPath(r)))
                                      .Where(tuple => File.Exists(tuple.Item2))
                                      .Select(tuple => new Tuple<Repository, long>(tuple.Item1,
@@ -142,11 +142,12 @@ namespace CKAN
             user.RaiseProgress(Properties.Resources.NetRepoCheckingForUpdates, 0);
             var toUpdate = repos.DefaultIfEmpty(new Repository("default", game.DefaultRepositoryURL))
                                 .DistinctBy(r => r.uri)
-                                .Where(r => r.uri.IsFile
-                                            || skipETags
-                                            || (!etags.TryGetValue(r.uri, out string etag)
-                                                || !File.Exists(GetRepoDataPath(r))
-                                                || etag != Net.CurrentETag(r.uri)))
+                                .Where(r => r.uri != null
+                                            && (r.uri.IsFile
+                                                || skipETags
+                                                || (!etags.TryGetValue(r.uri, out string etag)
+                                                    || !File.Exists(GetRepoDataPath(r))
+                                                    || etag != Net.CurrentETag(r.uri))))
                                 .ToArray();
             if (toUpdate.Length < 1)
             {
@@ -300,7 +301,7 @@ namespace CKAN
             new Dictionary<Repository, RepositoryData>();
 
         private string GetRepoDataPath(Repository repo)
-            => GetRepoDataPath(repo, NetFileCache.CreateURLHash(repo.uri));
+            => GetRepoDataPath(repo, NetFileCache.CreateURLHash(repo?.uri));
 
         private string GetRepoDataPath(Repository repo, string hash)
             => Directory.EnumerateFiles(reposDir)

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -134,7 +134,7 @@ namespace CKAN.GUI
                 .OrderBy(r => r.priority)
                 .Select(r => new ListViewItem(new string[]
                     {
-                        r.name, r.uri.ToString(),
+                        r.name, r.uri?.ToString() ?? "",
                     })
                     {
                         Tag = r,


### PR DESCRIPTION
## Problem

A Discord user reported an exception at startup:

```
5393 [1] ERROR CKAN.GUI.Main (null) - Object reference not set to an instance of an object.
System.NullReferenceException: Object reference not set to an instance of an object.
   at CKAN.RepositoryDataManager.<>c__DisplayClass7_0.<Update>b__1(Repository r)
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at CKAN.RepositoryDataManager.Update(Repository[] repos, IGame game, Boolean skipETags, NetAsyncDownloader downloader, IUser user)
   at CKAN.GUI.Main.UpdateRepo(Object sender, DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
```

## Cause

A code audit suggests that this exception could be thrown if `Repository.url` is null, which is not supposed to be possible but could happen if `registry.json` has the repo URL set to the empty string. (The deserializer throws an exception instead if it's `null` in the file, so we can rule that out.)

However, when I tried this, I got many other exceptions in other earlier spots in the code that access this property. At time of writing we have asked follow-up questions for further investigation but haven't heard back yet. The same user said they saw an earlier error message relating to `GUIConfig.xml` (we don't know which one), so it's possible they're experiencing some disk corruption.

## Changes

Now various places that access `Repository.url` are updated to handle null values better.
