### PR TITLE
Refactor + Modernise Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7'
       - name: Install runtime dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           apt-get install -y apt-transport-https
       - name: Installing checkout/build dependencies
         run: apt-get update && apt-get install -y git
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=${{ inputs.configuration }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,101 +1,37 @@
 name: Build CKAN + NetKAN
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  workflow_call:
+    inputs:
+      configuration:
+        type: string
+        default: Debug
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        mono:
-          - latest
-          - '6.12'
-          - '6.10'
-          - '6.8'
-        configuration:
-          - Debug
-          - Release
-
-    container:
-      image: mono:${{ matrix.mono }}
-
     steps:
-      - name: Adding HTTPS support to APT for old Mono images
-        run: |
-          apt-get update || true
-          apt-get install -y apt-transport-https
-      - name: Installing checkout/build dependencies
-        run: apt-get update && apt-get install -y git
       - uses: actions/checkout@v4
-
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7'
-      - name: Install runtime dependencies
-        run: apt-get install -y xvfb
-      - name: Restore cache for _build/tools
-        uses: actions/cache@v3
-        with:
-          path: _build/tools
-          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
-      - name: Restore cache for _build/cake
-        uses: actions/cache@v3
-        with:
-          path: _build/cake
-          key: build-cake-${{ hashFiles('build.cake') }}
-      - name: Restore cache for _build/lib/nuget
-        uses: actions/cache@v3
-        with:
-          path: _build/lib/nuget
-          key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
-      - name: Restore cache for ~/.nuget/packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.nuget/packages
-          key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
-
       - name: Build ckan.exe and netkan.exe
-        run: ./build --configuration=${{ matrix.configuration}}
-      - name: Run tests
-        run: xvfb-run ./build test+only --configuration=${{ matrix.configuration }} --where="Category!=FlakyNetwork"
-      - name: Run inflator container smoke test
-        run: |
-          cd _build
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sh get-docker.sh
-          docker build --tag inflator --file ../Dockerfile.netkan .
-          docker run --rm --name inflator --entrypoint /bin/bash inflator -c "
-            mono netkan.exe https://raw.githubusercontent.com/KSP-CKAN/NetKAN/master/NetKAN/ZeroMiniAVC.netkan
-          "
-        if: matrix.configuration == 'release'
-
+        run: ./build --configuration=${{ inputs.configuration }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.configuration }}-repack-unsigned
+          path: _build/repack/
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.configuration }}-out
+          path: _build/out/
+          retention-days: 1
       - name: Upload ckan.exe artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ckan.exe
           path: _build/repack/Release/ckan.exe
           retention-days: 7
-        if: matrix.configuration == 'release' && matrix.mono == 'latest' && github.event_name == 'pull_request'
-
-      - name: Send Discord Notification
-        env:
-          JOB_STATUS: ${{ job.status }}
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-          HOOK_OS_NAME: ${{ runner.os }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        if: ${{ failure() && env.WEBHOOK_URL }}
-        run: |
-          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
-          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
-        shell: bash
+        if: inputs.configuration == 'Release'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             git make sed gzip fakeroot lintian dpkg-dev gpg gpg-agent createrepo python3-pip
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check version
         id: check_version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7'
       - name: Installing runtime dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,107 +11,162 @@ on:
 
 concurrency: deploy
 
+env:
+  AWS_S3_BUCKET: ksp-ckan
+
 jobs:
-  deploy:
+  test-release:
+    uses: ./.github/workflows/test.yml
+
+  smoke-inflator:
+    uses: ./.github/workflows/smoke.yml
+
+  upload-release-s3:
+    needs:
+      - test-release
+      - smoke-inflator
     runs-on: ubuntu-latest
-
-    container:
-      image: mono:latest
-
+    outputs:
+      odd-build: ${{ steps.check-version.outputs.odd-build }}
+      credentials: ${{ steps.credentials.outputs.credentials }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - name: Installing checkout/build dependencies
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            git make sed gzip fakeroot lintian dpkg-dev gpg gpg-agent createrepo python3-pip
       - uses: actions/checkout@v4
-
       - name: Check version
-        id: check_version
+        id: check-version
         shell: bash
         run: |
           VERSION=$(egrep '^\s*\#\#\s+v.*$' CHANGELOG.md | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-.*$//')
           if [[ $VERSION =~ [13579]$ ]]
           then
-            echo 'odd_build=true' >> $GITHUB_OUTPUT
+            echo 'odd-build=true' >> $GITHUB_OUTPUT
           fi
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
+      - name: Credentials
+        id: credentials
+        run: echo 'credentials=false' >> $GITHUB_OUTPUT
+        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+        if: steps.credentials.outputs.credentials
+      - name: Push deb to S3
+        run: aws s3 sync _build/repack/Release s3://${AWS_S3_BUCKET} --follow-symlinks
+        if: steps.credentials.outputs.credentials
 
+  upload-deb:
+    needs: upload-release-s3
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    if: needs.upload-release-s3.outputs.odd-build && needs.upload-release-s3.outputs.credentials
+    steps:
+      - uses: actions/checkout@v4
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7'
-      - name: Installing runtime dependencies
-        run: apt-get install -y xvfb
-
-      - name: Restore cache for _build/tools
-        uses: actions/cache@v1
+      - uses: actions/download-artifact@v4
         with:
-          path: _build/tools
-          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
-      - name: Restore cache for _build/cake
-        uses: actions/cache@v1
-        with:
-          path: _build/cake
-          key: build-cake-${{ hashFiles('build.cake') }}
-      - name: Restore cache for _build/lib/nuget
-        uses: actions/cache@v1
-        with:
-          path: _build/lib/nuget
-          key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
-      - name: Restore cache for ~/.nuget/packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.nuget/packages
-          key: nuget-packref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
-
-      - name: Build ckan.exe and netkan.exe
-        run: ./build --configuration=Release
-
-      - name: Create a version.json file for S3
-        shell: bash
-        run: |
-          export PIP_ROOT_USER_ACTION=ignore
-          pip3 install --upgrade pip
-          pip3 install gitpython
-          git config --global --add safe.directory '*'
-          python3 bin/version_info.py > _build/repack/Release/version.json
-
+          name: Release-repack-unsigned
+          path: _build/repack/
       - name: Build deb
         env:
           CODENAME: nightly
         run: ./build deb --configuration=Release --exclusive
-        if: ${{ steps.check_version.outputs.odd_build }}
-      - name: Build rpm
-        run: ./build rpm --configuration=Release --exclusive
-        if: ${{ steps.check_version.outputs.odd_build }}
       - name: Import GPG key
         env:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: |
           echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
-        if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
+        if: ${{ env.DEBIAN_PRIVATE_KEY }}
       - name: Sign deb release
         env:
           CODENAME: nightly
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build deb-sign --configuration=Release --exclusive
-        if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
+        if: ${{ env.DEBIAN_PRIVATE_KEY }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Push deb to S3
+        run: aws s3 sync _build/deb/apt-repo-root s3://${AWS_S3_BUCKET}/deb --follow-symlinks
+      - name: Push stable APT repo to S3
+        run: aws s3 sync _build/deb/apt-repo-dist s3://${AWS_S3_BUCKET}/deb/dists/nightly --follow-symlinks
+
+  upload-rpm:
+    needs: upload-release-s3
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    if: needs.upload-release-s3.outputs.odd-build && needs.upload-release-s3.outputs.credentials
+    steps:
+      - uses: actions/checkout@v4
+      - name: Installing rpm build dependencies
+        run: sudo apt-get install -y createrepo-c
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7'
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
+      - name: Build rpm
+        run: ./build rpm --configuration=Release --exclusive
+      - name: Import GPG key
+        env:
+          DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
+        run: |
+          echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+        if: ${{ env.DEBIAN_PRIVATE_KEY }}
       - name: Build rpm repository
         env:
           CODENAME: nightly
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build rpm-repo --configuration=Release --exclusive
-        if: ${{ env.DEBIAN_PRIVATE_KEY && steps.check_version.outputs.odd_build }}
+        if: ${{ env.DEBIAN_PRIVATE_KEY }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Push rpm to S3
+        run: aws s3 sync _build/rpm/repo s3://${AWS_S3_BUCKET}/rpm/nightly --follow-symlinks
 
-      - name: Run tests
-        run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
-
-      - name: Install Docker
-        run: |
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sh get-docker.sh
-
+  upload-inflator:
+    needs: upload-release-s3
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    if: needs.upload-release-s3.outputs.credentials
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7'
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
       - name: Generate inflator Docker image and publish to Hub
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -119,10 +174,28 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-west-2
-        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD && env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          cp -v _build/repack/Release/netkan.exe _build/.
           ./build docker-inflator --exclusive
+
+  upload-metadata-tester:
+    needs:
+      - test-release
+      - smoke-inflator
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7'
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
       - name: Generate metadata tester Docker image and publish to Hub
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -130,66 +203,29 @@ jobs:
         if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          cp -v _build/repack/Release/*kan.exe _build/.
           ./build docker-metadata --exclusive
 
-      - name: Push ckan.exe and netkan.exe to S3
-        # Send ckan.exe and netkan.exe to https://ksp-ckan.s3-us-west-2.amazonaws.com/
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/repack/Release
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Push deb to S3
-        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-root
-          DEST_DIR: deb
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
-      - name: Push nightly APT repo to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-dist
-          DEST_DIR: deb/dists/nightly
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
-      - name: Push nightly RPM repo to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/rpm/repo
-          DEST_DIR: rpm/nightly
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && steps.check_version.outputs.odd_build }}
-
+  notify-discord:
+    runs-on: ubuntu-latest
+    needs:
+      - upload-deb
+      - upload-rpm
+      - upload-inflator
+      - upload-metadata-tester
+    env:
+      JOB_STATUS: failure
+    if: always()
+    steps:
+      - name: Set Success
+        run: echo "JOB_STATUS=success" >> $GITHUB_ENV
+        if: contains('failure', join(needs.*.result, ' ')) == false
       - name: Send Discord Notification
         env:
-          JOB_STATUS: ${{ job.status }}
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
-        if: ${{ always() && env.WEBHOOK_URL }}
+        if: env.WEBHOOK_URL
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -172,7 +172,6 @@ jobs:
       - test-release
       - smoke-inflator
     runs-on: ubuntu-latest
-    if: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,10 +71,6 @@ jobs:
     if: needs.upload-release-s3.outputs.odd-build && needs.upload-release-s3.outputs.credentials
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
@@ -118,10 +114,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Installing rpm build dependencies
         run: sudo apt-get install -y createrepo-c
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
@@ -159,10 +151,6 @@ jobs:
     if: needs.upload-release-s3.outputs.credentials
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
@@ -188,10 +176,6 @@ jobs:
     if: false
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,6 @@ jobs:
         if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          cp -v _build/repack/Release/netkan.exe _build/.
           ./build docker-inflator --exclusive
 
   upload-metadata-tester:
@@ -187,7 +186,6 @@ jobs:
         if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
         run: |
           echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          cp -v _build/repack/Release/*kan.exe _build/.
           ./build docker-metadata --exclusive
 
   notify-discord:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Installing checkout/build dependencies
         run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq dpkg-dev gpg createrepo
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7'
       - name: Installing runtime dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
     steps:
       - name: Set Success
         run: echo "JOB_STATUS=success" >> $GITHUB_ENV
-        if: contains('failure', join(needs.*.result, ' ')) == false
+        if: contains(needs.*.result, 'failure') == false
       - name: Send Discord Notification
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: OSX build dependencies
         run: sudo apt-get install -y libplist-utils xorriso
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
@@ -83,10 +79,6 @@ jobs:
       - smoke-inflator
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
@@ -136,10 +128,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Installing rpm build dependencies
         run: sudo apt-get install -y createrepo-c
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,30 +5,45 @@ on:
     types:
       - created
 
+env:
+  AWS_S3_BUCKET: ksp-ckan
+
 jobs:
-  release:
+  test-release:
+    uses: ./.github/workflows/test.yml
+
+  smoke-inflator:
+    uses: ./.github/workflows/smoke.yml
+
+  sign-release:
     runs-on: ubuntu-latest
-
-    container:
-      image: mono:latest
-
+    needs:
+      - test-release
+      - smoke-inflator
+    outputs:
+      artifact-url: ${{steps.sign.outputs.signing-request-id }}
     steps:
-      - name: Installing checkout/build dependencies
-        run: apt-get update && apt-get install -y git make sed libplist-utils xorriso gzip fakeroot lintian rpm wget jq dpkg-dev gpg createrepo
-      - uses: actions/checkout@v4
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
+      - uses: signpath/github-action-submit-signing-request@v0.3
+        id: sign
         with:
-          dotnet-version: '7'
-      - name: Installing runtime dependencies
-        run: apt-get install -y xvfb
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '0cd9fc3f-b78d-4214-b152-b2e93c952e14'
+          project-slug: 'CKAN'
+          signing-policy-slug: 'test-signing'
+          github-artifact-name: 'Release-repack-unsigned'
+          artifact-configuration-slug: release
+          wait-for-completion: true
 
-      - name: Build ckan.exe and netkan.exe
-        run: ./build --configuration=Release
-      - name: Run tests
-        run: xvfb-run ./build test+only --configuration=Release --where="Category!=FlakyNetwork"
-
+  upload-nuget:
+    runs-on: ubuntu-latest
+    needs:
+      - test-release
+      - smoke-inflator
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-out
+          path: _build/out/
       - name: Publish ckan.dll to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
@@ -37,14 +52,53 @@ jobs:
           curl -o nuget.exe -L 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
           mono nuget.exe push _build/out/CKAN/Release/bin/*.nupkg ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate
 
+  build-dmg:
+    runs-on: ubuntu-latest
+    needs:
+      - test-release
+      - smoke-inflator
+    steps:
+      - uses: actions/checkout@v4
+      - name: OSX build dependencies
+        run: sudo apt-get install -y libplist-utils xorriso
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7'
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
       - name: Build dmg
         run: ./build osx --configuration=Release --exclusive
+      - name: Upload OSX release
+        run: gh release upload ${{ github.event.release.tag_name }} _build/osx/CKAN.dmg
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-deb:
+    runs-on: ubuntu-latest
+    needs:
+      - test-release
+      - smoke-inflator
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7'
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
+      - name: Set Version
+        run: |
+          VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d "v")
+          echo "DEB_VERSION=${VERSION}.$(date +'%g%j')" >> $GITHUB_ENV
       - name: Build deb
         env:
           CODENAME: stable
         run: ./build deb --configuration=Release --exclusive
-      - name: Build rpm
-        run: ./build rpm --configuration=Release --exclusive
       - name: Import GPG key
         env:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
@@ -58,115 +112,107 @@ jobs:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build deb-sign --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Push deb to S3
+        run: aws s3 sync _build/deb/apt-repo-root s3://${AWS_S3_BUCKET}/deb --follow-symlinks
+      - name: Push stable APT repo to S3
+        run: aws s3 sync _build/deb/apt-repo-dist s3://${AWS_S3_BUCKET}/deb/dists/stable --follow-symlinks
+      - name: Upload Deb release
+        run: gh release upload ${{ github.event.release.tag_name }} _build/deb/ckan_${DEB_VERSION}_all.deb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-rpm:
+    runs-on: ubuntu-latest
+    needs:
+      - test-release
+      - smoke-inflator
+    steps:
+      - uses: actions/checkout@v4
+      - name: Installing rpm build dependencies
+        run: sudo apt-get install -y createrepo-c
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7'
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
+      - name: Set Version
+        run: |
+          VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d "v")
+          echo "RPM_VERSION=${VERSION}.$(date +'%g%j')" >> $GITHUB_ENV
+      - name: Build rpm
+        run: ./build rpm --configuration=Release --exclusive
+      - name: Import GPG key
+        env:
+          DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
+        run: |
+          echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
       - name: Build rpm repository
         env:
           CODENAME: stable
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build rpm-repo --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Push rpm to S3
+        run: aws s3 sync _build/rpm/repo s3://${AWS_S3_BUCKET}/rpm/stable --follow-symlinks
+      - name: Upload RPM release
+        run: gh release upload ${{ github.event.release.tag_name }} _build/rpm/RPMS/noarch/ckan-${RPM_VERSION}-1.noarch.rpm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get release data
-        id: release_data
-        run: |
-          URL=$(wget -qO- https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq '.[0].upload_url' | tr -d \")
-          echo "upload_url=$URL" >> $GITHUB_OUTPUT
-          VERSION=$(wget -qO- https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq '.[0].tag_name' | tr -d \"v)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          RPM_VERSION=$(echo ${VERSION}.$(date +'%g%j') | sed -e 's/-/_/g')
-          echo "rpm_version=$RPM_VERSION" >> $GITHUB_OUTPUT
-          DEB_VERSION=${VERSION}.$(date +'%g%j')
-          echo "deb_version=$DEB_VERSION" >> $GITHUB_OUTPUT
-      - name: Push deb to S3
-        # Send deb file to https://ksp-ckan.s3-us-west-2.amazonaws.com/
-        uses: jakejarvis/s3-sync-action@master
+  upload-binaries:
+    runs-on: ubuntu-latest
+    needs:
+      - test-release
+      - smoke-inflator
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/download-artifact@v4
         with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-root
-          DEST_DIR: deb
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
-      - name: Push stable APT repo to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/deb/apt-repo-dist
-          DEST_DIR: deb/dists/stable
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
-      - name: Push stable RPM repo to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --follow-symlinks
-        env:
-          AWS_S3_BUCKET: ksp-ckan
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: _build/rpm/repo
-          DEST_DIR: rpm/stable
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
-
+          name: Release-repack-unsigned
+          path: _build/repack/
       - name: Upload ckan.exe
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.upload_url }}
-          asset_path: _build/repack/Release/ckan.exe
-          asset_name: ckan.exe
-          asset_content_type: application/vnd.microsoft.portable-executable
-      - name: Upload CKAN.dmg
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.upload_url }}
-          asset_path: _build/osx/CKAN.dmg
-          asset_name: CKAN.dmg
-          asset_content_type: application/x-apple-diskimage
-      - name: Upload ckan_*.deb
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.upload_url }}
-          asset_path: _build/deb/ckan_${{ steps.release_data.outputs.deb_version }}_all.deb
-          asset_name: ckan_${{ steps.release_data.outputs.version }}_all.deb
-          asset_content_type: application/vnd.debian.binary-package
-      - name: Upload ckan-*.rpm
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.upload_url }}
-          asset_path: _build/rpm/RPMS/noarch/ckan-${{ steps.release_data.outputs.rpm_version }}-1.noarch.rpm
-          asset_name: ckan-${{ steps.release_data.outputs.version }}-1.noarch.rpm
-          asset_content_type: application/x-rpm
+        run: gh release upload ${{ github.event.release.tag_name }} _build/repack/Release/ckan.exe
       - name: Upload AutoUpdater.exe
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_data.outputs.upload_url }}
-          asset_path: _build/repack/Release/AutoUpdater.exe
-          asset_name: AutoUpdater.exe
-          asset_content_type: application/vnd.microsoft.portable-executable
+        run: gh release upload ${{ github.event.release.tag_name }} _build/repack/Release/AutoUpdater.exe
 
+  notify-discord:
+    runs-on: ubuntu-latest
+    needs:
+      - build-dmg
+      - build-deb
+      - build-rpm
+      - upload-binaries
+      - upload-nuget
+    env:
+      JOB_STATUS: failure
+    if: always()
+    steps:
+      - name: Set Success
+        run: echo "JOB_STATUS=success" >> $GITHUB_ENV
+        if: contains('failure', join(needs.*.result, ' ')) == false
       - name: Send Discord Notification
         env:
-          JOB_STATUS: ${{ job.status }}
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
           HOOK_OS_NAME: ${{ runner.os }}
           WORKFLOW_NAME: ${{ github.workflow }}
-        if: ${{ always() && env.WEBHOOK_URL }}]
+        if: env.WEBHOOK_URL
         run: |
           git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
       - uses: signpath/github-action-submit-signing-request@v0.3
         id: sign
         with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '0cd9fc3f-b78d-4214-b152-b2e93c952e14'
-          project-slug: 'CKAN'
-          signing-policy-slug: 'test-signing'
-          github-artifact-name: 'Release-repack-unsigned'
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: 0cd9fc3f-b78d-4214-b152-b2e93c952e14
+          project-slug: CKAN
+          signing-policy-slug: test-signing
+          github-artifact-name: Release-repack-unsigned
           artifact-configuration-slug: release
           wait-for-completion: true
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,49 @@
+name: Smoke Test NetKAN
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  workflow_call:
+
+jobs:
+  build-release:
+    uses: ./.github/workflows/build.yml
+    with:
+      configuration: Release
+  smoke-test-inflator:
+    needs: build-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
+      - name: Run inflator container smoke test
+        working-directory: _build
+        run: |
+          cp -v repack/Release/netkan.exe .
+          docker build --tag inflator --file ../Dockerfile.netkan .
+          docker run --rm --name inflator --entrypoint /bin/bash inflator -c "
+            mono netkan.exe https://raw.githubusercontent.com/KSP-CKAN/NetKAN/master/NetKAN/ZeroMiniAVC.netkan
+          "
+  notify:
+    needs:
+      - smoke-test-inflator
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Send Discord Notification
+        env:
+          JOB_STATUS: failure
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        if: env.WEBHOOK_URL
+        run: |
+          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+        shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test CKAN + NetKAN
+
+on:
+  push:
+    branches-ignore:
+      - master
+  workflow_call:
+
+jobs:
+  build-debug:
+    uses: ./.github/workflows/build.yml
+  test-build:
+    needs: build-debug
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install runtime dependencies
+        run: sudo apt-get install -y xvfb
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7'
+      - uses: actions/download-artifact@v4
+        with:
+          name: Debug-out
+          path: _build/out/
+      - uses: actions/download-artifact@v4
+        with:
+          name: Debug-repack-unsigned
+          path: _build/repack/
+      - name: Run tests
+        run: xvfb-run ./build test+only --configuration=Debug --where="Category!=FlakyNetwork"
+
+  notify:
+    needs:
+      - test-build
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Send Discord Notification
+        env:
+          JOB_STATUS: failure
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        if: env.WEBHOOK_URL
+        run: |
+          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+        shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install runtime dependencies
         run: sudo apt-get install -y xvfb
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '7'
       - uses: actions/download-artifact@v4
         with:
           name: Debug-out

--- a/build.cake
+++ b/build.cake
@@ -59,8 +59,7 @@ Task("docker-inflator")
     // Versions of Docker prior to 18.03.0-ce require the Dockerfile to be within the build context
     var dockerFile        = inflatorDirectory.CombineWithFilePath("Dockerfile.netkan");
     CreateDirectory(inflatorDirectory);
-    CopyFile(buildDirectory.CombineWithFilePath("netkan.exe"),
-          inflatorDirectory.CombineWithFilePath("netkan.exe"));
+    CopyFile(netkanFile, inflatorDirectory.CombineWithFilePath("netkan.exe"));
     CopyFile(rootDirectory.CombineWithFilePath("Dockerfile.netkan"), dockerFile);
 
     var mainTag   = "kspckan/inflator";
@@ -109,10 +108,8 @@ Task("docker-metadata")
     // Versions of Docker prior to 18.03.0-ce require the Dockerfile to be within the build context
     var dockerFile        = metadataDirectory.CombineWithFilePath("Dockerfile.metadata");
     CreateDirectory(metadataDirectory);
-    CopyFile(buildDirectory.CombineWithFilePath("netkan.exe"),
-          metadataDirectory.CombineWithFilePath("netkan.exe"));
-    CopyFile(buildDirectory.CombineWithFilePath("ckan.exe"),
-          metadataDirectory.CombineWithFilePath("ckan.exe"));
+    CopyFile(netkanFile, metadataDirectory.CombineWithFilePath("netkan.exe"));
+    CopyFile(ckanFile,   metadataDirectory.CombineWithFilePath("ckan.exe"));
     CopyFile(rootDirectory.CombineWithFilePath("Dockerfile.metadata"), dockerFile);
 
     var mainTag   = "kspckan/metadata";


### PR DESCRIPTION
This is a complete refactor and overhaul of our actions, and either updating or changing any outdated actions we have used within our workflows.

## Changes
### Building
The build workflow is now a self contained, and runs on master or via 'workflow_call'. Making a single source of truth for building CKAN/NetKAN.

Note: The build on master is intentional, I expect there we can do a small amount of work to enable [dotnet caching](https://github.com/actions/setup-dotnet?tab=readme-ov-file#caching-nuget-packages). For a cache to be available on branches, it *must* have been previously built on the default branch.

### Testing
There is a new test file that calls build first. It is unnecessary to build inside the Mono containers, as we still use dotnet to build. This however ensures we are keeping the same validation as before. We can likely look to considering if this is still required.

### Deploy
Deployment now calls build first, followed by versioning, and then the rest of the steps.
- All S3 actions now use the official AWS tools
- Only RPM needs an extra tool outside what comes by default

Example here: https://github.com/KSP-CKAN/CKAN/actions/runs/8948785797
Example with containers (fails as I omitted auth): https://github.com/KSP-CKAN/CKAN/actions/runs/8948756697/job/24582270638

### Release
Release has gone through a similar tidy up to deploy. Arguably a shared workflow could be built for this, but it felt prudent to keep it separate for now. When signing is fully available we can take a look at it then.
- All S3 actions now use the official AWS tools
- Only RPM + OSX needs an extra tool outside what comes by default

Example here: https://github.com/KSP-CKAN/CKAN/actions/runs/8936371852

## Other things of note
- Signing is waiting upon verification of the GitHub Action, it'll be a small amount of work to switch to the signed binaries
- I used a `/test` path for all S3 uploads, which look to have worked in the same manner as the previous action.