### PR TITLE
Ubuntu 24.04 breaks build

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,5 +1,5 @@
 # Everything we need in both the build and prod images
-FROM ubuntu:latest as base
+FROM ubuntu:22.04 as base
 
 # Don't prompt for time zone
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 # Don't prompt for time zone
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
There are a number of changes within 24.04 which upset the apple cart, for now 22.04 is still supported for another year, so we can pin while we give ourselves some time to update things.