### PR TITLE
Conflicting recommendations check for ConsoleUI

### DIFF
--- a/ConsoleUI/AuthTokenListScreen.cs
+++ b/ConsoleUI/AuthTokenListScreen.cs
@@ -85,7 +85,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-            return $"CKAN {Meta.GetVersion()}";
+            return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/ConsoleUI/DeleteDirectoriesScreen.cs
+++ b/ConsoleUI/DeleteDirectoriesScreen.cs
@@ -107,7 +107,7 @@ namespace CKAN.ConsoleUI {
         /// <summary>
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
-        protected override string LeftHeader() => $"CKAN {Meta.GetVersion()}";
+        protected override string LeftHeader() => $"{Meta.GetProductName()} {Meta.GetVersion()}";
 
         /// <summary>
         /// Show the Delete Directories header

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -126,10 +126,7 @@ namespace CKAN.ConsoleUI {
         /// <summary>
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
-        protected override string LeftHeader()
-        {
-            return $"CKAN {Meta.GetVersion()}";
-        }
+        protected override string LeftHeader() => $"{Meta.GetProductName()} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/ConsoleUI/ExitScreen.cs
+++ b/ConsoleUI/ExitScreen.cs
@@ -49,7 +49,7 @@ namespace CKAN.ConsoleUI {
 
             // Specially formatted snippets
             var ckanPiece = new FancyLinePiece(Meta.GetProductName(), theme.ExitInnerBg, theme.ExitHighlightFg);
-            var ckanVersionPiece = new FancyLinePiece($"CKAN {Meta.GetVersion()}", theme.ExitInnerBg, theme.ExitHighlightFg);
+            var ckanVersionPiece = new FancyLinePiece($"{Meta.GetProductName()} {Meta.GetVersion()}", theme.ExitInnerBg, theme.ExitHighlightFg);
             var releaseLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/releases/latest", theme.ExitInnerBg, theme.ExitLinkFg);
             var issuesLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/issues", theme.ExitInnerBg, theme.ExitLinkFg);
             var authorsLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/graphs/contributors", theme.ExitInnerBg, theme.ExitLinkFg);

--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -149,7 +149,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-            return $"CKAN {Meta.GetVersion()}";
+            return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/ConsoleUI/GameInstanceScreen.cs
+++ b/ConsoleUI/GameInstanceScreen.cs
@@ -55,7 +55,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-            return $"CKAN {Meta.GetVersion()}";
+            return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/ConsoleUI/InstallFiltersScreen.cs
+++ b/ConsoleUI/InstallFiltersScreen.cs
@@ -97,7 +97,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-            return $"CKAN {Meta.GetVersion()}";
+            return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -81,7 +81,8 @@ namespace CKAN.ConsoleUI {
                                                                                   registry.InstalledModules
                                                                                           .Select(im => im.Module)
                                                                                           .ToArray(),
-                                                                                  plan.Install))
+                                                                                  plan.Install)
+                                                         ?? m)
                                             .ToArray();
                             inst.InstallList(iList, resolvOpts, regMgr, ref possibleConfigOnlyDirs, dl);
                             plan.Install.Clear();

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -198,7 +198,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-             return $"CKAN {Meta.GetVersion()}";
+             return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -619,7 +619,7 @@ namespace CKAN.ConsoleUI {
                 // Because that's supposed to work.
                 regMgr.Save(true);
                 string path = Path.Combine(
-                    manager.CurrentInstance.CkanDir(),
+                    Platform.FormatPath(manager.CurrentInstance.CkanDir()),
                     $"{Properties.Resources.ModListExportPrefix}-{manager.CurrentInstance.Name}.ckan"
                 );
                 RaiseError(Properties.Resources.ModListExported, path);

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -351,7 +351,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-            return $"CKAN {Meta.GetVersion()}";
+            return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/ConsoleUI/ProgressScreen.cs
+++ b/ConsoleUI/ProgressScreen.cs
@@ -47,7 +47,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-            return $"CKAN {Meta.GetVersion()}";
+            return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/ConsoleUI/RepoScreen.cs
+++ b/ConsoleUI/RepoScreen.cs
@@ -75,7 +75,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         protected override string LeftHeader()
         {
-            return $"CKAN {Meta.GetVersion()}";
+            return $"{Meta.GetProductName()} {Meta.GetVersion()}";
         }
 
         /// <summary>

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -372,7 +372,7 @@ namespace CKAN
                 }
 
                 // If we haven't handled our exception, then it really was exceptional.
-                if (handled == false)
+                if (!handled)
                 {
                     if (exception == null)
                     {


### PR DESCRIPTION
## Problem

In ConsoleUI's recommendations screen for RP-1, <kbd>Ctrl+A</kbd>, <kbd>F9</kbd> throws an exception:

```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.             │
   at CKAN.RelationshipResolver.AddModulesToInstall(CkanModule[] modules)
   at CKAN.ModuleInstaller.InstallList(ICollection`1 modules, RelationshipResolverOptions options, RegistryManager registry_manager, HashSet`1& possibleConfigOnlyDirs, IDownloader downloader, Boolean ConfirmPrompt)
   at CKAN.ConsoleUI.InstallScreen.Run(ConsoleTheme theme, Action`1 process)
   at CKAN.ConsoleUI.ModListScreen.ApplyChanges(ConsoleTheme theme)
   at CKAN.ConsoleUI.ModListScreen.<>c__DisplayClass0_0.<.ctor>b__27(Object sender, ConsoleTheme theme)
   at CKAN.ConsoleUI.Toolkit.ScreenContainer.Interact(ConsoleTheme theme)
   at CKAN.ConsoleUI.Toolkit.ScreenContainer.Run(ConsoleTheme theme, Action`1 process)
   at CKAN.ConsoleUI.ConsoleCKAN..ctor(GameInstanceManager mgr, String themeName, Boolean debug)
   at CKAN.ConsoleUI.ConsoleUI.Main_(GameInstanceManager manager, String themeName, Boolean debug)
   at CKAN.CmdLine.MainClass.RunSimpleAction(Options cmdline, CommonOptions options, String[] args, IUser user, GameInstanceManager manager)
   at CKAN.CmdLine.MainClass.Execute(GameInstanceManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

Note that I had to turn off "Enable Ctrl key shortcuts" in the Windows terminal settings to allow <kbd>Ctrl+A</kbd> to reach the app code.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/72388e67-d8ae-4da6-ae82-ab74ac66714d)

## Cause

#4023 updated the install screen to find the latest module versions that don't conflict with any of the other modules. In the case of unavoidable conflicts, there may be no such version, so `null` values were sneaking into the list of mods to install.

## Motivation

In ConsoleUI, the recommendations screen leaves conflict checking to the install screen, so the user can select whatever recommended/suggested modules they want, only to find out that some combinations can't actually be installed.

## Changes

- Now the install screen's allowed-module logic will fall back to the original module in case of conflicts. (But also this will no longer happen, see below.)
- Now the ConsoleUI recommendations screen checks for conflicts when you:
  - Select a row
    ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/1f5afd4e-b349-45a9-91dd-d3f660973829)
  - Select all with <kbd>Ctrl+A</kbd>
    ![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/79341d63-2ccf-4f31-9709-95675d155c13)
  - Commit changes with <kbd>F9</kbd>

  In each case, if any conflicts are found, the user will be alerted and the proximate action will be cancelled (i.e., the mod won't be added to the list). This will mean that you can no longer leave this screen with a conflicting changeset, and the warning will appear at a time when you can do something about it.

Fixes #4072.
