### PR TITLE
Consolidate Discord notification steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,25 +188,14 @@ jobs:
           ./build docker-metadata --configuration=Release --exclusive
 
   notify-discord:
-    runs-on: ubuntu-latest
     needs:
       - upload-deb
       - upload-rpm
       - upload-inflator
       - upload-metadata-tester
-    env:
-      JOB_STATUS: failure
     if: always()
-    steps:
-      - name: Set Success
-        run: echo "JOB_STATUS=success" >> $GITHUB_ENV
-        if: contains(needs.*.result, 'failure') == false
-      - name: Send Discord Notification
-        env:
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-          HOOK_OS_NAME: ${{ runner.os }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        if: env.WEBHOOK_URL
-        run: |
-          git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
-          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+    uses: ./.github/workflows/notify.yml
+    with:
+      name: ${{ github.workflow }}
+      success: ${{ !contains(needs.*.result, 'failure') }}
+    secrets: inherit

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,26 @@
+name: Send Discord Notification
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        type: string
+        required: true
+      success:
+        type: boolean
+        required: true
+    secrets:
+      DISCORD_WEBHOOK:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          WORKFLOW_NAME: ${{ inputs.name }}
+          HOOK_OS_NAME: ${{ runner.os }}
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+          bash webhook/send.sh ${{ inputs.success && 'success' || 'failure' }} ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,26 +181,15 @@ jobs:
         run: gh release upload ${{ github.event.release.tag_name }} _build/repack/Release/AutoUpdater.exe
 
   notify-discord:
-    runs-on: ubuntu-latest
     needs:
       - build-dmg
       - build-deb
       - build-rpm
       - upload-binaries
       - upload-nuget
-    env:
-      JOB_STATUS: failure
     if: always()
-    steps:
-      - name: Set Success
-        run: echo "JOB_STATUS=success" >> $GITHUB_ENV
-        if: contains(needs.*.result, 'failure') == false
-      - name: Send Discord Notification
-        env:
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-          HOOK_OS_NAME: ${{ runner.os }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        if: env.WEBHOOK_URL
-        run: |
-          git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
-          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+    uses: ./.github/workflows/notify.yml
+    with:
+      name: ${{ github.workflow }}
+      success: ${{ !contains(needs.*.result, 'failure') }}
+    secrets: inherit

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,18 +32,11 @@ jobs:
           "
   notify:
     needs:
+      - build-release
       - smoke-test-inflator
-    runs-on: ubuntu-latest
     if: failure()
-    steps:
-      - name: Send Discord Notification
-        env:
-          JOB_STATUS: failure
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-          HOOK_OS_NAME: ${{ runner.os }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        if: env.WEBHOOK_URL
-        run: |
-          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
-          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
-        shell: bash
+    uses: ./.github/workflows/notify.yml
+    with:
+      name: ${{ github.workflow }}
+      success: ${{ !contains(needs.*.result, 'failure') }}
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,18 +29,11 @@ jobs:
 
   notify:
     needs:
+      - build-debug
       - test-build
-    runs-on: ubuntu-latest
     if: failure()
-    steps:
-      - name: Send Discord Notification
-        env:
-          JOB_STATUS: failure
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
-          HOOK_OS_NAME: ${{ runner.os }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        if: env.WEBHOOK_URL
-        run: |
-          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
-          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
-        shell: bash
+    uses: ./.github/workflows/notify.yml
+    with:
+      name: ${{ github.workflow }}
+      success: ${{ !contains(needs.*.result, 'failure') }}
+    secrets: inherit


### PR DESCRIPTION
## Motivation

After #4082, I wanted to look for ways to set the first parameter of the Discord notification script (`success` or `failure`) without environment variables, extra pseudo-steps ("Set Success"), or side effects. Gradually I realized that writing a `git clone` command in every place we want to notify was a bit duplicative and could use better encapsulation.

## Changes

- Now our own `notify.yml` action wrapper provides the nice API that `DiscordHooks/github-actions-discord-webhook` should have.
  - Inputs `name` and `success` are accepted, and the `DISCORD_WEBHOOK` secret is required.
  - The somewhat awkward `git clone` logic required to use it is now centralized in one place. If the optimal notification method changes in the future, we will be able to update it in just one spot.
- Now what [the action documentation](https://docs.github.com/en/actions/learn-github-actions/expressions#example) calls "ternary operator like behaviour" is used to choose between `success` and `failure` based on the value of the boolean `success` input, with no environment variable twiddling involved.
- Now all spots that previously sent their own notifications are updated to go through the new `notify.yml`, and the `contains` expression usees the `!` not operator instead of `== false`.
- The `notify` jobs in `test.yml` and `smoke.yml` now depend on their respective `build-*` steps to ensure that failure can be detected by checking `contains(needs.*.result, 'failure')` (if you only `needs` the intermediate step, its status will be `skipped` when a previous step fails).

This should be a bit more maintainable, and it gave me some more practice in action coding.
