### PR TITLE
Use checkout action for notify workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,6 +189,8 @@ jobs:
 
   notify-discord:
     needs:
+      - test-release
+      - smoke-inflator
       - upload-deb
       - upload-rpm
       - upload-inflator

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -17,10 +17,13 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: DiscordHooks/github-actions-discord-webhook
+          path: webhook
+          fetch-depth: 1
       - env:
           WORKFLOW_NAME: ${{ inputs.name }}
           HOOK_OS_NAME: ${{ runner.os }}
         shell: bash
-        run: |
-          git clone --depth 1 https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
-          bash webhook/send.sh ${{ inputs.success && 'success' || 'failure' }} ${{ secrets.DISCORD_WEBHOOK }}
+        run: bash webhook/send.sh ${{ inputs.success && 'success' || 'failure' }} ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,8 @@ jobs:
 
   notify-discord:
     needs:
+      - test-release
+      - smoke-inflator
       - build-dmg
       - build-deb
       - build-rpm

--- a/bin/ckan_merge_pr.py
+++ b/bin/ckan_merge_pr.py
@@ -153,6 +153,14 @@ class CkanPullRequest:
         if not branch:
             print(f'PR #{self.pull_request.number} commit {self.pull_request.head.sha} not found!')
             return False
+        pr_commits = self.pull_request.get_commits()
+        incomplete_checks = [run
+                             for run in pr_commits[pr_commits.totalCount - 1].get_check_runs()
+                             if run.status != 'completed'
+                                or run.conclusion not in ('success', 'skipped')]
+        if incomplete_checks:
+            print('Incomplete checks:', ', '.join(ch.name for ch in incomplete_checks))
+            return False
         # Valid; do it!
         # repo.index.merge_tree doesn't auto resolve conflicts
         repo.git.merge(branch, no_commit=True, no_ff=True)


### PR DESCRIPTION
## Motivation

#4088 seems to work, but a `git clone` command line is not the best level of abstraction for a workflow.

## Changes

- Now we use `actions/checkout` instead.
- Now the merge script is updated to prevent merging if any of the checks fail or are still pending.
- Now the notify jobs in `release.yml` and `deploy.yml` depend on their respective build/test jobs to ensure that any failures will be available in `needs.*.result`.
