### PR TITLE
Various fixes for the refactored workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upload out artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.configuration }}-out
+          name: ${{ inputs.configuration }}-out-unsigned
           path: _build/out/
           retention-days: 1
       - name: Upload ckan.exe artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=${{ inputs.configuration }}
-      - uses: actions/upload-artifact@v4
+      - name: Upload repack artifact
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.configuration }}-repack-unsigned
           path: _build/repack/
           retention-days: 7
-      - uses: actions/upload-artifact@v4
+      - name: Upload out artifact
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.configuration }}-out
           path: _build/out/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,16 @@ jobs:
         with:
           name: Release-repack-unsigned
           path: _build/repack/
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Create a version.json file for dev builds on S3
+        shell: bash
+        run: |
+          export PIP_ROOT_USER_ACTION=ignore
+          pip install gitpython
+          git config --global --add safe.directory '*'
+          python bin/version_info.py > _build/repack/Release/version.json
       - name: Push ckan.exe, netkan.exe, and version.json to S3
         run: aws s3 sync _build/repack/Release s3://${AWS_S3_BUCKET} --follow-symlinks
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,17 +21,10 @@ jobs:
   smoke-inflator:
     uses: ./.github/workflows/smoke.yml
 
-  upload-release-s3:
-    needs:
-      - test-release
-      - smoke-inflator
+  check-dev-build:
     runs-on: ubuntu-latest
     outputs:
-      odd-build: ${{ steps.check-version.outputs.odd-build }}
-      credentials: ${{ steps.credentials.outputs.credentials }}
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      dev-build: ${{ steps.check-version.outputs.dev-build }}
     steps:
       - uses: actions/checkout@v4
       - name: Treat as dev build if final piece of version is odd
@@ -41,35 +34,50 @@ jobs:
           VERSION=$(egrep '^\s*\#\#\s+v.*$' CHANGELOG.md | head -1 | sed -e 's/^\s*\#\#\s\+v//' -e 's/-.*$//')
           if [[ $VERSION =~ [13579]$ ]]
           then
-            echo 'odd-build=true' >> $GITHUB_OUTPUT
+            echo 'dev-build=true' >> $GITHUB_OUTPUT
           fi
-      - uses: actions/download-artifact@v4
-        with:
-          name: Release-repack-unsigned
-          path: _build/repack/
-      - name: Credentials
-        id: credentials
-        run: echo 'credentials=false' >> $GITHUB_OUTPUT
-        if: ${{ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY }}
-      - name: Configure AWS Credentials
+
+  upload-release-s3:
+    needs:
+      - test-release
+      - smoke-inflator
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-        if: steps.credentials.outputs.credentials
+      - uses: actions/checkout@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Release-repack-unsigned
+          path: _build/repack/
       - name: Push ckan.exe, netkan.exe, and version.json to S3
         run: aws s3 sync _build/repack/Release s3://${AWS_S3_BUCKET} --follow-symlinks
-        if: steps.credentials.outputs.credentials
 
   upload-deb:
-    needs: upload-release-s3
+    needs:
+      - check-dev-build
+      - test-release
+      - smoke-inflator
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    if: needs.upload-release-s3.outputs.odd-build && needs.upload-release-s3.outputs.credentials
+    if: needs.check-dev-build.outputs.dev-build
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
       - uses: actions/checkout@v4
       - name: Download repack artifact
         uses: actions/download-artifact@v4
@@ -93,25 +101,28 @@ jobs:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build deb-sign --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
       - name: Push deb to S3
         run: aws s3 sync _build/deb/apt-repo-root s3://${AWS_S3_BUCKET}/deb --follow-symlinks
       - name: Push nightly APT repo to S3
         run: aws s3 sync _build/deb/apt-repo-dist s3://${AWS_S3_BUCKET}/deb/dists/nightly --follow-symlinks
 
   upload-rpm:
-    needs: upload-release-s3
+    needs:
+      - check-dev-build
+      - test-release
+      - smoke-inflator
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    if: needs.upload-release-s3.outputs.odd-build && needs.upload-release-s3.outputs.credentials
+    if: needs.check-dev-build.outputs.dev-build
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
       - uses: actions/checkout@v4
       - name: Install rpm build dependencies
         run: sudo apt-get install -y createrepo-c
@@ -135,22 +146,17 @@ jobs:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build rpm-repo --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
       - name: Push nightly PRM repo to S3
         run: aws s3 sync _build/rpm/repo s3://${AWS_S3_BUCKET}/rpm/nightly --follow-symlinks
 
   upload-inflator:
-    needs: upload-release-s3
+    needs:
+      - test-release
+      - smoke-inflator
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    if: needs.upload-release-s3.outputs.credentials
     steps:
       - uses: actions/checkout@v4
       - name: Download repack artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
-      - name: Check version
+      - name: Treat as dev build if final piece of version is odd
         id: check-version
         shell: bash
         run: |
@@ -58,7 +58,7 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
         if: steps.credentials.outputs.credentials
-      - name: Push deb to S3
+      - name: Push ckan.exe, netkan.exe, and version.json to S3
         run: aws s3 sync _build/repack/Release s3://${AWS_S3_BUCKET} --follow-symlinks
         if: steps.credentials.outputs.credentials
 
@@ -71,7 +71,8 @@ jobs:
     if: needs.upload-release-s3.outputs.odd-build && needs.upload-release-s3.outputs.credentials
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/
@@ -100,7 +101,7 @@ jobs:
           aws-region: us-east-1
       - name: Push deb to S3
         run: aws s3 sync _build/deb/apt-repo-root s3://${AWS_S3_BUCKET}/deb --follow-symlinks
-      - name: Push stable APT repo to S3
+      - name: Push nightly APT repo to S3
         run: aws s3 sync _build/deb/apt-repo-dist s3://${AWS_S3_BUCKET}/deb/dists/nightly --follow-symlinks
 
   upload-rpm:
@@ -112,9 +113,10 @@ jobs:
     if: needs.upload-release-s3.outputs.odd-build && needs.upload-release-s3.outputs.credentials
     steps:
       - uses: actions/checkout@v4
-      - name: Installing rpm build dependencies
+      - name: Install rpm build dependencies
         run: sudo apt-get install -y createrepo-c
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/
@@ -127,7 +129,7 @@ jobs:
           echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
-      - name: Build rpm repository
+      - name: Build nightly RPM repo
         env:
           CODENAME: nightly
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
@@ -139,7 +141,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - name: Push rpm to S3
+      - name: Push nightly PRM repo to S3
         run: aws s3 sync _build/rpm/repo s3://${AWS_S3_BUCKET}/rpm/nightly --follow-symlinks
 
   upload-inflator:
@@ -151,11 +153,12 @@ jobs:
     if: needs.upload-release-s3.outputs.credentials
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/
-      - name: Generate inflator Docker image and publish to Hub
+      - name: Generate inflator Docker image, publish to Hub, and restart AWS containers
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -174,7 +177,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -15,14 +15,17 @@ on:
 
 jobs:
   notify:
+    name: Notify Discord
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Clone Discord hooks repo
+        uses: actions/checkout@v4
         with:
           repository: DiscordHooks/github-actions-discord-webhook
           path: webhook
           fetch-depth: 1
-      - env:
+      - name: Send notification
+        env:
           WORKFLOW_NAME: ${{ inputs.name }}
           HOOK_OS_NAME: ${{ runner.os }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           path: _build/repack/
       - name: Set Version
         run: |
-          VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d "v")
+          VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d v)
           echo "RPM_VERSION=${VERSION}.$(date +'%g%j')" >> $GITHUB_ENV
       - name: Build rpm
         run: ./build rpm --configuration=Release --exclusive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,12 @@ jobs:
       - test-release
       - smoke-inflator
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
       - uses: actions/checkout@v4
       - name: Download repack artifact
         uses: actions/download-artifact@v4
@@ -107,12 +113,6 @@ jobs:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build deb-sign --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
       - name: Push deb to S3
         run: aws s3 sync _build/deb/apt-repo-root s3://${AWS_S3_BUCKET}/deb --follow-symlinks
       - name: Push stable APT repo to S3
@@ -128,6 +128,12 @@ jobs:
       - test-release
       - smoke-inflator
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
       - uses: actions/checkout@v4
       - name: Install rpm build dependencies
         run: sudo apt-get install -y createrepo-c
@@ -154,12 +160,6 @@ jobs:
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
         run: ./build rpm-repo --configuration=Release --exclusive
         if: ${{ env.DEBIAN_PRIVATE_KEY }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
       - name: Push stable RPM repo to S3
         run: aws s3 sync _build/rpm/repo s3://${AWS_S3_BUCKET}/rpm/stable --follow-symlinks
       - name: Upload RPM release asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Download out artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-out
+          name: Release-out-unsigned
           path: _build/out/
       - name: Publish ckan.dll to NuGet
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,10 +180,8 @@ jobs:
         with:
           name: Release-repack-unsigned
           path: _build/repack/
-      - name: Upload ckan.exe
-        run: gh release upload ${{ github.event.release.tag_name }} _build/repack/Release/ckan.exe
-      - name: Upload AutoUpdater.exe
-        run: gh release upload ${{ github.event.release.tag_name }} _build/repack/Release/AutoUpdater.exe
+      - name: Upload ckan.exe and AutoUpdater.exe release assets
+        run: gh release upload ${{ github.event.release.tag_name }} _build/repack/Release/ckan.exe _build/repack/Release/AutoUpdater.exe
 
   notify-discord:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,8 @@ jobs:
       - test-release
       - smoke-inflator
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download out artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-out
           path: _build/out/
@@ -59,15 +60,16 @@ jobs:
       - smoke-inflator
     steps:
       - uses: actions/checkout@v4
-      - name: OSX build dependencies
+      - name: Install OSX build dependencies
         run: sudo apt-get install -y libplist-utils xorriso
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/
       - name: Build dmg
         run: ./build osx --configuration=Release --exclusive
-      - name: Upload OSX release
+      - name: Upload OSX release asset
         run: gh release upload ${{ github.event.release.tag_name }} _build/osx/CKAN.dmg
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,11 +81,12 @@ jobs:
       - smoke-inflator
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/
-      - name: Set Version
+      - name: Set deb version
         run: |
           VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d "v")
           echo "DEB_VERSION=${VERSION}.$(date +'%g%j')" >> $GITHUB_ENV
@@ -114,7 +117,7 @@ jobs:
         run: aws s3 sync _build/deb/apt-repo-root s3://${AWS_S3_BUCKET}/deb --follow-symlinks
       - name: Push stable APT repo to S3
         run: aws s3 sync _build/deb/apt-repo-dist s3://${AWS_S3_BUCKET}/deb/dists/stable --follow-symlinks
-      - name: Upload Deb release
+      - name: Upload deb release asset
         run: gh release upload ${{ github.event.release.tag_name }} _build/deb/ckan_${DEB_VERSION}_all.deb
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -126,13 +129,14 @@ jobs:
       - smoke-inflator
     steps:
       - uses: actions/checkout@v4
-      - name: Installing rpm build dependencies
+      - name: Install rpm build dependencies
         run: sudo apt-get install -y createrepo-c
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/
-      - name: Set Version
+      - name: Set rpm version
         run: |
           VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d v)
           echo "RPM_VERSION=${VERSION}.$(date +'%g%j')" >> $GITHUB_ENV
@@ -144,7 +148,7 @@ jobs:
         run: |
           echo "$DEBIAN_PRIVATE_KEY" | base64 --decode | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
-      - name: Build rpm repository
+      - name: Build stable RPM repo
         env:
           CODENAME: stable
           DEBIAN_PRIVATE_KEY: ${{ secrets.DEBIAN_PRIVATE_KEY }}
@@ -156,9 +160,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - name: Push rpm to S3
+      - name: Push stable RPM repo to S3
         run: aws s3 sync _build/rpm/repo s3://${AWS_S3_BUCKET}/rpm/stable --follow-symlinks
-      - name: Upload RPM release
+      - name: Upload RPM release asset
         run: gh release upload ${{ github.event.release.tag_name }} _build/rpm/RPMS/noarch/ckan-${RPM_VERSION}-1.noarch.rpm
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -171,7 +175,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Release-repack-unsigned
           path: _build/repack/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install runtime dependencies
         run: sudo apt-get install -y xvfb
-      - uses: actions/download-artifact@v4
+      - name: Download out artifact
+        uses: actions/download-artifact@v4
         with:
           name: Debug-out
           path: _build/out/
-      - uses: actions/download-artifact@v4
+      - name: Download repack artifact
+        uses: actions/download-artifact@v4
         with:
           name: Debug-repack-unsigned
           path: _build/repack/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Download out artifact
         uses: actions/download-artifact@v4
         with:
-          name: Debug-out
+          name: Debug-out-unsigned
           path: _build/out/
       - name: Download repack artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problems

- Dev builds are currently broken because the `version.json` file from #3997 isn't being generated anymore. I assume #4082 removed this because of some sort of Python dependency issues in the newer containers, but we still need it.
- `upload-nuget` in `release.yml` was trying to download a `Release-repack-out` artifact that doesn't exist (it's just `Release-out`)
- Several steps have incorrect names ("stable" instead of "nightly", "deb" instead of "ckan.exe and netkan.exe", etc.)
  - Many other steps have no names at all, and in a few places this makes the logs less clear (e.g., two consecutive steps with the same default name)
  - Still other steps have names that could be slightly clearer (e.g., "Upload XYZ release asset" instead of just "Upload XYZ" in a workflow that uploads lots of stuff to lots of places, or specifying which artifact we're downloading to make it easier to track what's happening)
- `upload-release-s3` in `deploy.yml` tightly couples checking for odd builds with a job that doesn't even need that, which should be done in a shorter, standalone job
- The `Credentials` step of `deploy.yml` is weird. I cannot figure out what it's supposed to be doing. It sets a `credentials` output to `false` if the credentials _do_ exist, whereas that name suggests to me it would be `true` if the credentials exist and `false` if they don't. But if the credentials don't exist, then the `credentials` output isn't set at all, which still means false in workflow expression syntax! So the meaning and purpose of the `credentials` output is very unclear. It is used as a condition in a couple of other jobs that somehow always run even though they depend on an output that's always false.

## Changes

- `version.json` is once again created and uploaded to S3. I'm expecting this to fail due to Python's extreme environmental sensitivity, but I'll fight with `deploy.yml` about it after merge.
- Since we are hoping to sign the NuGet package, the current `Release-out` and `Debug-out` artifacts are renamed `Release-out-unsigned` and `Debug-out-unsigned`.
- The `odd-build` output is renamed `dev-build` and is now generated by a smaller, simpler `check-dev-build` job with no side effects. Jobs that need this info are updated to `needs` this job instead of `upload-release-s3`.
- The `credentials` output stuff is removed, and the `aws-actions/configure-aws-credentials` steps are moved to be the first in their jobs so if the credentials are missing, the job stops early. If there's a reason why it was like that, then I'll find out what it was after merge.
