### PR TITLE
Linux: Improve desktop entries

### DIFF
--- a/debian/ckan-cmdprompt.desktop
+++ b/debian/ckan-cmdprompt.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=CKAN Command Prompt
 Comment=Comprehensive Kerbal Archive Network Command Prompt
+Keywords=Kerbal Space Program;KSP;Mod;Command Prompt;
 Icon=/usr/share/icons/ckan.ico
 Categories=Game;PackageManager;ConsoleOnly;
 Exec=/usr/bin/ckan prompt

--- a/debian/ckan-consoleui.desktop
+++ b/debian/ckan-consoleui.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=CKAN Console UI
 Comment=Comprehensive Kerbal Archive Network Console UI
+Keywords=Kerbal Space Program;KSP;Mod;Console;
 Icon=/usr/share/icons/ckan.ico
 Categories=Game;PackageManager;ConsoleOnly;
 Exec=/usr/bin/ckan consoleui

--- a/debian/ckan.desktop
+++ b/debian/ckan.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=CKAN
 Comment=Comprehensive Kerbal Archive Network Client
+Keywords=Kerbal Space Program;KSP;Mod;
 Icon=/usr/share/icons/ckan.ico
 Categories=Game;PackageManager;
 Exec=/usr/bin/ckan

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: http://webchat.esper.net/?channels=ckan
 Source: https://github.com/KSP-CKAN/CKAN/
 
 Files: *
-Copyright: 2014-2023, the Comprehensive Kerbal Archive Network (CKAN) Authors:
+Copyright: 2014-2024, the Comprehensive Kerbal Archive Network (CKAN) Authors:
     https://github.com/KSP-CKAN/CKAN/graphs/contributors
 Comment: You can use the CKAN and its associated files under the MIT license,
     reproduced below. This includes the right to sublicense under compatible


### PR DESCRIPTION
I added keywords to the `.desktop` files of CKAN, so that they can be found easier. For example when a user forgets the name of the program they just type in `Kerbal` and it shows up as well next to the game.

See: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
![image](https://github.com/KSP-CKAN/CKAN/assets/50550545/d3357441-3662-4b41-a5db-00f9467a2346)
![image](https://github.com/KSP-CKAN/CKAN/assets/50550545/c6538587-80f4-4f96-9796-e6331f586f4a)
