### PR TITLE
Pass image from smoke to deploy, restore build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Restore cache for _build/tools
+        uses: actions/cache@v3
+        with:
+          path: _build/tools
+          key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
+      - name: Restore cache for _build/cake
+        uses: actions/cache@v3
+        with:
+          path: _build/cake
+          key: build-cake-${{ hashFiles('build.cake') }}
+      - name: Restore cache for _build/lib/nuget
+        uses: actions/cache@v3
+        with:
+          path: |
+            _build/lib/nuget
+            ~/.nuget/packages
+          key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=${{ inputs.configuration }}
       - name: Upload repack artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,9 +164,6 @@ jobs:
       - test-release
       - smoke-inflator
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - name: Download repack artifact
@@ -174,17 +171,40 @@ jobs:
         with:
           name: Release-repack-unsigned
           path: _build/repack/
-      - name: Generate inflator Docker image, publish to Hub, and restart AWS containers
+      - name: Download Inflator image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: inflator-image
+          path: /tmp
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Load Inflator image
+        run: docker load --input /tmp/inflator-image.tar
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Push Inflator image to Docker Hub
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.netkan
+          context: _build/repack/Release
+          tags: kspckan/inflator:latest
+          push: true
+      - name: Redeploy Inflator containers
         env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-west-2
-        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
+        shell: bash
         run: |
-          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          ./build docker-inflator --configuration=Release --exclusive
+          docker image pull kspckan/netkan
+          for CONTAINER in InflatorKsp InflatorKsp2
+          do
+            docker run kspckan/netkan redeploy-service --cluster NetKANCluster --service-name $CONTAINER
+          done
 
   upload-metadata-tester:
     needs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,14 +23,31 @@ jobs:
         with:
           name: Release-repack-unsigned
           path: _build/repack/
-      - name: Run inflator container smoke test
-        working-directory: _build
-        run: |
-          cp -v repack/Release/netkan.exe .
-          docker build --tag inflator --file ../Dockerfile.netkan .
-          docker run --rm --name inflator --entrypoint /bin/bash inflator -c "
-            mono netkan.exe https://raw.githubusercontent.com/KSP-CKAN/NetKAN/master/NetKAN/ZeroMiniAVC.netkan
-          "
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Inflator image
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.netkan
+          context: _build/repack/Release
+          tags: kspckan/inflator
+          outputs: type=image
+      - name: Smoke test Inflator image
+        run: >
+          docker run --rm --entrypoint /bin/bash kspckan/inflator -c "mono netkan.exe
+          https://raw.githubusercontent.com/KSP-CKAN/NetKAN/master/NetKAN/ZeroMiniAVC.netkan"
+      - name: Export Inflator image tar file
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.netkan
+          context: _build/repack/Release
+          tags: kspckan/inflator
+          outputs: type=docker,dest=/tmp/inflator-image.tar
+      - name: Upload Inflator image tar file artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: inflator-image
+          path: /tmp/inflator-image.tar
   notify:
     needs:
       - build-release


### PR DESCRIPTION
## Motivation

Currently we build the Inflator image twice when pushing to `master`, once for smoke testing and again for pushing to Docker Hub. This is a small but not tiny amount of extra time and repeated work.

Another few extra seconds are spent re-downloading build dependencies that formerly were cached in the old workflows.

## Changes

- The Inflator image build / push / redeploy steps are moved out of `build.cake` and into `smoke.yml` and `deploy.yml` using the standard docker actions and commands, in order to allow the steps to be separated and smoke testing inserted before push.
  <https://github.com/docker/build-push-action>
- `smoke.yml` now uploads a tar of the image as an artifact after the smoke test passes
  <https://docs.docker.com/build/ci/github-actions/share-image-jobs/>
  <https://docs.docker.com/build/ci/github-actions/test-before-push/>
- `deploy.yml` now downloads the tar of the image and loads it instead of building it
- The caching of the tools and dependencies is restored in `build.yml`

This should eliminate some redundant work.
