### PR TITLE
Only redeploy the metadata tester on repo dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dev-build: ${{ steps.check-version.outputs.dev-build }}
+    if: github.event_name != 'repository_dispatch'
     steps:
       - uses: actions/checkout@v4
       - name: Treat as dev build if final piece of version is odd
@@ -45,6 +46,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    if: github.event_name != 'repository_dispatch'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -80,7 +82,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    if: needs.check-dev-build.outputs.dev-build
+    if: github.event_name != 'repository_dispatch' && needs.check-dev-build.outputs.dev-build
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -125,7 +127,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    if: needs.check-dev-build.outputs.dev-build
+    if: github.event_name != 'repository_dispatch' && needs.check-dev-build.outputs.dev-build
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -164,6 +166,7 @@ jobs:
       - test-release
       - smoke-inflator
     runs-on: ubuntu-latest
+    if: github.event_name != 'repository_dispatch'
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Background

#3575, KSP-CKAN/NetKAN-Infra#267, and KSP-CKAN/xKAN-meta_testing#86 made it so the main CKAN repo would run its `deploy.yml` workflow anytime we pushed changes to the Python code from the other two repos.

## Motivation

Currently the entire `deploy.yml` worklow is run, including some unnecessary jobs:

- Uploading `ckan.exe` and `netkan.exe` to S3
- Building the rpm/deb packages and uploading them to S3
- Rebuilding, pushing, and redeploying the Inflator

This takes a little more time and may unnecessarily mark some files as changed when they really aren't.

## Changes

Now when `deploy.yml` is triggered from `NetKAN-Infra` or `xKAN-meta_testing`, we only rebuild and push the metadata tester image (and run its dependencies). This is the only job that depends on the Python code from those other repos.
