### PR TITLE
Migrate metadata tester build from Cake to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,14 +210,20 @@ jobs:
         with:
           name: Release-repack-unsigned
           path: _build/repack/
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Generate metadata tester Docker image and publish to Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
-        run: |
-          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          ./build docker-metadata --configuration=Release --exclusive
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.metadata
+          context: _build/repack/Release
+          tags: kspckan/metadata
+          push: true
 
   notify-discord:
     needs:

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,5 @@
 #addin "nuget:?package=Cake.SemVer&version=4.0.0"
 #addin "nuget:?package=semver&version=2.3.0"
-#addin "nuget:?package=Cake.Docker&version=0.11.1"
 #addin nuget:?package=Cake.Git&version=3.0.0
 #tool "nuget:?package=ILRepack&version=2.0.27"
 #tool "nuget:?package=NUnit.ConsoleRunner&version=3.16.3"
@@ -48,35 +47,6 @@ Task("Ckan")
 Task("Netkan")
     .Description("Build only netkan.exe")
     .IsDependentOn("Repack-Netkan");
-
-Task("docker-metadata")
-    .Description("Build the Docker image for the metadata testing and push it to Dockerhub.")
-    .IsDependentOn("Repack-Netkan")
-    .IsDependentOn("Repack-Ckan")
-    .Does(() =>
-{
-    var dockerDirectory   = buildDirectory.Combine("docker");
-    var metadataDirectory = dockerDirectory.Combine("metadata");
-    // Versions of Docker prior to 18.03.0-ce require the Dockerfile to be within the build context
-    var dockerFile        = metadataDirectory.CombineWithFilePath("Dockerfile.metadata");
-    CreateDirectory(metadataDirectory);
-    CopyFile(netkanFile, metadataDirectory.CombineWithFilePath("netkan.exe"));
-    CopyFile(ckanFile,   metadataDirectory.CombineWithFilePath("ckan.exe"));
-    CopyFile(rootDirectory.CombineWithFilePath("Dockerfile.metadata"), dockerFile);
-
-    var mainTag   = "kspckan/metadata";
-    var latestTag = mainTag + ":latest";
-    DockerBuild(
-        new DockerImageBuildSettings()
-        {
-            File = dockerFile.FullPath,
-            Tag  = new string[] { mainTag }
-        },
-        metadataDirectory.FullPath
-    );
-    DockerTag(mainTag, latestTag);
-    DockerPush(latestTag);
-});
 
 Task("osx")
     .Description("Build the macOS(OSX) dmg package.")


### PR DESCRIPTION
## Motivation

#4093 moved the Inflator's build/upload steps from Cake to workflows, but the metdata tester was left alone.

## Changes

- Now the metadata tester is built and uploaded via the standard action without use of Cake, which should be more maintainable
- Now `build.cake` no longer does anything Docker-related
