### PR TITLE
Skip temp files for repo updates

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -52,8 +52,8 @@ namespace CKAN.CmdLine
                 try
                 {
                     var targets = options.ckan_files
-                                         .Select(arg => new NetAsyncDownloader.DownloadTarget(getUri(arg)))
-                                         .ToList();
+                                         .Select(arg => new NetAsyncDownloader.DownloadTargetFile(getUri(arg)))
+                                         .ToArray();
                     log.DebugFormat("Urls: {0}", targets.SelectMany(t => t.urls));
                     new NetAsyncDownloader(new NullUser()).DownloadAndWait(targets);
                     log.DebugFormat("Files: {0}", targets.Select(t => t.filename));

--- a/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
+++ b/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
@@ -54,9 +54,9 @@ namespace CKAN
 
         public override IList<NetAsyncDownloader.DownloadTarget> Targets => new[]
         {
-            new NetAsyncDownloader.DownloadTarget(
+            new NetAsyncDownloader.DownloadTargetFile(
                 UpdaterDownload, updaterFilename, UpdaterSize),
-            new NetAsyncDownloader.DownloadTarget(
+            new NetAsyncDownloader.DownloadTargetFile(
                 ReleaseDownload, ckanFilename, ReleaseSize),
         };
 

--- a/Core/AutoUpdate/S3BuildCkanUpdate.cs
+++ b/Core/AutoUpdate/S3BuildCkanUpdate.cs
@@ -29,9 +29,9 @@ namespace CKAN
 
         public override IList<NetAsyncDownloader.DownloadTarget> Targets => new[]
         {
-            new NetAsyncDownloader.DownloadTarget(
+            new NetAsyncDownloader.DownloadTargetFile(
                 UpdaterDownload, updaterFilename),
-            new NetAsyncDownloader.DownloadTarget(
+            new NetAsyncDownloader.DownloadTargetFile(
                 ReleaseDownload, ckanFilename),
         };
 

--- a/Core/FileIdentifier.cs
+++ b/Core/FileIdentifier.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Linq;
 
+using ICSharpCode.SharpZipLib.GZip;
+
 using CKAN.Extensions;
 
 namespace CKAN
@@ -173,11 +175,10 @@ namespace CKAN
             if (CheckGZip(stream))
             {
                 // This may contain a tar file inside, create a new stream and check.
-                stream.Seek (0, SeekOrigin.Begin);
-                using (ICSharpCode.SharpZipLib.GZip.GZipInputStream gz_stream = new ICSharpCode.SharpZipLib.GZip.GZipInputStream (stream))
-                {
-                    type = CheckTar(gz_stream) ? FileType.TarGz : FileType.GZip;
-                }
+                stream.Seek(0, SeekOrigin.Begin);
+                type = CheckTar(new GZipInputStream(stream))
+                    ? FileType.TarGz
+                    : FileType.GZip;
             }
             else if (CheckTar(stream))
             {

--- a/Core/Net/NetAsyncDownloader.DownloadPart.cs
+++ b/Core/Net/NetAsyncDownloader.DownloadPart.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.ComponentModel;
 
 using Autofac;
@@ -14,7 +13,6 @@ namespace CKAN
         private class DownloadPart
         {
             public readonly DownloadTarget target;
-            public readonly string         path;
 
             public DateTime  lastProgressUpdateTime;
             public long      lastProgressUpdateSize;
@@ -38,14 +36,14 @@ namespace CKAN
             public DownloadPart(DownloadTarget target)
             {
                 this.target = target;
-                path = target.filename ?? Path.GetTempFileName();
                 size = bytesLeft = target.size;
                 lastProgressUpdateTime = DateTime.Now;
                 triedDownloads = 0;
             }
 
-            public void Download(Uri url, string path)
+            public void Download()
             {
+                var url = CurrentUri;
                 ResetAgent();
                 // Check whether to use an auth token for this host
                 if (url.IsAbsoluteUri
@@ -56,7 +54,7 @@ namespace CKAN
                     // Send our auth token to the GitHub API (or whoever else needs one)
                     agent.Headers.Add("Authorization", $"token {token}");
                 }
-                agent.DownloadFileAsyncWithResume(url, path);
+                target.DownloadWith(agent, url);
             }
 
             public Uri CurrentUri => target.urls[triedDownloads];

--- a/Core/Net/NetAsyncDownloader.DownloadTarget.cs
+++ b/Core/Net/NetAsyncDownloader.DownloadTarget.cs
@@ -1,42 +1,99 @@
 using System;
+using System.IO;
 using System.Collections.Generic;
-
-using ChinhDo.Transactions.FileManager;
 
 namespace CKAN
 {
     public partial class NetAsyncDownloader
     {
-        public class DownloadTarget
+        public abstract class DownloadTarget
         {
-            public List<Uri> urls     { get; private set; }
-            public string    filename { get; private set; }
-            public long      size     { get; set; }
-            public string    mimeType { get; private set; }
+            public List<Uri> urls     { get; protected set; }
+            public long      size     { get; protected set; }
+            public string    mimeType { get; protected set; }
 
-            public DownloadTarget(List<Uri> urls,
-                                  string    filename = null,
-                                  long      size     = 0,
-                                  string    mimeType = "")
+            protected DownloadTarget(List<Uri> urls,
+                                     long      size     = 0,
+                                     string    mimeType = "")
             {
-                var FileTransaction = new TxFileManager();
-
                 this.urls     = urls;
-                this.filename = string.IsNullOrEmpty(filename)
-                                    ? FileTransaction.GetTempFileName()
-                                    : filename;
                 this.size     = size;
                 this.mimeType = mimeType;
             }
 
-            public DownloadTarget(Uri    url,
-                                  string filename = null,
-                                  long   size     = 0,
-                                  string mimeType = "")
-                : this(new List<Uri> { url },
-                       filename, size, mimeType)
+            public abstract long CalculateSize();
+            public abstract void DownloadWith(ResumingWebClient wc, Uri url);
+        }
+
+        public sealed class DownloadTargetFile : DownloadTarget
+        {
+            public string filename { get; private set; }
+
+            public DownloadTargetFile(List<Uri> urls,
+                                      string    filename = null,
+                                      long      size     = 0,
+                                      string    mimeType = "")
+                : base(urls, size, mimeType)
+            {
+                this.filename = filename ?? Path.GetTempFileName();
+            }
+
+            public DownloadTargetFile(Uri    url,
+                                      string filename = null,
+                                      long   size     = 0,
+                                      string mimeType = "")
+                : this(new List<Uri> { url }, filename, size, mimeType)
             {
             }
+
+            public override long CalculateSize()
+            {
+                size = new FileInfo(filename).Length;
+                return size;
+            }
+
+            public override void DownloadWith(ResumingWebClient wc, Uri url)
+            {
+                wc.DownloadFileAsyncWithResume(url, filename);
+            }
         }
+
+        public sealed class DownloadTargetStream : DownloadTarget, IDisposable
+        {
+            public Stream contents { get; private set; }
+
+            public DownloadTargetStream(List<Uri> urls,
+                                        long      size     = 0,
+                                        string    mimeType = "")
+                : base(urls, size, mimeType)
+            {
+                contents = new MemoryStream();
+            }
+
+            public DownloadTargetStream(Uri    url,
+                                        long   size     = 0,
+                                        string mimeType = "")
+                : this(new List<Uri> { url }, size, mimeType)
+            {
+            }
+
+            public override long CalculateSize()
+            {
+                size = contents.Length;
+                return size;
+            }
+
+            public override void DownloadWith(ResumingWebClient wc, Uri url)
+            {
+                wc.DownloadFileAsyncWithResume(url, contents);
+            }
+
+            public void Dispose()
+            {
+                // Close the stream
+                contents.Dispose();
+            }
+        }
+
     }
 }

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -152,6 +152,7 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="NetRepoLoadingModulesFromRepo" xml:space="preserve"><value>Loading modules from downloaded {0} repository...</value><comment>Should contain UserProgressDownloadSubstring from CmdLine</comment></data>
   <data name="NetRepoLoadedDownloadCounts" xml:space="preserve"><value>Loaded download counts from {0} repository</value></data>
   <data name="NetRepoNotATarGz" xml:space="preserve"><value>Not a .tar.gz or .zip, cannot process: {0}</value></data>
+  <data name="NetRepoNotATarGzStream" xml:space="preserve"><value>Input stream is not a .tar.gz or .zip, cannot process</value></data>
   <data name="JsonRelationshipConverterAnyOfCombined" xml:space="preserve"><value>`any_of` should not be combined with `{0}`</value></data>
   <data name="RegistryFileConflict" xml:space="preserve"><value>{0} wishes to install {1}, but this file is registered to {2}</value></data>
   <data name="RegistryFileNotRemoved" xml:space="preserve"><value>Error unregistering {1}, file not removed: {0}</value></data>

--- a/Tests/Core/Net/NetAsyncDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncDownloaderTests.cs
@@ -24,8 +24,8 @@ namespace Tests.Core.Net
             // Arrange
             var downloader = new NetAsyncDownloader(new NullUser());
             var fromPath   = TestData.DataDir(pathWithinTestData);
-            var target     = new NetAsyncDownloader.DownloadTarget(new Uri(fromPath),
-                                                         Path.GetTempFileName());
+            var target     = new NetAsyncDownloader.DownloadTargetFile(new Uri(fromPath),
+                                                                       Path.GetTempFileName());
             var targets    = new NetAsyncDownloader.DownloadTarget[] { target };
             var origSize   = new FileInfo(fromPath).Length;
 
@@ -70,8 +70,8 @@ namespace Tests.Core.Net
             // Arrange
             var downloader = new NetAsyncDownloader(new NullUser());
             var fromPaths  = pathsWithinTestData.Select(p => TestData.DataDir(p)).ToArray();
-            var targets    = fromPaths.Select(p => new NetAsyncDownloader.DownloadTarget(new Uri(p),
-                                                                               Path.GetTempFileName()))
+            var targets    = fromPaths.Select(p => new NetAsyncDownloader.DownloadTargetFile(new Uri(p),
+                                                                                             Path.GetTempFileName()))
                                       .ToArray();
             var origSizes  = fromPaths.Select(p => new FileInfo(p).Length).ToArray();
 
@@ -186,8 +186,8 @@ namespace Tests.Core.Net
             // Arrange
             var downloader   = new NetAsyncDownloader(new NullUser());
             var fromPaths    = pathsWithinTestData.Select(p => Path.GetFullPath(TestData.DataDir(p))).ToArray();
-            var targets      = fromPaths.Select(p => new NetAsyncDownloader.DownloadTarget(new Uri(p),
-                                                                                 Path.GetTempFileName()))
+            var targets      = fromPaths.Select(p => new NetAsyncDownloader.DownloadTargetFile(new Uri(p),
+                                                                                               Path.GetTempFileName()))
                                         .ToArray();
             var badIndices   = fromPaths.Select((p, i) => new Tuple<int, bool>(i, File.Exists(p)))
                                         .Where(tuple => !tuple.Item2)


### PR DESCRIPTION
## Problem

Windows users have reported "access denied" errors with `%TEMP%\CdFileMgr` during repo updates, see #3963:

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/7a9ff38b-cc05-4709-8bc5-4014b6fedc17)

## Cause

Repo updates are downloaded to temp files with paths in that folder, which are then loaded back from disk. Some users have found that their anti-virus software was stopping CKAN from accessing these temp files.

## Changes

Now repo updates are downloaded into a `MemoryStream` and processed directly (instead of being saved to disk, then immediately re-loaded and parsed). Since they are around 30 MiB for the biggest repo, this should work fine for everyone, including whomever or whatever is preventing us from reading the temp files.

- `NetAsyncDownloader.DownloadTarget` is now an abstract base class with child classes:
  - `NetAsyncDownloader.DownloadTargetFile` - downloads to a file on disk, replaces previous usages of `DownloadTarget`, and its default temp file path is now a standard path instead of one in the `CdFileMgr` folder
  - `NetAsyncDownloader.DownloadTargetStream` - downloads to a `MemoryStream`, now used by `RepositoryDataManager.Update`
- Various layers of code are updated to no longer handle certain streams with `using () {}`, since this closes the `MemoryStream` and makes it inaccessible for processing after download
- `NetAsyncDownloader.DownloadPart.path` was redundant with `NetAsyncDownloader.DownloadTarget.filename` and is now eliminated
