### PR TITLE
Install from .ckan file option for ConsoleUI

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -217,7 +217,7 @@ namespace CKAN.CmdLine
                                              .ToHashSet();
                     // The modules we'll have after upgrading as aggressively as possible
                     var limiters = identsAndVersions.Select(req => CkanModule.FromIDandVersion(registry, req, crit)
-                                                                   ?? DefaultIfThrows(
+                                                                   ?? Utilities.DefaultIfThrows(
                                                                        () => registry.LatestAvailable(req, crit))
                                                                    ?? registry.GetInstalledVersion(req))
                                                     .Concat(heldIdents.Select(ident => registry.GetInstalledVersion(ident)))
@@ -252,18 +252,6 @@ namespace CKAN.CmdLine
                     }
                 },
                 m => identsAndVersions.Add(m.identifier));
-        }
-
-        public static T DefaultIfThrows<T>(Func<T> func)
-        {
-            try
-            {
-                return func();
-            }
-            catch
-            {
-                return default;
-            }
         }
 
         private static string UpToFirst(string orig, char toFind)

--- a/ConsoleUI/DownloadImportDialog.cs
+++ b/ConsoleUI/DownloadImportDialog.cs
@@ -24,6 +24,7 @@ namespace CKAN.ConsoleUI {
                 Properties.Resources.ImportSelectTitle,
                 FindDownloadsPath(gameInst),
                 "*.zip",
+                Properties.Resources.ImportSelectHeader,
                 Properties.Resources.ImportSelectHeader
             );
             HashSet<FileInfo> files = cfmsd.Run(theme);

--- a/ConsoleUI/InstallFromCkanDialog.cs
+++ b/ConsoleUI/InstallFromCkanDialog.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+using CKAN.ConsoleUI.Toolkit;
+using System.Linq;
+
+namespace CKAN.ConsoleUI {
+
+    /// <summary>
+    /// A popup to let the user import manually downloaded zip files into the mod cache.
+    /// </summary>
+    public static class InstallFromCkanDialog {
+
+        /// <summary>
+        /// Let the user choose some zip files, then import them to the mod cache.
+        /// </summary>
+        /// <param name="theme">The visual theme to use to draw the dialog</param>
+        /// <param name="gameInst">Game instance to import into</param>
+        public static CkanModule[] ChooseCkanFiles(ConsoleTheme theme,
+                                                   GameInstance gameInst)
+        {
+            var cfmsd = new ConsoleFileMultiSelectDialog(
+                Properties.Resources.CkanFileSelectTitle,
+                FindDownloadsPath(gameInst),
+                "*.ckan",
+                Properties.Resources.CkanFileSelectHeader,
+                Properties.Resources.CkanFileSelectHeader);
+            return cfmsd.Run(theme)
+                        .Select(f => CkanModule.FromFile(f.FullName))
+                        .ToArray();
+        }
+
+        private static readonly string[] downloadPaths = new string[] {
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads"),
+            Environment.GetFolderPath(Environment.SpecialFolder.Desktop)
+        };
+
+        private static string FindDownloadsPath(GameInstance gameInst)
+        {
+            foreach (string p in downloadPaths) {
+                if (!string.IsNullOrEmpty(p) && Directory.Exists(p)) {
+                    return p;
+                }
+            }
+            return gameInst.GameDir();
+        }
+
+    }
+
+}

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -75,13 +75,14 @@ namespace CKAN.ConsoleUI {
                         NetAsyncModulesDownloader dl = new NetAsyncModulesDownloader(this, manager.Cache);
                         if (plan.Install.Count > 0) {
                             var iList = plan.Install
-                                            .Select(m => registry.LatestAvailable(m.identifier,
-                                                                                  manager.CurrentInstance.VersionCriteria(),
-                                                                                  null,
-                                                                                  registry.InstalledModules
-                                                                                          .Select(im => im.Module)
-                                                                                          .ToArray(),
-                                                                                  plan.Install)
+                                            .Select(m => Utilities.DefaultIfThrows(() =>
+                                                             registry.LatestAvailable(m.identifier,
+                                                                                      manager.CurrentInstance.VersionCriteria(),
+                                                                                      null,
+                                                                                      registry.InstalledModules
+                                                                                              .Select(im => im.Module)
+                                                                                              .ToArray(),
+                                                                                      plan.Install))
                                                          ?? m)
                                             .ToArray();
                             inst.InstallList(iList, resolvOpts, regMgr, ref possibleConfigOnlyDirs, dl);

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -153,7 +153,7 @@
   <data name="Details" xml:space="preserve"><value>Details</value></data>
   <data name="Up" xml:space="preserve"><value>Up</value></data>
   <data name="Down" xml:space="preserve"><value>Down</value></data>
-  <data name="FileSelectDirectory" xml:space="preserve"><value>Directory</value></data>
+  <data name="FileSelectDirectory" xml:space="preserve"><value>Directory:</value></data>
   <data name="FileSelectCountFooter" xml:space="preserve"><value>{0} selected, {1}</value></data>
   <data name="FileSelectNameHeader" xml:space="preserve"><value>Name</value></data>
   <data name="FileSelectSizeHeader" xml:space="preserve"><value>Size</value></data>
@@ -341,6 +341,11 @@ If you uninstall it, CKAN will not be able to re-install it.</value></data>
   <data name="ModListImportMenuTip" xml:space="preserve"><value>Select manually downloaded mods to import into CKAN</value></data>
   <data name="ModListExportMenu" xml:space="preserve"><value>Export installed...</value></data>
   <data name="ModListExportMenuTip" xml:space="preserve"><value>Save your mod list</value></data>
+  <data name="ModListInstallFromCkanMenu" xml:space="preserve"><value>Install from .ckan file...</value></data>
+  <data name="ModListInstallFromCkanMenuTip" xml:space="preserve"><value>Install modpacks or custom modules</value></data>
+  <data name="ModListInstallFromCkanFailed" xml:space="preserve"><value>Install from .ckan file failed!</value></data>
+  <data name="CkanFileSelectTitle" xml:space="preserve"><value>Choose .ckan Files to Install</value></data>
+  <data name="CkanFileSelectHeader" xml:space="preserve"><value>Install</value></data>
   <data name="ModListInstanceSettingsMenu" xml:space="preserve"><value>Game instance settings...</value></data>
   <data name="ModListInstanceSettingsMenuTip" xml:space="preserve"><value>Configure the current game instance</value></data>
   <data name="ModListSelectInstanceMenu" xml:space="preserve"><value>Select game instance...</value></data>

--- a/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
@@ -17,7 +17,12 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="startPath">Path of directory to start in</param>
         /// <param name="filPat">Glob-style wildcard string for matching files to show</param>
         /// <param name="toggleHeader">Header for the column with checkmarks for selected files</param>
-        public ConsoleFileMultiSelectDialog(string title, string startPath, string filPat, string toggleHeader)
+        /// <param name="acceptTip">Description of the F9 action to accept selections</param>
+        public ConsoleFileMultiSelectDialog(string title,
+                                            string startPath,
+                                            string filPat,
+                                            string toggleHeader,
+                                            string acceptTip)
             : base()
         {
             CenterHeader = () => title;
@@ -40,7 +45,7 @@ namespace CKAN.ConsoleUI.Toolkit {
             ));
 
             pathField = new ConsoleField(
-                left + 2 + labelW, top + 2, right - 2,
+                left + 2 + labelW + 1, top + 2, right - 2,
                 curDir.FullName
             );
             pathField.OnChange += pathFieldChanged;
@@ -128,10 +133,8 @@ namespace CKAN.ConsoleUI.Toolkit {
                 return true;
             });
 
-            AddTip("F9", Properties.Resources.FileSelectImport, () => chosenFiles.Count > 0);
-            AddBinding(Keys.F9, (object sender, ConsoleTheme theme) => {
-                return false;
-            });
+            AddTip("F9", acceptTip, () => chosenFiles.Count > 0);
+            AddBinding(Keys.F9, (object sender, ConsoleTheme theme) => false);
         }
 
         private bool selectRow()
@@ -141,7 +144,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                 {
                     curDir = di;
                     pathField.Value = curDir.FullName;
-                    fileList.SetData(getFileList());
+                    fileList.SetData(getFileList(), true);
                 }
             } else {
                 if (fileList.Selection is FileInfo fi)
@@ -300,11 +303,11 @@ namespace CKAN.ConsoleUI.Toolkit {
 
         private static readonly string chosen  = Symbols.checkmark;
 
-        private const int idealW = 76;
-        private       int labelW => Properties.Resources.FileSelectDirectory.Length;
-        private const int hPad   = 2;
-        private const int top    =  2;
-        private const int bottom = -2;
+        private const  int idealW = 76;
+        private static int labelW => Properties.Resources.FileSelectDirectory.Length;
+        private const  int hPad   = 2;
+        private const  int top    =  2;
+        private const  int bottom = -2;
     }
 
 }

--- a/ConsoleUI/Toolkit/ConsoleListBox.cs
+++ b/ConsoleUI/Toolkit/ConsoleListBox.cs
@@ -139,7 +139,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                 topRow = selectedRow - h + 2;
             }
 
-            var remainingWidth = contentR - l + 1
+            var remainingWidth = contentR - l - 1
                                  - columns.Select(col => col.Width ?? 0)
                                           .Sum()
                                  - (padding.Length * (columns.Count - 1));

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -133,7 +133,7 @@ namespace CKAN
                                               GameVersionCriteria     crit,
                                               ICollection<CkanModule> installed = null,
                                               ICollection<CkanModule> toInstall = null)
-            => registry.LatestAvailable(name, crit, this, installed, toInstall);
+            => Utilities.DefaultIfThrows(() => registry.LatestAvailable(name, crit, this, installed, toInstall));
 
         public override bool Equals(RelationshipDescriptor other)
             => Equals(other as ModuleRelationshipDescriptor);

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -27,6 +27,18 @@ namespace CKAN
             "nl-NL",
         };
 
+        public static T DefaultIfThrows<T>(Func<T> func)
+        {
+            try
+            {
+                return func();
+            }
+            catch
+            {
+                return default;
+            }
+        }
+
         /// <summary>
         /// Copies a directory and optionally its subdirectories as a transaction.
         /// </summary>


### PR DESCRIPTION
## Motivation

GUI and CmdLine have the ability to install modules from `.ckan` files, but currently ConsoleUI doesn't. This makes modpack installation inconvenient for Mac users.

## Changes

Now the main ConsoleUI menu has a new "Install from .ckan file..." option. When selected, a popup appears to let the user choose `.ckan` files. The user can press <kbd>Enter</kbd> to toggle files and <kbd>F9</kbd> to accept the selections, at which point any selected files will be loaded and installed.

Fixes #4084.
