### PR TITLE
Store GitHub Discussions links and display in UIs

### DIFF
--- a/CKAN.schema
+++ b/CKAN.schema
@@ -201,6 +201,11 @@
                     "type"        : "string",
                     "format"      : "uri"
                 },
+                "discussions" : {
+                    "description" : "Mod discussions",
+                    "type"        : "string",
+                    "format"      : "uri"
+                },
                 "license" : {
                     "description" : "Mod license",
                     "type"        : "string",

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -281,6 +281,11 @@ namespace CKAN.CmdLine
                     user.RaiseMessage(Properties.Resources.ShowBugTracker,
                                       Net.NormalizeUri(module.resources.bugtracker.ToString()));
                 }
+                if (module.resources.discussions != null)
+                {
+                    user.RaiseMessage(Properties.Resources.ShowDiscussions,
+                                      Net.NormalizeUri(module.resources.discussions.ToString()));
+                }
                 if (module.resources.curse != null)
                 {
                     user.RaiseMessage(Properties.Resources.ShowCurse,

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -349,6 +349,7 @@ Try `ckan list` for a list of installed mods.</value></data>
   <data name="ShowSpaceDock" xml:space="preserve"><value>  SpaceDock:	{0}</value></data>
   <data name="ShowRepository" xml:space="preserve"><value>  Repository:	{0}</value></data>
   <data name="ShowBugTracker" xml:space="preserve"><value>  Bug tracker:	{0}</value></data>
+  <data name="ShowDiscussions" xml:space="preserve"><value>  Discussions:	{0}</value></data>
   <data name="ShowCurse" xml:space="preserve"><value>  Curse:	{0}</value></data>
   <data name="ShowStore" xml:space="preserve"><value>  Store:	{0}</value></data>
   <data name="ShowSteamStore" xml:space="preserve"><value>  Steam store:	{0}</value></data>

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -150,6 +150,13 @@ namespace CKAN.ConsoleUI {
                         th => LaunchURL(th, mod.resources.bugtracker)
                     ));
                 }
+                if (mod.resources.discussions != null) {
+                    opts.Add(new ConsoleMenuOption(
+                        Properties.Resources.ModInfoDiscussions, "", Properties.Resources.ModInfoDiscussionsTip,
+                        true,
+                        th => LaunchURL(th, mod.resources.discussions)
+                    ));
+                }
                 if (mod.resources.spacedock != null) {
                     opts.Add(new ConsoleMenuOption(
                         Properties.Resources.ModInfoSpaceDock,  "", Properties.Resources.ModInfoSpaceDockTip,

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -262,6 +262,8 @@ If you uninstall it, CKAN will not be able to re-install it.</value></data>
   <data name="ModInfoRepositoryTip" xml:space="preserve"><value>Open the repository URL in a browser</value></data>
   <data name="ModInfoBugtracker" xml:space="preserve"><value>Bugtracker</value></data>
   <data name="ModInfoBugtrackerTip" xml:space="preserve"><value>Open the bug tracker URL in a browser</value></data>
+  <data name="ModInfoDiscussions" xml:space="preserve"><value>Discussions</value></data>
+  <data name="ModInfoDiscussionsTip" xml:space="preserve"><value>Open the discussions URL in a browser</value></data>
   <data name="ModInfoSpaceDock" xml:space="preserve"><value>SpaceDock</value></data>
   <data name="ModInfoSpaceDockTip" xml:space="preserve"><value>Open the SpaceDock URL in a browser</value></data>
   <data name="ModInfoCurse" xml:space="preserve"><value>Curse</value></data>

--- a/Core/Exporters/DelimeterSeparatedValueExporter.cs
+++ b/Core/Exporters/DelimeterSeparatedValueExporter.cs
@@ -50,6 +50,7 @@ namespace CKAN.Exporters
                                  "repository",
                                  "homepage",
                                  "bugtracker",
+                                 "discussions",
                                  "spacedock",
                                  "curse");
 
@@ -74,6 +75,7 @@ namespace CKAN.Exporters
                                      WriteRepository(mod.Module.resources),
                                      WriteHomepage(mod.Module.resources),
                                      WriteBugtracker(mod.Module.resources),
+                                     WriteDiscussions(mod.Module.resources),
                                      WriteSpaceDock(mod.Module.resources),
                                      WriteCurse(mod.Module.resources));
                 }
@@ -98,6 +100,11 @@ namespace CKAN.Exporters
         private string WriteBugtracker(ResourcesDescriptor resources)
             => resources != null && resources.bugtracker != null
                 ? QuoteIfNecessary(resources.bugtracker.ToString())
+                : string.Empty;
+
+        private string WriteDiscussions(ResourcesDescriptor resources)
+            => resources != null && resources.discussions != null
+                ? QuoteIfNecessary(resources.discussions.ToString())
                 : string.Empty;
 
         private string WriteSpaceDock(ResourcesDescriptor resources)

--- a/Core/Types/ResourcesDescriptor.cs
+++ b/Core/Types/ResourcesDescriptor.cs
@@ -26,35 +26,39 @@ namespace CKAN
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri bugtracker;
 
-        [JsonProperty("ci", Order = 6, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("discussions", Order = 6, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
+        public Uri discussions;
+
+        [JsonProperty("ci", Order = 7, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri ci;
 
-        [JsonProperty("license", Order = 7, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("license", Order = 8, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri license;
 
-        [JsonProperty("manual", Order = 8, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("manual", Order = 9, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonIgnoreBadUrlConverter))]
         public Uri manual;
 
-        [JsonProperty("metanetkan", Order = 9, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("metanetkan", Order = 10, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri metanetkan;
 
-        [JsonProperty("remote-avc", Order = 10, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("remote-avc", Order = 11, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri remoteAvc;
 
-        [JsonProperty("remote-swinfo", Order = 11, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("remote-swinfo", Order = 12, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri remoteSWInfo;
 
-        [JsonProperty("store", Order = 12, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("store", Order = 13, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri store;
 
-        [JsonProperty("steamstore", Order = 13, NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("steamstore", Order = 14, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonOldResourceUrlConverter))]
         public Uri steamstore;
     }

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -78,6 +78,7 @@ namespace CKAN.GUI
                     AddResourceLink(Properties.Resources.ModInfoCurseLabel,                 res.curse);
                     AddResourceLink(Properties.Resources.ModInfoRepositoryLabel,            res.repository);
                     AddResourceLink(Properties.Resources.ModInfoBugTrackerLabel,            res.bugtracker);
+                    AddResourceLink(Properties.Resources.ModInfoDiscussionsLabel,           res.discussions);
                     AddResourceLink(Properties.Resources.ModInfoContinuousIntegrationLabel, res.ci);
                     AddResourceLink(Properties.Resources.ModInfoLicenseLabel,               res.license);
                     AddResourceLink(Properties.Resources.ModInfoManualLabel,                res.manual);

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -280,6 +280,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ModInfoCurseLabel" xml:space="preserve"><value>Curse:</value></data>
   <data name="ModInfoRepositoryLabel" xml:space="preserve"><value>Repository:</value></data>
   <data name="ModInfoBugTrackerLabel" xml:space="preserve"><value>Bug tracker:</value></data>
+  <data name="ModInfoDiscussionsLabel" xml:space="preserve"><value>Discussions:</value></data>
   <data name="ModInfoContinuousIntegrationLabel" xml:space="preserve"><value>Continuous integration:</value></data>
   <data name="ModInfoLicenseLabel" xml:space="preserve"><value>Licence:</value></data>
   <data name="ModInfoManualLabel" xml:space="preserve"><value>Manual:</value></data>

--- a/Netkan/Sources/Github/GithubRepo.cs
+++ b/Netkan/Sources/Github/GithubRepo.cs
@@ -34,6 +34,9 @@ namespace CKAN.NetKAN.Sources.Github
         [JsonProperty("has_issues")]
         public bool HasIssues { get; set; }
 
+        [JsonProperty("has_discussions")]
+        public bool HasDiscussions { get; set; }
+
         [JsonProperty("archived")]
         public bool Archived { get; set; }
     }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -154,18 +154,9 @@ namespace CKAN.NetKAN.Transformers
             {
                 json["resources"] = new JObject();
             }
-
-            var resourcesJson = (JObject)json["resources"];
-
-            if (!string.IsNullOrWhiteSpace(ghRepo.Homepage))
+            if (json["resources"] is JObject resourcesJson)
             {
-                resourcesJson.SafeAdd("homepage", ghRepo.Homepage);
-            }
-
-            resourcesJson.SafeAdd("repository", ghRepo.HtmlUrl);
-            if (ghRepo.HasIssues)
-            {
-                resourcesJson.SafeAdd("bugtracker", $"{ghRepo.HtmlUrl}/issues");
+                SetRepoResources(ghRepo, resourcesJson);
             }
 
             if (ghRelease != null)
@@ -216,6 +207,23 @@ namespace CKAN.NetKAN.Transformers
             {
                 Log.WarnFormat("No releases found for {0}", ghRef.Repository);
                 return metadata;
+            }
+        }
+
+        public static void SetRepoResources(GithubRepo repo, JObject resources)
+        {
+            resources.SafeAdd("repository", repo.HtmlUrl);
+            if (!string.IsNullOrWhiteSpace(repo.Homepage))
+            {
+                resources.SafeAdd("homepage", repo.Homepage);
+            }
+            if (repo.HasIssues)
+            {
+                resources.SafeAdd("bugtracker", $"{repo.HtmlUrl}/issues");
+            }
+            if (repo.HasDiscussions)
+            {
+                resources.SafeAdd("discussions", $"{repo.HtmlUrl}/discussions");
             }
         }
 

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -152,17 +152,7 @@ namespace CKAN.NetKAN.Transformers
                                 $"#/ckan/github/{owner}/{repo}", false, false
                             ));
 
-                            if (sdMod.source_code != repoInfo.HtmlUrl)
-                            {
-                                TryAddResourceURL(metadata.Identifier, resourcesJson, "repository", repoInfo.HtmlUrl);
-                            }
-                            // Fall back to homepage from GitHub
-                            TryAddResourceURL(metadata.Identifier, resourcesJson, "homepage", repoInfo.Homepage);
-                            if (repoInfo.HasIssues)
-                            {
-                                // Set bugtracker if repo has issues list
-                                TryAddResourceURL(metadata.Identifier, resourcesJson, "bugtracker", $"{repoInfo.HtmlUrl}/issues");
-                            }
+                            GithubTransformer.SetRepoResources(repoInfo, resourcesJson);
                             if (repoInfo.Archived)
                             {
                                 Log.Warn("Repo is archived, consider freezing");

--- a/Spec.md
+++ b/Spec.md
@@ -640,6 +640,7 @@ are described. Unless specified otherwise, these are URLs:
 
 - `homepage` : The preferred landing page for the mod.
 - `bugtracker` : The mod's bugtracker if it exists.
+- `discussions` : The mod's discussions page if it exists.
 - `license` : The mod's license.
 - `repository` : The repository where the module source can be found.
 - `ci` :  (**v1.6**) Continuous Integration (e.g. Jenkins) Server where the module is being built. `x_ci` is an alias used in netkan.


### PR DESCRIPTION
## Motivation

The KSP franchise's future status has become a bit uncertain, and the forum web site has been somewhat unreliable lately.

If the forums became unavailable, GitHub Discussions would be one possible alternate place where particular mods might be discusssed.

![image](https://github.com/KSP-CKAN/CKAN/assets/1559108/212c06bf-1ad3-4066-a112-17b8a8d001f2)

- <https://github.com/HebaruSan/Astrogator/discussions>

## Changes

- Now the spec and schema allow `resources.discussions` to be a URL
  (But no `spec_version` limitations are imposed because it's easy for the old client to just ignore the new value)
- Now Netkan checks whether discussions are enabled for GitHub repos, and if so, it sets `resources.discussions` to that repo's discussions URL, just like we do for `resources.bugtracker`
- Now CmdLine, ConsoleUI, and GUI include the `resources.discussions` link in their respective mod info displays

This way if mod authors start enabling discussion for their repos, either now or upon the sudden disappearance of the forum, the URLs will begin appearing in CKAN so users can find out about them.

### Considered but not done

The obvious question here is: What about `resources.homepage`, which for most mods will be set to a forum thread? It would be amazing to automatically retire those links and switch `resources.homepage` over to discussions automatically, but after some consideration, I don't think that's a viable option:

- The forum is not yet dead, and Netkan won't know programmatically if that happens
- Some other forum preservation option may become available for migrating homepages, such as via the Internet Archive
- Some authors may prefer to keep the old links available for nostalgic purposes
- Some authors may _want_ to use both a hompage _and_ a discussions link (for example, when the homepage is non-interactive like a wiki)

For these reasons, the discussions link is added separately and homepage is left alone.
