### PR TITLE
Update Artifact Signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,24 +6,30 @@ on:
       configuration:
         type: string
         default: Debug
+    outputs:
+      repack-artifact-id:
+        description: "Artifact ID of the repack"
+        value: ${{ jobs.build.outputs.repack-artifact-id }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      repack-artifact-id: ${{ steps.upload-repack-artifact.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v4
       - name: Restore cache for _build/tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build/tools
           key: build-tools-${{ hashFiles('build', 'build.ps1', 'build.cake') }}
       - name: Restore cache for _build/cake
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build/cake
           key: build-cake-${{ hashFiles('build.cake') }}
       - name: Restore cache for _build/lib/nuget
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             _build/lib/nuget

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build ckan.exe and netkan.exe
         run: ./build --configuration=${{ inputs.configuration }}
       - name: Upload repack artifact
+        id: upload-repack-artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.configuration }}-repack-unsigned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
     outputs:
       artifact-url: ${{steps.sign.outputs.signing-request-id }}
     steps:
-      - uses: signpath/github-action-submit-signing-request@v0.3
+      - uses: signpath/github-action-submit-signing-request@v0.4
         id: sign
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: 0cd9fc3f-b78d-4214-b152-b2e93c952e14
           project-slug: CKAN
           signing-policy-slug: test-signing
-          github-artifact-name: Release-repack-unsigned
+          github-artifact-id: ${{ needs.smoke-inflator.outputs.repack-artifact-id }}
           artifact-configuration-slug: release
           wait-for-completion: true
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - reopened
   workflow_call:
+    outputs:
+      repack-artifact-id:
+        description: "Artifact ID of the repack"
+        value: ${{ jobs.build-release.outputs.repack-artifact-id }}
 
 jobs:
   build-release:


### PR DESCRIPTION
Version 4 of [SignPath/github-action-submit-signing-request](https://github.com/SignPath/github-action-submit-signing-request/tree/v0.4) required the following to be addressed:
> Id of the Github Actions artifact. Must be uploaded using the actions/upload-artifact v4+ action before it can be signed. Use {{ steps.<step-id>.outputs.artifact-id }} from the preceding actions/upload-artifact action step.

We now have outputs to be able to pass that artifact id through the workflows to the signing action. Results of this working can be seen here -> https://github.com/KSP-CKAN/CKAN/actions/runs/9804590624

## Extra
- Bumped `actions/cache` to v4