### PR TITLE
Fix default transaction timeout

### DIFF
--- a/Core/CkanTransaction.cs
+++ b/Core/CkanTransaction.cs
@@ -26,7 +26,7 @@ namespace CKAN
         }
 
         // System.ArgumentOutOfRangeException : Time-out interval must be less than 2^32-2. (Parameter 'dueTime')
-        private const double timeoutMs = 4294967294d;
+        private const double timeoutMs = Int32.MaxValue;
         private static readonly TimeSpan maxCoretimeout = TimeSpan.FromMilliseconds(timeoutMs);
 
         private static readonly TransactionOptions transOpts = new TransactionOptions()


### PR DESCRIPTION
Fixes GameInstance scanning described in #3770, switching over to a default `timeout` value of `Int32.MaxValue`.