### PR TITLE
Allow string "Harmony" in DLL parent folder names

### DIFF
--- a/Netkan/Validators/HarmonyValidator.cs
+++ b/Netkan/Validators/HarmonyValidator.cs
@@ -37,7 +37,8 @@ namespace CKAN.NetKAN.Validators
 
                     var harmonyDLLs = _moduleService.GetPlugins(mod, zip, inst)
                         .Select(instF => instF.source.Name)
-                        .Where(f => f.IndexOf("Harmony", StringComparison.InvariantCultureIgnoreCase) != -1)
+                        .Where(f => f.IndexOf("Harmony", Math.Max(0, f.LastIndexOf('/')),
+                                              StringComparison.InvariantCultureIgnoreCase) != -1)
                         .OrderBy(f => f)
                         .ToList();
                     bool bundlesHarmony   = harmonyDLLs.Any();


### PR DESCRIPTION
## Problem

`CelestialHarmony` has been having spurious inflation errors for a bit over a week.

![image](https://github.com/user-attachments/assets/372d297a-1807-4804-a8d6-eb1ac5aba4cf)

## Cause

The guardrail to catch bundled copies of the Harmony DLL from #3326 checks the entire file path, not just the file name, so a folder with a name coincidentally containing the string "Harmony" will cause a false positive if it contains a DLL.

## Changes

Now this check only looks for "Harmony" in the filename by starting the search at `Math.Max(0, f.LastIndexOf('/'))`.
