### PR TITLE
Use DriveInfo constructor to get drive from path

### DIFF
--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -127,16 +127,19 @@ namespace CKAN
 
         public static void CheckFreeSpace(DirectoryInfo where, long bytesToStore, string errorDescription)
         {
-            var bytesFree = where.GetDrive()?.AvailableFreeSpace;
-            if (bytesFree.HasValue && bytesToStore > bytesFree.Value) {
-                throw new NotEnoughSpaceKraken(errorDescription, where,
-                                               bytesFree.Value, bytesToStore);
+            if (bytesToStore > 0)
+            {
+                var bytesFree = where.GetDrive()?.AvailableFreeSpace;
+                if (bytesFree.HasValue && bytesToStore > bytesFree.Value) {
+                    throw new NotEnoughSpaceKraken(errorDescription, where,
+                                                   bytesFree.Value, bytesToStore);
+                }
+                log.DebugFormat("Storing {0} to {1} ({2} free)...",
+                                CkanModule.FmtSize(bytesToStore),
+                                where.FullName,
+                                bytesFree.HasValue ? CkanModule.FmtSize(bytesFree.Value)
+                                                   : "unknown bytes");
             }
-            log.DebugFormat("Storing {0} to {1} ({2} free)...",
-                            CkanModule.FmtSize(bytesToStore),
-                            where.FullName,
-                            bytesFree.HasValue ? CkanModule.FmtSize(bytesFree.Value)
-                                               : "unknown bytes");
         }
 
     }

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Collections.Generic;
 using System.Threading;
 using Timer = System.Timers.Timer;
@@ -9,55 +8,13 @@ namespace CKAN.Extensions
 {
     public static class IOExtensions
     {
-        private static bool StringArrayStartsWith(string[] child, string[] parent)
-        {
-            if (parent.Length > child.Length)
-            {
-                // Only child is allowed to have extra pieces
-                return false;
-            }
-            for (int i = 0; i < parent.Length; ++i)
-            {
-                if (!parent[i].Equals(child[i], Platform.PathComparison))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private static readonly char[] pathDelims = new char[] {Path.DirectorySeparatorChar};
-
         /// <summary>
-        /// Check whether a given path is an ancestor of another
-        /// </summary>
-        /// <param name="parent">The path to treat as potential ancestor</param>
-        /// <param name="child">The path to treat as potential descendant</param>
-        /// <returns>true if child is a descendant of parent, false otherwise</returns>
-        public static bool IsAncestorOf(this DirectoryInfo parent, DirectoryInfo child)
-            => StringArrayStartsWith(
-                child.FullName.Split(pathDelims, StringSplitOptions.RemoveEmptyEntries),
-                parent.FullName.Split(pathDelims, StringSplitOptions.RemoveEmptyEntries));
-
-        /// <summary>
-        /// Extension method to fill in the gap of getting from a
-        /// directory to its drive in .NET.
-        /// Returns the drive with the longest RootDirectory.FullName
-        /// that's a prefix of the dir's FullName.
+        /// Extension method to get from a directory to its drive.
         /// </summary>
         /// <param name="dir">Any DirectoryInfo object</param>
         /// <returns>The DriveInfo associated with this directory, if any, else null</returns>
         public static DriveInfo GetDrive(this DirectoryInfo dir)
-            => Platform.IsMono
-                // Mono's DriveInfo.GetDrives doesn't return mounted filesystems, so we
-                // can't get the drive for a dir on Linux or Mac
-                ? null
-                : DriveInfo.GetDrives()
-                           .Where(dr => dr.IsReady
-                                        && dr.DriveType != DriveType.NoRootDirectory
-                                        && dr.RootDirectory.IsAncestorOf(dir))
-                           .OrderByDescending(dr => dr.RootDirectory.FullName.Length)
-                           .FirstOrDefault();
+            => new DriveInfo(dir.FullName);
 
         /// <summary>
         /// A version of Stream.CopyTo with progress updates.


### PR DESCRIPTION
## Problem

Discord user `HB Stratos` reports that sometimes, a 20+ second delay occurs at the start of mod installation:

![image](https://github.com/user-attachments/assets/3b5c0807-2467-48a8-b508-2e83b34f28d6)

## Cause

Based on the log file provided, the delay happens between here:

https://github.com/KSP-CKAN/CKAN/blob/1b5948faa5d254ac40aa9ca522759a526f257e40/GUI/Main/MainInstall.cs#L204

and here:

https://github.com/KSP-CKAN/CKAN/blob/1b5948faa5d254ac40aa9ca522759a526f257e40/Core/CKANPathUtils.cs#L135-L139

CKAN doesn't do any significant work itself in that interval, but I suspect that there is a hibernating external HDD attached to this user's system, and `.GetDrive()`'s loop over all the drives causes that drive to be woken up, which takes several seconds. When it's finally ready, the loop continues. That loop was implemented in #3631 because there was no property or function to get the drive associated with a path. However, reading up on the documentation a bit more, `DriveInfo`'s _constructor_ can apparently accept an arbitrary fully qualified path, and returns the associated drive, just as we wanted:

- <https://learn.microsoft.com/en-us/dotnet/api/system.io.driveinfo.-ctor>

In testing, this even seems to work on Linux!

## Changes

- The logic from #3631 is replaced by calling `new DriveInfo(dir.FullName)`
- Disk space checking is restored to Linux clients (rolling back #3850)
- `CKANPathUtils.CheckFreeSpace` now no longer does anything when its `bytesToStore` parameter is 0, which will skip some unnecessary IO when installing older modules that don't have `install_size` defined

This should avoid waking up slumbering HDDs during mod installaiton.
