### PR TITLE
Detect changes to `replaced_by`

### DIFF
--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -624,6 +624,12 @@ namespace CKAN
                 return false;
             }
 
+            if (replaced_by == null ? other.replaced_by != null
+                                    : !replaced_by.Equals(other.replaced_by))
+            {
+                return false;
+            }
+
             if (provides != other.provides)
             {
                 if (provides == null || other.provides == null)


### PR DESCRIPTION
## Problem

During KSP-CKAN/NetKAN#10108, we noticed that `replaced_by` is a bit janky.

## Causes

- We check for the `replaced_by` property in the _installed_ module, not the available module, so if users install a module and then later we add `replaced_by` to migrate them to a new identifier, they won't see the replace checkbox unless they reinstall the mod to get the new metadata.
- Compounding this, when we decide whether to prompt for reinstallation, `replaced_by` isn't checked. So the user would have to reinstall manually, which mostly defeats the purpose.

## Changes

Now if you add `replaced_by` to a module, users who already have it installed will be prompted to reinstall it with the upgrade checkbox, after which they'll be prompted to replace it with the replace checkbox.

`replaced_by` could use more streamlining after this, but this will at least make it baseline usable.
