### PR TITLE
Update changeset on Replace checkbox change, other replaced_by fixes

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -922,6 +922,10 @@ namespace CKAN
 
             public override string ToString()
                 => string.Format(Properties.Resources.RelationshipResolverReplacementReason, Parent.name);
+
+            public override string DescribeWith(IEnumerable<SelectionReason> others)
+                => string.Format(Properties.Resources.RelationshipResolverReplacementReason,
+                    string.Join(", ", Enumerable.Repeat(this, 1).Concat(others).Select(r => r.Parent.name)));
         }
 
         public sealed class Suggested : SelectionReason

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -904,6 +904,10 @@ namespace CKAN.GUI
                                     gmod.SetAutoInstallChecked(row, AutoInstalled);
                                     OnRegistryChanged?.Invoke();
                                     break;
+                                case "ReplaceCol":
+                                    UpdateChangeSetAndConflicts(currentInstance,
+                                        RegistryManager.Instance(currentInstance, repoData).registry);
+                                    break;
                             }
                         }
                         break;

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -124,7 +124,10 @@ namespace CKAN.GUI
                         if (repl != null)
                         {
                             toUninstall.Add(repl.ToReplace);
-                            toInstall.Add(repl.ReplaceWith);
+                            if (!toInstall.Contains(repl.ReplaceWith))
+                            {
+                                toInstall.Add(repl.ReplaceWith);
+                            }
                         }
                         break;
                 }


### PR DESCRIPTION
## Problems

After #4127 and KSP-CKAN/CKAN-meta#3277, further testing found more issues with `replaced_by`:

- Checking and unchecking the Replace checkbox doesn't update the changeset or enable/disable the apply button
- If you fix that, changesets with a replace action look weird; they have both a Replace action and a Remove action for the installed mod, and the Install action for the new mod says the reason is "User requested", which is sort of true-ish but really should explain something to do with replacing
- If you fix _that_, changesets where one mod replaces multiple installed mods fail on the progress screen

## Causes

- `ManageMods.ModGrid_CellValueChanged` doesn't react to checkbox changes when the column is `ReplaceCol`
- Replace actions were being split into Remove and Install actions without a lot of careful attention to the end result, and `SelectionReason.Replacement` was not actually in use anywhere
- The replacement was ending up in the changeset multiple times, with one Install action per replaced mod

## Changes

- Now `ManageMods.ModGrid_CellValueChanged` updates the changeset when a checkbox changes in the `ReplaceCol` column, so the apply button becomes enabled when it should
- Now the changeset will only show Replace actions for the installed mods and an Install action for the replacing mod, with a reason of `Replacing <list of mods it replaces>`
- Now each replacement mod gets only one Install entry in the changeset

This should further move `replaced_by` towards becoming working, useful functionality. It still needs some massaging and refactoring, but now you can actually use it to replace mods.

Note that if you test this with the Nehemiah stuff (somewhat helpful), there are conflicts between some of the old mods and the new one, so you may have to replace them all to be able to continue.
