### PR TITLE
Option to clone smaller instances with junction points (Windows) or symbolic links (Unix)

### DIFF
--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -97,6 +97,9 @@ namespace CKAN.CmdLine
 
     internal class CloneOptions : CommonOptions
     {
+        [Option("share-stock", DefaultValue = false, HelpText = "Use junction points (Windows) or symbolic links (Unix) for stock dirs instead of copying")]
+        public bool shareStock { get; set; }
+
         [ValueOption(0)] public string nameOrPath { get; set; }
         [ValueOption(1)] public string new_name { get; set; }
         [ValueOption(2)] public string new_path { get; set; }
@@ -341,7 +344,7 @@ namespace CKAN.CmdLine
                         if (instance.Name == instanceNameOrPath)
                         {
                             // Found it, now clone it.
-                            Manager.CloneInstance(instance, newName, newPath);
+                            Manager.CloneInstance(instance, newName, newPath, options.shareStock);
                             break;
                         }
                     }
@@ -350,7 +353,7 @@ namespace CKAN.CmdLine
                 // If it's valid, go on.
                 else if (Manager.InstanceAt(instanceNameOrPath) is CKAN.GameInstance instance && instance.Valid)
                 {
-                    Manager.CloneInstance(instance, newName, newPath);
+                    Manager.CloneInstance(instance, newName, newPath, options.shareStock);
                 }
                 // There is no instance with this name or at this path.
                 else

--- a/Core/DirectoryLink.cs
+++ b/Core/DirectoryLink.cs
@@ -1,0 +1,167 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+using ChinhDo.Transactions.FileManager;
+
+namespace CKAN
+{
+    /// <summary>
+    /// Junctions on Windows, symbolic links on Unix
+    /// </summary>
+    public static class DirectoryLink
+    {
+        public static void Create(string target, string link, TxFileManager txMgr)
+        {
+            if (!CreateImpl(target, link, txMgr))
+            {
+                throw new Kraken(Platform.IsWindows
+                    ? $"Failed to create junction at {link}: {Marshal.GetLastWin32Error()}"
+                    : $"Failed to create symbolic link at {link}");
+            }
+        }
+
+        private static bool CreateImpl(string target, string link, TxFileManager txMgr)
+            => Platform.IsWindows ? CreateJunction(link, target, txMgr)
+                                  : symlink(target, link) == 0;
+
+        [DllImport("libc")]
+        private static extern int symlink(string target, string link);
+
+        private static bool CreateJunction(string link, string target, TxFileManager txMgr)
+        {
+            // A junction is a directory with some extra magic attached
+            if (!txMgr.DirectoryExists(link))
+            {
+                txMgr.CreateDirectory(link);
+            }
+            using (var h = CreateFile(link, GenericWrite, FileShare.Read | FileShare.Write, IntPtr.Zero,
+                                      FileMode.Open, BackupSemantics | OpenReparsePoint, IntPtr.Zero))
+            {
+                if (!h.IsInvalid)
+                {
+                    var junctionInfo = ReparseDataBuffer.FromPath(target, out int byteCount);
+                    return DeviceIoControl(h, FSCTL_SET_REPARSE_POINT,
+                                           ref junctionInfo, byteCount + 20,
+                                           null, 0,
+                                           out _, IntPtr.Zero);
+                }
+            }
+            return false;
+        }
+
+        public static bool TryGetTarget(string link, out string target)
+        {
+            target = null;
+            var fi = new DirectoryInfo(link);
+            if (fi.Attributes.HasFlag(FileAttributes.ReparsePoint))
+            {
+                if (Platform.IsWindows)
+                {
+                    var h = CreateFile(link, 0, FileShare.Read, IntPtr.Zero,
+                                       FileMode.Open, BackupSemantics | OpenReparsePoint, IntPtr.Zero);
+                    if (!h.IsInvalid)
+                    {
+                        if (DeviceIoControl(h, FSCTL_GET_REPARSE_POINT,
+                                            null, 0,
+                                            out ReparseDataBuffer junctionInfo, Marshal.SizeOf(typeof(ReparseDataBuffer)),
+                                            out _, IntPtr.Zero))
+                        {
+                            if (junctionInfo.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT)
+                            {
+                                target = junctionInfo.PathBuffer.TrimStart("\\\\?\\");
+                            }
+                        }
+                        h.Close();
+                    }
+                }
+                else
+                {
+                    var bytes = new byte[1024];
+                    var result = readlink(link, bytes, bytes.Length);
+                    if (result > 0)
+                    {
+                        target = Encoding.UTF8.GetString(bytes);
+                    }
+                }
+            }
+            return !string.IsNullOrEmpty(target);
+        }
+
+        private const uint GenericWrite               = 0x40000000u;
+        private const uint BackupSemantics            = 0x02000000u;
+        private const uint OpenReparsePoint           = 0x00200000u;
+        private const uint FSCTL_SET_REPARSE_POINT    = 0x000900A4u;
+        private const uint IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003u;
+        private const uint FSCTL_GET_REPARSE_POINT    = 0x000900A8u;
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool DeviceIoControl(SafeFileHandle        hDevice,
+                                                   uint                  IoControlCode,
+                                                   ref ReparseDataBuffer InBuffer,
+                                                   int                   nInBufferSize,
+                                                   byte[]                OutBuffer,
+                                                   int                   nOutBufferSize,
+                                                   out int               pBytesReturned,
+                                                   IntPtr                Overlapped);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool DeviceIoControl(SafeFileHandle        hDevice,
+                                                   uint                  IoControlCode,
+                                                   byte[]                InBuffer,
+                                                   int                   nInBufferSize,
+                                                   out ReparseDataBuffer OutBuffer,
+                                                   int                   nOutBufferSize,
+                                                   out int               pBytesReturned,
+                                                   IntPtr                Overlapped);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        private struct ReparseDataBuffer
+        {
+            public           uint   ReparseTag;
+            public           ushort ReparseDataLength;
+            private readonly ushort Reserved;
+            public           ushort SubstituteNameOffset;
+            public           ushort SubstituteNameLength;
+            public           ushort PrintNameOffset;
+            public           ushort PrintNameLength;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 8184)]
+            public           string PathBuffer;
+
+            public static ReparseDataBuffer FromPath(string target, out int byteCount)
+            {
+                var fullTarget = $@"\??\{Path.GetFullPath(target)}";
+                byteCount = Encoding.Unicode.GetByteCount(fullTarget);
+                return new ReparseDataBuffer
+                {
+                    ReparseTag           = IO_REPARSE_TAG_MOUNT_POINT,
+                    ReparseDataLength    = (ushort)(byteCount + 12),
+                    SubstituteNameOffset = 0,
+                    SubstituteNameLength = (ushort)byteCount,
+                    PrintNameOffset      = (ushort)(byteCount + 2),
+                    PrintNameLength      = 0,
+                    PathBuffer           = fullTarget,
+                };
+            }
+        }
+
+        [DllImport("libc")]
+        private static extern int readlink(string link, byte[] buf, int bufsize);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern SafeFileHandle CreateFile([MarshalAs(UnmanagedType.LPTStr)] string    filename,
+                                                        [MarshalAs(UnmanagedType.U4)]     uint      access,
+                                                        [MarshalAs(UnmanagedType.U4)]     FileShare share,
+                                                        IntPtr securityAttributes,
+                                                        [MarshalAs(UnmanagedType.U4)]     FileMode  creationDisposition,
+                                                        [MarshalAs(UnmanagedType.U4)]     uint      flagsAndAttributes,
+                                                        IntPtr templateFile);
+
+        private static string TrimStart(this string orig, string toRemove)
+            => orig.StartsWith(toRemove) ? orig.Remove(0, toRemove.Length)
+                                         : orig;
+
+    }
+}

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -239,7 +239,10 @@ namespace CKAN
         /// <exception cref="DirectoryNotFoundKraken">Thrown by CopyDirectory() if directory doesn't exist. Should never be thrown here.</exception>
         /// <exception cref="PathErrorKraken">Thrown by CopyDirectory() if the target folder already exists and is not empty.</exception>
         /// <exception cref="IOException">Thrown by CopyDirectory() if something goes wrong during the process.</exception>
-        public void CloneInstance(GameInstance existingInstance, string newName, string newPath)
+        public void CloneInstance(GameInstance existingInstance,
+                                  string       newName,
+                                  string       newPath,
+                                  bool         shareStockFolders = false)
         {
             if (HasInstance(newName))
             {
@@ -252,11 +255,13 @@ namespace CKAN
             }
 
             log.Debug("Copying directory.");
-            Utilities.CopyDirectory(existingInstance.GameDir(), newPath, true);
+            Utilities.CopyDirectory(existingInstance.GameDir(), newPath,
+                                    shareStockFolders ? existingInstance.game.StockFolders
+                                                      : Array.Empty<string>(),
+                                    existingInstance.game.LeaveEmptyInClones);
 
             // Add the new instance to the config
-            GameInstance new_instance = new GameInstance(existingInstance.game, newPath, newName, User);
-            AddInstance(new_instance);
+            AddInstance(new GameInstance(existingInstance.game, newPath, newName, User));
         }
 
         /// <summary>

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -24,10 +24,11 @@ namespace CKAN.Games
         string         PrimaryModDirectoryRelative     { get; }
         string[]       AlternateModDirectoriesRelative { get; }
         string         PrimaryModDirectory(GameInstance inst);
-        string[]       StockFolders      { get; }
-        string[]       ReservedPaths     { get; }
-        string[]       CreateableDirs    { get; }
-        string[]       AutoRemovableDirs { get; }
+        string[]       StockFolders       { get; }
+        string[]       LeaveEmptyInClones { get; }
+        string[]       ReservedPaths      { get; }
+        string[]       CreateableDirs     { get; }
+        string[]       AutoRemovableDirs  { get; }
         bool           IsReservedDirectory(GameInstance inst, string path);
         bool           AllowInstallationIn(string name, out string path);
         void           RebuildSubdirectories(string absGameRoot);

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -65,6 +65,17 @@ namespace CKAN.Games.KerbalSpaceProgram
             "PDLauncher",
         };
 
+        public string[] LeaveEmptyInClones => new string[]
+        {
+            "saves",
+            "Screenshots",
+            "thumbs",
+            "Missions",
+            "Logs",
+            "CKAN/history",
+            "CKAN/downloads",
+        };
+
         public string[] ReservedPaths => new string[]
         {
             "GameData", "Ships", "Missions"

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -59,6 +59,12 @@ namespace CKAN.Games.KerbalSpaceProgram2
             "PDLauncher",
         };
 
+        public string[] LeaveEmptyInClones => new string[]
+        {
+            "CKAN/history",
+            "CKAN/downloads",
+        };
+
         public string[] ReservedPaths => Array.Empty<string>();
 
         public string[] CreateableDirs => new string[]

--- a/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
@@ -30,6 +30,7 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(CloneGameInstanceDialog));
+            this.ToolTip = new System.Windows.Forms.ToolTip();
             this.labelOldInstance = new System.Windows.Forms.Label();
             this.comboBoxKnownInstance = new System.Windows.Forms.ComboBox();
             this.labelOldPath = new System.Windows.Forms.Label();
@@ -42,11 +43,19 @@ namespace CKAN.GUI
             this.buttonPathBrowser = new System.Windows.Forms.Button();
             this.checkBoxSetAsDefault = new System.Windows.Forms.CheckBox();
             this.checkBoxSwitchInstance = new System.Windows.Forms.CheckBox();
+            this.checkBoxShareStock = new System.Windows.Forms.CheckBox();
             this.buttonOK = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.progressBar = new System.Windows.Forms.ProgressBar();
             this.folderBrowserDialogNewPath = new System.Windows.Forms.FolderBrowserDialog();
             this.SuspendLayout();
+            //
+            // ToolTip
+            //
+            this.ToolTip.AutoPopDelay = 10000;
+            this.ToolTip.InitialDelay = 250;
+            this.ToolTip.ReshowDelay = 250;
+            this.ToolTip.ShowAlways = true;
             //
             // labelOldInstance
             //
@@ -154,7 +163,7 @@ namespace CKAN.GUI
             //
             this.checkBoxSetAsDefault.AutoSize = true;
             this.checkBoxSetAsDefault.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.checkBoxSetAsDefault.Location = new System.Drawing.Point(12, 144);
+            this.checkBoxSetAsDefault.Location = new System.Drawing.Point(181, 144);
             this.checkBoxSetAsDefault.Name = "checkBoxSetAsDefault";
             this.checkBoxSetAsDefault.Size = new System.Drawing.Size(157, 17);
             this.checkBoxSetAsDefault.TabIndex = 19;
@@ -167,20 +176,33 @@ namespace CKAN.GUI
             this.checkBoxSwitchInstance.Checked = true;
             this.checkBoxSwitchInstance.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxSwitchInstance.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.checkBoxSwitchInstance.Location = new System.Drawing.Point(181, 144);
+            this.checkBoxSwitchInstance.Location = new System.Drawing.Point(181, 174);
             this.checkBoxSwitchInstance.Name = "checkBoxSwitchInstance";
             this.checkBoxSwitchInstance.Size = new System.Drawing.Size(136, 17);
             this.checkBoxSwitchInstance.TabIndex = 20;
             this.checkBoxSwitchInstance.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.checkBoxSwitchInstance, "checkBoxSwitchInstance");
             //
+            // checkBoxShareStock
+            //
+            this.checkBoxShareStock.AutoSize = true;
+            this.checkBoxShareStock.Checked = true;
+            this.checkBoxShareStock.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxShareStock.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.checkBoxShareStock.Location = new System.Drawing.Point(181, 204);
+            this.checkBoxShareStock.Name = "checkBoxShareStock";
+            this.checkBoxShareStock.Size = new System.Drawing.Size(136, 17);
+            this.checkBoxShareStock.TabIndex = 21;
+            this.checkBoxShareStock.UseVisualStyleBackColor = true;
+            resources.ApplyResources(this.checkBoxShareStock, "checkBoxShareStock");
+            //
             // buttonOK
             //
             this.buttonOK.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.buttonOK.Location = new System.Drawing.Point(256, 170);
+            this.buttonOK.Location = new System.Drawing.Point(256, 230);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
-            this.buttonOK.TabIndex = 21;
+            this.buttonOK.TabIndex = 22;
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
             resources.ApplyResources(this.buttonOK, "buttonOK");
@@ -188,10 +210,10 @@ namespace CKAN.GUI
             // buttonCancel
             //
             this.buttonCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.buttonCancel.Location = new System.Drawing.Point(337, 170);
+            this.buttonCancel.Location = new System.Drawing.Point(337, 230);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-            this.buttonCancel.TabIndex = 22;
+            this.buttonCancel.TabIndex = 23;
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
             resources.ApplyResources(this.buttonCancel, "buttonCancel");
@@ -204,7 +226,7 @@ namespace CKAN.GUI
             this.progressBar.Name = "progressBar";
             this.progressBar.Size = new System.Drawing.Size(230, 23);
             this.progressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-            this.progressBar.TabIndex = 23;
+            this.progressBar.TabIndex = 24;
             this.progressBar.Visible = false;
             //
             // CloneGameInstanceDialog
@@ -213,7 +235,7 @@ namespace CKAN.GUI
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(424, 205);
+            this.ClientSize = new System.Drawing.Size(424, 265);
             this.Controls.Add(this.labelOldInstance);
             this.Controls.Add(this.comboBoxKnownInstance);
             this.Controls.Add(this.labelOldPath);
@@ -222,6 +244,7 @@ namespace CKAN.GUI
             this.Controls.Add(this.progressBar);
             this.Controls.Add(this.buttonPathBrowser);
             this.Controls.Add(this.checkBoxSwitchInstance);
+            this.Controls.Add(this.checkBoxShareStock);
             this.Controls.Add(this.textBoxNewPath);
             this.Controls.Add(this.labelNewPath);
             this.Controls.Add(this.checkBoxSetAsDefault);
@@ -247,6 +270,7 @@ namespace CKAN.GUI
 
         #endregion
 
+        private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.Label labelOldInstance;
         private System.Windows.Forms.ComboBox comboBoxKnownInstance;
         private System.Windows.Forms.Label labelOldPath;
@@ -259,6 +283,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.Button buttonPathBrowser;
         private System.Windows.Forms.CheckBox checkBoxSetAsDefault;
         private System.Windows.Forms.CheckBox checkBoxSwitchInstance;
+        private System.Windows.Forms.CheckBox checkBoxShareStock;
         private System.Windows.Forms.Button buttonOK;
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.FolderBrowserDialog folderBrowserDialogNewPath;

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -15,7 +15,7 @@ using CKAN.Games;
 namespace CKAN.GUI
 {
     /// <summary>
-    /// The GUI implementation of clone and fake.
+    /// The GUI implementation of clone.
     /// It's a separate window, handling the whole process.
     /// </summary>
     #if NET5_0_OR_GREATER
@@ -33,6 +33,8 @@ namespace CKAN.GUI
             this.user    = user;
 
             InitializeComponent();
+
+            ToolTip.SetToolTip(checkBoxShareStock, Properties.Resources.CloneGameInstanceToolTipShareStock);
 
             // Populate the instances combobox with names of known instances
             comboBoxKnownInstance.DataSource = new string[] { "" }
@@ -138,7 +140,7 @@ namespace CKAN.GUI
                 {
                     if (instanceToClone.Valid)
                     {
-                        manager.CloneInstance(instanceToClone, newName, newPath);
+                        manager.CloneInstance(instanceToClone, newName, newPath, checkBoxShareStock.Checked);
                     }
                     else
                     {

--- a/GUI/Dialogs/CloneGameInstanceDialog.resx
+++ b/GUI/Dialogs/CloneGameInstanceDialog.resx
@@ -125,7 +125,8 @@
   <data name="buttonPathBrowser.Text" xml:space="preserve"><value>Select...</value></data>
   <data name="checkBoxSetAsDefault.Text" xml:space="preserve"><value>Set new instance as default</value></data>
   <data name="checkBoxSwitchInstance.Text" xml:space="preserve"><value>Switch to new instance</value></data>
-  <data name="buttonOK.Text" xml:space="preserve"><value>Create</value></data>
+  <data name="checkBoxShareStock.Text" xml:space="preserve"><value>Share stock files</value></data>
+  <data name="buttonOK.Text" xml:space="preserve"><value>Clone</value></data>
   <data name="buttonCancel.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Clone Game Instance</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -133,6 +133,8 @@
   <data name="CloneFakeKspDialogCreatingInstance" xml:space="preserve"><value>Creating new instance...</value></data>
   <data name="CloneFakeKspDialogNameAlreadyUsed" xml:space="preserve"><value>This name is already used.</value></data>
   <data name="CloneFakeKspDialogSuccessfulCreate" xml:space="preserve"><value>Successfully created instance.</value></data>
+  <data name="CloneGameInstanceToolTipShareStock" xml:space="preserve"><value>Create junction points (Windows) or symbolic links (Unix) to stock directories instead of copying them.
+If you choose this option, DO NOT move or delete the old instance!!</value></data>
   <data name="CompatibleGameVersionsDialogNone" xml:space="preserve"><value>&lt;NONE&gt;</value></data>
   <data name="CompatibleGameVersionsDialogGameUpdated" xml:space="preserve"><value>The game has been updated since you last reviewed your compatible game versions. Please make sure that settings are correct.</value></data>
   <data name="CompatibleGameVersionsDialogVersionDetails" xml:space="preserve"><value>{0} (previous game version: {1})</value></data>

--- a/Tests/Core/GameInstance.cs
+++ b/Tests/Core/GameInstance.cs
@@ -22,7 +22,7 @@ namespace Tests.Core
         {
             ksp_dir = TestData.NewTempDir();
             nullUser = new NullUser();
-            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, true);
+            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, Array.Empty<string>(), Array.Empty<string>());
             ksp = new GameInstance(new KerbalSpaceProgram(), ksp_dir, "test", nullUser);
         }
 
@@ -111,7 +111,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
+            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, Array.Empty<string>(), Array.Empty<string>());
             File.Delete(buildid);
             File.Delete(readme);
 
@@ -143,7 +143,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, true);
+            CKAN.Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, Array.Empty<string>(), Array.Empty<string>());
             File.Delete(buildid);
             File.Delete(readme);
 

--- a/Tests/Core/Utilities.cs
+++ b/Tests/Core/Utilities.cs
@@ -1,7 +1,10 @@
+using System;
 using System.IO;
-using CKAN;
+
 using NUnit.Framework;
+
 using Tests.Data;
+using CKAN;
 
 namespace Tests.Core
 {
@@ -25,36 +28,39 @@ namespace Tests.Core
         [Test]
         public void CopyDirectory_Recursive_DestHasAllContents()
         {
-            CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, true);
+            CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, Array.Empty<string>(), Array.Empty<string>());
 
+            var fi = new FileInfo(Path.Combine(tempDir, "GameData"));
+            Assert.IsFalse(fi.Attributes.HasFlag(FileAttributes.ReparsePoint),
+                           "GameData should not be a symlink");
             Assert.IsTrue(UtilStatic.CompareFiles(
                 Path.Combine(goodKspDir, "GameData", "README.md"),
-                Path.Combine(tempDir,   "GameData", "README.md")));
+                Path.Combine(tempDir,    "GameData", "README.md")));
             Assert.IsTrue(UtilStatic.CompareFiles(
                 Path.Combine(goodKspDir, "buildID.txt"),
-                Path.Combine(tempDir,   "buildID.txt")));
+                Path.Combine(tempDir,    "buildID.txt")));
             Assert.IsTrue(UtilStatic.CompareFiles(
                 Path.Combine(goodKspDir, "readme.txt"),
-                Path.Combine(tempDir,   "readme.txt")));
+                Path.Combine(tempDir,    "readme.txt")));
         }
 
         [Test]
-        public void CopyDirectory_NotRecursive_DestHasOnlyFirstLevelFiles()
+        public void CopyDirectory_WithSymlinks_MakesSymlinks()
         {
-            CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, false);
+            // Arrange / Act
+            CKAN.Utilities.CopyDirectory(Path.Combine(TestData.DataDir(), "KSP"), tempDir,
+                                         new string[] { "KSP-0.25/GameData" }, Array.Empty<string>());
 
-            Assert.IsFalse(File.Exists(Path.Combine(tempDir, "GameData", "README.md")));
-            // The following assertion is per se already included in the above assertion,
-            // but this also tests CompareFiles, so no harm in including this.
-            Assert.IsFalse(UtilStatic.CompareFiles(
-                Path.Combine(goodKspDir, "GameData", "README.md"),
-                Path.Combine(tempDir, "GameData", "README.md")));
-            Assert.IsTrue(UtilStatic.CompareFiles(
-                Path.Combine(goodKspDir, "buildID.txt"),
-                Path.Combine(tempDir, "buildID.txt")));
-            Assert.IsTrue(UtilStatic.CompareFiles(
-                Path.Combine(goodKspDir, "readme.txt"),
-                Path.Combine(tempDir, "readme.txt")));
+            // Assert
+            var fi1 = new FileInfo(Path.Combine(tempDir, "KSP-0.25"));
+            Assert.IsFalse(fi1.Attributes.HasFlag(FileAttributes.ReparsePoint),
+                           "KSP-0.25 should not be a symlink");
+            var fi2 = new FileInfo(Path.Combine(tempDir, "KSP-0.25", "GameData"));
+            Assert.IsTrue(fi2.Attributes.HasFlag(FileAttributes.ReparsePoint),
+                          "KSP-0.25/GameData should be a symlink");
+            var fi3 = new FileInfo(Path.Combine(tempDir, "KSP-0.25", "GameData", "README.md"));
+            Assert.IsFalse(fi3.Attributes.HasFlag(FileAttributes.ReparsePoint),
+                           "KSP-0.25/GameData/README.md should not be a symlink");
         }
 
         [Test]
@@ -63,7 +69,7 @@ namespace Tests.Core
             var sourceDir = "/gibberish/DOESNTEXIST/hopefully";
 
             // Act and Assert
-            Assert.Throws<DirectoryNotFoundKraken>(() => CKAN.Utilities.CopyDirectory(sourceDir, tempDir, true));
+            Assert.Throws<DirectoryNotFoundKraken>(() => CKAN.Utilities.CopyDirectory(sourceDir, tempDir, Array.Empty<string>(), Array.Empty<string>()));
         }
 
         [Test]
@@ -71,7 +77,7 @@ namespace Tests.Core
         {
             File.WriteAllText(Path.Combine(tempDir, "thatsafile"), "not empty");
 
-            Assert.Throws<PathErrorKraken>(() => CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, true));
+            Assert.Throws<PathErrorKraken>(() => CKAN.Utilities.CopyDirectory(goodKspDir, tempDir, Array.Empty<string>(), Array.Empty<string>()));
         }
     }
 }

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -27,7 +27,7 @@ namespace Tests.Data
         public DisposableKSP()
         {
             _disposableDir = TestData.NewTempDir();
-            Utilities.CopyDirectory(_goodKsp, _disposableDir, true);
+            Utilities.CopyDirectory(_goodKsp, _disposableDir, Array.Empty<string>(), Array.Empty<string>());
             KSP = new GameInstance(new KerbalSpaceProgram(), _disposableDir, "disposable", new NullUser());
             Logging.Initialize();
         }


### PR DESCRIPTION
## Background

It's common for users to make extra copies of KSP1 so they can install different mod lists in each one. CKAN supports this by tracking multiple instances and providing a clone operation, which copies an existing instance to a new folder and adds it to CKAN.

## Motivation

- Each game instance contains about 5.5 GiB of files that come with the game and are necessary for it to run. Copying these takes a long time, and having multiple copies of them wastes a lot of space.
- Each game instance also contains files generated during gameplay and while CKAN is operating that are relevant to that instance but not really to clones. For example, screenshots are relevant to the instance where they're created, but having multiple copies of them isn't generally desirable. Copying these into cloned instances also wastes some time and space.

## Changes

- Now there is an option to share the stock files between the clone and the original instance, either via `ckan instance clone --share-stock` or a new "Share stock files" checkbox in GUI:
  ![image](https://github.com/user-attachments/assets/f16cc053-2bdd-4675-9e8e-1c387f92c14f)
  which is done by making junction points (Windows) or symbolic links (Unix) for the following directories instead of copying them:
  - `KSP_x64_Data` (the main stock game contents folder)
  - `KSP_Data` (same but on Linux)
  - `GameData/Squad`
  - `GameData/SquadExpansion`
  - Some stuff from the now defunct launchers, just in case those are present
- Any folders that are _already_ symbolic links (e.g., if you're cloning a previous thin clone or if you're a mod developer with symbolic links from GameData to your source folders) will be duplicated in the cloned instance as symbolic links to the same targets
- Now the following directories' contents aren't copied into cloned instances of KSP1; the directories are created, but left empty:
  - `CKAN/history` (old mod lists)
  - `CKAN/downloads` (deprecated but might still contain files in very old instances)
  - `saves`
  - `Screenshots`
  - `thumbs`
  - `Missions`
  - `Logs`
- Equivalent updates are made for KSP2 instances

This will allow the creation of game instances that are much smaller but still playable (a thin clone of my Steam instance shrinks from 7 GiB to 81 MiB, or about 1% of its original size, and is very quick to generate).

Note that the CKAN registry and the currently installed mods will still be copied across, so users will still be able to set up some mods in one instance and then clone them elsewhere as a starting point for a different mod list.

Fixes #4087.
