### PR TITLE
Allow licenses to be absent from netkans

### DIFF
--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -106,7 +106,7 @@ namespace CKAN.NetKAN.Transformers
             // "GPLv3" - Becomes "GPL-3.0"
             // "LGPL" - Specific version is indeterminate
 
-            var sdLicense = sdMod.license.Trim();
+            var sdLicense = sdMod.license.Trim().Replace(' ', '-');
 
             switch (sdLicense)
             {

--- a/Netkan/Validators/CkanValidator.cs
+++ b/Netkan/Validators/CkanValidator.cs
@@ -17,6 +17,7 @@ namespace CKAN.NetKAN.Validators
                 new IsCkanModuleValidator(),
                 new DownloadArrayValidator(),
                 new TagsValidator(),
+                new LicensesValidator(),
                 new InstallsFilesValidator(downloader, moduleService, game),
                 new MatchesKnownGameVersionsValidator(game),
                 new ObeysCKANSchemaValidator(),

--- a/Netkan/Validators/NetkanValidator.cs
+++ b/Netkan/Validators/NetkanValidator.cs
@@ -17,7 +17,6 @@ namespace CKAN.NetKAN.Validators
                 new KrefValidator(),
                 new AlphaNumericIdentifierValidator(),
                 new RelationshipsValidator(),
-                new LicensesValidator(),
                 new KrefDownloadMutexValidator(),
                 new DownloadVersionValidator(),
                 new OverrideValidator(),


### PR DESCRIPTION
## Problem

If you omit the `license` from a netkan, you get a `license should match spec` error from the inflator, even if the mod is hosted on a server that provides license info in its API.

## Cause

Many years ago, netkan validation was much more primitive (see https://github.com/KSP-CKAN/CKAN/issues/346#issuecomment-63204526). It did not inflate netkans into .ckan files, so all validation checks had to be performed with only the netkan available. A missing license in a netkan could mean a missing or invalid license in the ckan, which would make the client throw an exception. There was no way to catch that, so the field was made required, with a `x_netkan_license_ok` override for when the person reviewing the pull request had manually confirmed that the license on the server was valid.

Since then, inflation was added to the validation, which allows validation to be performed on the .ckans as well, so it is no longer necessary to require the license in the netkan.

## Changes

- Now the `LicensesValidator` is moved from `NetkanValidator` to `CkanValidator`. This will allow the license field to be omitted from netkans and filled in by the inflator.
- Now the `SpacedockTransformer` replaces spaces in licenses with `-`, to make SD's `CC-BY-NC-SA 4.0` strings translate properly to our `CC-BY-NC-SA-4.0`.

Fixes #4136.
