### PR TITLE
Make X skip buttons in changelog work better for modpacks

### DIFF
--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -79,6 +79,8 @@ namespace CKAN.GUI
                 && row.Change.IsRemovable
                 && row.ConfirmUncheck())
             {
+                (ChangesGrid.DataSource as BindingList<ChangesetRow>)?.Remove(row);
+                changeset.Remove(row.Change);
                 OnRemoveItem?.Invoke(row.Change);
             }
         }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -963,7 +963,9 @@ namespace CKAN.GUI
 
         public void RemoveChangesetItem(ModChange change)
         {
-            if (change.IsRemovable
+            if (currentChangeSet != null
+                && currentChangeSet.Contains(change)
+                && change.IsRemovable
                 && mainModList.full_list_of_mod_rows.TryGetValue(change.Mod.identifier,
                                                                  out DataGridViewRow row)
                 && row.Tag is GUIMod guiMod)


### PR DESCRIPTION
## Problem

If you install a modpack from a .ckan file, the X icons from #4033 are available, but clicking them and confirming the popup simply closes the changeset rather than removing the selected change.

Originally reported by Discord user Tollwütige Banane after trying out the dev build for its modpack fixes.

## Cause

When you click the X and confirm, it raises an event that triggers `ManageMods.RemoveChangesetItem`, which only works properly if you selected the changeset via the checkboxes in Manage Mods. The changeset for a modpack comes from elsewhere, so ManageMods was instead doing nothing and then refreshing the changeset tab with an empty changeset, which causes it to close.

## Changes

- Now `ManageMods.RemoveChangesetItem` only refreshes the changeset if it actually removes the change you clicked from its own changeset; it will do nothing if it originated in a modpack.
- Now the changeset tab removes the selected change from its own changeset, so the user can continue using the changeset and/or move on to installation of the reduced changeset.
  - For changesets from the Manage Mods tab, this quick simple change will then be overwritten by a new complete changeset that handles removal of depending mods, removal of auto-installed mods, conflicts, etc.
  - For modpacks, no such additional logic will be performed. Note that this means that the removed mod might might be pulled back in as a dependency during installation! Or installation might fail due to a conflict. These additional checks would be nice to have in the future, but for now, the basic functionality will work in most cases.
