### PR TITLE
Fix symlink tests on Windows

### DIFF
--- a/Tests/Core/Utilities.cs
+++ b/Tests/Core/Utilities.cs
@@ -61,6 +61,8 @@ namespace Tests.Core
             var fi3 = new FileInfo(Path.Combine(tempDir, "KSP-0.25", "GameData", "README.md"));
             Assert.IsFalse(fi3.Attributes.HasFlag(FileAttributes.ReparsePoint),
                            "KSP-0.25/GameData/README.md should not be a symlink");
+
+            DirectoryLink.Remove(fi2.FullName);
         }
 
         [Test]


### PR DESCRIPTION
## Problem

The test from #4129 is failing on Windows with an access denied exception.

## Cause

Apparently you need to remove the junction info from a dir before it can be deleted.

## Changes

- Now `DirectoryLink.Remove` is created to purge the junction info from a dir before deleting it on Windows
- Now the test calls this function at the end so the teardown can remove the dir
