### PR TITLE
Recommendation suppression for modpacks

### DIFF
--- a/GUI/Controls/EditModpack.Designer.cs
+++ b/GUI/Controls/EditModpack.Designer.cs
@@ -48,6 +48,7 @@ namespace CKAN.GUI
             this.LicenseLabel = new System.Windows.Forms.Label();
             this.LicenseComboBox = new System.Windows.Forms.ComboBox();
             this.IncludeVersionsCheckbox = new System.Windows.Forms.CheckBox();
+            this.IncludeOptRelsCheckbox = new System.Windows.Forms.CheckBox();
             this.RelationshipsListView = new CKAN.GUI.ThemedListView();
             this.ModNameColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ModVersionColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -91,6 +92,7 @@ namespace CKAN.GUI
             this.TopEditPanel.Controls.Add(this.LicenseLabel);
             this.TopEditPanel.Controls.Add(this.LicenseComboBox);
             this.TopEditPanel.Controls.Add(this.IncludeVersionsCheckbox);
+            this.TopEditPanel.Controls.Add(this.IncludeOptRelsCheckbox);
             this.TopEditPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.TopEditPanel.Name = "TopEditPanel";
             this.TopEditPanel.Size = new System.Drawing.Size(500, 160);
@@ -166,7 +168,7 @@ namespace CKAN.GUI
             this.AuthorLabel.Location = new System.Drawing.Point(10, 130);
             this.AuthorLabel.Name = "AuthorLabel";
             this.AuthorLabel.Size = new System.Drawing.Size(75, 23);
-            this.AuthorLabel.TabIndex = 4;
+            this.AuthorLabel.TabIndex = 6;
             resources.ApplyResources(this.AuthorLabel, "AuthorLabel");
             // 
             // AuthorTextBox
@@ -175,7 +177,7 @@ namespace CKAN.GUI
             this.AuthorTextBox.Location = new System.Drawing.Point(125, 130);
             this.AuthorTextBox.Name = "AbstractTextBox";
             this.AuthorTextBox.Size = new System.Drawing.Size(250, 23);
-            this.AuthorTextBox.TabIndex = 5;
+            this.AuthorTextBox.TabIndex = 7;
             this.AuthorTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.AuthorTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.AuthorTextBox, "AuthorTextBox");
@@ -187,7 +189,7 @@ namespace CKAN.GUI
             this.VersionLabel.Location = new System.Drawing.Point(400, 10);
             this.VersionLabel.Name = "VersionLabel";
             this.VersionLabel.Size = new System.Drawing.Size(75, 23);
-            this.VersionLabel.TabIndex = 6;
+            this.VersionLabel.TabIndex = 8;
             resources.ApplyResources(this.VersionLabel, "VersionLabel");
             // 
             // VersionTextBox
@@ -196,7 +198,7 @@ namespace CKAN.GUI
             this.VersionTextBox.Location = new System.Drawing.Point(515, 10);
             this.VersionTextBox.Name = "VersionTextBox";
             this.VersionTextBox.Size = new System.Drawing.Size(250, 23);
-            this.VersionTextBox.TabIndex = 7;
+            this.VersionTextBox.TabIndex = 9;
             this.VersionTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.VersionTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             resources.ApplyResources(this.VersionTextBox, "VersionTextBox");
@@ -208,7 +210,7 @@ namespace CKAN.GUI
             this.GameVersionLabel.Location = new System.Drawing.Point(400, 40);
             this.GameVersionLabel.Name = "GameVersionLabel";
             this.GameVersionLabel.Size = new System.Drawing.Size(75, 23);
-            this.GameVersionLabel.TabIndex = 8;
+            this.GameVersionLabel.TabIndex = 10;
             resources.ApplyResources(this.GameVersionLabel, "GameVersionLabel");
             // 
             // GameVersionMinComboBox
@@ -218,7 +220,7 @@ namespace CKAN.GUI
             this.GameVersionMinComboBox.Location = new System.Drawing.Point(515, 40);
             this.GameVersionMinComboBox.Name = "GameVersionMinComboBox";
             this.GameVersionMinComboBox.Size = new System.Drawing.Size(70, 23);
-            this.GameVersionMinComboBox.TabIndex = 9;
+            this.GameVersionMinComboBox.TabIndex = 11;
             resources.ApplyResources(this.GameVersionMinComboBox, "GameVersionMinComboBox");
             // 
             // GameVersionMaxComboBox
@@ -228,7 +230,7 @@ namespace CKAN.GUI
             this.GameVersionMaxComboBox.Location = new System.Drawing.Point(595, 40);
             this.GameVersionMaxComboBox.Name = "GameVersionMaxComboBox";
             this.GameVersionMaxComboBox.Size = new System.Drawing.Size(70, 23);
-            this.GameVersionMaxComboBox.TabIndex = 10;
+            this.GameVersionMaxComboBox.TabIndex = 12;
             resources.ApplyResources(this.GameVersionMaxComboBox, "GameVersionMaxComboBox");
             // 
             // LicenseLabel
@@ -238,7 +240,7 @@ namespace CKAN.GUI
             this.LicenseLabel.Location = new System.Drawing.Point(400, 70);
             this.LicenseLabel.Name = "LicenseLabel";
             this.LicenseLabel.Size = new System.Drawing.Size(75, 23);
-            this.LicenseLabel.TabIndex = 11;
+            this.LicenseLabel.TabIndex = 13;
             resources.ApplyResources(this.LicenseLabel, "LicenseLabel");
             // 
             // LicenseComboBox
@@ -248,7 +250,7 @@ namespace CKAN.GUI
             this.LicenseComboBox.Location = new System.Drawing.Point(515, 70);
             this.LicenseComboBox.Name = "LicenseComboBox";
             this.LicenseComboBox.Size = new System.Drawing.Size(150, 23);
-            this.LicenseComboBox.TabIndex = 12;
+            this.LicenseComboBox.TabIndex = 14;
             resources.ApplyResources(this.LicenseComboBox, "LicenseComboBox");
             //
             // IncludeVersionsCheckbox
@@ -260,8 +262,20 @@ namespace CKAN.GUI
             this.IncludeVersionsCheckbox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.IncludeVersionsCheckbox.Name = "IncludeVersionsCheckbox";
             this.IncludeVersionsCheckbox.Size = new System.Drawing.Size(131, 24);
-            this.IncludeVersionsCheckbox.TabIndex = 13;
+            this.IncludeVersionsCheckbox.TabIndex = 15;
             resources.ApplyResources(this.IncludeVersionsCheckbox, "IncludeVersionsCheckbox");
+            //
+            // IncludeOptRelsCheckbox
+            //
+            this.IncludeOptRelsCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            this.IncludeOptRelsCheckbox.AutoSize = true;
+            this.IncludeOptRelsCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IncludeOptRelsCheckbox.Location = new System.Drawing.Point(515, 130);
+            this.IncludeOptRelsCheckbox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.IncludeOptRelsCheckbox.Name = "IncludeOptRelsCheckbox";
+            this.IncludeOptRelsCheckbox.Size = new System.Drawing.Size(131, 24);
+            this.IncludeOptRelsCheckbox.TabIndex = 16;
+            resources.ApplyResources(this.IncludeOptRelsCheckbox, "IncludeOptRelsCheckbox");
             //
             // RelationshipsListView
             //
@@ -277,7 +291,7 @@ namespace CKAN.GUI
             this.RelationshipsListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.RelationshipsListView.Name = "RelationshipsListView";
             this.RelationshipsListView.Size = new System.Drawing.Size(1510, 841);
-            this.RelationshipsListView.TabIndex = 14;
+            this.RelationshipsListView.TabIndex = 17;
             this.RelationshipsListView.UseCompatibleStateImageBehavior = false;
             this.RelationshipsListView.View = System.Windows.Forms.View.Details;
             this.RelationshipsListView.Groups.Add(this.DependsGroup);
@@ -343,7 +357,7 @@ namespace CKAN.GUI
             this.DependsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.DependsRadioButton.Name = "DependsRadioButton";
             this.DependsRadioButton.Size = new System.Drawing.Size(112, 30);
-            this.DependsRadioButton.TabIndex = 16;
+            this.DependsRadioButton.TabIndex = 18;
             this.DependsRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.DependsRadioButton.Click += new System.EventHandler(this.DependsRadioButton_CheckedChanged);
             resources.ApplyResources(this.DependsRadioButton, "DependsRadioButton");
@@ -354,7 +368,7 @@ namespace CKAN.GUI
             this.RecommendsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.RecommendsRadioButton.Name = "RecommendsRadioButton";
             this.RecommendsRadioButton.Size = new System.Drawing.Size(112, 30);
-            this.RecommendsRadioButton.TabIndex = 17;
+            this.RecommendsRadioButton.TabIndex = 19;
             this.RecommendsRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.RecommendsRadioButton.Click += new System.EventHandler(this.RecommendsRadioButton_CheckedChanged);
             resources.ApplyResources(this.RecommendsRadioButton, "RecommendsRadioButton");
@@ -365,7 +379,7 @@ namespace CKAN.GUI
             this.SuggestsRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.SuggestsRadioButton.Name = "SuggestsRadioButton";
             this.SuggestsRadioButton.Size = new System.Drawing.Size(112, 30);
-            this.SuggestsRadioButton.TabIndex = 18;
+            this.SuggestsRadioButton.TabIndex = 20;
             this.SuggestsRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.SuggestsRadioButton.Click += new System.EventHandler(this.SuggestsRadioButton_CheckedChanged);
             resources.ApplyResources(this.SuggestsRadioButton, "SuggestsRadioButton");
@@ -376,7 +390,7 @@ namespace CKAN.GUI
             this.IgnoreRadioButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.IgnoreRadioButton.Name = "IgnoreRadioButton";
             this.IgnoreRadioButton.Size = new System.Drawing.Size(112, 30);
-            this.IgnoreRadioButton.TabIndex = 19;
+            this.IgnoreRadioButton.TabIndex = 21;
             this.IgnoreRadioButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.IgnoreRadioButton.Click += new System.EventHandler(this.IgnoreRadioButton_CheckedChanged);
             resources.ApplyResources(this.IgnoreRadioButton, "IgnoreRadioButton");
@@ -388,7 +402,7 @@ namespace CKAN.GUI
             this.CancelExportButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CancelExportButton.Name = "CancelExportButton";
             this.CancelExportButton.Size = new System.Drawing.Size(112, 30);
-            this.CancelExportButton.TabIndex = 20;
+            this.CancelExportButton.TabIndex = 22;
             this.CancelExportButton.UseVisualStyleBackColor = true;
             this.CancelExportButton.Click += new System.EventHandler(this.CancelExportButton_Click);
             resources.ApplyResources(this.CancelExportButton, "CancelExportButton");
@@ -442,6 +456,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.Label LicenseLabel;
         private System.Windows.Forms.ComboBox LicenseComboBox;
         private System.Windows.Forms.CheckBox IncludeVersionsCheckbox;
+        private System.Windows.Forms.CheckBox IncludeOptRelsCheckbox;
         private System.Windows.Forms.ListView RelationshipsListView;
         private System.Windows.Forms.ColumnHeader ModNameColumn;
         private System.Windows.Forms.ColumnHeader ModVersionColumn;

--- a/GUI/Controls/EditModpack.resx
+++ b/GUI/Controls/EditModpack.resx
@@ -125,6 +125,7 @@
   <data name="GameVersionLabel.Text" xml:space="preserve"><value>Game versions:</value></data>
   <data name="LicenseLabel.Text" xml:space="preserve"><value>Licence:</value></data>
   <data name="IncludeVersionsCheckbox.Text" xml:space="preserve"><value>Save mod versions</value></data>
+  <data name="IncludeOptRelsCheckbox.Text" xml:space="preserve"><value>Include optional relationships</value></data>
   <data name="ModNameColumn.Text" xml:space="preserve"><value>Mod</value></data>
   <data name="ModVersionColumn.Text" xml:space="preserve"><value>Version</value></data>
   <data name="ModAbstractColumn.Text" xml:space="preserve"><value>Description</value></data>

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -179,7 +179,7 @@ namespace CKAN.GUI
             if (!Directory.Exists(location))
             {
                 // User either selected the parent node
-                // or he clicked on the tree node of a cached, but not installed mod
+                // or clicked on the tree node of a cached, but not installed mod
                 return;
             }
 

--- a/GUI/Controls/UnmanagedFiles.cs
+++ b/GUI/Controls/UnmanagedFiles.cs
@@ -221,7 +221,7 @@ namespace CKAN.GUI
                 if (!Directory.Exists(location))
                 {
                     // User either selected the parent node
-                    // or he clicked on the tree node of a cached, but not installed mod
+                    // or clicked on the tree node of a cached, but not installed mod
                     return;
                 }
 

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -421,6 +421,8 @@ Are you sure you want to skip this change?</value></data>
   <data name="EditModpackTooltipGameVersionMax" xml:space="preserve"><value>Latest compatible game version, blank for all</value></data>
   <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The licence for this modpack</value></data>
   <data name="EditModpackTooltipIncludeVersions" xml:space="preserve"><value>If checked, the modpack will include the specific versions of the mods shown, otherwise any version will do</value></data>
+  <data name="EditModpackTooltipIncludeOptRels" xml:space="preserve"><value>If checked, users installing this modpack will be shown recommendations and suggestions from mods in the pack.
+If unchecked, only mods in the pack will be installed.</value></data>
   <data name="EditModpackTooltipDepends" xml:space="preserve"><value>Move selected mods to the Depends group. These mods will definitely be installed.</value></data>
   <data name="EditModpackTooltipRecommends" xml:space="preserve"><value>Move selected mods to the Recommends group. A user can drop these mods on installation.</value></data>
   <data name="EditModpackTooltipSuggests" xml:space="preserve"><value>Move selected mods to the Suggests group. These mods will be available for installation, but you have to explicitly select them.</value></data>


### PR DESCRIPTION
## Motivation

Currently, in order to install the exact list of mods in a modpack, the user has to deselect the recommendations of all the mods. It would be nice to be able to skip this step.

It looks like setting `suppress_recommendations` for each item in the `depends` list should work, but it doesn't because those items get added as first class members of the changeset, which causes that property to be ignored in the modpack.

A similar thing can happen in a normal changeset; if A and B are in the changeset, and both depend on C but only A has `suppress_recommendations` set, B's lack of the property will mean that C's recommendations are still shown. That probably frustrates the author of A, especially if they're from KSP-RO.

## Changes

- Now `suppress_recommendations` is obeyed if it is set for _any_ `depends` relationship in the changeset, even if other mods have the same dependency without that property or if the dependency is in the changeset itself.
  - Since modpacks are included in changesets, this means that `depends[].suppress_recommendations` in a modpack will now work.
  - It also means that in the above A/B/C scenario, C's recommendations will no longer be shown, which the KSP-RO folks will probably like.
- Now the export modpack screen in GUI has an "Include optional relationships" checkbox that sets `suppress_recommendations` for every relationship in `depends` if unchecked, to make it easy to generate such metadata.

Fixes #4145.
