### PR TITLE
Make `ckan compat add` take multiple versions, add `clear` and `set`

### DIFF
--- a/Cmdline/Action/AuthToken.cs
+++ b/Cmdline/Action/AuthToken.cs
@@ -135,31 +135,39 @@ namespace CKAN.CmdLine
         [HelpVerbOption]
         public string GetUsage(string verb)
         {
-            HelpText ht = HelpText.AutoBuild(this, verb);
+            var ht = HelpText.AutoBuild(this, verb);
+            foreach (var h in GetHelp(verb))
+            {
+                ht.AddPreOptionsLine(h);
+            }
+            return ht;
+        }
+
+        public static IEnumerable<string> GetHelp(string verb)
+        {
             // Add a usage prefix line
-            ht.AddPreOptionsLine(" ");
+            yield return " ";
             if (string.IsNullOrEmpty(verb))
             {
-                ht.AddPreOptionsLine($"ckan authtoken - {Properties.Resources.AuthTokenHelpSummary}");
-                ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan authtoken <{Properties.Resources.Command}> [{Properties.Resources.Options}]");
+                yield return $"ckan authtoken - {Properties.Resources.AuthTokenHelpSummary}";
+                yield return $"{Properties.Resources.Usage}: ckan authtoken <{Properties.Resources.Command}> [{Properties.Resources.Options}]";
             }
             else
             {
-                ht.AddPreOptionsLine("authtoken " + verb + " - " + GetDescription(verb));
+                yield return "authtoken " + verb + " - " + GetDescription(typeof(AuthTokenSubOptions), verb);
                 switch (verb)
                 {
                     case "add":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan authtoken {verb} [{Properties.Resources.Options}] host token");
+                        yield return $"{Properties.Resources.Usage}: ckan authtoken {verb} [{Properties.Resources.Options}] host token";
                         break;
                     case "remove":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan authtoken {verb} [{Properties.Resources.Options}] host");
+                        yield return $"{Properties.Resources.Usage}: ckan authtoken {verb} [{Properties.Resources.Options}] host";
                         break;
                     case "list":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan authtoken {verb} [{Properties.Resources.Options}]");
+                        yield return $"{Properties.Resources.Usage}: ckan authtoken {verb} [{Properties.Resources.Options}]";
                         break;
                 }
             }
-            return ht;
         }
     }
 

--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 
+using CommandLine;
+
 namespace CKAN.CmdLine
 {
     public class Available : ICommand
@@ -45,4 +47,11 @@ namespace CKAN.CmdLine
         private readonly IUser                 user;
         private readonly RepositoryDataManager repoData;
     }
+
+    internal class AvailableOptions : InstanceSpecificOptions
+    {
+        [Option("detail", HelpText = "Show short description of each module")]
+        public bool detail { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Compare.cs
+++ b/Cmdline/Action/Compare.cs
@@ -1,3 +1,5 @@
+using CommandLine;
+
 using CKAN.Versioning;
 
 namespace CKAN.CmdLine
@@ -46,11 +48,25 @@ namespace CKAN.CmdLine
             }
             else
             {
-                user.RaiseMessage("{0}: ckan compare version1 version2", Properties.Resources.Usage);
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                foreach (var h in Actions.GetHelp("compare"))
+                {
+                    user.RaiseError(h);
+                }
                 return Exit.BADOPT;
             }
 
             return Exit.OK;
         }
     }
+
+    internal class CompareOptions : CommonOptions
+    {
+        [Option("machine-readable", HelpText = "Output in a machine readable format: -1, 0 or 1")]
+        public bool machine_readable { get; set;}
+
+        [ValueOption(0)] public string Left  { get; set; }
+        [ValueOption(1)] public string Right { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Compat.cs
+++ b/Cmdline/Action/Compat.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using System.Collections.Generic;
 
 using CommandLine;
 using CommandLine.Text;
@@ -7,80 +9,106 @@ using CKAN.Versioning;
 
 namespace CKAN.CmdLine
 {
-    public class CompatOptions : VerbCommandOptions
+    public class CompatSubOptions : VerbCommandOptions
     {
-        [VerbOption("list", HelpText = "List compatible KSP versions")]
+        [VerbOption("list", HelpText = "List compatible game versions")]
         public CompatListOptions List { get; set; }
 
-        [VerbOption("add", HelpText = "Add version to KSP compatibility list")]
+        [VerbOption("clear", HelpText = "Forget all compatible game versions")]
+        public CompatClearOptions Clear { get; set; }
+
+        [VerbOption("add", HelpText = "Add versions to compatible game versions list")]
         public CompatAddOptions Add { get; set; }
 
-        [VerbOption("forget", HelpText = "Forget version on KSP compatibility list")]
+        [VerbOption("forget", HelpText = "Forget compatible game versions")]
         public CompatForgetOptions Forget { get; set; }
+
+        [VerbOption("set", HelpText = "Set the compatible game versions list")]
+        public CompatSetOptions Set { get; set; }
 
         [HelpVerbOption]
         public string GetUsage(string verb)
         {
-            HelpText ht = HelpText.AutoBuild(this, verb);
+            var ht = HelpText.AutoBuild(this, verb);
+            foreach (var h in GetHelp(verb))
+            {
+                ht.AddPreOptionsLine(h);
+            }
+            return ht;
+        }
+
+        public static IEnumerable<string> GetHelp(string verb)
+        {
             // Add a usage prefix line
-            ht.AddPreOptionsLine(" ");
+            yield return " ";
             if (string.IsNullOrEmpty(verb))
             {
-                ht.AddPreOptionsLine($"ckan compat - {Properties.Resources.CompatHelpSummary}");
-                ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan compat <{Properties.Resources.Command}> [{Properties.Resources.Options}]");
+                yield return $"ckan compat - {Properties.Resources.CompatHelpSummary}";
+                yield return $"{Properties.Resources.Usage}: ckan compat <{Properties.Resources.Command}> [{Properties.Resources.Options}]";
             }
             else
             {
-                ht.AddPreOptionsLine("compat " + verb + " - " + GetDescription(verb));
+                yield return "compat " + verb + " - " + GetDescription(typeof(CompatSubOptions), verb);
                 switch (verb)
                 {
                     // First the commands with one string argument
                     case "add":
+                    case "set":
                     case "forget":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan compat {verb} [{Properties.Resources.Options}] version");
+                        yield return $"{Properties.Resources.Usage}: ckan compat {verb} [{Properties.Resources.Options}] version [version2 ...]";
                         break;
 
                     // Now the commands with only --flag type options
                     case "list":
+                    case "clear":
                     default:
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan compat {verb} [{Properties.Resources.Options}]");
+                        yield return $"{Properties.Resources.Usage}: ckan compat {verb} [{Properties.Resources.Options}]";
                         break;
                 }
             }
-            return ht;
         }
     }
 
     public class CompatListOptions : InstanceSpecificOptions { }
 
+    public class CompatClearOptions : InstanceSpecificOptions { }
+
     public class CompatAddOptions : InstanceSpecificOptions
     {
-        [ValueOption(0)] public string Version { get; set; }
+        [ValueList(typeof(List<string>))]
+        public List<string> Versions { get; set; }
     }
 
     public class CompatForgetOptions : InstanceSpecificOptions
     {
-        [ValueOption(0)] public string Version { get; set; }
+        [ValueList(typeof(List<string>))]
+        public List<string> Versions { get; set; }
+    }
+
+    public class CompatSetOptions : InstanceSpecificOptions
+    {
+        [ValueList(typeof(List<string>))]
+        public List<string> Versions { get; set; }
     }
 
     public class Compat : ISubCommand
     {
-        public Compat() { }
-
-        public int RunSubCommand(GameInstanceManager manager, CommonOptions opts, SubCommandOptions options)
+        public int RunSubCommand(GameInstanceManager mgr,
+                                 CommonOptions       opts,
+                                 SubCommandOptions   options)
         {
             var exitCode = Exit.OK;
 
-            Parser.Default.ParseArgumentsStrict(options.options.ToArray(), new CompatOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(options.options.ToArray(), new CompatSubOptions(), (string option, object suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
                 {
                     CommonOptions comOpts = (CommonOptions)suboptions;
                     comOpts.Merge(opts);
-                    _user       = new ConsoleUser(comOpts.Headless);
-                    _kspManager = manager ?? new GameInstanceManager(_user);
-                    exitCode    = comOpts.Handle(_kspManager, _user);
+                    user     = new ConsoleUser(comOpts.Headless);
+                    manager  = mgr ?? new GameInstanceManager(user);
+                    exitCode = comOpts.Handle(manager, user);
                     if (exitCode != Exit.OK)
                     {
                         return;
@@ -89,108 +117,36 @@ namespace CKAN.CmdLine
                     switch (option)
                     {
                         case "list":
-                            {
-                                var instance = MainClass.GetGameInstance(_kspManager);
+                            exitCode = List(MainClass.GetGameInstance(manager))
+                                           ? Exit.OK
+                                           : Exit.ERROR;
+                            break;
 
-                                string versionHeader = Properties.Resources.CompatVersionHeader;
-                                string actualHeader  = Properties.Resources.CompatActualHeader;
-
-                                var output = instance
-                                    .GetCompatibleVersions()
-                                    .Select(i => new
-                                    {
-                                        Version = i,
-                                        Actual = false
-                                    })
-                                    .ToList();
-
-                                output.Add(new
-                                {
-                                    Version = instance.Version(),
-                                    Actual = true
-                                });
-
-                                output = output
-                                    .OrderByDescending(i => i.Actual)
-                                    .ThenByDescending(i => i.Version)
-                                    .ToList();
-
-                                var versionWidth = Enumerable
-                                    .Repeat(versionHeader, 1)
-                                    .Concat(output.Select(i => i.Version.ToString()))
-                                    .Max(i => i.Length);
-
-                                var actualWidth = Enumerable
-                                    .Repeat(actualHeader, 1)
-                                    .Concat(output.Select(i => i.Actual.ToString()))
-                                    .Max(i => i.Length);
-
-                                const string columnFormat = "{0}  {1}";
-
-                                _user.RaiseMessage(string.Format(columnFormat,
-                                    versionHeader.PadRight(versionWidth),
-                                    actualHeader.PadRight(actualWidth)
-                                ));
-
-                                _user.RaiseMessage(string.Format(columnFormat,
-                                    new string('-', versionWidth),
-                                    new string('-', actualWidth)
-                                ));
-
-                                foreach (var line in output)
-                                {
-                                    _user.RaiseMessage(columnFormat,
-                                       line.Version.ToString().PadRight(versionWidth),
-                                       line.Actual.ToString().PadRight(actualWidth)
-                                    );
-                                }
-                            }
+                        case "clear":
+                            exitCode = Clear(MainClass.GetGameInstance(manager))
+                                           ? Exit.OK
+                                           : Exit.ERROR;
                             break;
 
                         case "add":
-                            {
-                                var instance = MainClass.GetGameInstance(_kspManager);
-                                var addOptions = (CompatAddOptions)suboptions;
-
-                                if (GameVersion.TryParse(addOptions.Version, out GameVersion gv))
-                                {
-                                    var newCompatibleVersion = instance.GetCompatibleVersions();
-                                    newCompatibleVersion.Add(gv);
-                                    instance.SetCompatibleVersions(newCompatibleVersion);
-                                }
-                                else
-                                {
-                                    _user.RaiseError(Properties.Resources.CompatInvalid);
-                                    exitCode = Exit.ERROR;
-                                }
-                            }
+                            exitCode = Add(suboptions as CompatAddOptions,
+                                           MainClass.GetGameInstance(manager))
+                                           ? Exit.OK
+                                           : Exit.ERROR;
                             break;
 
                         case "forget":
-                            {
-                                var instance = MainClass.GetGameInstance(_kspManager);
-                                var addOptions = (CompatForgetOptions)suboptions;
+                            exitCode = Forget(suboptions as CompatForgetOptions,
+                                              MainClass.GetGameInstance(manager))
+                                           ? Exit.OK
+                                           : Exit.ERROR;
+                            break;
 
-                                if (GameVersion.TryParse(addOptions.Version, out GameVersion gv))
-                                {
-                                    if (gv != instance.Version())
-                                    {
-                                        var newCompatibleVersion = instance.GetCompatibleVersions();
-                                        newCompatibleVersion.RemoveAll(i => i == gv);
-                                        instance.SetCompatibleVersions(newCompatibleVersion);
-                                    }
-                                    else
-                                    {
-                                        _user.RaiseError(Properties.Resources.CompatCantForget);
-                                        exitCode = Exit.ERROR;
-                                    }
-                                }
-                                else
-                                {
-                                    _user.RaiseError(Properties.Resources.CompatInvalid);
-                                    exitCode = Exit.ERROR;
-                                }
-                            }
+                        case "set":
+                            exitCode = Set(suboptions as CompatSetOptions,
+                                           MainClass.GetGameInstance(manager))
+                                           ? Exit.OK
+                                           : Exit.ERROR;
                             break;
 
                         default:
@@ -202,7 +158,169 @@ namespace CKAN.CmdLine
             return exitCode;
         }
 
-        private IUser               _user;
-        private GameInstanceManager _kspManager;
+        private bool List(CKAN.GameInstance instance)
+        {
+            var versionHeader = Properties.Resources.CompatVersionHeader;
+            var actualHeader  = Properties.Resources.CompatActualHeader;
+            var output = Enumerable.Repeat(new
+                                           {
+                                               Version = instance.Version(),
+                                               Actual  = true,
+                                           },
+                                           1)
+                .Concat(instance.GetCompatibleVersions()
+                                .OrderByDescending(v => v)
+                                .Select(v => new
+                                             {
+                                                 Version = v,
+                                                 Actual  = false,
+                                             }))
+                .ToList();
+
+            var versionWidth = Enumerable.Repeat(versionHeader, 1)
+                .Concat(output.Select(i => i.Version.ToString()))
+                .Max(i => i.Length);
+
+            var actualWidth = Enumerable.Repeat(actualHeader, 1)
+                .Concat(output.Select(i => i.Actual.ToString()))
+                .Max(i => i.Length);
+
+            const string columnFormat = "{0}  {1}";
+
+            user.RaiseMessage(columnFormat,
+                              versionHeader.PadRight(versionWidth),
+                              actualHeader.PadRight(actualWidth));
+
+            user.RaiseMessage(columnFormat,
+                              new string('-', versionWidth),
+                              new string('-', actualWidth));
+
+            foreach (var line in output)
+            {
+                user.RaiseMessage(columnFormat,
+                                  line.Version.ToString()
+                                              .PadRight(versionWidth),
+                                  line.Actual.ToString()
+                                             .PadRight(actualWidth));
+            }
+            return true;
+        }
+
+        private bool Clear(CKAN.GameInstance instance)
+        {
+            instance.SetCompatibleVersions(new List<GameVersion>());
+            List(instance);
+            return true;
+        }
+
+        private bool Add(CompatAddOptions  addOptions,
+                         CKAN.GameInstance instance)
+        {
+            if (addOptions.Versions.Count < 1)
+            {
+                user.RaiseError(Properties.Resources.CompatMissing);
+                PrintUsage("add");
+                return false;
+            }
+            if (!TryParseVersions(addOptions.Versions,
+                                  out GameVersion[] goodVers,
+                                  out string[]      badVers))
+            {
+                user.RaiseError(Properties.Resources.CompatInvalid,
+                                string.Join(", ", badVers));
+                return false;
+            }
+            instance.SetCompatibleVersions(instance.GetCompatibleVersions()
+                                                   .Concat(goodVers)
+                                                   .Distinct()
+                                                   .ToList());
+            List(instance);
+            return true;
+        }
+
+        private bool Forget(CompatForgetOptions forgetOptions,
+                            CKAN.GameInstance   instance)
+        {
+            if (forgetOptions.Versions.Count < 1)
+            {
+                user.RaiseError(Properties.Resources.CompatMissing);
+                PrintUsage("forget");
+                return false;
+            }
+            if (!TryParseVersions(forgetOptions.Versions,
+                                  out GameVersion[] goodVers,
+                                  out string[]      badVers))
+            {
+                user.RaiseError(Properties.Resources.CompatInvalid,
+                                string.Join(", ", badVers));
+                return false;
+            }
+            var rmActualVers = goodVers.Intersect(new GameVersion[] { instance.Version(),
+                                                                      instance.Version().WithoutBuild })
+                                       .Select(gv => gv.ToString())
+                                       .ToArray();
+            if (rmActualVers.Length > 0)
+            {
+                user.RaiseError(Properties.Resources.CompatCantForget,
+                                string.Join(", ", rmActualVers));
+                return false;
+            }
+            instance.SetCompatibleVersions(instance.GetCompatibleVersions()
+                                                   .Except(goodVers)
+                                                   .ToList());
+            List(instance);
+            return true;
+        }
+
+        private bool Set(CompatSetOptions  setOptions,
+                         CKAN.GameInstance instance)
+        {
+            if (setOptions.Versions.Count < 1)
+            {
+                user.RaiseError(Properties.Resources.CompatMissing);
+                PrintUsage("set");
+                return false;
+            }
+            if (!TryParseVersions(setOptions.Versions,
+                                  out GameVersion[] goodVers,
+                                  out string[]      badVers))
+            {
+                user.RaiseError(Properties.Resources.CompatInvalid,
+                                string.Join(", ", badVers));
+                return false;
+            }
+            instance.SetCompatibleVersions(goodVers.Distinct().ToList());
+            List(instance);
+            return true;
+        }
+
+        private void PrintUsage(string verb)
+        {
+            foreach (var h in CompatSubOptions.GetHelp(verb))
+            {
+                user.RaiseError(h);
+            }
+        }
+
+        private static bool TryParseVersions(IEnumerable<string> versions,
+                                             out GameVersion[]   goodVers,
+                                             out string[]        badVers)
+        {
+            var gameVersions = versions
+                .Select(v => GameVersion.TryParse(v, out GameVersion gv)
+                                 ? new Tuple<string, GameVersion>(v, gv)
+                                 : new Tuple<string, GameVersion>(v, null))
+                .ToArray();
+            goodVers = gameVersions.Select(tuple => tuple.Item2)
+                                   .OfType<GameVersion>()
+                                   .ToArray();
+            badVers = gameVersions.Where(tuple => tuple.Item2 == null)
+                                  .Select(tuple => tuple.Item1)
+                                  .ToArray();
+            return badVers.Length < 1;
+        }
+
+        private IUser               user;
+        private GameInstanceManager manager;
     }
 }

--- a/Cmdline/Action/Filter.cs
+++ b/Cmdline/Action/Filter.cs
@@ -101,7 +101,8 @@ namespace CKAN.CmdLine
         {
             if (opts.filters.Count < 1)
             {
-                user.RaiseMessage("{0}: ckan filter {1} filter1 [filter2 ...]", Properties.Resources.Usage, verb);
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                PrintUsage(verb);
                 return Exit.BADOPT;
             }
 
@@ -162,7 +163,8 @@ namespace CKAN.CmdLine
         {
             if (opts.filters.Count < 1)
             {
-                user.RaiseMessage("{0}: ckan filter {1} filter1 [filter2 ...]", Properties.Resources.Usage, verb);
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                PrintUsage(verb);
                 return Exit.BADOPT;
             }
 
@@ -217,6 +219,14 @@ namespace CKAN.CmdLine
             return Exit.OK;
         }
 
+        private void PrintUsage(string verb)
+        {
+            foreach (var h in FilterSubOptions.GetHelp(verb))
+            {
+                user.RaiseError(h);
+            }
+        }
+
         private GameInstanceManager manager;
         private IUser               user;
     }
@@ -235,33 +245,41 @@ namespace CKAN.CmdLine
         [HelpVerbOption]
         public string GetUsage(string verb)
         {
-            HelpText ht = HelpText.AutoBuild(this, verb);
+            var ht = HelpText.AutoBuild(this, verb);
+            foreach (var h in GetHelp(verb))
+            {
+                ht.AddPreOptionsLine(h);
+            }
+            return ht;
+        }
+
+        public static IEnumerable<string> GetHelp(string verb)
+        {
             // Add a usage prefix line
-            ht.AddPreOptionsLine(" ");
+            yield return " ";
             if (string.IsNullOrEmpty(verb))
             {
-                ht.AddPreOptionsLine($"ckan filter - {Properties.Resources.FilterHelpSummary}");
-                ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan filter <{Properties.Resources.Command}> [{Properties.Resources.Options}]");
+                yield return $"ckan filter - {Properties.Resources.FilterHelpSummary}";
+                yield return $"{Properties.Resources.Usage}: ckan filter <{Properties.Resources.Command}> [{Properties.Resources.Options}]";
             }
             else
             {
-                ht.AddPreOptionsLine("filter " + verb + " - " + GetDescription(verb));
+                yield return "filter " + verb + " - " + GetDescription(typeof(FilterSubOptions), verb);
                 switch (verb)
                 {
                     case "list":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan filter {verb}");
+                        yield return $"{Properties.Resources.Usage}: ckan filter {verb}";
                         break;
 
                     case "add":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan filter {verb} [{Properties.Resources.Options}] filter1 [filter2 ...]");
+                        yield return $"{Properties.Resources.Usage}: ckan filter {verb} [{Properties.Resources.Options}] filter1 [filter2 ...]";
                         break;
 
                     case "remove":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan filter {verb} [{Properties.Resources.Options}] filter1 [filter2 ...]");
+                        yield return $"{Properties.Resources.Usage}: ckan filter {verb} [{Properties.Resources.Options}] filter1 [filter2 ...]";
                         break;
                 }
             }
-            return ht;
         }
     }
 

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
+using CommandLine;
 using log4net;
 
 namespace CKAN.CmdLine
@@ -39,7 +40,11 @@ namespace CKAN.CmdLine
                 HashSet<FileInfo> toImport = GetFiles(opts);
                 if (toImport.Count < 1)
                 {
-                    user.RaiseMessage($"{Properties.Resources.Usage}: ckan import {Properties.Resources.Path} [path2, ...]");
+                    user.RaiseError(Properties.Resources.ArgumentMissing);
+                    foreach (var h in Actions.GetHelp("import"))
+                    {
+                        user.RaiseError(h);
+                    }
                     return Exit.ERROR;
                 }
                 else
@@ -107,6 +112,12 @@ namespace CKAN.CmdLine
         private        readonly IUser                 user;
 
         private static readonly ILog                  log = LogManager.GetLogger(typeof(Import));
+    }
+
+    internal class ImportOptions : InstanceSpecificOptions
+    {
+        [ValueList(typeof(List<string>))]
+        public List<string> paths { get; set; }
     }
 
 }

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 
+using CommandLine;
 using log4net;
 
 namespace CKAN.CmdLine
@@ -34,12 +35,11 @@ namespace CKAN.CmdLine
             var options = raw_options as InstallOptions;
             if (options.modules.Count == 0 && options.ckan_files == null)
             {
-                // What? No mods specified?
-                user.RaiseMessage("{0}:", Properties.Resources.Usage);
-                user.RaiseMessage(
-                    "    ckan install Mod [Mod2, ...] [--with-suggests] [--with-all-suggests] [--no-recommends]");
-                user.RaiseMessage(
-                    "    ckan install -c file_or_url.ckan [file_or_url2.ckan, ...] [--with-suggests] [--with-all-suggests] [--no-recommends]");
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                foreach (var h in Actions.GetHelp("install"))
+                {
+                    user.RaiseError(h);
+                }
                 return Exit.BADOPT;
             }
 
@@ -257,4 +257,27 @@ namespace CKAN.CmdLine
 
         private static readonly ILog log = LogManager.GetLogger(typeof(Install));
     }
+
+    internal class InstallOptions : InstanceSpecificOptions
+    {
+        [OptionArray('c', "ckanfiles", HelpText = "Local CKAN files or URLs to process")]
+        public string[] ckan_files { get; set; }
+
+        [Option("no-recommends", DefaultValue = false, HelpText = "Do not install recommended modules")]
+        public bool no_recommends { get; set; }
+
+        [Option("with-suggests", DefaultValue = false, HelpText = "Install suggested modules")]
+        public bool with_suggests { get; set; }
+
+        [Option("with-all-suggests", DefaultValue = false, HelpText = "Install suggested modules all the way down")]
+        public bool with_all_suggests { get; set; }
+
+        [Option("allow-incompatible", DefaultValue = false, HelpText = "Install modules that are not compatible with the current game version")]
+        public bool allow_incompatible { get; set; }
+
+        [ValueList(typeof(List<string>))]
+        [AvailableIdentifiers]
+        public List<string> modules { get; set; }
+    }
+
 }

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using CommandLine;
 using log4net;
 
 using CKAN.Exporters;
@@ -177,4 +178,14 @@ namespace CKAN.CmdLine
 
         private static readonly ILog log = LogManager.GetLogger(typeof(List));
     }
+
+    internal class ListOptions : InstanceSpecificOptions
+    {
+        [Option("porcelain", HelpText = "Dump raw list of modules, good for shell scripting")]
+        public bool porcelain { get; set; }
+
+        [Option("export", HelpText = "Export list of modules in specified format to stdout")]
+        public string export { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -72,7 +72,8 @@ namespace CKAN.CmdLine
         {
             if (opts.modules.Count < 1)
             {
-                user.RaiseMessage("{0}: ckan mark {1} Mod [Mod2 ...]", Properties.Resources.Usage, verb);
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                PrintUsage(verb);
                 return Exit.BADOPT;
             }
 
@@ -120,6 +121,14 @@ namespace CKAN.CmdLine
             return Exit.OK;
         }
 
+        private void PrintUsage(string verb)
+        {
+            foreach (var h in MarkSubOptions.GetHelp(verb))
+            {
+                user.RaiseError(h);
+            }
+        }
+
         private GameInstanceManager   manager;
         private readonly RepositoryDataManager repoData;
         private IUser                 user;
@@ -136,29 +145,37 @@ namespace CKAN.CmdLine
         [HelpVerbOption]
         public string GetUsage(string verb)
         {
-            HelpText ht = HelpText.AutoBuild(this, verb);
+            var ht = HelpText.AutoBuild(this, verb);
+            foreach (var h in GetHelp(verb))
+            {
+                ht.AddPreOptionsLine(h);
+            }
+            return ht;
+        }
+
+        public static IEnumerable<string> GetHelp(string verb)
+        {
             // Add a usage prefix line
-            ht.AddPreOptionsLine(" ");
+            yield return " ";
             if (string.IsNullOrEmpty(verb))
             {
-                ht.AddPreOptionsLine($"ckan mark - {Properties.Resources.MarkHelpSummary}");
-                ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan mark <{Properties.Resources.Command}> [{Properties.Resources.Options}]");
+                yield return $"ckan mark - {Properties.Resources.MarkHelpSummary}";
+                yield return $"{Properties.Resources.Usage}: ckan mark <{Properties.Resources.Command}> [{Properties.Resources.Options}]";
             }
             else
             {
-                ht.AddPreOptionsLine("mark " + verb + " - " + GetDescription(verb));
+                yield return "mark " + verb + " - " + GetDescription(typeof(MarkSubOptions), verb);
                 switch (verb)
                 {
                     case "auto":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan mark {verb} [{Properties.Resources.Options}] Mod [Mod2 ...]");
+                        yield return $"{Properties.Resources.Usage}: ckan mark {verb} [{Properties.Resources.Options}] Mod [Mod2 ...]";
                         break;
 
                     case "user":
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan mark {verb} [{Properties.Resources.Options}] Mod [Mod2 ...]");
+                        yield return $"{Properties.Resources.Usage}: ckan mark {verb} [{Properties.Resources.Options}] Mod [Mod2 ...]";
                         break;
                 }
             }
-            return ht;
         }
     }
 

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
+using CommandLine;
 using log4net;
 
 namespace CKAN.CmdLine
@@ -107,7 +108,11 @@ namespace CKAN.CmdLine
             }
             else
             {
-                user.RaiseMessage(Properties.Resources.RemoveNothing);
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                foreach (var h in Actions.GetHelp("remove"))
+                {
+                    user.RaiseError(h);
+                }
                 return Exit.BADOPT;
             }
 
@@ -120,4 +125,18 @@ namespace CKAN.CmdLine
 
         private static readonly ILog log = LogManager.GetLogger(typeof(Remove));
     }
+
+    internal class RemoveOptions : InstanceSpecificOptions
+    {
+        [Option("re", HelpText = "Parse arguments as regular expressions")]
+        public bool regex { get; set; }
+
+        [ValueList(typeof(List<string>))]
+        [InstalledIdentifiers]
+        public List<string> modules { get; set; }
+
+        [Option("all", DefaultValue = false, HelpText = "Remove all installed mods.")]
+        public bool rmall { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using CommandLine;
 using CommandLine.Text;
 
@@ -11,27 +13,35 @@ namespace CKAN.CmdLine
         [HelpVerbOption]
         public string GetUsage(string verb)
         {
-            HelpText ht = HelpText.AutoBuild(this, verb);
+            var ht = HelpText.AutoBuild(this, verb);
+            foreach (var h in GetHelp(verb))
+            {
+                ht.AddPreOptionsLine(h);
+            }
+            return ht;
+        }
+
+        public static IEnumerable<string> GetHelp(string verb)
+        {
             // Add a usage prefix line
-            ht.AddPreOptionsLine(" ");
+            yield return " ";
             if (string.IsNullOrEmpty(verb))
             {
-                ht.AddPreOptionsLine($"ckan repair - {Properties.Resources.RepairHelpSummary}");
-                ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan repair <{Properties.Resources.Command}> [{Properties.Resources.Options}]");
+                yield return $"ckan repair - {Properties.Resources.RepairHelpSummary}";
+                yield return $"{Properties.Resources.Usage}: ckan repair <{Properties.Resources.Command}> [{Properties.Resources.Options}]";
             }
             else
             {
-                ht.AddPreOptionsLine("repair " + verb + " - " + GetDescription(verb));
+                yield return "repair " + verb + " - " + GetDescription(typeof(RepairSubOptions), verb);
                 switch (verb)
                 {
                     // Commands with only --flag type options
                     case "registry":
                     default:
-                        ht.AddPreOptionsLine($"{Properties.Resources.Usage}: ckan repair {verb} [{Properties.Resources.Options}]");
+                        yield return $"{Properties.Resources.Usage}: ckan repair {verb} [{Properties.Resources.Options}]";
                         break;
                 }
             }
-            return ht;
         }
     }
 

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using CommandLine;
 using log4net;
+
 using CKAN.Versioning;
 
 namespace CKAN.CmdLine
@@ -26,9 +28,11 @@ namespace CKAN.CmdLine
 
             if (options.modules.Count == 0 && ! options.replace_all)
             {
-                // What? No mods specified?
-                user.RaiseMessage("{0}: ckan replace Mod [Mod2, ...]", Properties.Resources.Usage);
-                user.RaiseMessage("  or   ckan replace --all");
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                foreach (var h in Actions.GetHelp("replace"))
+                {
+                    user.RaiseError(h);
+                }
                 return Exit.BADOPT;
             }
 
@@ -178,4 +182,31 @@ namespace CKAN.CmdLine
 
         private static readonly ILog log = LogManager.GetLogger(typeof(Replace));
     }
+
+    internal class ReplaceOptions : InstanceSpecificOptions
+    {
+        [Option('c', "ckanfile", HelpText = "Local CKAN file to process")]
+        public string ckan_file { get; set; }
+
+        [Option("no-recommends", HelpText = "Do not install recommended modules")]
+        public bool no_recommends { get; set; }
+
+        [Option("with-suggests", HelpText = "Install suggested modules")]
+        public bool with_suggests { get; set; }
+
+        [Option("with-all-suggests", HelpText = "Install suggested modules all the way down")]
+        public bool with_all_suggests { get; set; }
+
+        [Option("allow-incompatible", DefaultValue = false, HelpText = "Install modules that are not compatible with the current game version")]
+        public bool allow_incompatible { get; set; }
+
+        [Option("all", HelpText = "Replace all available replaced modules")]
+        public bool replace_all { get; set; }
+
+        // TODO: How do we provide helptext on this?
+        [ValueList(typeof (List<string>))]
+        [InstalledIdentifiers]
+        public List<string> modules { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Search.cs
+++ b/Cmdline/Action/Search.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
+using CommandLine;
+
 namespace CKAN.CmdLine
 {
     public class Search : ICommand
@@ -20,7 +22,11 @@ namespace CKAN.CmdLine
             // Check the input.
             if (string.IsNullOrWhiteSpace(options.search_term) && string.IsNullOrWhiteSpace(options.author_term))
             {
-                user.RaiseError(Properties.Resources.SearchNoTerm);
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                foreach (var h in Actions.GetHelp("search"))
+                {
+                    user.RaiseError(h);
+                }
                 return Exit.BADOPT;
             }
 
@@ -198,4 +204,20 @@ namespace CKAN.CmdLine
         private readonly RepositoryDataManager repoData;
         private readonly IUser                 user;
     }
+
+    internal class SearchOptions : InstanceSpecificOptions
+    {
+        [Option("detail", HelpText = "Show full name, latest compatible version and short description of each module")]
+        public bool detail { get; set; }
+
+        [Option("all", HelpText = "Show incompatible mods too")]
+        public bool all { get; set; }
+
+        [Option("author", HelpText = "Limit search results to mods by matching authors")]
+        public string author_term { get; set; }
+
+        [ValueOption(0)]
+        public string search_term { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using CommandLine;
+
 using CKAN.Versioning;
 
 namespace CKAN.CmdLine
@@ -20,8 +22,11 @@ namespace CKAN.CmdLine
             ShowOptions options = (ShowOptions) raw_options;
             if (options.modules == null || options.modules.Count < 1)
             {
-                // empty argument
-                user.RaiseMessage("show <module> - {0}", Properties.Resources.ArgumentMissing);
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                foreach (var h in Actions.GetHelp("show"))
+                {
+                    user.RaiseError(h);
+                }
                 return Exit.BADOPT;
             }
 
@@ -381,4 +386,30 @@ namespace CKAN.CmdLine
         private IUser user { get; set; }
         private readonly RepositoryDataManager repoData;
     }
+
+    internal class ShowOptions : InstanceSpecificOptions
+    {
+        [Option("without-description", HelpText = "Don't show the name, abstract, or description")]
+        public bool without_description { get; set; }
+
+        [Option("without-module-info", HelpText = "Don't show the version, authors, status, license, tags, languages")]
+        public bool without_module_info { get; set; }
+
+        [Option("without-relationships", HelpText = "Don't show dependencies or conflicts")]
+        public bool without_relationships { get; set; }
+
+        [Option("without-resources", HelpText = "Don't show home page, etc.")]
+        public bool without_resources { get; set; }
+
+        [Option("without-files", HelpText = "Don't show contained files")]
+        public bool without_files { get; set; }
+
+        [Option("with-versions", HelpText = "Print table of all versions of the mod and their compatible game versions")]
+        public bool with_versions { get; set; }
+
+        [ValueList(typeof(List<string>))]
+        [AvailableIdentifiers]
+        public List<string> modules { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using CommandLine;
+
 namespace CKAN.CmdLine
 {
     public class Update : ICommand
@@ -141,4 +143,11 @@ namespace CKAN.CmdLine
         private readonly RepositoryDataManager repoData;
         private readonly IUser                 user;
     }
+
+    internal class UpdateOptions : InstanceSpecificOptions
+    {
+        [Option("list-changes", DefaultValue = false, HelpText = "List new and removed modules")]
+        public bool list_changes { get; set; }
+    }
+
 }

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Transactions;
 
+using CommandLine;
 using Autofac;
 
 using CKAN.Versioning;
@@ -44,12 +45,10 @@ namespace CKAN.CmdLine
 
             if (options.modules.Count == 0 && !options.upgrade_all)
             {
-                // What? No files specified?
-                user.RaiseMessage("{0}: ckan upgrade Mod [Mod2, ...]", Properties.Resources.Usage);
-                user.RaiseMessage("  or   ckan upgrade --all");
-                if (AutoUpdate.CanUpdate)
+                user.RaiseError(Properties.Resources.ArgumentMissing);
+                foreach (var h in Actions.GetHelp("upgrade"))
                 {
-                    user.RaiseMessage("  or   ckan upgrade ckan [--stable-release|--dev-build]");
+                    user.RaiseError(h);
                 }
                 return Exit.BADOPT;
             }
@@ -318,4 +317,35 @@ namespace CKAN.CmdLine
         private readonly GameInstanceManager   manager;
         private readonly RepositoryDataManager repoData;
     }
+
+    internal class UpgradeOptions : InstanceSpecificOptions
+    {
+        [Option('c', "ckanfile", HelpText = "Local CKAN file to process")]
+        public string ckan_file { get; set; }
+
+        [Option("no-recommends", DefaultValue = false, HelpText = "Do not install recommended modules")]
+        public bool no_recommends { get; set; }
+
+        [Option("with-suggests", DefaultValue = false, HelpText = "Install suggested modules")]
+        public bool with_suggests { get; set; }
+
+        [Option("with-all-suggests", DefaultValue = false, HelpText = "Install suggested modules all the way down")]
+        public bool with_all_suggests { get; set; }
+
+        [Option("all", DefaultValue = false, HelpText = "Upgrade all available updated modules")]
+        public bool upgrade_all { get; set; }
+
+        [Option("dev-build", DefaultValue = false,
+                HelpText = "For `ckan` option only, use dev builds")]
+        public bool dev_build { get; set; }
+
+        [Option("stable-release", DefaultValue = false,
+                HelpText = "For `ckan` option only, use stable releases")]
+        public bool stable_release { get; set; }
+
+        [ValueList(typeof (List<string>))]
+        [InstalledIdentifiers]
+        public List<string> modules { get; set; }
+    }
+
 }

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -178,8 +178,9 @@ If you must run as an administrator, the `--asroot` parameter will bypass this c
   <data name="CompatHelpSummary" xml:space="preserve"><value>Manage game version compatibility</value></data>
   <data name="CompatVersionHeader" xml:space="preserve"><value>Version</value></data>
   <data name="CompatActualHeader" xml:space="preserve"><value>Actual</value></data>
-  <data name="CompatInvalid" xml:space="preserve"><value>ERROR: Invalid game version</value></data>
-  <data name="CompatCantForget" xml:space="preserve"><value>ERROR: Cannot forget actual game version</value></data>
+  <data name="CompatMissing" xml:space="preserve"><value>No game versions specified!</value></data>
+  <data name="CompatInvalid" xml:space="preserve"><value>Invalid game versions: {0}</value></data>
+  <data name="CompatCantForget" xml:space="preserve"><value>Cannot forget actual game version: {0}</value></data>
   <data name="InstanceHelpSummary" xml:space="preserve"><value>Manage game instances</value></data>
   <data name="InstanceListNoVersion" xml:space="preserve"><value>&lt;NONE&gt;</value></data>
   <data name="InstanceListYes" xml:space="preserve"><value>Yes</value></data>

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -126,7 +126,9 @@ namespace CKAN
 
         public void SetCompatibleVersions(List<GameVersion> compatibleVersions)
         {
-            _compatibleVersions = compatibleVersions.Distinct().ToList();
+            _compatibleVersions = compatibleVersions.Distinct()
+                                                    .OrderByDescending(v => v)
+                                                    .ToList();
             SaveCompatibleVersions();
         }
 


### PR DESCRIPTION
## Motivations

- Currently `ckan compat add` accepts only one version string argument, but it's common to need to add multiple versions (for example, [we do exactly this in the metadata tester](https://github.com/KSP-CKAN/xKAN-meta_testing/blob/f4845f71bd8185e4c4c3f9ac6d689c6eba65ad8b/ckan_meta_tester/dummy_game_instance.py#L38-L41), and @JonnyOThan needs it for [KSPBuildTools](https://github.com/KSPModdingLibs/Shabby/actions/runs/10286246006/job/28466437650#step:3:320)).
- The `list`, `add`, and `forget` operations of `ckan compat` do not make it easy to ["get your compatible versions into a consistent reproducible state"](https://github.com/KSP-CKAN/CKAN/issues/4150#issue-2454235252)

## Changes

- Now `ckan compat add` accepts multiple version strings
- Now `ckan compat forget` accepts multiple version strings
- Now `ckan compat clear` is created to remove all compatible versions
- Now `ckan compat set` is created to overwrite the compatible versions with the given versions
- Now the commands that change the compatible versions display the compatible version list after the change is applied
- Now when you run a command with missing arguments, the resulting usage output is the same as the usage output in that command's `--help` page, rather than a separate ad hoc string

Fixes #4150.
