### PR TITLE
Use latest compatible instead of latest available for Install checkboxes

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -302,7 +302,7 @@ namespace CKAN
                     );
 
                 // This object lets us find the modules associated with a cached file
-                Dictionary<string, List<CkanModule>> hashMap = registry.GetDownloadHashIndex();
+                var hashMap = registry.GetDownloadUrlHashIndex();
 
                 // Prune the module lists to only those that are compatible
                 foreach (var kvp in hashMap)

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -323,4 +323,6 @@ Free up space on that device or change your settings to use another location.
   <data name="NetModuleCacheModuleResuming" xml:space="preserve"><value>{0} {1} ({2}, {3} remaining)</value></data>
   <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve"><value> * Upgrade: {0} {1} to {2} ({3}, {4} remaining)</value></data>
   <data name="ModpackName" xml:space="preserve"><value>installed-{0}</value></data>
+  <data name="InstalledModuleToString" xml:space="preserve"><value>{0} (installed {1})</value></data>
+  <data name="InstalledModuleToStringAutoInstalled" xml:space="preserve"><value>{0} (installed {1}, auto-installed)</value></data>
 </root>

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -45,10 +45,10 @@ namespace CKAN
         [JsonProperty]
         private Dictionary<string, InstalledModuleFile> installed_files;
 
-        public IEnumerable<string> Files => installed_files.Keys;
-        public string identifier => source_module.identifier;
-        public CkanModule Module => source_module;
-        public DateTime InstallTime => install_time;
+        public IEnumerable<string> Files       => installed_files.Keys;
+        public string              identifier  => source_module.identifier;
+        public CkanModule          Module      => source_module;
+        public DateTime            InstallTime => install_time;
 
         public bool AutoInstalled
         {
@@ -125,7 +125,7 @@ namespace CKAN
             // We need case insensitive path matching on Windows
             var normalised_installed_files = new Dictionary<string, InstalledModuleFile>(Platform.PathComparer);
 
-            foreach (KeyValuePair<string, InstalledModuleFile> tuple in installed_files)
+            foreach (var tuple in installed_files)
             {
                 string path = CKANPathUtils.NormalizePath(tuple.Key);
 
@@ -141,5 +141,11 @@ namespace CKAN
         }
 
         #endregion
+
+        public override string ToString()
+            => string.Format(AutoInstalled ? Properties.Resources.InstalledModuleToStringAutoInstalled
+                                           : Properties.Resources.InstalledModuleToString,
+                             Module,
+                             InstallTime);
     }
 }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1069,7 +1069,7 @@ namespace CKAN
         /// <summary>
         /// <see cref = "IRegistryQuerier.InstalledVersion" />
         /// </summary>
-        public ModuleVersion InstalledVersion(string modIdentifier, bool with_provides=true)
+        public ModuleVersion InstalledVersion(string modIdentifier, bool with_provides = true)
         {
             // If it's genuinely installed, return the details we have.
             // (Includes DLCs)
@@ -1100,27 +1100,17 @@ namespace CKAN
         /// <see cref = "IRegistryQuerier.GetInstalledVersion" />
         /// </summary>
         public CkanModule GetInstalledVersion(string mod_identifier)
-            => installed_modules.TryGetValue(mod_identifier, out InstalledModule installedModule)
-                ? installedModule.Module
-                : null;
+            => InstalledModule(mod_identifier)?.Module;
 
         /// <summary>
         /// Returns the module which owns this file, or null if not known.
         /// Throws a PathErrorKraken if an absolute path is provided.
         /// </summary>
-        public string FileOwner(string file)
-        {
-            file = CKANPathUtils.NormalizePath(file);
-
-            if (Path.IsPathRooted(file))
-            {
-                throw new PathErrorKraken(
-                    file,
-                    "KSPUtils.FileOwner can only work with relative paths.");
-            }
-
-            return installed_files.TryGetValue(file, out string fileOwner) ? fileOwner : null;
-        }
+        public InstalledModule FileOwner(string file)
+            => installed_files.TryGetValue(CKANPathUtils.NormalizePath(file),
+                                           out string fileOwner)
+                ? InstalledModule(fileOwner)
+                : null;
 
         /// <summary>
         /// <see cref="IRegistryQuerier.CheckSanity"/>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -276,8 +276,8 @@ namespace CKAN
 
         // These aren't set at construction time, but exist so that we can decorate the
         // kraken as appropriate.
-        public CkanModule installingModule;
-        public string owningModule;
+        public CkanModule      installingModule;
+        public InstalledModule owningModule;
 
         public FileExistsKraken(string filename, string reason = null, Exception innerException = null)
             : base(reason, innerException)

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -2,7 +2,7 @@
 FROM ubuntu:22.04 as base
 
 # Don't prompt for time zone
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 
 # Put user-installed Python code in path
 ENV PATH "$PATH:/root/.local/bin"
@@ -33,7 +33,8 @@ RUN apt-get install -y --no-install-recommends \
     python3-pip python3-setuptools python3-dev
 
 # Install the meta tester's Python code and its Infra dep
-ENV PIP_ROOT_USER_ACTION=ignore
+ENV PIP_ROOT_USER_ACTION ignore
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
 RUN pip3 install --upgrade pip
 RUN pip3 install 'git+https://github.com/KSP-CKAN/NetKAN-Infra#subdirectory=netkan'
 RUN pip3 install 'git+https://github.com/KSP-CKAN/xKAN-meta_testing'

--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Don't prompt for time zone
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 
 # Set up Mono's APT repo
 RUN apt-get update \

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -523,7 +523,7 @@ namespace CKAN.GUI
                     {
                         if (!Main.Instance.LabelsHeld(gmod.Identifier))
                         {
-                            gmod.SelectedMod = gmod.LatestAvailableMod;
+                            gmod.SelectedMod = gmod.LatestCompatibleMod;
                         }
                     }
                 }
@@ -881,7 +881,7 @@ namespace CKAN.GUI
                                 case "Installed":
                                     gmod.SelectedMod = nowChecked ? gmod.SelectedMod
                                                                     ?? gmod.InstalledMod?.Module
-                                                                    ?? gmod.LatestAvailableMod
+                                                                    ?? gmod.LatestCompatibleMod
                                                                   : null;
                                     break;
                                 case "UpdateCol":
@@ -890,10 +890,10 @@ namespace CKAN.GUI
                                           && (gmod.InstalledMod == null
                                               || gmod.InstalledMod.Module.version < gmod.SelectedMod.version)
                                             ? gmod.SelectedMod
-                                            : gmod.LatestAvailableMod
+                                            : gmod.LatestCompatibleMod
                                         : gmod.InstalledMod?.Module;
 
-                                    if (nowChecked && gmod.SelectedMod == gmod.LatestAvailableMod)
+                                    if (nowChecked && gmod.SelectedMod == gmod.LatestCompatibleMod)
                                     {
                                         // Reinstall, force update without change
                                         UpdateChangeSetAndConflicts(currentInstance,

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -49,7 +49,9 @@ namespace CKAN.GUI
                     MetadataModuleReleaseStatusTextBox.Text = module.release_status.ToString();
                 }
 
-                var compatMod = gui_module.LatestCompatibleMod ?? gui_module.LatestAvailableMod ?? gui_module.ToModule();
+                var compatMod = gui_module.LatestCompatibleMod
+                                ?? gui_module.LatestAvailableMod
+                                ?? gui_module.ToModule();
                 MetadataModuleGameCompatibilityTextBox.Text = string.Format(
                     Properties.Resources.GUIModGameCompatibilityLong,
                     gui_module.GameCompatibility,

--- a/GUI/Dialogs/AskUserForAutoUpdatesDialog.resx
+++ b/GUI/Dialogs/AskUserForAutoUpdatesDialog.resx
@@ -117,7 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="autoCheckLabel.Text" xml:space="preserve"><value>Do you wish for CKAN to automatically check for updates on start-up? (Can be changed later from Settings)</value></data>
+  <data name="autoCheckLabel.Text" xml:space="preserve"><value>Would you like CKAN to check for new versions of CKAN automatically at start-up?
+
+You can check for new versions of CKAN manually or change this setting later in the Settings window.</value></data>
   <data name="YesButton.Text" xml:space="preserve"><value>Yes, check for updates</value></data>
   <data name="NoButton.Text" xml:space="preserve"><value>No</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Check for updates</value></data>

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -717,7 +717,7 @@ namespace CKAN.GUI
                                 rel.ExactMatch(registry_manager.registry, crit, installed, toInstall)
                                 // Otherwise look for incompatible
                                 ?? rel.ExactMatch(registry_manager.registry, null, installed, toInstall))
-                            .Where(mod => mod != null));
+                            .OfType<CkanModule>());
                     }
                     toInstall.Add(module);
                 }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -329,7 +329,9 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="MainRepoFailed" xml:space="preserve"><value>Repository update failed!</value></data>
   <data name="MainRepoSuccess" xml:space="preserve"><value>Repositories successfully updated.</value></data>
   <data name="MainRepoOutdatedClient" xml:space="preserve"><value>Repositories updated, but found modules that require a new version of CKAN. Checking for updates...</value></data>
-  <data name="MainRepoAutoRefreshPrompt" xml:space="preserve"><value>Would you like CKAN to refresh the modlist every time it is loaded? (You can always manually refresh using the button up top.)</value></data>
+  <data name="MainRepoAutoRefreshPrompt" xml:space="preserve"><value>Would you like CKAN to refresh the mod list automatically every time it is loaded?
+
+You can refresh the mod list manually with the Refresh button at the top, and you can change this setting later in the Settings. If you disable automatic refreshes, it's a good idea to refresh every few days.</value></data>
   <data name="MainRepoBalloonTipDetails" xml:space="preserve"><value>{0} update(s) available</value></data>
   <data name="MainRepoBalloonTipTooltip" xml:space="preserve"><value>Click to upgrade</value></data>
   <data name="MainTrayIconResume" xml:space="preserve"><value>Resume</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -231,10 +231,10 @@ https://github.com/KSP-CKAN/NetKAN/issues/new/choose
 
 Please include the following information in your report:
 
-File      : {0}
-Installing Mod : {1}
+File: {0}
+Installing Mod: {1}
 Owning Mod: {2}
-CKAN Version   : {3}</value></data>
+CKAN Version: {3}</value></data>
   <data name="MainInstallUnownedFileExists" xml:space="preserve"><value>Oh no!
 
 It looks like you're trying to install a mod which is already installed,


### PR DESCRIPTION
## Problems

While setting up to reproduce KSP-CKAN/NetKAN#10157 in a fake 1.9.1 instance, I noticed some problems:

- My CKAN was trying to install the latest RealismOverhaul when I clicked its Install checkbox, which isn't compatible with KSP 1.9.1, rather than the latest compatible v13.1.1 as in that issue's screenshot
- The GUI prompts that ask the user about auto-updating CKAN and auto-updating metadata are confusing. When I first switched into the fake 1.9.1 instance, I honestly could not tell what the first one was asking me about, since it didn't specify (the second one was clearer, but by then I already had to decide what to do about the first one).
- The file conflict message says "Owning Mod: TweakScale" without the version, so I had to ask the author of the issue to check what the version was, even though CKAN definitely knows the version since it's an installed module.
- Dropping SHA-1 as #4135 planned to do would break importing manually-downloaded ZIP files

## Causes

- #4023 set the mod to be installed to `GUIMod.LatestAvailableMod`, which is the absolute most recent, rather than `GUIMod.LatestCompatibleMod` as it should have been
- `ModuleInstaller.ImportFiles` only checks the SHA-1, so any module with only an SHA-256 in `download_hash` would fail to be detected

## Changes

- Now we install `GUIMod.LatestCompatibleMod`, so the right version will be installed on old game versions
- Now both auto-update prompts are rewritten to be hopefully easier to understand, with the parentheses removed and some newlines added for readability
  - The GUI prompt about auto-updating CKAN specifies that it is talking about updating CKAN itself
  - The GUI prompt about auto-updating metadata says that you should click Refresh once in a while if you don't auto-update and mentions the settings
- Now the file conflict kraken captures an `InstalledModule` instead of a just an identifier, and renders it with `InstalledModule.ToString()`, which includes the version, install date, and whether it was auto-installed as a dependency of another mod
- Now `ModuleInstaller.ImportFiles` first checks the SHA-256, then falls back to the SHA-1 if not found
  - Now `Registry.GetSha1Index` is renamed `GetDownloadHashesIndex` and includes both SHA-256 and SHA-1 hashes as keys in the dictionary it returns.
  - `Registry.GetDownloadHashIndex` is renamed to `GetDownloadUrlHashIndex`
  - Both `Get*Index` functions are refactored (and LINQified) to cache their calculated dictionaries in between repo updates, in case the user needs them multiple times in a row
