### PR TITLE
Refactor ZIP importing

### DIFF
--- a/Core/Extensions/CryptoExtensions.cs
+++ b/Core/Extensions/CryptoExtensions.cs
@@ -20,8 +20,10 @@ namespace CKAN.Extensions
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
         /// <param name="cancelToken">A cancellation token that can be used to abort the hash</param>
         /// <returns>The requested hash of the input stream</returns>
-        public static byte[] ComputeHash(this HashAlgorithm hashAlgo, Stream stream,
-            IProgress<long> progress, CancellationToken cancelToken = default)
+        public static byte[] ComputeHash(this HashAlgorithm hashAlgo,
+                                         Stream             stream,
+                                         IProgress<int>     progress,
+                                         CancellationToken  cancelToken = default)
         {
             const int bufSize = 1024 * 1024;
             var buffer = new byte[bufSize];
@@ -44,7 +46,7 @@ namespace CKAN.Extensions
                 }
 
                 totalBytesRead += bytesRead;
-                progress.Report(100 * totalBytesRead / stream.Length);
+                progress.Report((int)(100 * totalBytesRead / stream.Length));
             }
             return hashAlgo.Hash;
         }

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -150,7 +150,7 @@ namespace CKAN
                                                 || m.InternetArchiveDownload == url);
                     User.RaiseMessage(Properties.Resources.NetAsyncDownloaderValidating, module);
                     cache.Store(module, filename,
-                        new Progress<long>(percent => StoreProgress?.Invoke(module, 100 - percent, 100)),
+                        new Progress<int>(percent => StoreProgress?.Invoke(module, 100 - percent, 100)),
                         module.StandardName(),
                         false,
                         cancelTokenSrc.Token);

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -569,7 +569,7 @@ namespace CKAN
         /// <returns>
         /// SHA1 hash, in all-caps hexadecimal format
         /// </returns>
-        public string GetFileHashSha1(string filePath, IProgress<long> progress, CancellationToken cancelToken = default)
+        public string GetFileHashSha1(string filePath, IProgress<int> progress, CancellationToken cancelToken = default)
             => GetFileHash(filePath, "sha1", sha1Cache, SHA1.Create, progress, cancelToken);
 
         /// <summary>
@@ -580,7 +580,7 @@ namespace CKAN
         /// <returns>
         /// SHA256 hash, in all-caps hexadecimal format
         /// </returns>
-        public string GetFileHashSha256(string filePath, IProgress<long> progress, CancellationToken cancelToken = default)
+        public string GetFileHashSha256(string filePath, IProgress<int> progress, CancellationToken cancelToken = default)
             => GetFileHash(filePath, "sha256", sha256Cache, SHA256.Create, progress, cancelToken);
 
         /// <summary>
@@ -595,7 +595,7 @@ namespace CKAN
                                    string hashSuffix,
                                    Dictionary<string, string> cache,
                                    Func<HashAlgorithm> getHashAlgo,
-                                   IProgress<long> progress,
+                                   IProgress<int> progress,
                                    CancellationToken cancelToken)
         {
             string hashFile = $"{filePath}.{hashSuffix}";

--- a/Core/Properties/Resources.fr-FR.resx
+++ b/Core/Properties/Resources.fr-FR.resx
@@ -515,7 +515,7 @@ Veuillez le retirer manuellement avant d'essayer de l'installer.</value>
     <value>Impossible de remplacer {0} car il n'est pas installé. Veuillez essayer d'installer {1} à la place.</value>
   </data>
   <data name="ModuleInstallerImporting" xml:space="preserve">
-    <value>Importation de {0}... ({1}%)</value>
+    <value>Importation de {0}...</value>
   </data>
   <data name="ModuleInstallerImportAlreadyCached" xml:space="preserve">
     <value>Déjà en cache : {0}</value>
@@ -593,7 +593,7 @@ Pensez à ajouter un jeton d'authentification pour augmenter la limite avant bri
   <data name="KrakenAlreadyRunning" xml:space="preserve">
     <value>Fichier verrou avec un ID de processus actif à {0}
 
-Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu. 
+Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu.
 
 Voulez-vous supprimez ce fichier verrou pour forcer l'accès ?</value>
   </data>

--- a/Core/Properties/Resources.it-IT.resx
+++ b/Core/Properties/Resources.it-IT.resx
@@ -504,7 +504,7 @@ Rimuovilo manualmente prima di provare a installarlo.</value>
     <value>Non è possibile sostituire {0} perché non è installato. Prova invece a installare {1}.</value>
   </data>
   <data name="ModuleInstallerImporting" xml:space="preserve">
-    <value>Importazione di {0}... ({1}%)</value>
+    <value>Importazione di {0}...</value>
   </data>
   <data name="ModuleInstallerImportAlreadyCached" xml:space="preserve">
     <value>Già in cache: {0}</value>

--- a/Core/Properties/Resources.pl-PL.resx
+++ b/Core/Properties/Resources.pl-PL.resx
@@ -488,7 +488,7 @@ Proszę usunąć go ręcznie, zanim spróbujesz go zainstalować.</value>
     <value>Nie można zastąpić {0} ponieważ nie jest zainstalowany. Spróbuj zainstalować {1}.</value>
   </data>
   <data name="ModuleInstallerImporting" xml:space="preserve">
-    <value>Importowanie {0}... ({1}%)</value>
+    <value>Importowanie {0}...</value>
   </data>
   <data name="ModuleInstallerImportAlreadyCached" xml:space="preserve">
     <value>Już w folderze cache: {0}</value>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -255,12 +255,13 @@ Overwrite?</value></data>
   <data name="ModuleInstallerReplaceAutodetected" xml:space="preserve"><value>Can't replace {0} as it was not installed by CKAN.
 Please remove manually before trying to install it.</value></data>
   <data name="ModuleInstallerReplaceNotInstalled" xml:space="preserve"><value>Can't replace {0} as it is not installed. Please attempt to install {1} instead.</value></data>
-  <data name="ModuleInstallerImporting" xml:space="preserve"><value>Importing {0}... ({1}%)</value></data>
+  <data name="ModuleInstallerImportScanningFiles" xml:space="preserve"><value>Scanning files...</value></data>
+  <data name="ModuleInstallerImporting" xml:space="preserve"><value>Importing {0}...</value></data>
   <data name="ModuleInstallerImportAlreadyCached" xml:space="preserve"><value>Already cached: {0}</value></data>
   <data name="ModuleInstallerImportingMod" xml:space="preserve"><value>Importing {0} {1}...</value></data>
   <data name="ModuleInstallerImportNotFound" xml:space="preserve"><value>Not found in index: {0}</value></data>
   <data name="ModuleInstallerImportInstallPrompt" xml:space="preserve"><value>Install {0} compatible imported mods in game instance {1} ({2})?</value></data>
-  <data name="ModuleInstallerImportDeletePrompt" xml:space="preserve"><value>Import complete. Delete {0} old files?</value></data>
+  <data name="ModuleInstallerImportDeletePrompt" xml:space="preserve"><value>Scanning complete. Delete {0} old files after import?</value></data>
   <data name="KrakenDependencyNotSatisfied" xml:space="preserve"><value>Dependency on {0} version {1} not satisfied</value></data>
   <data name="KrakenDependencyModuleNotFound" xml:space="preserve"><value>Module not found: {0} {1}</value></data>
   <data name="KrakenParentDependencyNotSatisfied" xml:space="preserve"><value>{0} dependency on {1} version {2} not satisfied</value></data>

--- a/Core/Properties/Resources.ru-RU.resx
+++ b/Core/Properties/Resources.ru-RU.resx
@@ -245,7 +245,7 @@
   <data name="ModuleInstallerReplaceAutodetected" xml:space="preserve"><value>Невозможно заменить {0}, так как он не был установлен CKAN.
 Удалите его вручную и попробуйте снова.</value></data>
   <data name="ModuleInstallerReplaceNotInstalled" xml:space="preserve"><value>Невозможно заменить {0}, так как он не установлен. Сначала установите {1}.</value></data>
-  <data name="ModuleInstallerImporting" xml:space="preserve"><value>Импорт {0}... ({1}%)</value></data>
+  <data name="ModuleInstallerImporting" xml:space="preserve"><value>Импорт {0}...</value></data>
   <data name="ModuleInstallerImportAlreadyCached" xml:space="preserve"><value>Уже кэшировано: {0}</value></data>
   <data name="ModuleInstallerImportingMod" xml:space="preserve"><value>Импорт {0} {1}...</value></data>
   <data name="ModuleInstallerImportNotFound" xml:space="preserve"><value>Не найдено в указателе: {0}</value></data>

--- a/Core/Properties/Resources.zh-CN.resx
+++ b/Core/Properties/Resources.zh-CN.resx
@@ -506,7 +506,7 @@
     <value>无法替换 {0} 因为它还未安装。请尝试安装 {1}。</value>
   </data>
   <data name="ModuleInstallerImporting" xml:space="preserve">
-    <value>导入 {0}... ({1}%)</value>
+    <value>导入 {0}...</value>
   </data>
   <data name="ModuleInstallerImportAlreadyCached" xml:space="preserve">
     <value>已缓存: {0}</value>

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -19,7 +19,7 @@ namespace CKAN.GUI
         private void ImportModules()
         {
             // Prompt the user to select one or more ZIP files
-            OpenFileDialog dlg = new OpenFileDialog()
+            var dlg = new OpenFileDialog()
             {
                 Title            = Properties.Resources.MainImportTitle,
                 AddExtension     = true,
@@ -37,31 +37,45 @@ namespace CKAN.GUI
                 tabController.RenameTab("WaitTabPage", Properties.Resources.MainImportWaitTitle);
                 ShowWaitDialog();
                 DisableMainWindow();
-
-                try
-                {
-                    new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser).ImportFiles(
-                        GetFiles(dlg.FileNames),
-                        currentUser,
-                        (CkanModule mod) =>
-                        {
-                            if (ManageMods.mainModList
-                                          .full_list_of_mod_rows
-                                          .TryGetValue(mod.identifier,
-                                                       out DataGridViewRow row)
-                                && row.Tag is GUIMod gmod)
+                Wait.StartWaiting(
+                    (sender, e) =>
+                    {
+                        e.Result = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser).ImportFiles(
+                            GetFiles(dlg.FileNames),
+                            currentUser,
+                            (CkanModule mod) =>
                             {
-                                gmod.SelectedMod = mod;
+                                if (ManageMods.mainModList
+                                              .full_list_of_mod_rows
+                                              .TryGetValue(mod.identifier,
+                                                           out DataGridViewRow row)
+                                    && row.Tag is GUIMod gmod)
+                                {
+                                    gmod.SelectedMod = mod;
+                                }
+                            },
+                            RegistryManager.Instance(CurrentInstance, repoData).registry);
+                    },
+                    (sender, e) =>
+                    {
+                        if (e.Error == null && e.Result is bool result && result)
+                        {
+                            // Put GUI back the way we found it
+                            HideWaitDialog();
+                        }
+                        else
+                        {
+                            if (e.Error is Exception exc)
+                            {
+                                log.Error(exc.Message, exc);
+                                currentUser.RaiseMessage(exc.Message);
                             }
-                        },
-                        RegistryManager.Instance(CurrentInstance, repoData).registry);
-                }
-                finally
-                {
-                    // Put GUI back the way we found it
-                    EnableMainWindow();
-                    HideWaitDialog();
-                }
+                            Wait.Finish();
+                        }
+                        EnableMainWindow();
+                    },
+                    false,
+                    null);
             }
         }
 

--- a/Netkan/Services/FileService.cs
+++ b/Netkan/Services/FileService.cs
@@ -16,12 +16,12 @@ namespace CKAN.NetKAN.Services
         public string GetFileHashSha1(string filePath)
         // Use shared implementation from Core.
         // Also needs to be an instance method so it can be Moq'd for testing.
-            => cache.GetFileHashSha1(filePath, new Progress<long>(bytes => {}));
+            => cache.GetFileHashSha1(filePath, new Progress<int>(percent => {}));
 
         public string GetFileHashSha256(string filePath)
         // Use shared implementation from Core.
         // Also needs to be an instance method so it can be Moq'd for testing.
-            => cache.GetFileHashSha256(filePath, new Progress<long>(bytes => {}));
+            => cache.GetFileHashSha256(filePath, new Progress<int>(percent => {}));
 
         public string GetMimetype(string filePath)
         {

--- a/Tests/Core/Cache.cs
+++ b/Tests/Core/Cache.cs
@@ -115,14 +115,14 @@ namespace Tests.Core
             Assert.Throws<FileNotFoundKraken>(() =>
                 module_cache.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    "/DoesNotExist.zip", new Progress<long>(bytes => {})));
+                    "/DoesNotExist.zip", new Progress<int>(percent => {})));
 
             // Try to store the LZMA-format DogeCoin zip into a NetModuleCache
             // and expect an InvalidModuleFileKraken
             Assert.Throws<InvalidModuleFileKraken>(() =>
                 module_cache.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    TestData.DogeCoinFlagZipLZMA, new Progress<long>(bytes => {})));
+                    TestData.DogeCoinFlagZipLZMA, new Progress<int>(percent => {})));
 
             // Try to store the normal DogeCoin zip into a NetModuleCache
             // using the WRONG metadata (file size and hashes)
@@ -130,7 +130,7 @@ namespace Tests.Core
             Assert.Throws<InvalidModuleFileKraken>(() =>
                 module_cache.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {})));
+                    TestData.DogeCoinFlagZip(), new Progress<int>(percent => {})));
         }
 
         [Test]

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -58,7 +58,7 @@ namespace Tests.Core
             _gameDir = _instance.KSP.GameDir();
             _gameDataDir = _instance.KSP.game.PrimaryModDirectory(_instance.KSP);
             var testModFile = TestData.DogeCoinFlagZip();
-            _manager.Cache.Store(_testModule, testModFile, new Progress<long>(bytes => {}));
+            _manager.Cache.Store(_testModule, testModFile, new Progress<int>(percent => {}));
             HashSet<string> possibleConfigOnlyDirs = null;
             _installer.InstallList(
                 new List<CkanModule>() { _testModule },

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -413,7 +413,7 @@ namespace Tests.Core
 
                 string cache_path = manager.Cache.Store(TestData.DogeCoinFlag_101_module(),
                                                         TestData.DogeCoinFlagZip(),
-                                                        new Progress<long>(bytes => {}));
+                                                        new Progress<int>(percent => {}));
 
                 Assert.IsTrue(manager.Cache.IsCached(TestData.DogeCoinFlag_101_module()));
                 Assert.IsTrue(File.Exists(cache_path));
@@ -462,7 +462,7 @@ namespace Tests.Core
                 registry.RepositoriesAdd(repo.repo);
                 manager.Cache.Store(TestData.DogeCoinFlag_101_module(),
                                     TestData.DogeCoinFlagZip(),
-                                    new Progress<long>(bytes => {}));
+                                    new Progress<int>(percent => {}));
 
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
@@ -510,7 +510,7 @@ namespace Tests.Core
                 registry.RepositoriesAdd(repo.repo);
                 manager.Cache.Store(TestData.DogeCoinFlag_101_module(),
                                     TestData.DogeCoinFlagZip(),
-                                    new Progress<long>(bytes => {}));
+                                    new Progress<int>(percent => {}));
 
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
@@ -526,7 +526,7 @@ namespace Tests.Core
                 // Install the plugin test mod.
                 manager.Cache.Store(TestData.DogeCoinPlugin_module(),
                                     TestData.DogeCoinPluginZip(),
-                                    new Progress<long>(bytes => {}));
+                                    new Progress<int>(percent => {}));
 
                 modules.Add(TestData.DogeCoinPlugin_module());
 
@@ -719,7 +719,7 @@ namespace Tests.Core
                         // Copy the zip file to the cache directory.
                         manager.Cache.Store(TestData.DogeCoinFlag_101_module(),
                                             TestData.DogeCoinFlagZip(),
-                                            new Progress<long>(bytes => {}));
+                                            new Progress<int>(percent => {}));
 
                         // Attempt to install it.
                         var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
@@ -875,7 +875,7 @@ namespace Tests.Core
 
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
-                manager.Cache.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
+                manager.Cache.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<int>(percent => {}));
                 var replacement = querier.GetReplacement(replaced.identifier,
                                                          new GameVersionCriteria(new GameVersion(1, 12)));
                 installer.Replace(Enumerable.Repeat(replacement, 1),
@@ -941,7 +941,7 @@ namespace Tests.Core
 
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
-                manager.Cache.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
+                manager.Cache.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<int>(percent => {}));
                 var replacement = querier.GetReplacement(replaced.identifier,
                                                          new GameVersionCriteria(new GameVersion(1, 11)));
 
@@ -1094,7 +1094,7 @@ namespace Tests.Core
                     var module = CkanModule.FromJson(m);
                     manager.Cache.Store(module,
                                         TestData.DogeCoinFlagZip(),
-                                        new Progress<long>(bytes => {}));
+                                        new Progress<int>(percent => {}));
                     if (!querier.IsInstalled(module.identifier, false))
                     {
                         registry.RegisterModule(module,
@@ -1166,7 +1166,7 @@ namespace Tests.Core
                 File.WriteAllText(inst.KSP.ToAbsoluteGameDir(unmanaged),
                                   "Not really a DLL, are we?");
                 regMgr.ScanUnmanagedFiles();
-                manager.Cache.Store(module, zipPath, new Progress<long>(bytes => {}));
+                manager.Cache.Store(module, zipPath, new Progress<int>(percent => {}));
 
                 // Act
                 HashSet<string> possibleConfigOnlyDirs = null;

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -160,7 +160,7 @@ namespace Tests.GUI
                 // Act
 
                 // Install module and set it as pre-installed
-                manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
+                manager.Cache.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<int>(percent => {}));
                 registry.RegisterModule(anyVersionModule, new List<string>(), instance.KSP, false);
 
                 HashSet<string> possibleConfigOnlyDirs = null;


### PR DESCRIPTION
## Problems

During and after #4152, I noticed some issues with ZIP importing in GUI:

- It appears to freeze for quite a while before it shows a popup
- It's slow
- The progress bar for importing treats each file as the same fraction of total completion, even if one is 1 GiB and another is 1 KiB, and the updates can be infrequent

Since importing ZIPs is our go-to workaround when users report slow mod download speeds, it should be usable and performant.

## Causes

- `GUI.Main.ImportModules` calls `ModuleInstaller.ImportFiles` on a foreground thread, so all UI updates pause until it finishes
- For mods that share a ZIP, the import stores the ZIP once for every such mod, which can involve deleting and re-writing the same file in the cache multiple times
- The import will copy each file into the cache and then ask if it can delete them, whereas if you're OK with losing the original, moving would be faster
- The files' hashes are checked _twice_, once to find the module associated with each file, and then again to validate them before storing in the cache, which is redundant

## Changes

- Now `GUI.Main.ImportModules` uses `Wait.StartWaiting` to do the imports in a background thread, so the UI will be responsive
- Now the ZIPs are stored to cache _once per URL_, so mods that share URLs will no longer clobber one another
- Now the not-indexed files are reported together in one message
- Now the already-cached mods are reported together in one message
- Now if the user says it's OK to delete, the files are moved instead of copied into the cache
- Now the hashes are not re-validated, so storing is faster
- Now import progress bar updates are proportional to file size, so they feel nice and smooth and linear

This should make importing ZIPs in GUI more pleasant overall.
