### PR TITLE
Add mod support links to Help menu

### DIFF
--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -49,5 +49,6 @@ namespace CKAN.Games
         Uri DefaultRepositoryURL  { get; }
         Uri RepositoryListURL     { get; }
         Uri MetadataBugtrackerURL { get; }
+        Uri ModSupportURL         { get; }
     }
 }

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -244,6 +244,8 @@ namespace CKAN.Games.KerbalSpaceProgram
 
         public Uri MetadataBugtrackerURL => new Uri("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
 
+        public Uri ModSupportURL => new Uri("https://forum.kerbalspaceprogram.com/forum/70-ksp1-technical-support-pc-modded-installs/");
+
         private static string Missions(GameInstance inst)
             => CKANPathUtils.NormalizePath(Path.Combine(inst.GameDir(), "Missions"));
 

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -213,6 +213,8 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public Uri MetadataBugtrackerURL => new Uri("https://github.com/KSP-CKAN/KSP2-NetKAN/issues/new/choose");
 
+        public Uri ModSupportURL => new Uri("https://forum.kerbalspaceprogram.com/forum/137-ksp2-technical-support-pc-modded-installs/");
+
         private const string DataDir = "KSP2_x64_Data";
 
         // Key: Allowed value of install_to

--- a/Core/HelpURLs.cs
+++ b/Core/HelpURLs.cs
@@ -5,6 +5,8 @@ namespace CKAN
     /// </summary>
     public static class HelpURLs
     {
+        #region CKAN documentation
+
         public const string UserGuide = "https://github.com/KSP-CKAN/CKAN/wiki/User-guide";
         public const string ManageInstances = "https://github.com/KSP-CKAN/CKAN/wiki/User-guide#adding-game-folders";
         public const string CompatibleGameVersions = "https://github.com/KSP-CKAN/CKAN/wiki/User-guide#choosing-compatible-game-versions";
@@ -23,6 +25,14 @@ namespace CKAN
         public const string UnmanagedFiles = "https://github.com/KSP-CKAN/CKAN/pull/3833";
         public const string InstallationHistory = "https://github.com/KSP-CKAN/CKAN/pull/3834";
 
-        public const string Discord = "https://discord.gg/Mb4nXQD";
+        #endregion
+
+        #region Support
+
+        // See IGame.ModSupportURL for in-game support links
+        public const string CKANDiscord = "https://discord.gg/Mb4nXQD";
+        public const string CKANIssues = "https://github.com/KSP-CKAN/CKAN/issues/new/choose";
+
+        #endregion
     }
 }

--- a/GUI/Dialogs/PluginsDialog.resx
+++ b/GUI/Dialogs/PluginsDialog.resx
@@ -124,5 +124,5 @@
   <data name="ActivatePluginButton.Text" xml:space="preserve"><value>Activate</value></data>
   <data name="AddNewPluginButton.Text" xml:space="preserve"><value>Add new...</value></data>
   <data name="UnloadPluginButton.Text" xml:space="preserve"><value>Unload</value></data>
-  <data name="$this.Text" xml:space="preserve"><value>CKAN Plugins</value></data>
+  <data name="$this.Text" xml:space="preserve"><value>Plugins</value></data>
 </root>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -53,6 +53,7 @@ namespace CKAN.GUI
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.userGuideToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.discordToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.modSupportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportClientIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportMetadataIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -309,6 +310,7 @@ namespace CKAN.GUI
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.userGuideToolStripMenuItem,
             this.discordToolStripMenuItem,
+            this.modSupportToolStripMenuItem,
             this.reportClientIssueToolStripMenuItem,
             this.reportMetadataIssueToolStripMenuItem,
             this.aboutToolStripMenuItem});
@@ -329,6 +331,13 @@ namespace CKAN.GUI
             this.discordToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
             this.discordToolStripMenuItem.Click += new System.EventHandler(this.discordToolStripMenuItem_Click);
             resources.ApplyResources(this.discordToolStripMenuItem, "discordToolStripMenuItem");
+            //
+            // modSupportToolStripMenuItem
+            //
+            this.modSupportToolStripMenuItem.Name = "modSupportToolStripMenuItem";
+            this.modSupportToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.modSupportToolStripMenuItem.Click += new System.EventHandler(this.modSupportToolStripMenuItem_Click);
+            resources.ApplyResources(this.modSupportToolStripMenuItem, "modSupportToolStripMenuItem");
             //
             // reportClientIssueToolStripMenuItem
             //
@@ -901,6 +910,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem userGuideToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem discordToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem modSupportToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportClientIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportMetadataIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -952,12 +952,17 @@ namespace CKAN.GUI
 
         private void discordToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Utilities.ProcessStartURL(HelpURLs.Discord);
+            Utilities.ProcessStartURL(HelpURLs.CKANDiscord);
+        }
+
+        private void modSupportToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Utilities.ProcessStartURL(Manager.CurrentInstance.game.ModSupportURL.ToString());
         }
 
         private void reportClientIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Utilities.ProcessStartURL("https://github.com/KSP-CKAN/CKAN/issues/new/choose");
+            Utilities.ProcessStartURL(HelpURLs.CKANIssues);
         }
 
         private void reportMetadataIssueToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -131,14 +131,15 @@
   <data name="ExitToolButton.Text" xml:space="preserve"><value>E&amp;xit</value></data>
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Settings</value></data>
   <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;settings</value></data>
-  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;plugins</value></data>
+  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Plugins</value></data>
   <data name="preferredHostsToolStripMenuItem.Text" xml:space="preserve"><value>Preferred &amp;hosts</value></data>
   <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;filters</value></data>
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Game command lines</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Compatible game versions</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Help</value></data>
-  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>&amp;User guide</value></data>
-  <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Discord</value></data>
+  <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;user guide</value></data>
+  <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;Discord</value></data>
+  <data name="modSupportToolStripMenuItem.Text" xml:space="preserve"><value>Get help for an in-game problem with mods</value></data>
   <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN &amp;client</value></data>
   <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod &amp;metadata</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>&amp;About</value></data>


### PR DESCRIPTION
## Motivation

Discord user elhsgiuloigtn clicked the `Help → Discord` menu in CKAN to visit the CKAN Discord with a support request for an in-game problem with mods, which is fairly common. It's currently not clear that it takes you to the _CKAN_ Discord which is focused on CKAN itself, and that there are better places to go for mod support.

## Changes

- Now the Help menu has an item for getting mod support that opens the modded support forum subsection for KSP1 or KSP2 depending on the current game instance
- Now the menu says `Help → CKAN Discord` to make it clearer what it's for
- Now the menu says `Help → CKAN user guide` to make it clearer what it's for
- Now the `Settings → CKAN plugins` menu is renamed `Settings → Plugins`, and the same change is made to the plugin dialog's title, because what other plugins could it be talking about?
