### PR TITLE
Trigger mod installer deploy after APT repo update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,15 @@ jobs:
         run: aws s3 sync _build/deb/apt-repo-root s3://${AWS_S3_BUCKET}/deb --follow-symlinks
       - name: Push nightly APT repo to S3
         run: aws s3 sync _build/deb/apt-repo-dist s3://${AWS_S3_BUCKET}/deb/dists/nightly --follow-symlinks
+      - name: CKAN-ModInstaller repo dispatch
+        env:
+          REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+        if: env.REPO_ACCESS_TOKEN
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          repository: KSP-CKAN/CKAN-ModInstaller
+          event-type: deploy
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
 
   upload-rpm:
     needs:

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,5 +1,5 @@
 # Everything we need in both the build and prod images
-FROM ubuntu:22.04 as base
+FROM ubuntu:22.04 AS base
 
 # Don't prompt for time zone
 ENV DEBIAN_FRONTEND noninteractive
@@ -26,7 +26,7 @@ RUN apt-get install -y --no-install-recommends \
     mono-runtime ca-certificates-mono libmono-microsoft-csharp4.0-cil libmono-system-data4.0-cil libmono-system-runtime-serialization4.0-cil libmono-system-transactions4.0-cil libmono-system-net-http-webrequest4.0-cil
 
 # Isolate Python build stuff in a separate container
-FROM base as build
+FROM base AS build
 
 # Install Python build deps
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Motivation

<https://github.com/KSP-CKAN/CKAN-ModInstaller> is a simple GitHub action consisting of CKAN installed in a Docker image with all the needed dependencies and a simple bash driver script. It should be redeployed when changes are made to CKAN.

## Changes

Now a new step at the end of the `upload-deb` job of the `deploy` workflow triggers the `deploy` repo dispatch event in the CKAN-ModInstaller repo so its GitHub Action image will be rebuilt.

Note that this required adding a `REPO_ACCESS_TOKEN` secret to this repo containing a [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with `public_repo` scope and `write` access to the CKAN repo. This has been done.
