### PR TITLE
Ability to update repos without a game instance

### DIFF
--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -1,21 +1,28 @@
+using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 
 using CommandLine;
 
+using CKAN.Versioning;
+using CKAN.Games;
+
 namespace CKAN.CmdLine
 {
-    public class Update : ICommand
+    // Does not always need an instance, so this is not an ICommand
+    public class Update
     {
         /// <summary>
         /// Initialize the update command object
         /// </summary>
         /// <param name="mgr">GameInstanceManager containing our instances</param>
         /// <param name="user">IUser object for interaction</param>
-        public Update(RepositoryDataManager repoData, IUser user)
+        public Update(RepositoryDataManager repoData, IUser user, GameInstanceManager manager)
         {
             this.repoData = repoData;
             this.user     = user;
+            this.manager  = manager;
         }
 
         /// <summary>
@@ -26,34 +33,72 @@ namespace CKAN.CmdLine
         /// <returns>
         /// Exit code for shell environment
         /// </returns>
-        public int RunCommand(CKAN.GameInstance instance, object raw_options)
+        public int RunCommand(object raw_options)
         {
             UpdateOptions options = (UpdateOptions) raw_options;
 
-            List<CkanModule> compatible_prior = null;
-
-            if (options.list_changes)
-            {
-                // Get a list of compatible modules prior to the update.
-                var registry = RegistryManager.Instance(instance, repoData).registry;
-                compatible_prior = registry.CompatibleModules(instance.VersionCriteria()).ToList();
-            }
-
             try
             {
-                UpdateRepository(instance);
+                if (options.repositoryURLs != null || options.game != null)
+                {
+                    var game  = options.game == null ? KnownGames.knownGames.First()
+                                                     : KnownGames.GameByShortName(options.game);
+                    if (game == null)
+                    {
+                        user.RaiseError(Properties.Resources.UpdateBadGame,
+                                        options.game,
+                                        string.Join(", ", KnownGames.AllGameShortNames()));
+                        return Exit.BADOPT;
+                    }
+                    var repos = (options.repositoryURLs ?? Enumerable.Empty<string>())
+                                        .Select((url, i) =>
+                                            new Repository(string.Format(Properties.Resources.UpdateURLRepoName,
+                                                                         i + 1),
+                                                           getUri(url)))
+                                        .DefaultIfEmpty(Repository.DefaultGameRepo(game))
+                                        .ToArray();
+                    List<CkanModule> availablePrior = null;
+                    if (options.list_changes)
+                    {
+                        availablePrior = repoData.GetAllAvailableModules(repos)
+                                                 .Select(am => am.Latest())
+                                                 .ToList();
+                    }
+                    UpdateRepositories(game, repos, options.force);
+                    if (options.list_changes)
+                    {
+                        PrintChanges(availablePrior,
+                                     repoData.GetAllAvailableModules(repos)
+                                             .Select(am => am.Latest())
+                                             .ToList());
+                    }
+                }
+                else
+                {
+                    var instance = MainClass.GetGameInstance(manager);
+                    Registry            registry         = null;
+                    List<CkanModule>    compatible_prior = null;
+                    GameVersionCriteria crit             = null;
+                    if (options.list_changes)
+                    {
+                        // Get a list of compatible modules prior to the update.
+                        registry = RegistryManager.Instance(instance, repoData).registry;
+                        crit     = instance.VersionCriteria();
+                        compatible_prior = registry.CompatibleModules(crit).ToList();
+                    }
+                    UpdateRepositories(instance, options.force);
+                    if (options.list_changes)
+                    {
+                        PrintChanges(compatible_prior,
+                                     registry.CompatibleModules(crit).ToList());
+                    }
+                }
             }
             catch (MissingCertificateKraken kraken)
             {
                 // Handling the kraken means we have prettier output.
                 user.RaiseMessage(kraken.ToString());
                 return Exit.ERROR;
-            }
-
-            if (options.list_changes)
-            {
-                var registry = RegistryManager.Instance(instance, repoData).registry;
-                PrintChanges(compatible_prior, registry.CompatibleModules(instance.VersionCriteria()).ToList());
             }
 
             return Exit.OK;
@@ -64,22 +109,25 @@ namespace CKAN.CmdLine
         /// </summary>
         /// <param name="modules_prior">List of the compatible modules prior to the update.</param>
         /// <param name="modules_post">List of the compatible modules after the update.</param>
-        private void PrintChanges(List<CkanModule> modules_prior, List<CkanModule> modules_post)
+        private void PrintChanges(List<CkanModule> modules_prior,
+                                  List<CkanModule> modules_post)
         {
             var prior = new HashSet<CkanModule>(modules_prior, new NameComparer());
-            var post = new HashSet<CkanModule>(modules_post, new NameComparer());
+            var post  = new HashSet<CkanModule>(modules_post,  new NameComparer());
 
-
-            var added = new HashSet<CkanModule>(post.Except(prior, new NameComparer()));
+            var added   = new HashSet<CkanModule>(post.Except(prior, new NameComparer()));
             var removed = new HashSet<CkanModule>(prior.Except(post, new NameComparer()));
-
 
             // Default compare includes versions
             var unchanged = post.Intersect(prior);
-            var updated = post.Except(unchanged).Except(added).Except(removed).ToList();
+            var updated   = post.Except(unchanged)
+                                .Except(added)
+                                .Except(removed)
+                                .ToList();
 
             // Print the changes.
-            user.RaiseMessage(Properties.Resources.UpdateChangesSummary, added.Count(), removed.Count(), updated.Count());
+            user.RaiseMessage(Properties.Resources.UpdateChangesSummary,
+                              added.Count(), removed.Count(), updated.Count());
 
             if (added.Count > 0)
             {
@@ -126,28 +174,64 @@ namespace CKAN.CmdLine
         }
 
         /// <summary>
-        /// Updates the repository.
+        /// Updates repositories for a game instance
         /// </summary>
-        /// <param name="instance">The KSP instance to work on.</param>
+        /// <param name="instance">The game instance to work on.</param>
         /// <param name="repository">Repository to update. If null all repositories are used.</param>
-        private void UpdateRepository(CKAN.GameInstance instance)
+        private void UpdateRepositories(CKAN.GameInstance instance, bool force = false)
         {
-            RegistryManager registry_manager = RegistryManager.Instance(instance, repoData);
-
-            repoData.Update(registry_manager.registry.Repositories.Values.ToArray(),
-                            instance.game, false, new NetAsyncDownloader(user), user);
-
-            user.RaiseMessage(Properties.Resources.UpdateSummary, registry_manager.registry.CompatibleModules(instance.VersionCriteria()).Count());
+            var registry = RegistryManager.Instance(instance, repoData).registry;
+            var result = repoData.Update(registry.Repositories.Values.ToArray(),
+                                         instance.game, force,
+                                         new NetAsyncDownloader(user), user);
+            if (result == RepositoryDataManager.UpdateResult.Updated)
+            {
+                user.RaiseMessage(Properties.Resources.UpdateSummary,
+                                  registry.CompatibleModules(instance.VersionCriteria()).Count());
+            }
         }
+
+        /// <summary>
+        /// Updates repositories
+        /// </summary>
+        /// <param name="game">The game for which the URLs contain metadata</param>
+        /// <param name="repos">Repositories to update</param>
+        private void UpdateRepositories(IGame game, Repository[] repos, bool force = false)
+        {
+            var result = repoData.Update(repos, game, force, new NetAsyncDownloader(user), user);
+            if (result == RepositoryDataManager.UpdateResult.Updated)
+            {
+                user.RaiseMessage(Properties.Resources.UpdateSummary,
+                                  repoData.GetAllAvailableModules(repos).Count());
+            }
+        }
+
+        private Uri getUri(string arg)
+            => Uri.IsWellFormedUriString(arg, UriKind.Absolute)
+                ? new Uri(arg)
+                : File.Exists(arg)
+                    ? new Uri(Path.GetFullPath(arg))
+                    : throw new FileNotFoundKraken(arg);
 
         private readonly RepositoryDataManager repoData;
         private readonly IUser                 user;
+        private readonly GameInstanceManager   manager;
     }
 
     internal class UpdateOptions : InstanceSpecificOptions
     {
-        [Option("list-changes", DefaultValue = false, HelpText = "List new and removed modules")]
+        [Option('l', "list-changes", DefaultValue = false, HelpText = "List new and removed modules")]
         public bool list_changes { get; set; }
+
+        // Can't specify DefaultValue here because we want to fall back to instance-based updates when omitted
+        [Option('g', "game", HelpText = "Game for which to update repositories")]
+        public string game { set; get; }
+
+        [OptionArray('u', "urls", HelpText = "URLs of repositories to update")]
+        public string[] repositoryURLs { get; set; }
+
+        [Option('f', "force", DefaultValue = false, HelpText = "Download and parse metadata even if it hasn't changed")]
+        public bool force { get; set; }
     }
 
 }

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -217,12 +217,11 @@ namespace CKAN.CmdLine
                         return Version(user);
 
                     case "update":
-                        return (new Update(repoData, user)).RunCommand(GetGameInstance(manager), cmdline.options);
+                        return (new Update(repoData, user, manager)).RunCommand(cmdline.options);
 
                     case "available":
                         return (new Available(repoData, user)).RunCommand(GetGameInstance(manager), cmdline.options);
 
-                    case "add":
                     case "install":
                         Scan(GetGameInstance(manager), user, cmdline.action);
                         return (new Install(manager, repoData, user)).RunCommand(GetGameInstance(manager), cmdline.options);
@@ -247,7 +246,6 @@ namespace CKAN.CmdLine
                     case "search":
                         return (new Search(repoData, user)).RunCommand(GetGameInstance(manager), options);
 
-                    case "uninstall":
                     case "remove":
                         return (new Remove(manager, repoData, user)).RunCommand(GetGameInstance(manager), cmdline.options);
 

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -359,11 +359,13 @@ Try `ckan list` for a list of installed mods.</value></data>
   <data name="ShowFileName" xml:space="preserve"><value>Filename: {0}</value></data>
   <data name="ShowVersionHeader" xml:space="preserve"><value>Version</value></data>
   <data name="ShowGameVersionsHeader" xml:space="preserve"><value>Game Versions</value></data>
-  <data name="UpdateChangesSummary" xml:space="preserve"><value>Found {0} new modules, {1} removed modules and {2} updated modules</value></data>
+  <data name="UpdateBadGame" xml:space="preserve"><value>Game {0} not found! Valid options are: {1}</value></data>
+  <data name="UpdateURLRepoName" xml:space="preserve"><value>URL #{0}</value></data>
+  <data name="UpdateChangesSummary" xml:space="preserve"><value>Found {0} new modules, {1} removed modules, and {2} updated modules.</value></data>
   <data name="UpdateAddedHeader" xml:space="preserve"><value>New modules [Name (CKAN identifier)]:</value></data>
   <data name="UpdateRemovedHeader" xml:space="preserve"><value>Removed modules [Name (CKAN identifier)]:</value></data>
   <data name="UpdateUpdatedHeader" xml:space="preserve"><value>Updated modules [Name (CKAN identifier)]:</value></data>
-  <data name="UpdateSummary" xml:space="preserve"><value>Updated information on {0} compatible modules</value></data>
+  <data name="UpdateSummary" xml:space="preserve"><value>Updated information on {0} modules.</value></data>
   <data name="UpgradeCannotCombineFlags" xml:space="preserve"><value>The `--dev-build` and `--stable-release` flags cannot be combined!</value></data>
   <data name="UpgradeSwitchingToDevBuilds" xml:space="preserve"><value>Switching to dev builds</value></data>
   <data name="UpgradeSwitchingToStableReleases" xml:space="preserve"><value>Switching to stable releases</value></data>

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -694,7 +694,7 @@ namespace CKAN
         /// Depends relationships with suppress_recommendations=true,
         /// to be applied to all recommendations and suggestions
         /// </summary>
-        private HashSet<RelationshipDescriptor> suppressedRecommenders = new HashSet<RelationshipDescriptor>();
+        private readonly HashSet<RelationshipDescriptor> suppressedRecommenders = new HashSet<RelationshipDescriptor>();
 
         private readonly IRegistryQuerier            registry;
         private readonly GameVersionCriteria         versionCrit;

--- a/Core/Repositories/Repository.cs
+++ b/Core/Repositories/Repository.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 
 using Newtonsoft.Json;
 
+using CKAN.Games;
+
 namespace CKAN
 {
     public class Repository : IEquatable<Repository>
@@ -53,5 +55,9 @@ namespace CKAN
 
         public override string ToString()
             => string.Format("{0} ({1}, {2})", name, priority, uri);
+
+        public static Repository DefaultGameRepo(IGame game)
+            => new Repository($"{game.ShortName}-{default_ckan_repo_name}",
+                              game.DefaultRepositoryURL);
     }
 }

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -151,8 +151,7 @@ namespace CKAN
 
             // Check if any ETags have changed, quit if not
             user.RaiseProgress(Properties.Resources.NetRepoCheckingForUpdates, 0);
-            var toUpdate = repos.DefaultIfEmpty(new Repository($"{game.ShortName}-{Repository.default_ckan_repo_name}",
-                                                               game.DefaultRepositoryURL))
+            var toUpdate = repos.DefaultIfEmpty(Repository.DefaultGameRepo(game))
                                 .DistinctBy(r => r.uri)
                                 .Where(r => r.uri != null
                                             && (r.uri.IsFile


### PR DESCRIPTION
## Background

The `ckan update` command retrieves fresh metadata from repositories, but currently it requires a game instance to work. Since #3904, repositories and game instances have been decoupled somewhat, so this should not be strictly necessary anymore.

## Motivation

For <https://github.com/KSP-CKAN/CKAN-ModInstaller>, it would be nice to be able to pre-load the Docker image with metadata so a mod's build wouldn't have to wait for a `ckan update` command to run. Ideally we could do this without creating a temporary game instance during the docker build.

## Changes

Now the `ckan update` command has several new flags:

- `-g KSP -u URL [URL2 ...]` will update the repos with the given URLs, using the `-g` parameter to determine the game to use
- `-g KSP` / `-g KSP2` without `-u` will update the default repo for the given game (limit one per command)
- `-f` will force an update to be performed even if the repo's ETags haven't changed
- `-l` is now an alias for `--list-changes`

This will allow us to add these commands to the ModInstaller's Dockerfile to pre-load it with metadata:

```bash
ckan update -g KSP
ckan update -g KSP2
```
