### PR TITLE
Update Signpath Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       artifact-url: ${{steps.sign.outputs.signing-request-id }}
     steps:
-      - uses: signpath/github-action-submit-signing-request@v0.4
+      - uses: signpath/github-action-submit-signing-request@v1
         id: sign
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}


### PR DESCRIPTION
The release version is now available for signpath, though there are still a couple of steps to go through, this will ensure signing is working correctly with the release action.

- Successful run: https://github.com/KSP-CKAN/CKAN/actions/runs/10438536973/job/28905992320
- Signed artifact: [Release-repack-unsigned.zip](https://github.com/user-attachments/files/16647463/Release-repack-unsigned.zip)
