### PR TITLE
Don't hide other providing mods for installed, make installed bold

### DIFF
--- a/GUI/Controls/ModInfoTabs/Relationships.Designer.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.Designer.cs
@@ -32,6 +32,7 @@ namespace CKAN.GUI
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(Relationships));
             this.ToolTip = new System.Windows.Forms.ToolTip();
             this.DependsGraphTree = new System.Windows.Forms.TreeView();
+            this.LegendInstalledLabel = new System.Windows.Forms.Label();
             this.LegendProvidesImage = new System.Windows.Forms.PictureBox();
             this.LegendProvidesLabel = new System.Windows.Forms.Label();
             this.LegendDependsImage = new System.Windows.Forms.PictureBox();
@@ -60,7 +61,7 @@ namespace CKAN.GUI
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.DependsGraphTree.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.DependsGraphTree.Location = new System.Drawing.Point(3, 114);
+            this.DependsGraphTree.Location = new System.Drawing.Point(3, 132);
             this.DependsGraphTree.Name = "DependsGraphTree";
             this.DependsGraphTree.Size = new System.Drawing.Size(494, 364);
             this.DependsGraphTree.TabIndex = 0;
@@ -79,88 +80,95 @@ namespace CKAN.GUI
             this.DependsGraphTree.ImageList.Images.Add("Supports", global::CKAN.GUI.EmbeddedImages.smile);
             this.DependsGraphTree.ImageList.Images.Add("Conflicts", global::CKAN.GUI.EmbeddedImages.alert);
             //
+            // LegendInstalledLabel
+            //
+            this.LegendInstalledLabel.AutoSize = true;
+            this.LegendInstalledLabel.Location = new System.Drawing.Point(24, 3);
+            this.LegendInstalledLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 8, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            resources.ApplyResources(this.LegendInstalledLabel, "LegendInstalledLabel");
+            //
             // LegendProvidesImage
             //
             this.LegendProvidesImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendProvidesImage.Image = global::CKAN.GUI.EmbeddedImages.ballot;
-            this.LegendProvidesImage.Location = new System.Drawing.Point(6, 3);
+            this.LegendProvidesImage.Location = new System.Drawing.Point(6, 21);
             this.LegendProvidesImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.LegendProvidesImage.ClientSize = new System.Drawing.Size(14, 14);
             //
             // LegendProvidesLabel
             //
             this.LegendProvidesLabel.AutoSize = true;
-            this.LegendProvidesLabel.Location = new System.Drawing.Point(24, 3);
+            this.LegendProvidesLabel.Location = new System.Drawing.Point(24, 21);
             resources.ApplyResources(this.LegendProvidesLabel, "LegendProvidesLabel");
             //
             // LegendDependsImage
             //
             this.LegendDependsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendDependsImage.Image = global::CKAN.GUI.EmbeddedImages.star;
-            this.LegendDependsImage.Location = new System.Drawing.Point(6, 21);
+            this.LegendDependsImage.Location = new System.Drawing.Point(6, 39);
             this.LegendDependsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.LegendDependsImage.ClientSize = new System.Drawing.Size(14, 14);
             //
             // LegendDependsLabel
             //
             this.LegendDependsLabel.AutoSize = true;
-            this.LegendDependsLabel.Location = new System.Drawing.Point(24, 21);
+            this.LegendDependsLabel.Location = new System.Drawing.Point(24, 39);
             resources.ApplyResources(this.LegendDependsLabel, "LegendDependsLabel");
             //
             // LegendRecommendsImage
             //
             this.LegendRecommendsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendRecommendsImage.Image = global::CKAN.GUI.EmbeddedImages.thumbup;
-            this.LegendRecommendsImage.Location = new System.Drawing.Point(6, 39);
+            this.LegendRecommendsImage.Location = new System.Drawing.Point(6, 57);
             this.LegendRecommendsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.LegendRecommendsImage.ClientSize = new System.Drawing.Size(14, 14);
             //
             // LegendRecommendsLabel
             //
             this.LegendRecommendsLabel.AutoSize = true;
-            this.LegendRecommendsLabel.Location = new System.Drawing.Point(24, 39);
+            this.LegendRecommendsLabel.Location = new System.Drawing.Point(24, 57);
             resources.ApplyResources(this.LegendRecommendsLabel, "LegendRecommendsLabel");
             //
             // LegendSuggestsImage
             //
             this.LegendSuggestsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendSuggestsImage.Image = global::CKAN.GUI.EmbeddedImages.info;
-            this.LegendSuggestsImage.Location = new System.Drawing.Point(6, 57);
+            this.LegendSuggestsImage.Location = new System.Drawing.Point(6, 75);
             this.LegendSuggestsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.LegendSuggestsImage.ClientSize = new System.Drawing.Size(14, 14);
             //
             // LegendSuggestsLabel
             //
             this.LegendSuggestsLabel.AutoSize = true;
-            this.LegendSuggestsLabel.Location = new System.Drawing.Point(24, 57);
+            this.LegendSuggestsLabel.Location = new System.Drawing.Point(24, 75);
             resources.ApplyResources(this.LegendSuggestsLabel, "LegendSuggestsLabel");
             //
             // LegendSupportsImage
             //
             this.LegendSupportsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendSupportsImage.Image = global::CKAN.GUI.EmbeddedImages.smile;
-            this.LegendSupportsImage.Location = new System.Drawing.Point(6, 75);
+            this.LegendSupportsImage.Location = new System.Drawing.Point(6, 93);
             this.LegendSupportsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.LegendSupportsImage.ClientSize = new System.Drawing.Size(14, 14);
             //
             // LegendSupportsLabel
             //
             this.LegendSupportsLabel.AutoSize = true;
-            this.LegendSupportsLabel.Location = new System.Drawing.Point(24, 75);
+            this.LegendSupportsLabel.Location = new System.Drawing.Point(24, 93);
             resources.ApplyResources(this.LegendSupportsLabel, "LegendSupportsLabel");
             //
             // LegendConflictsImage
             //
             this.LegendConflictsImage.BackColor = System.Drawing.SystemColors.Window;
             this.LegendConflictsImage.Image = global::CKAN.GUI.EmbeddedImages.alert;
-            this.LegendConflictsImage.Location = new System.Drawing.Point(6, 93);
+            this.LegendConflictsImage.Location = new System.Drawing.Point(6, 111);
             this.LegendConflictsImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.LegendConflictsImage.ClientSize = new System.Drawing.Size(14, 14);
             //
             // LegendConflictsLabel
             //
             this.LegendConflictsLabel.AutoSize = true;
-            this.LegendConflictsLabel.Location = new System.Drawing.Point(24, 93);
+            this.LegendConflictsLabel.Location = new System.Drawing.Point(24, 111);
             resources.ApplyResources(this.LegendConflictsLabel, "LegendConflictsLabel");
             //
             // ReverseRelationshipsCheckbox
@@ -181,6 +189,7 @@ namespace CKAN.GUI
             // Relationships
             //
             this.Controls.Add(this.DependsGraphTree);
+            this.Controls.Add(this.LegendInstalledLabel);
             this.Controls.Add(this.LegendProvidesImage);
             this.Controls.Add(this.LegendProvidesLabel);
             this.Controls.Add(this.LegendDependsImage);
@@ -205,6 +214,7 @@ namespace CKAN.GUI
 
         private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.TreeView DependsGraphTree;
+        private System.Windows.Forms.Label LegendInstalledLabel;
         private System.Windows.Forms.PictureBox LegendProvidesImage;
         private System.Windows.Forms.Label LegendProvidesLabel;
         private System.Windows.Forms.PictureBox LegendDependsImage;

--- a/GUI/Controls/ModInfoTabs/Relationships.resx
+++ b/GUI/Controls/ModInfoTabs/Relationships.resx
@@ -117,6 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="LegendInstalledLabel.Text" xml:space="preserve"><value>Installed</value></data>
   <data name="LegendProvidesLabel.Text" xml:space="preserve"><value>Provides</value></data>
   <data name="LegendDependsLabel.Text" xml:space="preserve"><value>Depends</value></data>
   <data name="LegendRecommendsLabel.Text" xml:space="preserve"><value>Recommends</value></data>


### PR DESCRIPTION
## Motivation

When an installed module satisfies a relationship by providing an identifier, the Relationships tab shows only the installed module without its peer providing mods, which makes it look like the dependency is more specific than it is.

## Changes

- Now virtual dependencies are expanded by default in the initial view of the tree so they're easier to see
- Now virtual relationships always show the full list of providing mods, even if one of them is installed
- Now installed mods are shown in bold, with a new bold "Installed" label added to the legend section at the top

![image](https://github.com/user-attachments/assets/6c92ee25-8918-46a8-a111-1cd6db57c0ae)
