### PR TITLE
Set headless mode automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
         env:
           REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         if: env.REPO_ACCESS_TOKEN
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           repository: KSP-CKAN/CKAN-ModInstaller
           event-type: deploy

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -262,6 +262,18 @@ namespace CKAN.CmdLine
                 log.Info("Verbose logging enabled");
             }
 
+            // Auto-detect whether IO device is interactive
+            if (!Headless && (Console.IsInputRedirected || Console.IsOutputRedirected))
+            {
+                log.InfoFormat("Setting headless mode ({0})",
+                               Console.IsInputRedirected
+                                   ? Console.IsOutputRedirected
+                                       ? "I/O redirected"
+                                       : "input redirected"
+                                   : "output redirected");
+                Headless = true;
+            }
+
             // Assign user-agent string if user has given us one
             if (NetUserAgent != null)
             {


### PR DESCRIPTION
## Motivation

CmdLine has a `--headless` flag that lets CKAN know that it is not connected to an interactive terminal to suppress certain prompts or outputs. Many other terminal programs handle this automatically by checking properties of the stdin/stdout file handles.

## Changes

Now if stdin or stdout is redirected, we set `--headless` automatically.

If you pass `--verbose`, a notification is printed that also gives a little detail about which file handle was detected as redirected:

```
777 [1] INFO CKAN.CmdLine.CommonOptions (null) - Setting headless mode (input redirected)
```
