### PR TITLE
Work around OpenFileDialog always showing all shortcuts despite filters

### DIFF
--- a/Core/CkanTransaction.cs
+++ b/Core/CkanTransaction.cs
@@ -26,7 +26,7 @@ namespace CKAN
         }
 
         // System.ArgumentOutOfRangeException : Time-out interval must be less than 2^32-2. (Parameter 'dueTime')
-        private const double timeoutMs = Int32.MaxValue;
+        private const double timeoutMs = int.MaxValue;
         private static readonly TimeSpan maxCoretimeout = TimeSpan.FromMilliseconds(timeoutMs);
 
         private static readonly TransactionOptions transOpts = new TransactionOptions()

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -75,7 +75,7 @@ namespace CKAN.Configuration
         // If you have multiple instances of CKAN running at the same time, each will
         // believe that their copy of the config file in memory is authoritative, so
         // changes made by one copy will not be respected by the other.
-        private string configFile = defaultConfigFile;
+        private readonly string configFile = defaultConfigFile;
         private Config config     = null;
 
         public string DownloadCacheDir

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -326,7 +326,7 @@ namespace CKAN.GUI
             bool gotInstance = false;
             Util.Invoke(this, () =>
             {
-                var result = new ManageGameInstancesDialog(!actuallyVisible, currentUser).ShowDialog(this);
+                var result = new ManageGameInstancesDialog(Manager, !actuallyVisible, currentUser).ShowDialog(this);
                 gotInstance = result == DialogResult.OK;
             });
             return gotInstance;
@@ -335,7 +335,7 @@ namespace CKAN.GUI
         private void manageGameInstancesMenuItem_Click(object sender, EventArgs e)
         {
             var old_instance = CurrentInstance;
-            var result = new ManageGameInstancesDialog(!actuallyVisible, currentUser).ShowDialog(this);
+            var result = new ManageGameInstancesDialog(Manager, !actuallyVisible, currentUser).ShowDialog(this);
             if (result == DialogResult.OK && !Equals(old_instance, CurrentInstance))
             {
                 for (bool done = false; !done;)

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -193,7 +193,7 @@ namespace CKAN.GUI
             }
 
             foreach (var im in registry.FindRemovableAutoInstalled(
-                InstalledAfterChanges(registry, changeSet, version).ToList(), version))
+                InstalledAfterChanges(registry, changeSet).ToList(), version))
             {
                 changeSet.Add(new ModChange(im.Module, GUIModChangeType.Remove, new SelectionReason.NoLongerUsed()));
                 modules_to_remove.Add(im.Module);
@@ -228,7 +228,7 @@ namespace CKAN.GUI
         /// <param name="crit">Compatible versions of current instance</param>
         /// <returns>Sequence of InstalledModules after the changes are applied, not including dependencies</returns>
         private IEnumerable<InstalledModule> InstalledAfterChanges(
-            IRegistryQuerier registry, HashSet<ModChange> changeSet, GameVersionCriteria crit)
+            IRegistryQuerier registry, HashSet<ModChange> changeSet)
         {
             var removingIdents = changeSet
                 .Where(ch => ch.ChangeType != GUIModChangeType.Install)

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -344,6 +344,13 @@ You can refresh the mod list manually with the Refresh button at the top, and yo
   <data name="ManageGameInstancesDirectoryDeleted" xml:space="preserve"><value>Directory "{0}" doesn't exist.</value></data>
   <data name="ManageGameInstancesNameColumnInvalid" xml:space="preserve"><value>{0} (INVALID)</value></data>
   <data name="ManageGameInstancesNameColumnLocked" xml:space="preserve"><value>{0} (LOCKED)</value></data>
+  <data name="ManageGameInstancesInvalidFileSelected" xml:space="preserve"><value>Not a valid game instance file:  "{0}"
+
+If you selected a shortcut, don't do that; Windows won't let us hide them from this dialog even though they're invalid.
+
+Find the folder where your game is installed and choose one of these files:
+
+{1}</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Failed to fetch master list.</value></data>
   <data name="PluginsDialogFilter" xml:space="preserve"><value>CKAN Plugins (*.dll)|*.dll</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using log4net;
 
-using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;

--- a/Netkan/Transformers/MetaNetkanTransformer.cs
+++ b/Netkan/Transformers/MetaNetkanTransformer.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using log4net;
 using Newtonsoft.Json.Linq;
 
-using CKAN.Versioning;
 using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;


### PR DESCRIPTION
## Problem

The popup to add a game instance is only supposed to let the user choose game executable files of known games, but it always shows all shortcuts:

![image](https://github.com/user-attachments/assets/994c7eb5-e436-4ef6-a5cd-19bbb2d66eb4)

If you choose one of these and try to use it to add a game instance, you get a (quite funny) "Catastrophic failure" message:

![image](https://github.com/user-attachments/assets/5a3d4937-abaf-4aa1-8959-2bc43d9f6df8)

Reported by @PoofImAlex in KSP-CKAN/CKAN#4167.

## Cause

This seems to be just how `OpenFileDialog` "works". I'm sure there's some obscure rationale for it in some Microsoft document somewhere, but it is truly inappropriate and in need of fixing in our case.

## Changes

It seems to be impossible to hide shortcuts, so instead we hook into the `FileOk` event and reject any files that don't match the filter that _we already gave to `OpenFileDialog` but which it decided to partially ignore_:

![image](https://github.com/user-attachments/assets/6338e37c-4ecc-4d81-a3ba-ec0133eeb740)
