### PR TITLE
Avoid index out of range

### DIFF
--- a/AutoUpdate/CKAN-autoupdate.csproj
+++ b/AutoUpdate/CKAN-autoupdate.csproj
@@ -33,6 +33,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
+    <PackageReference Include="IndexRange" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">

--- a/AutoUpdate/Main.cs
+++ b/AutoUpdate/Main.cs
@@ -28,18 +28,22 @@ namespace CKAN.AutoUpdateHelper
         {
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;
 
-            if (args.Length != 4)
+            if (//args is not [string pid_str,
+                //             string local_path,
+                //             string updated_path,
+                //             string launch and ("launch" or "nolaunch")]
+                args.Length < 4
+                    || args[0] is not string pid_str
+                    || args[1] is not string local_path
+                    || args[2] is not string updated_path
+                    || args[3] is not (string launch and ("launch" or "nolaunch")))
             {
-                ReportError("{0}: AutoUpdater.exe pid oldPath newPath [no]launch", Properties.Resources.Usage);
+                ReportError("{0}: AutoUpdater.exe pid oldPath newPath [no]launch",
+                            Properties.Resources.Usage);
                 return ExitBADOPT;
             }
-
-            // Yes, it's a global variable, but we're an ephemeral singleton so :shrug:
-            fromGui = (args[3] == "launch");
-
-            int    pid          = int.Parse(args[0]);
-            string local_path   = args[1];
-            string updated_path = args[2];
+            int pid = int.Parse(pid_str);
+            fromGui = (launch == "launch");
 
             if (!File.Exists(updated_path))
             {

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -53,7 +53,7 @@ namespace CKAN.CmdLine
                     var toInstall = new List<CkanModule>();
                     var installer = new ModuleInstaller(instance, manager.Cache, user);
                     var regMgr    = RegistryManager.Instance(instance, repoData);
-                    installer.ImportFiles(toImport, user, mod => toInstall.Add(mod), regMgr.registry, !opts?.Headless ?? false);
+                    installer.ImportFiles(toImport, user, toInstall.Add, regMgr.registry, !opts?.Headless ?? false);
                     if (toInstall.Count > 0)
                     {
                         HashSet<string>? possibleConfigOnlyDirs = null;

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -55,7 +55,12 @@ namespace CKAN.CmdLine
                 return Exit.BADOPT;
             }
 
-            if (!options.upgrade_all && options.modules?[0] == "ckan" && AutoUpdate.CanUpdate)
+            if (!options.upgrade_all
+                //&& options.modules is ["ckan"]
+                && options.modules != null
+                && options.modules.Count > 0
+                && options.modules[0] is "ckan"
+                && AutoUpdate.CanUpdate)
             {
                 if (options.dev_build && options.stable_release)
                 {
@@ -196,7 +201,7 @@ namespace CKAN.CmdLine
                     installer.Upgrade(modules, downloader,
                                       ref possibleConfigOnlyDirs,
                                       regMgr, true, true, true),
-                m => modules.Add(m));
+                modules.Add);
         }
 
         /// <summary>

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -105,7 +105,9 @@ namespace CKAN.CmdLine
             // Check if we have a default selection.
             int defaultSelection = -1;
 
-            if (args[0] is int v)
+            if (//args is [int v, ..]
+                args.Length > 0
+                && args[0] is int v)
             {
                 // Check that the default selection makes sense.
                 defaultSelection = v;

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -87,32 +87,35 @@ namespace CKAN.CmdLine
             // It breaks command-specific help, for starters.
             try
             {
-                switch (args[0])
+                if (args.Length > 0)
                 {
-                    case "repair":
-                        return (new Repair(repoData)).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                    switch (args[0])
+                    {
+                        case "repair":
+                            return (new Repair(repoData)).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
-                    case "instance":
-                        return (new GameInstance()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                        case "instance":
+                            return (new GameInstance()).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
-                    case "compat":
-                        return (new Compat()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                        case "compat":
+                            return (new Compat()).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
-                    case "repo":
-                        return (new Repo(repoData)).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                        case "repo":
+                            return (new Repo(repoData)).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
-                    case "authtoken":
-                        return (new AuthToken()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                        case "authtoken":
+                            return (new AuthToken()).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
-                    case "cache":
-                        return (new Cache()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                        case "cache":
+                            return (new Cache()).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
-                    case "mark":
-                        return (new Mark(repoData)).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                        case "mark":
+                            return (new Mark(repoData)).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
-                    case "filter":
-                        return (new Filter()).RunSubCommand(manager, opts, new SubCommandOptions(args));
+                        case "filter":
+                            return (new Filter()).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
+                    }
                 }
             }
             catch (NoGameInstanceKraken)

--- a/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
@@ -73,7 +73,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                         getRowName, compareNames, null),
                     new ConsoleListBoxColumn<FileSystemInfo>(
                         Properties.Resources.FileSelectSizeHeader,
-                        (FileSystemInfo fi) => getLength(fi),
+                        getLength,
                         (a, b) => {
                             var fb = b as FileInfo;
                             return a is not FileInfo fa

--- a/ConsoleUI/Toolkit/Symbols.cs
+++ b/ConsoleUI/Toolkit/Symbols.cs
@@ -145,7 +145,12 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         public static readonly char leftHalfBlock = cp437c(0xdd);
 
-        private static char   cp437c(byte num) => dosCodePage.GetChars(new byte[] {num})[0];
+        private static char   cp437c(byte num) => //dosCodePage.GetChars(new byte[] {num}) is [char val]
+                                                  dosCodePage.GetChars(new byte[] {num}) is char[] chars
+                                                  && chars.Length > 0
+                                                  && chars[0] is char val
+                                                      ? val
+                                                      : (char)0;
         private static string cp437s(byte num) => $"{cp437c(num)}";
     }
 

--- a/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
+++ b/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
@@ -85,8 +85,21 @@ namespace CKAN
         {
             const string divider = "\r\n---\r\n";
             // Get at most two pieces, the first is the image, the second is the release notes
-            string[] notesArray = releaseBody.Split(new string[] { divider }, 2, StringSplitOptions.None);
-            return notesArray.Length > 1 ? notesArray[1] : notesArray[0];
+            //return releaseBody.Split(new string[] { divider },
+            //                         2, StringSplitOptions.None) switch {
+            //    [_, string val, ..] => val,
+            //    [string val]        => val,
+            //    _                   => "",
+            //};
+            var array = releaseBody.Split(new string[] { divider },
+                                          2, StringSplitOptions.None);
+            return array.Length > 1
+                   && array[1] is string val
+                       ? val
+                       : array.Length == 1
+                         && array[0] is string val2
+                             ? val2
+                             : "";
         }
 
         private static readonly Uri latestCKANReleaseApiUrl =

--- a/Core/Converters/JsonSingleOrArrayConverter.cs
+++ b/Core/Converters/JsonSingleOrArrayConverter.cs
@@ -28,8 +28,12 @@ namespace CKAN
 
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            var list = value as List<T>;
-            serializer.Serialize(writer, list?.Count == 1 ? list[0] : value);
+            serializer.Serialize(writer, //value is List<T> and [T val]
+                                         value is List<T> list
+                                         && list.Count == 1
+                                         && list[0] is T val
+                                             ? val
+                                             : value);
         }
 
         /// <summary>

--- a/Core/Converters/JsonToGamesDictionaryConverter.cs
+++ b/Core/Converters/JsonToGamesDictionaryConverter.cs
@@ -57,8 +57,11 @@ namespace CKAN
             {
                 return token.ToObject(objectType);
             }
-            var valueType = objectType.GetGenericArguments()[1];
-            if (Activator.CreateInstance(objectType) is IDictionary obj
+            if (//objectType.GetGenericArguments() is [_, var valueType, ..]
+                objectType.GetGenericArguments() is Type[] types
+                && types.Length > 0
+                && types[1] is var valueType
+                && Activator.CreateInstance(objectType) is IDictionary obj
                 && !IsTokenEmpty(token))
             {
                 foreach (var gameName in KnownGames.AllGameShortNames())

--- a/Core/Exporters/DelimiterSeparatedValueExporter.cs
+++ b/Core/Exporters/DelimiterSeparatedValueExporter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace CKAN.Exporters
 {
@@ -53,7 +54,7 @@ namespace CKAN.Exporters
                                                  QuoteIfNecessary(mod.Module.description),
                                                  QuoteIfNecessary(mod.Module.author == null ? "" : string.Join(";", mod.Module.author)),
                                                  QuoteIfNecessary(mod.Module.kind),
-                                                 WriteUri(mod.Module.download?[0]),
+                                                 WriteUri(mod.Module.download),
                                                  mod.Module.download_size,
                                                  mod.Module.ksp_version,
                                                  mod.Module.ksp_version_min,
@@ -71,9 +72,16 @@ namespace CKAN.Exporters
         }
 
         private string WriteUri(Uri? uri)
-            => uri != null
-                ? QuoteIfNecessary(uri.ToString())
-                : string.Empty;
+            => uri != null ? QuoteIfNecessary(uri.ToString())
+                           : string.Empty;
+
+        private string WriteUri(List<Uri>? uris)
+            => WriteUri(//uris is [Uri uri, ..]
+                        uris != null
+                        && uris.Count > 0
+                        && uris[0] is Uri uri
+                            ? uri
+                            : null);
 
         private string WriteRepository(ResourcesDescriptor? resources)
             => resources != null && resources.repository != null

--- a/Core/Extensions/DictionaryExtensions.cs
+++ b/Core/Extensions/DictionaryExtensions.cs
@@ -9,7 +9,7 @@ namespace CKAN.Extensions
                                                   IDictionary<K, V>?      b)
             => a == null ? b == null
                          : b != null && a.Count == b.Count
-                           && a.Keys.All(k => b.ContainsKey(k))
+                           && a.Keys.All(b.ContainsKey)
                            && b.Keys.All(k => a.ContainsKey(k)
                                               && EqualityComparer<V>.Default.Equals(a[k], b[k]));
 

--- a/Core/Extensions/EnumExtensions.cs
+++ b/Core/Extensions/EnumExtensions.cs
@@ -7,7 +7,7 @@ namespace CKAN.Extensions
     {
 
         public static bool HasAnyFlag(this Enum val, params Enum[] flags)
-            => flags.Any(f => val.HasFlag(f));
+            => flags.Any(val.HasFlag);
 
     }
 }

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -544,7 +544,7 @@ namespace CKAN
                 try
                 {
                     var game = KnownGames.knownGames.FirstOrDefault(g => g.ShortName == gameName)
-                        ?? KnownGames.knownGames[0];
+                        ?? KnownGames.knownGames.First();
                     log.DebugFormat("Loading {0} from {1}", name, path);
                     // Add unconditionally, sort out invalid instances downstream
                     instances.Add(name, new GameInstance(game, path, name, User));

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -341,7 +341,7 @@ namespace CKAN
                         var dllFolders = files
                             .Select(f => instance.ToRelativeGameDir(f.destination))
                             .Where(relPath => instance.DllPathToIdentifier(relPath) == module.identifier)
-                            .Select(relPath => Path.GetDirectoryName(relPath))
+                            .Select(Path.GetDirectoryName)
                             .ToHashSet();
                         // Make sure that the DLL is actually included in the install
                         // (NearFutureElectrical, NearFutureElectrical-Core)
@@ -715,7 +715,7 @@ namespace CKAN
             }
 
             var instDlc = mods
-                .Select(ident => registry_manager.registry.InstalledModule(ident))
+                .Select(registry_manager.registry.InstalledModule)
                 .OfType<InstalledModule>()
                 .FirstOrDefault(m => m.Module.IsDLC);
             if (instDlc != null)
@@ -750,7 +750,7 @@ namespace CKAN
             User.RaiseMessage(Properties.Resources.ModuleInstallerAboutToRemove);
             User.RaiseMessage("");
 
-            foreach (var module in goners.Select(m => registry_manager.registry.InstalledModule(m))
+            foreach (var module in goners.Select(registry_manager.registry.InstalledModule)
                                          .OfType<InstalledModule>())
             {
                 User.RaiseMessage(" * {0} {1}", module.Module.name, module.Module.version);
@@ -901,7 +901,7 @@ namespace CKAN
                                           (Directory.Exists(directory)
                                               ? Directory.EnumerateFileSystemEntries(directory, "*", SearchOption.AllDirectories)
                                               : Enumerable.Empty<string>())
-                                           .Select(f => instance.ToRelativeGameDir(f))
+                                           .Select(instance.ToRelativeGameDir)
                                            .ToArray(),
                                           out string[] removable,
                                           out string[] notRemovable);

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -124,7 +124,7 @@ namespace CKAN
         {
             var filenames = urls?.Select(url => GetInProgressFileName(CreateURLHash(url), description))
                                  .ToArray();
-            return filenames?.FirstOrDefault(filename => File.Exists(filename))
+            return filenames?.FirstOrDefault(File.Exists)
                 ?? filenames?.FirstOrDefault();
         }
 
@@ -287,7 +287,7 @@ namespace CKAN
             => manager?.Instances.Values
                 .Where(ksp => ksp.Valid)
                 .Select(ksp => ksp.DownloadCacheDir())
-                .Where(dir => Directory.Exists(dir))
+                .Where(Directory.Exists)
                 .ToHashSet()
                 ?? new HashSet<string>();
 

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -60,7 +60,7 @@ namespace CKAN
             cache.MoveFrom(fromDir);
         }
         public bool IsCached(CkanModule m)
-            => m.download?.Any(dlUri => cache.IsCached(dlUri))
+            => m.download?.Any(cache.IsCached)
                 ?? false;
         public bool IsCached(CkanModule m, out string? outFilename)
         {
@@ -231,7 +231,14 @@ namespace CKAN
                 cancelToken?.ThrowIfCancellationRequested();
             }
             // If no exceptions, then everything is fine
-            var success = cache.Store(module.download?[0]!, path, description ?? module.StandardName(), move);
+            var success = //module.download is [Uri url, ..]
+                          module.download != null
+                          && module.download.Count > 0
+                          && module.download[0] is Uri url
+                            ? cache.Store(url, path,
+                                          description ?? module.StandardName(),
+                                          move)
+                            : "";
             // Make sure completion is signalled so progress bars go away
             progress?.Report(100);
             ModStored?.Invoke(module);

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -140,7 +140,7 @@ namespace CKAN
                         .GroupBy(kvp => kvp.Key,
                                  kvp => kvp.Value)
                         .ToDictionary(grp => grp.Key,
-                                      grp => AvailableModule.Merge(grp))
+                                      AvailableModule.Merge)
                         // Group into trivially [in]compatible (false/true) and indeterminate (null)
                         .AsParallel()
                         .GroupBy(kvp => kvp.Value.AllAvailable()
@@ -196,7 +196,7 @@ namespace CKAN
                             // For each of those identifiers, if it is provided by at least one module, get all the modules
                             // that provide it (and make sure each is only once in the list)
                             var candidates = RelationshipIdentifiers(rel)
-                                .Where(ident => providers.ContainsKey(ident))
+                                .Where(providers.ContainsKey)
                                 .SelectMany(ident => providers[ident])
                                 .Distinct();
 

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -874,7 +874,7 @@ namespace CKAN
             var inconsistencies = new List<string>();
 
             // We always work with relative files, so let's get some!
-            var relativeFiles = absoluteFiles.Select(x => inst.ToRelativeGameDir(x))
+            var relativeFiles = absoluteFiles.Select(inst.ToRelativeGameDir)
                                              .ToHashSet(Platform.PathComparer);
 
             // For now, it's always cool if a module wants to register a directory.

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -562,8 +562,8 @@ namespace CKAN
             {
                 var dlls = Enumerable.Repeat(gameInstance.game.PrimaryModDirectoryRelative, 1)
                                      .Concat(gameInstance.game.AlternateModDirectoriesRelative)
-                                     .Select(relDir => gameInstance.ToAbsoluteGameDir(relDir))
-                                     .Where(absDir => Directory.Exists(absDir))
+                                     .Select(gameInstance.ToAbsoluteGameDir)
+                                     .Where(Directory.Exists)
                                      // EnumerateFiles is *case-sensitive* in its pattern, which causes
                                      // DLL files to be missed under Linux; we have to pick .dll, .DLL, or scanning
                                      // GameData *twice*.
@@ -572,7 +572,7 @@ namespace CKAN
                                      .SelectMany(absDir => Directory.EnumerateFiles(absDir, "*",
                                                                                     SearchOption.AllDirectories))
                                      .Where(file => file.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase))
-                                     .Select(absPath => gameInstance.ToRelativeGameDir(absPath))
+                                     .Select(gameInstance.ToRelativeGameDir)
                                      .Where(relPath => !gameInstance.game.StockFolders.Any(f => relPath.StartsWith($"{f}/")))
                                      .GroupBy(relPath => gameInstance.DllPathToIdentifier(relPath) ?? "")
                                      .ToDictionary(grp => grp.Key,

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -369,7 +369,7 @@ namespace CKAN
                     }
                 }
 
-                CkanModule candidate = candidates[0];
+                CkanModule candidate = candidates.First();
 
                 // Finally, check our candidate against everything which might object
                 // to it being installed; that's all the mods which are fixed in our

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -211,7 +211,7 @@ namespace CKAN
                                   .Aggregate((best, r) => r.Upper == GameVersionBound.Highest(best.Upper, r.Upper)
                                                               ? r
                                                               : best);
-            return realVersions?.LastOrDefault(v => bestRange.Contains(v))
+            return realVersions?.LastOrDefault(bestRange.Contains)
                                // This is needed for when we have no real versions loaded, such as tests
                                ?? module_version.Values.Select(m => m.LatestCompatibleGameVersion())
                                                        .Max()

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -110,8 +110,8 @@ namespace CKAN
         }
 
         public TimeSpan LastUpdate(IEnumerable<Repository> repos)
-            => repos.Distinct().Where(r => repoDataStale(r))
-                               .Select(r => RepoUpdateTimestamp(r))
+            => repos.Distinct().Where(repoDataStale)
+                               .Select(RepoUpdateTimestamp)
                                .OfType<DateTime>()
                                .Select(dt => DateTime.Now - dt)
                                .DefaultIfEmpty(TimeSpan.Zero)
@@ -327,7 +327,7 @@ namespace CKAN
         private IEnumerable<RepositoryData> GetRepoDatas(IEnumerable<Repository>? repos)
             => repos?.OrderBy(repo => repo.priority)
                      .ThenBy(repo => repo.name)
-                     .Select(repo => GetRepoData(repo))
+                     .Select(GetRepoData)
                      .OfType<RepositoryData>()
                ?? Enumerable.Empty<RepositoryData>();
 

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -533,7 +533,7 @@ namespace CKAN
 
         private GameVersion LatestCompatibleRealGameVersion(GameVersionRange range,
                                                             List<GameVersion> realVers)
-            => (realVers?.LastOrDefault(v => range.Contains(v))
+            => (realVers?.LastOrDefault(range.Contains)
                         ?? LatestCompatibleGameVersion());
 
         public bool IsMetapackage => kind == "metapackage";

--- a/Core/Versioning/ModuleVersion.cs
+++ b/Core/Versioning/ModuleVersion.cs
@@ -230,17 +230,19 @@ namespace CKAN.Versioning
 
                 // Then compare the two strings, and return our comparison state.
                 // Override sorting of '.' to higher than other characters.
-                if (str1.Length > 0 && str2.Length > 0)
+                if (//str1 is [char first1, ..] && str2 is [char first2, ..]
+                    str1.Length > 0 && str1[0] is var first1
+                 && str2.Length > 0 && str2[0] is var first2)
                 {
-                    if (str1[0] != '.' && str2[0] == '.')
+                    if (first1 != '.' && first2 == '.')
                     {
                         comparison.CompareTo = -1;
                     }
-                    else if (str1[0] == '.' && str2[0] != '.')
+                    else if (first1 == '.' && first2 != '.')
                     {
                         comparison.CompareTo = 1;
                     }
-                    else if (str1[0] == '.' && str2[0] == '.')
+                    else if (first1 == '.' && first2 == '.')
                     {
                         if (str1.Length == 1 && str2.Length > 1)
                         {

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -69,7 +69,7 @@ namespace CKAN.GUI
             if (Platform.IsMono)
             {
                 // Workaround: make sure the ListView headers are drawn
-                Util.Invoke(this, () => RecommendedModsListView.EndUpdate());
+                Util.Invoke(this, RecommendedModsListView.EndUpdate);
             }
             task = new TaskCompletionSource<HashSet<CkanModule>?>();
             return task.Task.Result;
@@ -190,19 +190,26 @@ namespace CKAN.GUI
                                                                && kvp.Value.Item1
                                                                && !uncheckLabels.Any(mlbl =>
                                                                    mlbl.ContainsModule(game, kvp.Key.identifier))))
-                              .OrderBy(item => item.SubItems[1].Text)
+                              .OrderBy(SecondColumn)
                               .Concat(suggestions.Select(kvp => getRecSugItem(cache,
                                                                               kvp.Key,
                                                                               string.Join(", ", kvp.Value),
                                                                               SuggestionsGroup,
                                                                               false))
-                                                 .OrderBy(item => item.SubItems[1].Text))
+                                                 .OrderBy(SecondColumn))
                               .Concat(supporters.Select(kvp => getRecSugItem(cache,
                                                                              kvp.Key,
                                                                              string.Join(", ", kvp.Value.OrderBy(s => s)),
                                                                              SupportedByGroup,
                                                                              false))
-                                                .OrderBy(item => item.SubItems[1].Text));
+                                                .OrderBy(SecondColumn));
+
+        private string SecondColumn(ListViewItem item)
+            => //item.SubItems is [_, {Text: string text}, ..]
+               item.SubItems.Count > 1
+               && item.SubItems[0].Text is string text
+                   ? text
+                   : "";
 
         private ListViewItem getRecSugItem(NetModuleCache cache,
                                            CkanModule     module,

--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -34,7 +34,12 @@ namespace CKAN.GUI
             {
                 RemoveSearch(editors[i]);
             }
-            editors[0].Clear();
+            if (//editors is [var editor]
+                editors.Count == 1
+                && editors[0] is var editor)
+            {
+                editor.Clear();
+            }
         }
 
         public void ExpandCollapse()
@@ -66,7 +71,12 @@ namespace CKAN.GUI
             }
             if (searches.Count < 1)
             {
-                editors[0].Clear();
+                if (//editors is [var editor]
+                    editors.Count == 1
+                    && editors[0] is var editor)
+                {
+                    editor.Clear();
+                }
             }
             else
             {
@@ -149,7 +159,12 @@ namespace CKAN.GUI
                 editors.Remove(which);
                 Controls.Remove(which);
                 // Make sure the top label is always visible
-                editors[0].ShowLabel = true;
+                if (//editors is [var editor, ..]
+                    editors.Count > 0
+                    && editors[0] is var editor)
+                {
+                    editor.ShowLabel = true;
+                }
 
                 AddSearchButton.Top = editors[^1].Top;
 

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -81,7 +81,7 @@ namespace CKAN.GUI
             if (Platform.IsMono)
             {
                 // Workaround: make sure the ListView headers are drawn
-                Util.Invoke(this, () => RelationshipsListView.EndUpdate());
+                Util.Invoke(this, RelationshipsListView.EndUpdate);
             }
             this.user = user;
             task = new TaskCompletionSource<bool>();

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -526,7 +526,7 @@ namespace CKAN.GUI
             if (guiConfig != null)
             {
                 var hiddenColumnNames = guiConfig.HiddenColumnNames;
-                foreach (var colName in installedColumnNames.Where(nm => ModGrid.Columns.Contains(nm)))
+                foreach (var colName in installedColumnNames.Where(ModGrid.Columns.Contains))
                 {
                     ModGrid.Columns[colName].Visible = visible && !hiddenColumnNames.Contains(colName);
                 }
@@ -561,9 +561,11 @@ namespace CKAN.GUI
                     AddSort(UpdateCol, true);
                     UpdateFilters();
                     // Select the top row and scroll the list to it.
-                    if (ModGrid.Rows.Count > 0)
+                    if (//ModGrid.Rows is [DataGridViewRow row, ..]
+                        ModGrid.Rows.Count > 0
+                        && ModGrid.Rows[0] is DataGridViewRow row)
                     {
-                        ModGrid.CurrentCell = ModGrid.Rows[0].Cells[SelectableColumnIndex()];
+                        ModGrid.CurrentCell = row.Cells[SelectableColumnIndex()];
                     }
                 }
             });
@@ -773,9 +775,12 @@ namespace CKAN.GUI
             {
                 case Keys.Home:
                     // First row.
-                    if (ModGrid.Rows.Count > 0) //Handles for empty filters
+                    // Handles for empty filters
+                    if (//ModGrid.Rows is [DataGridViewRow top, ..]
+                        ModGrid.Rows.Count > 0
+                        && ModGrid.Rows[0] is DataGridViewRow top)
                     {
-                        ModGrid.CurrentCell = ModGrid.Rows[0].Cells[SelectableColumnIndex()];
+                        ModGrid.CurrentCell = top.Cells[SelectableColumnIndex()];
                     }
 
                     e.Handled = true;
@@ -783,9 +788,12 @@ namespace CKAN.GUI
 
                 case Keys.End:
                     // Last row.
-                    if (ModGrid.Rows.Count > 0) //Handles for empty filters
+                    // Handles for empty filters
+                    if (//ModGrid.Rows is [.., DataGridViewRow bottom]
+                        ModGrid.Rows.Count > 0
+                        && ModGrid.Rows[^1] is DataGridViewRow bottom)
                     {
-                        ModGrid.CurrentCell = ModGrid.Rows[^1].Cells[SelectableColumnIndex()];
+                        ModGrid.CurrentCell = bottom.Cells[SelectableColumnIndex()];
                     }
 
                     e.Handled = true;
@@ -873,20 +881,21 @@ namespace CKAN.GUI
             {
                 return;
             }
-
             if (e.RowIndex < 0)
             {
                 return;
             }
 
             DataGridViewRow row = ModGrid.Rows[e.RowIndex];
-            if (row.Cells[0] is not DataGridViewCheckBoxCell)
+            if (//row.Cells is not [DataGridViewCheckBoxCell cell, ..]
+                row.Cells.Count < 1
+                || row.Cells[0] is not DataGridViewCheckBoxCell cell)
             {
                 return;
             }
 
             // Need to change the state here, because the user hasn't clicked on a checkbox.
-            row.Cells[0].Value = !(bool)row.Cells[0].Value;
+            cell.Value = !(bool)cell.Value;
             ModGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
         }
 
@@ -1552,7 +1561,10 @@ namespace CKAN.GUI
 
         private void SetSort(DataGridViewColumn col)
         {
-            if (SortColumns.Count == 1 && SortColumns[0] == col.Name)
+            if (//SortColumns is [string colName]
+                SortColumns.Count == 1
+                && SortColumns[0] is string colName
+                && colName == col.Name)
             {
                 descending[0] = !descending[0];
             }
@@ -1762,9 +1774,11 @@ namespace CKAN.GUI
         }
 
         public GUIMod? SelectedModule =>
-            ModGrid.SelectedRows.Count == 0
-                ? null
-                : ModGrid.SelectedRows[0]?.Tag as GUIMod;
+            //ModGrid.SelectedRows is [{Tag: GUIMod gmod}, ..]
+            ModGrid.SelectedRows.Count > 0
+            && ModGrid.SelectedRows[0] is {Tag: GUIMod gmod}
+                ? gmod
+                : null;
 
         public void CloseSearch(Point screenCoords)
         {

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -100,7 +100,7 @@ namespace CKAN.GUI
             AuthorsPanel.SuspendLayout();
             AuthorsPanel.Controls.Clear();
             AuthorsPanel.Controls.AddRange(
-                authors.Select(a => AuthorLink(a)).ToArray());
+                authors.Select(AuthorLink).ToArray());
             AuthorsPanel.ResumeLayout();
         }
 

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -273,7 +273,7 @@ namespace CKAN.GUI
         }
 
         private IEnumerable<TreeNode> ForwardRelationships(IRegistryQuerier registry, CkanModule module, GameVersionCriteria crit)
-            => (module.provides?.Select(p => providedNode(p))
+            => (module.provides?.Select(providedNode)
                     ?? Enumerable.Empty<TreeNode>())
                 .Concat(kindsOfRelationships.SelectMany(relationship =>
                     GetModRelationships(module, relationship).Select(dependency =>
@@ -328,12 +328,12 @@ namespace CKAN.GUI
                 // Nothing found, don't return a node
                 return null;
             }
-            else if (childNodes.Count == 1
-                     && childNodes[0].Tag is CkanModule module
+            else if (//childNodes is [var node and {Tag: CkanModule module}]
+                     childNodes[0] is var node and {Tag: CkanModule module}
                      && relDescr.ContainsAny(new string[] { module.identifier }))
             {
                 // Only one exact match module, return a simple node
-                return childNodes[0];
+                return node;
             }
             else
             {

--- a/GUI/Controls/UnmanagedFiles.cs
+++ b/GUI/Controls/UnmanagedFiles.cs
@@ -132,7 +132,12 @@ namespace CKAN.GUI
         {
             GameFolderTree.BeginUpdate();
             GameFolderTree.ExpandAll();
-            GameFolderTree.Nodes[0].EnsureVisible();
+            if (//GameFolderTree.Nodes is [TreeNode top, ..]
+                GameFolderTree.Nodes.Count > 0
+                && GameFolderTree.Nodes[0] is TreeNode top)
+            {
+                top.EnsureVisible();
+            }
             GameFolderTree.EndUpdate();
             GameFolderTree.Focus();
         }
@@ -141,20 +146,28 @@ namespace CKAN.GUI
         {
             GameFolderTree.BeginUpdate();
             GameFolderTree.CollapseAll();
-            GameFolderTree.Nodes[0].Expand();
+            if (//GameFolderTree.Nodes is [TreeNode top, ..]
+                GameFolderTree.Nodes.Count > 0
+                && GameFolderTree.Nodes[0] is TreeNode top)
+            {
+                top.Expand();
+            }
             GameFolderTree.EndUpdate();
             GameFolderTree.Focus();
         }
 
         private void ResetCollapseButton_Click(object? sender, EventArgs? e)
         {
-            if (inst != null)
+            if (inst != null
+                //&& GameFolderTree.Nodes is [TreeNode top, ..]
+                && GameFolderTree.Nodes.Count > 0
+                && GameFolderTree.Nodes[0] is TreeNode top)
             {
                 GameFolderTree.BeginUpdate();
                 GameFolderTree.CollapseAll();
-                GameFolderTree.Nodes[0].Expand();
+                top.Expand();
                 ExpandDefaultModDir(inst.game);
-                GameFolderTree.Nodes[0].EnsureVisible();
+                top.EnsureVisible();
                 GameFolderTree.EndUpdate();
                 GameFolderTree.Focus();
             }

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.cs
@@ -89,7 +89,15 @@ namespace CKAN.GUI
         private void AddButton_Click(object? sender, EventArgs? e)
         {
             (CmdLineGrid.DataSource as BindingList<CmdLineRow>)?.AddNew();
-            CmdLineGrid.CurrentCell = CmdLineGrid.Rows[CmdLineGrid.RowCount - 1].Cells[0];
+            if (//CmdLineGrid.Rows is [.., var last]
+                //&& last.Cells is [var first, ..]
+                CmdLineGrid.Rows.Count > 0
+                && CmdLineGrid.Rows[^1] is DataGridViewRow last
+                && last.Cells.Count > 0
+                && last.Cells[0] is var first)
+            {
+                CmdLineGrid.CurrentCell = first;
+            }
             CmdLineGrid.BeginEdit(false);
         }
 

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -202,7 +202,9 @@ namespace CKAN.GUI
 
         private void CloneGameInstanceMenuItem_Click(object? sender, EventArgs? e)
         {
-            if (GameInstancesListView.SelectedItems[0].Tag is string instName)
+            if (//GameInstancesListView.SelectedItems is [{Tag: string instName}, ..]
+                GameInstancesListView.SelectedItems.Count > 0
+                && GameInstancesListView.SelectedItems[0] is {Tag: string instName})
             {
                 var old_instance = manager.CurrentInstance;
 
@@ -229,8 +231,9 @@ namespace CKAN.GUI
                 return;
             }
 
-            var selected = GameInstancesListView.SelectedItems[0];
-            if (selected?.Tag is string instName)
+            if (//GameInstancesListView.SelectedItems is [{Tag: string instName}, ..]
+                GameInstancesListView.SelectedItems.Count > 0
+                && GameInstancesListView.SelectedItems[0] is {Tag: string instName})
             {
                 try
                 {
@@ -254,8 +257,9 @@ namespace CKAN.GUI
                 return;
             }
 
-            var selected = GameInstancesListView.SelectedItems[0];
-            if (selected?.Tag is string instName)
+            if (//GameInstancesListView.SelectedItems is [{Tag: string instName}, ..]
+                GameInstancesListView.SelectedItems.Count > 0
+                && GameInstancesListView.SelectedItems[0] is {Tag: string instName})
             {
                 try
                 {
@@ -271,7 +275,9 @@ namespace CKAN.GUI
 
         private void GameInstancesListView_SelectedIndexChanged(object? sender, EventArgs? e)
         {
-            if (GameInstancesListView.SelectedItems[0].Tag is string instName)
+            if (//GameInstancesListView.SelectedItems is [{Tag: string instName}, ..]
+                GameInstancesListView.SelectedItems.Count > 0
+                && GameInstancesListView.SelectedItems[0] is {Tag: string instName})
             {
                 UpdateButtonState();
 
@@ -313,7 +319,9 @@ namespace CKAN.GUI
 
         private void OpenDirectoryMenuItem_Click(object? sender, EventArgs? e)
         {
-            if (GameInstancesListView.SelectedItems[0].Tag is string instName)
+            if (//GameInstancesListView.SelectedItems is [{Tag: string instName}, ..]
+                GameInstancesListView.SelectedItems.Count > 0
+                && GameInstancesListView.SelectedItems[0] is {Tag: string instName})
             {
                 string path = manager.Instances[instName].GameDir();
 
@@ -329,7 +337,9 @@ namespace CKAN.GUI
 
         private void RenameButton_Click(object? sender, EventArgs? e)
         {
-            if (GameInstancesListView.SelectedItems[0].Tag is string instName)
+            if (//GameInstancesListView.SelectedItems is [{Tag: string instName}, ..]
+                GameInstancesListView.SelectedItems.Count > 0
+                && GameInstancesListView.SelectedItems[0] is {Tag: string instName})
             {
                 // show the dialog, and only continue if the user selected "OK"
                 var renameInstanceDialog = new RenameInstanceDialog();
@@ -363,7 +373,9 @@ namespace CKAN.GUI
                                  = CloneGameInstanceMenuItem.Enabled
                                  = HasSelections;
             ForgetButton.Enabled = HasSelections
-                                   && GameInstancesListView.SelectedItems[0].Tag is string instName
+                                   //&& GameInstancesListView.SelectedItems is [{Tag: string instName}, ..]
+                                   && GameInstancesListView.SelectedItems.Count > 0
+                                   && GameInstancesListView.SelectedItems[0] is {Tag: string instName}
                                    && instName != manager.CurrentInstance?.Name;
             ImportFromSteamMenuItem.Enabled = manager.SteamLibrary.Games.Length > 0;
         }

--- a/GUI/Dialogs/NewRepoDialog.cs
+++ b/GUI/Dialogs/NewRepoDialog.cs
@@ -36,8 +36,9 @@ namespace CKAN.GUI
 
         private void ReposListBox_SelectedIndexChanged(object? sender, EventArgs? e)
         {
-            if (ReposListBox.SelectedItems.Count > 0
-                && ReposListBox.SelectedItems[0].Tag is Repository r)
+            if (//ReposListBox.SelectedItems is [{Tag: Repository r}, ..]
+                ReposListBox.SelectedItems.Count > 0
+                && ReposListBox.SelectedItems[0] is {Tag: Repository r})
             {
                 RepoNameTextBox.Text = r.name;
                 RepoUrlTextBox.Text = r.uri.ToString();

--- a/GUI/Dialogs/SelectionDialog.cs
+++ b/GUI/Dialogs/SelectionDialog.cs
@@ -50,7 +50,9 @@ namespace CKAN.GUI
             Util.Invoke(OptionsList, OptionsList.Items.Clear);
 
             // Check if we have a default option.
-            if (args[0] is int v)
+            if (//args is [int v, ..]
+                args.Length > 0
+                && args[0] is int v)
             {
                 // Check that the default selection makes sense.
                 defaultSelection = v;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -338,19 +338,26 @@ namespace CKAN.GUI
                 // re-added automatically at load, so empty repos isn't a valid state.
                 // To remove the last one, add its replacement first.
                 && ReposListBox.Items.Count > 1;
-            UpRepoButton.Enabled = ReposListBox.SelectedIndices.Count > 0
-                && ReposListBox.SelectedIndices[0] > 0
-                && ReposListBox.SelectedIndices[0] < ReposListBox.Items.Count;
-            DownRepoButton.Enabled = ReposListBox.SelectedIndices.Count > 0
-                && ReposListBox.SelectedIndices[0] < ReposListBox.Items.Count - 1
-                && ReposListBox.SelectedIndices[0] >= 0;
+            UpRepoButton.Enabled =
+                //ReposListBox.SelectedIndices is [int i and > 0, ..]
+                ReposListBox.SelectedIndices.Count > 0
+                && ReposListBox.SelectedIndices[0] is int i
+                && i > 0
+                && i < ReposListBox.Items.Count;
+            DownRepoButton.Enabled =
+                //ReposListBox.SelectedIndices is [int j and >= 0, ..]
+                ReposListBox.SelectedIndices.Count > 0
+                && ReposListBox.SelectedIndices[0] is int j
+                && j > 0
+                && j < ReposListBox.Items.Count - 1;
         }
 
         private void DeleteRepoButton_Click(object? sender, EventArgs? e)
         {
             YesNoDialog deleteConfirmationDialog = new YesNoDialog();
-            if (ReposListBox.SelectedItems.Count > 0
-                && ReposListBox.SelectedItems[0].Tag is Repository repo
+            if (//ReposListBox.SelectedItems is [{Tag: Repository repo}, ..]
+                ReposListBox.SelectedItems.Count > 0
+                && ReposListBox.SelectedItems[0] is {Tag: Repository repo}
                 && deleteConfirmationDialog.ShowYesNoDialog(this,
                     string.Format(Properties.Resources.SettingsDialogRepoDeleteConfirm,
                                   repo.name),
@@ -401,9 +408,12 @@ namespace CKAN.GUI
 
         private void UpRepoButton_Click(object? sender, EventArgs? e)
         {
-            if (ReposListBox.SelectedIndices.Count > 0
-                && ReposListBox.SelectedIndices[0] != 0
-                && ReposListBox.SelectedItems[0].Tag is Repository selected)
+            if (//ReposListBox.SelectedIndices is [> 0, ..]
+                ReposListBox.SelectedIndices.Count > 0
+                && ReposListBox.SelectedIndices[0] > 0
+                //&& ReposListBox.SelectedItems is [{Tag: Repository selected}, ..]
+                && ReposListBox.SelectedItems.Count > 0
+                && ReposListBox.SelectedItems[0] is {Tag: Repository selected})
             {
                 var prev = ReposListBox.Items.OfType<ListViewItem>()
                                              .Select(item => item.Tag as Repository)
@@ -421,14 +431,18 @@ namespace CKAN.GUI
 
         private void DownRepoButton_Click(object? sender, EventArgs? e)
         {
-            if (ReposListBox.SelectedIndices.Count > 0
-                && ReposListBox.SelectedIndices[0] != ReposListBox.Items.Count - 1
-                && ReposListBox.SelectedItems[0].Tag is Repository selected)
+            if (//ReposListBox.SelectedIndices is [int i, ..]
+                ReposListBox.SelectedIndices.Count > 0
+                && ReposListBox.SelectedIndices[0] is int i
+                && i < ReposListBox.Items.Count - 1
+                //&& ReposListBox.SelectedItems is [{Tag: Repository selected}]
+                && ReposListBox.SelectedItems.Count > 0
+                && ReposListBox.SelectedItems[0] is {Tag: Repository selected})
             {
-                var next     = ReposListBox.Items.Cast<ListViewItem>()
-                                                 .Select(item => item.Tag as Repository)
-                                                 .OfType<Repository>()
-                                                 .FirstOrDefault(r => r.priority == selected.priority + 1);
+                var next = ReposListBox.Items.Cast<ListViewItem>()
+                                             .Select(item => item.Tag as Repository)
+                                             .OfType<Repository>()
+                                             .FirstOrDefault(r => r.priority == selected.priority + 1);
                 ++selected.priority;
                 RepositoryMoved = true;
                 if (next != null)
@@ -573,16 +587,18 @@ namespace CKAN.GUI
 
         private void DeleteAuthTokenButton_Click(object? sender, EventArgs? e)
         {
-            if (AuthTokensListBox.SelectedItems.Count > 0)
+            if (//AuthTokensListBox.SelectedItems is [{Tag: string item}, ..]
+                AuthTokensListBox.SelectedItems.Count > 0
+                && AuthTokensListBox.SelectedItems[0] is {Tag: string item}
+                //&& item.Split('|') is [var firstPiece, ..]
+                && item.Split('|') is string[] pieces
+                && pieces.Length > 0
+                && pieces[0] is string firstPiece)
             {
-                var item = AuthTokensListBox.SelectedItems[0].Tag as string;
-                var host = item?.Split('|')[0].Trim();
-                if (host != null)
-                {
-                    coreConfig.SetAuthToken(host, null);
-                    RefreshAuthTokensListBox();
-                    DeleteAuthTokenButton.Enabled = false;
-                }
+                var host = firstPiece.Trim();
+                coreConfig.SetAuthToken(host, null);
+                RefreshAuthTokensListBox();
+                DeleteAuthTokenButton.Enabled = false;
             }
         }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -61,19 +61,22 @@ namespace CKAN.GUI
         public Main(string[] cmdlineArgs, GameInstanceManager? mgr)
         {
             log.Info("Starting the GUI");
-            if (cmdlineArgs.Length >= 2)
+            if (//cmdlineArgs is [_, string focusIdent, ..]
+                cmdlineArgs.Length > 1
+                && cmdlineArgs[1] is string focusIdent)
             {
-                focusIdent = cmdlineArgs[1];
-                if (focusIdent.StartsWith("//"))
+                if (//focusIdent is ['/', '/', .. var rest]
+                    focusIdent.Length > 2)
                 {
                     focusIdent = focusIdent[2..];
                 }
-                else if (focusIdent.StartsWith("ckan://"))
+                else if (//focusIdent is ['c', 'k', 'a', 'n', ':', '/', '/', .. var rest2]
+                    focusIdent.StartsWith("ckan://"))
                 {
                     focusIdent = focusIdent[7..];
                 }
-
-                if (focusIdent.EndsWith("/"))
+                if (//focusIdent is [.. var start, '/']
+                    focusIdent.EndsWith("/"))
                 {
                     focusIdent = focusIdent[..^1];
                 }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -8,8 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 #endif
 
-using Autofac;
-
 using CKAN.Versioning;
 
 namespace CKAN.GUI
@@ -223,7 +221,14 @@ namespace CKAN.GUI
             Name          = mod.name.Trim();
             Abstract      = mod.@abstract.Trim();
             Description   = mod.description?.Trim() ?? string.Empty;
-            Abbrevation   = new string(Name.Split(' ').Where(s => s.Length > 0).Select(s => s[0]).ToArray());
+            Abbrevation   = new string(Name.Split(' ')
+                                           .Select(s => //s is [char first, ..]
+                                                        s.Length > 0
+                                                        && s[0] is char first
+                                                            ? (char?)first
+                                                            : null)
+                                           .OfType<char>()
+                                           .ToArray());
 
             HasReplacement = registry.GetReplacement(mod, current_game_version) != null;
             DownloadSize   = mod.download_size == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.download_size);

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -286,7 +286,8 @@ namespace CKAN.GUI
 
         public static Color BlendColors(Color[] colors)
             => colors.Length <  1 ? Color.Empty
-             : colors.Length == 1 ? colors[0]
+             //: colors is [var c] ? c
+             : colors.Length == 1 && colors[0] is var c ? c
              : colors.Aggregate((back, fore) => fore.AlphaBlendWith(1f / colors.Length, back));
 
         public static Color AlphaBlendWith(this Color c1, float alpha, Color c2)

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -107,7 +107,9 @@ namespace CKAN.NetKAN
             // Check if we have a default selection.
             int defaultSelection = -1;
 
-            if (args[0] is int v)
+            if (//args is [int v, ..]
+                args.Length > 0
+                && args[0] is int v)
             {
                 // Check that the default selection makes sense.
                 defaultSelection = v;

--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -123,10 +123,13 @@ namespace CKAN.NetKAN.Model
         }
 
         public static Metadata Merge(Metadata[] modules)
-            => modules.Length == 1 ? modules[0]
-                                   : PropertySortTransformer.SortProperties(
-                                       new Metadata(MergeJson(modules.Select(m => m._json)
-                                                                     .ToArray())));
+            => //modules is [var m]
+               modules.Length == 1
+               && modules[0] is var m
+                   ? m
+                   : PropertySortTransformer.SortProperties(
+                       new Metadata(MergeJson(modules.Select(m => m._json)
+                                                     .ToArray())));
 
         private static JObject MergeJson(JObject[] jsons)
         {

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -60,7 +60,7 @@ namespace CKAN.NetKAN.Processors
 
                 foreach (Metadata ckan in ckans)
                 {
-                    ckanValidator.ValidateCkan(ckan, netkans[0]);
+                    ckanValidator.ValidateCkan(ckan, netkans.First());
                 }
                 log.Debug("Output successfully passed post-validation");
                 return ckans;

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -162,7 +162,7 @@ namespace CKAN.NetKAN.Processors
                                                          netkans.First().StagingReason);
             try
             {
-                ckans = inflator.Inflate($"{netkans[0].Identifier}.netkan", netkans, opts)
+                ckans = inflator.Inflate($"{netkans.First().Identifier}.netkan", netkans, opts)
                     .ToArray();
             }
             catch (Exception e)

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -62,12 +62,18 @@ namespace CKAN.NetKAN
                     return ExitOk;
                 }
 
-                if (Options.Queues != null && !string.IsNullOrEmpty(Options.Queues))
+                if (Options.Queues != null
+                    && !string.IsNullOrEmpty(Options.Queues)
+                    && Options.Queues.Split(new char[] { ',' }, 2)
+                       //is [var input, var output]
+                       is string[] array
+                    && array.Length == 2
+                    && array[0] is var input
+                    && array[1] is var output)
                 {
-                    var queues = Options.Queues.Split(new char[] { ',' }, 2);
                     var qh = new QueueHandler(
-                        queues[0],
-                        queues[1],
+                        input,
+                        output,
                         Options.CacheDir,
                         Options.OutputDir,
                         Options.OverwriteCache,
@@ -92,8 +98,7 @@ namespace CKAN.NetKAN
                         Options.GitHubToken,
                         Options.GitLabToken,
                         Options.PreRelease,
-                        game
-                    );
+                        game);
                     var ckans = inf.Inflate(
                             Options.File,
                             netkans,
@@ -101,8 +106,8 @@ namespace CKAN.NetKAN
                                 ParseReleases(Options.Releases),
                                 ParseSkipReleases(Options.SkipReleases),
                                 ParseHighestVersion(Options.HighestVersion),
-                                netkans[0].Staged,
-                                netkans[0].StagingReason))
+                                netkans.First().Staged,
+                                netkans.First().StagingReason))
                         .ToArray();
                     foreach (Metadata ckan in ckans)
                     {

--- a/Netkan/Sources/Avc/JsonAvcToGameVersion.cs
+++ b/Netkan/Sources/Avc/JsonAvcToGameVersion.cs
@@ -36,20 +36,23 @@ namespace CKAN.NetKAN.Sources.Avc
             {
                 case JTokenType.String:
                     var tokenArray = token.ToString().Split('.');
-
-                    if (tokenArray.Length > 0)
+                    if (//tokenArray is [var majorToken, ..]
+                        tokenArray.Length > 0
+                        && tokenArray[0] is var majorToken)
                     {
-                        major = tokenArray[0];
-                    }
-
-                    if (tokenArray.Length > 1)
-                    {
-                        minor = tokenArray[1];
-                    }
-
-                    if (tokenArray.Length > 2)
-                    {
-                        patch = tokenArray[2];
+                        major = majorToken;
+                        if (//tokenArray is [_, var minorToken, ..]
+                            tokenArray.Length > 1
+                            && tokenArray[1] is var minorToken)
+                        {
+                            minor = minorToken;
+                            if (//tokenArray is [_, _, var patchToken, ..]
+                                tokenArray.Length > 2
+                                && tokenArray[2] is var patchToken)
+                            {
+                                patch = patchToken;
+                            }
+                        }
                     }
                     break;
                 case JTokenType.Object:
@@ -121,27 +124,30 @@ namespace CKAN.NetKAN.Sources.Avc
             {
                 case JTokenType.String:
                     var tokenArray = token.ToString().Split('.');
-
-                    if (tokenArray.Length > 0)
+                    if (//tokenArray is [var majorToken, ..]
+                        tokenArray.Length > 0
+                        && tokenArray[0] is var majorToken)
                     {
-                        major = tokenArray[0];
+                        major = majorToken;
+                        if (//tokenArray is [_, var minorToken, ..]
+                            tokenArray.Length > 1
+                            && tokenArray[1] is var minorToken)
+                        {
+                            minor = minorToken;
+                            if (//tokenArray is [_, _, var patchToken, ..]
+                                tokenArray.Length > 2
+                                && tokenArray[2] is var patchToken)
+                            {
+                                patch = patchToken;
+                                if (//tokenArray is [_, _, _, var buildToken, ..]
+                                    tokenArray.Length > 3
+                                    && tokenArray[3] is var buildToken)
+                                {
+                                    build = buildToken;
+                                }
+                            }
+                        }
                     }
-
-                    if (tokenArray.Length > 1)
-                    {
-                        minor = tokenArray[1];
-                    }
-
-                    if (tokenArray.Length > 2)
-                    {
-                        patch = tokenArray[2];
-                    }
-
-                    if (tokenArray.Length > 3)
-                    {
-                        build = tokenArray[3];
-                    }
-
                     break;
                 case JTokenType.Object:
                     major = token.Value<string>("MAJOR") ?? major;

--- a/Netkan/Sources/Curse/CurseFile.cs
+++ b/Netkan/Sources/Curse/CurseFile.cs
@@ -66,9 +66,11 @@ namespace CKAN.NetKAN.Sources.Curse
             if (_filename == null)
             {
                 Match match = Regex.Match(GetDownloadUrl(), "[^/]*\\.zip");
-                _filename = match.Groups.Count > 0
-                    ? match.Groups[0].Value
-                    : GetCurseIdVersion();
+                _filename = //match.Groups is [var grp, ..]
+                            match.Groups.Count > 0
+                            && match.Groups[0] is var grp
+                                ? grp.Value
+                                : GetCurseIdVersion();
             }
             return _filename;
         }
@@ -82,9 +84,11 @@ namespace CKAN.NetKAN.Sources.Curse
             if (_fileVersion == null)
             {
                 Match match = Regex.Match(GetDownloadUrl(), "(v?[0-9][0-9a-z.]*[0-9a-z])[^0-9]*\\.zip");
-                if (match.Groups.Count > 1)
+                if (//match.Groups is [_, var grp, ..]
+                    match.Groups.Count > 1
+                    && match.Groups[1] is var grp)
                 {
-                    _fileVersion = match.Groups[1].Value;
+                    _fileVersion = grp.Value;
                 }
                 else
                 {

--- a/Netkan/Sources/Curse/CurseMod.cs
+++ b/Netkan/Sources/Curse/CurseMod.cs
@@ -68,9 +68,11 @@ namespace CKAN.NetKAN.Sources.Curse
                 // Matches the longest sequence of letters and spaces ending in two letters from the beggining of the string
                 // This is to filter out version information
                 Match match = Regex.Match(title ?? "", "^([A-Za-z ]*[A-Za-z][A-Za-z])");
-                if (match.Groups.Count > 1)
+                if (//match.Groups is [_, var grp, ..]
+                    match.Groups.Count > 1
+                    && match.Groups[1] is var grp)
                 {
-                    _name = match.Groups[1].Value;
+                    _name = grp.Value;
                 }
                 else
                 {

--- a/Netkan/Transformers/VersionedOverrideTransformer.cs
+++ b/Netkan/Transformers/VersionedOverrideTransformer.cs
@@ -156,7 +156,7 @@ namespace CKAN.NetKAN.Transformers
                 if (overrideStanza.TryGetValue("override", out JToken? overrideBlock)
                     && overrideBlock is JObject overrides)
                 {
-                    if (gameVersionProperties.Any(p => overrides.ContainsKey(p)))
+                    if (gameVersionProperties.Any(overrides.ContainsKey))
                     {
                         ModuleService.ApplyVersions(
                             metadata,

--- a/Netkan/Validators/PluginsValidator.cs
+++ b/Netkan/Validators/PluginsValidator.cs
@@ -41,7 +41,7 @@ namespace CKAN.NetKAN.Validators
                             .OrderBy(f => f)
                             .ToList();
                         var dllIdentifiers = dllPaths
-                            .Select(p => inst.DllPathToIdentifier(p))
+                            .Select(inst.DllPathToIdentifier)
                             .Where(ident => !string.IsNullOrEmpty(ident)
                                 && !identifiersToIgnore.Contains(ident))
                             .ToHashSet();

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -654,7 +654,7 @@ namespace Tests.Core
                 var game     = new KerbalSpaceProgram();
                 var registry = RegistryManager.Instance(inst.KSP, repoData.Manager).registry;
                 // Make files to be registered to another mod
-                var absFiles = registeredFiles.Select(f => inst.KSP.ToAbsoluteGameDir(f))
+                var absFiles = registeredFiles.Select(inst.KSP.ToAbsoluteGameDir)
                                               .ToList();
                 foreach (var absPath in absFiles)
                 {

--- a/Tests/Core/Net/NetAsyncDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncDownloaderTests.cs
@@ -69,7 +69,7 @@ namespace Tests.Core.Net
         {
             // Arrange
             var downloader = new NetAsyncDownloader(new NullUser());
-            var fromPaths  = pathsWithinTestData.Select(p => TestData.DataDir(p)).ToArray();
+            var fromPaths  = pathsWithinTestData.Select(TestData.DataDir).ToArray();
             var targets    = fromPaths.Select(p => new NetAsyncDownloader.DownloadTargetFile(new Uri(p),
                                                                                              Path.GetTempFileName()))
                                       .ToArray();

--- a/Tests/Core/Registry/RegistryManager.cs
+++ b/Tests/Core/Registry/RegistryManager.cs
@@ -198,9 +198,9 @@ namespace Tests.Core.Registry
                 var gameInst = dispInst.KSP;
                 var regMgr   = RegistryManager.Instance(gameInst, repoData.Manager);
                 var registry = regMgr.registry;
-                var absReg   = registered.Select(p => gameInst.ToAbsoluteGameDir(p))
+                var absReg   = registered.Select(gameInst.ToAbsoluteGameDir)
                                                 .ToList();
-                var absUnreg = unregistered.Select(p => gameInst.ToAbsoluteGameDir(p))
+                var absUnreg = unregistered.Select(gameInst.ToAbsoluteGameDir)
                                                   .ToArray();
 
                 // Create all the files
@@ -225,7 +225,7 @@ namespace Tests.Core.Registry
                 // Assert
                 CollectionAssert.AreEquivalent(
                     unregistered,
-                    registry.InstalledDlls.Select(ident => registry.DllPath(ident))
+                    registry.InstalledDlls.Select(registry.DllPath)
                                           .ToArray());
             }
         }

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -1051,7 +1051,7 @@ namespace Tests.Core.Relationships
                 registry.RegisterModule(eve, new List<string>(), ksp.KSP, false);
                 registry.RegisterModule(eveDefaultConfig, new List<string>(), ksp.KSP, false);
 
-                Assert.DoesNotThrow(() => registry.CheckSanity());
+                Assert.DoesNotThrow(registry.CheckSanity);
 
                 List<CkanModule> modulesToInstall;
                 List<CkanModule> modulesToRemove;

--- a/Tests/Core/Types/CkanModuleTests.cs
+++ b/Tests/Core/Types/CkanModuleTests.cs
@@ -330,7 +330,7 @@ namespace Tests.Core.Types
         public void GroupByDownloads_WithModules_GroupsBySharedURLs(string[] moduleJsons, params string[][] correctGroups)
         {
             // Arrange
-            var modules = moduleJsons.Select(j => CkanModule.FromJson(j))
+            var modules = moduleJsons.Select(CkanModule.FromJson)
                                      .ToArray();
             // Turn [null] into [] as Workaround for params argument not allowing no values
             // (params argument itself is a workaround for TestCase not allowing string[][])
@@ -449,7 +449,7 @@ namespace Tests.Core.Types
             // Arrange
             var module         = CkanModule.FromJson(moduleJson);
             var correctVersion = GameVersion.Parse(correct);
-            var realVersions   = real.Select(v => GameVersion.Parse(v)).ToList();
+            var realVersions   = real.Select(GameVersion.Parse).ToList();
 
             // Act
             var latestCompat = module.LatestCompatibleRealGameVersion(realVersions);

--- a/Tests/GUI/ThreadSafetyTests.cs
+++ b/Tests/GUI/ThreadSafetyTests.cs
@@ -25,7 +25,7 @@ namespace Tests.GUI
             var mainModule = ModuleDefinition.ReadModule(Assembly.GetAssembly(typeof(CKAN.GUI.Main))!
                                                                  .Location);
             var allMethods = mainModule.Types
-                                       .SelectMany(t => GetAllNestedTypes(t))
+                                       .SelectMany(GetAllNestedTypes)
                                        .SelectMany(t => t.Methods)
                                        .ToArray();
             var calls = allMethods.Where(hasForbidGUIAttribute)
@@ -46,7 +46,7 @@ namespace Tests.GUI
 
         private IEnumerable<TypeDefinition> GetAllNestedTypes(TypeDefinition td)
             => Enumerable.Repeat(td, 1)
-                         .Concat(td.NestedTypes.SelectMany(nested => GetAllNestedTypes(nested)));
+                         .Concat(td.NestedTypes.SelectMany(GetAllNestedTypes));
 
         private IEnumerable<MethodCall> FindStartedTasks(MethodDefinition md)
             => StartNewCalls(md).Select(FindStartNewArgument)


### PR DESCRIPTION
## Problem

Right after #4171, we got a report of an index out of bounds exception in the manage game instances dialog, which was fixed in 2ddf740aca139f017c061ee916958f3cbfc39b72. Today another came up in a different method of the same class.

## Cause

Lines like this cause warnings (which we promote to errors) with nullable reference enabled:

https://github.com/KSP-CKAN/CKAN/blob/82e5c3576c3a8abaa42092edeb41399bc03af3b8/GUI/Dialogs/ManageGameInstancesDialog.cs#L352

We need to check whether `GameInstancesListView.SelectedItems[0].Tag` is actually a string rather than null before we cast it, so I did that:

https://github.com/KSP-CKAN/CKAN/blob/c13930f3cb400bfe22ee7a6c5a84a4e807e91a4a/GUI/Dialogs/ManageGameInstancesDialog.cs#L361-L366

But now we're evaluating `GameInstancesListView.SelectedItems[0]` before `HasSelections` runs to confirm that list is non-empty, so when it is empty, it's an array bounds error.

## Ideal solution and why we can't do it

C# 11 provides a great way to simplify checking array bounds _and_ eliminate hard coded indexes:

- <https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/list-patterns>

Initially I did a code search to find every instance of a hard coded array index and worked up a set of changes to replace them with list patterns, but I hit a snag when I tried to build it with Mono:

```
2>CSC : error CS1617: Invalid option '11' for /langversion. Use '/langversion:?' to list supported values.
```
```
$ csc /langversion:?
Supported language versions:
default
1
2
3
4
5
6
7.0
7.1
7.2
7.3
8.0
9.0 (default)
latestmajor
preview
latest
```

So we need a solution that works on C# 9.

## Changes

Now every hard coded array index access is replaced by:

- A comment with a list pattern illustrating the intended behavior
- A set of explicit, non-list-pattern checks that do exactly the same thing
- My brief adventure in C# 11 enabled an "unnecessary lambda" message in vscode, so those have been addressed

If we are ever able to migrate to C# 11, we will have the option of switching to the list patterns that are already there in these comments.
