### PR TITLE
Inflation error for multi-hosted mods with mismatched versions

### DIFF
--- a/Netkan/Model/Metadata.cs
+++ b/Netkan/Model/Metadata.cs
@@ -34,6 +34,18 @@ namespace CKAN.NetKAN.Model
         public bool           Staged          { get; private set; }
         public string?        StagingReason   { get; private set; }
 
+        public string[]       Hosts
+            => (_json.TryGetValue(DownloadPropertyName, out JToken? downloadToken)
+                    ? downloadToken.Type == JTokenType.String
+                      && (string?)downloadToken is string url
+                          ? Enumerable.Repeat(url, 1)
+                          : downloadToken.Children()
+                                         .Select(ch => (string?)ch)
+                                         .OfType<string>()
+                    : Enumerable.Empty<string>())
+                .Select(u => new Uri(u).Host)
+                .ToArray();
+
         public Metadata(JObject? json)
         {
             if (json == null)


### PR DESCRIPTION
## Motivation

Authors of multi-hosted mods don't always upload the same versions to all hosts. Currently this results in an `Out-of-order version found on unreliable server` error (about 8 of these are active currently); this message does not accurately report what the actual problem is, and but it's possible for a partially-inflated mod to be indexed first.

## Changes

Now if we get more modules than requested, an inflation error is thrown that describes which versions were found on which hosts:

```
$ netkan.exe NetKAN/ZTheme.netkan --releases 3
6461 [1] FATAL CKAN.NetKAN.Program (null) - Generated 4 modules but only 3 requested: v1.1.3.1 on github.com; v1.1.3 on github.com, spacedock.info; v1.1.2 on github.com, spacedock.info; v1.1.1 on spacedock.info
```
