### PR TITLE
Include version in Inflator useragent string

### DIFF
--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -23,5 +23,5 @@ USER netkan
 WORKDIR /home/netkan
 ADD --chown=netkan netkan.exe .
 ENTRYPOINT /usr/bin/mono netkan.exe --game ${GAME:-KSP} --queues $QUEUES \
-  --net-useragent 'Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN; +https://github.com/KSP-CKAN/NetKAN-Infra)' \
+  --net-useragent "Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN/$(/usr/bin/mono netkan.exe --version); +https://github.com/KSP-CKAN/NetKAN-Infra)" \
   --github-token $GH_Token --gitlab-token "$GL_Token" --cachedir ckan_cache -v


### PR DESCRIPTION
## Motivation

See #3490 and #4184; we use a custom useragent string for the Inflator, and it would be nice if it included the client version.

## Changes

Now the Inflator's `ENTRYPOINT` passes `$(/usr/bin/mono netkan.exe --version)` as part of its `--net-useragent` argument, so remote hosts will be able to log the version of the bot that made a request.

```
Mozilla/5.0 (compatible; Netkanbot/1.0; CKAN/v1.34.5+24261; +https://github.com/KSP-CKAN/NetKAN-Infra)
```