### PR TITLE
Label search fixes

### DIFF
--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Drawing;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER
@@ -139,10 +138,7 @@ namespace CKAN.GUI
                 if (Main.Instance?.CurrentInstance != null)
                 {
                     // Sync the search boxes immediately
-                    currentSearch = ModSearch.Parse(
-                        FilterCombinedTextBox.Text,
-                        ModuleLabelList.ModuleLabels.LabelsFor(Main.Instance.CurrentInstance.Name)
-                                                    .ToList());
+                    currentSearch = ModSearch.Parse(FilterCombinedTextBox.Text);
                 }
                 SearchToEditor();
             }

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER
@@ -45,11 +44,6 @@ namespace CKAN.GUI
         }
 
         public ModSearch CurrentSearch()
-            => CurrentSearch(
-                ModuleLabelList.ModuleLabels.LabelsFor(Main.Instance?.CurrentInstance?.Name ?? "")
-                                            .ToList());
-
-        private ModSearch CurrentSearch(List<ModuleLabel>? knownLabels)
             => new ModSearch(
                 FilterByNameTextBox.Text,
                 FilterByAuthorTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
@@ -62,10 +56,7 @@ namespace CKAN.GUI
                 FilterByConflictsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterBySupportsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterByTagsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
-                FilterByLabelsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries)
-                                          .Select(ln => knownLabels?.FirstOrDefault(lb => lb.Name == ln))
-                                          .OfType<ModuleLabel>()
-                                          .ToList(),
+                FilterByLabelsTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
                 CompatibleToggle.Value,
                 InstalledToggle.Value,
                 CachedToggle.Value,
@@ -97,8 +88,7 @@ namespace CKAN.GUI
                                               ?? "";
             FilterByTagsTextBox.Text        = search?.TagNames.Aggregate("", CombinePieces)
                                               ?? "";
-            FilterByLabelsTextBox.Text      = search?.Labels.Select(lb => lb.Name)
-                                                            .Aggregate("", CombinePieces)
+            FilterByLabelsTextBox.Text      = search?.LabelNames.Aggregate("", CombinePieces)
                                               ?? "";
 
             CompatibleToggle.Value      = search?.Compatible;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -465,10 +465,8 @@ namespace CKAN.GUI
         {
             if (currentInstance != null)
             {
-                var lbls = ModuleLabelList.ModuleLabels.LabelsFor(currentInstance.Name)
-                                                       .ToList();
                 var searches = search.Values
-                                     .Select(s => ModSearch.Parse(s, lbls))
+                                     .Select(s => ModSearch.Parse(s))
                                      .OfType<ModSearch>()
                                      .ToList();
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -634,8 +634,7 @@ namespace CKAN.GUI
                 }
                 else
                 {
-                    var labels = ModuleLabelList.ModuleLabels.LabelsFor(CurrentInstance.Name).ToList();
-                    var searches = def.Select(s => ModSearch.Parse(s, labels))
+                    var searches = def.Select(s => ModSearch.Parse(s))
                                       .OfType<ModSearch>()
                                       .ToList();
                     ManageMods.SetSearches(searches);

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -255,7 +255,7 @@ namespace CKAN.GUI
             => activeSearches?.Any(s => s?.TagNames.Contains(tag.Name) ?? false) ?? false;
 
         private bool LabelInSearches(ModuleLabel label)
-            => activeSearches?.Any(s => s?.Labels.Contains(label) ?? false) ?? false;
+            => activeSearches?.Any(s => s?.LabelNames.Contains(label.Name) ?? false) ?? false;
 
         private bool HiddenByTagsOrLabels(GUIMod m, string instanceName, IGame game, Registry registry)
             // "Hide" labels apply to all non-custom filters


### PR DESCRIPTION
## Problems

- In the GUI search details editing dropdown, there's a Labels field, but you can't type into it. It is only used to display labels that are already in your search via the Filters menu or clicking a link.
- Label searches can't be negated with a `-` prefix like all other searches

It has worked this way since #3323 (and #3460 even partially explained why), but no one seemed to care.
Recently we finally got a report from Discord user Epsilon:

![image](https://github.com/user-attachments/assets/15c0a139-46ce-405a-b471-4eb7e7d49286)

## Cause

`ModSearch` stores `string`s for tags but `ModuleLabel`s for labels. This was done because it's trivial to check whether a tag name matches a module by looking for it in the `CkanModule.Tags` property, but the _label_ object stores which mods it contains rather than the other way around. To check label membership, you need the `ModuleLabel` object, so `ModSearch` stored them, which meant that when we translate it back into a search string, partially typed label searches could not be represented since there was no such label in the list of labels.

## Changes

- Now `ModSearch.Labels` is replaced with a string list `ModSearch.LabelNames` which can contain partial names while the user is typing
- Now `ModSearch.MatchesLabels` is rewritten to handle looking up the labels from `ModuleLabelList.ModuleLabels` and scan them for matching names
- Now the Labels field in the search dropdown is editable normally.
  `label:Favorites` matches all mods in the Favories label if it exists.
  `-label:Favorites` excludes all mods in the Favories label if it exists.
  `label:` by itself matches all mods with _no_ labels.
  `-label:` by itself excludes all mods with _no_ labels.
  `label:partial` matches nothing if there is no "partial" label.
  `-label:partial` matches all mods if there is no "partial" label.
