### PR TITLE
Sign releases, dev builds, and nuget package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ on:
         type: string
         default: Debug
     outputs:
-      repack-artifact-id:
-        description: "Artifact ID of the repack"
-        value: ${{ jobs.build.outputs.repack-artifact-id }}
+      unsigned-artifact-id:
+        description: Artifact ID of the assets to be signed
+        value: ${{ jobs.build.outputs.unsigned-artifact-id }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      repack-artifact-id: ${{ steps.upload-repack-artifact.outputs.artifact-id }}
+      unsigned-artifact-id: ${{ steps.upload-unsigned-artifact.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v4
       - name: Restore cache for _build/tools
@@ -50,10 +50,21 @@ jobs:
           name: ${{ inputs.configuration }}-out-unsigned
           path: _build/out/
           retention-days: 1
+      - name: Bundle assets for signing
+        if: inputs.configuration == 'Release'
+        run: ./build Prepare-SignPath --configuration=${{ inputs.configuration }} --exclusive
+      - name: Upload unsigned artifact
+        id: upload-unsigned-artifact
+        if: inputs.configuration == 'Release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned
+          path: _build/signpath
+          retention-days: 7
       - name: Upload ckan.exe artifact
+        if: inputs.configuration == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: ckan.exe
           path: _build/repack/Release/ckan.exe
           retention-days: 7
-        if: inputs.configuration == 'Release'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: unsigned
-          path: _build/signpath
+          path: _build/signpath/Release
           retention-days: 7
       - name: Upload ckan.exe artifact
         if: inputs.configuration == 'Release'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,8 @@ env:
   AWS_S3_BUCKET: ksp-ckan
 
 jobs:
-  test-release:
-    uses: ./.github/workflows/test.yml
-
-  smoke-inflator:
-    uses: ./.github/workflows/smoke.yml
+  sign-assets:
+    uses: ./.github/workflows/sign.yml
 
   check-dev-build:
     runs-on: ubuntu-latest
@@ -40,13 +37,12 @@ jobs:
 
   upload-release-s3:
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
+    if: github.event_name != 'repository_dispatch'
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    if: github.event_name != 'repository_dispatch'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -55,11 +51,15 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - uses: actions/checkout@v4
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
+      - name: Put signed exes into repack path
+        run: |
+          mkdir -p _build/repack/Release
+          cp _build/signed/*.exe _build/repack/Release
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
@@ -70,14 +70,13 @@ jobs:
           pip install gitpython
           git config --global --add safe.directory '*'
           python bin/version_info.py > _build/repack/Release/version.json
-      - name: Push ckan.exe, netkan.exe, and version.json to S3
+      - name: Push ckan.exe, AutoUpdater.exe, netkan.exe, and version.json to S3
         run: aws s3 sync _build/repack/Release s3://${AWS_S3_BUCKET} --follow-symlinks
 
   upload-dmg:
     needs:
       - check-dev-build
-      - test-release
-      - smoke-inflator
+      - sign-assets
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -93,11 +92,15 @@ jobs:
       - name: Install OSX build dependencies
         run: sudo apt-get install -y libplist-utils xorriso
       - uses: actions/checkout@v4
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
+      - name: Put signed exe into repack path
+        run: |
+          mkdir -p _build/repack/Release
+          cp _build/signed/ckan.exe _build/repack/Release
       - name: Build dmg
         run: ./build osx --configuration=Release --exclusive
       - name: Push dmg to S3
@@ -106,8 +109,7 @@ jobs:
   upload-deb:
     needs:
       - check-dev-build
-      - test-release
-      - smoke-inflator
+      - sign-assets
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -121,11 +123,15 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - uses: actions/checkout@v4
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
+      - name: Put signed exe into repack path
+        run: |
+          mkdir -p _build/repack/Release
+          cp _build/signed/ckan.exe _build/repack/Release
       - name: Build deb
         env:
           CODENAME: nightly
@@ -160,8 +166,7 @@ jobs:
   upload-rpm:
     needs:
       - check-dev-build
-      - test-release
-      - smoke-inflator
+      - sign-assets
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -177,11 +182,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rpm build dependencies
         run: sudo apt-get install -y createrepo-c
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
+      - name: Put signed exe into repack path
+        run: |
+          mkdir -p _build/repack/Release
+          cp _build/signed/ckan.exe _build/repack/Release
       - name: Build rpm
         run: ./build rpm --configuration=Release --exclusive
       - name: Import GPG key
@@ -202,10 +211,9 @@ jobs:
 
   upload-inflator:
     needs:
-      - test-release
-      - smoke-inflator
-    runs-on: ubuntu-latest
+      - sign-assets
     if: github.event_name != 'repository_dispatch'
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -239,8 +247,7 @@ jobs:
 
   upload-metadata-tester:
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -266,8 +273,7 @@ jobs:
 
   notify-discord:
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
       - upload-release-s3
       - upload-dmg
       - upload-deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,64 +9,44 @@ env:
   AWS_S3_BUCKET: ksp-ckan
 
 jobs:
-  test-release:
-    uses: ./.github/workflows/test.yml
-
-  smoke-inflator:
-    uses: ./.github/workflows/smoke.yml
-
-  sign-release:
-    runs-on: ubuntu-latest
-    needs:
-      - test-release
-      - smoke-inflator
-    outputs:
-      artifact-url: ${{steps.sign.outputs.signing-request-id }}
-    steps:
-      - uses: signpath/github-action-submit-signing-request@v1
-        id: sign
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: 0cd9fc3f-b78d-4214-b152-b2e93c952e14
-          project-slug: CKAN
-          signing-policy-slug: test-signing
-          github-artifact-id: ${{ needs.smoke-inflator.outputs.repack-artifact-id }}
-          artifact-configuration-slug: release
-          wait-for-completion: true
+  sign-assets:
+    uses: ./.github/workflows/sign.yml
 
   upload-nuget:
     runs-on: ubuntu-latest
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
     steps:
-      - name: Download out artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-out-unsigned
-          path: _build/out/
+          name: signed
+          path: _build/signed
       - name: Publish ckan.dll to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         if: env.NUGET_API_KEY
         run: |
           curl -o nuget.exe -L 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
-          mono nuget.exe push _build/out/CKAN/Release/bin/*.nupkg ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate
+          mono nuget.exe push _build/signed/*.nupkg ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate
 
   build-dmg:
     runs-on: ubuntu-latest
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
     steps:
       - uses: actions/checkout@v4
       - name: Install OSX build dependencies
         run: sudo apt-get install -y libplist-utils xorriso
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
+      - name: Put signed ckan.exe into repack path
+        run: |
+          mkdir -p _build/repack/Release
+          cp _build/signed/ckan.exe _build/repack/Release
       - name: Build dmg
         run: ./build osx --configuration=Release --exclusive
       - name: Upload OSX release asset
@@ -77,8 +57,7 @@ jobs:
   build-deb:
     runs-on: ubuntu-latest
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -87,11 +66,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - uses: actions/checkout@v4
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
+      - name: Put signed ckan.exe into repack path
+        run: |
+          mkdir -p _build/repack/Release
+          cp _build/signed/ckan.exe _build/repack/Release
       - name: Set deb version
         run: |
           VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d "v")
@@ -125,8 +108,7 @@ jobs:
   build-rpm:
     runs-on: ubuntu-latest
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -137,11 +119,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rpm build dependencies
         run: sudo apt-get install -y createrepo-c
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
+      - name: Put signed ckan.exe into repack path
+        run: |
+          mkdir -p _build/repack/Release
+          cp _build/signed/ckan.exe _build/repack/Release
       - name: Set rpm version
         run: |
           VERSION=$(echo "${{ github.event.release.tag_name }}" | tr -d v)
@@ -170,23 +156,21 @@ jobs:
   upload-binaries:
     runs-on: ubuntu-latest
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Download repack artifact
+      - name: Download signed artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
+          name: signed
+          path: _build/signed
       - name: Upload ckan.exe and AutoUpdater.exe release assets
-        run: gh release upload ${{ github.event.release.tag_name }} _build/repack/Release/ckan.exe _build/repack/Release/AutoUpdater.exe
+        run: gh release upload ${{ github.event.release.tag_name }} _build/signed/ckan.exe _build/signed/AutoUpdater.exe
 
   notify-discord:
     needs:
-      - test-release
-      - smoke-inflator
+      - sign-assets
       - build-dmg
       - build-deb
       - build-rpm

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,0 +1,40 @@
+name: Sign assets
+
+on:
+  workflow_call:
+
+jobs:
+  build-release:
+    uses: ./.github/workflows/build.yml
+    with:
+      configuration: Release
+  test-release:
+    uses: ./.github/workflows/test.yml
+  smoke-inflator:
+    uses: ./.github/workflows/smoke.yml
+
+  sign:
+    runs-on: ubuntu-latest
+    needs:
+      - build-release
+      - test-release
+      - smoke-inflator
+    steps:
+      - uses: signpath/github-action-submit-signing-request@v1
+        id: sign
+        with:
+          project-slug: CKAN
+          organization-id: 0cd9fc3f-b78d-4214-b152-b2e93c952e14
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: release
+          github-artifact-id: ${{ needs.build-release.outputs.unsigned-artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: _build/signed
+      - name: Upload signed artifact
+        id: upload-signed-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed
+          path: _build/signed/
+          retention-days: 7

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -4,10 +4,6 @@ on:
   workflow_call:
 
 jobs:
-  build-release:
-    uses: ./.github/workflows/build.yml
-    with:
-      configuration: Release
   test-release:
     uses: ./.github/workflows/test.yml
   smoke-inflator:
@@ -16,7 +12,6 @@ jobs:
   sign:
     runs-on: ubuntu-latest
     needs:
-      - build-release
       - test-release
       - smoke-inflator
     steps:
@@ -28,7 +23,7 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           signing-policy-slug: release-signing
           artifact-configuration-slug: release
-          github-artifact-id: ${{ needs.build-release.outputs.unsigned-artifact-id }}
+          github-artifact-id: ${{ needs.smoke-inflator.outputs.unsigned-artifact-id }}
           wait-for-completion: true
           output-artifact-directory: _build/signed
       - name: Upload signed artifact

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,16 +7,13 @@ on:
       - synchronize
       - reopened
   workflow_call:
-    outputs:
-      repack-artifact-id:
-        description: "Artifact ID of the repack"
-        value: ${{ jobs.build-release.outputs.repack-artifact-id }}
 
 jobs:
   build-release:
     uses: ./.github/workflows/build.yml
     with:
       configuration: Release
+
   smoke-test-inflator:
     needs: build-release
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - reopened
   workflow_call:
+    outputs:
+      unsigned-artifact-id:
+        description: Artifact ID of the assets to be signed
+        value: ${{ jobs.build-release.outputs.unsigned-artifact-id }}
 
 jobs:
   build-release:

--- a/README.md
+++ b/README.md
@@ -49,16 +49,22 @@ If the metadata we have is incorrect please [open an issue][7] and let us know.
 
 If you want to contribute, please read our [CONTRIBUTING][4] file.
 
+## Thanks
+
+Our sincere thanks to [SignPath.io][10] for allowing us to use their free code signing service, and to [the SignPath Foundation][11] for giving us a free code signing certificate!
+
 ---
+
 Note: Are you looking for the Open Data portal software called CKAN? If so, their GitHub repository is found [here][9].
 
-
- [1]:https://github.com/KSP-CKAN/CKAN/commits/master
- [2]:https://github.com/KSP-CKAN/CKAN/wiki/User-guide
- [3]:https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-mod-to-the-CKAN#verifying-metadata-files
- [4]:https://github.com/KSP-CKAN/.github/blob/master/CONTRIBUTING.md
- [5]:https://github.com/KSP-CKAN/CKAN/wiki
- [6]:https://github.com/KSP-CKAN/CKAN/issues/new
- [7]:https://github.com/KSP-CKAN/NetKAN/issues/new
- [8]:http://schemastore.org/json/
- [9]:https://github.com/ckan/ckan
+ [1]: https://github.com/KSP-CKAN/CKAN/commits/master
+ [2]: https://github.com/KSP-CKAN/CKAN/wiki/User-guide
+ [3]: https://github.com/KSP-CKAN/CKAN/wiki/Adding-a-mod-to-the-CKAN#verifying-metadata-files
+ [4]: https://github.com/KSP-CKAN/.github/blob/master/CONTRIBUTING.md
+ [5]: https://github.com/KSP-CKAN/CKAN/wiki
+ [6]: https://github.com/KSP-CKAN/CKAN/issues/new
+ [7]: https://github.com/KSP-CKAN/NetKAN/issues/new
+ [8]: http://schemastore.org/json/
+ [9]: https://github.com/ckan/ckan
+ [10]: https://signpath.io/
+ [11]: https://signpath.org/


### PR DESCRIPTION
## Motivation

SignPath's action is ready, we have a certificate, and #4188 created a helper build target to collect assets for signing. The next step toward signing releases is updating our workflows.

## Changes

- Now `build.yml` uses the build target from #4188 to upload an artifact containing the assets we need to sign for the Release configuration
- Now `sign.yml` is created to retrieve that artifact, get it signed, and upload a new `signed` artifact with the results
- Now `release.yml` calls `sign.yml` to generate signed assets for releases
- Now `deploy.yml` calls `sign.yml` to generate signed assets for uploading dev builds
