### PR TITLE
Set compat of new instances based on Unity updates and alert user

### DIFF
--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -179,12 +179,12 @@ namespace CKAN.Configuration
         /// <summary>
         /// Not implemented because the Windows registry is deprecated
         /// </summary>
-        public string[] GlobalInstallFilters { get; set; } = new string[] { };
+        public string[] GlobalInstallFilters { get; set; } = Array.Empty<string>();
 
         /// <summary>
         /// Not implemented because the Windows registry is deprecated
         /// </summary>
-        public string?[] PreferredHosts { get; set; } = new string?[] { };
+        public string?[] PreferredHosts { get; set; } = Array.Empty<string?>();
 
         /// <summary>
         /// Not implemented because the Windows registry is deprecated

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -164,6 +164,11 @@ namespace CKAN
                 GameVersion.TryParse(compatibleGameVersions.GameVersionWhenWritten, out GameVersion? mainVer);
                 GameVersionWhenCompatibleVersionsWereStored = mainVer;
             }
+            else if (Version() is GameVersion gv)
+            {
+                _compatibleVersions = game.DefaultCompatibleVersions(gv)
+                                          .ToList();
+            }
         }
 
         private string CompatibleGameVersionsFile()

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -43,6 +43,7 @@ namespace CKAN.Games
         GameVersion[]     EmbeddedGameVersions { get; }
         GameVersion[]     ParseBuildsJson(JToken json);
         GameVersion?      DetectVersion(DirectoryInfo where);
+        GameVersion[]     DefaultCompatibleVersions(GameVersion installedVersion);
         string            CompatibleVersionsFile { get; }
         string[]          InstanceAnchorFiles { get; }
 

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -213,14 +213,14 @@ namespace CKAN.Games.KerbalSpaceProgram
                 ?.Builds
                 ?.Select(b => GameVersion.Parse(b.Value))
                  .ToArray()
-                ?? new GameVersion[] { };
+                ?? Array.Empty<GameVersion>();
 
         public GameVersion[] ParseBuildsJson(JToken json)
             => json.ToObject<JBuilds>()
                    ?.Builds
                    ?.Select(b => GameVersion.Parse(b.Value))
                     .ToArray()
-                   ?? new GameVersion[] { };
+                   ?? Array.Empty<GameVersion>();
 
         public GameVersion? DetectVersion(DirectoryInfo where)
             => ServiceLocator.Container

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -233,6 +233,28 @@ namespace CKAN.Games.KerbalSpaceProgram
                             ? verFromReadme
                             : null;
 
+        public GameVersion[] DefaultCompatibleVersions(GameVersion installedVersion)
+            // 1.2.9 was a prerelease that broke compatibility with previous 1.2 releases
+            => installedVersion.Major == 1 && installedVersion.Minor == 2 && installedVersion.Patch == 9
+                   ? Array.Empty<GameVersion>()
+                   : UnityBreakVersions.FirstOrDefault(brk => brk <= installedVersion)
+                     is GameVersion latestUnityBreak
+                       ? MinorVersionsInRange(latestUnityBreak, installedVersion)
+                       : new GameVersion[]
+                         {
+                             new GameVersion(installedVersion.Major,
+                                             installedVersion.Minor)
+                         };
+
+        private static readonly GameVersion[] UnityBreakVersions =
+            new int[] {8, 4, 2, 1}.Select(minor => new GameVersion(1, minor))
+                                  .ToArray();
+
+        private static GameVersion[] MinorVersionsInRange(GameVersion min, GameVersion max)
+            => Enumerable.Range(min.Minor, max.Minor - min.Minor + 1)
+                         .Select(minor => new GameVersion(min.Major, minor))
+                         .ToArray();
+
         public string CompatibleVersionsFile => "compatible_ksp_versions.json";
 
         public string[] InstanceAnchorFiles =>

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -161,11 +161,11 @@ namespace CKAN.Games.KerbalSpaceProgram2
                 is Stream s
                     ? JsonConvert.DeserializeObject<GameVersion[]>(new StreamReader(s).ReadToEnd())
                     : null)
-                ?? new GameVersion[] { };
+                ?? Array.Empty<GameVersion>();
 
         public GameVersion[] ParseBuildsJson(JToken json)
             => json.ToObject<GameVersion[]>()
-                ?? new GameVersion[] { };
+                ?? Array.Empty<GameVersion>();
 
         public GameVersion DetectVersion(DirectoryInfo where)
             => VersionFromAssembly(Path.Combine(where.FullName,

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -202,6 +202,12 @@ namespace CKAN.Games.KerbalSpaceProgram2
                     ? v
                     : null;
 
+        public GameVersion[] DefaultCompatibleVersions(GameVersion installedVersion)
+            // KSP2 didn't last long enough to break compatibility :~(
+            => Enumerable.Range(1, 2)
+                         .Select(minor => new GameVersion(0, minor))
+                         .ToArray();
+
         public string CompatibleVersionsFile => "compatible_game_versions.json";
 
         public string[] InstanceAnchorFiles =>

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.ComponentModel;
 using System.Collections.Generic;
@@ -226,7 +227,7 @@ namespace CKAN.GUI
 
                 return items;
             }
-            return new ListViewItem[] { };
+            return Array.Empty<ListViewItem>();
         }
 
         [ForbidGUICalls]

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
@@ -30,6 +30,8 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(CompatibleGameVersionsDialog));
+            this.MessageLabel = new System.Windows.Forms.Label();
+            this.MainContentsPanel = new System.Windows.Forms.Panel();
             this.InstancePathLabel = new System.Windows.Forms.Label();
             this.ActualInstancePathLabel = new System.Windows.Forms.Label();
             this.GameVersionLabel = new System.Windows.Forms.Label();
@@ -45,7 +47,44 @@ namespace CKAN.GUI
             this.WarningLabel = new System.Windows.Forms.Label();
             this.CancelChooseCompatibleVersionsButton = new System.Windows.Forms.Button();
             this.SaveButton = new System.Windows.Forms.Button();
+            this.MainContentsPanel.SuspendLayout();
             this.SuspendLayout();
+            //
+            // MessageLabel
+            //
+            this.MessageLabel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.MessageLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 12, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Pixel);
+            this.MessageLabel.BackColor = System.Drawing.SystemColors.Window;
+            this.MessageLabel.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.MessageLabel.Location = new System.Drawing.Point(0, 0);
+            this.MessageLabel.Margin = new System.Windows.Forms.Padding(8, 6, 8, 6);
+            this.MessageLabel.Padding = new System.Windows.Forms.Padding(8, 6, 8, 6);
+            this.MessageLabel.Name = "MessageLabel";
+            this.MessageLabel.Size = new System.Drawing.Size(60, 13);
+            this.MessageLabel.TabIndex = 0;
+            this.MessageLabel.Visible = false;
+            resources.ApplyResources(this.MessageLabel, "MessageLabel");
+            //
+            // MainContentsPanel
+            //
+            this.MainContentsPanel.Controls.Add(this.InstancePathLabel);
+            this.MainContentsPanel.Controls.Add(this.ActualInstancePathLabel);
+            this.MainContentsPanel.Controls.Add(this.GameVersionLabel);
+            this.MainContentsPanel.Controls.Add(this.ActualGameVersionLabel);
+            this.MainContentsPanel.Controls.Add(this.ListHeaderLabel);
+            this.MainContentsPanel.Controls.Add(this.SelectedVersionsCheckedListBox);
+            this.MainContentsPanel.Controls.Add(this.ClearSelectionButton);
+            this.MainContentsPanel.Controls.Add(this.AddVersionLabel);
+            this.MainContentsPanel.Controls.Add(this.AddVersionToListTextBox);
+            this.MainContentsPanel.Controls.Add(this.AddVersionToListButton);
+            this.MainContentsPanel.Controls.Add(this.WildcardExplanationLabel);
+            this.MainContentsPanel.Controls.Add(this.FutureUpdatesLabel);
+            this.MainContentsPanel.Controls.Add(this.WarningLabel);
+            this.MainContentsPanel.Controls.Add(this.CancelChooseCompatibleVersionsButton);
+            this.MainContentsPanel.Controls.Add(this.SaveButton);
+            this.MainContentsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MainContentsPanel.Name = "MainContentsPanel";
+            this.MainContentsPanel.Size = new System.Drawing.Size(443, 383);
             //
             // InstancePathLabel
             //
@@ -216,21 +255,8 @@ namespace CKAN.GUI
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.CancelChooseCompatibleVersionsButton;
             this.ClientSize = new System.Drawing.Size(443, 383);
-            this.Controls.Add(this.InstancePathLabel);
-            this.Controls.Add(this.ActualInstancePathLabel);
-            this.Controls.Add(this.GameVersionLabel);
-            this.Controls.Add(this.ActualGameVersionLabel);
-            this.Controls.Add(this.ListHeaderLabel);
-            this.Controls.Add(this.SelectedVersionsCheckedListBox);
-            this.Controls.Add(this.ClearSelectionButton);
-            this.Controls.Add(this.AddVersionLabel);
-            this.Controls.Add(this.AddVersionToListTextBox);
-            this.Controls.Add(this.AddVersionToListButton);
-            this.Controls.Add(this.WildcardExplanationLabel);
-            this.Controls.Add(this.FutureUpdatesLabel);
-            this.Controls.Add(this.WarningLabel);
-            this.Controls.Add(this.CancelChooseCompatibleVersionsButton);
-            this.Controls.Add(this.SaveButton);
+            this.Controls.Add(this.MainContentsPanel);
+            this.Controls.Add(this.MessageLabel);
             this.Icon = EmbeddedImages.AppIcon;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -240,12 +266,16 @@ namespace CKAN.GUI
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Shown += new System.EventHandler(this.CompatibleGameVersionsDialog_Shown);
             resources.ApplyResources(this, "$this");
+            this.MainContentsPanel.ResumeLayout(false);
+            this.MainContentsPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
 
         #endregion
 
+        private System.Windows.Forms.Label MessageLabel;
+        private System.Windows.Forms.Panel MainContentsPanel;
         private System.Windows.Forms.Label InstancePathLabel;
         private System.Windows.Forms.Label ActualInstancePathLabel;
         private System.Windows.Forms.Label GameVersionLabel;

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.cs
@@ -67,21 +67,51 @@ namespace CKAN.GUI
             evt.Cancel = Util.TryOpenWebPage(HelpURLs.CompatibleGameVersions);
         }
 
+        private void ShowMessage(string msg)
+        {
+            if (string.IsNullOrEmpty(msg))
+            {
+                MessageLabel.Text = "";
+                MessageLabel.Visible = false;
+            }
+            else
+            {
+                MessageLabel.Text = msg;
+                MessageLabel.Visible = true;
+                MessageLabel.Height = Util.LabelStringHeight(CreateGraphics(),
+                                                             MessageLabel);
+                Height += MessageLabel.Height;
+            }
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            if (MessageLabel.Visible)
+            {
+                MessageLabel.Height = Util.LabelStringHeight(CreateGraphics(),
+                                                             MessageLabel);
+            }
+        }
+
         private void CompatibleGameVersionsDialog_Shown(object? sender, EventArgs? e)
         {
             if (_inst.CompatibleVersionsAreFromDifferentGameVersion)
             {
                 CancelChooseCompatibleVersionsButton.Visible = false;
-                ActualGameVersionLabel.Text = string.Format(
-                    Properties.Resources.CompatibleGameVersionsDialogVersionDetails,
-                    _inst.Version(),
-                    _inst.GameVersionWhenCompatibleVersionsWereStored);
-                ActualGameVersionLabel.ForeColor = Color.Red;
-                MessageBox.Show(this,
-                                Properties.Resources.CompatibleGameVersionsDialogGameUpdatedDetails,
-                                Properties.Resources.CompatibleGameVersionsDialogGameUpdatedTitle,
-                                MessageBoxButtons.OK,
-                                MessageBoxIcon.Information);
+                if (_inst.GameVersionWhenCompatibleVersionsWereStored == null)
+                {
+                    ShowMessage(Properties.Resources.CompatibleGameVersionsDialogDefaultedDetails);
+                }
+                else
+                {
+                    ActualGameVersionLabel.Text = string.Format(
+                        Properties.Resources.CompatibleGameVersionsDialogVersionDetails,
+                        _inst.Version(),
+                        _inst.GameVersionWhenCompatibleVersionsWereStored);
+                    ActualGameVersionLabel.ForeColor = Color.Red;
+                    ShowMessage(Properties.Resources.CompatibleGameVersionsDialogGameUpdatedDetails);
+                }
             }
         }
 

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -136,7 +136,9 @@
   <data name="CloneGameInstanceToolTipShareStock" xml:space="preserve"><value>Create junction points (Windows) or symbolic links (Unix) to stock directories instead of copying them.
 If you choose this option, DO NOT move or delete the old instance!!</value></data>
   <data name="CompatibleGameVersionsDialogNone" xml:space="preserve"><value>&lt;NONE&gt;</value></data>
-  <data name="CompatibleGameVersionsDialogGameUpdatedTitle" xml:space="preserve"><value>Game Version Updated</value></data>
+  <data name="CompatibleGameVersionsDialogDefaultedDetails" xml:space="preserve"><value>Default compatibility has been set based on your installed game version. These settings should bring the greatest number of working mods to the most users, but it's still possible that some older mods might misbehave.
+
+If you want to be cautious, click "Clear selection" to uncheck all the boxes.</value></data>
   <data name="CompatibleGameVersionsDialogGameUpdatedDetails" xml:space="preserve"><value>The game has been updated since you last reviewed your compatible game versions. Please make sure that settings are correct.</value></data>
   <data name="CompatibleGameVersionsDialogVersionDetails" xml:space="preserve"><value>{0} (previous game version: {1})</value></data>
   <data name="CompatibleGameVersionsDialogInvalidFormat" xml:space="preserve"><value>Version has invalid format</value></data>

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -306,26 +306,26 @@ namespace CKAN.GUI
                               a.G + b.G,
                               a.B + b.B);
 
-        public static Bitmap LerpBitmaps(Bitmap a, Bitmap b, float amount)
+        public static Bitmap LerpBitmaps(Bitmap a, Bitmap b,
+                                         float amount)
+            => amount <= 0 ? a
+             : amount >= 1 ? b
+             : MergeBitmaps(a, b,
+                            // Note pixA and pixB are swapped because our blend function
+                            // pretends 'amount' is the first argument's alpha channel,
+                            // so 0 -> third param by itself
+                            (pixA, pixB) => AlphaBlendWith(pixB, amount, pixA));
+
+        private static Bitmap MergeBitmaps(Bitmap a, Bitmap b,
+                                           Func<Color, Color, Color> how)
         {
-            if (amount <= 0)
-            {
-                return a;
-            }
-            if (amount >= 1)
-            {
-                return b;
-            }
             var c = new Bitmap(a);
-            for (int y = 0; y < c.Height; ++y)
+            foreach (var y in Enumerable.Range(0, c.Height))
             {
-                for (int x = 0; x < c.Width; ++x)
+                foreach (var x in Enumerable.Range(0, c.Width))
                 {
-                    // Note a and b are swapped because our blend function pretends 'amount'
-                    // is the first argument's alpha channel, so 0 -> third param by itself
-                    c.SetPixel(x, y, AlphaBlendWith(b.GetPixel(x, y),
-                                                    amount,
-                                                    a.GetPixel(x, y)));
+                    c.SetPixel(x, y, how(a.GetPixel(x, y),
+                                         b.GetPixel(x, y)));
                 }
             }
             return c;

--- a/Tests/Core/Games/KerbalSpaceProgram2Tests.cs
+++ b/Tests/Core/Games/KerbalSpaceProgram2Tests.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+
+using CKAN.Versioning;
+using CKAN.Games.KerbalSpaceProgram2;
+using System.Linq;
+
+namespace Tests.Core.Games
+{
+    [TestFixture]
+    public class KerbalSpaceProgram2Tests
+    {
+        [Test, TestCase("0.1.0.0",
+                        new string[] { "0.1", "0.2" }),
+               TestCase("0.1.1.0",
+                        new string[] { "0.1", "0.2" }),
+               TestCase("0.2.0.0",
+                        new string[] { "0.1", "0.2" }),
+               TestCase("0.2.2.0",
+                        new string[] { "0.1", "0.2" }),
+        ]
+        public void DefaultCompatibleVersions_RealVersion_CorrectRange(string   installedVersion,
+                                                                       string[] correctCompatVersions)
+        {
+            // Arrange
+            var game = new KerbalSpaceProgram2();
+
+            // Act
+            var compat = game.DefaultCompatibleVersions(GameVersion.Parse(installedVersion));
+
+            // Assert
+            CollectionAssert.AreEqual(correctCompatVersions.Select(GameVersion.Parse),
+                                      compat);
+        }
+    }
+}

--- a/Tests/Core/Games/KerbalSpaceProgramTests.cs
+++ b/Tests/Core/Games/KerbalSpaceProgramTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+
+using CKAN.Versioning;
+using CKAN.Games.KerbalSpaceProgram;
+using System.Linq;
+
+namespace Tests.Core.Games
+{
+    [TestFixture]
+    public class KerbalSpaceProgramTests
+    {
+        [Test, TestCase("1.12.5",
+                        new string[] { "1.8", "1.9", "1.10", "1.11", "1.12" }),
+               TestCase("1.12.0",
+                        new string[] { "1.8", "1.9", "1.10", "1.11", "1.12" }),
+               TestCase("1.10.1",
+                        new string[] { "1.8", "1.9", "1.10" }),
+               TestCase("1.8.0",
+                        new string[] { "1.8" }),
+               TestCase("1.7.3",
+                        new string[] { "1.4", "1.5", "1.6", "1.7" }),
+               TestCase("1.5.1",
+                        new string[] { "1.4", "1.5" }),
+               TestCase("1.3.1",
+                        new string[] { "1.2", "1.3" }),
+               TestCase("1.2.9",
+                        new string[] { }),
+               TestCase("1.0.5",
+                        new string[] { "1.0" })]
+        public void DefaultCompatibleVersions_RealVersion_CorrectRange(string   installedVersion,
+                                                                       string[] correctCompatVersions)
+        {
+            // Arrange
+            var game = new KerbalSpaceProgram();
+
+            // Act
+            var compat = game.DefaultCompatibleVersions(GameVersion.Parse(installedVersion));
+
+            // Assert
+            CollectionAssert.AreEqual(correctCompatVersions.Select(GameVersion.Parse),
+                                      compat);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

One of the top user support requests at the moment is still how to make more mods show up as installable, with the answer still being to [set compatible versions in the settings](https://github.com/KSP-CKAN/CKAN/wiki/User-guide#choosing-compatible-game-versions) to work around still-missing compatibility metadata updates from mod authors:

![image](https://github.com/user-attachments/assets/20b5f76a-8884-4cfa-a61e-e19cb9210a48)

## Cause

New users have no concept of the history of game updates and mod updates and how they interacted; they see a more or less static landscape, and it doesn't make sense to them that they would have to change settings to install anything.

Meanwhile, a great number of mods that still work in the latest version were abandoned long before it was released, and so their compatibility still only goes up to whatever was the latest game version at that time.

## Changes

- Now `IGame.DefaultCompatibleVersions(GameVersion)` defines which additional versions should be considered compatible for a given installed game version
  - For KSP1, this is implemented as returning the major+minor versions between the most recent significantly compatibility-breaking Unity upgrade and the installed verson, inclusive. For KSP 1.12.5, the default is 1.8–1.12.
  - For KSP2, this is implemented as covering all released game versions (`0.1` and `0.2`), because version compatibility never really became a thing for that game
  - A few new tests exercise the above behaviors
  - When a game instance is loaded, if it has no compatible versions set:
    - The above default range is copied into the settings
    - The compatible game versions popup appears with a message about the defaulting that just happened, so users can know about it and take action if they don't like it
      ![image](https://github.com/user-attachments/assets/b4b180ab-36c7-48d3-b618-7f68f5b86475)
- The extra OK-only popup that announced an updated game version is now replaced by a top-message as for the above feature (even if no one ever sees it again)

This should help new users to find the mods they're looking for with a lower support burden, and expert users who prefer other settings can select them in the pop-up.
