### PR TITLE
Fix installation of metapackages from repositories

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -421,11 +421,6 @@ namespace CKAN
         /// </summary>
         private void Add(CkanModule module, SelectionReason reason)
         {
-            if (module.IsMetapackage)
-            {
-                AddReason(module, reason);
-                return;
-            }
             if (module.IsDLC)
             {
                 throw new ModuleIsDLCKraken(module);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1000,6 +1000,12 @@ namespace CKAN.GUI
                                 RegistryManager.Instance(currentInstance, repoData).registry);
                         });
                         break;
+
+                    case "IsAutoInstalled":
+                        // Update the changeset
+                        UpdateChangeSetAndConflicts(currentInstance,
+                            RegistryManager.Instance(currentInstance, repoData).registry);
+                        break;
                 }
             }
         }

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -46,7 +46,7 @@ namespace CKAN.GUI
             {
                 Wait.StartWaiting(InstallMods, PostInstallMods, true,
                     new InstallArgument(
-                            // Only pass along user requested mods, so auto-installed can be determined
+                        // Only pass along user requested mods, so auto-installed can be determined
                         changeset.Where(ch => ch.Reasons.Any(r => r is SelectionReason.UserRequested)
                                               // Include all removes and upgrades
                                               || ch.ChangeType != GUIModChangeType.Install)

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -56,7 +56,7 @@ namespace CKAN.GUI
 
         public string Name { get; private set; }
         public bool IsInstalled { get; private set; }
-        public bool IsAutoInstalled { get; private set; }
+        public bool IsAutoInstalled => InstalledMod?.AutoInstalled ?? false;
         public bool HasUpdate { get; set; }
         public bool HasReplacement { get; private set; }
         public bool IsIncompatible { get; private set; }
@@ -128,7 +128,6 @@ namespace CKAN.GUI
             InstalledMod     = instMod;
             selectedMod      = registry.GetModuleByVersion(instMod.identifier, instMod.Module.version)
                                ?? instMod.Module;
-            IsAutoInstalled  = instMod.AutoInstalled;
             InstallDate      = instMod.InstallTime;
 
             InstalledVersion = instMod.Module.version.ToString(hideEpochs, hideV);
@@ -342,8 +341,8 @@ namespace CKAN.GUI
                 var old_value = (bool) auto_cell.Value;
 
                 bool value = set_value_to ?? old_value;
-                IsAutoInstalled = value;
                 InstalledMod.AutoInstalled = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IsAutoInstalled"));
 
                 if (old_value != value)
                 {

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -214,7 +214,6 @@ namespace CKAN.GUI
                          .Union(resolver.ModList()
                                         // Changeset already contains changes for these
                                         .Except(extraInstalls)
-                                        .Where(m => !m.IsMetapackage)
                                         .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonsFor(m)))),
                 resolver.ConflictList,
                 resolver.ConflictDescriptions.ToList());

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -173,6 +173,14 @@ namespace CKAN.NetKAN.Transformers
                 json.SafeAdd("author",   () => GetAuthors(ghRepo, ghRelease));
                 json.Remove("$kref");
                 json.SafeAdd("download", ghAsset.Download.ToString());
+                if (ghRef.UseSourceArchive)
+                {
+                    // https://docs.github.com/en/rest/repos/contents#download-a-repository-archive-zip
+                    // GitHub requires clients to specify JSON format
+                    // to download a source ZIP (!!!)
+                    json.SafeAdd("download_content_type",
+                                 "application/vnd.github+json");
+                }
                 json.SafeAdd(Metadata.UpdatedPropertyName, ghAsset.Updated);
 
                 if (ghRef.Project.Contains('_'))

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -1226,7 +1226,8 @@ namespace Tests.Core
                 // Act
                 installer.Upgrade(upgradeIdentifiers.Select(ident =>
                                       registry.LatestAvailable(ident, inst.KSP.VersionCriteria()))
-                                                    .OfType<CkanModule>(),
+                                                    .OfType<CkanModule>()
+                                                    .ToArray(),
                                   downloader, ref possibleConfigOnlyDirs, regMgr, false);
 
                 // Assert


### PR DESCRIPTION
## Problems

- @ProgrammerFailure reported problems installing modpacks from <https://github.com/ProgrammerFailure/MyCKANMetaData>, contained in this metadata repo:
  <https://github.com/ProgrammerFailure/MyCKANMetaData/archive/main.tar.gz>
  ![image](https://github.com/user-attachments/assets/53c3c60c-5aad-422a-83af-20b5e49be3f8)
  The changeset appears, but when you confirm it, the install is skipped.
- Once that was fixed, I got HTTP status 415 errors trying to install a mod that was indexed based on its source archive
  ![image](https://github.com/user-attachments/assets/c694c234-f9e6-4bda-9415-eb046eaaa22c)
- Then once the modpack was finally installed, I noticed that the changeset wasn't updating when I toggled the Auto-Installed checkbox

## Causes

- Metapackages and dependencies were being filtered out, so the install flow was quitting on an empty changeset
- GitHub's API documentation now says to set the `Accept` header to `application/vnd.github+json` to download a source ZIP rather than a value that corresponds to a ZIP file type (!!!)
  <https://docs.github.com/en/rest/repos/contents#download-a-repository-archive-zip>
  ![image](https://github.com/user-attachments/assets/1014ee7d-e6a0-43fa-b6c6-4c3013331ea5)
- The Auto-Installed checkbox has gone through a number of changes relating to the ability to remove individual items from the changeset screen, which at some point probably severed the link between it and refreshing the changeset, but I was not able to pinpoint precisely when this occurred.

## Changes

- Now it's fine to put metapackages in a changeset; they'll just be skipped during the parts of installation that involve downloading and unzipping files. An `InstalledModule` will still be added to the registry even though no files are installed for a metapackage, so it can be upgraded when there are updates in the upstream repo. Immediate dependencies of a metapackage will be marked as non-auto-installed by default so the metapackage does not have to remain installed to keep the mods (since this is how "install from .ckan" currently works).
- Now the `GithubTransformer` will set `download_content_type` to `application/vnd.github+json` when `x_netkan_github.use_source_archive` is true, so clients will pass the mime type that GitHub foolishly requires for source ZIPs
- Now `GUIMod.SetAutoInstallChecked` raises the `PropertyChanged` event with an argument of `IsAutoInstalled`, which `ManageMods` receives and handles by refreshing the changeset
