### PR TITLE
Tests for safety of string format calls

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -22,8 +22,9 @@ namespace CKAN.CmdLine
                 .Where(m => !m.IsDLC)
                 .OrderBy(m => m.identifier);
 
-            user.RaiseMessage(string.Format(Properties.Resources.AvailableHeader,
-                instance.game.ShortName, instance.Version()));
+            user.RaiseMessage(Properties.Resources.AvailableHeader,
+                              instance.game.ShortName,
+                              instance.Version()?.ToString() ?? "");
             user.RaiseMessage("");
 
             if (opts.detail)

--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -224,7 +224,7 @@ namespace CKAN.CmdLine
             IConfiguration cfg = ServiceLocator.Container.Resolve<IConfiguration>();
             if (cfg.CacheSizeLimit.HasValue)
             {
-                user?.RaiseMessage(CkanModule.FmtSize(cfg.CacheSizeLimit.Value));
+                user?.RaiseMessage("{0}", CkanModule.FmtSize(cfg.CacheSizeLimit.Value));
             }
             else
             {
@@ -258,7 +258,7 @@ namespace CKAN.CmdLine
         {
             foreach (var h in CacheSubOptions.GetHelp(verb))
             {
-                user?.RaiseError(h);
+                user?.RaiseError("{0}", h);
             }
         }
 

--- a/Cmdline/Action/Compare.cs
+++ b/Cmdline/Action/Compare.cs
@@ -27,7 +27,7 @@ namespace CKAN.CmdLine
 
                 if (options.machine_readable)
                 {
-                    user.RaiseMessage(compareResult.ToString());
+                    user.RaiseMessage("{0}", compareResult.ToString());
                 }
                 else if (compareResult == 0)
                 {
@@ -51,7 +51,7 @@ namespace CKAN.CmdLine
                 user.RaiseError(Properties.Resources.ArgumentMissing);
                 foreach (var h in Actions.GetHelp("compare"))
                 {
-                    user.RaiseError(h);
+                    user.RaiseError("{0}", h);
                 }
                 return Exit.BADOPT;
             }

--- a/Cmdline/Action/Compat.cs
+++ b/Cmdline/Action/Compat.cs
@@ -295,7 +295,7 @@ namespace CKAN.CmdLine
         {
             foreach (var h in CompatSubOptions.GetHelp(verb))
             {
-                user?.RaiseError(h);
+                user?.RaiseError("{0}", h);
             }
         }
 

--- a/Cmdline/Action/Filter.cs
+++ b/Cmdline/Action/Filter.cs
@@ -224,7 +224,7 @@ namespace CKAN.CmdLine
         {
             foreach (var h in FilterSubOptions.GetHelp(verb))
             {
-                user?.RaiseError(h);
+                user?.RaiseError("{0}", h);
             }
         }
 

--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -690,7 +690,7 @@ namespace CKAN.CmdLine
         {
             foreach (var h in InstanceSubOptions.GetHelp(verb))
             {
-                user?.RaiseError(h);
+                user?.RaiseError("{0}", h);
             }
         }
 

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -43,7 +43,7 @@ namespace CKAN.CmdLine
                     user.RaiseError(Properties.Resources.ArgumentMissing);
                     foreach (var h in Actions.GetHelp("import"))
                     {
-                        user.RaiseError(h);
+                        user.RaiseError("{0}", h);
                     }
                     return Exit.ERROR;
                 }

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -38,7 +38,7 @@ namespace CKAN.CmdLine
                 user.RaiseError(Properties.Resources.ArgumentMissing);
                 foreach (var h in Actions.GetHelp("install"))
                 {
-                    user.RaiseError(h);
+                    user.RaiseError("{0}", h);
                 }
                 return Exit.BADOPT;
             }
@@ -164,7 +164,7 @@ namespace CKAN.CmdLine
                     }
                     catch (Kraken e)
                     {
-                        user.RaiseMessage(e.Message);
+                        user.RaiseMessage("{0}", e.Message);
                         return Exit.ERROR;
                     }
 

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -147,7 +147,7 @@ namespace CKAN.CmdLine
         {
             foreach (var h in MarkSubOptions.GetHelp(verb))
             {
-                user.RaiseError(h);
+                user.RaiseError("{0}", h);
             }
         }
 

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -113,7 +113,7 @@ namespace CKAN.CmdLine
                 user.RaiseError(Properties.Resources.ArgumentMissing);
                 foreach (var h in Actions.GetHelp("remove"))
                 {
-                    user.RaiseError(h);
+                    user.RaiseError("{0}", h);
                 }
                 return Exit.BADOPT;
             }

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -30,7 +30,7 @@ namespace CKAN.CmdLine
                 user.RaiseError(Properties.Resources.ArgumentMissing);
                 foreach (var h in Actions.GetHelp("replace"))
                 {
-                    user.RaiseError(h);
+                    user.RaiseError("{0}", h);
                 }
                 return Exit.BADOPT;
             }

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -451,7 +451,7 @@ namespace CKAN.CmdLine
         {
             foreach (var h in RepoSubOptions.GetHelp(verb))
             {
-                user?.RaiseError(h);
+                user?.RaiseError("{0}", h);
             }
         }
 

--- a/Cmdline/Action/Search.cs
+++ b/Cmdline/Action/Search.cs
@@ -27,7 +27,7 @@ namespace CKAN.CmdLine
                 user.RaiseError(Properties.Resources.ArgumentMissing);
                 foreach (var h in Actions.GetHelp("search"))
                 {
-                    user.RaiseError(h);
+                    user.RaiseError("{0}", h);
                 }
                 return Exit.BADOPT;
             }
@@ -117,7 +117,7 @@ namespace CKAN.CmdLine
 
                 foreach (CkanModule mod in matching)
                 {
-                    user.RaiseMessage(mod.identifier);
+                    user.RaiseMessage("{0}", mod.identifier);
                 }
             }
 

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -25,7 +25,7 @@ namespace CKAN.CmdLine
                 user.RaiseError(Properties.Resources.ArgumentMissing);
                 foreach (var h in Actions.GetHelp("show"))
                 {
-                    user.RaiseError(h);
+                    user.RaiseError("{0}", h);
                 }
                 return Exit.BADOPT;
             }

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -96,7 +96,7 @@ namespace CKAN.CmdLine
             catch (MissingCertificateKraken kraken)
             {
                 // Handling the kraken means we have prettier output.
-                user.RaiseMessage(kraken.ToString());
+                user.RaiseMessage("{0}", kraken.ToString());
                 return Exit.ERROR;
             }
 
@@ -162,7 +162,7 @@ namespace CKAN.CmdLine
                 throw new BadCommandKraken("List of modules cannot be null.");
             }
 
-            user.RaiseMessage(message);
+            user.RaiseMessage("{0}", message);
 
             foreach (CkanModule module in modules)
             {

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -50,7 +50,7 @@ namespace CKAN.CmdLine
                 user.RaiseError(Properties.Resources.ArgumentMissing);
                 foreach (var h in Actions.GetHelp("upgrade"))
                 {
-                    user.RaiseError(h);
+                    user.RaiseError("{0}", h);
                 }
                 return Exit.BADOPT;
             }
@@ -93,7 +93,7 @@ namespace CKAN.CmdLine
                                           latestVersion?.ToString() ?? "");
                         if (update.ReleaseNotes != null)
                         {
-                            user.RaiseMessage(update.ReleaseNotes);
+                            user.RaiseMessage("{0}", update.ReleaseNotes);
                         }
                         user.RaiseMessage("");
                         user.RaiseMessage("");
@@ -157,7 +157,7 @@ namespace CKAN.CmdLine
             }
             catch (InconsistentKraken kraken)
             {
-                user.RaiseMessage(kraken.ToString());
+                user.RaiseMessage("{0}", kraken.ToString());
                 return Exit.ERROR;
             }
             catch (ModuleIsDLCKraken kraken)

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -317,7 +317,7 @@ namespace CKAN.CmdLine
 
         private static int Version(IUser user)
         {
-            user.RaiseMessage(Meta.GetVersion(VersionFormat.Full));
+            user.RaiseMessage("{0}", Meta.GetVersion(VersionFormat.Full));
 
             return Exit.OK;
         }

--- a/ConsoleUI/CKAN-ConsoleUI.csproj
+++ b/ConsoleUI/CKAN-ConsoleUI.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
+    <PackageReference Include="StringSyntaxAttribute" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />

--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -94,7 +94,7 @@ namespace CKAN.ConsoleUI {
                         } catch (Exception ex) {
                             // This can throw if the previous current instance had an error,
                             // since it gets destructed when it's replaced.
-                            RaiseError(ex.Message);
+                            RaiseError("{0}", ex.Message);
                         }
                         return false;
                     } else {

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -123,9 +123,9 @@ namespace CKAN.ConsoleUI {
                             // Don't need to tell the user they just cancelled out.
                         } catch (FileNotFoundKraken ex) {
                             // Possible file corruption
-                            RaiseError(ex.Message);
+                            RaiseError("{0}", ex.Message);
                         } catch (DirectoryNotFoundKraken ex) {
-                            RaiseError(ex.Message);
+                            RaiseError("{0}", ex.Message);
                         } catch (FileExistsKraken ex) {
                             if (ex.owningModule != null) {
                                 RaiseMessage(Properties.Resources.InstallOwnedFileConflict, ex.installingModule?.ToString() ?? "", ex.filename, ex.owningModule);
@@ -134,9 +134,9 @@ namespace CKAN.ConsoleUI {
                             }
                             RaiseError(Properties.Resources.InstallFilesReverted);
                         } catch (DownloadErrorsKraken ex) {
-                            RaiseError(ex.ToString());
+                            RaiseError("{0}", ex.ToString());
                         } catch (ModuleDownloadErrorsKraken ex) {
-                            RaiseError(ex.ToString());
+                            RaiseError("{0}", ex.ToString());
                         } catch (DownloadThrottledKraken ex) {
                             if (RaiseYesNoDialog(string.Format(Properties.Resources.InstallAuthTokenPrompt, ex.ToString()))) {
                                 if (ex.infoUrl != null) {
@@ -145,9 +145,9 @@ namespace CKAN.ConsoleUI {
                                 LaunchSubScreen(new AuthTokenScreen(theme));
                             }
                         } catch (MissingCertificateKraken ex) {
-                            RaiseError(ex.ToString());
+                            RaiseError("{0}", ex.ToString());
                         } catch (InconsistentKraken ex) {
-                            RaiseError(ex.Message);
+                            RaiseError("{0}", ex.Message);
                         } catch (TooManyModsProvideKraken ex) {
 
                             var ch = new ConsoleChoiceDialog<CkanModule>(
@@ -174,7 +174,7 @@ namespace CKAN.ConsoleUI {
                         } catch (ModNotInstalledKraken ex) {
                             RaiseError(Properties.Resources.InstallNotInstalled, ex.mod);
                         } catch (DllLocationMismatchKraken ex) {
-                            RaiseError(ex.Message);
+                            RaiseError("{0}", ex.Message);
                         }
                     } while (retry);
                 }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -455,7 +455,7 @@ namespace CKAN.ConsoleUI {
                     RaiseError(Properties.Resources.ModListAuditNotFound);
                 }
             } catch (ModuleNotFoundKraken k) {
-                RaiseError($"{k.module} {k.version}: {k.Message}");
+                RaiseError("{0} {1}: {2}", k.module, k.version ?? "", k.Message);
             }
             return true;
         }
@@ -496,7 +496,7 @@ namespace CKAN.ConsoleUI {
                                         userAgent);
                     } catch (Exception ex) {
                         // There can be errors while you re-install mods with changed metadata
-                        ps.RaiseError(ex.Message + ex.StackTrace);
+                        ps.RaiseError("{0}", ex.Message + ex.StackTrace);
                     }
                     // Update recent with mods that were updated in this pass
                     foreach (CkanModule mod in registry.CompatibleModules(
@@ -517,11 +517,9 @@ namespace CKAN.ConsoleUI {
         }
 
         private static string newModPrompt(int howMany)
-        {
-            return howMany == 1
+            => howMany == 1
                 ? string.Format(Properties.Resources.ModListNewMod,  howMany)
                 : string.Format(Properties.Resources.ModListNewMods, howMany);
-        }
 
         private bool ScanForMods()
         {

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CKAN.ConsoleUI.Toolkit {
 
@@ -141,7 +142,8 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         /// <param name="message">Format string for the message</param>
         /// <param name="args">Values to be interpolated into the format string</param>
-        public void RaiseError(string message, params object[] args)
+        public void RaiseError([StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+                               string message, params object[] args)
         {
             var d = new ConsoleMessageDialog(
                 theme,
@@ -159,7 +161,8 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// </summary>
         /// <param name="message">Format string for the message</param>
         /// <param name="args">Values to be interpolated into the format string</param>
-        public void RaiseMessage(string message, params object[] args)
+        public void RaiseMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+                                 string message, params object[] args)
         {
             Message(message, args);
             Draw();

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="IndexRange" Version="1.0.3" />
+    <PackageReference Include="StringSyntaxAttribute" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -62,7 +62,7 @@ namespace CKAN
             {
                 if (error != null)
                 {
-                    user?.RaiseError(error.ToString());
+                    user?.RaiseError("{0}", error.ToString());
                 }
             };
             downloader.DownloadAndWait(downloadTargets);

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -161,7 +161,7 @@ namespace CKAN
                     }
                     catch (InvalidModuleFileKraken kraken)
                     {
-                        User.RaiseError(kraken.ToString());
+                        User.RaiseError("{0}", kraken.ToString());
                         if (module != null)
                         {
                             // Finish out the progress bar
@@ -176,7 +176,7 @@ namespace CKAN
                     catch (OperationCanceledException exc)
                     {
                         log.WarnFormat("Cancellation token threw, validation incomplete: {0}", filename);
-                        User.RaiseMessage(exc.Message);
+                        User.RaiseMessage("{0}", exc.Message);
                         if (module != null)
                         {
                             // Finish out the progress bar

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace CKAN
 {
     /// <summary>
@@ -18,11 +20,13 @@ namespace CKAN
         /// </summary>
         /// <returns>The index of the item selected from the array or -1 if cancelled</returns>
         int  RaiseSelectionDialog(string message, params object[] args);
-        void RaiseError(string message, params object[] args);
+        void RaiseError([StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+                        string message, params object[] args);
 
         void RaiseProgress(string message, int percent);
         void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft);
-        void RaiseMessage(string message, params object[] args);
+        void RaiseMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+                          string message, params object[] args);
     }
 
     /// <summary>

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -333,7 +333,7 @@ namespace CKAN.GUI
             if (!TryFieldsToModule(out string? error, out Control? badField))
             {
                 badField.Focus();
-                user?.RaiseError(error);
+                user?.RaiseError("{0}", error);
             }
             else if (module != null && TrySavePrompt(modpackExportOptions, out string? filename))
             {

--- a/GUI/Controls/UnmanagedFiles.cs
+++ b/GUI/Controls/UnmanagedFiles.cs
@@ -210,7 +210,7 @@ namespace CKAN.GUI
                     }
                     catch (Exception exc)
                     {
-                        user?.RaiseError(exc.Message);
+                        user?.RaiseError("{0}", exc.Message);
                     }
                 }
             }

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -173,24 +173,24 @@ namespace CKAN.GUI
             }
             catch (NotKSPDirKraken kraken)
             {
-                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogInstanceNotValid,
-                                Platform.FormatPath(kraken.path)));
+                user.RaiseError(Properties.Resources.CloneFakeKspDialogInstanceNotValid,
+                                Platform.FormatPath(kraken.path));
                 reactivateDialog();
             }
             catch (PathErrorKraken kraken)
             {
-                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogDestinationNotEmpty,
-                                Platform.FormatPath(kraken?.path ?? "")));
+                user.RaiseError(Properties.Resources.CloneFakeKspDialogDestinationNotEmpty,
+                                Platform.FormatPath(kraken?.path ?? ""));
                 reactivateDialog();
             }
             catch (IOException ex)
             {
-                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogCloneFailed, ex.Message));
+                user.RaiseError(Properties.Resources.CloneFakeKspDialogCloneFailed, ex.Message);
                 reactivateDialog();
             }
             catch (Exception ex)
             {
-                user.RaiseError(string.Format(Properties.Resources.CloneFakeKspDialogCloneFailed, ex.Message));
+                user.RaiseError(Properties.Resources.CloneFakeKspDialogCloneFailed, ex.Message);
                 reactivateDialog();
             }
         }

--- a/GUI/Dialogs/EditLabelsDialog.cs
+++ b/GUI/Dialogs/EditLabelsDialog.cs
@@ -154,7 +154,7 @@ namespace CKAN.GUI
             }
             else
             {
-                user.RaiseError(errMsg);
+                user.RaiseError("{0}", errMsg);
             }
         }
 
@@ -281,7 +281,7 @@ namespace CKAN.GUI
                 {
                     if (!TrySave(out string errMsg))
                     {
-                        user.RaiseError(errMsg);
+                        user.RaiseError("{0}", errMsg);
                         return false;
                     }
                 }

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -182,7 +182,7 @@ namespace CKAN.GUI
             }
             catch (Exception exc)
             {
-                user.RaiseError(exc.Message);
+                user.RaiseError("{0}", exc.Message);
             }
         }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -777,7 +777,7 @@ namespace CKAN.GUI
                 }
                 catch (Kraken kraken)
                 {
-                    currentUser.RaiseError(kraken.InnerException == null
+                    currentUser.RaiseError("{0}", kraken.InnerException == null
                         ? kraken.Message
                         : $"{kraken.Message}: {kraken.InnerException.Message}");
 
@@ -785,7 +785,7 @@ namespace CKAN.GUI
                 }
                 catch (Exception ex)
                 {
-                    currentUser.RaiseError(ex.Message);
+                    currentUser.RaiseError("{0}", ex.Message);
                     continue;
                 }
 
@@ -960,12 +960,12 @@ namespace CKAN.GUI
 
         private void ManageMods_RaiseMessage(string message)
         {
-            currentUser.RaiseMessage(message);
+            currentUser.RaiseMessage("{0}", message);
         }
 
         private void ManageMods_RaiseError(string error)
         {
-            currentUser.RaiseError(error);
+            currentUser.RaiseError("{0}", error);
         }
 
         private void ManageMods_SetStatusBar(string message)

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -74,7 +74,7 @@ namespace CKAN.GUI
                                 if (e?.Error is Exception exc)
                                 {
                                     log.Error(exc.Message, exc);
-                                    currentUser.RaiseMessage(exc.Message);
+                                    currentUser.RaiseMessage("{0}", exc.Message);
                                 }
                                 Wait.Finish();
                             }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -374,8 +374,8 @@ namespace CKAN.GUI
 
         private void OnModInstalled(CkanModule mod)
         {
-            currentUser.RaiseMessage(string.Format(Properties.Resources.MainInstallModSuccess,
-                                     mod));
+            currentUser.RaiseMessage(Properties.Resources.MainInstallModSuccess,
+                                     mod);
             LabelsAfterInstall(mod);
         }
 
@@ -399,7 +399,7 @@ namespace CKAN.GUI
                         break;
 
                     case NotEnoughSpaceKraken exc:
-                        currentUser.RaiseMessage(exc.Message);
+                        currentUser.RaiseMessage("{0}", exc.Message);
                         break;
 
                     case FileExistsKraken exc:
@@ -420,7 +420,7 @@ namespace CKAN.GUI
                         break;
 
                     case InconsistentKraken exc:
-                        currentUser.RaiseMessage(exc.Message);
+                        currentUser.RaiseMessage("{0}", exc.Message);
                         break;
 
                     case CancelledActionKraken exc:
@@ -430,12 +430,12 @@ namespace CKAN.GUI
                         break;
 
                     case MissingCertificateKraken exc:
-                        currentUser.RaiseMessage(exc.ToString());
+                        currentUser.RaiseMessage("{0}", exc.ToString());
                         break;
 
                     case DownloadThrottledKraken exc:
                         string msg = exc.ToString();
-                        currentUser.RaiseMessage(msg);
+                        currentUser.RaiseMessage("{0}", msg);
                         if (configuration != null && CurrentInstance != null
                             && YesNoDialog(string.Format(Properties.Resources.MainInstallOpenSettingsPrompt, msg),
                                 Properties.Resources.MainInstallOpenSettings,
@@ -465,15 +465,15 @@ namespace CKAN.GUI
 
                     case ModuleIsDLCKraken exc:
                         string dlcMsg = string.Format(Properties.Resources.MainInstallCantInstallDLC, exc.module.name);
-                        currentUser.RaiseMessage(dlcMsg);
-                        currentUser.RaiseError(dlcMsg);
+                        currentUser.RaiseMessage("{0}", dlcMsg);
+                        currentUser.RaiseError("{0}", dlcMsg);
                         break;
 
                     case TransactionalKraken exc:
                         // Thrown when the Registry tries to enlist with multiple different transactions
                         // Want to see the stack trace for this one
-                        currentUser.RaiseMessage(exc.ToString());
-                        currentUser.RaiseError(exc.ToString());
+                        currentUser.RaiseMessage("{0}", exc.ToString());
+                        currentUser.RaiseError("{0}", exc.ToString());
                         break;
 
                     case TransactionException texc:
@@ -483,12 +483,12 @@ namespace CKAN.GUI
                                                 .Reverse())
                         {
                             log.Error(exc.Message, exc);
-                            currentUser.RaiseMessage(exc.Message);
+                            currentUser.RaiseMessage("{0}", exc.Message);
                         }
                         break;
 
                     default:
-                        currentUser.RaiseMessage(e.Error.Message);
+                        currentUser.RaiseMessage("{0}", e.Error.Message);
                         break;
                 }
 

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -187,7 +187,7 @@ namespace CKAN.GUI
                                                 .Reverse())
                         {
                             log.Error(exc.Message, exc);
-                            currentUser.RaiseMessage(exc.Message);
+                            currentUser.RaiseMessage("{0}", exc.Message);
                         }
                         currentUser.RaiseMessage(Properties.Resources.MainRepoFailed);
                         Wait.Finish();
@@ -201,7 +201,7 @@ namespace CKAN.GUI
                                                           .Reverse()))
                         {
                             log.Error(inner.Message, inner);
-                            currentUser.RaiseMessage(inner.Message);
+                            currentUser.RaiseMessage("{0}", inner.Message);
                         }
                         currentUser.RaiseMessage(Properties.Resources.MainRepoFailed);
                         Wait.Finish();
@@ -210,7 +210,7 @@ namespace CKAN.GUI
 
                     case Exception exc:
                         log.Error(exc.Message, exc);
-                        currentUser.RaiseMessage(exc.Message);
+                        currentUser.RaiseMessage("{0}", exc.Message);
                         currentUser.RaiseMessage(Properties.Resources.MainRepoFailed);
                         Wait.Finish();
                         EnableMainWindow();

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -54,14 +54,14 @@ namespace CKAN.GUI
             Util.Invoke(statusStrip1, () =>
             {
                 StatusProgress.Visible = false;
-                currentUser.RaiseMessage(statusMsg);
+                currentUser.RaiseMessage("{0}", statusMsg);
             });
             Util.Invoke(WaitTabPage, () =>
             {
                 RecreateDialogs();
                 Wait.Finish();
             });
-            currentUser.RaiseMessage(logMsg);
+            currentUser.RaiseMessage("{0}", logMsg);
             Wait.SetDescription(description);
         }
 

--- a/Tests/MonoCecilAnalysisTestsBase.cs
+++ b/Tests/MonoCecilAnalysisTestsBase.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using CKAN.Extensions;
+
+namespace Tests
+{
+    using MethodCall = List<MethodDefinition>;
+    using CallsDict  = Dictionary<MethodDefinition, List<MethodDefinition>>;
+
+    public abstract class MonoCecilAnalysisBase
+    {
+        protected static string FullyQualifiedName(MethodReference md)
+            => $"{FullyQualifiedName(md.DeclaringType)}.{md.Name}";
+
+        protected static string FullyQualifiedName(TypeReference td)
+            => string.Join(".", td.TraverseNodes(td => td.DeclaringType)
+                                  .Reverse()
+                                  .Select(td => td.DeclaringType == null
+                                                && td.Namespace != null
+                                                    ? $"{td.Namespace}.{td.Name}"
+                                                    : td.Name));
+
+        protected static string SimpleName(MethodDefinition md)
+            => $"{md.DeclaringType.Name}.{md.Name}";
+
+        // https://gist.github.com/lnicola/b48db1a6ff3617bdac2a
+        protected static IEnumerable<MethodCall> VisitMethodDefinition(MethodCall                   fullStack,
+                                                                       MethodDefinition             methDef,
+                                                                       CallsDict                    calls,
+                                                                       Func<MethodDefinition, bool> skip,
+                                                                       Func<MethodDefinition, bool> stopAfter)
+        {
+            var called = calls[methDef] = methodsCalledBy(methDef).Distinct().ToList();
+            foreach (var calledMeth in called)
+            {
+                if (!calls.ContainsKey(calledMeth) && !skip(calledMeth))
+                {
+                    var newStack = fullStack.Append(calledMeth).ToList();
+                    yield return newStack;
+                    if (!stopAfter(calledMeth))
+                    {
+                        // yield from, please!
+                        foreach (var subcall in VisitMethodDefinition(newStack, calledMeth, calls, skip, stopAfter))
+                        {
+                            yield return subcall;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<MethodDefinition> methodsCalledBy(MethodDefinition methDef)
+            => GetCallsBy(methDef).Select(instr => instr.Operand as MethodDefinition
+                                                   ?? GetSetterDef(instr.Operand as MethodReference))
+                                  .OfType<MethodDefinition>();
+
+        protected static IEnumerable<Instruction> GetCallsBy(MethodDefinition methDef)
+            => methDef.Body
+                      ?.Instructions
+                       .Where(instr => callOpCodes.Contains(instr.OpCode.Name))
+                      ?? Enumerable.Empty<Instruction>();
+
+        // Property setters are virtual and have references instead of definitions
+        private static MethodDefinition? GetSetterDef(MethodReference? mr)
+            => (mr?.Name.StartsWith("set_") ?? false) ? mr.Resolve()
+                                                      : null;
+
+        protected static IEnumerable<TypeDefinition> GetAllNestedTypes(TypeDefinition td)
+            => Enumerable.Repeat(td, 1)
+                         .Concat(td.NestedTypes.SelectMany(GetAllNestedTypes));
+
+        protected static IEnumerable<MethodCall> FindStartedTasks(MethodDefinition md)
+            => StartNewCalls(md).Select(FindStartNewArgument)
+                                .OfType<MethodDefinition>()
+                                .Select(taskArg => new MethodCall() { md, taskArg });
+
+        private static IEnumerable<Instruction> StartNewCalls(MethodDefinition md)
+            => md.Body?.Instructions.Where(instr => callOpCodes.Contains(instr.OpCode.Name)
+                                                    && instr.Operand is MethodReference mr
+                                                    && isStartNew(mr))
+                      ?? Enumerable.Empty<Instruction>();
+
+        private static bool isStartNew(MethodReference mr)
+            => (mr.DeclaringType.Namespace == "System.Threading.Tasks"
+                && mr.DeclaringType.Name   == "TaskFactory"
+                && mr.Name                 == "StartNew")
+               || (mr.DeclaringType.Namespace == "System.Threading.Tasks"
+                   && mr.DeclaringType.Name   == "Task"
+                   && mr.Name                 == "Run");
+
+        private static MethodDefinition? FindStartNewArgument(Instruction instr)
+            => instr.OpCode.Name == "ldftn" ? instr.Operand as MethodDefinition
+                                            : FindStartNewArgument(instr.Previous);
+
+        private static readonly HashSet<string> callOpCodes = new HashSet<string>
+        {
+            // Constructors
+            "newobj",
+
+            // Normal function calls
+            "call",
+
+            // Virtual function calls (includes property setters)
+            "callvirt",
+        };
+    }
+}

--- a/Tests/StringFormatSafetyTests.cs
+++ b/Tests/StringFormatSafetyTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+using CKAN.Extensions;
+
+namespace Tests
+{
+    [TestFixture]
+    public class StringFormatSafetyTests : MonoCecilAnalysisBase
+    {
+        [TestCase(new object[]
+                  {
+                      typeof(CKAN.IUser),
+                      typeof(CKAN.CmdLine.ConsoleUser),
+                      typeof(CKAN.ConsoleUI.Toolkit.ConsoleScreen),
+                      #if NETFRAMEWORK || WINDOWS
+                      typeof(CKAN.GUI.GUIUser),
+                      #endif
+                      typeof(CKAN.NetKAN.ConsoleUser),
+                  })]
+        public void AssemblyModule_StringSyntaxCompositeFormat_SameOrLiteralsOnly(object[] types)
+        {
+            // Arrange
+            var methodsByName = types.OfType<Type>()
+                                     .Select(t => Assembly.GetAssembly(t))
+                                     .OfType<Assembly>()
+                                     .Select(a => ModuleDefinition.ReadModule(a.Location))
+                                     .SelectMany(m => m.Types
+                                                       .SelectMany(GetAllNestedTypes)
+                                                       .SelectMany(t => t.Methods)
+                                                       .SelectMany(GetMethodAndTasks))
+                                     .GroupBy(FullyQualifiedName)
+                                     .Where(grp => grp.Count() == 1)
+                                     .ToDictionary(grp => grp.Key,
+                                                   grp => grp.Single());
+            var specialNames = methodsByName.Values.Where(AnyParamHasStringSyntaxAttribute)
+                                                   .Select(FullyQualifiedName)
+                                                   .ToHashSet();
+
+            // Act / Assert
+            Assert.Multiple(() =>
+            {
+                foreach ((string name, MethodDefinition meth) in methodsByName)
+                {
+                    foreach (var call in GetCallsBy(meth))
+                    {
+                        if (call.Operand is MethodReference calledRef
+                            && FullyQualifiedName(calledRef) is string calledRefName
+                            && specialNames.Contains(calledRefName))
+                        {
+                            Assert.IsFalse(IsEmptyArray(call.Previous)
+                                           && !IsStringLiteral(call.Previous.Previous)
+                                           && !IsI18nResource(call.Previous.Previous),
+                                           $"Unsafe format string in {name} --> {InstrDescription(call, meth)}({InstrDescription(call.Previous.Previous, meth)})");
+                        }
+                    }
+                }
+            });
+        }
+
+        private static string? InstrDescription(Instruction instr, MethodDefinition parent)
+            => instr switch
+               {
+                   {
+                       Operand: MethodReference mRef,
+                   } => FullyQualifiedName(mRef),
+                   {
+                       OpCode:  {Name: "ldstr"},
+                       Operand: string s,
+                   } => $"literal \"{s}\"",
+                   {
+                       OpCode:  {Name: "ldfld"},
+                       Operand: FieldReference fRef,
+                   } => $"field \"{fRef.Name}\"",
+                   {
+                       OpCode: {Name: string a},
+                   } => ldargPattern.TryMatch(a, out Match? argM)
+                        && int.TryParse(argM.Groups["argNum"].Value, out int argNum)
+                        && argNum > 0 && argNum <= parent.Parameters.Count
+                            ? $"argument \"{parent.Parameters[argNum - 1].Name}\""
+                            : ldlocPattern.TryMatch(a, out Match? locM)
+                                ? $"local {locM.Groups["locNum"].Value}"
+                                : a,
+                   _ => null,
+               };
+
+        private static readonly Regex ldargPattern =
+            new Regex(@"ldarg\.(?<argNum>\d+$)",
+                      RegexOptions.Compiled);
+
+        private static readonly Regex ldlocPattern =
+            new Regex(@"ldloc\.(?<locNum>.+$)",
+                      RegexOptions.Compiled);
+
+        private static bool IsEmptyArray(Instruction instr)
+            => instr.OpCode.Name == "call"
+                && instr.Operand is MethodReference mRef
+                && mRef.Name == "Empty";
+
+        private static bool IsI18nResource(Instruction instr)
+            => instr.Operand is MethodReference mRef
+                && FullyQualifiedName(mRef).Contains(".Properties.Resources.");
+
+        private static bool IsStringLiteral(Instruction instr)
+            => instr.OpCode.Name == "ldstr" && instr.Operand is string;
+
+        private static IEnumerable<MethodDefinition> GetMethodAndTasks(MethodDefinition meth)
+            => Enumerable.Repeat(meth, 1)
+                         .Concat(FindStartedTasks(meth).Select(stack => stack.Last()));
+
+        private static readonly Type strSynAttrib = typeof(StringSyntaxAttribute);
+
+        private static bool AnyParamHasStringSyntaxAttribute(MethodDefinition md)
+            => AnyParamHasAttribute(md, strSynAttrib);
+
+        private static bool AnyParamHasAttribute(MethodDefinition md, Type attrib)
+            => md.Parameters.SelectMany(p => p.CustomAttributes)
+                            .Any(attr => attr.AttributeType.Namespace == attrib.Namespace
+                                      && attr.AttributeType.Name      == attrib.Name);
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -20,6 +20,7 @@
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>CS0436</WarningsNotAsErrors>
     <NoWarn>IDE1006,NU1701</NoWarn>
     <TargetFrameworks>net48;net8.0;net8.0-windows</TargetFrameworks>
     <BaseTargetFramework>$(TargetFramework.Replace("-windows", ""))</BaseTargetFramework>
@@ -42,6 +43,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
+    <PackageReference Include="StringSyntaxAttribute" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">


### PR DESCRIPTION
## Motivation

My first code fix for CKAN was to remove a superfluous `String.Format` call that was causing exceptions to be thrown because externally-generated strings were being used as part of a format string (see #2111).

This problem generalizes; _any_ call to `IUser.RaiseMessage` or `IUser.RaiseError` can throw an exception if the first parameter isn't a valid format string. We can ensure that a string literal is safe by looking at it, and we can ensure that an i18n resource is safe by inspecting our resx files, but anytime a value is externally sourced, it isn't safe to use it as a format string because curly braces could turn up any time and ruin our day.

In principle, the C# compiler _could_ check this and emit warnings similar to what it does for nullable references, but currently it doesn't. The closest thing is the [`StringSyntax` attribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.stringsyntaxattribute), which can be used to mark a parameter as a format string, but which doesn't have any built-in functionality associated with it.

## Changes

- Now a new `MonoCecilAnalysisTestsBase` base class is factored out of the test from #3914
- Now a new `StringFormatSafetyTests` class inherits from `MonoCecilAnalysisTestsBase` and scans all code in all of our assemblies for calls to functions with the `StringSyntax` attribute. These calls are deemed safe if the argument list is non-empty, if the format string is a string literal, or if the format string is from `Properties.Resources`; otherwise a test failure is logged.
- Now our format string parameters are tagged with the `StringSyntax` attribute
- Now the 67 existing places that fail the new test are updated to use a format string of `"{0}"`, or to remove a superfluous call to `string.Format`, or other such solutions

This guard rail will help us to write safer code.
