### PR TITLE
Usability improvements for missing files

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -584,21 +584,21 @@ namespace CKAN
 
         /// <summary>
         /// Returns the module contents if and only if we have it
-        /// available in our cache. Returns null, otherwise.
+        /// available in our cache, empty sequence otherwise.
         ///
         /// Intended for previews.
         /// </summary>
-        public static IEnumerable<string> GetModuleContentsList(NetModuleCache Cache,
-                                                                GameInstance   instance,
-
-                                                                CkanModule     module)
+        public static IEnumerable<InstallableFile> GetModuleContents(NetModuleCache  Cache,
+                                                                     GameInstance    instance,
+                                                                     CkanModule      module,
+                                                                     HashSet<string> filters)
             => (Cache.GetCachedFilename(module) is string filename
                     ? Utilities.DefaultIfThrows(() => FindInstallableFiles(module, filename, instance)
-                                                          // Skip folders
-                                                          .Where(f => !f.source.IsDirectory)
-                                                          .Select(f => instance.ToRelativeGameDir(f.destination)))
+                                                          .Where(instF => !filters.Any(filt =>
+                                                                  instF.destination != null
+                                                                  && instF.destination.Contains(filt))))
                     : null)
-               ?? Enumerable.Empty<string>();
+               ?? Enumerable.Empty<InstallableFile>();
 
         #endregion
 

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -274,7 +274,7 @@ namespace CKAN
             };
         }
 
-        private static bool MetadataChanged(this IRegistryQuerier querier, string identifier)
+        public static bool MetadataChanged(this IRegistryQuerier querier, string identifier)
         {
             try
             {

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1291,7 +1291,7 @@ namespace CKAN.GUI
                                    registry.GetModuleByVersion(module.identifier,
                                                                module.version)
                                            ?? module,
-                                   true)
+                                   true, false)
                 }, null);
             }
         }

--- a/GUI/Controls/ModInfoTabs/Contents.Designer.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.Designer.cs
@@ -85,6 +85,7 @@ namespace CKAN.GUI
             this.ContentsPreviewTree.ImageList.Images.Add("file", global::CKAN.GUI.EmbeddedImages.file);
             this.ContentsPreviewTree.ShowPlusMinus = true;
             this.ContentsPreviewTree.ShowRootLines = false;
+            this.ContentsPreviewTree.ShowNodeToolTips = true;
             this.ContentsPreviewTree.Location = new System.Drawing.Point(3, 65);
             this.ContentsPreviewTree.Name = "ContentsPreviewTree";
             this.ContentsPreviewTree.Size = new System.Drawing.Size(494, 431);

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -291,7 +291,9 @@ namespace CKAN.GUI
         /// <returns>The CkanModule associated with this GUIMod or null if there is none</returns>
         public CkanModule ToModule() => Mod;
 
-        public IEnumerable<ModChange> GetModChanges(bool upgradeChecked, bool replaceChecked)
+        public IEnumerable<ModChange> GetModChanges(bool upgradeChecked,
+                                                    bool replaceChecked,
+                                                    bool metadataChanged)
         {
             if (replaceChecked)
             {
@@ -309,7 +311,7 @@ namespace CKAN.GUI
                     yield return new ModUpgrade(Mod,
                                                 GUIModChangeType.Update,
                                                 SelectedMod,
-                                                false);
+                                                false, false);
                 }
                 else
                 {
@@ -329,7 +331,7 @@ namespace CKAN.GUI
                 yield return new ModUpgrade(Mod,
                                             GUIModChangeType.Update,
                                             SelectedMod,
-                                            false);
+                                            false, metadataChanged);
             }
         }
 

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -138,11 +138,13 @@ namespace CKAN.GUI
         public ModUpgrade(CkanModule       mod,
                           GUIModChangeType changeType,
                           CkanModule       targetMod,
-                          bool             userReinstall)
+                          bool             userReinstall,
+                          bool             metadataChanged)
             : base(mod, changeType)
         {
-            this.targetMod     = targetMod;
-            this.userReinstall = userReinstall;
+            this.targetMod       = targetMod;
+            this.userReinstall   = userReinstall;
+            this.metadataChanged = metadataChanged;
         }
 
         public override string? NameAndStatus
@@ -150,8 +152,9 @@ namespace CKAN.GUI
 
         public override string Description
             => IsReinstall
-                ? userReinstall ? Properties.Resources.MainChangesetUserReinstall
-                                : Properties.Resources.MainChangesetReinstall
+                ? userReinstall ? Properties.Resources.MainChangesetReinstallUser
+                                : metadataChanged ? Properties.Resources.MainChangesetReinstallMetadataChanged
+                                                  : Properties.Resources.MainChangesetReinstallMissing
                 : string.Format(Properties.Resources.MainChangesetUpdateSelected,
                                 targetMod.version);
 
@@ -165,5 +168,6 @@ namespace CKAN.GUI
                 && targetMod.version == Mod.version;
 
         private readonly bool userReinstall;
+        private readonly bool metadataChanged;
     }
 }

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -184,7 +184,7 @@ Möchten Sie es wirklich installieren?</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Installieren</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Abbrechen</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Mod-Update ausgewählt vom Nutzer {0}.</value></data>
-  <data name="MainChangesetReinstall" xml:space="preserve"><value>Neu installieren (Metadaten geändert)</value></data>
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve"><value>Neu installieren (Metadaten geändert)</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Mod-Import</value></data>
   <data name="MainImportWaitTitle" xml:space="preserve"><value>Statuslog</value></data>
   <data name="MainInstallWaitTitle" xml:space="preserve"><value>Statuslog</value></data>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -359,10 +359,10 @@ Voulez-vous vraiment les installer ? L'annulation annulera toute l'installation.
   <data name="MainChangesetUpdateSelected" xml:space="preserve">
     <value>Mise à jour demandée vers la version {0}.</value>
   </data>
-  <data name="MainChangesetReinstall" xml:space="preserve">
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve">
     <value>Réinstaller (métadonnées modifiées)</value>
   </data>
-  <data name="MainChangesetUserReinstall" xml:space="preserve">
+  <data name="MainChangesetReinstallUser" xml:space="preserve">
     <value>Réinstallation (à la demande de l'utilisateur)</value>
   </data>
   <data name="MainImportTitle" xml:space="preserve">

--- a/GUI/Properties/Resources.it-IT.resx
+++ b/GUI/Properties/Resources.it-IT.resx
@@ -323,7 +323,7 @@ Sei sicuro di volerli installare? L'annullamento interromperà l'intera installa
   <data name="MainChangesetUpdateSelected" xml:space="preserve">
     <value>Aggiorna la versione selezionata dall'utente alla versione {0}.</value>
   </data>
-  <data name="MainChangesetReinstall" xml:space="preserve">
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve">
     <value>Reinstallazione (Metadati cambiati)</value>
   </data>
   <data name="MainImportTitle" xml:space="preserve">

--- a/GUI/Properties/Resources.ja-JP.resx
+++ b/GUI/Properties/Resources.ja-JP.resx
@@ -187,7 +187,7 @@ Try to move {2} out of {3} and restart CKAN.</value></data>
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>インストール</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>取消</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>選択されたものをバージョン{0}にアップデートする。</value></data>
-  <data name="MainChangesetReinstall" xml:space="preserve"><value> ()</value></data>
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve"><value> ()</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Modインポート</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Mod (*.zip)|*.zip</value></data>
   <data name="MainImportWaitTitle" xml:space="preserve"><value>ステータスログ</value></data>

--- a/GUI/Properties/Resources.ko-KR.resx
+++ b/GUI/Properties/Resources.ko-KR.resx
@@ -188,7 +188,7 @@
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>설치</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>취소하기</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>유저가 선택한 것을 버전 {0}으로 업데이트 하기.</value></data>
-  <data name="MainChangesetReinstall" xml:space="preserve"><value> ()</value></data>
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve"><value> ()</value></data>
   <data name="MainChangesetNewInstall" xml:space="preserve"><value>유저가 선택한 모드를 설치하기.</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>모드들 가져오기</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>모드들 (*.zip)|*.zip</value></data>

--- a/GUI/Properties/Resources.pl-PL.resx
+++ b/GUI/Properties/Resources.pl-PL.resx
@@ -330,7 +330,7 @@ Na pewno chcesz je zainstalować? Anulowanie przerwie całą instalację.</value
   <data name="MainChangesetUpdateSelected" xml:space="preserve">
     <value>Aktualizacja wybrana przez użytkownika do wersji {0}.</value>
   </data>
-  <data name="MainChangesetReinstall" xml:space="preserve">
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve">
     <value>Zainstaluj ponownie (Metadane zmienione)</value>
   </data>
   <data name="MainImportTitle" xml:space="preserve">

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -215,8 +215,9 @@ Do you want to add the additional versions to this game instance's compatibility
 
 Are you sure you want to install them? Cancelling will abort the entire installation.</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Update selected by user to version {0}.</value></data>
-  <data name="MainChangesetReinstall" xml:space="preserve"><value>Re-install (metadata changed)</value></data>
-  <data name="MainChangesetUserReinstall" xml:space="preserve"><value>Re-install (user requested)</value></data>
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve"><value>Re-install (metadata changed)</value></data>
+  <data name="MainChangesetReinstallMissing" xml:space="preserve"><value>Re-install (missing folders or files)</value></data>
+  <data name="MainChangesetReinstallUser" xml:space="preserve"><value>Re-install (user requested)</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Import Mods</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Mods (*.zip)|*.zip</value></data>
   <data name="MainImportWaitTitle" xml:space="preserve"><value>Status log</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -280,6 +280,8 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ModInfoNotCached" xml:space="preserve"><value>This mod is not in the cache, click 'Download' to preview contents</value></data>
   <data name="ModInfoCached" xml:space="preserve"><value>Module is cached, preview available</value></data>
   <data name="ModInfoNoDownload" xml:space="preserve"><value>Module has no download</value></data>
+  <data name="ModInfoFolderNotFound" xml:space="preserve"><value>Folder not found!</value></data>
+  <data name="ModInfoFileNotFound" xml:space="preserve"><value>File not found!</value></data>
   <data name="ModInfoHomepageLabel" xml:space="preserve"><value>Home page:</value></data>
   <data name="ModInfoSpaceDockLabel" xml:space="preserve"><value>SpaceDock:</value></data>
   <data name="ModInfoCurseLabel" xml:space="preserve"><value>Curse:</value></data>

--- a/GUI/Properties/Resources.ru-RU.resx
+++ b/GUI/Properties/Resources.ru-RU.resx
@@ -187,7 +187,7 @@
   <data name="AllModVersionsInstallYes" xml:space="preserve"><value>Установить</value></data>
   <data name="AllModVersionsInstallNo" xml:space="preserve"><value>Отмена</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Обновить выбранное пользователем до версии {0}.</value></data>
-  <data name="MainChangesetReinstall" xml:space="preserve"><value>Переустановка (Метаданные изменены)</value></data>
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve"><value>Переустановка (Метаданные изменены)</value></data>
   <data name="MainImportTitle" xml:space="preserve"><value>Импортировать модификации</value></data>
   <data name="MainImportFilter" xml:space="preserve"><value>Модификации (*.zip)|*.zip</value></data>
   <data name="MainImportWaitTitle" xml:space="preserve"><value>Журнал</value></data>

--- a/GUI/Properties/Resources.zh-CN.resx
+++ b/GUI/Properties/Resources.zh-CN.resx
@@ -354,10 +354,10 @@
   <data name="MainChangesetUpdateSelected" xml:space="preserve">
     <value>用户选择更新到 {0} 版本.</value>
   </data>
-  <data name="MainChangesetReinstall" xml:space="preserve">
+  <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve">
     <value>重新安装 (元数据已更改)</value>
   </data>
-  <data name="MainChangesetUserReinstall" xml:space="preserve">
+  <data name="MainChangesetReinstallUser" xml:space="preserve">
     <value>重新安装 (用户请求)</value>
   </data>
   <data name="MainImportTitle" xml:space="preserve">

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -27,7 +27,7 @@ namespace Tests.GUI
         public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList();
-            Assert.That(item.ComputeUserChangeSet(null, null, null, null, null), Is.Empty);
+            Assert.That(item.ComputeUserChangeSet(Registry.Empty(), null, null, null, null), Is.Empty);
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace Tests.GUI
                 {
                     // Install the "other" module
                     installer.InstallList(
-                        modList.ComputeUserChangeSet(null, null, null, null, null).Select(change => change.Mod).ToList(),
+                        modList.ComputeUserChangeSet(Registry.Empty(), null, null, null, null).Select(change => change.Mod).ToList(),
                         new RelationshipResolverOptions(),
                         registryManager,
                         ref possibleConfigOnlyDirs,


### PR DESCRIPTION
## Problem

Discord user `dan` reported frequent prompts from the dev build to reinstall mods after running the game, which said "metadata changed" even though the metadata for those mods had either never changed or changed over two years previously:

![image](https://github.com/user-attachments/assets/d9e481c2-87d3-4788-885b-096d2d047a62)

## Cause

This turned out to be due to ZeroMiniAVC, which deletes files that CKAN installed. The feature from KSP-CKAN/CKAN#4067 detects that as a mod with missing files and prompts the user to reinstall that mod.

This was challenging to figure out for a CKAN developer and a dev build power user. It should be understandable for anyone.

## Changes

- Now if a reinstall is due to a missing folder or file, the change reason says "Re-install (missing folders or files)"
- Now the Contents tab shows missing folders and files in red, with a "Folder not found!" or "File not found!" tooltip, and scrolls to the first one when there are any
- Now the Contents tab shows empty folders (previously hidden)
- Now the Contents tab hides paths that are matched by the installation filters from #3458 (previously shown)
- Now the Contents tab's double-click-to-open-in-file-explorer feature works more reliably when CKAN isn't started from the game folder

Separately, KSP-CKAN/NetKAN#10230 is updating ZeroMiniAVC's metdata to direct users to the CKAN setting they should be using instead.
