### PR TITLE
Skip corrupted .acf files in Steam library

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -262,6 +262,22 @@ namespace CKAN.Extensions
             => source.Select(val => pattern.TryMatch(val, out Match? match) ? match : null)
                      .OfType<Match>();
 
+        /// <summary>
+        /// Apply a function to a sequence and handle any exceptions that are thrown
+        /// </summary>
+        /// <typeparam name="TSrc">Type of source sequence</typeparam>
+        /// <typeparam name="TDest">Type of destination sequence</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="func">Function to apply to each item</param>
+        /// <param name="onThrow">Function to call if there's an exception</param>
+        /// <returns>Sequence of return values of given function</returns>
+        public static IEnumerable<TDest?> SelectWithCatch<TSrc, TDest>(this IEnumerable<TSrc>       source,
+                                                                      Func<TSrc, TDest>             func,
+                                                                      Func<TSrc, Exception, TDest?> onThrow)
+                where TDest : class
+            => source.Select(item => Utilities.DefaultIfThrows(()  => func(item),
+                                                               exc => onThrow(item, exc)));
+
     }
 
     /// <summary>

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -28,15 +28,23 @@ namespace CKAN
             "nl-NL",
         };
 
-        public static T? DefaultIfThrows<T>(Func<T?> func) where T : class
+        /// <summary>
+        /// Call a function and take a default action if it throws an exception
+        /// </summary>
+        /// <typeparam name="T">Return type of the function</typeparam>
+        /// <param name="func">Function to call</param>
+        /// <param name="onThrow">Function to call if an exception is thrown</param>
+        /// <returns>Return value of the function</returns>
+        public static T? DefaultIfThrows<T>(Func<T?>             func,
+                                            Func<Exception, T?>? onThrow = null) where T : class
         {
             try
             {
                 return func();
             }
-            catch
+            catch (Exception exc)
             {
-                return default;
+                return onThrow?.Invoke(exc) ?? default;
             }
         }
 


### PR DESCRIPTION
## Problem

After the v1.35.0 release, several users reported an exception at launch:

```
Unhandled Exception: ValveKeyValue.KeyValueException: Found end of file when another token type was expected. ---> System.InvalidOperationException: Attempted to finalize object while in state InObjectBetweenKeyAndValue.
   at ValveKeyValue.Deserialization.KV1TextReader.FinalizeCurrentObject(Boolean explicit)
   at ValveKeyValue.Deserialization.KV1TextReader.FinalizeDocument()
   at ValveKeyValue.Deserialization.KV1TextReader.ReadObject()
   --- End of inner exception stack trace ---
   at ValveKeyValue.Deserialization.KV1TextReader.ReadObject()
   at ValveKeyValue.KVSerializer.Deserialize(Stream stream, KVSerializerOptions options)
   at CKAN.SteamLibrary.<>c__DisplayClass3_0.<LibraryPathGames>b__0(String acfFile)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
   at System.Linq.Enumerable.<ConcatIterator>d__59`1.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at CKAN.SteamLibrary..ctor()
   at CKAN.GameInstanceManager..ctor(IUser user, IConfiguration configuration)
   at CKAN.CmdLine.MainClass.Execute(GameInstanceManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

## Cause

@Halbann reports:

> I stepped through the code and found it was just one acf file responsible that was just a few hundred null bytes with no text. I don't own the game it was for anymore. I deleted the file and CKAN worked fine after that.
> 
> Side note: the file was last modified in 2018 so it had obviously been there corrupted for some time without Steam cleaning it up.

Apparently Steam sometimes corrupts one of the important files in its database and then just leaves it there (in addition to leaving a bunch of empty folders after it disables a DLC, see #4002). (Windows may be partly responsible, since this all-null file strongly is strongly reminiscent of #4078, which our code would never cause if the OS ran it as written.) Once this happens, `KeyValueValue.KVSerializer.Deserialize` throws an exception when asked to read such a file.

## Changes

Now if `Deserialize` throws an exception, we log a warning and continue with the other `.acf` files.

We will continue to investigate this as other affected users report back, in case they are experiencing the same issue with different causes, but for now this is one definite problem we can address.

Fixes #4197.
