### PR TITLE
Fix label color blending

### DIFF
--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -392,6 +392,8 @@ namespace CKAN.GUI
                                                                       .Where(l => l.ContainsModule(game, mod.Identifier))
                                                                       .Select(l => l.Color)
                                                                       .OfType<Color>()
+                                                                      // No transparent blending
+                                                                      .Where(c => c.A == byte.MaxValue)
                                                                       .ToArray())
              : Color.Transparent;
 

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -288,7 +288,10 @@ namespace CKAN.GUI
             => colors.Length <  1 ? Color.Empty
              //: colors is [var c] ? c
              : colors.Length == 1 && colors[0] is var c ? c
-             : colors.Aggregate((back, fore) => fore.AlphaBlendWith(1f / colors.Length, back));
+             : Color.FromArgb(colors.Sum(c => c.A) / colors.Length,
+                              colors.Sum(c => c.R) / colors.Length,
+                              colors.Sum(c => c.G) / colors.Length,
+                              colors.Sum(c => c.B) / colors.Length);
 
         public static Color AlphaBlendWith(this Color c1, float alpha, Color c2)
             => AddColors(c1.MultiplyBy(alpha),


### PR DESCRIPTION
## Problem

If you apply multiple labels to the same mod, some weird visual artifacts can happen; the affected row can have the text of multiple mods overlapping each other:

![image](https://github.com/user-attachments/assets/8549d68a-6eba-4016-8631-20f27b43cd1e)

## Causes

- Apparently `DataGridView` can only handle row colors with an alpha channel of 0 or 255; if you set anything in between, it gets confused and basically seems to not paint the row
- If a label has a transparent background color, blending it with a solid color produces an alpha channel of 127, which confuses the grid as per above
- `Util.BlendColors` is implemented in terms of `Util.AlphaBlendWith`, which uses a floating point alpha channel to compute what it would look like if one color was overlaid over the other with the given level of transparency. Unfortunately, even for two colors with an alpha channel of 255, this can produce a blended color with an alpha channel of 254, which is still enough to confuse the grid.

## Changes

- Now when we blend label colors, transparent labels are excluded
- Now label color blending is done with integer math only, so no rounding errors can creep into the alpha channel

Fixes #4202.
