### PR TITLE
Improvements for missing file checks

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -170,8 +170,9 @@ namespace CKAN.Extensions
         /// <param name="getNext">Function to go from one node to the next</param>
         /// <returns>All the nodes in the list as a sequence</returns>
         public static IEnumerable<T> TraverseNodes<T>(this T start, Func<T, T?> getNext)
+            where T : class
         {
-            for (T? t = start; t != null; t = getNext(t))
+            for (T? t = start; t != null; t = Utilities.DefaultIfThrows(() => getNext(t)))
             {
                 yield return t;
             }

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
+using Autofac;
 using log4net;
 
+using CKAN.Configuration;
 using CKAN.Versioning;
 using CKAN.Games;
 #if NETSTANDARD2_0
@@ -174,6 +176,7 @@ namespace CKAN
         public static bool HasUpdate(this IRegistryQuerier    querier,
                                      string                   identifier,
                                      GameInstance?            instance,
+                                     HashSet<string>          filters,
                                      out CkanModule?          latestMod,
                                      ICollection<CkanModule>? installed = null)
         {
@@ -205,6 +208,8 @@ namespace CKAN
                               && (instance == null
                                   || (querier.InstalledModule(identifier)
                                              ?.Files
+                                              // Don't make them reinstall files they've filtered out since installing
+                                              .Where(f => !filters.Any(filt => f.Contains(filt)))
                                               .Select(instance.ToAbsoluteGameDir)
                                               .All(p => Directory.Exists(p) || File.Exists(p))
                                              // Manually installed, consider up to date
@@ -224,12 +229,17 @@ namespace CKAN
                                                                           GameInstance?         instance,
                                                                           HashSet<string>       heldIdents)
         {
+            var filters = ServiceLocator.Container.Resolve<IConfiguration>()
+                                                  .GlobalInstallFilters
+                                                  .Concat(instance?.InstallFilters
+                                                                  ?? Enumerable.Empty<string>())
+                                                  .ToHashSet();
             // Get the absolute latest versions ignoring restrictions,
             // to break out of mutual version-depending deadlocks
             var unlimited = querier.Installed(false)
                                    .Keys
                                    .Select(ident => !heldIdents.Contains(ident)
-                                                    && querier.HasUpdate(ident, instance,
+                                                    && querier.HasUpdate(ident, instance, filters,
                                                                          out CkanModule? latest)
                                                     && latest is not null
                                                     && !latest.IsDLC
@@ -237,21 +247,27 @@ namespace CKAN
                                                         : querier.GetInstalledVersion(ident))
                                    .OfType<CkanModule>()
                                    .ToList();
-            return querier.CheckUpgradeable(instance, heldIdents, unlimited);
+            return querier.CheckUpgradeable(instance, heldIdents, unlimited, filters);
         }
 
         public static Dictionary<bool, List<CkanModule>> CheckUpgradeable(this IRegistryQuerier querier,
                                                                           GameInstance?         instance,
                                                                           HashSet<string>       heldIdents,
-                                                                          List<CkanModule>      initial)
+                                                                          List<CkanModule>      initial,
+                                                                          HashSet<string>?      filters = null)
         {
+            filters ??= ServiceLocator.Container.Resolve<IConfiguration>()
+                                                .GlobalInstallFilters
+                                                .Concat(instance?.InstallFilters
+                                                                ?? Enumerable.Empty<string>())
+                                                .ToHashSet();
             // Use those as the installed modules
             var upgradeable    = new List<CkanModule>();
             var notUpgradeable = new List<CkanModule>();
             foreach (var ident in initial.Select(module => module.identifier))
             {
                 if (!heldIdents.Contains(ident)
-                    && querier.HasUpdate(ident, instance,
+                    && querier.HasUpdate(ident, instance, filters,
                                          out CkanModule? latest, initial)
                     && latest is not null
                     && !latest.IsDLC)

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -209,11 +208,7 @@ namespace CKAN
                               && (!checkMissingFiles
                                   || instance == null
                                   || (querier.InstalledModule(identifier)
-                                             ?.Files
-                                              // Don't make them reinstall files they've filtered out since installing
-                                              .Where(f => !filters.Any(filt => f.Contains(filt)))
-                                              .Select(instance.ToAbsoluteGameDir)
-                                              .All(p => Directory.Exists(p) || File.Exists(p))
+                                             ?.AllFilesExist(instance, filters)
                                              // Manually installed, consider up to date
                                              ?? true))))
             {

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -45,10 +45,10 @@ namespace CKAN
         [JsonProperty]
         private Dictionary<string, InstalledModuleFile> installed_files;
 
-        public IEnumerable<string> Files       => installed_files.Keys;
-        public string              identifier  => source_module.identifier;
-        public CkanModule          Module      => source_module;
-        public DateTime            InstallTime => install_time;
+        public IReadOnlyCollection<string> Files       => installed_files.Keys;
+        public string                      identifier  => source_module.identifier;
+        public CkanModule                  Module      => source_module;
+        public DateTime                    InstallTime => install_time;
 
         public bool AutoInstalled
         {

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.ComponentModel;
 using System.Collections.Generic;
 using System.IO;
@@ -131,6 +132,13 @@ namespace CKAN
         }
 
         #endregion
+
+        public bool AllFilesExist(GameInstance    instance,
+                                  HashSet<string> filters)
+            // Don't make them reinstall files they've filtered out since installing
+            => Files.Where(f => !filters.Any(filt => f.Contains(filt)))
+                    .Select(instance.ToAbsoluteGameDir)
+                    .All(p => Directory.Exists(p) || File.Exists(p));
 
         public override string ToString()
             => string.Format(AutoInstalled ? Properties.Resources.InstalledModuleToStringAutoInstalled

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -538,19 +538,18 @@ namespace CKAN.GUI
         {
             WithFrozenChangeset(() =>
             {
-                foreach (var gmod in mainModList.full_list_of_mod_rows
-                                                .Values
-                                                .Select(row => row.Tag)
-                                                .OfType<GUIMod>())
+                var checkboxes = mainModList.full_list_of_mod_rows
+                                            .Values
+                                            .Where(row => row.Tag is GUIMod {Identifier: string ident}
+                                                          && (!Main.Instance?.LabelsHeld(ident) ?? false))
+                                            .SelectWithCatch(row => row.Cells[UpdateCol.Index],
+                                                             (row, exc) => null)
+                                            .OfType<DataGridViewCheckBoxCell>();
+                foreach (var checkbox in checkboxes)
                 {
-                    if (gmod?.HasUpdate ?? false)
-                    {
-                        if (!Main.Instance?.LabelsHeld(gmod.Identifier) ?? false)
-                        {
-                            gmod.SelectedMod = gmod.LatestCompatibleMod;
-                        }
-                    }
+                    checkbox.Value = true;
                 }
+                ModGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
 
                 // only sort by Update column if checkbox in settings checked
                 if (guiConfig?.AutoSortByUpdate ?? false)

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -335,24 +335,27 @@ namespace CKAN.GUI
 
         private void labelMenuItem_Click(object? sender, EventArgs? e)
         {
-            if (user != null && manager != null && currentInstance != null && SelectedModule != null)
+            if (user != null
+                && manager != null
+                && currentInstance != null
+                && SelectedModule != null
+                && sender is ToolStripMenuItem item
+                && item.Tag is ModuleLabel mlbl)
             {
-                var item   = sender    as ToolStripMenuItem;
-                var mlbl   = item?.Tag as ModuleLabel;
-                if (item?.Checked ?? false)
+                if (item.Checked)
                 {
-                    mlbl?.Add(currentInstance.game, SelectedModule.Identifier);
+                    mlbl.Add(currentInstance.game, SelectedModule.Identifier);
                 }
                 else
                 {
-                    mlbl?.Remove(currentInstance.game, SelectedModule.Identifier);
+                    mlbl.Remove(currentInstance.game, SelectedModule.Identifier);
                 }
                 var registry = RegistryManager.Instance(currentInstance, repoData).registry;
                 mainModList.ReapplyLabels(SelectedModule, Conflicts?.ContainsKey(SelectedModule) ?? false,
                                           currentInstance.Name, currentInstance.game, registry);
                 ModuleLabelList.ModuleLabels.Save(ModuleLabelList.DefaultPath);
                 UpdateHiddenTagsAndLabels();
-                if (mlbl?.HoldVersion ?? false)
+                if (mlbl.HoldVersion || mlbl.IgnoreMissingFiles)
                 {
                     UpdateCol.Visible = UpdateAllToolButton.Enabled =
                         mainModList.ResetHasUpdate(currentInstance, registry, ChangeSet, ModGrid.Rows);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -934,7 +934,7 @@ namespace CKAN.GUI
                                             : gmod.LatestCompatibleMod
                                         : gmod.InstalledMod?.Module;
 
-                                    if (nowChecked && gmod.SelectedMod == gmod.LatestCompatibleMod)
+                                    if (gmod.SelectedMod == gmod.LatestCompatibleMod)
                                     {
                                         // Reinstall, force update without change
                                         UpdateChangeSetAndConflicts(currentInstance,

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -7,6 +7,7 @@ using System.Runtime.Versioning;
 
 using Autofac;
 
+using CKAN.Configuration;
 using CKAN.Versioning;
 using CKAN.GUI.Attributes;
 
@@ -137,6 +138,19 @@ namespace CKAN.GUI
                 {
                     var pageToAlert = module.IsCompatible(crit) ? RelationshipTabPage : VersionsTabPage;
                     pageToAlert.ImageKey = "Stop";
+                }
+                if (manager?.CurrentInstance is GameInstance inst)
+                {
+                    var filters = ServiceLocator.Container.Resolve<IConfiguration>()
+                                                          .GlobalInstallFilters
+                                                          .Concat(inst.InstallFilters)
+                                                          .ToHashSet();
+                    ContentTabPage.ImageKey = ModuleLabels.IgnoreMissingIdentifiers(inst)
+                                                          .Contains(gmod.Identifier)
+                                              || (gmod.InstalledMod?.AllFilesExist(inst, filters)
+                                                                   ?? true)
+                                                  ? ""
+                                                  : "Stop";
                 }
 
                 ModInfoTabControl.ResumeLayout();

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -190,10 +190,11 @@ namespace CKAN.GUI
                                                          dir, exists);
                                     }
                                     rootNode.ExpandAll();
-                                    var initialFocus = FirstMatching(rootNode,
-                                                                     n => n.ForeColor == Color.Red)
-                                                       ?? rootNode;
-                                    initialFocus.EnsureVisible();
+                                    // First scroll to the top
+                                    rootNode.EnsureVisible();
+                                    // Then scroll down to the first red node
+                                    FirstMatching(rootNode, n => n.ForeColor == Color.Red)
+                                        ?.EnsureVisible();
                                     ContentsPreviewTree.EndUpdate();
                                     UseWaitCursor = false;
                                 });

--- a/GUI/Dialogs/EditLabelsDialog.Designer.cs
+++ b/GUI/Dialogs/EditLabelsDialog.Designer.cs
@@ -46,6 +46,7 @@ namespace CKAN.GUI
             this.AlertOnInstallCheckBox = new System.Windows.Forms.CheckBox();
             this.RemoveOnInstallCheckBox = new System.Windows.Forms.CheckBox();
             this.HoldVersionCheckBox = new System.Windows.Forms.CheckBox();
+            this.IgnoreMissingFilesCheckBox = new System.Windows.Forms.CheckBox();
             this.CreateButton = new System.Windows.Forms.Button();
             this.CloseButton = new System.Windows.Forms.Button();
             this.SaveButton = new System.Windows.Forms.Button();
@@ -67,6 +68,8 @@ namespace CKAN.GUI
             // 
             this.CreateButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
+            this.CreateButton.AutoSize = true;
+            this.CreateButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.CreateButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CreateButton.Location = new System.Drawing.Point(10, 10);
             this.CreateButton.Name = "CreateButton";
@@ -121,6 +124,7 @@ namespace CKAN.GUI
             this.EditDetailsPanel.Controls.Add(this.AlertOnInstallCheckBox);
             this.EditDetailsPanel.Controls.Add(this.RemoveOnInstallCheckBox);
             this.EditDetailsPanel.Controls.Add(this.HoldVersionCheckBox);
+            this.EditDetailsPanel.Controls.Add(this.IgnoreMissingFilesCheckBox);
             this.EditDetailsPanel.Controls.Add(this.SaveButton);
             this.EditDetailsPanel.Controls.Add(this.CancelEditButton);
             this.EditDetailsPanel.Controls.Add(this.DeleteButton);
@@ -192,6 +196,8 @@ namespace CKAN.GUI
             // 
             this.ColorButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
+            this.ColorButton.AutoSize = true;
+            this.ColorButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.ColorButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ColorButton.Location = new System.Drawing.Point(118, 40);
             this.ColorButton.Name = "ColorButton";
@@ -231,7 +237,7 @@ namespace CKAN.GUI
             // 
             this.NotifyOnChangesCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
             this.NotifyOnChangesCheckBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.NotifyOnChangesCheckBox.Location = new System.Drawing.Point(118, 130);
+            this.NotifyOnChangesCheckBox.Location = new System.Drawing.Point(118, 124);
             this.NotifyOnChangesCheckBox.Name = "NotifyOnChangesCheckBox";
             this.NotifyOnChangesCheckBox.Size = new System.Drawing.Size(200, 23);
             resources.ApplyResources(this.NotifyOnChangesCheckBox, "NotifyOnChangesCheckBox");
@@ -240,7 +246,7 @@ namespace CKAN.GUI
             // 
             this.RemoveOnChangesCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
             this.RemoveOnChangesCheckBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RemoveOnChangesCheckBox.Location = new System.Drawing.Point(118, 160);
+            this.RemoveOnChangesCheckBox.Location = new System.Drawing.Point(118, 148);
             this.RemoveOnChangesCheckBox.Name = "RemoveOnChangesCheckBox";
             this.RemoveOnChangesCheckBox.Size = new System.Drawing.Size(200, 23);
             resources.ApplyResources(this.RemoveOnChangesCheckBox, "RemoveOnChangesCheckBox");
@@ -249,7 +255,7 @@ namespace CKAN.GUI
             // 
             this.AlertOnInstallCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
             this.AlertOnInstallCheckBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.AlertOnInstallCheckBox.Location = new System.Drawing.Point(118, 190);
+            this.AlertOnInstallCheckBox.Location = new System.Drawing.Point(118, 172);
             this.AlertOnInstallCheckBox.Name = "AlertOnInstallCheckBox";
             this.AlertOnInstallCheckBox.Size = new System.Drawing.Size(200, 23);
             resources.ApplyResources(this.AlertOnInstallCheckBox, "AlertOnInstallCheckBox");
@@ -258,7 +264,7 @@ namespace CKAN.GUI
             // 
             this.RemoveOnInstallCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
             this.RemoveOnInstallCheckBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RemoveOnInstallCheckBox.Location = new System.Drawing.Point(118, 220);
+            this.RemoveOnInstallCheckBox.Location = new System.Drawing.Point(118, 196);
             this.RemoveOnInstallCheckBox.Name = "RemoveOnInstallCheckBox";
             this.RemoveOnInstallCheckBox.Size = new System.Drawing.Size(200, 23);
             resources.ApplyResources(this.RemoveOnInstallCheckBox, "RemoveOnInstallCheckBox");
@@ -267,15 +273,26 @@ namespace CKAN.GUI
             // 
             this.HoldVersionCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
             this.HoldVersionCheckBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.HoldVersionCheckBox.Location = new System.Drawing.Point(118, 250);
+            this.HoldVersionCheckBox.Location = new System.Drawing.Point(118, 220);
             this.HoldVersionCheckBox.Name = "HoldVersionCheckBox";
             this.HoldVersionCheckBox.Size = new System.Drawing.Size(200, 23);
             resources.ApplyResources(this.HoldVersionCheckBox, "HoldVersionCheckBox");
+            //
+            // IgnoreMissingFilesCheckBox
+            //
+            this.IgnoreMissingFilesCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left));
+            this.IgnoreMissingFilesCheckBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.IgnoreMissingFilesCheckBox.Location = new System.Drawing.Point(118, 244);
+            this.IgnoreMissingFilesCheckBox.Name = "IgnoreMissingFilesCheckBox";
+            this.IgnoreMissingFilesCheckBox.Size = new System.Drawing.Size(200, 23);
+            resources.ApplyResources(this.IgnoreMissingFilesCheckBox, "IgnoreMissingFilesCheckBox");
             // 
             // SaveButton
             // 
             this.SaveButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
+            this.SaveButton.AutoSize = true;
+            this.SaveButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.SaveButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.SaveButton.Location = new System.Drawing.Point(38, 320);
             this.SaveButton.Name = "SaveButton";
@@ -289,6 +306,8 @@ namespace CKAN.GUI
             // 
             this.CancelEditButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
+            this.CancelEditButton.AutoSize = true;
+            this.CancelEditButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.CancelEditButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CancelEditButton.Location = new System.Drawing.Point(118, 320);
             this.CancelEditButton.Name = "CancelEditButton";
@@ -302,6 +321,8 @@ namespace CKAN.GUI
             // 
             this.DeleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
+            this.DeleteButton.AutoSize = true;
+            this.DeleteButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.DeleteButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.DeleteButton.Location = new System.Drawing.Point(198, 320);
             this.DeleteButton.Name = "DeleteButton";
@@ -315,6 +336,8 @@ namespace CKAN.GUI
             // 
             this.CloseButton.Anchor = ((System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Bottom
             | System.Windows.Forms.AnchorStyles.Left));
+            this.CloseButton.AutoSize = true;
+            this.CloseButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.CloseButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CloseButton.Location = new System.Drawing.Point(10, 397);
             this.CloseButton.Name = "CloseButton";
@@ -362,6 +385,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.CheckBox AlertOnInstallCheckBox;
         private System.Windows.Forms.CheckBox RemoveOnInstallCheckBox;
         private System.Windows.Forms.CheckBox HoldVersionCheckBox;
+        private System.Windows.Forms.CheckBox IgnoreMissingFilesCheckBox;
         private System.Windows.Forms.Label ColorLabel;
         private System.Windows.Forms.Button ColorButton;
         private System.Windows.Forms.Button CreateButton;

--- a/GUI/Dialogs/EditLabelsDialog.cs
+++ b/GUI/Dialogs/EditLabelsDialog.cs
@@ -33,6 +33,7 @@ namespace CKAN.GUI
             ToolTip.SetToolTip(AlertOnInstallCheckBox, Properties.Resources.EditLabelsToolTipAlertOnInstall);
             ToolTip.SetToolTip(RemoveOnInstallCheckBox, Properties.Resources.EditLabelsToolTipRemoveOnInstall);
             ToolTip.SetToolTip(HoldVersionCheckBox, Properties.Resources.EditLabelsToolTipHoldVersion);
+            ToolTip.SetToolTip(IgnoreMissingFilesCheckBox, Properties.Resources.EditLabelsToolTipIgnoreMissingFiles);
             ToolTip.SetToolTip(MoveUpButton, Properties.Resources.EditLabelsToolTipMoveUp);
             ToolTip.SetToolTip(MoveDownButton, Properties.Resources.EditLabelsToolTipMoveDown);
         }
@@ -204,6 +205,7 @@ namespace CKAN.GUI
             AlertOnInstallCheckBox.Checked       = lbl.AlertOnInstall;
             RemoveOnInstallCheckBox.Checked      = lbl.RemoveOnInstall;
             HoldVersionCheckBox.Checked          = lbl.HoldVersion;
+            IgnoreMissingFilesCheckBox.Checked   = lbl.IgnoreMissingFiles;
 
             DeleteButton.Enabled = labels.Labels.Contains(lbl);
             EnableDisableUpDownButtons();
@@ -300,12 +302,13 @@ namespace CKAN.GUI
                     || string.IsNullOrWhiteSpace(InstanceNameComboBox.SelectedItem.ToString())
                         ? null
                         : InstanceNameComboBox.SelectedItem.ToString();
-                currentlyEditing.Hide            = HideFromOtherFiltersCheckBox.Checked;
-                currentlyEditing.NotifyOnChange  = NotifyOnChangesCheckBox.Checked;
-                currentlyEditing.RemoveOnChange  = RemoveOnChangesCheckBox.Checked;
-                currentlyEditing.AlertOnInstall  = AlertOnInstallCheckBox.Checked;
-                currentlyEditing.RemoveOnInstall = RemoveOnInstallCheckBox.Checked;
-                currentlyEditing.HoldVersion     = HoldVersionCheckBox.Checked;
+                currentlyEditing.Hide               = HideFromOtherFiltersCheckBox.Checked;
+                currentlyEditing.NotifyOnChange     = NotifyOnChangesCheckBox.Checked;
+                currentlyEditing.RemoveOnChange     = RemoveOnChangesCheckBox.Checked;
+                currentlyEditing.AlertOnInstall     = AlertOnInstallCheckBox.Checked;
+                currentlyEditing.RemoveOnInstall    = RemoveOnInstallCheckBox.Checked;
+                currentlyEditing.HoldVersion        = HoldVersionCheckBox.Checked;
+                currentlyEditing.IgnoreMissingFiles = IgnoreMissingFilesCheckBox.Checked;
                 if (!labels.Labels.Contains(currentlyEditing))
                 {
                     labels.Labels = labels.Labels
@@ -367,16 +370,16 @@ namespace CKAN.GUI
                               ? null
                               : InstanceNameComboBox.SelectedItem.ToString();
             return EditDetailsPanel.Visible && currentlyEditing != null
-                && (   currentlyEditing.Name            != NameTextBox.Text
-                    || currentlyEditing.Color           != ColorButton.BackColor
-                    || currentlyEditing.InstanceName    != newInst
-                    || currentlyEditing.Hide            != HideFromOtherFiltersCheckBox.Checked
-                    || currentlyEditing.NotifyOnChange  != NotifyOnChangesCheckBox.Checked
-                    || currentlyEditing.RemoveOnChange  != RemoveOnChangesCheckBox.Checked
-                    || currentlyEditing.AlertOnInstall  != AlertOnInstallCheckBox.Checked
-                    || currentlyEditing.RemoveOnInstall != RemoveOnInstallCheckBox.Checked
-                    || currentlyEditing.HoldVersion     != HoldVersionCheckBox.Checked
-                );
+                && (   currentlyEditing.Name               != NameTextBox.Text
+                    || currentlyEditing.Color              != ColorButton.BackColor
+                    || currentlyEditing.InstanceName       != newInst
+                    || currentlyEditing.Hide               != HideFromOtherFiltersCheckBox.Checked
+                    || currentlyEditing.NotifyOnChange     != NotifyOnChangesCheckBox.Checked
+                    || currentlyEditing.RemoveOnChange     != RemoveOnChangesCheckBox.Checked
+                    || currentlyEditing.AlertOnInstall     != AlertOnInstallCheckBox.Checked
+                    || currentlyEditing.RemoveOnInstall    != RemoveOnInstallCheckBox.Checked
+                    || currentlyEditing.HoldVersion        != HoldVersionCheckBox.Checked
+                    || currentlyEditing.IgnoreMissingFiles != IgnoreMissingFilesCheckBox.Checked);
         }
 
         private          ModuleLabel?    currentlyEditing;

--- a/GUI/Dialogs/EditLabelsDialog.resx
+++ b/GUI/Dialogs/EditLabelsDialog.resx
@@ -130,6 +130,7 @@
   <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Alert on install</value></data>
   <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Remove on install</value></data>
   <data name="HoldVersionCheckBox.Text" xml:space="preserve"><value>Don't upgrade</value></data>
+  <data name="IgnoreMissingFilesCheckBox.Text" xml:space="preserve"><value>Ignore missing files</value></data>
   <data name="CloseButton.Text" xml:space="preserve"><value>Close</value></data>
   <data name="SaveButton.Text" xml:space="preserve"><value>Save</value></data>
   <data name="CancelEditButton.Text" xml:space="preserve"><value>Cancel</value></data>

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -22,6 +22,8 @@ namespace CKAN.GUI
             this.instance     = instance;
         }
 
+        public bool Changed { get; private set; } = false;
+
         /// <summary>
         /// Open the user guide when the user presses F1
         /// </summary>
@@ -48,8 +50,12 @@ namespace CKAN.GUI
 
         private void InstallFiltersDialog_Closing(object? sender, CancelEventArgs? e)
         {
-            globalConfig.GlobalInstallFilters = GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
-            instance.InstallFilters = InstanceFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+            var newGlobal = GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+            var newInstance = InstanceFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+            Changed = !globalConfig.GlobalInstallFilters.SequenceEqual(newGlobal)
+                      || !instance.InstallFilters.SequenceEqual(newInstance);
+            globalConfig.GlobalInstallFilters = newGlobal;
+            instance.InstallFilters = newInstance;
         }
 
         private void AddMiniAVCButton_Click(object? sender, EventArgs? e)
@@ -57,8 +63,7 @@ namespace CKAN.GUI
             GlobalFiltersTextBox.Text = string.Join(Environment.NewLine,
                 GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries)
                     .Concat(miniAVC)
-                    .Distinct()
-            );
+                    .Distinct());
         }
 
         private readonly IConfiguration globalConfig;

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -57,6 +57,10 @@ namespace CKAN.GUI
         [DefaultValue(false)]
         public bool    HoldVersion;
 
+        [JsonProperty("ignore_missing_files", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(false)]
+        public bool    IgnoreMissingFiles;
+
         [JsonProperty("module_identifiers_by_game", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonToGamesDictionaryConverter))]
         private readonly Dictionary<string, HashSet<string>> ModuleIdentifiers =

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -83,5 +83,10 @@ namespace CKAN.GUI
             => LabelsFor(inst.Name).Where(l => l.HoldVersion)
                                    .SelectMany(l => l.IdentifiersFor(inst.game))
                                    .Distinct();
+
+        public IEnumerable<string> IgnoreMissingIdentifiers(GameInstance inst)
+            => LabelsFor(inst.Name).Where(l => l.IgnoreMissingFiles)
+                                   .SelectMany(l => l.IdentifiersFor(inst.game))
+                                   .Distinct();
     }
 }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -724,6 +724,12 @@ namespace CKAN.GUI
                 var dlg = new InstallFiltersDialog(ServiceLocator.Container.Resolve<IConfiguration>(), CurrentInstance);
                 dlg.ShowDialog(this);
                 Enabled = true;
+                if (dlg.Changed)
+                {
+                    // The Update checkbox might appear or disappear if missing files were or are filtered out
+                    RefreshModList(false);
+                    ModInfo.RefreshModContentsTree();
+                }
             }
         }
 

--- a/GUI/Main/MainLabels.cs
+++ b/GUI/Main/MainLabels.cs
@@ -68,6 +68,11 @@ namespace CKAN.GUI
                 && ModuleLabelList.ModuleLabels.LabelsFor(CurrentInstance.Name)
                                                .Any(l => l.HoldVersion && l.ContainsModule(CurrentInstance.game, identifier));
 
+        public bool LabelsIgnoreMissing(string identifier)
+            => CurrentInstance != null
+                && ModuleLabelList.ModuleLabels.LabelsFor(CurrentInstance.Name)
+                                               .Any(l => l.IgnoreMissingFiles && l.ContainsModule(CurrentInstance.game, identifier));
+
         #endregion
     }
 }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -470,14 +470,17 @@ namespace CKAN.GUI
                                          // Skip reinstalls
                                          .Where(upg => upg.Mod != upg.targetMod)
                                          .ToArray();
-                if (upgrades.Length > 0)
+                if (upgrades.Length > 0 && instance != null)
                 {
                     var upgradeable = registry.CheckUpgradeable(instance,
                                                                 // Hold identifiers not chosen for upgrading
                                                                 registry.Installed(false)
                                                                         .Select(kvp => kvp.Key)
                                                                         .Except(upgrades.Select(ch => ch.Mod.identifier))
-                                                                        .ToHashSet())
+                                                                        .ToHashSet(),
+                                                                ModuleLabelList.ModuleLabels
+                                                                               .IgnoreMissingIdentifiers(instance)
+                                                                               .ToHashSet())
                                               [true]
                                               .ToDictionary(m => m.identifier,
                                                             m => m);
@@ -523,6 +526,8 @@ namespace CKAN.GUI
         {
             var upgGroups = registry.CheckUpgradeable(inst,
                                                       ModuleLabelList.ModuleLabels.HeldIdentifiers(inst)
+                                                                                  .ToHashSet(),
+                                                      ModuleLabelList.ModuleLabels.IgnoreMissingIdentifiers(inst)
                                                                                   .ToHashSet());
             var dlls = registry.InstalledDlls.ToList();
             foreach ((var upgradeable, var mods) in upgGroups)
@@ -591,6 +596,8 @@ namespace CKAN.GUI
                                                       bool                  hideV)
             => registry.CheckUpgradeable(inst,
                                          ModuleLabelList.ModuleLabels.HeldIdentifiers(inst)
+                                                                     .ToHashSet(),
+                                         ModuleLabelList.ModuleLabels.IgnoreMissingIdentifiers(inst)
                                                                      .ToHashSet())
                        .SelectMany(kvp => kvp.Value
                                              .Select(mod => registry.IsAutodetected(mod.identifier)

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -583,12 +583,12 @@ namespace CKAN.GUI
                           config?.HideEpochs ?? false, config?.HideV ?? false);
 
         private static IEnumerable<GUIMod> GetGUIMods(IRegistryQuerier      registry,
-                                               RepositoryDataManager repoData,
-                                               GameInstance          inst,
-                                               GameVersionCriteria   versionCriteria,
-                                               HashSet<string>       installedIdents,
-                                               bool                  hideEpochs,
-                                               bool                  hideV)
+                                                      RepositoryDataManager repoData,
+                                                      GameInstance          inst,
+                                                      GameVersionCriteria   versionCriteria,
+                                                      HashSet<string>       installedIdents,
+                                                      bool                  hideEpochs,
+                                                      bool                  hideV)
             => registry.CheckUpgradeable(inst,
                                          ModuleLabelList.ModuleLabels.HeldIdentifiers(inst)
                                                                      .ToHashSet())

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -564,8 +564,13 @@ namespace CKAN.GUI
                         full_list_of_mod_rows[ident] =
                             MakeRow(gmod, ChangeSet, inst.Name, inst.game);
                     var rowIndex = row.Index;
+                    var selected = row.Selected;
                     rows.Remove(row);
                     rows.Insert(rowIndex, newRow);
+                    if (selected)
+                    {
+                        rows[rowIndex].Selected = true;
+                    }
                 }
             }
         }

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -417,6 +417,7 @@ Are you sure you want to skip this change?</value></data>
   <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>If checked, the change set screen will alert you if this mod is about to be installed</value></data>
   <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>If checked, modules will be removed from this label if they are installed</value></data>
   <data name="EditLabelsToolTipHoldVersion" xml:space="preserve"><value>If checked, modules will not be upgraded</value></data>
+  <data name="EditLabelsToolTipIgnoreMissingFiles" xml:space="preserve"><value>If checked, you will not be prompted to re-install missing files for modules with this label</value></data>
   <data name="EditLabelsToolTipMoveUp" xml:space="preserve"><value>Move up</value></data>
   <data name="EditLabelsToolTipMoveDown" xml:space="preserve"><value>Move down</value></data>
   <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Some of your watched mods have updated:

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -271,7 +271,7 @@ namespace Tests.Core.Registry
                 });
 
                 // Act
-                bool has = registry.HasUpdate(mod.identifier, gameInst, new HashSet<string>(), out _);
+                bool has = registry.HasUpdate(mod.identifier, gameInst, new HashSet<string>(), false, out _);
 
                 // Assert
                 Assert.IsTrue(has, "Can't upgrade manually installed DLL");
@@ -327,7 +327,8 @@ namespace Tests.Core.Registry
                 GameVersionCriteria crit = new GameVersionCriteria(olderDepMod?.ksp_version);
 
                 // Act
-                bool has = registry.HasUpdate(olderDepMod?.identifier!, gameInst, new HashSet<string>(), out _,
+                bool has = registry.HasUpdate(olderDepMod?.identifier!, gameInst, new HashSet<string>(), false,
+                                              out _,
                                               registry.InstalledModules
                                                       .Select(im => im.Module)
                                                       .ToList());

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -271,7 +271,7 @@ namespace Tests.Core.Registry
                 });
 
                 // Act
-                bool has = registry.HasUpdate(mod.identifier, gameInst, out _);
+                bool has = registry.HasUpdate(mod.identifier, gameInst, new HashSet<string>(), out _);
 
                 // Assert
                 Assert.IsTrue(has, "Can't upgrade manually installed DLL");
@@ -327,7 +327,7 @@ namespace Tests.Core.Registry
                 GameVersionCriteria crit = new GameVersionCriteria(olderDepMod?.ksp_version);
 
                 // Act
-                bool has = registry.HasUpdate(olderDepMod?.identifier!, gameInst, out _,
+                bool has = registry.HasUpdate(olderDepMod?.identifier!, gameInst, new HashSet<string>(), out _,
                                               registry.InstalledModules
                                                       .Select(im => im.Module)
                                                       .ToList());


### PR DESCRIPTION
## Background

As of #4067, manually deleting files installed by CKAN causes that mod to be shown as having an update that reinstalls the mod to restore the deleted files. This is to ensure that all CKAN-installed mods are installed correctly according to the instructions in their metadata.

## Problems

- If you click Update all, the update checkbox for such mods is not checked
- If you check the Update checkbox for a mod, the changeset is updated with the corresponding action, but unchecking it does _not_ refresh the changeset
- Users may delete certain files from certain mods to disable the functionality from that file. This use case is a good fit for #3458's installation filters, and they do work for this, but the user experience is clunky and can require patience and workarounds:
  - The Contents tab does not obey the installation filters, so it looks like filtered-out files are missing when they aren't supposed to be installed
  - After you edit the installation filters, you have to reinstall the mod to update the installed module metadata, then update the mod list to get it to actually show up as not missing the files
- `FerramAerospaceResearch` contains a file `FARForceDataUpdate.cfg` that it deletes at run-time, which CKAN then detects as a missing file and prompts the user to re-install.
  ![image](https://github.com/user-attachments/assets/57cd9e7d-c325-424d-b508-408f0cb69bf8)

## Causes

- The Update all button is implemented by setting the mod's selected version equal to its latest compatible version. This is already the case for a re-install step, so this doesn't cause its checkbox to become checked.
- Installation filters weren't well-integrated into other features because it wasn't clear it was needed or how it should have been done
- I do not know why FAR does this, but the file is quite old. Maybe it was to affect the Module Manager cache in a particular way? I have queried the modder meta-brain and will update if anybody knows the relevant history.

## Changes

- Now the Update all button checks all of the update checkboxes regardless of the type of change they represent.
  Fixes #4207.
- Now unchecking the Update checkbox refreshes the changeset
- Now the installation filters work better as a way to tell CKAN about files you don't want installed (fixes #4205):
  - The Contents tab obeys the installation filters immediately, so files that you have filtered out won't be shown, and also will not trigger a prompt for re-installation, without having to re-install the mod
  - Changing the installation filters causes the mod list and the Contents tab to be refreshed
  - Note that the installation filters are **not** a good fit for the FAR scenario described above, because the `FARForceDataUpdate.cfg` file should be installed at least once (and presumably re-installed at each upgrade) to ensure the mod works as it's supposed to.
- Now it is possible to create a label with a new "Ignore missing files" option. A mod that does this behavior of deleting its own file can be marked with such a label to suppress re-installation prompting.
  ![image](https://github.com/user-attachments/assets/ecb07ab8-2854-4e6d-8ff7-ab72092cdd6d)
  Fixes #4204.
  - Adding or removing such a label caused the next mod in the list to be selected. Now the same mod remains selected.
  - Adding or removing such a label immediately updates its row in the mod list and the Content tab
  - Note that such a label is **not** a good fit for files the user intentionally deletes, because upgrading the mod or uninstalling and then installing it again later will restore the file, whereas using an installation filter will always ensure it is _never_ installed in the first place.
- Now the Contents tab has a red alert icon on it when files are missing, to help the user figure out why the mod has an Update checkbox available
  ![image](https://github.com/user-attachments/assets/794f1465-38d8-4b14-aed4-a255ad77d470)
