### PR TITLE
Label spacing and alignment, show zero download counts as blank in ConsoleUI

### DIFF
--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -276,13 +276,13 @@ namespace CKAN.ConsoleUI {
             });
 
             // Abstract of currently selected mod under grid
-            AddObject(new ConsoleLabel(1, -1, -1,
+            AddObject(new ConsoleLabel(1, -1, -updatedWidth - 1,
                                        () => moduleList.Selection?.@abstract.Trim() ?? "",
                                        null,
                                        th => th.DimLabelFg));
 
             AddObject(new ConsoleLabel(
-                -searchWidth, -1, -2,
+                -updatedWidth, -1, -1,
                 () => {
                     var days = Math.Round(timeSinceUpdate.TotalDays);
                     return days <  1 ? ""
@@ -294,8 +294,8 @@ namespace CKAN.ConsoleUI {
                     return timeSinceUpdate < RepositoryDataManager.TimeTillStale     ? th.RegistryUpToDate
                         :  timeSinceUpdate < RepositoryDataManager.TimeTillVeryStale ? th.RegistryStale
                         :                                                              th.RegistryVeryStale;
-                }
-            ));
+                },
+                TextAlign.Right));
 
             var opts = new List<ConsoleMenuOption?>() {
                 new ConsoleMenuOption(Properties.Resources.ModListPlayMenu, "",
@@ -765,6 +765,10 @@ namespace CKAN.ConsoleUI {
             Properties.Resources.ModListSearchFocusedGhostText.Length,
             Properties.Resources.ModListSearchUnfocusedGhostText.Length
         ));
+
+        private static readonly int updatedWidth =
+            string.Format(Properties.Resources.ModListUpdatedDaysAgo, 9999)
+                  .Length;
 
         private static readonly string unavailable   = "!";
         private static readonly string notinstalled  = " ";

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -71,8 +71,8 @@ namespace CKAN.ConsoleUI {
                     new ConsoleListBoxColumn<CkanModule>(
                         Properties.Resources.ModListDownloadsHeader,
                         m => repoData.GetDownloadCount(registry.Repositories.Values, m.identifier)
-                                                ?.ToString()
-                                                ?? "",
+                                is int i and > 0
+                                    ? i.ToString() : "",
                         (a, b) => (repoData.GetDownloadCount(registry.Repositories.Values, a.identifier) ?? 0)
                                              .CompareTo(repoData.GetDownloadCount(registry.Repositories.Values, b.identifier) ?? 0),
                         12),

--- a/ConsoleUI/Toolkit/ConsoleLabel.cs
+++ b/ConsoleUI/Toolkit/ConsoleLabel.cs
@@ -16,17 +16,20 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="lf">Function returning the text to show in the label</param>
         /// <param name="bgFunc">Function returning the background color for the label</param>
         /// <param name="fgFunc">Function returning the foreground color for the label</param>
+        /// <param name="ta">Alignment of text within the label</param>
         public ConsoleLabel(int l,
                             int t,
                             int r,
                             Func<string> lf,
                             Func<ConsoleTheme, ConsoleColor>? bgFunc = null,
-                            Func<ConsoleTheme, ConsoleColor>? fgFunc = null)
+                            Func<ConsoleTheme, ConsoleColor>? fgFunc = null,
+                            TextAlign ta = TextAlign.Left)
             : base(l, t, r, t)
         {
             labelFunc  = lf;
             getBgColor = bgFunc;
             getFgColor = fgFunc;
+            textAlign  = ta;
         }
 
         /// <summary>
@@ -41,9 +44,9 @@ namespace CKAN.ConsoleUI.Toolkit {
             Console.BackgroundColor = getBgColor == null ? theme.LabelBg : getBgColor(theme);
             Console.ForegroundColor = getFgColor == null ? theme.LabelFg : getFgColor(theme);
             try {
-                Console.Write(FormatExactWidth(labelFunc(), w));
+                Console.Write(FormatExactWidth(labelFunc(), w, ta: textAlign));
             } catch (Exception ex) {
-                Console.Write(FormatExactWidth(ex.Message,  w));
+                Console.Write(FormatExactWidth(ex.Message,  w, ta: textAlign));
             }
         }
 
@@ -55,6 +58,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         private readonly Func<string>       labelFunc;
         private readonly Func<ConsoleTheme, ConsoleColor>? getBgColor;
         private readonly Func<ConsoleTheme, ConsoleColor>? getFgColor;
+        private readonly TextAlign                         textAlign;
     }
 
 }

--- a/ConsoleUI/Toolkit/ScreenObject.cs
+++ b/ConsoleUI/Toolkit/ScreenObject.cs
@@ -48,13 +48,20 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <param name="val">String to process</param>
         /// <param name="w">Width to fit</param>
         /// <param name="pad">Character to use for padding</param>
+        /// <param name="ta">Alignment of text within the label</param>
         /// <returns>
         /// val{padding} or substring of val
         /// </returns>
-        public static string FormatExactWidth(string val, int w, char pad = ' ')
-        {
-            return val.PadRight(w, pad)[..w];
-        }
+        public static string FormatExactWidth(string    val,
+                                              int       w,
+                                              char      pad = ' ',
+                                              TextAlign ta  = TextAlign.Left)
+            => ta switch
+            {
+                TextAlign.Right     => val.PadLeft(w, pad)[..w],
+                TextAlign.Center    => PadCenter(val, w, pad),
+                TextAlign.Left or _ => val.PadRight(w, pad)[..w],
+            };
 
         /// <summary>
         /// Truncate a string if it's longer than the limit


### PR DESCRIPTION
## Motivations

- I saw a screenshot of ConsoleUI recently where the new mod-abstract label from 0fae2a2a763c4ffb12fbeb0c9ddf9b245ccc5d6e was overlapping the "updated X days ago" label
- The "updated X days ago" label is left aligned and wider than it needs to be
- While working on the above, I noticed that the download counts from #4063 for the DLCs were being shown as 0, which doesn't make sense

![image](https://github.com/user-attachments/assets/e498f753-b3e2-4f9c-bcf9-5a23cc7706d3)

## Changes

- Now the abstract label stops where the "updated X days ago" label starts so they won't overlap
- Now the "updated X days ago" label's size fits its content with a little padding, and it's right-aligned
- Now 0 download counts are left blank instead
