### PR TITLE
Reconcile compatibility after internal .ckan merge

### DIFF
--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -60,6 +60,7 @@ namespace CKAN.NetKAN.Transformers
                         json.SafeAdd(property.Name, property.Value);
                     }
 
+                    ModuleService.ApplyVersions(json, null, null, null);
                     json.SafeMerge("resources", internalJson["resources"]);
 
                     Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);


### PR DESCRIPTION
## Problem

@SofieBrink is testing out using internal .ckan files and hit a snag:

```
FATAL CKAN.NetKAN.Program (null) - ksp_version mixed with ksp_version_(min|max)
```

## Cause

SpaceDock provides `ksp_version`, and the internal .ckan file provides `ksp_version_min`, and they're not reconciled.

## Changes

Now after an internal .ckan file is merged, `ModuleService.ApplyVersions` is called to massage the compatibility metadata into consistency. This will allow mods on SpaceDock to set their compatibility in internal .ckan files.
