### PR TITLE
Tests for Newtonsoft.Json's handling of octal literals in version files

### DIFF
--- a/Tests/NetKAN/Sources/Avc/AVC.cs
+++ b/Tests/NetKAN/Sources/Avc/AVC.cs
@@ -1,11 +1,14 @@
+using System;
 using System.IO;
-using CKAN.NetKAN.Sources.Avc;
-using CKAN.Versioning;
+
 using Newtonsoft.Json;
 using NUnit.Framework;
+
+using CKAN.NetKAN.Sources.Avc;
+using CKAN.Versioning;
 using Tests.Data;
 
-namespace Tests.NetKAN
+namespace Tests.NetKAN.Sources.Avc
 {
     [TestFixture]
     public class AVC
@@ -92,6 +95,90 @@ namespace Tests.NetKAN
             var reader = new JsonTextReader(new StringReader(json));
             var result = (GameVersion)converter.ReadJson(reader, null, null, null)!;
             Assert.That(result, Is.EqualTo(GameVersion.Parse("1.5")));
+        }
+
+        [TestCase("02024", "7",  "13"),
+         TestCase("2024",  "07", "13"),
+         TestCase("2024",  "7",  "013")]
+        public void ModVersionConverterReadJson_ValidOctalLiteral_DoesNotThrow(
+            string major, string minor, string patch)
+        {
+            // Arrange
+            var json = $@"{{
+                              ""MAJOR"": {major},
+                              ""MINOR"": {minor},
+                              ""PATCH"": {patch}
+                          }}";
+            var reader = new JsonTextReader(new StringReader(json));
+            var converter = new JsonAvcToVersion();
+            var correct = new ModuleVersion(string.Join(".",
+                                                        FromMaybeOctal(major),
+                                                        FromMaybeOctal(minor),
+                                                        FromMaybeOctal(patch)));
+
+            // Act / Assert
+            Assert.DoesNotThrow(() =>
+            {
+                var result = converter.ReadJson(reader, null, null, null);
+                Assert.AreEqual(correct, result);
+            });
+        }
+
+        private int FromMaybeOctal(string val)
+            => val.StartsWith("0")
+                ? Convert.ToInt32(val, 8)
+                : int.Parse(val);
+
+        [TestCase("02028", "10",  "9"),
+         TestCase("2024",  "080", "9"),
+         TestCase("2024",  "10",  "08"),
+         TestCase("02029", "10",  "9"),
+         TestCase("2024",  "090", "9"),
+         TestCase("2024",  "10",  "09")]
+        public void ModVersionConverterReadJson_InvalidOctalLiteral_Throws(
+            string major, string minor, string patch)
+        {
+            // Arrange
+            var json = $@"{{
+                              ""MAJOR"": {major},
+                              ""MINOR"": {minor},
+                              ""PATCH"": {patch}
+                          }}";
+            var reader = new JsonTextReader(new StringReader(json));
+            var converter = new JsonAvcToVersion();
+
+            // Act / Assert
+            Assert.Throws<JsonReaderException>(() =>
+            {
+                var result = converter.ReadJson(reader, null, null, null);
+            });
+        }
+
+        [TestCase("02028", "10",  "9"),
+         TestCase("2024",  "080", "9"),
+         TestCase("2024",  "10",  "08"),
+         TestCase("02029", "10",  "9"),
+         TestCase("2024",  "090", "9"),
+         TestCase("2024",  "10",  "09")]
+        public void ModVersionConverterReadJson_QuotedInvalidOctalNumber_DoesNotThrow(
+            string major, string minor, string patch)
+        {
+            // Arrange
+            var json = $@"{{
+                              ""MAJOR"": ""{major}"",
+                              ""MINOR"": ""{minor}"",
+                              ""PATCH"": ""{patch}""
+                          }}";
+            var reader = new JsonTextReader(new StringReader(json));
+            var converter = new JsonAvcToVersion();
+            var correct = new ModuleVersion(string.Join(".", major, minor, patch));
+
+            // Act / Assert
+            Assert.DoesNotThrow(() =>
+            {
+                var result = converter.ReadJson(reader, null, null, null);
+                Assert.AreEqual(correct, result);
+            });
         }
 
     }


### PR DESCRIPTION
## Motivation

A mod uploaded a release today with this in its version file:

```json
		"PATCH":09,
```

This causes an inflation error:

> `New inflation error for <mod name>: Error parsing version file <path to version file>.version: Input string '09' is not a valid number. Path 'VERSION.PATCH', line 9, position 12.`

Digging into this, apparently a `0` prefix for numbers isn't technically allowed at all in strict JSON (and a few online validators confirm this), but some parsers (including the most popular one for C#, Newtonsoft.Json) decided to be lenient and parse them as C-style octal literals. But `08` and `09` are not valid octal literals because only the digits `01234567` can be used in octal.

## Changes

Now several new test cases are added to check and document exactly what is and is not allowed by Newtonsoft.Json's numeric parser, for future reference.

Note that the `QuotedInvalidOctalNumber` test is technically using an exploit, as the [version file schema](https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/3cca622167dabcb24f1267a865abc13ee6d96c6e/KSP-AVC.schema.json#L122-L145) requires these fields to be [integers](https://json-schema.org/understanding-json-schema/reference/numeric#integer), not strings, but CKAN does not enforce this. 
