### PR TITLE
Set focus better on Ctrl+F

### DIFF
--- a/Cmdline/Action/Search.cs
+++ b/Cmdline/Action/Search.cs
@@ -70,8 +70,8 @@ namespace CKAN.CmdLine
             }
 
             // Present the results.
-            if (!matching_compatible.Any()
-                && (!options.all || !matching_incompatible.Any()))
+            if (matching_compatible.Count == 0
+                && (!options.all || matching_incompatible.Count == 0))
             {
                 return Exit.OK;
             }
@@ -89,7 +89,7 @@ namespace CKAN.CmdLine
                                       mod.@abstract);
                 }
 
-                if (matching_incompatible.Any())
+                if (matching_incompatible.Count != 0)
                 {
                     user.RaiseMessage(Properties.Resources.SearchIncompatibleModsHeader);
                     foreach (CkanModule mod in matching_incompatible)

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -68,7 +68,7 @@ namespace CKAN.CmdLine
                     var matches = search.PerformSearch(instance, modName);
 
                     // Display the results of the search.
-                    if (!matches.Any())
+                    if (matches.Count == 0)
                     {
                         // No matches found.
                         user.RaiseMessage(Properties.Resources.ShowNoClose);

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -133,7 +133,7 @@ namespace CKAN
             // If we know of no instances, try to find one.
             // Otherwise, we know of too many instances!
             // We don't know which one to pick, so we return null.
-            return !instances.Any() ? FindAndRegisterDefaultInstances() : null;
+            return instances.Count == 0 ? FindAndRegisterDefaultInstances() : null;
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace CKAN
         /// </summary>
         public GameInstance? FindAndRegisterDefaultInstances()
         {
-            if (instances.Any())
+            if (instances.Count != 0)
             {
                 throw new KSPManagerKraken("Attempted to scan for defaults with instances");
             }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -779,7 +779,7 @@ namespace CKAN
                 .ToList();
 
             // If there is nothing to uninstall, skip out.
-            if (!goners.Any())
+            if (goners.Count == 0)
             {
                 return;
             }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1164,7 +1164,7 @@ namespace CKAN
 
             // The empty list has no reverse dependencies
             // (Don't remove broken modules if we're only installing)
-            if (modulesToRemove.Any())
+            if (modulesToRemove.Count != 0)
             {
                 // All modules in the input are included in the output
                 foreach (string starter in modulesToRemove)

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -307,7 +307,7 @@ namespace CKAN
                                   && reason is SelectionReason.RelationshipReason rel
                                   && MightBeInstallable(mod, rel.Parent, installed_modules))
                     .ToList();
-                if (!candidates.Any())
+                if (candidates.Count == 0)
                 {
                     // Nothing found, try again while simulating an empty mod list
                     // Necessary for e.g. proceed_with_inconsistencies, conflicts will still be caught below
@@ -319,7 +319,7 @@ namespace CKAN
                         .ToList();
                 }
 
-                if (!candidates.Any())
+                if (candidates.Count == 0)
                 {
                     if (!soft_resolve && reason is SelectionReason.RelationshipReason rel)
                     {
@@ -645,7 +645,7 @@ namespace CKAN
                             conflictingModDescription(kvp.Key,   null),
                             conflictingModDescription(kvp.Value, null)));
 
-        public bool IsConsistent => !conflicts.Any();
+        public bool IsConsistent => conflicts.Count == 0;
 
         public List<SelectionReason> ReasonsFor(CkanModule mod)
             => reasons.TryGetValue(mod, out List<SelectionReason>? r)

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -54,7 +54,7 @@ namespace CKAN
             var dllSet = dlls?.ToHashSet();
             UnmetDepends = FindUnsatisfiedDepends(modList, dllSet, dlc).ToList();
             Conflicts = FindConflicting(modList, dllSet, dlc);
-            return !UnmetDepends.Any() && !Conflicts.Any();
+            return UnmetDepends.Count == 0 && Conflicts.Count == 0;
         }
 
         /// <summary>

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -34,7 +34,7 @@ namespace CKAN.GUI
                                   Dictionary<CkanModule, string>? conflicts)
         {
             changeset = changes;
-            ConfirmChangesButton.Enabled = conflicts == null || !conflicts.Any();
+            ConfirmChangesButton.Enabled = conflicts == null || conflicts.Count == 0;
             CloseTheGameLabel.Visible = changes?.Any(ch => DeletingChanges.Contains(ch.ChangeType))
                                         ?? false;
             ChangesGrid.DataSource = new BindingList<ChangesetRow>(

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -157,7 +157,7 @@ namespace CKAN.GUI
                             ? Color.LightCoral
                             : Color.Empty;
                     }
-                    RecommendedModsContinueButton.Enabled = !conflicts.Any();
+                    RecommendedModsContinueButton.Enabled = conflicts.Count == 0;
                     OnConflictFound?.Invoke(string.Join("; ", resolver.ConflictDescriptions));
                 }
                 catch (DependencyNotSatisfiedKraken k)

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -144,7 +144,7 @@ namespace CKAN.GUI
         {
             Util.Invoke(this, () =>
             {
-                if (ChangeSet != null && ChangeSet.Any())
+                if (ChangeSet != null && ChangeSet.Count != 0)
                 {
                     ApplyToolButton.Enabled = true;
                 }
@@ -1923,7 +1923,7 @@ namespace CKAN.GUI
 
         public bool AllowClose()
         {
-            if (Conflicts != null && Conflicts.Any())
+            if (Conflicts != null && Conflicts.Count != 0)
             {
                 // Ask if they want to resolve conflicts
                 string confDescrip = Conflicts

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -19,7 +19,7 @@ namespace CKAN.GUI
     #if NET5_0_OR_GREATER
     [SupportedOSPlatform("windows")]
     #endif
-    public partial class ManageMods : UserControl
+    public partial class ManageMods : UserControl, ISearchableControl
     {
         public ManageMods()
         {
@@ -1900,17 +1900,8 @@ namespace CKAN.GUI
         {
             switch (keyData)
             {
-                case Keys.Control | Keys.F:
-                    ActiveControl = EditModSearches;
-                    return true;
-
-                case Keys.Control | Keys.Shift | Keys.F:
-                    EditModSearches.ExpandCollapse();
-                    ActiveControl = EditModSearches;
-                    return true;
-
                 case Keys.Control | Keys.S:
-                    if (ChangeSet != null && ChangeSet.Any())
+                    if (ChangeSet != null && ChangeSet.Count != 0)
                     {
                         ApplyToolButton_Click(null, null);
                     }
@@ -1919,6 +1910,16 @@ namespace CKAN.GUI
             }
 
             return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        public void FocusSearch(bool expandCollapse = false)
+        {
+            ActiveControl = EditModSearches;
+            EditModSearches.Focus();
+            if (expandCollapse)
+            {
+                EditModSearches.ExpandCollapse();
+            }
         }
 
         public bool AllowClose()

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -41,7 +41,7 @@ namespace CKAN.GUI
                 StartPosition = FormStartPosition.CenterScreen;
             }
 
-            if (!manager.Instances.Any())
+            if (manager.Instances.Count == 0)
             {
                 manager.FindAndRegisterDefaultInstances();
             }

--- a/GUI/ISearchableControl.cs
+++ b/GUI/ISearchableControl.cs
@@ -1,0 +1,7 @@
+namespace CKAN.GUI
+{
+    public interface ISearchableControl
+    {
+        void FocusSearch(bool expandCollapse = false);
+    }
+}

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -611,6 +611,38 @@ namespace CKAN.GUI
             ManageMods?.ParentMoved();
         }
 
+        private IEnumerable<T> VisibleControls<T>()
+            => (MainTabControl?.SelectedTab
+                              ?.Controls
+                               .OfType<T>()
+                              ?? Enumerable.Empty<T>())
+                  .Concat(!splitContainer1.Panel2Collapsed
+                          && ModInfo is T t
+                              ? Enumerable.Repeat(t, 1)
+                              : Enumerable.Empty<T>());
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            switch (e.KeyData)
+            {
+                case Keys.Control | Keys.F:
+                    VisibleControls<ISearchableControl>()
+                        .FirstOrDefault()
+                        ?.FocusSearch(false);
+                    e.Handled = true;
+                    break;
+                case Keys.Control | Keys.Shift | Keys.F:
+                    VisibleControls<ISearchableControl>()
+                        .FirstOrDefault()
+                        ?.FocusSearch(true);
+                    e.Handled = true;
+                    break;
+                default:
+                    base.OnKeyDown(e);
+                    break;
+            }
+        }
+
         private void SetupDefaultSearch()
         {
             if (CurrentInstance != null && configuration != null)

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -821,7 +821,7 @@ namespace CKAN.GUI
                                              .Select(gv => new GameVersion(gv.Major, gv.Minor))
                                              .Distinct()
                                              .ToList();
-                if (missing.Any()
+                if (missing.Count != 0
                     && YesNoDialog(string.Format(Properties.Resources.MetapackageAddCompatibilityPrompt,
                                                  filesRange.ToSummaryString(CurrentInstance.game),
                                                  crit.ToSummaryString(CurrentInstance.game)),
@@ -841,7 +841,7 @@ namespace CKAN.GUI
                 .ToHashSet();
             // Get incompatible mods we're installing
             var myIncompat = toInstall.Where(mod => allIncompat.Contains(mod.identifier)).ToList();
-            if (!myIncompat.Any()
+            if (myIncompat.Count == 0
                 // Confirm installation of incompatible like the Versions tab does
                 || YesNoDialog(string.Format(Properties.Resources.ModpackInstallIncompatiblePrompt,
                                              string.Join(Environment.NewLine, myIncompat),
@@ -943,7 +943,7 @@ namespace CKAN.GUI
 
         private void ManageMods_OnChangeSetChanged(List<ModChange> changeset, Dictionary<GUIMod, string> conflicts)
         {
-            if (changeset != null && changeset.Any())
+            if (changeset != null && changeset.Count != 0)
             {
                 tabController.ShowTab("ChangesetTabPage", 1, false);
                 UpdateChangesDialog(
@@ -1069,7 +1069,7 @@ namespace CKAN.GUI
                 var incomp = registry.IncompatibleInstalled(CurrentInstance.VersionCriteria())
                     .Where(m => !m.Module.IsDLC && !suppressedIdentifiers.Contains(m.identifier))
                     .ToList();
-                if (incomp.Any() && CurrentInstance.Version() is GameVersion gv)
+                if (incomp.Count != 0 && CurrentInstance.Version() is GameVersion gv)
                 {
                     // Warn that it might not be safe to run game with incompatible modules installed
                     string incompatDescrip = incomp

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -62,7 +62,7 @@ namespace CKAN.GUI
                         recommendations, suggestions, supporters);
                     var result = ChooseRecommendedMods.Wait();
                     tabController.HideTab("ChooseRecommendedModsTabPage");
-                    if (result != null && result.Any())
+                    if (result != null && result.Count != 0)
                     {
                         Wait.StartWaiting(InstallMods, PostInstallMods, true,
                             new InstallArgument(

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -92,7 +92,7 @@ namespace CKAN.NetKAN.Processors
                 VisibilityTimeout     = (int)TimeSpan.FromMinutes(timeoutMinutes).TotalSeconds,
                 MessageAttributeNames = new List<string>() { "All" },
             }).Result;
-            if (!resp.Messages.Any())
+            if (resp.Messages.Count == 0)
             {
                 log.Debug("No metadata in queue");
             }
@@ -261,7 +261,7 @@ namespace CKAN.NetKAN.Processors
                     }
                 );
             }
-            if (warningAppender.Warnings.Any())
+            if (warningAppender.Warnings.Count != 0)
             {
                 attribs.Add(
                     "WarningMessages",

--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -82,7 +82,7 @@ namespace CKAN.NetKAN.Sources.Github
                         ghRel.PreRelease == reference.UsePrerelease
                         // Skip releases without assets
                         && ghRel.Assets != null
-                        && ghRel.Assets.Any())
+                        && ghRel.Assets.Count != 0)
                     // Insurance against GitHub returning them in the wrong order
                     .OrderByDescending(ghRel => ghRel.PublishedAt)
                     .ToList();

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -107,7 +107,7 @@ namespace CKAN.NetKAN.Transformers
                 result.Add(transformers[i]);
             }
 
-            if (result.Any())
+            if (result.Count != 0)
             {
                 if (result.First() is VersionedOverrideTransformer firstVersionedOverride)
                 {

--- a/Netkan/Validators/CraftsInShipsValidator.cs
+++ b/Netkan/Validators/CraftsInShipsValidator.cs
@@ -35,7 +35,7 @@ namespace CKAN.NetKAN.Validators
                         .Where(f => !AllowedCraftPath(inst.ToRelativeGameDir(f.destination)))
                         .ToList();
 
-                    if (badCrafts.Any())
+                    if (badCrafts.Count != 0)
                     {
                         Log.WarnFormat(
                             "Craft files installed outside Ships folder: {0}",

--- a/Netkan/Validators/HarmonyValidator.cs
+++ b/Netkan/Validators/HarmonyValidator.cs
@@ -41,7 +41,7 @@ namespace CKAN.NetKAN.Validators
                                               StringComparison.InvariantCultureIgnoreCase) != -1)
                         .OrderBy(f => f)
                         .ToList();
-                    bool bundlesHarmony   = harmonyDLLs.Any();
+                    bool bundlesHarmony   = harmonyDLLs.Count != 0;
                     bool providesHarmony1 = mod.ProvidesList.Contains("Harmony1");
                     if (bundlesHarmony && !providesHarmony1)
                     {

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -48,7 +48,7 @@ namespace CKAN.NetKAN.Validators
                                     && p.LastIndexOf($"/{dir}/", StringComparison.InvariantCultureIgnoreCase) > 0)
                         .OrderBy(f => f)
                         .ToList();
-                    if (gamedatas.Any())
+                    if (gamedatas.Count != 0)
                     {
                         var badPaths = string.Join("\r\n", gamedatas);
                         throw new Kraken($"{dir} directory found within {dir}:\r\n{badPaths}");
@@ -60,7 +60,7 @@ namespace CKAN.NetKAN.Validators
                     .GroupBy(f => f)
                     .SelectMany(grp => grp.Skip(1).OrderBy(f => f))
                     .ToList();
-                if (duplicates.Any())
+                if (duplicates.Count != 0)
                 {
                     var badPaths = string.Join("\r\n", duplicates);
                     throw new Kraken($"Multiple files attempted to install to:\r\n{badPaths}");
@@ -75,7 +75,7 @@ namespace CKAN.NetKAN.Validators
                         .Distinct()
                         .Where(incl => !allFiles.Any(f => f.Contains(incl)))
                         .ToList();
-                    if (unmatchedIncludeOnlys.Any())
+                    if (unmatchedIncludeOnlys.Count != 0)
                     {
                         log.WarnFormat("No matches for includes_only: {0}",
                                        string.Join(", ", unmatchedIncludeOnlys));

--- a/Netkan/Validators/PluginsValidator.cs
+++ b/Netkan/Validators/PluginsValidator.cs
@@ -33,7 +33,7 @@ namespace CKAN.NetKAN.Validators
                     GameInstance inst = new GameInstance(_game, "/", "dummy", new NullUser());
 
                     var plugins    = _moduleService.GetPlugins(mod, zip, inst).ToList();
-                    bool hasPlugin = plugins.Any();
+                    bool hasPlugin = plugins.Count != 0;
                     if (hasPlugin)
                     {
                         var dllPaths = plugins
@@ -45,7 +45,7 @@ namespace CKAN.NetKAN.Validators
                             .Where(ident => !string.IsNullOrEmpty(ident)
                                 && !identifiersToIgnore.Contains(ident))
                             .ToHashSet();
-                        if (dllIdentifiers.Any() && !dllIdentifiers.Contains(metadata.Identifier))
+                        if (dllIdentifiers.Count != 0 && !dllIdentifiers.Contains(metadata.Identifier))
                         {
                             Log.WarnFormat(
                                 "No plugin matching the identifier, manual installations won't be detected: {0}",

--- a/Netkan/Validators/SpaceWarpInfoValidator.cs
+++ b/Netkan/Validators/SpaceWarpInfoValidator.cs
@@ -49,7 +49,7 @@ namespace CKAN.NetKAN.Validators
                                               StringComparer.InvariantCultureIgnoreCase))
                                          ?? Enumerable.Empty<string>())
                                           .ToList();
-                if (missingDeps.Any())
+                if (missingDeps.Count != 0)
                 {
                     log.WarnFormat("Dependencies from swinfo.json missing from module: {0}",
                                    string.Join(", ", missingDeps));

--- a/Tests/Util.cs
+++ b/Tests/Util.cs
@@ -63,7 +63,7 @@ namespace Tests
                                                 method.DeclaringType?.Name ?? "",
                                                 method.Name))
                 .ToList();
-            Assert.False(messages.Any(),
+            Assert.False(messages.Count != 0,
                 "Async void methods found!" + Environment.NewLine + string.Join(Environment.NewLine, messages));
         }
 


### PR DESCRIPTION
## Problems

- <kbd>Ctrl</kbd>+<kbd>F</kbd> is supposed to focus the search box, but currently it doesn't
- Even if we fix the broken <kbd>Ctrl</kbd>+<kbd>F</kbd> handler, it will only work when the mod grid has focus, not mod info or any of the other parts of the UI

## Cause

- Going back to a3d96f6df90abb4b745a14b2bfa7e190fd3cad55, the focus has been set solely by setting `ActiveControl`, which doesn't always work (details unclear, but possibly related to the search control containing sub-controls?)
- <kbd>Ctrl</kbd>+<kbd>F</kbd> is currently handled by `ManageMods.ProcessCmdKey`, which is only called when that control has focus

## Changes

- Now `.Focus()` is used to set the focus
- Now the handler for the <kbd>Ctrl</kbd>+<kbd>F</kbd> keystroke is moved from `ManageMods` back to `Main` so it can be global
  - Now `ManageMods` implements a new `ISearchableControl` interface to advertise its ability to respond to <kbd>Ctrl</kbd>+<kbd>F</kbd> keystroke, which `Main` then uses to find a control
- Courtesy of a VSCode performance-improvement suggestion, many usages of `.Any()` are replaced by checking `.Count` instead

After this, <kbd>Ctrl</kbd>+<kbd>F</kbd> sets the focus to the search box whenever it's visible, and if other controls (Edit Modpack, Unmanaged Files, etc.) add their own search tools in the future, they can implement `ISearchableControl`.
