### PR TITLE
Minor tray icon improvements

### DIFF
--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -713,6 +713,7 @@ namespace CKAN.GUI
             //
             this.minimizeNotifyIcon.ContextMenuStrip = this.minimizedContextMenuStrip;
             this.minimizeNotifyIcon.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.minimizeNotifyIcon_MouseDoubleClick);
+            this.minimizeNotifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.minimizeNotifyIcon_MouseClick);
             this.minimizeNotifyIcon.BalloonTipClicked += new System.EventHandler(this.minimizeNotifyIcon_BalloonTipClicked);
             this.minimizeNotifyIcon.Icon = EmbeddedImages.AppIcon;
             resources.ApplyResources(this.minimizeNotifyIcon, "minimizeNotifyIcon");
@@ -740,12 +741,14 @@ namespace CKAN.GUI
             this.updatesToolStripMenuItem.Name = "updatesToolStripMenuItem";
             this.updatesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.updatesToolStripMenuItem.Click += new System.EventHandler(this.updatesToolStripMenuItem_Click);
+            this.updatesToolStripMenuItem.Visible = false;
             resources.ApplyResources(this.updatesToolStripMenuItem, "updatesToolStripMenuItem");
             //
             // toolStripSeparator4
             //
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(177, 6);
+            this.toolStripSeparator4.Visible = false;
             //
             // refreshToolStripMenuItem
             //
@@ -771,6 +774,7 @@ namespace CKAN.GUI
             this.openCKANToolStripMenuItem.Name = "openCKANToolStripMenuItem";
             this.openCKANToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.openCKANToolStripMenuItem.Click += new System.EventHandler(this.openCKANToolStripMenuItem_Click);
+            this.openCKANToolStripMenuItem.Visible = false;
             resources.ApplyResources(this.openCKANToolStripMenuItem, "openCKANToolStripMenuItem");
             //
             // openGameToolStripMenuItem

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -416,7 +416,8 @@ namespace CKAN.GUI
 
             Util.Invoke(this, () =>
             {
-                Text = $"CKAN {Meta.GetVersion()} - {CurrentInstance.game.ShortName} {CurrentInstance.Version()}    --    {Platform.FormatPath(CurrentInstance.GameDir())}";
+                Text = $"{Meta.GetProductName()} {Meta.GetVersion()} - {CurrentInstance.game.ShortName} {CurrentInstance.Version()}    --    {Platform.FormatPath(CurrentInstance.GameDir())}";
+                minimizeNotifyIcon.Text = $"{Meta.GetProductName()} - {CurrentInstance.Name}";
                 UpdateStatusBar();
             });
 

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -154,7 +154,6 @@
   <data name="UnmanagedFilesTabPage.Text" xml:space="preserve"><value>Unmanaged Files</value></data>
   <data name="InstallationHistoryTabPage.Text" xml:space="preserve"><value>Installation History</value></data>
   <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
-  <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N available updates</value></data>
   <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Refresh</value></data>
   <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Pause</value></data>
   <data name="openCKANToolStripMenuItem.Text" xml:space="preserve"><value>Open CKAN</value></data>

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -38,11 +38,13 @@ namespace CKAN.GUI
                         // Remove our taskbar entry
                         Hide();
                     }
+                    openCKANToolStripMenuItem.Visible = true;
                 }
                 else
                 {
                     // Save the window state
                     configuration.IsWindowMaximised = WindowState == FormWindowState.Maximized;
+                    openCKANToolStripMenuItem.Visible = false;
                 }
             }
             else
@@ -65,6 +67,8 @@ namespace CKAN.GUI
                 updatesToolStripMenuItem.Enabled = true;
                 updatesToolStripMenuItem.Text = string.Format(Properties.Resources.MainTrayUpdatesAvailable, count);
             }
+            toolStripSeparator4.Visible = true;
+            updatesToolStripMenuItem.Visible = true;
         }
 
         /// <summary>
@@ -74,11 +78,23 @@ namespace CKAN.GUI
         {
             Show();
             WindowState = configuration?.IsWindowMaximised ?? false ? FormWindowState.Maximized : FormWindowState.Normal;
+            openCKANToolStripMenuItem.Visible = false;
+        }
+
+        private void minimizeNotifyIcon_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                OpenWindow();
+            }
         }
 
         private void minimizeNotifyIcon_MouseDoubleClick(object sender, MouseEventArgs e)
         {
-            OpenWindow();
+            if (e.Button == MouseButtons.Left)
+            {
+                OpenWindow();
+            }
         }
 
         private void updatesToolStripMenuItem_Click(object? sender, EventArgs? e)
@@ -134,9 +150,9 @@ namespace CKAN.GUI
         {
             // The menu location can be partly off-screen by default.
             // Fix it.
-            minimizedContextMenuStrip.Location = Util.ClampedLocation(
-                minimizedContextMenuStrip.Location,
-                minimizedContextMenuStrip.Size);
+            minimizedContextMenuStrip.Location =
+                Util.ClampedLocation(minimizedContextMenuStrip.Location,
+                                     minimizedContextMenuStrip.Size);
         }
 
         private void minimizeNotifyIcon_BalloonTipClicked(object? sender, EventArgs? e)
@@ -149,11 +165,9 @@ namespace CKAN.GUI
 
             // Install
             Wait.StartWaiting(InstallMods, PostInstallMods, true,
-                new InstallArgument(
-                    ManageMods.ComputeUserChangeSet()
-                              .ToList(),
-                    RelationshipResolverOptions.DependsOnlyOpts())
-            );
+                              new InstallArgument(ManageMods.ComputeUserChangeSet()
+                                                            .ToList(),
+                                                  RelationshipResolverOptions.DependsOnlyOpts()));
         }
         #endregion
     }


### PR DESCRIPTION
## Motivation

@JonnyOThan requested to have the tray icon re-open the window on single click, rather than just on double click (see #2565).

Sure, why not.

## Changes

- Now single clicking the tray icon un-hides the window
- Now the tooltip of the tray icon has the game instance name, so you can tell which icon is which when there are multiple
- Now the "Open CKAN" menu option is hidden while the window is already visible
- Now the "N available updates" option is hidden while the initial game instance is loading and becomes visible once it's loaded
