### PR TITLE
Refactor relationship resolver to capture full resolved tree

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -123,7 +123,7 @@ namespace CKAN.CmdLine
                     user.RaiseMessage("");
                     done = true;
                 }
-                catch (DependencyNotSatisfiedKraken ex)
+                catch (DependenciesNotSatisfiedKraken ex)
                 {
                     user.RaiseError("{0}", ex.Message);
                     user.RaiseMessage(Properties.Resources.InstallTryAgain);

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -163,10 +163,9 @@ namespace CKAN.CmdLine
                                  regMgr);
                     user.RaiseMessage("");
                 }
-                catch (DependencyNotSatisfiedKraken ex)
+                catch (DependenciesNotSatisfiedKraken ex)
                 {
-                    user.RaiseMessage(Properties.Resources.ReplaceDependencyNotSatisfied,
-                        ex.parent, ex.module, ex.version ?? "", instance.game.ShortName);
+                    user.RaiseMessage("{0}", ex.Message);
                 }
             }
             else

--- a/Cmdline/Properties/Resources.fr-FR.resx
+++ b/Cmdline/Properties/Resources.fr-FR.resx
@@ -390,7 +390,6 @@ Soyez sûr d'avoir saisi au moins les valeurs de version majeure et mineure au f
   </data>
   <data name="InstallTryAgain" xml:space="preserve">
     <value>Si vous êtes chanceux, vous pouvez taper `ckan update` et réessayer.
-Essayez `ckan install --no-recommends` pour ignorer l'installation des modules recommandés.
 Ou `ckan install --allow-incompatible` pour ignorer la compatibilité des modules.</value>
   </data>
   <data name="InstallUnversionedDependencyNotSatisfied" xml:space="preserve">

--- a/Cmdline/Properties/Resources.it-IT.resx
+++ b/Cmdline/Properties/Resources.it-IT.resx
@@ -380,7 +380,6 @@ Assicurati di inserire almeno i valori di versione maggiore e minore nella forma
   </data>
   <data name="InstallTryAgain" xml:space="preserve">
     <value>Se sei fortunato, puoi fare un `ckan update` e riprovare.
-Prova `ckan install --no-recommends` per saltare l'installazione dei moduli consigliati.
 Oppure `ckan install --allow-incompatible` per ignorare la compatibilità dei moduli.</value>
   </data>
   <data name="InstallUnversionedDependencyNotSatisfied" xml:space="preserve">

--- a/Cmdline/Properties/Resources.pl-PL.resx
+++ b/Cmdline/Properties/Resources.pl-PL.resx
@@ -367,7 +367,6 @@ Upewnij się, że wprowadziłeś wersję w postaci Maj.Min - np. 1.5</value>
   </data>
   <data name="InstallTryAgain" xml:space="preserve">
     <value>Jeśli masz szczęście, możesz wykonać `ckan update` i spróbować ponownie.
-Spróbuj `ckan install --no-recommends` aby pominąć instalację zalecanych modułów.
 Lub `ckan install --allow-niecompatible` aby zignorować kompatybilność modułów.</value>
   </data>
   <data name="InstallUnversionedDependencyNotSatisfied" xml:space="preserve">

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -218,9 +218,10 @@ Make sure to enter at least the version major and minor values in the form Maj.M
   <data name="ImportError" xml:space="preserve"><value>Import error: {0}</value></data>
   <data name="ImportNotFound" xml:space="preserve"><value>File not found: {0}</value></data>
   <data name="InstallNotFound" xml:space="preserve"><value>File not found, exiting: {0}</value></data>
-  <data name="InstallTryAgain" xml:space="preserve"><value>If you're lucky, you can do a `ckan update` and try again.
-Try `ckan install --no-recommends` to skip installation of recommended modules.
-Or `ckan install --allow-incompatible` to ignore module compatibility.</value></data>
+  <data name="InstallTryAgain" xml:space="preserve"><value>
+You can use the `ckan compat` commands to change which game versions are treated as compatible.
+If a newly compatible version was just released, you can do a `ckan update` and try again.
+Or `ckan install --allow-incompatible` to ignore compatibility of the modules on the command line (but not dependencies).</value></data>
   <data name="InstallUnversionedDependencyNotSatisfied" xml:space="preserve"><value>Module {0} required but it is not listed in the index, or not available for your version of {1}</value></data>
   <data name="InstallVersionedDependencyNotSatisfied" xml:space="preserve"><value>Module {0} {1} required but it is not listed in the index, or not available for your version of {2}</value></data>
   <data name="InstallBadMetadata" xml:space="preserve"><value>Bad metadata detected for module {0}: {1}</value></data>

--- a/Cmdline/Properties/Resources.ru-RU.resx
+++ b/Cmdline/Properties/Resources.ru-RU.resx
@@ -206,7 +206,6 @@
   <data name="ImportNotFound" xml:space="preserve"><value>Файл не найден: {0}</value></data>
   <data name="InstallNotFound" xml:space="preserve"><value>Файл не найден, выход: {0}</value></data>
   <data name="InstallTryAgain" xml:space="preserve"><value>Попробуйте совершить `ckan update` и попытайтесь заново.
-Используйте `ckan install --no-recommends`, чтобы пропустить установку рекомендуемых модулей.
 Либо используйте `ckan install --allow-incompatible`, чтобы игнорировать проблемы совместимости.</value></data>
   <data name="InstallUnversionedDependencyNotSatisfied" xml:space="preserve"><value>Необходим модуль {0}, но он отсутствует в указателе либо недоступен для вашей версии {1}</value></data>
   <data name="InstallVersionedDependencyNotSatisfied" xml:space="preserve"><value>Необходим модуль {0} {1}, но он отсутствует в указателе либо недоступен для вашей версии {2}</value></data>

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -216,11 +216,12 @@ namespace CKAN.ConsoleUI {
                         plan.Remove.Select(ident => registry.InstalledModule(ident)?.Module)
                                    .OfType<CkanModule>(),
                         RelationshipResolverOptions.ConflictsOpts(), registry,
+                        manager.CurrentInstance.game,
                         manager.CurrentInstance.VersionCriteria());
                     descriptions = resolver.ConflictDescriptions.ToList();
                     return descriptions.Count > 0;
                 }
-                catch (DependencyNotSatisfiedKraken k)
+                catch (DependenciesNotSatisfiedKraken k)
                 {
                     descriptions = new List<string>() { k.Message };
                     return true;

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -155,12 +155,13 @@ namespace CKAN.ConsoleUI {
 
         private void generateList(HashSet<CkanModule> inst)
         {
-            if (ModuleInstaller.FindRecommendations(
-                manager.CurrentInstance,
-                inst, new List<CkanModule>(inst), registry,
-                out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
-                out Dictionary<CkanModule, List<string>> suggestions,
-                out Dictionary<CkanModule, HashSet<string>> supporters
+            if (manager.CurrentInstance is GameInstance instance
+                && ModuleInstaller.FindRecommendations(
+                    instance,
+                    inst, new List<CkanModule>(inst), registry,
+                    out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
+                    out Dictionary<CkanModule, List<string>> suggestions,
+                    out Dictionary<CkanModule, HashSet<string>> supporters
             )) {
                 foreach ((CkanModule mod, Tuple<bool, List<string>> checkedAndDependents) in recommendations) {
                     dependencies.Add(mod, new Dependency(

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -167,8 +167,8 @@ namespace CKAN.ConsoleUI {
 
                         } catch (BadMetadataKraken ex) {
                             RaiseError(Properties.Resources.InstallBadMetadata, ex.module?.ToString() ?? "", ex.Message);
-                        } catch (DependencyNotSatisfiedKraken ex) {
-                            RaiseError(Properties.Resources.InstallUnsatisfiedDependency, ex.parent, ex.module, ex.Message);
+                        } catch (DependenciesNotSatisfiedKraken ex) {
+                            RaiseError("{0}", ex.Message);
                         } catch (ModuleNotFoundKraken ex) {
                             RaiseError(Properties.Resources.InstallModuleNotFound, ex.module, ex.Message);
                         } catch (ModNotInstalledKraken ex) {

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="IndexRange" Version="1.0.3" />
     <PackageReference Include="StringSyntaxAttribute" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -279,6 +279,20 @@ namespace CKAN.Extensions
             => source.Select(item => Utilities.DefaultIfThrows(()  => func(item),
                                                                exc => onThrow(item, exc)));
 
+        /// <summary>
+        /// Get a hash code for a sequence with a variable number of elements
+        /// </summary>
+        /// <typeparam name="T">Type of the elements in the sequence</typeparam>
+        /// <param name="source">The sequence</param>
+        /// <returns></returns>
+        public static int ToSequenceHashCode<T>(this IEnumerable<T> source)
+            => source.Aggregate(new HashCode(),
+                                (hc, item) =>
+                                {
+                                    hc.Add(item);
+                                    return hc;
+                                },
+                                hc => hc.ToHashCode());
     }
 
     /// <summary>

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1433,7 +1433,7 @@ namespace CKAN
         /// <returns>
         /// true if anything found, false otherwise
         /// </returns>
-        public static bool FindRecommendations(GameInstance?                                         instance,
+        public static bool FindRecommendations(GameInstance                                          instance,
                                                HashSet<CkanModule>                                   sourceModules,
                                                List<CkanModule>                                      toInstall,
                                                Registry                                              registry,
@@ -1441,7 +1441,7 @@ namespace CKAN
                                                out Dictionary<CkanModule, List<string>>              suggestions,
                                                out Dictionary<CkanModule, HashSet<string>>           supporters)
         {
-            var crit     = instance?.VersionCriteria();
+            var crit     = instance.VersionCriteria();
             var resolver = new RelationshipResolver(sourceModules.Where(m => !m.IsDLC),
                                                     null,
                                                     RelationshipResolverOptions.KitchenSinkOpts(),
@@ -1507,7 +1507,7 @@ namespace CKAN
         public static bool CanInstall(List<CkanModule>            toInstall,
                                       RelationshipResolverOptions opts,
                                       IRegistryQuerier            registry,
-                                      GameVersionCriteria?        crit)
+                                      GameVersionCriteria         crit)
         {
             string request = string.Join(", ", toInstall.Select(m => m.identifier));
             try

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -146,6 +146,7 @@ namespace CKAN
             }
             var resolver = new RelationshipResolver(modules, null, options,
                                                     registry_manager.registry,
+                                                    instance.game,
                                                     instance.VersionCriteria());
             var modsToInstall = resolver.ModList().ToList();
             var downloads = new List<CkanModule>();
@@ -774,6 +775,7 @@ namespace CKAN
                             .Where(im => !revdep.Contains(im.identifier))
                             .Concat(installing?.Select(m => new InstalledModule(null, m, Array.Empty<string>(), false)) ?? Array.Empty<InstalledModule>())
                             .ToList(),
+                        instance.game,
                         instance.VersionCriteria())
                     .Select(im => im.identifier))
                 .ToList();
@@ -1185,6 +1187,7 @@ namespace CKAN
                            .OfType<CkanModule>(),
                     RelationshipResolverOptions.DependsOnlyOpts(),
                     registry,
+                    instance.game,
                     instance.VersionCriteria());
                 modules = resolver.ModList().ToArray();
                 autoInstalled = modules.ToDictionary(m => m, resolver.IsAutoInstalled);
@@ -1285,6 +1288,7 @@ namespace CKAN
                             .Where(im => !removingIdents.Contains(im.identifier))
                             .Concat(modules.Select(m => new InstalledModule(null, m, Array.Empty<string>(), false)))
                             .ToList(),
+                    instance.game,
                     instance.VersionCriteria())
                 .ToList();
             if (autoRemoving.Count > 0)
@@ -1318,7 +1322,7 @@ namespace CKAN
         /// Enacts listed Module Replacements to the specified versions for the user's KSP.
         /// Will *re-install* or *downgrade* (with a warning) as well as upgrade.
         /// </summary>
-        /// <exception cref="DependencyNotSatisfiedKraken">Thrown if a dependency for a replacing module couldn't be satisfied.</exception>
+        /// <exception cref="DependenciesNotSatisfiedKraken">Thrown if a dependency for a replacing module couldn't be satisfied.</exception>
         /// <exception cref="ModuleNotFoundKraken">Thrown if a module that should be replaced is not installed.</exception>
         public void Replace(IEnumerable<ModuleReplacement> replacements,
                             RelationshipResolverOptions    options,
@@ -1401,7 +1405,8 @@ namespace CKAN
                     }
                 }
             }
-            var resolver = new RelationshipResolver(modsToInstall, null, options, registry_manager.registry, instance.VersionCriteria());
+            var resolver = new RelationshipResolver(modsToInstall, null, options, registry_manager.registry,
+                                                    instance.game, instance.VersionCriteria());
             var resolvedModsToInstall = resolver.ModList().ToList();
             AddRemove(ref possibleConfigOnlyDirs,
                       registry_manager,
@@ -1445,7 +1450,7 @@ namespace CKAN
             var resolver = new RelationshipResolver(sourceModules.Where(m => !m.IsDLC),
                                                     null,
                                                     RelationshipResolverOptions.KitchenSinkOpts(),
-                                                    registry, crit);
+                                                    registry, instance.game, crit);
             var recommenders = resolver.Dependencies().ToHashSet();
 
             var checkedRecs = resolver.Recommendations(recommenders)
@@ -1454,7 +1459,7 @@ namespace CKAN
                                       .ToHashSet();
             var conflicting = new RelationshipResolver(toInstall.Concat(checkedRecs), null,
                                                        RelationshipResolverOptions.ConflictsOpts(),
-                                                       registry, crit)
+                                                       registry, instance.game, crit)
                                   .ConflictList.Keys;
             // Don't check recommendations that conflict with installed or installing mods
             checkedRecs.ExceptWith(conflicting);
@@ -1486,7 +1491,7 @@ namespace CKAN
                                              toInstall.Concat(recommendations.Keys)
                                                       .Concat(suggestions.Keys))
                                  .Where(kvp => CanInstall(toInstall.Append(kvp.Key).ToList(),
-                                                          opts, registry, crit))
+                                                          opts, registry, instance.game, crit))
                                  .ToDictionary();
 
             return recommendations.Count > 0
@@ -1507,6 +1512,7 @@ namespace CKAN
         public static bool CanInstall(List<CkanModule>            toInstall,
                                       RelationshipResolverOptions opts,
                                       IRegistryQuerier            registry,
+                                      IGame                       game,
                                       GameVersionCriteria         crit)
         {
             string request = string.Join(", ", toInstall.Select(m => m.identifier));
@@ -1514,7 +1520,7 @@ namespace CKAN
             {
                 var installed = toInstall.Select(m => registry.InstalledModule(m.identifier)?.Module)
                                          .OfType<CkanModule>();
-                var resolver = new RelationshipResolver(toInstall, installed, opts, registry, crit);
+                var resolver = new RelationshipResolver(toInstall, installed, opts, registry, game, crit);
 
                 var resolverModList = resolver.ModList(false).ToList();
                 if (resolverModList.Count >= toInstall.Count(m => !m.IsMetapackage))
@@ -1536,7 +1542,7 @@ namespace CKAN
                 foreach (var mod in k.modules)
                 {
                     // Try each option recursively to see if any are successful
-                    if (CanInstall(toInstall.Append(mod).ToList(), opts, registry, crit))
+                    if (CanInstall(toInstall.Append(mod).ToList(), opts, registry, game, crit))
                     {
                         // Child call will emit debug output, so we don't need to here
                         return true;

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -275,7 +275,8 @@ Which {0} provider would you like to install?</value></data>
 {1}
 
 If the game is still running, close it and try again. Otherwise check the permissions.</value></data>
-  <data name="KrakenMissingDependency" xml:space="preserve"><value>{0} missing dependency {1}</value></data>
+  <data name="KrakenMissingDependency" xml:space="preserve"><value>Unsatisfied dependency {1} needed for: {0}</value></data>
+  <data name="KrakenMissingDependencyNeededFor" xml:space="preserve"><value>needed for {0}</value></data>
   <data name="KrakenConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="KrakenDownloadErrorsHeader" xml:space="preserve"><value>Uh oh, the following things went wrong when downloading...</value></data>
   <data name="KrakenModuleDownloadErrorsHeader" xml:space="preserve"><value>One or more downloads were unsuccessful:</value></data>

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -28,7 +28,7 @@ namespace CKAN
                                    IEnumerable<Dictionary<string, AvailableModule>> available,
                                    Dictionary<string, HashSet<AvailableModule>>     providers,
                                    Dictionary<string, InstalledModule>              installed,
-                                   HashSet<string>                                  dlls,
+                                   ICollection<string>                              dlls,
                                    IDictionary<string, ModuleVersion>               dlc)
         {
             CompatibleVersions = crit;
@@ -104,8 +104,8 @@ namespace CKAN
         }
 
         private readonly Dictionary<string, InstalledModule> installed;
-        private readonly HashSet<string> dlls;
-        private readonly IDictionary<string, ModuleVersion> dlc;
+        private readonly ICollection<string>                 dlls;
+        private readonly IDictionary<string, ModuleVersion>  dlc;
 
         private List<CkanModule>? latestCompatible;
         private List<CkanModule>? latestIncompatible;

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -432,7 +432,7 @@ namespace CKAN
             List<InstalledModule>              installedModules,
             HashSet<string>                    dlls,
             IDictionary<string, ModuleVersion> dlc,
-            GameVersionCriteria?               crit)
+            GameVersionCriteria                crit)
         {
             log.DebugFormat("Finding removable autoInstalled for: {0}",
                             string.Join(", ", installedModules.Select(im => im.identifier)));
@@ -474,7 +474,7 @@ namespace CKAN
         public static IEnumerable<InstalledModule> FindRemovableAutoInstalled(
             this IRegistryQuerier querier,
             List<InstalledModule> installedModules,
-            GameVersionCriteria?  crit)
+            GameVersionCriteria   crit)
             => querier?.FindRemovableAutoInstalled(installedModules,
                                                    querier.InstalledDlls.ToHashSet(),
                                                    querier.InstalledDlc,

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -22,7 +22,7 @@ namespace CKAN
     {
         ReadOnlyDictionary<string, Repository> Repositories     { get; }
         IEnumerable<InstalledModule>           InstalledModules { get; }
-        IEnumerable<string>                    InstalledDlls    { get; }
+        ICollection<string>                    InstalledDlls    { get; }
         IDictionary<string, ModuleVersion>     InstalledDlc     { get; }
 
         /// <summary>
@@ -63,6 +63,8 @@ namespace CKAN
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
         IEnumerable<CkanModule> AvailableByIdentifier(string identifier);
+
+        IEnumerable<AvailableModule> AllAvailableByProvides(string identifier);
 
         /// <summary>
         /// Returns the latest available version of a module that satisfies the specified version and
@@ -427,12 +429,11 @@ namespace CKAN
         /// <returns>
         /// Sequence of removable auto-installed modules, if any
         /// </returns>
-        private static IEnumerable<InstalledModule> FindRemovableAutoInstalled(
-            this IRegistryQuerier              querier,
-            List<InstalledModule>              installedModules,
-            HashSet<string>                    dlls,
-            IDictionary<string, ModuleVersion> dlc,
-            GameVersionCriteria                crit)
+        public static IEnumerable<InstalledModule> FindRemovableAutoInstalled(
+            this IRegistryQuerier querier,
+            List<InstalledModule> installedModules,
+            IGame                 game,
+            GameVersionCriteria   crit)
         {
             log.DebugFormat("Finding removable autoInstalled for: {0}",
                             string.Join(", ", installedModules.Select(im => im.identifier)));
@@ -450,36 +451,17 @@ namespace CKAN
                 installedModules.Where(im => !im.Module.IsDLC)
                                 .Select(im => im.Module),
                 null,
-                opts, querier, crit);
+                opts, querier, game, crit);
 
             var mods = resolver.ModList().ToHashSet();
             return autoInstMods.Where(
                 im => autoInstIds.IsSupersetOf(
                     Registry.FindReverseDependencies(new List<string> { im.identifier },
                                                      new List<CkanModule>(),
-                                                     mods, dlls, dlc)));
+                                                     mods,
+                                                     querier.InstalledDlls,
+                                                     querier.InstalledDlc)));
         }
-
-        /// <summary>
-        /// Find auto-installed modules that have no depending modules
-        /// or only auto-installed depending modules.
-        /// installedModules is a parameter so we can experiment with
-        /// changes that have not yet been made, such as removing other modules.
-        /// </summary>
-        /// <param name="installedModules">The modules currently installed</param>
-        /// <param name="crit">Version criteria for resolving relationships</param>
-        /// <returns>
-        /// Sequence of removable auto-installed modules, if any
-        /// </returns>
-        public static IEnumerable<InstalledModule> FindRemovableAutoInstalled(
-            this IRegistryQuerier querier,
-            List<InstalledModule> installedModules,
-            GameVersionCriteria   crit)
-            => querier?.FindRemovableAutoInstalled(installedModules,
-                                                   querier.InstalledDlls.ToHashSet(),
-                                                   querier.InstalledDlc,
-                                                   crit)
-                      ?? Enumerable.Empty<InstalledModule>();
 
         private static readonly ILog log = LogManager.GetLogger(typeof(IRegistryQuerierHelpers));
     }

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -31,7 +31,7 @@ namespace CKAN
                                     IEnumerable<CkanModule>?    modulesToRemove,
                                     RelationshipResolverOptions options,
                                     IRegistryQuerier            registry,
-                                    GameVersionCriteria?        versionCrit)
+                                    GameVersionCriteria         versionCrit)
             : this(options, registry, versionCrit)
         {
             if (modulesToRemove != null)
@@ -52,7 +52,7 @@ namespace CKAN
         /// <param name="versionCrit">The current KSP version criteria to consider</param>
         private RelationshipResolver(RelationshipResolverOptions options,
                                      IRegistryQuerier            registry,
-                                     GameVersionCriteria?        versionCrit)
+                                     GameVersionCriteria         versionCrit)
         {
             this.options     = options;
             this.registry    = registry;
@@ -698,7 +698,7 @@ namespace CKAN
         private readonly HashSet<RelationshipDescriptor> suppressedRecommenders = new HashSet<RelationshipDescriptor>();
 
         private readonly IRegistryQuerier            registry;
-        private readonly GameVersionCriteria?        versionCrit;
+        private readonly GameVersionCriteria         versionCrit;
         private readonly RelationshipResolverOptions options;
 
         /// <summary>

--- a/Core/Relationships/RelationshipResolverOptions.cs
+++ b/Core/Relationships/RelationshipResolverOptions.cs
@@ -1,0 +1,141 @@
+namespace CKAN
+{
+    // TODO: It would be lovely to get rid of the `without` fields,
+    // and replace them with `with` fields. Humans suck at inverting
+    // cases in their heads.
+    public class RelationshipResolverOptions
+    {
+        /// <summary>
+        /// Default options for relationship resolution.
+        /// </summary>
+        public static RelationshipResolverOptions DefaultOpts()
+            => new RelationshipResolverOptions();
+
+        /// <summary>
+        /// Options to install without recommendations.
+        /// </summary>
+        public static RelationshipResolverOptions DependsOnlyOpts()
+            => new RelationshipResolverOptions()
+            {
+                with_recommends   = false,
+                with_suggests     = false,
+                with_all_suggests = false,
+            };
+
+        /// <summary>
+        /// Options to find all dependencies, recommendations, and suggestions
+        /// of anything in the changeset (except when suppress_recommendations==true),
+        /// without throwing exceptions, so the calling code can decide what to do about conflicts
+        /// </summary>
+        public static RelationshipResolverOptions KitchenSinkOpts()
+            => new RelationshipResolverOptions()
+            {
+                with_recommends                = true,
+                with_suggests                  = true,
+                without_toomanyprovides_kraken = true,
+                without_enforce_consistency    = true,
+                proceed_with_inconsistencies   = true,
+                get_recommenders               = true,
+            };
+
+        public static RelationshipResolverOptions ConflictsOpts()
+            => new RelationshipResolverOptions()
+            {
+                without_toomanyprovides_kraken = true,
+                proceed_with_inconsistencies   = true,
+                without_enforce_consistency    = true,
+                with_recommends                = false,
+            };
+
+        /// <summary>
+        /// If true, add recommended mods, and their recommendations.
+        /// </summary>
+        public bool with_recommends = true;
+
+        /// <summary>
+        /// If true, add suggests, but not suggested suggests. :)
+        /// </summary>
+        public bool with_suggests = false;
+
+        /// <summary>
+        /// If true, add suggested modules, and *their* suggested modules, too!
+        /// </summary>
+        public bool with_all_suggests = false;
+
+        /// <summary>
+        /// If true, surpresses the TooManyProvides kraken when resolving
+        /// relationships. Otherwise, we just pick the first.
+        /// </summary>
+        public bool without_toomanyprovides_kraken = false;
+
+        /// <summary>
+        /// If true, we skip our sanity check at the end of our relationship
+        /// resolution. Note that non-sane resolutions can't actually be
+        /// installed, so this is mostly useful for giving the user feedback
+        /// on failed resolutions.
+        /// </summary>
+        public bool without_enforce_consistency = false;
+
+        /// <summary>
+        /// If true, we'll populate the `conflicts` field, rather than immediately
+        /// throwing a kraken when inconsistencies are detected. Again, these
+        /// solutions are non-installable, so mostly of use to provide user
+        /// feedback when things go wrong.
+        /// </summary>
+        public bool proceed_with_inconsistencies = false;
+
+        /// <summary>
+        /// If true, then if a module has no versions that are compatible with
+        /// the current game version, then we will consider incompatible versions
+        /// of that module.
+        /// This replaces the former behavior of ignoring compatibility for
+        /// `install identifier=version` commands.
+        /// </summary>
+        public bool allow_incompatible = false;
+
+        /// <summary>
+        /// If true, get the list of mods that should be checked for
+        /// recommendations and suggestions.
+        /// Differs from normal resolution in that it stops when
+        /// ModuleRelationshipDescriptor.suppress_recommendations==true
+        /// </summary>
+        public bool get_recommenders = false;
+
+        public RelationshipResolverOptions OptionsFor(RelationshipDescriptor descr)
+            => descr.suppress_recommendations ? WithoutRecommendations() : this;
+
+        public RelationshipResolverOptions WithoutRecommendations()
+        {
+            if (with_recommends || with_all_suggests || with_suggests)
+            {
+                var newOptions = (RelationshipResolverOptions)MemberwiseClone();
+                newOptions.with_recommends   = false;
+                newOptions.with_all_suggests = false;
+                newOptions.with_suggests     = false;
+                return newOptions;
+            }
+            return this;
+        }
+
+        public RelationshipResolverOptions WithoutSuggestions()
+        {
+            if (with_suggests)
+            {
+                var newOptions = (RelationshipResolverOptions)MemberwiseClone();
+                newOptions.with_suggests = false;
+                return newOptions;
+            }
+            return this;
+        }
+
+        public OptionalRelationships OptionalHandling()
+            => (with_all_suggests ? OptionalRelationships.AllSuggestions | OptionalRelationships.Suggestions
+                                  : OptionalRelationships.None)
+               | (with_suggests   ? OptionalRelationships.Suggestions
+                                  : OptionalRelationships.None)
+               | (with_recommends ? OptionalRelationships.Recommendations
+                                  : OptionalRelationships.None);
+
+    }
+
+}

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+using CKAN.Versioning;
+
+namespace CKAN
+{
+    using RelationshipCache = ConcurrentDictionary<RelationshipDescriptor, ResolvedRelationship>;
+
+    public abstract class ResolvedRelationship : IEquatable<ResolvedRelationship>
+    {
+        public ResolvedRelationship(CkanModule             source,
+                                    RelationshipDescriptor relationship,
+                                    SelectionReason        reason)
+        {
+            this.source       = source;
+            this.relationship = relationship;
+            this.reason       = reason;
+        }
+
+        public readonly CkanModule             source;
+        public readonly RelationshipDescriptor relationship;
+        public readonly SelectionReason        reason;
+
+        public virtual bool Contains(CkanModule mod)
+            => false;
+
+        public virtual bool Unsatisfied()
+            => false;
+
+        public virtual bool Unsatisfied(ICollection<CkanModule> installing)
+            => false;
+
+        public override string ToString()
+            => $"{source} {reason.GetType().Name} {relationship}";
+
+        public virtual IEnumerable<string> ToLines()
+            => Enumerable.Repeat(ToString(), 1);
+
+        public abstract ResolvedRelationship WithSource(CkanModule      newSrc,
+                                                        SelectionReason newRsn);
+
+        public override bool Equals(object? other)
+            => Equals(other as ResolvedRelationship);
+
+        public bool Equals(ResolvedRelationship? other)
+            => source.Equals(other?.source)
+               && relationship.Equals(other?.relationship)
+               && reason.Equals(other?.reason);
+
+        public override int GetHashCode()
+            => (source, relationship, reason).GetHashCode();
+    }
+
+    public class ResolvedByInstalled : ResolvedRelationship
+    {
+        public ResolvedByInstalled(CkanModule             source,
+                                   RelationshipDescriptor relationship,
+                                   SelectionReason        reason,
+                                   CkanModule             installed)
+             : base(source, relationship, reason)
+        {
+            this.installed = installed;
+        }
+
+        public readonly CkanModule installed;
+
+        public override bool Contains(CkanModule mod)
+            => installed == mod;
+
+        public override string ToString()
+            => $"{source} {relationship}: Installed {installed}";
+
+        public override ResolvedRelationship WithSource(CkanModule newSrc, SelectionReason newRsn)
+            => new ResolvedByInstalled(newSrc, relationship, newRsn, installed);
+    }
+
+    public class ResolvedByInstalling : ResolvedRelationship
+    {
+        public ResolvedByInstalling(CkanModule             source,
+                                    RelationshipDescriptor relationship,
+                                    SelectionReason        reason,
+                                    CkanModule             installing)
+             : base(source, relationship, reason)
+        {
+            this.installing = installing;
+        }
+
+        public readonly CkanModule installing;
+
+        public override bool Contains(CkanModule mod)
+            => installing == mod;
+
+        public override string ToString()
+            => $"{base.ToString()}: Installing {installing}";
+
+        public override ResolvedRelationship WithSource(CkanModule newSrc, SelectionReason newRsn)
+            => new ResolvedByInstalling(newSrc, relationship, newRsn, installing);
+    }
+
+    public class ResolvedByDLL : ResolvedRelationship
+    {
+        public ResolvedByDLL(CkanModule             source,
+                             RelationshipDescriptor relationship,
+                             SelectionReason        reason)
+             : base(source, relationship, reason)
+        {
+        }
+
+        public override string ToString()
+            => $"{base.ToString()}: DLL";
+
+        public override ResolvedRelationship WithSource(CkanModule newSrc, SelectionReason newRsn)
+            => new ResolvedByDLL(newSrc, relationship, newRsn);
+    }
+
+    public class ResolvedByNew : ResolvedRelationship
+    {
+        public ResolvedByNew(CkanModule                                              source,
+                             RelationshipDescriptor                                  relationship,
+                             SelectionReason                                         reason,
+                             IReadOnlyDictionary<CkanModule, ResolvedRelationship[]> resolved)
+              : base(source, relationship, reason)
+        {
+            this.resolved = resolved;
+        }
+
+        public ResolvedByNew(CkanModule             source,
+                             RelationshipDescriptor relationship,
+                             SelectionReason        reason)
+             : this(source, relationship, reason,
+                    new Dictionary<CkanModule, ResolvedRelationship[]>())
+        {
+        }
+
+        public ResolvedByNew(CkanModule              source,
+                             RelationshipDescriptor  relationship,
+                             SelectionReason         reason,
+                             IEnumerable<CkanModule> providers,
+                             ICollection<CkanModule> definitelyInstalling,
+                             ICollection<CkanModule> allInstalling,
+                             IRegistryQuerier        registry,
+                             ICollection<CkanModule> installed,
+                             GameVersionCriteria     crit,
+                             OptionalRelationships   optRels,
+                             RelationshipCache       relationshipCache)
+             : this(source, relationship, reason,
+                    providers.ToDictionary(prov => prov,
+                                           prov => ResolvedRelationshipsTree.ResolveModule(
+                                                       prov, definitelyInstalling, allInstalling, registry, installed, crit,
+                                                       (optRels & OptionalRelationships.AllSuggestions) == 0
+                                                           ? optRels & ~OptionalRelationships.Suggestions
+                                                           : optRels,
+                                                       relationshipCache)
+                                                       .ToArray()))
+        {
+        }
+
+        /// <summary>
+        /// The modules that can satisfy this relationship and their own relationships.
+        /// If this is empty, then the relationship cannot be satisfied.
+        /// </summary>
+        public readonly IReadOnlyDictionary<CkanModule, ResolvedRelationship[]> resolved;
+
+        public override bool Contains(CkanModule mod)
+            => resolved.Any(rr => rr.Key == mod || rr.Value.Any(rrr => rrr.Contains(mod)));
+
+        public override bool Unsatisfied()
+            => reason is SelectionReason.Depends && resolved.Count == 0;
+
+        public override bool Unsatisfied(ICollection<CkanModule> installing)
+            => reason is SelectionReason.Depends
+               && !resolved.Any(kvp => AvailableModule.DependsAndConflictsOK(kvp.Key, installing)
+                                       && kvp.Value.All(rr => !rr.Unsatisfied(installing)));
+
+        public override string ToString()
+            => string.Join(Environment.NewLine, ToLines());
+
+        public override IEnumerable<string> ToLines()
+            => Enumerable.Repeat(resolved.Count > 0 ? $"{base.ToString()}:"
+                                                    : $"UNRESOLVED {base.ToString()}", 1)
+                         .Concat(resolved.SelectMany(kvp => Enumerable.Repeat(kvp.Value.Length > 0
+                                                                                  ? $"Module {kvp.Key}:"
+                                                                                  : $"Module {kvp.Key}", 1)
+                                                                      .Concat(kvp.Value
+                                                                                 .SelectMany(rr => rr.ToLines())
+                                                                                 .Select(line => $"\t{line}")))
+                                         .Select(line => $"\t{line}"));
+
+        public override ResolvedRelationship WithSource(CkanModule newSrc, SelectionReason newRsn)
+            => new ResolvedByNew(newSrc, relationship, newRsn, resolved);
+    }
+}

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+using CKAN.Versioning;
+using CKAN.Extensions;
+
+namespace CKAN
+{
+    using RelationshipCache = ConcurrentDictionary<RelationshipDescriptor, ResolvedRelationship>;
+
+    [Flags]
+    public enum OptionalRelationships
+    {
+        None            = 0,
+        Recommendations = 1,
+        Suggestions     = 2,
+        AllSuggestions  = 4,
+    }
+
+    public class ResolvedRelationshipsTree
+    {
+        public ResolvedRelationshipsTree(ICollection<CkanModule> modules,
+                                         IRegistryQuerier        registry,
+                                         ICollection<CkanModule> installed,
+                                         GameVersionCriteria     crit,
+                                         OptionalRelationships   optRels)
+        {
+            resolved = ResolveManyCached(modules, registry, installed, crit, optRels, relationshipCache).ToArray();
+        }
+
+        public static IEnumerable<ResolvedRelationship> ResolveModule(CkanModule              module,
+                                                                      ICollection<CkanModule> definitelyInstalling,
+                                                                      ICollection<CkanModule> allInstalling,
+                                                                      IRegistryQuerier        registry,
+                                                                      ICollection<CkanModule> installed,
+                                                                      GameVersionCriteria     crit,
+                                                                      OptionalRelationships   optRels,
+                                                                      RelationshipCache       relationshipCache)
+            => ResolveRelationships(module, module.depends, new SelectionReason.Depends(module),
+                                    definitelyInstalling, allInstalling, registry, installed, crit, optRels, relationshipCache)
+                .Concat((optRels & OptionalRelationships.Recommendations) == 0
+                    ? Enumerable.Empty<ResolvedRelationship>()
+                    : ResolveRelationships(module, module.recommends, new SelectionReason.Recommended(module, 0),
+                                           definitelyInstalling, allInstalling, registry, installed, crit, optRels, relationshipCache))
+                .Concat((optRels & OptionalRelationships.Suggestions) == 0
+                    ? Enumerable.Empty<ResolvedRelationship>()
+                    : ResolveRelationships(module, module.suggests, new SelectionReason.Suggested(module),
+                                           definitelyInstalling, allInstalling, registry, installed, crit, optRels, relationshipCache));
+
+        public IEnumerable<ResolvedRelationship[]> Unsatisfied()
+            => resolved.SelectMany(UnsatisfiedFrom);
+
+        private static IEnumerable<ResolvedRelationship[]> UnsatisfiedFrom(ResolvedRelationship rr)
+        {
+            // Our goal here is to return an array of ResolvedRelationships for each full
+            // trace from rr to a relationship we can't satisfy.
+            // First we need to make sure we even care about this one, i.e. that it's required.
+            if (rr.reason is SelectionReason.Depends)
+            {
+                // Now if this relationship itself can't be resolved directly, return it.
+                if (rr.Unsatisfied())
+                {
+                    return Enumerable.Repeat(new ResolvedRelationship[] { rr }, 1);
+                }
+                // Now we know it's a dependency that has at least one option for satisfying it,
+                // but those options may or may not be fully satisfied when considering _their_ dependencies.
+
+                // If any of these options works, then we want to return nothing.
+                // Otherwise we want to return all of the descriptions of why everything failed,
+                // with rr prepended to the start of each array.
+                if (rr is ResolvedByNew rbn)
+                {
+                    var unsats = rbn.resolved.Values
+                                             .Select(modsRels => modsRels.SelectMany(UnsatisfiedFrom)
+                                                                         .ToArray())
+                                             .Memoize();
+
+                    return unsats.Any(u => u.Length == 0)
+                        // One of the dependencies is fully satisfied
+                        ? Enumerable.Empty<ResolvedRelationship[]>()
+                        : unsats.SelectMany(uns => uns.Select(u => u.Prepend(rr).ToArray()));
+                }
+            }
+            return Enumerable.Empty<ResolvedRelationship[]>();
+        }
+
+        public IEnumerable<CkanModule> Candidates(RelationshipDescriptor  rel,
+                                                  ICollection<CkanModule> installing)
+            => relationshipCache.TryGetValue(rel, out ResolvedRelationship? rr)
+               && rr is ResolvedByNew resRel
+                   ? resRel.resolved
+                           .Where(kvp => AvailableModule.DependsAndConflictsOK(kvp.Key, installing)
+                                         && kvp.Value.All(subRR => !subRR.Unsatisfied(installing)))
+                           .Select(kvp => kvp.Key)
+                   : Enumerable.Empty<CkanModule>();
+
+        public override string ToString()
+            => string.Join(Environment.NewLine,
+                           resolved.Select(rr => rr.ToString()));
+
+        private static IEnumerable<ResolvedRelationship> ResolveManyCached(ICollection<CkanModule> modules,
+                                                                           IRegistryQuerier        registry,
+                                                                           ICollection<CkanModule> installed,
+                                                                           GameVersionCriteria     crit,
+                                                                           OptionalRelationships   optRels,
+                                                                           RelationshipCache       relationshipCache)
+            => modules.SelectMany(m => ResolveModule(m, modules, modules, registry, installed, crit, optRels,
+                                                     relationshipCache));
+
+        private static IEnumerable<ResolvedRelationship> ResolveRelationships(CkanModule                    module,
+                                                                              List<RelationshipDescriptor>? relationships,
+                                                                              SelectionReason               reason,
+                                                                              ICollection<CkanModule>       definitelyInstalling,
+                                                                              ICollection<CkanModule>       allInstalling,
+                                                                              IRegistryQuerier              registry,
+                                                                              ICollection<CkanModule>       installed,
+                                                                              GameVersionCriteria           crit,
+                                                                              OptionalRelationships         optRels,
+                                                                              RelationshipCache             relationshipCache)
+            => relationships?.Select(dep => Resolve(module, dep, reason,
+                                                    definitelyInstalling, allInstalling, registry, installed,
+                                                    crit, optRels, relationshipCache))
+                            ?? Enumerable.Empty<ResolvedRelationship>();
+
+        private static ResolvedRelationship Resolve(CkanModule              source,
+                                                    RelationshipDescriptor  relationship,
+                                                    SelectionReason         reason,
+                                                    ICollection<CkanModule> definitelyInstalling,
+                                                    ICollection<CkanModule> allInstalling,
+                                                    IRegistryQuerier        registry,
+                                                    ICollection<CkanModule> installed,
+                                                    GameVersionCriteria     crit,
+                                                    OptionalRelationships   optRels,
+                                                    RelationshipCache       relationshipCache)
+            => relationshipCache.TryGetValue(relationship,
+                                             out ResolvedRelationship? cachedRel)
+                ? cachedRel.WithSource(source, reason)
+                : relationship.MatchesAny(installed, registry.InstalledDlls, registry.InstalledDlc,
+                                          out CkanModule? installedMatch)
+                        ? relationshipCache.GetOrAdd(
+                            relationship,
+                            installedMatch == null ? new ResolvedByDLL(source, relationship, reason)
+                                                   : new ResolvedByInstalled(source, relationship, reason,
+                                                                             installedMatch))
+                        : relationship.MatchesAny(allInstalling, null, null,
+                                                  out CkanModule? installingMatch)
+                          && installingMatch != null
+                            // Installing mods are branch-specific, so don't cache them
+                            ? new ResolvedByInstalling(source, relationship, reason, installingMatch)
+                            : relationshipCache.GetOrAdd(
+                                relationship,
+                                new ResolvedByNew(source, relationship, reason,
+                                                  relationship.LatestAvailableWithProvides(registry, crit,
+                                                                                           installed, definitelyInstalling),
+                                                  definitelyInstalling,
+                                                  allInstalling.Append(source).ToArray(),
+                                                  registry, installed, crit, optRels,
+                                                  relationshipCache));
+
+        private readonly ResolvedRelationship[] resolved;
+        private readonly RelationshipCache      relationshipCache = new RelationshipCache();
+    }
+}

--- a/Core/Relationships/SelectionReason.cs
+++ b/Core/Relationships/SelectionReason.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CKAN
+{
+    /// <summary>
+    /// Used to keep track of the relationships between modules in the resolver.
+    /// Intended to be used for displaying messages to the user.
+    /// </summary>
+    public abstract class SelectionReason : IEquatable<SelectionReason>
+    {
+        // Currently assumed to exist for any relationship other than UserRequested or Installed
+        public virtual string DescribeWith(IEnumerable<SelectionReason> others)
+            => ToString() ?? "";
+
+        public override bool Equals(object? obj)
+            => Equals(obj as SelectionReason);
+
+        public bool Equals(SelectionReason? rsn)
+            => GetType() == rsn?.GetType();
+
+        public override int GetHashCode()
+            => GetType().GetHashCode();
+
+        public virtual SelectionReason WithIndex(int providesIndex)
+            => this;
+
+        public class Installed : SelectionReason
+        {
+            public override string ToString()
+                => Properties.Resources.RelationshipResolverInstalledReason;
+        }
+
+        public class UserRequested : SelectionReason
+        {
+            public override string ToString()
+                => Properties.Resources.RelationshipResolverUserReason;
+        }
+
+        public class DependencyRemoved : SelectionReason
+        {
+            public override string ToString()
+                => Properties.Resources.RelationshipResolverDependencyRemoved;
+        }
+
+        public class NoLongerUsed : SelectionReason
+        {
+            public override string ToString()
+                => Properties.Resources.RelationshipResolverNoLongerUsedReason;
+        }
+
+        public abstract class RelationshipReason : SelectionReason, IEquatable<RelationshipReason>
+        {
+            public RelationshipReason(CkanModule parent)
+            {
+                Parent = parent;
+            }
+
+            public CkanModule Parent;
+
+            public bool Equals(RelationshipReason? rsn)
+                => GetType() == rsn?.GetType()
+                   && Parent == rsn?.Parent;
+
+            public override bool Equals(object? obj)
+                => Equals(obj as RelationshipReason);
+
+            public override int GetHashCode()
+            {
+                var type = GetType();
+                #if NET5_0_OR_GREATER
+                return HashCode.Combine(type, Parent);
+                #else
+                unchecked
+                {
+                    return (type, Parent).GetHashCode();
+                }
+                #endif
+            }
+
+        }
+
+        public class Replacement : RelationshipReason
+        {
+            public Replacement(CkanModule module)
+                : base(module)
+            {
+            }
+
+            public override string ToString()
+                => string.Format(Properties.Resources.RelationshipResolverReplacementReason,
+                                 Parent.name);
+
+            public override string DescribeWith(IEnumerable<SelectionReason> others)
+                => string.Format(Properties.Resources.RelationshipResolverReplacementReason,
+                                 string.Join(", ",
+                                             Enumerable.Repeat(this, 1)
+                                                       .Concat(others)
+                                                       .OfType<RelationshipReason>()
+                                                       .Select(r => r.Parent.name)));
+        }
+
+        public sealed class Suggested : RelationshipReason
+        {
+            public Suggested(CkanModule module)
+                : base(module)
+            {
+            }
+
+            public override string ToString()
+                => string.Format(Properties.Resources.RelationshipResolverSuggestedReason,
+                                 Parent.name);
+        }
+
+        public sealed class Depends : RelationshipReason
+        {
+            public Depends(CkanModule module)
+                : base(module)
+            {
+            }
+
+            public override string ToString()
+                => string.Format(Properties.Resources.RelationshipResolverDependsReason,
+                                 Parent.name);
+
+            public override string DescribeWith(IEnumerable<SelectionReason> others)
+                => string.Format(Properties.Resources.RelationshipResolverDependsReason,
+                                 string.Join(", ",
+                                             Enumerable.Repeat(this, 1)
+                                                       .Concat(others)
+                                                       .OfType<RelationshipReason>()
+                                                       .Select(r => r.Parent.name)));
+        }
+
+        public sealed class Recommended : RelationshipReason
+        {
+            public Recommended(CkanModule module, int providesIndex)
+                : base(module)
+            {
+                ProvidesIndex = providesIndex;
+            }
+
+            public readonly int ProvidesIndex;
+
+            public override SelectionReason WithIndex(int providesIndex)
+                => new Recommended(Parent, providesIndex);
+
+            public override string ToString()
+                => string.Format(Properties.Resources.RelationshipResolverRecommendedReason,
+                                 Parent.name);
+        }
+    }
+}

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -100,11 +100,10 @@ namespace CKAN
         /// <param name="installed">Modules that are already installed</param>
         /// <param name="toInstall">Modules that are planned to be installed</param>
         /// <returns></returns>
-        public CkanModule? Latest(
-            GameVersionCriteria?     ksp_version  = null,
-            RelationshipDescriptor?  relationship = null,
-            ICollection<CkanModule>? installed    = null,
-            ICollection<CkanModule>? toInstall    = null)
+        public CkanModule? Latest(GameVersionCriteria?     ksp_version  = null,
+                                  RelationshipDescriptor?  relationship = null,
+                                  ICollection<CkanModule>? installed    = null,
+                                  ICollection<CkanModule>? toInstall    = null)
         {
             IEnumerable<CkanModule> modules = module_version.Values.Reverse();
             if (relationship != null)
@@ -126,7 +125,8 @@ namespace CKAN
             return modules.FirstOrDefault();
         }
 
-        private static bool DependsAndConflictsOK(CkanModule module, ICollection<CkanModule> others)
+        public static bool DependsAndConflictsOK(CkanModule              module,
+                                                 ICollection<CkanModule> others)
         {
             if (module.depends != null)
             {

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -496,7 +496,9 @@ namespace CKAN
         {
             var compat = _comparator.Compatible(version, this);
             log.DebugFormat("Checking compat of {0} with game versions {1}: {2}",
-                this, version.ToString(), compat ? "Compatible": "Incompatible");
+                            this,
+                            version.ToString(),
+                            compat ? "Compatible": "Incompatible");
             return compat;
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1997,7 +1997,7 @@ namespace CKAN.GUI
                        gmod.SelectedMod = ch.targetMod;
                     }
                 }
-                var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, gameVersion);
+                var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, inst.game, gameVersion);
                 full_change_set = tuple.Item1.ToList();
                 new_conflicts = tuple.Item2.ToDictionary(
                     item => new GUIMod(item.Key, repoData, registry, gameVersion, null,
@@ -2014,14 +2014,20 @@ namespace CKAN.GUI
                     ClearStatusBar?.Invoke();
                 }
             }
-            catch (DependencyNotSatisfiedKraken k)
+            catch (DependenciesNotSatisfiedKraken k)
             {
-                RaiseError?.Invoke(string.Format(Properties.Resources.MainDepNotSatisfied,
-                                                 k.parent, k.module));
-                // Uncheck the box
-                if (mainModList.full_list_of_mod_rows[k.parent.identifier].Tag is GUIMod gmod)
+                RaiseError?.Invoke(k.Message);
+                var identifiers = k.unsatisfied
+                                   .SelectMany(uns => uns.Select(rr => rr.source.identifier))
+                                   .Distinct();
+
+                foreach (var ident in identifiers)
                 {
-                    gmod.SelectedMod = null;
+                    // Uncheck the box
+                    if (mainModList.full_list_of_mod_rows[ident].Tag is GUIMod gmod)
+                    {
+                        gmod.SelectedMod = null;
+                    }
                 }
             }
 

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -298,7 +298,7 @@ namespace CKAN.GUI
 
             // Check if this dependency is installed
             if (relDescr.MatchesAny(registry.InstalledModules.Select(im => im.Module).ToList(),
-                                    registry.InstalledDlls.ToHashSet(),
+                                    registry.InstalledDlls,
                                     // Maybe it's a DLC?
                                     registry.InstalledDlc,
                                     out CkanModule? matched))

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -13,6 +13,7 @@ using System.Runtime.Versioning;
 
 using Autofac;
 
+using CKAN.Games;
 using CKAN.Versioning;
 using CKAN.GUI.Attributes;
 
@@ -107,16 +108,18 @@ namespace CKAN.GUI
                                         IRegistryQuerier registry)
             => currentInstance != null
                 && installable(module, registry,
+                               currentInstance.game,
                                currentInstance.VersionCriteria());
 
         [ForbidGUICalls]
         private static bool installable(CkanModule          module,
                                         IRegistryQuerier    registry,
+                                        IGame               game,
                                         GameVersionCriteria crit)
             => module.IsCompatible(crit)
                 && ModuleInstaller.CanInstall(new List<CkanModule>() { module },
                                               RelationshipResolverOptions.DependsOnlyOpts(),
-                                              registry, crit);
+                                              registry, game, crit);
 
         private bool allowInstall(CkanModule module)
         {

--- a/GUI/Controls/UnmanagedFiles.cs
+++ b/GUI/Controls/UnmanagedFiles.cs
@@ -104,7 +104,7 @@ namespace CKAN.GUI
             }
         }
 
-        private void AddContentPieces(TreeNode parent, IEnumerable<string> pieces)
+        private static void AddContentPieces(TreeNode parent, IEnumerable<string> pieces)
         {
             var firstPiece = pieces.FirstOrDefault();
             if (firstPiece != null)
@@ -116,7 +116,7 @@ namespace CKAN.GUI
                 // Key/Name needs to be the full relative path for double click to work
                 var key = string.IsNullOrEmpty(parent.Name)
                     ? firstPiece
-                    : $"{parent.Name}/{firstPiece}";
+                    : Path.Combine(parent.Name, firstPiece);
                 var node = parent.Nodes[key]
                         ?? parent.Nodes.Add(key, firstPiece, "file", "file");
                 AddContentPieces(node, pieces.Skip(1));
@@ -175,8 +175,12 @@ namespace CKAN.GUI
 
         private void ShowInFolderButton_Click(object? sender, EventArgs? e)
         {
-            Utilities.OpenFileBrowser(GameFolderTree.SelectedNode.Name);
-            GameFolderTree.Focus();
+            if (GameFolderTree.SelectedNode is TreeNode node
+                && inst != null)
+            {
+                Utilities.OpenFileBrowser(inst.ToAbsoluteGameDir(node.Name));
+                GameFolderTree.Focus();
+            }
         }
 
         private void DeleteButton_Click(object? sender, EventArgs? e)

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -26,6 +26,7 @@ namespace CKAN.GUI
                     RegistryManager.Instance(CurrentInstance, repoData).registry,
                     modules.Select(mod => new ModChange(mod, GUIModChangeType.Install))
                            .ToHashSet(),
+                    CurrentInstance.game,
                     CurrentInstance.VersionCriteria());
                 UpdateChangesDialog(tuple.Item1.ToList(), tuple.Item2);
                 tabController.ShowTab("ChangesetTabPage", 1);

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -14,7 +14,6 @@ namespace CKAN.GUI
             {
                 InstallationHistory.LoadHistory(CurrentInstance, configuration, repoData);
                 tabController.ShowTab("InstallationHistoryTabPage", 2);
-                DisableMainWindow();
             }
         }
 
@@ -38,7 +37,6 @@ namespace CKAN.GUI
             UpdateStatusBar();
             tabController.ShowTab("ManageModsTabPage");
             tabController.HideTab("InstallationHistoryTabPage");
-            EnableMainWindow();
         }
 
         private void InstallationHistory_OnSelectedModuleChanged(CkanModule m)

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -245,7 +245,7 @@ namespace CKAN.GUI
                             // Get full changeset (toInstall only includes user's selections, not dependencies)
                             var crit = CurrentInstance.VersionCriteria();
                             var fullChangeset = new RelationshipResolver(
-                                toInstall.Concat(toUpgrade), toUninstall, options, registry, crit
+                                toInstall.Concat(toUpgrade), toUninstall, options, registry, CurrentInstance.game, crit
                             ).ModList().ToList();
                             DownloadsFailedDialog? dfd = null;
                             Util.Invoke(this, () =>
@@ -385,8 +385,8 @@ namespace CKAN.GUI
             {
                 switch (e.Error)
                 {
-                    case DependencyNotSatisfiedKraken exc:
-                        currentUser.RaiseMessage(Properties.Resources.MainInstallDepNotSatisfied, exc.parent, exc.module);
+                    case DependenciesNotSatisfiedKraken exc:
+                        currentUser.RaiseMessage("{0}", exc.Message);
                         break;
 
                     case ModuleNotFoundKraken exc:

--- a/GUI/Main/MainUnmanaged.cs
+++ b/GUI/Main/MainUnmanaged.cs
@@ -13,7 +13,6 @@ namespace CKAN.GUI
             {
                 UnmanagedFiles.LoadFiles(Manager.CurrentInstance, repoData, currentUser);
                 tabController.ShowTab("UnmanagedFilesTabPage", 2);
-                DisableMainWindow();
             }
         }
 
@@ -22,7 +21,6 @@ namespace CKAN.GUI
             UpdateStatusBar();
             tabController.ShowTab("ManageModsTabPage");
             tabController.HideTab("UnmanagedFilesTabPage");
-            EnableMainWindow();
         }
     }
 }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -451,7 +451,7 @@ namespace CKAN.GUI
                : Enumerable.Empty<ModChange>();
 
         public HashSet<ModChange> ComputeUserChangeSet(IRegistryQuerier     registry,
-                                                       GameVersionCriteria? crit,
+                                                       GameVersionCriteria  crit,
                                                        GameInstance?        instance,
                                                        DataGridViewColumn?  upgradeCol,
                                                        DataGridViewColumn?  replaceCol)

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -125,7 +125,10 @@ namespace CKAN.GUI
         /// <param name="changeSet"></param>
         /// <param name="version">The version of the current game instance</param>
         public Tuple<IEnumerable<ModChange>, Dictionary<CkanModule, string>, List<string>> ComputeFullChangeSetFromUserChangeSet(
-            IRegistryQuerier registry, HashSet<ModChange> changeSet, GameVersionCriteria version)
+            IRegistryQuerier    registry,
+            HashSet<ModChange>  changeSet,
+            IGame               game,
+            GameVersionCriteria version)
         {
             var modules_to_install = new List<CkanModule>();
             var modules_to_remove = new HashSet<CkanModule>();
@@ -194,7 +197,7 @@ namespace CKAN.GUI
             }
 
             foreach (var im in registry.FindRemovableAutoInstalled(
-                InstalledAfterChanges(registry, changeSet).ToList(), version))
+                InstalledAfterChanges(registry, changeSet).ToList(), game, version))
             {
                 changeSet.Add(new ModChange(im.Module, GUIModChangeType.Remove, new SelectionReason.NoLongerUsed()));
                 modules_to_remove.Add(im.Module);
@@ -203,7 +206,7 @@ namespace CKAN.GUI
             // Get as many dependencies as we can, but leave decisions and prompts for installation time
             var resolver = new RelationshipResolver(
                 modules_to_install, modules_to_remove,
-                conflictOptions, registry, version);
+                conflictOptions, registry, game, version);
 
             // Replace Install entries in changeset with the ones from resolver to get all the reasons
             return new Tuple<IEnumerable<ModChange>, Dictionary<CkanModule, string>, List<string>>(
@@ -452,7 +455,7 @@ namespace CKAN.GUI
 
         public HashSet<ModChange> ComputeUserChangeSet(IRegistryQuerier     registry,
                                                        GameVersionCriteria  crit,
-                                                       GameInstance?        instance,
+                                                       GameInstance         instance,
                                                        DataGridViewColumn?  upgradeCol,
                                                        DataGridViewColumn?  replaceCol)
         {
@@ -470,7 +473,7 @@ namespace CKAN.GUI
                                          // Skip reinstalls
                                          .Where(upg => upg.Mod != upg.targetMod)
                                          .ToArray();
-                if (upgrades.Length > 0 && instance != null)
+                if (upgrades.Length > 0)
                 {
                     var upgradeable = registry.CheckUpgradeable(instance,
                                                                 // Hold identifiers not chosen for upgrading
@@ -504,7 +507,7 @@ namespace CKAN.GUI
             return (registry == null
                 ? modChanges
                 : modChanges.Union(
-                    registry.FindRemovableAutoInstalled(registry.InstalledModules.ToList(), crit)
+                    registry.FindRemovableAutoInstalled(registry.InstalledModules.ToList(), instance.game, crit)
                         .Select(im => new ModChange(
                             im.Module, GUIModChangeType.Remove,
                             new SelectionReason.NoLongerUsed()))))

--- a/GUI/Model/ModSearch.cs
+++ b/GUI/Model/ModSearch.cs
@@ -80,27 +80,17 @@ namespace CKAN.GUI
         {
             switch (filter)
             {
-                case GUIModFilter.Compatible:               Compatible      = true;  break;
-                case GUIModFilter.Incompatible:             Compatible      = false; break;
-                case GUIModFilter.Installed:                Installed       = true;  break;
-                case GUIModFilter.NotInstalled:             Installed       = false; break;
-                case GUIModFilter.InstalledUpdateAvailable: Upgradeable     = true;  break;
-                case GUIModFilter.Replaceable:              Replaceable     = true;  break;
-                case GUIModFilter.Cached:                   Cached          = true;  break;
-                case GUIModFilter.Uncached:                 Cached          = false; break;
-                case GUIModFilter.NewInRepository:          NewlyCompatible = true;  break;
-                case GUIModFilter.Tag:
-                    if (tag?.Name is string tn)
-                    {
-                        TagNames.Add(tn);
-                    }
-                    break;
-                case GUIModFilter.CustomLabel:
-                    if (label?.Name is string ln)
-                    {
-                        LabelNames.Add(ln);
-                    }
-                    break;
+                case GUIModFilter.Compatible:               Compatible      = true;            break;
+                case GUIModFilter.Incompatible:             Compatible      = false;           break;
+                case GUIModFilter.Installed:                Installed       = true;            break;
+                case GUIModFilter.NotInstalled:             Installed       = false;           break;
+                case GUIModFilter.InstalledUpdateAvailable: Upgradeable     = true;            break;
+                case GUIModFilter.Replaceable:              Replaceable     = true;            break;
+                case GUIModFilter.Cached:                   Cached          = true;            break;
+                case GUIModFilter.Uncached:                 Cached          = false;           break;
+                case GUIModFilter.NewInRepository:          NewlyCompatible = true;            break;
+                case GUIModFilter.Tag:                      TagNames.Add(tag?.Name ?? "");     break;
+                case GUIModFilter.CustomLabel:              LabelNames.Add(label?.Name ?? ""); break;
                 default:
                 case GUIModFilter.All:
                     break;

--- a/Tests/Core/Registry/CompatibilitySorter.cs
+++ b/Tests/Core/Registry/CompatibilitySorter.cs
@@ -80,7 +80,7 @@ namespace Tests.Core.Registry
                                         .ToDictionary(grp => grp.Key,
                                                       grp => grp.ToHashSet());
                 var installed = new Dictionary<string, InstalledModule>();
-                var dlls      = new HashSet<string>();
+                var dlls      = new Dictionary<string, string>().Keys;
                 var dlcs      = new Dictionary<string, ModuleVersion>();
                 var highPrio  = repoData.Manager
                                         .GetAvailableModules(Enumerable.Repeat(repo1.repo, 1),

--- a/Tests/Core/Relationships/RelationshipResolver.cs
+++ b/Tests/Core/Relationships/RelationshipResolver.cs
@@ -18,6 +18,7 @@ namespace Tests.Core.Relationships
     {
         private RelationshipResolverOptions? options;
         private RandomModuleGenerator? generator;
+        private static readonly GameVersionCriteria crit = new GameVersionCriteria(null);
 
         [SetUp]
         public void Setup()
@@ -34,7 +35,7 @@ namespace Tests.Core.Relationships
             var registry = CKAN.Registry.Empty();
             options = RelationshipResolverOptions.DefaultOpts();
             Assert.DoesNotThrow(() => new RelationshipResolver(new List<CkanModule>(),
-                null, options, registry, null));
+                null, options, registry, crit));
         }
 
         [Test]
@@ -55,10 +56,10 @@ namespace Tests.Core.Relationships
 
                 var list = new List<CkanModule> { mod_a, mod_b };
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
 
                 options!.proceed_with_inconsistencies = true;
-                var resolver = new RelationshipResolver(list, null, options, registry, null);
+                var resolver = new RelationshipResolver(list, null, options, registry, crit);
 
                 Assert.That(resolver.ConflictList.Any(s => Equals(s.Key, mod_a)));
                 Assert.That(resolver.ConflictList.Any(s => Equals(s.Key, mod_b)));
@@ -85,7 +86,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -110,7 +111,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -135,7 +136,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -166,7 +167,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -191,7 +192,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -215,7 +216,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -239,7 +240,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -264,7 +265,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -297,7 +298,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_d };
 
                 Assert.Throws<TooManyModsProvideKraken>(() => new RelationshipResolver(
-                    list, null, options, registry, null));
+                    list, null, options, registry, crit));
             }
         }
 
@@ -316,7 +317,7 @@ namespace Tests.Core.Relationships
                 registry.RegisterModule(mod_a, new List<string>(), ksp.KSP, false);
 
                 var relationship_resolver = new RelationshipResolver(
-                    list, null, options!, registry, null);
+                    list, null, options!, registry, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), mod_a);
                 CollectionAssert.AreEquivalent(new List<SelectionReason>
                                           {
@@ -346,7 +347,7 @@ namespace Tests.Core.Relationships
                 registry.Installed().Add(suggested.identifier, suggested.version);
                 var list = new List<CkanModule> { suggester };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
             }
         }
@@ -374,7 +375,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { suggester, mod };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
                 CollectionAssert.DoesNotContain(relationship_resolver.ModList(), suggested);
             }
         }
@@ -402,7 +403,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { depender, conflicts_with_dependant };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -424,7 +425,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { suggester };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
             }
         }
@@ -456,12 +457,12 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { suggester };
 
                 options!.with_all_suggests = true;
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested2);
 
                 options.with_all_suggests = false;
 
-                relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
+                relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
                 CollectionAssert.DoesNotContain(relationship_resolver.ModList(), suggested2);
             }
         }
@@ -486,7 +487,7 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
 
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
@@ -513,7 +514,7 @@ namespace Tests.Core.Relationships
 
                 Assert.Throws<DependencyNotSatisfiedKraken>(() =>
                     new RelationshipResolver(new List<CkanModule> { depender },
-                                             null, options!, registry, null));
+                                             null, options!, registry, crit));
             }
         }
 
@@ -541,7 +542,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { depender };
 
                 Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -565,10 +566,10 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule>() { depender };
 
                 Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
                 list.Add(dependant);
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -592,7 +593,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { depender, dependant };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -622,7 +623,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { depender, dependant };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, null));
+                    list, null, options!, registry, crit));
             }
         }
 
@@ -649,7 +650,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
                     dependant,
@@ -682,7 +683,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
                     dependant,
@@ -715,7 +716,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
                     dependant,
@@ -753,7 +754,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
                     dependant,
@@ -810,7 +811,7 @@ namespace Tests.Core.Relationships
                 // Act
                 RelationshipResolver rr = new RelationshipResolver(
                     new CkanModule[] { depender }, null,
-                    options!, registry, null);
+                    options!, registry, crit);
 
                 // Assert
                 CollectionAssert.Contains(      rr.ModList(), olderDependency);
@@ -861,7 +862,7 @@ namespace Tests.Core.Relationships
                 // Act
                 RelationshipResolver rr = new RelationshipResolver(
                     new CkanModule[] { depender }, null,
-                    options!, registry, null);
+                    options!, registry, crit);
 
                 // Assert
                 CollectionAssert.Contains(      rr.ModList(), olderDependency);
@@ -880,7 +881,7 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { mod };
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
 
                 var mod_not_in_resolver_list = generator.GeneratorRandomModule();
                 CollectionAssert.DoesNotContain(relationship_resolver.ModList(), mod_not_in_resolver_list);
@@ -900,7 +901,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { mod };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
                 var reasons = relationship_resolver.ReasonsFor(mod);
                 Assert.That(reasons[0], Is.AssignableTo<SelectionReason.UserRequested>());
             }
@@ -923,7 +924,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod };
 
                 options!.with_all_suggests = true;
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
                 var reasons = relationship_resolver.ReasonsFor(suggested);
 
                 Assert.IsTrue(reasons[0] is SelectionReason.Suggested sug
@@ -961,7 +962,7 @@ namespace Tests.Core.Relationships
 
                 options!.with_all_suggests = true;
                 options.with_recommends = true;
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, null);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
                 var reasons = relationship_resolver.ReasonsFor(recommendedA);
                 Assert.IsTrue(reasons[0] is SelectionReason.Recommended rec
                               && rec.Parent.Equals(suggested));
@@ -1066,7 +1067,7 @@ namespace Tests.Core.Relationships
                 options!.proceed_with_inconsistencies = false;
                 var exception = Assert.Throws<InconsistentKraken>(() =>
                 {
-                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, null);
+                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, crit);
                 });
                 Assert.AreEqual($"{avp} conflicts with {eveDefaultConfig}",
                                 exception?.ShortDescription);
@@ -1077,7 +1078,7 @@ namespace Tests.Core.Relationships
                 options.proceed_with_inconsistencies = true;
                 Assert.DoesNotThrow(() =>
                 {
-                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, null);
+                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, crit);
                 });
                 CollectionAssert.AreEquivalent(modulesToInstall,
                                                resolver?.ConflictList.Keys);
@@ -1093,7 +1094,7 @@ namespace Tests.Core.Relationships
                 options.proceed_with_inconsistencies = false;
                 Assert.DoesNotThrow(() =>
                 {
-                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, null);
+                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, crit);
                 });
                 Assert.IsEmpty(resolver!.ConflictList);
                 CollectionAssert.AreEquivalent(new List<CkanModule> {avp, avp2kTextures}, resolver.ModList());

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -3,11 +3,14 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using Tests.Data;
 
 using CKAN;
+using CKAN.Games;
+using CKAN.Games.KerbalSpaceProgram;
 using CKAN.Versioning;
 using RelationshipDescriptor = CKAN.RelationshipDescriptor;
 
@@ -18,6 +21,7 @@ namespace Tests.Core.Relationships
     {
         private RelationshipResolverOptions? options;
         private RandomModuleGenerator? generator;
+        private static readonly IGame               game = new KerbalSpaceProgram();
         private static readonly GameVersionCriteria crit = new GameVersionCriteria(null);
 
         [SetUp]
@@ -35,7 +39,7 @@ namespace Tests.Core.Relationships
             var registry = CKAN.Registry.Empty();
             options = RelationshipResolverOptions.DefaultOpts();
             Assert.DoesNotThrow(() => new RelationshipResolver(new List<CkanModule>(),
-                null, options, registry, crit));
+                null, options, registry, game, crit));
         }
 
         [Test]
@@ -56,10 +60,10 @@ namespace Tests.Core.Relationships
 
                 var list = new List<CkanModule> { mod_a, mod_b };
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
 
                 options!.proceed_with_inconsistencies = true;
-                var resolver = new RelationshipResolver(list, null, options, registry, crit);
+                var resolver = new RelationshipResolver(list, null, options, registry, game, crit);
 
                 Assert.That(resolver.ConflictList.Any(s => Equals(s.Key, mod_a)));
                 Assert.That(resolver.ConflictList.Any(s => Equals(s.Key, mod_b)));
@@ -74,7 +78,11 @@ namespace Tests.Core.Relationships
             var mod_a = generator!.GeneratorRandomModule();
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier, version=mod_a.version}
+                new ModuleRelationshipDescriptor
+                {
+                    name = mod_a.identifier,
+                    version = mod_a.version
+                }
             });
 
             var user = new NullUser();
@@ -86,7 +94,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -99,7 +107,11 @@ namespace Tests.Core.Relationships
             var mod_a = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = mod_a.identifier,
+                    min_version = new ModuleVersion(conf_min)
+                }
             });
 
             var user = new NullUser();
@@ -111,7 +123,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -124,7 +136,11 @@ namespace Tests.Core.Relationships
             var mod_a = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier, max_version=new ModuleVersion(conf_max)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = mod_a.identifier,
+                    max_version = new ModuleVersion(conf_max)
+                }
             });
 
             var user = new NullUser();
@@ -136,7 +152,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -167,7 +183,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -180,7 +196,11 @@ namespace Tests.Core.Relationships
             var mod_a = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier, version=new ModuleVersion(conf)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = mod_a.identifier,
+                    version = new ModuleVersion(conf)
+                }
             });
 
             var user = new NullUser();
@@ -192,7 +212,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -204,7 +224,11 @@ namespace Tests.Core.Relationships
             var mod_a = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = mod_a.identifier,
+                    min_version = new ModuleVersion(conf_min)
+                }
             });
 
             var user = new NullUser();
@@ -216,7 +240,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -228,7 +252,11 @@ namespace Tests.Core.Relationships
             var mod_a = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier, max_version=new ModuleVersion(conf_max)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = mod_a.identifier,
+                    max_version = new ModuleVersion(conf_max)
+                }
             });
 
             var user = new NullUser();
@@ -240,7 +268,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -253,7 +281,12 @@ namespace Tests.Core.Relationships
             var mod_a = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var mod_b = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier, min_version=new ModuleVersion(conf_min), max_version=new ModuleVersion(conf_max)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = mod_a.identifier,
+                    min_version = new ModuleVersion(conf_min),
+                    max_version = new ModuleVersion(conf_max)
+                }
             });
 
             var user = new NullUser();
@@ -265,7 +298,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_a, mod_b };
 
                 Assert.DoesNotThrow(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -285,7 +318,7 @@ namespace Tests.Core.Relationships
             });
             var mod_d = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=mod_a.identifier}
+                new ModuleRelationshipDescriptor {name = mod_a.identifier}
             });
 
             var user = new NullUser();
@@ -298,7 +331,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod_d };
 
                 Assert.Throws<TooManyModsProvideKraken>(() => new RelationshipResolver(
-                    list, null, options, registry, crit));
+                    list, null, options, registry, game, crit));
             }
         }
 
@@ -317,7 +350,7 @@ namespace Tests.Core.Relationships
                 registry.RegisterModule(mod_a, new List<string>(), ksp.KSP, false);
 
                 var relationship_resolver = new RelationshipResolver(
-                    list, null, options!, registry, crit);
+                    list, null, options!, registry, game, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), mod_a);
                 CollectionAssert.AreEquivalent(new List<SelectionReason>
                                           {
@@ -347,7 +380,7 @@ namespace Tests.Core.Relationships
                 registry.Installed().Add(suggested.identifier, suggested.version);
                 var list = new List<CkanModule> { suggester };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, game, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
             }
         }
@@ -375,7 +408,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { suggester, mod };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, game, crit);
                 CollectionAssert.DoesNotContain(relationship_resolver.ModList(), suggested);
             }
         }
@@ -383,27 +416,27 @@ namespace Tests.Core.Relationships
         [Test]
         public void Constructor_WithConflictingModulesInDependencies_ThrowUnderDefaultSettings()
         {
-            var dependant = generator!.GeneratorRandomModule();
+            var dependent = generator!.GeneratorRandomModule();
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier}
+                new ModuleRelationshipDescriptor {name = dependent.identifier}
             });
-            var conflicts_with_dependant = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
+            var conflicts_with_dependent = generator.GeneratorRandomModule(conflicts: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name=dependant.identifier}
+                new ModuleRelationshipDescriptor {name = dependent.identifier}
             });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant),
-                                                      CkanModule.ToJson(conflicts_with_dependant)))
+                                                      CkanModule.ToJson(dependent),
+                                                      CkanModule.ToJson(conflicts_with_dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<CkanModule> { depender, conflicts_with_dependant };
+                var list = new List<CkanModule> { depender, conflicts_with_dependent };
 
-                Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                Assert.Throws<DependenciesNotSatisfiedKraken>(() => new RelationshipResolver(
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -425,13 +458,13 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { suggester };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, game, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested);
             }
         }
 
         [Test]
-        public void Constructor_ContainsSugestedOfSuggested_When_With_all_suggests()
+        public void Constructor_WithAllSuggests_ContainsSuggestedOfSuggested()
         {
             var suggested2 = generator!.GeneratorRandomModule();
             var suggested = generator.GeneratorRandomModule(
@@ -457,12 +490,12 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { suggester };
 
                 options!.with_all_suggests = true;
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, game, crit);
                 CollectionAssert.Contains(relationship_resolver.ModList(), suggested2);
 
                 options.with_all_suggests = false;
 
-                relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
+                relationship_resolver = new RelationshipResolver(list, null, options, registry, game, crit);
                 CollectionAssert.DoesNotContain(relationship_resolver.ModList(), suggested2);
             }
         }
@@ -487,7 +520,7 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, game, crit);
 
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
@@ -498,12 +531,12 @@ namespace Tests.Core.Relationships
         }
 
         [Test]
-        public void Constructor_WithMissingDependants_Throws()
+        public void Constructor_WithMissingDependents_Throws()
         {
-            var dependant = generator!.GeneratorRandomModule();
+            var dependent = generator!.GeneratorRandomModule();
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier}
+                new ModuleRelationshipDescriptor {name = dependent.identifier}
             });
 
             var user = new NullUser();
@@ -512,9 +545,9 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
 
-                Assert.Throws<DependencyNotSatisfiedKraken>(() =>
+                Assert.Throws<DependenciesNotSatisfiedKraken>(() =>
                     new RelationshipResolver(new List<CkanModule> { depender },
-                                             null, options!, registry, crit));
+                                             null, options!, registry, game, crit));
             }
         }
 
@@ -524,76 +557,88 @@ namespace Tests.Core.Relationships
         [TestCase("1.0", "0.2")]
         [TestCase("0",   "0.2")]
         [TestCase("1.0", "0")]
-        public void Constructor_WithMissingDependantsVersion_Throws(string ver, string dep)
+        public void Constructor_WithMissingDependentsVersion_Throws(string ver, string dep)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier, version = new ModuleVersion(dep)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = dependent.identifier,
+                    version = new ModuleVersion(dep)
+                }
             });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant)))
+                                                      CkanModule.ToJson(dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
 
                 var list = new List<CkanModule> { depender };
 
-                Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                Assert.Throws<DependenciesNotSatisfiedKraken>(() => new RelationshipResolver(
+                    list, null, options!, registry, game, crit));
             }
         }
 
         [Test]
         [Category("Version")]
         [TestCase("1.0", "2.0")]
-        public void Constructor_WithMissingDependantsVersionMin_Throws(string ver, string dep_min)
+        public void Constructor_WithMissingDependentsVersionMin_Throws(string ver, string dep_min)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = dependent.identifier,
+                    min_version = new ModuleVersion(dep_min)
+                }
             });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant)))
+                                                      CkanModule.ToJson(dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule>() { depender };
 
-                Assert.Throws<DependencyNotSatisfiedKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
-                list.Add(dependant);
-                Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                Assert.Throws<DependenciesNotSatisfiedKraken>(() => new RelationshipResolver(
+                    list, null, options!, registry, game, crit));
+                list.Add(dependent);
+                Assert.Throws<DependenciesNotSatisfiedKraken>(() => new RelationshipResolver(
+                    list, null, options!, registry, game, crit));
             }
         }
 
         [Test]
         [Category("Version")]
         [TestCase("1.0", "0.5")]
-        public void Constructor_WithMissingDependantsVersionMax_Throws(string ver, string dep_max)
+        public void Constructor_WithMissingDependentsVersionMax_Throws(string ver, string dep_max)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier, max_version = new ModuleVersion(dep_max)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = dependent.identifier,
+                    max_version = new ModuleVersion(dep_max)
+                }
             });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant)))
+                                                      CkanModule.ToJson(dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<CkanModule> { depender, dependant };
+                var list = new List<CkanModule> { depender, dependent };
 
-                Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                Assert.Throws<DependenciesNotSatisfiedKraken>(() => new RelationshipResolver(
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -601,14 +646,14 @@ namespace Tests.Core.Relationships
         [Category("Version")]
         [TestCase("1.0", "2.0", "3.0")]
         [TestCase("4.0", "2.0", "3.0")]
-        public void Constructor_WithMissingDependantsVersionMinMax_Throws(string ver, string dep_min, string dep_max)
+        public void Constructor_WithMissingDependentsVersionMinMax_Throws(string ver, string dep_min, string dep_max)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
                 new ModuleRelationshipDescriptor
                 {
-                    name = dependant.identifier,
+                    name = dependent.identifier,
                     min_version = new ModuleVersion(dep_min),
                     max_version = new ModuleVersion(dep_max)
                 }
@@ -616,14 +661,14 @@ namespace Tests.Core.Relationships
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant)))
+                                                      CkanModule.ToJson(dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
-                var list = new List<CkanModule> { depender, dependant };
+                var list = new List<CkanModule> { depender, dependent };
 
-                Assert.Throws<InconsistentKraken>(() => new RelationshipResolver(
-                    list, null, options!, registry, crit));
+                Assert.Throws<DependenciesNotSatisfiedKraken>(() => new RelationshipResolver(
+                    list, null, options!, registry, game, crit));
             }
         }
 
@@ -631,29 +676,33 @@ namespace Tests.Core.Relationships
         [Category("Version")]
         [TestCase("1.0", "1.0", "2.0")]
         [TestCase("1.0", "1.0", "0.5")]//what to do if a mod is present twice with the same version ?
-        public void Constructor_WithDependantVersion_ChooseCorrectly(string ver, string dep, string other)
+        public void Constructor_WithDependentVersion_ChooseCorrectly(string ver, string dep, string other)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new ModuleVersion(other));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var other_dependent = generator.GeneratorRandomModule(identifier: dependent.identifier, version: new ModuleVersion(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier, version = new ModuleVersion(dep)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = dependent.identifier,
+                    version = new ModuleVersion(dep)
+                }
             });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant),
-                                                      CkanModule.ToJson(other_dependant)))
+                                                      CkanModule.ToJson(dependent),
+                                                      CkanModule.ToJson(other_dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, game, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
-                    dependant,
+                    dependent,
                     depender
                 });
             }
@@ -664,29 +713,33 @@ namespace Tests.Core.Relationships
         [TestCase("2.0", "1.0", "0.5")]
         [TestCase("2.0", "1.0", "1.5")]
         [TestCase("2.0", "2.0", "0.5")]
-        public void Constructor_WithDependantVersionMin_ChooseCorrectly(string ver, string dep_min, string other)
+        public void Constructor_WithDependentVersionMin_ChooseCorrectly(string ver, string dep_min, string other)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new ModuleVersion(other));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var other_dependent = generator.GeneratorRandomModule(identifier: dependent.identifier, version: new ModuleVersion(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier, min_version = new ModuleVersion(dep_min)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = dependent.identifier,
+                    min_version = new ModuleVersion(dep_min)
+                }
             });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant),
-                                                      CkanModule.ToJson(other_dependant)))
+                                                      CkanModule.ToJson(dependent),
+                                                      CkanModule.ToJson(other_dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, game, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
-                    dependant,
+                    dependent,
                     depender
                 });
             }
@@ -697,29 +750,33 @@ namespace Tests.Core.Relationships
         [TestCase("2.0", "2.0", "0.5")]
         [TestCase("2.0", "3.0", "0.5")]
         [TestCase("2.0", "3.0", "4.0")]
-        public void Constructor_WithDependantVersionMax_ChooseCorrectly(string ver, string dep_max, string other)
+        public void Constructor_WithDependentVersionMax_ChooseCorrectly(string ver, string dep_max, string other)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new ModuleVersion(other));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var other_dependent = generator.GeneratorRandomModule(identifier: dependent.identifier, version: new ModuleVersion(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
-                new ModuleRelationshipDescriptor {name = dependant.identifier, max_version = new ModuleVersion(dep_max)}
+                new ModuleRelationshipDescriptor
+                {
+                    name = dependent.identifier,
+                    max_version = new ModuleVersion(dep_max)
+                }
             });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant),
-                                                      CkanModule.ToJson(other_dependant)))
+                                                      CkanModule.ToJson(dependent),
+                                                      CkanModule.ToJson(other_dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, game, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
-                    dependant,
+                    dependent,
                     depender
                 });
             }
@@ -730,16 +787,16 @@ namespace Tests.Core.Relationships
         [TestCase("2.0", "1.0", "3.0", "0.5")]
         [TestCase("2.0", "1.0", "3.0", "1.5")]
         [TestCase("2.0", "1.0", "3.0", "3.5")]
-        public void Constructor_WithDependantVersionMinMax_ChooseCorrectly(string ver, string dep_min, string dep_max, string other)
+        public void Constructor_WithDependentVersionMinMax_ChooseCorrectly(string ver, string dep_min, string dep_max, string other)
         {
-            var dependant = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
-            var other_dependant = generator.GeneratorRandomModule(identifier: dependant.identifier, version: new ModuleVersion(other));
+            var dependent = generator!.GeneratorRandomModule(version: new ModuleVersion(ver));
+            var other_dependent = generator.GeneratorRandomModule(identifier: dependent.identifier, version: new ModuleVersion(other));
 
             var depender = generator.GeneratorRandomModule(depends: new List<RelationshipDescriptor>
             {
                 new ModuleRelationshipDescriptor
                 {
-                    name = dependant.identifier,
+                    name = dependent.identifier,
                     min_version = new ModuleVersion(dep_min),
                     max_version = new ModuleVersion(dep_max)
                 }
@@ -747,17 +804,17 @@ namespace Tests.Core.Relationships
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(depender),
-                                                      CkanModule.ToJson(dependant),
-                                                      CkanModule.ToJson(other_dependant)))
+                                                      CkanModule.ToJson(dependent),
+                                                      CkanModule.ToJson(other_dependent)))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { depender };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, game, crit);
                 CollectionAssert.AreEquivalent(relationship_resolver.ModList(), new List<CkanModule>
                 {
-                    dependant,
+                    dependent,
                     depender
                 });
             }
@@ -811,7 +868,7 @@ namespace Tests.Core.Relationships
                 // Act
                 RelationshipResolver rr = new RelationshipResolver(
                     new CkanModule[] { depender }, null,
-                    options!, registry, crit);
+                    options!, registry, game, crit);
 
                 // Assert
                 CollectionAssert.Contains(      rr.ModList(), olderDependency);
@@ -862,7 +919,7 @@ namespace Tests.Core.Relationships
                 // Act
                 RelationshipResolver rr = new RelationshipResolver(
                     new CkanModule[] { depender }, null,
-                    options!, registry, crit);
+                    options!, registry, game, crit);
 
                 // Assert
                 CollectionAssert.Contains(      rr.ModList(), olderDependency);
@@ -881,7 +938,7 @@ namespace Tests.Core.Relationships
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { mod };
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, game, crit);
 
                 var mod_not_in_resolver_list = generator.GeneratorRandomModule();
                 CollectionAssert.DoesNotContain(relationship_resolver.ModList(), mod_not_in_resolver_list);
@@ -901,7 +958,7 @@ namespace Tests.Core.Relationships
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
                 var list = new List<CkanModule> { mod };
 
-                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options!, registry, game, crit);
                 var reasons = relationship_resolver.ReasonsFor(mod);
                 Assert.That(reasons[0], Is.AssignableTo<SelectionReason.UserRequested>());
             }
@@ -911,9 +968,14 @@ namespace Tests.Core.Relationships
         public void ReasonFor_WithSuggestedMods_GivesCorrectParent()
         {
             var suggested = generator!.GeneratorRandomModule();
-            var mod =
-                generator.GeneratorRandomModule(suggests:
-                    new List<RelationshipDescriptor> {new ModuleRelationshipDescriptor {name = suggested.identifier}});
+            var mod = generator.GeneratorRandomModule(suggests:
+                new List<RelationshipDescriptor>
+                {
+                    new ModuleRelationshipDescriptor
+                    {
+                        name = suggested.identifier
+                    }
+                });
 
             var user = new NullUser();
             using (var repo = new TemporaryRepository(CkanModule.ToJson(mod),
@@ -924,7 +986,7 @@ namespace Tests.Core.Relationships
                 var list = new List<CkanModule> { mod };
 
                 options!.with_all_suggests = true;
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, game, crit);
                 var reasons = relationship_resolver.ReasonsFor(suggested);
 
                 Assert.IsTrue(reasons[0] is SelectionReason.Suggested sug
@@ -962,7 +1024,7 @@ namespace Tests.Core.Relationships
 
                 options!.with_all_suggests = true;
                 options.with_recommends = true;
-                var relationship_resolver = new RelationshipResolver(list, null, options, registry, crit);
+                var relationship_resolver = new RelationshipResolver(list, null, options, registry, game, crit);
                 var reasons = relationship_resolver.ReasonsFor(recommendedA);
                 Assert.IsTrue(reasons[0] is SelectionReason.Recommended rec
                               && rec.Parent.Equals(suggested));
@@ -999,7 +1061,7 @@ namespace Tests.Core.Relationships
 
                 new RelationshipResolver(
                     new CkanModule[] { mod }, null, RelationshipResolverOptions.DefaultOpts(),
-                    registry, new GameVersionCriteria(GameVersion.Parse("1.0.0")));
+                    registry, game, new GameVersionCriteria(GameVersion.Parse("1.0.0")));
             }
         }
 
@@ -1067,7 +1129,7 @@ namespace Tests.Core.Relationships
                 options!.proceed_with_inconsistencies = false;
                 var exception = Assert.Throws<InconsistentKraken>(() =>
                 {
-                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, crit);
+                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, game, crit);
                 });
                 Assert.AreEqual($"{avp} conflicts with {eveDefaultConfig}",
                                 exception?.ShortDescription);
@@ -1078,7 +1140,7 @@ namespace Tests.Core.Relationships
                 options.proceed_with_inconsistencies = true;
                 Assert.DoesNotThrow(() =>
                 {
-                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, crit);
+                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, game, crit);
                 });
                 CollectionAssert.AreEquivalent(modulesToInstall,
                                                resolver?.ConflictList.Keys);
@@ -1094,11 +1156,220 @@ namespace Tests.Core.Relationships
                 options.proceed_with_inconsistencies = false;
                 Assert.DoesNotThrow(() =>
                 {
-                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, crit);
+                    resolver = new RelationshipResolver(modulesToInstall, modulesToRemove, options, registry, game, crit);
                 });
                 Assert.IsEmpty(resolver!.ConflictList);
                 CollectionAssert.AreEquivalent(new List<CkanModule> {avp, avp2kTextures}, resolver.ModList());
             }
         }
+
+        [Test,
+         TestCase(new string[] {
+                      @"{
+                          ""identifier"":  ""PopularMod"",
+                          ""ksp_version"": ""1.10.0""
+                      }",
+                  },
+                  @"{
+                      ""identifier"": ""MyModpack"",
+                      ""kind"":       ""metapackage"",
+                      ""depends"":    [ { ""name"": ""PopularMod"" } ]
+                  }",
+                  "Unsatisfied dependency PopularMod (KSP 1.10.0) needed for: MyModpack 1.0"),
+         TestCase(new string[] {
+                      @"{
+                          ""identifier"":  ""IncompatibleDependency"",
+                          ""ksp_version"": ""1.11.0""
+                      }",
+                      @"{
+                          ""identifier"":  ""CompatibleDepending1"",
+                          ""ksp_version"": ""1.12"",
+                          ""depends"":     [ { ""name"": ""IncompatibleDependency"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""CompatibleDepending2"",
+                          ""ksp_version"": ""1.12"",
+                          ""depends"":     [ { ""name"": ""IncompatibleDependency"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""CompatibleDepending3"",
+                          ""ksp_version"": ""1.12"",
+                          ""depends"":     [ { ""name"": ""CompatibleDepending2"" } ]
+                      }",
+                  },
+                  @"{
+                      ""identifier"": ""MyModpack"",
+                      ""kind"":       ""metapackage"",
+                      ""depends"":    [ { ""name"": ""CompatibleDepending1"" },
+                                        { ""name"": ""CompatibleDepending3"" } ]
+                  }",
+                  "Unsatisfied dependency IncompatibleDependency (KSP 1.11.0) needed for: CompatibleDepending1 1.0 (needed for MyModpack 1.0); CompatibleDepending2 1.0 (needed for CompatibleDepending3 1.0, needed for MyModpack 1.0)"),
+        ]
+        public void Constructor_ModpackWithIncompatibleDepends_Throws(string[] availableModules,
+                                                                      string   modpackModule,
+                                                                      string   exceptionMessage)
+        {
+            // Arrange
+            var user    = new NullUser();
+            var game    = new KerbalSpaceProgram();
+            var crit    = new GameVersionCriteria(new GameVersion(1, 12, 5));
+            var modpack = CkanModule.FromJson(MergeWithDefaults(modpackModule));
+            using (var repo     = new TemporaryRepository(availableModules.Select(MergeWithDefaults)
+                                                                          .ToArray()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+
+                // Act / Assert
+                var exc = Assert.Throws<DependenciesNotSatisfiedKraken>(() =>
+                {
+                    var rr = new RelationshipResolver(
+                        Enumerable.Repeat(modpack, 1), null,
+                        RelationshipResolverOptions.DependsOnlyOpts(),
+                        registry, game, crit);
+                });
+                Assert.AreEqual(exceptionMessage, exc?.Message);
+            }
+        }
+
+        [Test,
+         TestCase(new string[] {
+                      @"{
+                          ""identifier"":  ""WildBlueTools"",
+                          ""depends"":     [ { ""name"": ""WildBlue-PlayMode"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""WildBlue-PlayMode-CRP"",
+                          ""provides"":    [ ""WildBlue-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""WildBlue-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlueTools"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""WildBlue-PlayMode-ClassicStock"",
+                          ""provides"":    [ ""WildBlue-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""WildBlue-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlueTools"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""Heisenberg"",
+                          ""depends"":     [ { ""name"": ""Heisenberg-PlayMode"" },
+                                             { ""name"": ""WildBlueTools"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""Heisenberg-PlayMode-CRP"",
+                          ""provides"":    [ ""Heisenberg-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""Heisenberg-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlue-PlayMode-CRP"" },
+                                             { ""name"": ""Heisenberg"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""Heisenberg-PlayMode-ClassicStock"",
+                          ""provides"":    [ ""Heisenberg-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""Heisenberg-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlue-PlayMode-ClassicStock"" },
+                                             { ""name"": ""Heisenberg"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""DSEV"",
+                          ""depends"":     [ { ""name"": ""DSEV-PlayMode"" },
+                                             { ""name"": ""WildBlueTools"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""DSEV-PlayMode-CRP"",
+                          ""provides"":    [ ""DSEV-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""DSEV-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlue-PlayMode-CRP"" },
+                                             { ""name"": ""DSEV"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""DSEV-PlayMode-ClassicStock"",
+                          ""provides"":    [ ""DSEV-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""DSEV-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlue-PlayMode-ClassicStock"" },
+                                             { ""name"": ""DSEV"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""Pathfinder"",
+                          ""depends"":     [ { ""name"": ""Pathfinder-PlayMode"" },
+                                             { ""name"": ""WildBlueTools"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""Pathfinder-PlayMode-CRP"",
+                          ""provides"":    [ ""Pathfinder-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""Pathfinder-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlue-PlayMode-CRP"" },
+                                             { ""name"": ""Pathfinder"" } ]
+                      }",
+                      @"{
+                          ""identifier"":  ""Pathfinder-PlayMode-ClassicStock"",
+                          ""provides"":    [ ""Pathfinder-PlayMode"" ],
+                          ""conflicts"":   [ { ""name"": ""Pathfinder-PlayMode"" } ],
+                          ""depends"":     [ { ""name"": ""WildBlue-PlayMode-ClassicStock"" },
+                                             { ""name"": ""Pathfinder"" } ]
+                      }",
+                  },
+                  new string[] { "Heisenberg-PlayMode-ClassicStock", "DSEV", "Pathfinder" },
+                  new string[] { "DSEV-PlayMode-", "Pathfinder-PlayMode-", "WildBlue-PlayMode-" },
+                  new string[] { "CRP" }),
+        ]
+        public void Constructor_WithPlayModes_DoesNotThrow(string[] availableModules,
+                                                           string[] installIdents,
+                                                           string[] goodSubstrings,
+                                                           string[] badSubstrings)
+        {
+            var user = new NullUser();
+            var game = new KerbalSpaceProgram();
+            var crit = new GameVersionCriteria(new GameVersion(1, 12, 5));
+            using (var repo     = new TemporaryRepository(availableModules.Select(MergeWithDefaults)
+                                                                          .ToArray()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+
+                // Act / Assert
+                Assert.DoesNotThrow(() =>
+                {
+                    var rr = new RelationshipResolver(
+                        installIdents.Select(ident => registry.LatestAvailable(ident, crit))
+                                     .OfType<CkanModule>(),
+                        null,
+                        RelationshipResolverOptions.DependsOnlyOpts(),
+                        registry,
+                        game,
+                        crit);
+                    var idents = rr.ModList().Select(m => m.identifier).ToArray();
+                    foreach (var goodSubstring in goodSubstrings)
+                    {
+                        Assert.IsTrue(idents.Any(ident => ident.Contains(goodSubstring)),
+                                      $"Some identifier containing {goodSubstring} must be in resolver");
+                    }
+                    foreach (var ident in idents)
+                    {
+                        foreach (var badSubstring in badSubstrings)
+                        {
+                            Assert.IsFalse(ident.Contains(badSubstring),
+                                           $"No identifiers containing {badSubstring} should be in resolver");
+                        }
+                    }
+                });
+            }
+        }
+
+        private static string MergeWithDefaults(string json)
+        {
+            var incoming = JObject.Parse(json);
+            incoming.Merge(moduleDefaults);
+            return incoming.ToString();
+        }
+
+        // Unimportant required fields that we don't want to duplicate
+        private static readonly JObject moduleDefaults = JObject.Parse(
+            @"{
+                ""spec_version"": ""v1.34"",
+                ""name"":         ""A mod or modpack"",
+                ""author"":       ""An author"",
+                ""version"":      ""1.0"",
+                ""download"":     ""https://www.nonexistent.com/download""
+            }");
     }
 }

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -83,7 +83,7 @@ namespace Tests.Core.Relationships
         public void CustomBiomesWithDlls()
         {
             var mods = new List<CkanModule>();
-            var dlls = new List<string> { "CustomBiomes" };
+            var dlls = new Dictionary<string, string> { { "CustomBiomes", "" } }.Keys;
 
             Assert.IsTrue(CKAN.SanityChecker.IsConsistent(mods, dlls), "CustomBiomes dll by itself");
 
@@ -100,7 +100,7 @@ namespace Tests.Core.Relationships
         public void ConflictWithDll()
         {
             var mods = new List<CkanModule> { registry?.LatestAvailable("SRL", null)! };
-            var dlls = new List<string> { "QuickRevert" };
+            var dlls = new Dictionary<string, string> { { "QuickRevert", "" } }.Keys;
 
             Assert.IsTrue(CKAN.SanityChecker.IsConsistent(mods), "SRL can be installed by itself");
             Assert.IsFalse(CKAN.SanityChecker.IsConsistent(mods, dlls), "SRL conflicts with QuickRevert DLL");
@@ -110,7 +110,7 @@ namespace Tests.Core.Relationships
         public void FindUnsatisfiedDepends()
         {
             var mods = new List<CkanModule>();
-            var dlls = Enumerable.Empty<string>().ToHashSet();
+            var dlls = new Dictionary<string, string>().Keys;
             var dlc = new Dictionary<string, ModuleVersion>();
 
             Assert.IsEmpty(CKAN.SanityChecker.FindUnsatisfiedDepends(mods, dlls, dlc), "Empty list");
@@ -363,14 +363,14 @@ namespace Tests.Core.Relationships
             Assert.IsTrue(CKAN.SanityChecker.IsConsistent(modules));
         }
 
-        private static void TestDepends(List<string>                       to_remove,
-                                        HashSet<CkanModule>                mods,
-                                        HashSet<string>?                   dlls,
-                                        Dictionary<string, ModuleVersion>? dlc,
-                                        List<string>                       expected,
-                                        string                             message)
+        private static void TestDepends(List<string>                              to_remove,
+                                        HashSet<CkanModule>                       mods,
+                                        ICollection<string>?                      dlls,
+                                        Dictionary<string, ModuleVersion>?        dlc,
+                                        List<string>                              expected,
+                                        string                                    message)
         {
-            dlls ??= new HashSet<string>();
+            dlls ??= new Dictionary<string, string>().Keys;
 
             var remove_count = to_remove.Count;
             var dll_count = dlls.Count;

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -15,6 +15,7 @@ using Tests.Data;
 using CKAN;
 using CKAN.Versioning;
 using CKAN.GUI;
+using CKAN.Games.KerbalSpaceProgram;
 
 namespace Tests.GUI
 {
@@ -30,7 +31,9 @@ namespace Tests.GUI
         public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList();
-            Assert.That(item.ComputeUserChangeSet(Registry.Empty(), crit, null, null, null), Is.Empty);
+            var game = new KerbalSpaceProgram();
+            var inst = new GameInstance(game, "/", "dummy", new NullUser());
+            Assert.That(item.ComputeUserChangeSet(Registry.Empty(), crit, inst, null, null), Is.Empty);
         }
 
         [Test]
@@ -210,11 +213,14 @@ namespace Tests.GUI
                 Assert.IsTrue(otherModule.SelectedMod == otherModule.LatestAvailableMod);
                 Assert.IsFalse(otherModule.IsInstalled);
 
+                var game = new KerbalSpaceProgram();
+                var inst = new GameInstance(game, "/", "dummy", new NullUser());
+
                 Assert.DoesNotThrow(() =>
                 {
                     // Install the "other" module
                     installer.InstallList(
-                        modList.ComputeUserChangeSet(Registry.Empty(), crit, null, null, null).Select(change => change.Mod).ToList(),
+                        modList.ComputeUserChangeSet(Registry.Empty(), crit, inst, null, null).Select(change => change.Mod).ToList(),
                         new RelationshipResolverOptions(),
                         registryManager,
                         ref possibleConfigOnlyDirs,

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -13,6 +13,7 @@ using Tests.Core.Configuration;
 using Tests.Data;
 
 using CKAN;
+using CKAN.Versioning;
 using CKAN.GUI;
 
 namespace Tests.GUI
@@ -23,11 +24,13 @@ namespace Tests.GUI
     [TestFixture]
     public class ModListTests
     {
+        private static readonly GameVersionCriteria crit = new GameVersionCriteria(null);
+
         [Test]
         public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList();
-            Assert.That(item.ComputeUserChangeSet(Registry.Empty(), null, null, null, null), Is.Empty);
+            Assert.That(item.ComputeUserChangeSet(Registry.Empty(), crit, null, null, null), Is.Empty);
         }
 
         [Test]
@@ -211,7 +214,7 @@ namespace Tests.GUI
                 {
                     // Install the "other" module
                     installer.InstallList(
-                        modList.ComputeUserChangeSet(Registry.Empty(), null, null, null, null).Select(change => change.Mod).ToList(),
+                        modList.ComputeUserChangeSet(Registry.Empty(), crit, null, null, null).Select(change => change.Mod).ToList(),
                         new RelationshipResolverOptions(),
                         registryManager,
                         ref possibleConfigOnlyDirs,


### PR DESCRIPTION
## Problems

If you use `ckan install -c modpack.ckan` to install a modpack with incompatible dependencies, the message is something like:

```
Module installed-Auto-KSP 2024.05.15.01.03.25 required but it is not listed in the 
index, or not available for your version of KSP
If you're lucky, you can do a `ckan update` and try again.
Try `ckan install --no-recommends` to skip installation of recommended modules.
Or `ckan install --allow-incompatible` to ignore module compatibility.
```

This does not explain the problem, can only report one problem with one mod, and almost all of the advice at the bottom is useless. A similar poor message can also appear in GUI if the user force-selects a mod with incompatible dependencies on the Versions tab.

## Causes

When the relationship resolver checks dependencies recursively to make sure a mod can be installed, it loses the information from the "leaf nodes" and just reports the outermost mod that can't be resolved.

## Changes

- Now the relationship resolver generates a tree of resolved relationships and queries it so the error message for incompatible modpack dependencies can report every mod that isn't compatible, the full chain of dependencies to it starting from the module given on the command line, and the game version compatibility range of each missing dependency:
  ```
  Unsatisfied dependency B9PartSwitch (KSP 1.0.5-1.12.3) needed for: BluedogDB v1.13.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); CryoTanks 1.6.6 (needed for BluedogDB-Methalox v1.13.0, needed for CommunityLifeBoat 2024.09.05.11.08.59); CryoEngines 1:2.0.7 (needed for CommunityLifeBoat 2024.09.05.11.08.59); FarFutureTechnologies 1.3.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); SpaceDust 0.5.4 (needed for FarFutureTechnologies 1.3.0, needed for CommunityLifeBoat 2024.09.05.11.08.59); HabTech2 1.0.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); HabTechRobotics v1.0.1 (needed for HabTech2 1.0.0, needed for CommunityLifeBoat 2024.09.05.11.08.59); HeatControl 0.6.2 (needed for CommunityLifeBoat 2024.09.05.11.08.59); KerbalAtomics 1:1.3.4 (needed for CommunityLifeBoat 2024.09.05.11.08.59); Mk2Expansion 2:1.9.1.4 (needed for CommunityLifeBoat 2024.09.05.11.08.59); Mk3Expansion 1.6.1.4 (needed for CommunityLifeBoat 2024.09.05.11.08.59); ModularLaunchPads 2.7.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); NearFutureAeronautics 2.1.2 (needed for CommunityLifeBoat 2024.09.05.11.08.59); NearFutureElectrical 1.2.3 (needed for CommunityLifeBoat 2024.09.05.11.08.59); NearFutureExploration 1.1.3 (needed for CommunityLifeBoat 2024.09.05.11.08.59); NearFutureLaunchVehicles 2.2.1 (needed for CommunityLifeBoat 2024.09.05.11.08.59); NearFuturePropulsion 1.3.6 (needed for CommunityLifeBoat 2024.09.05.11.08.59); NearFutureSolar 1.3.3 (needed for CommunityLifeBoat 2024.09.05.11.08.59); NearFutureSpacecraft 1.4.5 (needed for CommunityLifeBoat 2024.09.05.11.08.59); OmicronFlyingSpaceCar 0.6.6.6 (needed for CommunityLifeBoat 2024.09.05.11.08.59); PlanetsideExplorationTechnologies 1.0.2 (needed for CommunityLifeBoat 2024.09.05.11.08.59); RaginCaucasian 1.5.3.1 (needed for CommunityLifeBoat 2024.09.05.11.08.59); RocketMotorMenagerie v1.1.2 (needed for CommunityLifeBoat 2024.09.05.11.08.59); ShuttleOrbiterConstructionKit 1.1.8 (needed for CommunityLifeBoat 2024.09.05.11.08.59); ShuttlePayloadDeliverySystems 3.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); SillyPhotonDrives 1.0.1 (needed for CommunityLifeBoat 2024.09.05.11.08.59); StationPartsExpansionRedux 2.0.11 (needed for CommunityLifeBoat 2024.09.05.11.08.59); StockWaterfallEffects 0.8.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); WaterfallExtensions 0.4.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); Wyvern-5 0.5 (needed for CommunityLifeBoat 2024.09.05.11.08.59)

  Unsatisfied dependency SimpleAdjustableFairings (KSP 1.2.2-1.11.2) needed for: BluedogDB v1.13.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59); TantaresSAF v3.0 (needed for CommunityLifeBoat 2024.09.05.11.08.59)

  Unsatisfied dependency AdditionToTantaresSP 0.2 (KSP 1.12.4) needed for: CommunityLifeBoat 2024.09.05.11.08.59
  ```
  - A new test is created to exercise the incompatible dependencies scenario
- Now the error footer might actually be helpful, since it suggests using `ckan compat` instead of `--no-recommends`, better explains what "lucky" means for `ckan update`, and notes that `--allow-incompatible` doesn't apply to dependencies:
  ```
  You can use the `ckan compat` commands to change which game versions are treated as compatible.
  If a newly compatible version was just released, you can do a `ckan update` and try again.
  Or `ckan install --allow-incompatible` to ignore compatibility of the modules on the command line (but not dependencies).
  ```

Fixes #4108.

### Side fixes

While working on the above, I tossed in a few opportunistic fixes:

- The user can get redundant prompts for play modes when installing some of the Wild Blue mods, which can be answered in a way that creates conflicts in the changeset. Now the relationship resolver's new tree logic doesn't present conflicting play modes as options.
  - A new test is created to exercise this scenario, which passes with the new code and fails with the old
- Several methods of `Registry` and related classes are refactored to use `ICollection` instead of `IEnumerable` or specific collection types, which allows us to eliminate repeated calls to `.ToHashSet()`, `.ToList()`, etc. to improve performance.
- The Untagged search in GUI wasn't working because it was generating a `ModSearch` object with no tag names rather than the empty string. Now it works.
- The Show in folder button in Unmanaged Files wasn't working because it was trying to open relative paths instead of absolute. Now it gets the absolute path and works.
- `RelationshipResolverOptions` and `SelectionReason` are moved to their own files.
