### PR TITLE
Fix skipping failed dependency downloads

### DIFF
--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -339,7 +339,7 @@ namespace CKAN
             }
         }
 
-        private static int compareFiles(Dictionary<string, List<CkanModule>> hashMap, FileInfo a, FileInfo b)
+        private static int compareFiles(IReadOnlyDictionary<string, List<CkanModule>> hashMap, FileInfo a, FileInfo b)
         {
             // Compatible modules for file A
             hashMap.TryGetValue(a.Name[..8], out List<CkanModule>? modulesA);


### PR DESCRIPTION
## Problem

If you try to install a mod that has a dependency, and the dependency fails to download, and you try to Skip/Retry, CKAN will try to download it again. The only option that works is Abort whole changeset.

## Cause

To get the mods from the changeset that depend on the mod we're trying to skip (since we also will not be able to install them), we call `Registry.FindReverseDependencies`, but we call the version of it that only returns identifiers _that are already installed_. This means the depending mod won't be returned and won't be removed from the changeset, so when the install is retried, the dependency is pulled back in.

## Changes

Now this codepath calls the static `Registry.FindReverseDependencies` that allows us to specify the overall superset of mods, which we pass as the full changeset. This allows the depending mod to be removed from the changeset so the Skip/Retry operation can succeed.

Fixes #4234.
