### PR TITLE
Fix reporting of wrong download as failed

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -134,10 +134,10 @@ namespace CKAN
             }
 
             // Check to see if we've had any errors. If so, then release the kraken!
-            var exceptions = downloads.Select((dl, i) => dl.error is Exception exc
-                                                         ? new KeyValuePair<int, Exception>(i, exc)
-                                                         : (KeyValuePair<int, Exception>?)null)
-                                      .OfType<KeyValuePair<int, Exception>>()
+            var exceptions = downloads.Select(dl => dl.error != null
+                                                        ? new KeyValuePair<DownloadTarget, Exception>(dl.target, dl.error)
+                                                        : (KeyValuePair<DownloadTarget, Exception>?)null)
+                                      .OfType<KeyValuePair<DownloadTarget, Exception>>()
                                       .ToList();
 
             if (exceptions.Select(kvp => kvp.Value)
@@ -153,7 +153,7 @@ namespace CKAN
                                                      && wex.Response is HttpWebResponse hresp
                                                      // Handle HTTP 403 used for throttling
                                                      && hresp.StatusCode == HttpStatusCode.Forbidden
-                                                     && downloads[kvp.Key].CurrentUri is Uri url
+                                                     && kvp.Key.urls.LastOrDefault() is Uri url
                                                      && url.IsAbsoluteUri
                                                      && Net.ThrottledHosts.TryGetValue(url.Host, out Uri? infoUrl)
                                                      && infoUrl is not null

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -210,7 +210,7 @@ namespace CKAN
                     catch (UnsupportedKraken kraken)
                     {
                         // Show parsing errors in the Downloads Failed popup
-                        throw new DownloadErrorsKraken(Array.IndexOf(toUpdate, repo), kraken);
+                        throw new DownloadErrorsKraken(target, kraken);
                     }
                     progress.NextFile();
                 }
@@ -220,15 +220,10 @@ namespace CKAN
                 // Fire an event so affected registry objects can clear their caches
                 Updated?.Invoke(toUpdate);
             }
-            catch (DownloadErrorsKraken exc)
+            catch (DownloadErrorsKraken)
             {
                 loadETags();
-                throw new DownloadErrorsKraken(
-                    // Renumber the exceptions based on the original repo list
-                    exc.Exceptions.Select(kvp => new KeyValuePair<int, Exception>(
-                                                     Array.IndexOf(repos, toUpdate[kvp.Key]),
-                                                     kvp.Value))
-                                  .ToList());
+                throw;
             }
             catch (Exception exc)
             {

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -137,7 +137,9 @@ namespace CKAN.GUI
                                     Properties.Resources.RepoDownloadsFailedColHdr,
                                     Properties.Resources.RepoDownloadsFailedAbortBtn,
                                     k.Exceptions.Select(kvp => new KeyValuePair<object[], Exception>(
-                                        new object[] { repos[kvp.Key] }, kvp.Value)),
+                                        repos.Where(r => kvp.Key.urls.Contains(r.uri))
+                                             .ToArray(),
+                                        kvp.Value)),
                                     // Rows are only linked to themselves
                                     (r1, r2) => r1 == r2);
                                 dfd.ShowDialog(this);

--- a/Tests/Core/Net/NetAsyncDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncDownloaderTests.cs
@@ -206,7 +206,8 @@ namespace Tests.Core.Net
                 foreach (var kvp in exception?.Exceptions!)
                 {
                     var baseExc = kvp.Value.GetBaseException() as FileNotFoundException;
-                    Assert.AreEqual(fromPaths[kvp.Key], baseExc?.FileName);
+                    Assert.AreEqual(fromPaths[Array.IndexOf(targets, kvp.Key)],
+                                    baseExc?.FileName);
                 }
                 foreach (var t in validTargets)
                 {


### PR DESCRIPTION
## Problem

With archive.org down, taniwha's mods hosted only there (before KSP-CKAN/NetKAN#10262 and KSP-CKAN/NetKAN#10263), and the life boat modpack depending on Extraplanetary Launchpads, our failed downloads handling has been undergoing a comprehensive stress test.

KSP-CKAN/NetKAN#10262's validation log reported a download failure for KIS, _after_ reporting that KIS downloaded successfully:

https://github.com/KSP-CKAN/NetKAN/actions/runs/11407171543/job/31743515317

```
  Downloading https://archive.org/download/KerbalStats-3.1.0/0E71BD9E-KerbalStats-3.1.0.zip ...

...

  Finished downloading KIS 1.29, validating and storing to cache...
  
  0 B/sec - downloading - 3.1 MiB left - 93%           
  Downloading https://spacedock.info/mod/1987/Kerbal%20Attachment%20System%20(KAS)/download/1.12 ...
  Finished downloading InfernalRoboticsRealismOverhaul 2.3.1, validating and storing to cache...
  Finished downloading KAS 1.12, validating and storing to cache...
  Error: 13138 [1] ERROR CKAN.CmdLine.ConsoleUser (null) - One or more downloads were unsuccessful:
  
  Error downloading KIS 1.29: The remote server returned an error: (503) Service Temporarily Unavailable.
```

Meanwhile KerbalStats is downloading from the unavailable archive.org and just disappears from the log. That's the mod that actually failed to download.

## Cause

`NetAsyncDownloader` reports download failures by throwing `DownloadErrorsKraken` which contains index/exception pairs, where the index is supposed to correspond to the original list of `DownloadTarget`s that was passed in. However, the index it actually uses comes from the internal array of `DownloadPart`s, which is built in the order that the downloads are started, which will not be the same as the targets if there is a mix of hosts. So the calling code gets scrambled info when trying to understand the exception.

## Changes

Now `DownloadErrorsKraken` contains pairs of `DownloadTarget`s and exceptions, which both come directly from the same `DownloadPart` object that had the failure. No indexes are involved anymore, so there's nothing to confuse. All calling code is updated to examine the target objects where it previously looked at the indexes.
