### PR TITLE
Cache migration and other fixes

### DIFF
--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using CommandLine;
@@ -177,7 +178,9 @@ namespace CKAN.CmdLine
 
             if (manager != null)
             {
-                if (manager.TrySetupCache(options.Path, out string? failReason))
+                if (manager.TrySetupCache(options.Path,
+                                          new Progress<int>(p => {}),
+                                          out string? failReason))
                 {
                     IConfiguration cfg = ServiceLocator.Container.Resolve<IConfiguration>();
                     user?.RaiseMessage(Properties.Resources.CacheSet, cfg.DownloadCacheDir ?? "");
@@ -205,7 +208,9 @@ namespace CKAN.CmdLine
         {
             if (manager != null)
             {
-                if (manager.TrySetupCache("", out string? failReason))
+                if (manager.TrySetupCache("",
+                                          new Progress<int>(p => {}),
+                                          out string? failReason))
                 {
                     IConfiguration cfg = ServiceLocator.Container.Resolve<IConfiguration>();
                     user?.RaiseMessage(Properties.Resources.CacheReset, cfg.DownloadCacheDir ?? "");

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -114,7 +114,9 @@ namespace CKAN
             return NormalizePath(Path.Combine(root, path));
         }
 
-        public static void CheckFreeSpace(DirectoryInfo where, long bytesToStore, string errorDescription)
+        public static void CheckFreeSpace(DirectoryInfo where,
+                                          long          bytesToStore,
+                                          string        errorDescription)
         {
             if (bytesToStore > 0)
             {
@@ -130,6 +132,11 @@ namespace CKAN
                                                    : "unknown bytes");
             }
         }
+
+        public static bool PathEquals(this FileSystemInfo a,
+                                      FileSystemInfo      b)
+            => NormalizePath(a.FullName).Equals(NormalizePath(b.FullName),
+                                                Platform.PathComparison);
 
     }
 }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1210,9 +1210,8 @@ namespace CKAN
                 if (installed_mod == null)
                 {
                     if (!Cache.IsMaybeCachedZip(module)
-                        && Cache.GetInProgressFileName(module) is string p)
+                        && Cache.GetInProgressFileName(module) is FileInfo inProgressFile)
                     {
-                        var inProgressFile = new FileInfo(p);
                         if (inProgressFile.Exists)
                         {
                             User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingResuming,
@@ -1253,9 +1252,8 @@ namespace CKAN
                     else
                     {
                         if (!Cache.IsMaybeCachedZip(module)
-                            && Cache.GetInProgressFileName(module) is string p)
+                            && Cache.GetInProgressFileName(module) is FileInfo inProgressFile)
                         {
-                            var inProgressFile = new FileInfo(p);
                             if (inProgressFile.Exists)
                             {
                                 User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingResuming,

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -60,7 +60,7 @@ namespace CKAN
                      .OrderBy(u => u,
                               new PreferredHostUriComparer(preferredHosts))
                      .ToList(),
-                cache.GetInProgressFileName(first),
+                cache.GetInProgressFileName(first)?.FullName,
                 first.download_size,
                 string.IsNullOrEmpty(first.download_content_type)
                     ? defaultMimeType

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -205,6 +205,14 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="GameInstanceManagerPortable" xml:space="preserve"><value>portable</value></data>
   <data name="GameInstanceManagerAuto" xml:space="preserve"><value>Auto {0}</value></data>
   <data name="GameInstanceManagerSelectGamePrompt" xml:space="preserve"><value>Please select the game that is installed at {0}</value></data>
+  <data name="GameInstanceManagerCacheMigrationPrompt" xml:space="preserve"><value>Old cache folder contains {0}. New cache folder has {1} free.
+What would you like to do?</value></data>
+  <data name="GameInstanceManagerCacheMigrationMove" xml:space="preserve"><value>Move old cached files to new cache folder</value></data>
+  <data name="GameInstanceManagerCacheMigrationDelete" xml:space="preserve"><value>Delete cached files</value></data>
+  <data name="GameInstanceManagerCacheMigrationOpen" xml:space="preserve"><value>Open old and new cache folders in file browsers</value></data>
+  <data name="GameInstanceManagerCacheMigrationNothing" xml:space="preserve"><value>Do nothing</value></data>
+  <data name="GameInstanceManagerCacheMigrationRevert" xml:space="preserve"><value>Revert back to using the old cache folder</value></data>
+  <data name="GameInstanceManagerCacheMigrationNotEnoughFreeSpace" xml:space="preserve"><value>Not enough space to move files!</value></data>
   <data name="GameInstanceCloneInvalid" xml:space="preserve"><value>The specified instance is not a valid {0} instance</value></data>
   <data name="GameInstanceFakeBadVersion" xml:space="preserve"><value>The specified {0} version is not a known version: {1}</value></data>
   <data name="GameInstanceFakeNotEmpty" xml:space="preserve"><value>The specified folder already exists and is not empty</value></data>

--- a/Core/SteamLibrary.cs
+++ b/Core/SteamLibrary.cs
@@ -84,8 +84,9 @@ namespace CKAN
 
         private static IEnumerable<GameBase> ShortcutsFileGames(KVSerializer vdfParser,
                                                                 string       path)
-            => vdfParser.Deserialize<List<NonSteamGame>>(File.OpenRead(path))
-                        .Select(nsg => nsg.NormalizeDir(path));
+            => Utilities.DefaultIfThrows(() => vdfParser.Deserialize<List<NonSteamGame>>(File.OpenRead(path)))
+                        ?.Select(nsg => nsg.NormalizeDir(path))
+                        ?? Enumerable.Empty<NonSteamGame>();
 
         private const  string   registryKey   = @"HKEY_CURRENT_USER\Software\Valve\Steam";
         private const  string   registryValue = @"SteamPath";

--- a/GUI/Controls/EditModSearches.Designer.cs
+++ b/GUI/Controls/EditModSearches.Designer.cs
@@ -44,7 +44,7 @@ namespace CKAN.GUI
             // AddSearchButton
             //
             this.AddSearchButton.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Right
-            | System.Windows.Forms.AnchorStyles.Top);
+            | System.Windows.Forms.AnchorStyles.Bottom);
             this.AddSearchButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.AddSearchButton.Cursor = System.Windows.Forms.Cursors.Hand;
             this.AddSearchButton.Enabled = false;
@@ -52,6 +52,7 @@ namespace CKAN.GUI
             this.AddSearchButton.Location = new System.Drawing.Point(426, 2);
             this.AddSearchButton.Name = "AddSearchButton";
             this.AddSearchButton.Padding = new System.Windows.Forms.Padding(0, 0, 0, 0);
+            this.AddSearchButton.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
             this.AddSearchButton.Size = new System.Drawing.Size(22, 22);
             this.AddSearchButton.TabIndex = 1;
             this.AddSearchButton.Text = "+";
@@ -63,7 +64,7 @@ namespace CKAN.GUI
             //
             this.Controls.Add(this.AddSearchButton);
             this.Name = "EditModSearches";
-            this.Size = new System.Drawing.Size(500, 54);
+            this.Size = new System.Drawing.Size(500, 29);
             this.ResumeLayout(false);
             this.PerformLayout();
         }

--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -133,12 +133,10 @@ namespace CKAN.GUI
             // Still need to be able to see the add button, without this it's covered up
             AddSearchButton.BringToFront();
 
-            Height = editors.Sum(ems => ems.Height);
-
             ResumeLayout(false);
             PerformLayout();
 
-            AddSearchButton.Top = editors[^1].Top;
+            Height = editors.Sum(ems => ems.Height);
 
             return ctl;
         }
@@ -147,6 +145,8 @@ namespace CKAN.GUI
         {
             if (editors.Count >= 2)
             {
+                SuspendLayout();
+
                 if (which == ActiveControl)
                 {
                     // Move focus to next control, or previous if last in list
@@ -166,7 +166,8 @@ namespace CKAN.GUI
                     editor.ShowLabel = true;
                 }
 
-                AddSearchButton.Top = editors[^1].Top;
+                ResumeLayout(false);
+                PerformLayout();
 
                 Height = editors.Sum(ems => ems.Height);
             }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1308,14 +1308,15 @@ namespace CKAN.GUI
             // Purge other versions as well since the user is likely to want that
             // and has no other way to achieve it
             var selected = SelectedModule;
-            if (selected != null && currentInstance != null)
+            if (selected != null
+                && currentInstance != null
+                && manager?.Cache != null)
             {
-                IRegistryQuerier registry = RegistryManager.Instance(currentInstance, repoData).registry;
-                var allAvail = registry.AvailableByIdentifier(selected.Identifier);
-                foreach (CkanModule mod in allAvail)
-                {
-                    manager?.Cache?.Purge(mod);
-                }
+                manager.Cache.Purge(
+                    RegistryManager.Instance(currentInstance, repoData)
+                                   .registry
+                                   .AvailableByIdentifier(selected.Identifier)
+                                   .ToArray());
             }
         }
 

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -53,6 +53,11 @@ namespace CKAN.GUI
             Contents.RefreshModContentsTree();
         }
 
+        public void SwitchTab(string name)
+        {
+            ModInfoTabControl.SelectedTab = ModInfoTabControl.TabPages[name];
+        }
+
         public event Action<GUIMod>?            OnDownloadClick;
         public event Action<SavedSearch, bool>? OnChangeFilter;
         public event Action<CkanModule>?        ModuleDoubleClicked;

--- a/GUI/Dialogs/SelectionDialog.Designer.cs
+++ b/GUI/Dialogs/SelectionDialog.Designer.cs
@@ -34,50 +34,57 @@ namespace CKAN.GUI
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(SelectionDialog));
             this.panel1 = new System.Windows.Forms.Panel();
             this.MessageLabel = new System.Windows.Forms.Label();
-            this.SelectButton = new System.Windows.Forms.Button();
-            this.DefaultButton = new System.Windows.Forms.Button();
-            this.CancelButton = new System.Windows.Forms.Button();
             this.OptionsList = new System.Windows.Forms.ListBox();
+            this.CancelSelectionButton = new System.Windows.Forms.Button();
+            this.DefaultButton = new System.Windows.Forms.Button();
+            this.SelectButton = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
             //
-            // panel1
-            //
-            this.panel1.Controls.Add(this.MessageLabel);
-            this.panel1.Controls.Add(this.OptionsList);
-            this.panel1.Controls.Add(this.CancelButton);
-            this.panel1.Controls.Add(this.DefaultButton);
-            this.panel1.Controls.Add(this.SelectButton);
-            this.panel1.Location = new System.Drawing.Point(10, 10);
-            this.panel1.Size = new System.Drawing.Size(400, 400);
-            this.panel1.Name = "panel1";
-            this.OptionsList.TabStop = false;
-            this.DefaultButton.UseVisualStyleBackColor = true;
-            //
             // MessageLabel
             //
+            this.MessageLabel.Dock = System.Windows.Forms.DockStyle.Top;
             this.MessageLabel.Location = new System.Drawing.Point(5, 5);
             this.MessageLabel.Size = new System.Drawing.Size(390, 40);
             this.MessageLabel.Name = "MessageLabel";
-            this.OptionsList.TabStop = false;
+            this.MessageLabel.TabStop = false;
             this.MessageLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.DefaultButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.MessageLabel, "MessageLabel");
+            //
+            // panel1
+            //
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Controls.Add(this.OptionsList);
+            this.panel1.Controls.Add(this.CancelSelectionButton);
+            this.panel1.Controls.Add(this.DefaultButton);
+            this.panel1.Controls.Add(this.SelectButton);
+            this.panel1.Margin = new System.Windows.Forms.Padding(10);
+            this.panel1.Padding = new System.Windows.Forms.Padding(10);
+            this.panel1.Location = new System.Drawing.Point(10, 10);
+            this.panel1.Size = new System.Drawing.Size(400, 300);
+            this.panel1.Name = "panel1";
+            this.panel1.TabStop = false;
             //
             // OptionsList
             //
-            this.OptionsList.Location = new System.Drawing.Point(5, 55);
-            this.OptionsList.Size = new System.Drawing.Size(390, 315);
+            this.OptionsList.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            this.OptionsList.Location = new System.Drawing.Point(5, 5);
+            this.OptionsList.Size = new System.Drawing.Size(390, 265);
             this.OptionsList.SelectionMode = System.Windows.Forms.SelectionMode.One;
             this.OptionsList.MultiColumn = false;
-            this.OptionsList.SelectedIndexChanged += new System.EventHandler(OptionsList_SelectedIndexChanged);
             this.OptionsList.Name = "OptionsList";
-            this.DefaultButton.UseVisualStyleBackColor = true;
+            this.OptionsList.SelectedIndexChanged += new System.EventHandler(OptionsList_SelectedIndexChanged);
+            this.OptionsList.DoubleClick += new System.EventHandler(this.OptionsList_DoubleClick);
+            this.OptionsList.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OptionsList_KeyDown);
+            resources.ApplyResources(this.OptionsList, "OptionsList");
             //
             // SelectButton
             //
+            this.SelectButton.AutoSize = true;
+            this.SelectButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.SelectButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
             this.SelectButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.SelectButton.Location = new System.Drawing.Point(325, 375);
+            this.SelectButton.Location = new System.Drawing.Point(325, 275);
             this.SelectButton.Size = new System.Drawing.Size(60, 20);
             this.SelectButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.SelectButton.Name = "SelectButton";
@@ -87,8 +94,11 @@ namespace CKAN.GUI
             //
             // DefaultButton
             //
+            this.DefaultButton.AutoSize = true;
+            this.DefaultButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.DefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.DefaultButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.DefaultButton.Location = new System.Drawing.Point(160, 375);
+            this.DefaultButton.Location = new System.Drawing.Point(175, 275);
             this.DefaultButton.Size = new System.Drawing.Size(60, 20);
             this.DefaultButton.DialogResult = System.Windows.Forms.DialogResult.Yes;
             this.DefaultButton.Name = "SelectButton";
@@ -96,27 +106,35 @@ namespace CKAN.GUI
             this.DefaultButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.DefaultButton, "DefaultButton");
             //
-            // CancelButton
+            // CancelSelectionButton
             //
-            this.CancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.CancelButton.Location = new System.Drawing.Point(5, 375);
-            this.CancelButton.Size = new System.Drawing.Size(60, 20);
-            this.CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton.Name = "CancelButton";
-            this.CancelButton.TabIndex = 2;
-            this.CancelButton.UseVisualStyleBackColor = true;
-            resources.ApplyResources(this.CancelButton, "CancelButton");
+            this.CancelSelectionButton.AutoSize = true;
+            this.CancelSelectionButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.CancelSelectionButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            this.CancelSelectionButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.CancelSelectionButton.Location = new System.Drawing.Point(5, 275);
+            this.CancelSelectionButton.Size = new System.Drawing.Size(60, 20);
+            this.CancelSelectionButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CancelSelectionButton.Name = "CancelSelectionButton";
+            this.CancelSelectionButton.TabIndex = 2;
+            this.CancelSelectionButton.UseVisualStyleBackColor = true;
+            resources.ApplyResources(this.CancelSelectionButton, "CancelSelectionButton");
             //
             // SelectionDialog
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(420, 420);
+            this.MinimumSize = new System.Drawing.Size(300, 200);
+            this.AcceptButton = this.SelectButton;
+            this.CancelButton = this.CancelSelectionButton;
+            this.ControlBox = false;
             this.Controls.Add(this.panel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Controls.Add(this.MessageLabel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.Icon = EmbeddedImages.AppIcon;
             this.Name = "SelectionDialog";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
             this.panel1.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -125,11 +143,11 @@ namespace CKAN.GUI
 
         #endregion
 
-        private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Label MessageLabel;
-        private System.Windows.Forms.Button SelectButton;
-        private System.Windows.Forms.Button DefaultButton;
-        private new System.Windows.Forms.Button CancelButton;
+        private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.ListBox OptionsList;
+        private System.Windows.Forms.Button CancelSelectionButton;
+        private System.Windows.Forms.Button DefaultButton;
+        private System.Windows.Forms.Button SelectButton;
     }
 }

--- a/GUI/Dialogs/SelectionDialog.cs
+++ b/GUI/Dialogs/SelectionDialog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
@@ -13,30 +14,53 @@ namespace CKAN.GUI
     #endif
     public partial class SelectionDialog : Form
     {
-        private int currentSelected;
-
-        public SelectionDialog ()
+        public SelectionDialog()
         {
             InitializeComponent();
             currentSelected = 0;
         }
 
         /// <summary>
-        /// Shows the selection dialog.
+        /// Shows the selection dialog
         /// </summary>
-        /// <returns>The selected index, -1 if canceled.</returns>
+        /// <returns>The selected index, -1 if canceled</returns>
         /// <param name="message">Message.</param>
-        /// <param name="args">Array of items to select from.</param>
+        /// <param name="args">Array of items to select from. If first is an int, it will be interpreted as the index of the default option.</param>
         [ForbidGUICalls]
-        public int ShowSelectionDialog (string message, params object[] args)
+        public int ShowSelectionDialog(string message, params object[] args)
         {
             int defaultSelection = -1;
-            int return_cancel = -1;
+            int return_cancel    = -1;
 
-            // Validate input.
+            // Validate input
             if (string.IsNullOrWhiteSpace(message))
             {
                 throw new Kraken("Passed message string must be non-empty.");
+            }
+
+            // Check if we have a default option
+            if (//args is [int v, ..]
+                args.Length > 0
+                && args[0] is int v)
+            {
+                // Check that the default selection makes sense
+                defaultSelection = v;
+
+                if (defaultSelection < 0 || defaultSelection > args.Length - 1)
+                {
+                    throw new Kraken("Passed default argument is out of range of the selection candidates.");
+                }
+
+                // Extract the relevant arguments.
+                args = args.Skip(1).ToArray();
+
+                // Show the default button
+                Util.Invoke(this, DefaultButton.Show);
+            }
+            else
+            {
+                // Hide the default button unless we have a default option
+                Util.Invoke(this, DefaultButton.Hide);
             }
 
             if (args.Length == 0)
@@ -44,90 +68,94 @@ namespace CKAN.GUI
                 throw new Kraken("Passed list of selection candidates must be non-empty.");
             }
 
-            // Hide the default button unless we have a default option
-            Util.Invoke(DefaultButton, DefaultButton.Hide);
-            // Clear the item list.
-            Util.Invoke(OptionsList, OptionsList.Items.Clear);
-
-            // Check if we have a default option.
-            if (//args is [int v, ..]
-                args.Length > 0
-                && args[0] is int v)
+            // Further data validation
+            var argStrs = args.Select(arg => arg.ToString() ?? "").ToArray();
+            if (argStrs.Any(string.IsNullOrWhiteSpace))
             {
-                // Check that the default selection makes sense.
-                defaultSelection = v;
+                throw new Kraken("Candidate may not be empty.");
+            }
 
-                if (defaultSelection < 0 || defaultSelection > args.Length - 1)
+            DialogResult result = DialogResult.Cancel;
+
+            // Validation completed, set up the UI
+            Util.Invoke(this, () =>
+            {
+                // Write the message to the label
+                MessageLabel.Text = message;
+
+                // Clear the item list.
+                OptionsList.Items.Clear();
+
+                // Add all items to the OptionsList
+                OptionsList.Items.AddRange(
+                    argStrs.Select((arg, i) =>
+                                defaultSelection == i
+                                    ? string.Format(Properties.Resources.SelectionDialogDefault,
+                                                    arg)
+                                    : arg)
+                           .ToArray());
+
+                if (defaultSelection >= 0)
                 {
-                    throw new Kraken("Passed default arguments is out of range of the selection candidates.");
+                    OptionsList.SetSelected(defaultSelection, true);
                 }
 
-                // Extract the relevant arguments.
-                object[] newArgs = new object[args.Length - 1];
+                Height = Height - OptionsList.Height
+                         + (OptionsList.ItemHeight * (OptionsList.Items.Count + 2));
 
-                for (int i = 1; i < args.Length; i++)
-                {
-                    newArgs[i - 1] = args[i];
-                }
+                result = ShowDialog(ActiveForm);
+            });
 
-                args = newArgs;
-
-                // Show the defaultButton.
-                Util.Invoke(DefaultButton, DefaultButton.Show);
-            }
-
-            // Further data validation.
-            foreach (object argument in args)
+            // Show the dialog and get the return values
+            return result switch
             {
-                if (string.IsNullOrWhiteSpace(argument.ToString()))
-                {
-                    throw new Kraken("Candidate may not be empty.");
-                }
-            }
+                // Lots of dialog results we don't care about
+                DialogResult.Abort or DialogResult.Retry or DialogResult.Ignore
+                or DialogResult.No or DialogResult.None
+                    => throw new NotImplementedException(),
 
-            // Add all items to the OptionsList.
-            for (int i = 0; i < args.Length; i++)
-            {
-                if (defaultSelection == i)
-                {
-                    Util.Invoke(OptionsList, () => OptionsList.Items.Add(string.Concat(args[i].ToString(), "  -- Default")));
+                // If pressed Default button
+                DialogResult.Yes => defaultSelection,
 
-                }
-                else
-                {
-                    Util.Invoke(OptionsList, () => OptionsList.Items.Add(args[i].ToString() ?? ""));
-                }
-            }
+                // If pressed Cancel button
+                DialogResult.Cancel => return_cancel,
 
-            // Write the message to the label.
-            Util.Invoke(MessageLabel, () => MessageLabel.Text = message);
-
-            // Now show the dialog and get the return values.
-            DialogResult result = ShowDialog();
-            if (result == DialogResult.Yes)
-            {
-                // If pressed Defaultbutton
-                return defaultSelection;
-            }
-            else if (result == DialogResult.Cancel)
-            {
-                // If pressed CancelButton
-                return return_cancel;
-            }
-            else
-            {
-                return currentSelected;
-            }
-        }
-
-        public void HideYesNoDialog ()
-        {
-            Util.Invoke(this, Close);
+                // If pressed Select button or double clicked
+                DialogResult.OK or _ => currentSelected,
+            };
         }
 
         private void OptionsList_SelectedIndexChanged(object? sender, EventArgs? e)
         {
             currentSelected = OptionsList.SelectedIndex;
         }
+
+        private void OptionsList_DoubleClick(object? sender, EventArgs? e)
+        {
+            currentSelected = OptionsList.SelectedIndex;
+            DialogResult    = SelectButton.DialogResult;
+            Close();
+        }
+
+        private void OptionsList_KeyDown(object? sender, KeyEventArgs? e)
+        {
+            switch (e?.KeyCode)
+            {
+                case Keys.Enter:
+                    e.Handled = true;
+                    currentSelected = OptionsList.SelectedIndex;
+                    DialogResult    = SelectButton.DialogResult;
+                    Close();
+                    break;
+
+                case Keys.Escape:
+                    e.Handled = true;
+                    DialogResult = CancelSelectionButton.DialogResult;
+                    Close();
+                    break;
+            }
+        }
+
+        private int currentSelected;
     }
 }

--- a/GUI/Dialogs/SelectionDialog.resx
+++ b/GUI/Dialogs/SelectionDialog.resx
@@ -120,6 +120,6 @@
   <data name="MessageLabel.Text" xml:space="preserve"><value>Please select:</value></data>
   <data name="SelectButton.Text" xml:space="preserve"><value>Select</value></data>
   <data name="DefaultButton.Text" xml:space="preserve"><value>Default</value></data>
-  <data name="CancelButton.Text" xml:space="preserve"><value>Cancel</value></data>
+  <data name="CancelSelectionButton.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="$this.Text" xml:space="preserve"><value>CKAN Selection Dialog</value></data>
 </root>

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -80,7 +80,7 @@ namespace CKAN.GUI
             this.HideEpochsCheckbox = new System.Windows.Forms.CheckBox();
             this.HideVCheckbox = new System.Windows.Forms.CheckBox();
             this.AutoSortUpdateCheckBox = new System.Windows.Forms.CheckBox();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.RepositoryGroupBox.SuspendLayout();
             this.AuthTokensGroupBox.SuspendLayout();
             this.CacheGroupBox.SuspendLayout();
@@ -89,6 +89,13 @@ namespace CKAN.GUI
             this.BehaviourGroupBox.SuspendLayout();
             this.MoreSettingsGroupBox.SuspendLayout();
             this.SuspendLayout();
+            //
+            // ToolTip
+            //
+            this.ToolTip.AutoPopDelay = 10000;
+            this.ToolTip.InitialDelay = 250;
+            this.ToolTip.ReshowDelay = 250;
+            this.ToolTip.ShowAlways = true;
             //
             // RepositoryGroupBox
             //
@@ -523,7 +530,6 @@ namespace CKAN.GUI
             this.RefreshTextBox.Name = "RefreshTextBox";
             this.RefreshTextBox.Size = new System.Drawing.Size(25, 20);
             this.RefreshTextBox.TabIndex = 33;
-            this.toolTip1.SetToolTip(this.RefreshTextBox, "Setting to 0 will not refresh modlist");
             this.RefreshTextBox.TextChanged += new System.EventHandler(this.RefreshTextBox_TextChanged);
             this.RefreshTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.RefreshTextBox_KeyPress);
             //
@@ -630,7 +636,6 @@ namespace CKAN.GUI
             this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
             resources.ApplyResources(this.AutoSortUpdateCheckBox, "AutoSortUpdateCheckBox");
             //
-            //
             // SettingsDialog
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -717,6 +722,6 @@ namespace CKAN.GUI
         private System.Windows.Forms.CheckBox HideEpochsCheckbox;
         private System.Windows.Forms.CheckBox HideVCheckbox;
         private System.Windows.Forms.CheckBox AutoSortUpdateCheckBox;
-        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.ToolTip ToolTip;
     }
 }

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -30,8 +30,9 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(SettingsDialog));
+            this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.RepositoryGroupBox = new System.Windows.Forms.GroupBox();
-            this.ReposListBox = new ThemedListView();
+            this.ReposListBox = new CKAN.GUI.ThemedListView();
             this.RepoNameHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.RepoURLHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.NewRepoButton = new System.Windows.Forms.Button();
@@ -39,13 +40,16 @@ namespace CKAN.GUI
             this.DownRepoButton = new System.Windows.Forms.Button();
             this.DeleteRepoButton = new System.Windows.Forms.Button();
             this.AuthTokensGroupBox = new System.Windows.Forms.GroupBox();
-            this.AuthTokensListBox = new ThemedListView();
+            this.AuthTokensListBox = new CKAN.GUI.ThemedListView();
             this.AuthHostHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.AuthTokenHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.NewAuthTokenButton = new System.Windows.Forms.Button();
             this.DeleteAuthTokenButton = new System.Windows.Forms.Button();
             this.CacheGroupBox = new System.Windows.Forms.GroupBox();
-            this.CachePath = new System.Windows.Forms.TextBox();
+            this.CachePathTextBox = new System.Windows.Forms.TextBox();
+            this.CachePathEditButton = new System.Windows.Forms.Button();
+            this.CachePathSaveButton = new System.Windows.Forms.Button();
+            this.CachePathCancelButton = new System.Windows.Forms.Button();
             this.CacheSummary = new System.Windows.Forms.Label();
             this.CacheLimitPreLabel = new System.Windows.Forms.Label();
             this.CacheLimit = new System.Windows.Forms.TextBox();
@@ -57,6 +61,7 @@ namespace CKAN.GUI
             this.PurgeAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ResetCacheButton = new System.Windows.Forms.Button();
             this.OpenCacheButton = new System.Windows.Forms.Button();
+            this.MoveCacheProgressBar = new System.Windows.Forms.ProgressBar();
             this.AutoUpdateGroupBox = new System.Windows.Forms.GroupBox();
             this.LocalVersionPreLabel = new System.Windows.Forms.Label();
             this.LocalVersionLabel = new System.Windows.Forms.Label();
@@ -80,7 +85,6 @@ namespace CKAN.GUI
             this.HideEpochsCheckbox = new System.Windows.Forms.CheckBox();
             this.HideVCheckbox = new System.Windows.Forms.CheckBox();
             this.AutoSortUpdateCheckBox = new System.Windows.Forms.CheckBox();
-            this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.RepositoryGroupBox.SuspendLayout();
             this.AuthTokensGroupBox.SuspendLayout();
             this.CacheGroupBox.SuspendLayout();
@@ -341,7 +345,10 @@ namespace CKAN.GUI
             //
             // CacheGroupBox
             //
-            this.CacheGroupBox.Controls.Add(this.CachePath);
+            this.CacheGroupBox.Controls.Add(this.CachePathTextBox);
+            this.CacheGroupBox.Controls.Add(this.CachePathEditButton);
+            this.CacheGroupBox.Controls.Add(this.CachePathSaveButton);
+            this.CacheGroupBox.Controls.Add(this.CachePathCancelButton);
             this.CacheGroupBox.Controls.Add(this.CacheSummary);
             this.CacheGroupBox.Controls.Add(this.CacheLimitPreLabel);
             this.CacheGroupBox.Controls.Add(this.CacheLimit);
@@ -350,6 +357,7 @@ namespace CKAN.GUI
             this.CacheGroupBox.Controls.Add(this.ClearCacheButton);
             this.CacheGroupBox.Controls.Add(this.ResetCacheButton);
             this.CacheGroupBox.Controls.Add(this.OpenCacheButton);
+            this.CacheGroupBox.Controls.Add(this.MoveCacheProgressBar);
             this.CacheGroupBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.CacheGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CacheGroupBox.Location = new System.Drawing.Point(280, 144);
@@ -359,17 +367,59 @@ namespace CKAN.GUI
             this.CacheGroupBox.TabStop = false;
             resources.ApplyResources(this.CacheGroupBox, "CacheGroupBox");
             //
-            // CachePath
+            // CachePathTextBox
             //
-            this.CachePath.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.CachePath.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.CachePath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.CachePath.Location = new System.Drawing.Point(12, 18);
-            this.CachePath.Margin = new System.Windows.Forms.Padding(2);
-            this.CachePath.Name = "CachePath";
-            this.CachePath.Size = new System.Drawing.Size(452, 20);
-            this.CachePath.TabIndex = 20;
-            this.CachePath.TextChanged += new System.EventHandler(this.CachePath_TextChanged);
+            this.CachePathTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CachePathTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
+            this.CachePathTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.CachePathTextBox.Enabled = false;
+            this.CachePathTextBox.Location = new System.Drawing.Point(12, 18);
+            this.CachePathTextBox.Name = "CachePathTextBox";
+            this.CachePathTextBox.Size = new System.Drawing.Size(402, 20);
+            this.CachePathTextBox.TabIndex = 20;
+            this.CachePathTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.CachePathTextBox_KeyDown);
+            //
+            // CachePathEditButton
+            //
+            this.CachePathEditButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            this.CachePathEditButton.AutoSize = true;
+            this.CachePathEditButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.CachePathEditButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.CachePathEditButton.Location = new System.Drawing.Point(414, 18);
+            this.CachePathEditButton.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.CachePathEditButton.Name = "CachePathEditButton";
+            this.CachePathEditButton.Size = new System.Drawing.Size(50, 12);
+            this.CachePathEditButton.TabIndex = 21;
+            this.CachePathEditButton.Click += new System.EventHandler(this.CachePathEditButton_Click);
+            resources.ApplyResources(this.CachePathEditButton, "CachePathEditButton");
+            //
+            // CachePathSaveButton
+            //
+            this.CachePathSaveButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            this.CachePathSaveButton.AutoSize = true;
+            this.CachePathSaveButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.CachePathSaveButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.CachePathSaveButton.Location = new System.Drawing.Point(414, 18);
+            this.CachePathSaveButton.Name = "CachePathSaveButton";
+            this.CachePathSaveButton.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.CachePathSaveButton.Size = new System.Drawing.Size(50, 12);
+            this.CachePathSaveButton.TabIndex = 22;
+            this.CachePathSaveButton.Click += new System.EventHandler(this.CachePathSaveButton_Click);
+            resources.ApplyResources(this.CachePathSaveButton, "CachePathSaveButton");
+            //
+            // CachePathCancelButton
+            //
+            this.CachePathCancelButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            this.CachePathCancelButton.AutoSize = true;
+            this.CachePathCancelButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.CachePathCancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.CachePathCancelButton.Location = new System.Drawing.Point(364, 18);
+            this.CachePathCancelButton.Name = "CachePathCancelButton";
+            this.CachePathCancelButton.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.CachePathCancelButton.Size = new System.Drawing.Size(50, 12);
+            this.CachePathCancelButton.TabIndex = 23;
+            this.CachePathCancelButton.Click += new System.EventHandler(this.CachePathCancelButton_Click);
+            resources.ApplyResources(this.CachePathCancelButton, "CachePathCancelButton");
             //
             // CacheSummary
             //
@@ -377,7 +427,7 @@ namespace CKAN.GUI
             this.CacheSummary.Location = new System.Drawing.Point(9, 44);
             this.CacheSummary.Name = "CacheSummary";
             this.CacheSummary.Size = new System.Drawing.Size(70, 13);
-            this.CacheSummary.TabIndex = 21;
+            this.CacheSummary.TabIndex = 24;
             resources.ApplyResources(this.CacheSummary, "CacheSummary");
             //
             // CacheLimitPreLabel
@@ -386,7 +436,7 @@ namespace CKAN.GUI
             this.CacheLimitPreLabel.Location = new System.Drawing.Point(9, 65);
             this.CacheLimitPreLabel.Name = "CacheLimitPreLabel";
             this.CacheLimitPreLabel.Size = new System.Drawing.Size(108, 13);
-            this.CacheLimitPreLabel.TabIndex = 22;
+            this.CacheLimitPreLabel.TabIndex = 25;
             resources.ApplyResources(this.CacheLimitPreLabel, "CacheLimitPreLabel");
             //
             // CacheLimit
@@ -398,7 +448,7 @@ namespace CKAN.GUI
             this.CacheLimit.Margin = new System.Windows.Forms.Padding(2);
             this.CacheLimit.Name = "CacheLimit";
             this.CacheLimit.Size = new System.Drawing.Size(50, 20);
-            this.CacheLimit.TabIndex = 23;
+            this.CacheLimit.TabIndex = 26;
             this.CacheLimit.TextChanged += new System.EventHandler(this.CacheLimit_TextChanged);
             this.CacheLimit.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.CacheLimit_KeyPress);
             //
@@ -408,7 +458,7 @@ namespace CKAN.GUI
             this.CacheLimitPostLabel.Location = new System.Drawing.Point(167, 65);
             this.CacheLimitPostLabel.Name = "CacheLimitPostLabel";
             this.CacheLimitPostLabel.Size = new System.Drawing.Size(119, 13);
-            this.CacheLimitPostLabel.TabIndex = 24;
+            this.CacheLimitPostLabel.TabIndex = 27;
             resources.ApplyResources(this.CacheLimitPostLabel, "CacheLimitPostLabel");
             //
             // ChangeCacheButton
@@ -417,7 +467,7 @@ namespace CKAN.GUI
             this.ChangeCacheButton.Location = new System.Drawing.Point(12, 89);
             this.ChangeCacheButton.Name = "ChangeCacheButton";
             this.ChangeCacheButton.Size = new System.Drawing.Size(75, 25);
-            this.ChangeCacheButton.TabIndex = 25;
+            this.ChangeCacheButton.TabIndex = 28;
             this.ChangeCacheButton.Click += new System.EventHandler(this.ChangeCacheButton_Click);
             resources.ApplyResources(this.ChangeCacheButton, "ChangeCacheButton");
             //
@@ -428,7 +478,7 @@ namespace CKAN.GUI
             this.ClearCacheButton.Menu = this.ClearCacheMenu;
             this.ClearCacheButton.Name = "ClearCacheButton";
             this.ClearCacheButton.Size = new System.Drawing.Size(75, 25);
-            this.ClearCacheButton.TabIndex = 26;
+            this.ClearCacheButton.TabIndex = 29;
             resources.ApplyResources(this.ClearCacheButton, "ClearCacheButton");
             //
             // ClearCacheMenu
@@ -459,7 +509,7 @@ namespace CKAN.GUI
             this.ResetCacheButton.Location = new System.Drawing.Point(174, 89);
             this.ResetCacheButton.Name = "ResetCacheButton";
             this.ResetCacheButton.Size = new System.Drawing.Size(75, 25);
-            this.ResetCacheButton.TabIndex = 27;
+            this.ResetCacheButton.TabIndex = 30;
             this.ResetCacheButton.Click += new System.EventHandler(this.ResetCacheButton_Click);
             resources.ApplyResources(this.ResetCacheButton, "ResetCacheButton");
             //
@@ -469,9 +519,20 @@ namespace CKAN.GUI
             this.OpenCacheButton.Location = new System.Drawing.Point(255, 89);
             this.OpenCacheButton.Name = "OpenCacheButton";
             this.OpenCacheButton.Size = new System.Drawing.Size(75, 25);
-            this.OpenCacheButton.TabIndex = 28;
+            this.OpenCacheButton.TabIndex = 31;
             this.OpenCacheButton.Click += new System.EventHandler(this.OpenCacheButton_Click);
             resources.ApplyResources(this.OpenCacheButton, "OpenCacheButton");
+            //
+            // MoveCacheProgressBar
+            //
+            this.MoveCacheProgressBar.Location = new System.Drawing.Point(12, 123);
+            this.MoveCacheProgressBar.Name = "MoveCacheProgressBar";
+            this.MoveCacheProgressBar.Size = new System.Drawing.Size(452, 20);
+            this.MoveCacheProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+            this.MoveCacheProgressBar.TabStop = false;
+            this.MoveCacheProgressBar.Minimum = 0;
+            this.MoveCacheProgressBar.Maximum = 100;
+            this.MoveCacheProgressBar.Visible = false;
             //
             // BehaviourGroupBox
             //
@@ -486,7 +547,7 @@ namespace CKAN.GUI
             this.BehaviourGroupBox.Location = new System.Drawing.Point(12, 310);
             this.BehaviourGroupBox.Name = "BehaviourGroupBox";
             this.BehaviourGroupBox.Size = new System.Drawing.Size(254, 150);
-            this.BehaviourGroupBox.TabIndex = 29;
+            this.BehaviourGroupBox.TabIndex = 32;
             this.BehaviourGroupBox.TabStop = false;
             resources.ApplyResources(this.BehaviourGroupBox, "BehaviourGroupBox");
             //
@@ -497,7 +558,7 @@ namespace CKAN.GUI
             this.EnableTrayIconCheckBox.Location = new System.Drawing.Point(12, 18);
             this.EnableTrayIconCheckBox.Name = "EnableTrayIconCheckBox";
             this.EnableTrayIconCheckBox.Size = new System.Drawing.Size(102, 17);
-            this.EnableTrayIconCheckBox.TabIndex = 30;
+            this.EnableTrayIconCheckBox.TabIndex = 33;
             this.EnableTrayIconCheckBox.CheckedChanged += new System.EventHandler(this.EnableTrayIconCheckBox_CheckedChanged);
             resources.ApplyResources(this.EnableTrayIconCheckBox, "EnableTrayIconCheckBox");
             //
@@ -508,7 +569,7 @@ namespace CKAN.GUI
             this.MinimizeToTrayCheckBox.Location = new System.Drawing.Point(12, 41);
             this.MinimizeToTrayCheckBox.Name = "MinimizeToTrayCheckBox";
             this.MinimizeToTrayCheckBox.Size = new System.Drawing.Size(98, 17);
-            this.MinimizeToTrayCheckBox.TabIndex = 31;
+            this.MinimizeToTrayCheckBox.TabIndex = 34;
             this.MinimizeToTrayCheckBox.CheckedChanged += new System.EventHandler(this.MinimizeToTrayCheckBox_CheckedChanged);
             resources.ApplyResources(this.MinimizeToTrayCheckBox, "MinimizeToTrayCheckBox");
             //
@@ -518,7 +579,7 @@ namespace CKAN.GUI
             this.RefreshPreLabel.Location = new System.Drawing.Point(9, 66);
             this.RefreshPreLabel.Name = "RefreshPreLabel";
             this.RefreshPreLabel.Size = new System.Drawing.Size(114, 26);
-            this.RefreshPreLabel.TabIndex = 32;
+            this.RefreshPreLabel.TabIndex = 35;
             resources.ApplyResources(this.RefreshPreLabel, "RefreshPreLabel");
             //
             // RefreshTextBox
@@ -529,7 +590,7 @@ namespace CKAN.GUI
             this.RefreshTextBox.Location = new System.Drawing.Point(125, 64);
             this.RefreshTextBox.Name = "RefreshTextBox";
             this.RefreshTextBox.Size = new System.Drawing.Size(25, 20);
-            this.RefreshTextBox.TabIndex = 33;
+            this.RefreshTextBox.TabIndex = 36;
             this.RefreshTextBox.TextChanged += new System.EventHandler(this.RefreshTextBox_TextChanged);
             this.RefreshTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.RefreshTextBox_KeyPress);
             //
@@ -539,7 +600,7 @@ namespace CKAN.GUI
             this.RefreshPostLabel.Location = new System.Drawing.Point(153, 66);
             this.RefreshPostLabel.Name = "RefreshPostLabel";
             this.RefreshPostLabel.Size = new System.Drawing.Size(49, 13);
-            this.RefreshPostLabel.TabIndex = 34;
+            this.RefreshPostLabel.TabIndex = 37;
             resources.ApplyResources(this.RefreshPostLabel, "RefreshPostLabel");
             //
             // PauseRefreshCheckBox
@@ -549,7 +610,7 @@ namespace CKAN.GUI
             this.PauseRefreshCheckBox.Location = new System.Drawing.Point(12, 103);
             this.PauseRefreshCheckBox.Name = "PauseRefreshCheckBox";
             this.PauseRefreshCheckBox.Size = new System.Drawing.Size(105, 17);
-            this.PauseRefreshCheckBox.TabIndex = 35;
+            this.PauseRefreshCheckBox.TabIndex = 38;
             this.PauseRefreshCheckBox.CheckedChanged += new System.EventHandler(this.PauseRefreshCheckBox_CheckedChanged);
             resources.ApplyResources(this.PauseRefreshCheckBox, "PauseRefreshCheckBox");
             //
@@ -566,7 +627,7 @@ namespace CKAN.GUI
             this.MoreSettingsGroupBox.Location = new System.Drawing.Point(280, 310);
             this.MoreSettingsGroupBox.Name = "MoreSettingsGroupBox";
             this.MoreSettingsGroupBox.Size = new System.Drawing.Size(476, 150);
-            this.MoreSettingsGroupBox.TabIndex = 36;
+            this.MoreSettingsGroupBox.TabIndex = 39;
             this.MoreSettingsGroupBox.TabStop = false;
             resources.ApplyResources(this.MoreSettingsGroupBox, "MoreSettingsGroupBox");
             //
@@ -585,7 +646,7 @@ namespace CKAN.GUI
             this.LanguageSelectionComboBox.Location = new System.Drawing.Point(244, 18);
             this.LanguageSelectionComboBox.Name = "LanguageSelectionComboBox";
             this.LanguageSelectionComboBox.Size = new System.Drawing.Size(220, 17);
-            this.LanguageSelectionComboBox.TabIndex = 37;
+            this.LanguageSelectionComboBox.TabIndex = 40;
             this.LanguageSelectionComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.LanguageSelectionComboBox.SelectionChangeCommitted += new System.EventHandler(this.LanguageSelectionComboBox_SelectionChanged);
             this.LanguageSelectionComboBox.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.LanguageSelectionComboBox_MouseWheel);
@@ -597,7 +658,7 @@ namespace CKAN.GUI
             this.RefreshOnStartupCheckbox.Location = new System.Drawing.Point(12, 41);
             this.RefreshOnStartupCheckbox.Name = "RefreshOnStartupCheckbox";
             this.RefreshOnStartupCheckbox.Size = new System.Drawing.Size(167, 17);
-            this.RefreshOnStartupCheckbox.TabIndex = 38;
+            this.RefreshOnStartupCheckbox.TabIndex = 41;
             this.RefreshOnStartupCheckbox.CheckedChanged += new System.EventHandler(this.RefreshOnStartupCheckbox_CheckedChanged);
             resources.ApplyResources(this.RefreshOnStartupCheckbox, "RefreshOnStartupCheckbox");
             //
@@ -608,7 +669,7 @@ namespace CKAN.GUI
             this.HideEpochsCheckbox.Location = new System.Drawing.Point(12, 64);
             this.HideEpochsCheckbox.Name = "HideEpochsCheckbox";
             this.HideEpochsCheckbox.Size = new System.Drawing.Size(261, 17);
-            this.HideEpochsCheckbox.TabIndex = 39;
+            this.HideEpochsCheckbox.TabIndex = 42;
             this.HideEpochsCheckbox.CheckedChanged += new System.EventHandler(this.HideEpochsCheckbox_CheckedChanged);
             resources.ApplyResources(this.HideEpochsCheckbox, "HideEpochsCheckbox");
             //
@@ -619,7 +680,7 @@ namespace CKAN.GUI
             this.HideVCheckbox.Location = new System.Drawing.Point(12, 87);
             this.HideVCheckbox.Name = "HideVCheckbox";
             this.HideVCheckbox.Size = new System.Drawing.Size(204, 17);
-            this.HideVCheckbox.TabIndex = 40;
+            this.HideVCheckbox.TabIndex = 43;
             this.HideVCheckbox.CheckedChanged += new System.EventHandler(this.HideVCheckbox_CheckedChanged);
             resources.ApplyResources(this.HideVCheckbox, "HideVCheckbox");
             //
@@ -632,7 +693,7 @@ namespace CKAN.GUI
             this.AutoSortUpdateCheckBox.Location = new System.Drawing.Point(12, 110);
             this.AutoSortUpdateCheckBox.Name = "AutoSortUpdateCheckBox";
             this.AutoSortUpdateCheckBox.Size = new System.Drawing.Size(452, 32);
-            this.AutoSortUpdateCheckBox.TabIndex = 41;
+            this.AutoSortUpdateCheckBox.TabIndex = 44;
             this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
             resources.ApplyResources(this.AutoSortUpdateCheckBox, "AutoSortUpdateCheckBox");
             //
@@ -672,6 +733,7 @@ namespace CKAN.GUI
 
         #endregion
 
+        private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.GroupBox RepositoryGroupBox;
         private System.Windows.Forms.ListView ReposListBox;
         private System.Windows.Forms.ColumnHeader RepoNameHeader;
@@ -687,7 +749,10 @@ namespace CKAN.GUI
         private System.Windows.Forms.Button NewAuthTokenButton;
         private System.Windows.Forms.Button DeleteAuthTokenButton;
         private System.Windows.Forms.GroupBox CacheGroupBox;
-        private System.Windows.Forms.TextBox CachePath;
+        private System.Windows.Forms.TextBox CachePathTextBox;
+        private System.Windows.Forms.Button CachePathEditButton;
+        private System.Windows.Forms.Button CachePathSaveButton;
+        private System.Windows.Forms.Button CachePathCancelButton;
         private System.Windows.Forms.Label CacheSummary;
         private System.Windows.Forms.Label CacheLimitPreLabel;
         private System.Windows.Forms.TextBox CacheLimit;
@@ -699,6 +764,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem PurgeAllMenuItem;
         private System.Windows.Forms.Button ResetCacheButton;
         private System.Windows.Forms.Button OpenCacheButton;
+        private System.Windows.Forms.ProgressBar MoveCacheProgressBar;
         private System.Windows.Forms.GroupBox AutoUpdateGroupBox;
         private System.Windows.Forms.Label LocalVersionPreLabel;
         private System.Windows.Forms.Label LocalVersionLabel;
@@ -722,6 +788,5 @@ namespace CKAN.GUI
         private System.Windows.Forms.CheckBox HideEpochsCheckbox;
         private System.Windows.Forms.CheckBox HideVCheckbox;
         private System.Windows.Forms.CheckBox AutoSortUpdateCheckBox;
-        private System.Windows.Forms.ToolTip ToolTip;
     }
 }

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -19,21 +19,6 @@ namespace CKAN.GUI
     #endif
     public partial class SettingsDialog : Form
     {
-        private static readonly ILog log = LogManager.GetLogger(typeof(SettingsDialog));
-
-        public bool RepositoryAdded   { get; private set; } = false;
-        public bool RepositoryRemoved { get; private set; } = false;
-        public bool RepositoryMoved   { get; private set; } = false;
-
-        private static GameInstanceManager? manager => Main.Instance?.Manager;
-
-        private readonly IConfiguration   coreConfig;
-        private readonly GUIConfiguration guiConfig;
-        private readonly RegistryManager  regMgr;
-        private readonly AutoUpdate       updater;
-        private readonly IUser            user;
-        private readonly string?          userAgent;
-
         /// <summary>
         /// Initialize a settings window
         /// </summary>
@@ -46,7 +31,11 @@ namespace CKAN.GUI
         {
             InitializeComponent();
 
-            ToolTip.SetToolTip(RefreshTextBox, Properties.Resources.SettingsToolTipRefreshTextBox);
+            ToolTip.SetToolTip(RefreshTextBox,    Properties.Resources.SettingsToolTipRefreshTextBox);
+            ToolTip.SetToolTip(ChangeCacheButton, Properties.Resources.SettingsToolTipChangeCacheButton);
+            ToolTip.SetToolTip(ResetCacheButton,  Properties.Resources.SettingsToolTipResetCacheButton);
+            ToolTip.SetToolTip(OpenCacheButton,   Properties.Resources.SettingsToolTipOpenCacheButton);
+            ToolTip.SetToolTip(ClearCacheButton,  Properties.Resources.SettingsToolTipClearCacheButton);
 
             this.coreConfig = coreConfig;
             this.guiConfig  = guiConfig;
@@ -58,6 +47,8 @@ namespace CKAN.GUI
             {
                 ClearCacheMenu.Renderer = new FlatToolStripRenderer();
             }
+            CachePathEditButton.Height = CachePathSaveButton.Height =
+                CachePathCancelButton.Height = CachePathTextBox.Height;
         }
 
         private void SettingsDialog_Load(object? sender, EventArgs? e)
@@ -84,40 +75,14 @@ namespace CKAN.GUI
 
             UpdateRefreshRate();
 
-            if (coreConfig.DownloadCacheDir != null)
-            {
-                UpdateCacheInfo(coreConfig.DownloadCacheDir);
-            }
-        }
-
-        private void UpdateAutoUpdate()
-        {
-            LocalVersionLabel.Text = Meta.GetVersion();
-            try
-            {
-                var latestVersion = updater.GetUpdate(coreConfig.DevBuilds ?? false, userAgent)
-                                           .Version;
-                LatestVersionLabel.Text = latestVersion?.ToString() ?? "";
-                // Allow downgrading in case they want to stop using dev builds
-                InstallUpdateButton.Enabled = !latestVersion?.Equals(new ModuleVersion(Meta.GetVersion())) ?? false;
-            }
-            catch
-            {
-                // Can't get the version, reset the label
-                var resources = new SingleAssemblyComponentResourceManager(typeof(SettingsDialog));
-                resources.ApplyResources(LatestVersionLabel,
-                                         LatestVersionLabel.Name);
-                InstallUpdateButton.Enabled = false;
-            }
+            UpdateCacheInfo(coreConfig.DownloadCacheDir ?? JsonConfiguration.DefaultDownloadCacheDir);
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            if (CachePath.Text != coreConfig.DownloadCacheDir
-                && manager != null
-                && !manager.TrySetupCache(CachePath.Text, out string? failReason))
+            if (!RepositoryGroupBox.Enabled)
             {
-                user.RaiseError(Properties.Resources.SettingsDialogSummaryInvalid, failReason);
+                // Don't close the window if still editing the cache path
                 e.Cancel = true;
             }
             else
@@ -126,17 +91,265 @@ namespace CKAN.GUI
             }
         }
 
-        private void UpdateRefreshRate()
+        #region Cache path and limit
+
+        private void UpdateCacheInfo(string newPath)
         {
-            if (Main.Instance != null)
+            CachePathTextBox.Text = newPath;
+            EnableDisableCachePath(false);
+            if (manager?.Cache != null)
             {
-                int rate = coreConfig.RefreshRate;
-                RefreshTextBox.Text = rate.ToString();
-                PauseRefreshCheckBox.Enabled = rate != 0;
-                Main.Instance.pauseToolStripMenuItem.Enabled = coreConfig.RefreshRate != 0;
-                Main.Instance.UpdateRefreshTimer();
+                // Background thread in case GetSizeInfo takes a while
+                Task.Factory.StartNew(() =>
+                {
+                    try
+                    {
+                        manager.Cache.GetSizeInfo(out int  cacheFileCount,
+                                                  out long cacheSize,
+                                                  out long cacheFreeSpace);
+
+                        Util.Invoke(this, () =>
+                        {
+                            if (coreConfig.CacheSizeLimit.HasValue)
+                            {
+                                // Show setting in MiB
+                                CacheLimit.Text = (coreConfig.CacheSizeLimit.Value / 1024 / 1024).ToString();
+                            }
+                            CacheSummary.Text = string.Format(Properties.Resources.SettingsDialogSummmary,
+                                                              cacheFileCount,
+                                                              CkanModule.FmtSize(cacheSize),
+                                                              CkanModule.FmtSize(cacheFreeSpace));
+                            CacheSummary.ForeColor   = SystemColors.ControlText;
+                            OpenCacheButton.Enabled  = true;
+                            ClearCacheButton.Enabled = (cacheSize > 0);
+                            PurgeToLimitMenuItem.Enabled = (coreConfig.CacheSizeLimit.HasValue
+                                                            && cacheSize > coreConfig.CacheSizeLimit.Value);
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        Util.Invoke(this, () =>
+                        {
+                            CacheSummary.Text        = string.Format(Properties.Resources.SettingsDialogSummaryInvalid,
+                                                                     ex.Message);
+                            CacheSummary.ForeColor   = Color.Red;
+                            OpenCacheButton.Enabled  = false;
+                            ClearCacheButton.Enabled = false;
+                        });
+                    }
+                });
             }
         }
+
+        private async void CachePathTextBox_KeyDown(object? sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Escape:
+                    e.Handled = true;
+                    e.SuppressKeyPress = true;
+                    UpdateCacheInfo(coreConfig.DownloadCacheDir ?? JsonConfiguration.DefaultDownloadCacheDir);
+                    break;
+
+                case Keys.Enter:
+                    e.Handled = true;
+                    e.SuppressKeyPress = true;
+                    await TrySaveCachePath(CachePathTextBox.Text);
+                    break;
+            }
+        }
+
+        private void CachePathEditButton_Click(object? sender, EventArgs? e)
+        {
+            EnableDisableCachePath(true);
+            CachePathTextBox.Focus();
+        }
+
+        private async void CachePathSaveButton_Click(object? sender, EventArgs? e)
+        {
+            await TrySaveCachePath(CachePathTextBox.Text);
+        }
+
+        private void CachePathCancelButton_Click(object? sender, EventArgs? e)
+        {
+            UpdateCacheInfo(coreConfig.DownloadCacheDir
+                            ?? JsonConfiguration.DefaultDownloadCacheDir);
+        }
+
+        private async Task<bool> TrySaveCachePath(string newPath)
+        {
+            CachePathTextBox.Enabled      = false;
+            CachePathSaveButton.Enabled   = false;
+            CachePathCancelButton.Enabled = false;
+            return await Task.Run(() =>
+            {
+                if (newPath != coreConfig.DownloadCacheDir
+                    && manager != null
+                    && !manager.TrySetupCache(newPath,
+                                              new Progress<int>(UpdateCacheProgress),
+                                              out string? failReason))
+                {
+                    Util.Invoke(this, () =>
+                    {
+                        MoveCacheProgressBar.Visible = false;
+                        if (failReason.Length > 0)
+                        {
+                            user.RaiseError(Properties.Resources.SettingsDialogSummaryInvalid,
+                                            failReason);
+                        }
+                        else
+                        {
+                            // User cancelled the choice popup, reset UI
+                            UpdateCacheInfo(coreConfig.DownloadCacheDir
+                                            ?? JsonConfiguration.DefaultDownloadCacheDir);
+                        }
+                    });
+                    return false;
+                }
+                else
+                {
+                    Util.Invoke(this, () =>
+                    {
+                        MoveCacheProgressBar.Visible = false;
+                        UpdateCacheInfo(newPath);
+                    });
+                    return true;
+                }
+            });
+        }
+
+        private void UpdateCacheProgress(int percent)
+        {
+            Util.Invoke(CachePathTextBox, () =>
+            {
+                MoveCacheProgressBar.Visible = true;
+                MoveCacheProgressBar.Value = percent;
+            });
+        }
+
+        private void EnableDisableCachePath(bool enable)
+        {
+            ControlBox                    = !enable;
+            BehaviourGroupBox.Enabled     = !enable;
+            AuthTokensGroupBox.Enabled    = !enable;
+            AutoUpdateGroupBox.Enabled    = !enable;
+            RepositoryGroupBox.Enabled    = !enable;
+            MoreSettingsGroupBox.Enabled  = !enable;
+            CachePathTextBox.Enabled      = enable;
+            CachePathEditButton.Visible   = !enable;
+            CachePathSaveButton.Enabled   = true;
+            CachePathSaveButton.Visible   = enable;
+            CachePathCancelButton.Enabled = true;
+            CachePathCancelButton.Visible = enable;
+            ChangeCacheButton.Enabled     = !enable;
+            ResetCacheButton.Enabled      = !enable
+                                            && CachePathTextBox.Text != JsonConfiguration.DefaultDownloadCacheDir;
+            ClearCacheButton.Enabled      = !enable;
+            if (enable)
+            {
+                CachePathCancelButton.Left = CachePathSaveButton.Left - CachePathCancelButton.Width;
+            }
+            CachePathTextBox.Width = enable ? CachePathCancelButton.Left - CachePathTextBox.Left
+                                     : CachePathEditButton.Left   - CachePathTextBox.Left;
+        }
+
+        private void CacheLimit_TextChanged(object? sender, EventArgs? e)
+        {
+            if (string.IsNullOrEmpty(CacheLimit.Text))
+            {
+                coreConfig.CacheSizeLimit = null;
+            }
+            else
+            {
+                // Translate from MB to bytes
+                coreConfig.CacheSizeLimit = Convert.ToInt64(CacheLimit.Text) * 1024 * 1024;
+            }
+            UpdateCacheInfo(CachePathTextBox.Text);
+        }
+
+        private void CacheLimit_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private async void ChangeCacheButton_Click(object? sender, EventArgs? e)
+        {
+            var cacheChooser = new FolderBrowserDialog()
+            {
+                Description         = Properties.Resources.SettingsDialogCacheDescrip,
+                RootFolder          = Environment.SpecialFolder.MyComputer,
+                SelectedPath        = coreConfig.DownloadCacheDir
+                                      ?? JsonConfiguration.DefaultDownloadCacheDir,
+                ShowNewFolderButton = true
+            };
+            if (cacheChooser.ShowDialog(this) == DialogResult.OK)
+            {
+                await TrySaveCachePath(cacheChooser.SelectedPath);
+            }
+        }
+
+        private void PurgeToLimitMenuItem_Click(object? sender, EventArgs? e)
+        {
+            // Purge old downloads if we're over the limit
+            if (coreConfig.CacheSizeLimit.HasValue
+                && manager?.Cache != null
+                && coreConfig.DownloadCacheDir != null)
+            {
+                manager.Cache.EnforceSizeLimit(coreConfig.CacheSizeLimit.Value,
+                                               regMgr.registry);
+                UpdateCacheInfo(coreConfig.DownloadCacheDir);
+            }
+        }
+
+        private void PurgeAllMenuItem_Click(object? sender, EventArgs? e)
+        {
+            if (manager?.Cache != null)
+            {
+                manager.Cache.GetSizeInfo(out int cacheFileCount,
+                                          out long cacheSize,
+                                          out _);
+
+                var deleteConfirmationDialog = new YesNoDialog();
+                var confirmationText = string.Format(
+                    Properties.Resources.SettingsDialogDeleteConfirm,
+                    cacheFileCount,
+                    CkanModule.FmtSize(cacheSize));
+
+                if (deleteConfirmationDialog.ShowYesNoDialog(this, confirmationText) == DialogResult.Yes)
+                {
+                    // Tell the cache object to nuke itself
+                    manager.Cache.RemoveAll();
+
+                    if (coreConfig.DownloadCacheDir != null)
+                    {
+                        UpdateCacheInfo(coreConfig.DownloadCacheDir);
+                    }
+                }
+            }
+        }
+
+        private async void ResetCacheButton_Click(object? sender, EventArgs? e)
+        {
+            // Reset to default cache path
+            await TrySaveCachePath(JsonConfiguration.DefaultDownloadCacheDir);
+        }
+
+        private void OpenCacheButton_Click(object? sender, EventArgs? e)
+        {
+            Utilities.ProcessStartURL(coreConfig.DownloadCacheDir
+                                      ?? JsonConfiguration.DefaultDownloadCacheDir);
+        }
+
+        #endregion
+
+        #region Repositories
+
+        public bool RepositoryAdded   { get; private set; } = false;
+        public bool RepositoryRemoved { get; private set; } = false;
+        public bool RepositoryMoved   { get; private set; } = false;
 
         private void RefreshReposListBox(bool        saveChanges = true,
                                          Repository? toSelect    = null)
@@ -172,167 +385,6 @@ namespace CKAN.GUI
                     Util.Invoke(this, () => UseWaitCursor = false);
                 });
             }
-        }
-
-        private void UpdateLanguageSelectionComboBox()
-        {
-            LanguageSelectionComboBox.Items.Clear();
-            LanguageSelectionComboBox.Items.AddRange(Utilities.AvailableLanguages);
-            // If the current language is supported by CKAN, set is as selected.
-            // Else display a blank field.
-            LanguageSelectionComboBox.SelectedIndex = LanguageSelectionComboBox.FindStringExact(coreConfig.Language);
-        }
-
-        private void UpdateCacheInfo(string newPath)
-        {
-            CachePath.Text = newPath;
-            // Background thread in case GetSizeInfo takes a while
-            Task.Factory.StartNew(() =>
-            {
-                try
-                {
-                    // Make a temporary cache object to validate the path without changing the setting till close
-                    var cache = new NetModuleCache(newPath);
-                    cache.GetSizeInfo(out int cacheFileCount, out long cacheSize, out long cacheFreeSpace);
-
-                    Util.Invoke(this, () =>
-                    {
-                        if (coreConfig.CacheSizeLimit.HasValue)
-                        {
-                            // Show setting in MiB
-                            CacheLimit.Text = (coreConfig.CacheSizeLimit.Value / 1024 / 1024).ToString();
-                        }
-                        CacheSummary.Text = string.Format(
-                            Properties.Resources.SettingsDialogSummmary,
-                            cacheFileCount, CkanModule.FmtSize(cacheSize), CkanModule.FmtSize(cacheFreeSpace));
-                        CacheSummary.ForeColor   = SystemColors.ControlText;
-                        OpenCacheButton.Enabled  = true;
-                        ClearCacheButton.Enabled = (cacheSize > 0);
-                        PurgeToLimitMenuItem.Enabled = (coreConfig.CacheSizeLimit.HasValue
-                            && cacheSize > coreConfig.CacheSizeLimit.Value);
-                    });
-
-                }
-                catch (Exception ex)
-                {
-                    Util.Invoke(this, () =>
-                    {
-                        CacheSummary.Text        = string.Format(Properties.Resources.SettingsDialogSummaryInvalid,
-                                                                 ex.Message);
-                        CacheSummary.ForeColor   = Color.Red;
-                        OpenCacheButton.Enabled  = false;
-                        ClearCacheButton.Enabled = false;
-                    });
-                }
-            });
-        }
-
-        private void CachePath_TextChanged(object? sender, EventArgs? e)
-        {
-            UpdateCacheInfo(CachePath.Text);
-        }
-
-        private void CacheLimit_TextChanged(object? sender, EventArgs? e)
-        {
-            if (string.IsNullOrEmpty(CacheLimit.Text))
-            {
-                coreConfig.CacheSizeLimit = null;
-            }
-            else
-            {
-                // Translate from MB to bytes
-                coreConfig.CacheSizeLimit = Convert.ToInt64(CacheLimit.Text) * 1024 * 1024;
-            }
-            UpdateCacheInfo(CachePath.Text);
-        }
-
-        private void CacheLimit_KeyPress(object sender, KeyPressEventArgs e)
-        {
-            if (!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar))
-            {
-                e.Handled = true;
-            }
-        }
-
-        private void ChangeCacheButton_Click(object? sender, EventArgs? e)
-        {
-            var cacheChooser = new FolderBrowserDialog()
-            {
-                Description         = Properties.Resources.SettingsDialogCacheDescrip,
-                RootFolder          = Environment.SpecialFolder.MyComputer,
-                SelectedPath        = coreConfig.DownloadCacheDir
-                                      ?? JsonConfiguration.DefaultDownloadCacheDir,
-                ShowNewFolderButton = true
-            };
-            if (cacheChooser.ShowDialog(this) == DialogResult.OK)
-            {
-                UpdateCacheInfo(cacheChooser.SelectedPath);
-            }
-        }
-
-        private void PurgeToLimitMenuItem_Click(object? sender, EventArgs? e)
-        {
-            // Purge old downloads if we're over the limit
-            if (coreConfig.CacheSizeLimit.HasValue && manager != null && coreConfig.DownloadCacheDir != null)
-            {
-                // Switch main cache since user seems committed to this path
-                if (CachePath.Text != coreConfig.DownloadCacheDir
-                    && !manager.TrySetupCache(CachePath.Text, out string? failReason))
-                {
-                    user.RaiseError(Properties.Resources.SettingsDialogSummaryInvalid, failReason);
-                    return;
-                }
-
-                manager.Cache?.EnforceSizeLimit(
-                    coreConfig.CacheSizeLimit.Value,
-                    regMgr.registry);
-                UpdateCacheInfo(coreConfig.DownloadCacheDir);
-            }
-        }
-
-        private void PurgeAllMenuItem_Click(object? sender, EventArgs? e)
-        {
-            if (manager?.Cache != null)
-            {
-                // Switch main cache since user seems committed to this path
-                if (CachePath.Text != coreConfig.DownloadCacheDir
-                    && !manager.TrySetupCache(CachePath.Text, out string? failReason))
-                {
-                    user.RaiseError(Properties.Resources.SettingsDialogSummaryInvalid, failReason);
-                    return;
-                }
-
-                manager.Cache.GetSizeInfo(
-                    out int cacheFileCount, out long cacheSize, out _);
-
-                YesNoDialog deleteConfirmationDialog = new YesNoDialog();
-                string confirmationText = string.Format(
-                    Properties.Resources.SettingsDialogDeleteConfirm,
-                    cacheFileCount,
-                    CkanModule.FmtSize(cacheSize));
-
-                if (deleteConfirmationDialog.ShowYesNoDialog(this, confirmationText) == DialogResult.Yes)
-                {
-                    // Tell the cache object to nuke itself
-                    manager.Cache.RemoveAll();
-
-                    if (coreConfig.DownloadCacheDir != null)
-                    {
-                        UpdateCacheInfo(coreConfig.DownloadCacheDir);
-                    }
-                }
-            }
-        }
-
-        private void ResetCacheButton_Click(object? sender, EventArgs? e)
-        {
-            // Reset to default cache path
-            UpdateCacheInfo(JsonConfiguration.DefaultDownloadCacheDir);
-        }
-
-        private void OpenCacheButton_Click(object? sender, EventArgs? e)
-        {
-            Utilities.ProcessStartURL(coreConfig.DownloadCacheDir ?? JsonConfiguration.DefaultDownloadCacheDir);
         }
 
         private void ReposListBox_SelectedIndexChanged(object? sender, EventArgs? e)
@@ -462,6 +514,10 @@ namespace CKAN.GUI
             }
         }
 
+        #endregion
+
+        #region Auth tokens
+
         private void RefreshAuthTokensListBox()
         {
             AuthTokensListBox.Items.Clear();
@@ -476,6 +532,8 @@ namespace CKAN.GUI
                     });
                 }
             }
+            AuthTokensListBox.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+            AuthTokensListBox.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
         }
 
         private void AuthTokensListBox_SelectedIndexChanged(object? sender, EventArgs? e)
@@ -611,6 +669,31 @@ namespace CKAN.GUI
             }
         }
 
+        #endregion
+
+        #region CKAN updates
+
+        private void UpdateAutoUpdate()
+        {
+            LocalVersionLabel.Text = Meta.GetVersion();
+            try
+            {
+                var latestVersion = updater.GetUpdate(coreConfig.DevBuilds ?? false, userAgent)
+                                           .Version;
+                LatestVersionLabel.Text = latestVersion?.ToString() ?? "";
+                // Allow downgrading in case they want to stop using dev builds
+                InstallUpdateButton.Enabled = !latestVersion?.Equals(new ModuleVersion(Meta.GetVersion())) ?? false;
+            }
+            catch
+            {
+                // Can't get the version, reset the label
+                var resources = new SingleAssemblyComponentResourceManager(typeof(SettingsDialog));
+                resources.ApplyResources(LatestVersionLabel,
+                                         LatestVersionLabel.Name);
+                InstallUpdateButton.Enabled = false;
+            }
+        }
+
         private void CheckForUpdatesButton_Click(object? sender, EventArgs? e)
         {
             try
@@ -647,6 +730,19 @@ namespace CKAN.GUI
             UpdateAutoUpdate();
         }
 
+        #endregion
+
+        #region More settings
+
+        private void UpdateLanguageSelectionComboBox()
+        {
+            LanguageSelectionComboBox.Items.Clear();
+            LanguageSelectionComboBox.Items.AddRange(Utilities.AvailableLanguages);
+            // If the current language is supported by CKAN, set is as selected.
+            // Else display a blank field.
+            LanguageSelectionComboBox.SelectedIndex = LanguageSelectionComboBox.FindStringExact(coreConfig.Language);
+        }
+
         private void RefreshOnStartupCheckbox_CheckedChanged(object? sender, EventArgs? e)
         {
             guiConfig.RefreshOnStartup = RefreshOnStartupCheckbox.Checked;
@@ -679,6 +775,22 @@ namespace CKAN.GUI
         private void AutoSortUpdateCheckBox_CheckedChanged(object? sender, EventArgs? e)
         {
             guiConfig.AutoSortByUpdate = AutoSortUpdateCheckBox.Checked;
+        }
+
+        #endregion
+
+        #region Tray icon
+
+        private void UpdateRefreshRate()
+        {
+            if (Main.Instance != null)
+            {
+                int rate = coreConfig.RefreshRate;
+                RefreshTextBox.Text = rate.ToString();
+                PauseRefreshCheckBox.Enabled = rate != 0;
+                Main.Instance.pauseToolStripMenuItem.Enabled = coreConfig.RefreshRate != 0;
+                Main.Instance.UpdateRefreshTimer();
+            }
         }
 
         private void EnableTrayIconCheckBox_CheckedChanged(object? sender, EventArgs? e)
@@ -720,5 +832,18 @@ namespace CKAN.GUI
                 Main.Instance?.refreshTimer?.Start();
             }
         }
+
+        #endregion
+
+        private static GameInstanceManager? manager => Main.Instance?.Manager;
+
+        private readonly IConfiguration   coreConfig;
+        private readonly GUIConfiguration guiConfig;
+        private readonly RegistryManager  regMgr;
+        private readonly AutoUpdate       updater;
+        private readonly IUser            user;
+        private readonly string?          userAgent;
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(SettingsDialog));
     }
 }

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -45,6 +45,9 @@ namespace CKAN.GUI
                               string?          userAgent)
         {
             InitializeComponent();
+
+            ToolTip.SetToolTip(RefreshTextBox, Properties.Resources.SettingsToolTipRefreshTextBox);
+
             this.coreConfig = coreConfig;
             this.guiConfig  = guiConfig;
             this.regMgr     = regMgr;

--- a/GUI/Dialogs/SettingsDialog.resx
+++ b/GUI/Dialogs/SettingsDialog.resx
@@ -129,6 +129,9 @@
   <data name="NewAuthTokenButton.Text" xml:space="preserve"><value>New</value></data>
   <data name="DeleteAuthTokenButton.Text" xml:space="preserve"><value>Delete</value></data>
   <data name="CacheGroupBox.Text" xml:space="preserve"><value>Download Cache</value></data>
+  <data name="CachePathEditButton.Text" xml:space="preserve"><value>Edit</value></data>
+  <data name="CachePathSaveButton.Text" xml:space="preserve"><value>Save</value></data>
+  <data name="CachePathCancelButton.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="CacheSummary.Text" xml:space="preserve"><value>N files, M MiB</value></data>
   <data name="CacheLimitPreLabel.Text" xml:space="preserve"><value>Maximum cache size:</value></data>
   <data name="CacheLimitPostLabel.Text" xml:space="preserve"><value>MiB (empty for unlimited)</value></data>

--- a/GUI/Dialogs/YesNoDialog.Designer.cs
+++ b/GUI/Dialogs/YesNoDialog.Designer.cs
@@ -131,7 +131,7 @@ namespace CKAN.GUI
             this.panel1.ResumeLayout(false);
             this.BottomButtonPanel.ResumeLayout(false);
             this.BottomButtonPanel.PerformLayout();
-             this.ResumeLayout(false);
+            this.ResumeLayout(false);
             this.PerformLayout();
         }
 

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -78,11 +78,6 @@ namespace CKAN.GUI
             SuppressCheckbox.Visible = true;
         }
 
-        public void HideYesNoDialog()
-        {
-            Util.Invoke(this, Close);
-        }
-
         private const int maxHeight = 600;
         private TaskCompletionSource<Tuple<DialogResult, bool>>? task;
         private readonly string defaultYes;

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -56,7 +56,16 @@ namespace CKAN.GUI
         /// <param name="args">Array of offered options.</param>
         [ForbidGUICalls]
         public int RaiseSelectionDialog(string message, params object[] args)
-            => main.SelectionDialog(message, args);
+        {
+            int result = 0;
+            Util.Invoke(main, () =>
+            {
+                var dlg = new SelectionDialog();
+                result = dlg.ShowSelectionDialog(message, args);
+                dlg.Dispose();
+            });
+            return result;
+        }
 
         /// <summary>
         /// Shows a message box containing the formatted error message.

--- a/GUI/Localization/de-DE/SelectionDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/SelectionDialog.de-DE.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>Standard</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>Abbrechen</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/fr-FR/SelectionDialog.fr-FR.resx
+++ b/GUI/Localization/fr-FR/SelectionDialog.fr-FR.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>Défaut</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>Annuler</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/it-IT/SelectionDialog.it-IT.resx
+++ b/GUI/Localization/it-IT/SelectionDialog.it-IT.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>Predefinito</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>Annulla</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/ja-JP/SelectionDialog.ja-JP.resx
+++ b/GUI/Localization/ja-JP/SelectionDialog.ja-JP.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>デフォルト</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>取消</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/ko-KR/SelectionDialog.ko-KR.resx
+++ b/GUI/Localization/ko-KR/SelectionDialog.ko-KR.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>기본</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>취소하기</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/nl-NL/SelectionDialog.nl-NL.resx
+++ b/GUI/Localization/nl-NL/SelectionDialog.nl-NL.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>Standaard</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>Annuleer</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/pl-PL/SelectionDialog.pl-PL.resx
+++ b/GUI/Localization/pl-PL/SelectionDialog.pl-PL.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>Domyślny</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>Anuluj</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/pt-BR/SelectionDialog.pt-BR.resx
+++ b/GUI/Localization/pt-BR/SelectionDialog.pt-BR.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>Padrão</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>Cancelar</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/ru-RU/SelectionDialog.ru-RU.resx
+++ b/GUI/Localization/ru-RU/SelectionDialog.ru-RU.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>По умолчанию</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>Отмена</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Localization/zh-CN/SelectionDialog.zh-CN.resx
+++ b/GUI/Localization/zh-CN/SelectionDialog.zh-CN.resx
@@ -126,7 +126,7 @@
   <data name="DefaultButton.Text" xml:space="preserve">
     <value>默认</value>
   </data>
-  <data name="CancelButton.Text" xml:space="preserve">
+  <data name="CancelSelectionButton.Text" xml:space="preserve">
     <value>取消</value>
   </data>
   <data name="$this.Text" xml:space="preserve">

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -158,11 +158,8 @@ namespace CKAN.GUI
                 Manager = new GameInstanceManager(currentUser);
             }
 
-            if (Manager.Cache != null)
-            {
-                Manager.Cache.ModStored += OnModStoredOrPurged;
-                Manager.Cache.ModPurged += OnModStoredOrPurged;
-            }
+            Manager.CacheChanged += OnCacheChanged;
+            OnCacheChanged(null);
 
             tabController = new TabController(MainTabControl);
             tabController.ShowTab("ManageModsTabPage");

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -8,21 +8,19 @@ namespace CKAN.GUI
 {
     public partial class Main
     {
-        public ControlFactory   controlFactory;
+        public  ControlFactory  controlFactory;
         private ErrorDialog     errorDialog;
         private PluginsDialog   pluginsDialog;
         private YesNoDialog     yesNoDialog;
-        private SelectionDialog selectionDialog;
 
         [MemberNotNull(nameof(controlFactory), nameof(errorDialog), nameof(pluginsDialog),
-                       nameof(yesNoDialog),   nameof(selectionDialog))]
+                       nameof(yesNoDialog))]
         public void RecreateDialogs()
         {
             controlFactory ??= new ControlFactory();
-            errorDialog = controlFactory.CreateControl<ErrorDialog>();
+            errorDialog   = controlFactory.CreateControl<ErrorDialog>();
             pluginsDialog = controlFactory.CreateControl<PluginsDialog>();
-            yesNoDialog = controlFactory.CreateControl<YesNoDialog>();
-            selectionDialog = controlFactory.CreateControl<SelectionDialog>();
+            yesNoDialog   = controlFactory.CreateControl<YesNoDialog>();
         }
 
         [ForbidGUICalls]
@@ -43,9 +41,5 @@ namespace CKAN.GUI
         [ForbidGUICalls]
         public Tuple<DialogResult, bool> SuppressableYesNoDialog(string text, string suppressText, string? yesText = null, string? noText = null)
             => yesNoDialog.ShowSuppressableYesNoDialog(this, text, suppressText, yesText, noText);
-
-        [ForbidGUICalls]
-        public int SelectionDialog(string message, params object[] args)
-            => selectionDialog.ShowSelectionDialog(message, args);
     }
 }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -91,6 +91,7 @@ namespace CKAN.GUI
                 // Close progress tab and switch back to mod list
                 HideWaitDialog();
                 EnableMainWindow();
+                ModInfo.SwitchTab("ContentTabPage");
             }
         }
 
@@ -103,11 +104,28 @@ namespace CKAN.GUI
                                                     .Select(guiMod => guiMod.ToModule())
                                                     .OfType<CkanModule>())
                        .Select(other => allGuiMods[other.identifier])
-                ?? allGuiMods.Values;
+                      ?? allGuiMods.Values;
             foreach (var otherMod in affectedMods)
             {
                 otherMod.UpdateIsCached();
             }
+        }
+
+        [ForbidGUICalls]
+        private void OnCacheChanged(NetModuleCache? prev)
+        {
+            if (prev != null)
+            {
+                prev.ModStored -= OnModStoredOrPurged;
+                prev.ModPurged -= OnModStoredOrPurged;
+            }
+            if (Manager.Cache != null)
+            {
+                Manager.Cache.ModStored += OnModStoredOrPurged;
+                Manager.Cache.ModPurged += OnModStoredOrPurged;
+            }
+            UpdateCachedByDownloads(null);
+            ModInfo.RefreshModContentsTree();
         }
 
         [ForbidGUICalls]

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -360,6 +360,10 @@ Find the folder where your game is installed and choose one of these files:
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Failed to fetch master list.</value></data>
   <data name="PluginsDialogFilter" xml:space="preserve"><value>CKAN Plugins (*.dll)|*.dll</value></data>
   <data name="SettingsToolTipRefreshTextBox" xml:space="preserve"><value>Setting to 0 will not refresh modlist</value></data>
+  <data name="SettingsToolTipChangeCacheButton" xml:space="preserve"><value>Choose a new download cache folder</value></data>
+  <data name="SettingsToolTipResetCacheButton" xml:space="preserve"><value>Use the default download cache folder </value></data>
+  <data name="SettingsToolTipOpenCacheButton" xml:space="preserve"><value>Browse the cache folder</value></data>
+  <data name="SettingsToolTipClearCacheButton" xml:space="preserve"><value>Delete files from the cache</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Invalid path: {0}</value></data>
   <data name="SettingsDialogCacheDescrip" xml:space="preserve"><value>Choose a folder for storing CKAN's mod downloads:</value></data>
@@ -513,4 +517,5 @@ This action cannot be undone!</value></data>
   <data name="PreferredHostsTooltipMoveLeft" xml:space="preserve"><value>Remove selected host from preferences list</value></data>
   <data name="PreferredHostsTooltipMoveUp" xml:space="preserve"><value>Make selected host higher priority</value></data>
   <data name="PreferredHostsTooltipMoveDown" xml:space="preserve"><value>Make selected host lower priority</value></data>
+  <data name="SelectionDialogDefault" xml:space="preserve"><value>{0} (DEFAULT)</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -359,6 +359,7 @@ Find the folder where your game is installed and choose one of these files:
 {1}</value></data>
   <data name="NewRepoDialogFailed" xml:space="preserve"><value>Failed to fetch master list.</value></data>
   <data name="PluginsDialogFilter" xml:space="preserve"><value>CKAN Plugins (*.dll)|*.dll</value></data>
+  <data name="SettingsToolTipRefreshTextBox" xml:space="preserve"><value>Setting to 0 will not refresh modlist</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Invalid path: {0}</value></data>
   <data name="SettingsDialogCacheDescrip" xml:space="preserve"><value>Choose a folder for storing CKAN's mod downloads:</value></data>

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -106,7 +106,7 @@ namespace CKAN.NetKAN.Processors
             {
                 log.InfoFormat("Using main CKAN meta-cache at {0}", cfg.DownloadCacheDir);
                 // Create a new file cache in the same location so NetKAN can download pure URLs not sourced from CkanModules
-                return new NetFileCache(null, cfg.DownloadCacheDir ?? JsonConfiguration.DefaultDownloadCacheDir);
+                return new NetFileCache(cfg.DownloadCacheDir ?? JsonConfiguration.DefaultDownloadCacheDir);
             }
             catch
             {

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -64,8 +64,8 @@ namespace CKAN.NetKAN.Services
                     ? GetFilesBySuffix(module, zip, ".ckan", inst)
                         .Select(instF => instF.source)
                     // Find embedded .ckan files anywhere in the ZIP
-                    : zip.Cast<ZipEntry>()
-                        .Where(entry => entry.Name.EndsWith(".ckan", StringComparison.InvariantCultureIgnoreCase)))
+                    : zip.OfType<ZipEntry>()
+                         .Where(entry => entry.Name.EndsWith(".ckan", StringComparison.InvariantCultureIgnoreCase)))
                 .Select(entry => DeserializeFromStream(
                                     zip.GetInputStream(entry)))
                 .FirstOrDefault();


### PR DESCRIPTION
## Background

- In #2535, the cache path setting was introduced, always fully editable, with automatic migration of cached files to new locations as you typed
- In #2538, the automatic file migration was removed because it deleted and scrambled the developers' folders and was generally unsafe
- In #3804, the updating of the setting was moved from when you edit the box to when you close the form, to work around problems with attempting to set it to a drive letter temporarily on Windows

The core issue was that the settings dialog primarily uses a live-editing paradigm (check a checkbox and the setting is updated instantly), but the cache path needs an edit/cancel/accept paradigm where the user explicitly chooses to validate and commit the input when it's ready and can address any errors or further choices at that time.

## Motivation / Initial Problems

Users want a cache migration option.

Some related issues were also reported:

- Since the original functionality assumed auto-migration, the GUI still treats mods as cached or uncached according to the old cache rather than the new
- After changing the settings, the GUI still considers a mod to be cached after purging, and vice versa for downloading and uncached

### Causes

- The cache object raises events when mods are added and purged, but GUI wasn't re-subscribing to those events after a new cache object replaced an old one
- `NetModuleCache` wasn't handling mods with multiple download URLs correctly; one failed purge was treated as the mod not being cached at all when one of the other URLs might still be cached

## Problems

While working on the above, a few small things came up:

- A new Steam exception
- A tooltip in the Settings dialog (for the "refresh modlist every" text box) isn't internationalized, so it will always appear in English regardless of locale
- The button in Manage Mods to add a new search was not vertically aligned well with the search text box
- Purging a mod can make the Contents tab flicker

### Causes

- Apparently the `shortcuts.vdf` file itself can be corrupted
- The `ToolTip.SetToolTip` call was hard-coded in `SettingsDialog.Designer.cs` and so got missed when looking for strings
- Purging a mod purges _all_ historical versions of that mod, each of which was refreshing the Contents tab even if it wasn't cached

## Changes

- Now editing the cache path works differently:
  - The text box is read-only by default, with an "Edit" button to enable it:
  ![image](https://github.com/user-attachments/assets/bad0533f-3230-429f-a19f-b7441f82e6db)
  - When you click Edit, the text box becomes editable, but the rest of the form becomes read-only, the close X is hidden, and the Edit button is replaced by Cancel and Save buttons:
  ![image](https://github.com/user-attachments/assets/fea0f0fc-ab4a-4e6e-b2da-7e333f912e70)
  - Clicking the Cancel button or pressing Escape reverts the setting to what it was before you clicked Edit
  - Clicking the Save button or pressing Enter tries to set the setting to the value in the text box. If it doesn't exist or can't be used for some reason, an error is presented and you can continue editing.
  - If you change the setting to a different, valid folder, a prompt appears asking you what to do next: move the files (the default if there's enough space), delete the files, open both folders in a file browser for manual partial migration (the default if there isn't enough space), nothing, or cancel the change and keep using the old folder:
  ![image](https://github.com/user-attachments/assets/1fef1218-60f9-494a-8118-bde39cec3bb6)
  - A progress bar appears while a cache move is in progress and disappears when it completes:
  ![image](https://github.com/user-attachments/assets/a618207d-9767-426f-b347-5fe0b4cc0056)
  - The selection dialog has many usability improvements, including internationalization of the ` -- Default` string as `{0} (DEFAULT)`, resizability with a minimum size, auto-sizing to fit, centering on the parent window, auto-selecting the default option, accepting on double-click, accepting on Enter, and cancelling on Escape
  - The settings window's buttons to change the cache via folder selection popup, reset the cache to default, open the cache in file browser, and purge the cache now have tooltips
  - `NetModuleCache.MoveFrom` and `NetFileCache.MoveFrom` are updated to support an `IProgress<int>` object and recursive moving of files in subdirectories (to handle the `downloading` folder)
- The settings dialog now uses `#region`/`#endregion` to organize its many groups of functions
- The settings dialog's auth tokens list box now auto-sizes its columns to fit
- Many parameters and return values are changed from a path `string` to `FileInfo` because it's better and because we were using those `string`s to make `FileInfo`s much of the time anyway
- Now the settings dialog raises a `CacheChanged` event after it replaces the main cache object, which `Main` uses to re-subscribe to the mod added/purged events
- Now `NetFileCache.Remove` has an overload acccepting a sequence of `Uri`s, which attempts to remove all of them and returns true if any was present, and `NetModuleCache.Purge` uses this to purge a mod
- Now `NetModuleCache.Purge` has an overload accepting a sequence of `CkanModules`, which attempts to remove all of them and only raises the `ModPurged` event once
- Now if you right click to download a mod to the cache, the Contents tab is shown afterwards to cue users in that it exists
- Now we ignore corrupted `shortcuts.vdf` files
- Now the tooltip is internationalized
- Now the search button's `Anchor` property has `Top` removed and `Bottom` added, so it'll move up and down as its container resizes, and the container is initialized to the same height as the first search box, which will keep the button aligned
- Now `GUIUser.RaiseSelectionDialog` no longer uses a reference in `Main.selectionDialog` because this makes the dialog crash when the settings dialog tries to use it

Fixes #4086.
