### PR TITLE
Start installing mods while downloads are still in progress

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 using CommandLine;
 
@@ -17,10 +19,24 @@ namespace CKAN.CmdLine
             AvailableOptions opts     = (AvailableOptions)raw_options;
             IRegistryQuerier registry = RegistryManager.Instance(instance, repoData).registry;
 
-            var compatible = registry
+            IEnumerable<CkanModule> compatible = registry
                 .CompatibleModules(instance.VersionCriteria())
                 .Where(m => !m.IsDLC)
                 .OrderBy(m => m.identifier);
+
+            if (opts.globs != null)
+            {
+                var regexes = opts.globs
+                                  .Select(str => new Regex("^"
+                                                           + str.Replace("?", ".")
+                                                                .Replace("*", ".*")
+                                                           + "$",
+                                                           RegexOptions.Compiled
+                                                           | RegexOptions.IgnoreCase))
+                                  .ToArray();
+                compatible = compatible.Where(m => regexes.Any(re => re.IsMatch(m.identifier)
+                                                                     || re.IsMatch(m.name)));
+            }
 
             user.RaiseMessage(Properties.Resources.AvailableHeader,
                               instance.game.ShortName,
@@ -31,14 +47,18 @@ namespace CKAN.CmdLine
             {
                 foreach (CkanModule module in compatible)
                 {
-                    user.RaiseMessage("* {0} ({1}) - {2} - {3}", module.identifier, module.version, module.name, module.@abstract);
+                    user.RaiseMessage("* {0} ({1}) - {2} - {3}",
+                                      module.identifier, module.version,
+                                      module.name, module.@abstract);
                 }
             }
             else
             {
                 foreach (CkanModule module in compatible)
                 {
-                    user.RaiseMessage("* {0} ({1}) - {2}", module.identifier, module.version, module.name);
+                    user.RaiseMessage("* {0} ({1}) - {2}",
+                                      module.identifier, module.version,
+                                      module.name);
                 }
             }
 
@@ -53,6 +73,9 @@ namespace CKAN.CmdLine
     {
         [Option("detail", HelpText = "Show short description of each module")]
         public bool detail { get; set; }
+
+        [ValueList(typeof(List<string>))]
+        public List<string>? globs { get; set; }
     }
 
 }

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -55,7 +55,7 @@ namespace CKAN.CmdLine
                                          .Select(arg => new NetAsyncDownloader.DownloadTargetFile(getUri(arg)))
                                          .ToArray();
                     log.DebugFormat("Urls: {0}", targets.SelectMany(t => t.urls));
-                    new NetAsyncDownloader(new NullUser(), options.NetUserAgent).DownloadAndWait(targets);
+                    new NetAsyncDownloader(new NullUser(), () => null, options.NetUserAgent).DownloadAndWait(targets);
                     log.DebugFormat("Files: {0}", targets.Select(t => t.filename));
                     modules = targets.Select(t => MainClass.LoadCkanFromFile(t.filename))
                                      .ToList();

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -182,7 +182,7 @@ namespace CKAN.CmdLine
             var registry = RegistryManager.Instance(instance, repoData).registry;
             var result = repoData.Update(registry.Repositories.Values.ToArray(),
                                          instance.game, force,
-                                         new NetAsyncDownloader(user, userAgent), user, userAgent);
+                                         new NetAsyncDownloader(user, () => null, userAgent), user, userAgent);
             if (result == RepositoryDataManager.UpdateResult.Updated)
             {
                 user.RaiseMessage(Properties.Resources.UpdateSummary,
@@ -197,7 +197,9 @@ namespace CKAN.CmdLine
         /// <param name="repos">Repositories to update</param>
         private void UpdateRepositories(IGame game, Repository[] repos, string? userAgent, bool force = false)
         {
-            var result = repoData.Update(repos, game, force, new NetAsyncDownloader(user, userAgent), user, userAgent);
+            var result = repoData.Update(repos, game, force,
+                                         new NetAsyncDownloader(user, () => null, userAgent),
+                                         user, userAgent);
             if (result == RepositoryDataManager.UpdateResult.Updated)
             {
                 user.RaiseMessage(Properties.Resources.UpdateSummary,

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -184,18 +184,18 @@ namespace CKAN.CmdLine
         /// <param name="user">IUser object for output</param>
         /// <param name="instance">Game instance to use</param>
         /// <param name="modules">List of modules to upgrade</param>
-        private void UpgradeModules(NetModuleCache      cache,
-                                    string?             userAgent,
-                                    IUser               user,
-                                    CKAN.GameInstance   instance,
-                                    List<CkanModule>    modules)
+        private void UpgradeModules(NetModuleCache    cache,
+                                    string?           userAgent,
+                                    IUser             user,
+                                    CKAN.GameInstance instance,
+                                    List<CkanModule>  modules)
         {
             UpgradeModules(
                 cache, userAgent, user, instance, repoData,
                 (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string>? possibleConfigOnlyDirs) =>
                     installer.Upgrade(modules, downloader,
                                       ref possibleConfigOnlyDirs,
-                                      regMgr, true, true, true),
+                                      regMgr, true, true),
                 modules.Add);
         }
 
@@ -206,11 +206,11 @@ namespace CKAN.CmdLine
         /// <param name="user">IUser object for output</param>
         /// <param name="instance">Game instance to use</param>
         /// <param name="identsAndVersions">List of identifier[=version] to upgrade</param>
-        private void UpgradeModules(NetModuleCache      cache,
-                                    string?             userAgent,
-                                    IUser               user,
-                                    CKAN.GameInstance   instance,
-                                    List<string>        identsAndVersions)
+        private void UpgradeModules(NetModuleCache    cache,
+                                    string?           userAgent,
+                                    IUser             user,
+                                    CKAN.GameInstance instance,
+                                    List<string>      identsAndVersions)
         {
             UpgradeModules(
                 cache, userAgent, user, instance, repoData,

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -258,29 +258,21 @@ namespace CKAN.CmdLine
         {
             if (message != lastProgressMessage)
             {
-                // The percent looks weird on non-download messages.
-                // The leading newline makes sure we don't end up with a mess from previous
-                // download messages.
                 GoToStartOfLine();
-                Console.Write("{0}", message);
+                // The percent looks weird on non-download messages
+                Console.WriteLine("{0}", message);
                 lastProgressMessage = message;
             }
-
-            // This message leaves the cursor at the end of a line of text
-            atStartOfLine = false;
+            atStartOfLine = true;
         }
 
-        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        public void RaiseProgress(ByteRateCounter rateCounter)
         {
-            if (!Headless || percent != previousPercent)
+            if (!Headless || rateCounter.Percent != previousPercent)
             {
-                GoToStartOfLine();
-                var fullMsg = string.Format(CKAN.Properties.Resources.NetAsyncDownloaderProgress,
-                                            CkanModule.FmtSize(bytesPerSecond),
-                                            CkanModule.FmtSize(bytesLeft));
                 // The \r at the front here causes download messages to *overwrite* each other.
-                Console.Write("\r{0} - {1}%           ", fullMsg, percent);
-                previousPercent = percent;
+                Console.Write("\r{0}           ", rateCounter.Summary);
+                previousPercent = rateCounter.Percent;
 
                 // This message leaves the cursor at the end of a line of text
                 atStartOfLine = false;

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -175,10 +175,12 @@ namespace CKAN.CmdLine
                     case "import":
                         yield return $"{Properties.Resources.Usage}: ckan {verb} [{Properties.Resources.Options}] path [path2 ...]";
                         break;
+                    case "available":
+                        yield return $"{Properties.Resources.Usage}: ckan {verb} [{Properties.Resources.Options}] [glob ...]";
+                        break;
 
                     // Commands with only --flag type options
                     case "gui":
-                    case "available":
                     case "list":
                     case "update":
                     case "scan":

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -76,7 +76,7 @@ namespace CKAN.ConsoleUI {
                             HashSet<string>? possibleConfigOnlyDirs = null;
 
                             ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this, userAgent);
-                            inst.onReportModInstalled += OnModInstalled;
+                            inst.OneComplete += OnModInstalled;
                             if (plan.Remove.Count > 0) {
                                 inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr, true, new List<CkanModule>(plan.Install));
                                 plan.Remove.Clear();
@@ -113,7 +113,7 @@ namespace CKAN.ConsoleUI {
                             }
 
                             trans.Complete();
-                            inst.onReportModInstalled -= OnModInstalled;
+                            inst.OneComplete -= OnModInstalled;
                             // Don't let the installer re-use old screen references
                             inst.User = new NullUser();
 

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -491,7 +491,7 @@ namespace CKAN.ConsoleUI {
                         repoData.Update(registry.Repositories.Values.ToArray(),
                                         manager.CurrentInstance.game,
                                         false,
-                                        new NetAsyncDownloader(ps, userAgent),
+                                        new NetAsyncDownloader(ps, () => null, userAgent),
                                         ps,
                                         userAgent);
                     } catch (Exception ex) {

--- a/ConsoleUI/SplashScreen.cs
+++ b/ConsoleUI/SplashScreen.cs
@@ -32,7 +32,7 @@ namespace CKAN.ConsoleUI {
             if (ksp != null
                 && !GameInstanceListScreen.TryGetInstance(theme, ksp, repoData,
                                                           (ConsoleTheme th) => Draw(th, false),
-                                                          new Progress<int>(p => drawProgressBar(theme, 22, 20, p)))) {
+                                                          new ProgressImmediate<int>(p => drawProgressBar(theme, 22, 20, p)))) {
                 Console.ResetColor();
                 Console.Clear();
                 Console.CursorVisible = true;

--- a/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
@@ -97,8 +97,8 @@ namespace CKAN.ConsoleUI.Toolkit {
                 return false;
             });
 
-            AddTip("F10", Properties.Resources.Sort);
-            AddBinding(Keys.F10, (object sender) => {
+            AddTip(ConsoleScreen.MainMenuKeyTip, Properties.Resources.Sort);
+            AddBinding(ConsoleScreen.MainMenuKeys, (object sender) => {
                 fileList.SortMenu().Run(theme, right - 2, top + 2);
                 DrawBackground();
                 return true;

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -223,15 +223,10 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <summary>
         /// Update a user visible progress bar
         /// </summary>
-        /// <param name="percent">Value 0-100 representing the progress</param>
-        /// <param name="bytesPerSecond">Current download rate</param>
-        /// <param name="bytesLeft">Bytes remaining in the downloads</param>
-        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        /// <param name="rateCounter">Object with the progress info</param>
+        public void RaiseProgress(ByteRateCounter rateCounter)
         {
-            var fullMsg = string.Format(CKAN.Properties.Resources.NetAsyncDownloaderProgress,
-                                        CkanModule.FmtSize(bytesPerSecond),
-                                        CkanModule.FmtSize(bytesLeft));
-            Progress(fullMsg, percent);
+            Progress(rateCounter.Summary, rateCounter.Percent);
             Draw();
         }
 

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -19,10 +19,10 @@ namespace CKAN.ConsoleUI.Toolkit {
             : base(theme)
         {
             AddTip(
-                "F10", MenuTip(),
+                MainMenuKeyTip, MenuTip(),
                 () => mainMenu != null
             );
-            AddBinding(new ConsoleKeyInfo[] {Keys.F10, Keys.Apps}, (object sender) => {
+            AddBinding(MainMenuKeys, (object sender) => {
                 bool val = true;
                 if (mainMenu != null) {
                     DrawSelectedHamburger();
@@ -46,6 +46,21 @@ namespace CKAN.ConsoleUI.Toolkit {
             DrawBackground();
             Draw();
         }
+
+        /// <summary>
+        /// String that describes which key to press to open the main menu
+        /// MacOS has a conflicting default key bind for F10 (the CUA standard for opening the menu)
+        /// </summary>
+        public static readonly string MainMenuKeyTip = Platform.IsMac ? "Ctrl+T" : "F10";
+
+        /// <summary>
+        /// Keys that open the main menu
+        /// </summary>
+        public static readonly ConsoleKeyInfo[] MainMenuKeys = new ConsoleKeyInfo[] {
+            Keys.F10,
+            Keys.CtrlT,
+            Keys.Apps,
+        };
 
         /// <summary>
         /// Function returning text to be shown at the left edge of the top header bar

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -198,6 +198,13 @@ namespace CKAN.ConsoleUI.Toolkit {
         );
 
         /// <summary>
+        /// Representation of Ctrl+R for key bindings
+        /// </summary>
+        public static readonly ConsoleKeyInfo CtrlT = new ConsoleKeyInfo(
+            (char)20, ConsoleKey.T, false, false, true
+        );
+
+        /// <summary>
         /// Representation of Ctrl+U for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo CtrlU = new ConsoleKeyInfo(

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -120,16 +120,15 @@ namespace CKAN
         {
             if (bytesToStore > 0)
             {
-                var bytesFree = where.GetDrive()?.AvailableFreeSpace;
-                if (bytesFree.HasValue && bytesToStore > bytesFree.Value) {
+                var bytesFree = where.GetDrive().AvailableFreeSpace;
+                if (bytesToStore > bytesFree) {
                     throw new NotEnoughSpaceKraken(errorDescription, where,
-                                                   bytesFree.Value, bytesToStore);
+                                                   bytesFree, bytesToStore);
                 }
                 log.DebugFormat("Storing {0} to {1} ({2} free)...",
                                 CkanModule.FmtSize(bytesToStore),
                                 where.FullName,
-                                bytesFree.HasValue ? CkanModule.FmtSize(bytesFree.Value)
-                                                   : "unknown bytes");
+                                CkanModule.FmtSize(bytesFree));
             }
         }
 

--- a/Core/Extensions/DictionaryExtensions.cs
+++ b/Core/Extensions/DictionaryExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -22,6 +23,14 @@ namespace CKAN.Extensions
             }
             return val;
         }
+
+        public static IEnumerable<Tuple<K, V1, V2>> KeyZip<K, V1, V2>(this IDictionary<K, V1> source,
+                                                                      IDictionary<K, V2>      other)
+            where K : notnull
+            => source.Select(kvp => other.TryGetValue(kvp.Key, out V2? val2)
+                                        ? Tuple.Create(kvp.Key, kvp.Value, val2)
+                                        : null)
+                     .OfType<Tuple<K, V1, V2>>();
 
     }
 }

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -581,7 +581,7 @@ namespace CKAN
                 }
             }
 
-            var progress = new Progress<int>(p => {});
+            var progress = new ProgressImmediate<int>(p => {});
             if (!TrySetupCache(Configuration.DownloadCacheDir,
                                progress,
                                out string? failReason))

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -616,7 +616,7 @@ namespace CKAN
                 else
                 {
                     // Make sure we can access it
-                    var bytesFree = new DirectoryInfo(path).GetDrive()?.AvailableFreeSpace;
+                    var bytesFree = new DirectoryInfo(path).GetDrive().AvailableFreeSpace;
                     Cache = new NetModuleCache(this, path);
                     Configuration.DownloadCacheDir = path;
                 }

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 using ICSharpCode.SharpZipLib.Core;

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1437,8 +1437,8 @@ namespace CKAN
         /// true if anything found, false otherwise
         /// </returns>
         public static bool FindRecommendations(GameInstance                                          instance,
-                                               HashSet<CkanModule>                                   sourceModules,
-                                               List<CkanModule>                                      toInstall,
+                                               ICollection<CkanModule>                               sourceModules,
+                                               ICollection<CkanModule>                               toInstall,
                                                Registry                                              registry,
                                                out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
                                                out Dictionary<CkanModule, List<string>>              suggestions,

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -71,7 +71,7 @@ namespace CKAN
                 .First(),
                 userAgent);
 
-            return cache.Store(module, tmp_file, new Progress<int>(percent => {}), filename, true);
+            return cache.Store(module, tmp_file, new ProgressImmediate<int>(percent => {}), filename, true);
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace CKAN
             {
                 CkanModule? installing = null;
                 var progress = new ProgressScalePercentsByFileSizes(
-                    new Progress<int>(p => User.RaiseProgress(
+                    new ProgressImmediate<int>(p => User.RaiseProgress(
                                                string.Format(Properties.Resources.ModuleInstallerInstallingMod,
                                                              installing),
                                                // The post-install steps start at 90%,
@@ -805,7 +805,7 @@ namespace CKAN
                 var registry = registry_manager.registry;
                 var progDescr = "";
                 var progress = new ProgressScalePercentsByFileSizes(
-                                   new Progress<int>(percent => User.RaiseProgress(progDescr, percent)),
+                                   new ProgressImmediate<int>(percent => User.RaiseProgress(progDescr, percent)),
                                    goners.Select(id => (long?)registry.InstalledModule(id)?.Files.Count()
                                                                                           ?? 0));
                 foreach (string ident in goners)
@@ -1127,7 +1127,7 @@ namespace CKAN
 
                 string progDescr = "";
                 var rmProgress = new ProgressScalePercentsByFileSizes(
-                                     new Progress<int>(percent =>
+                                     new ProgressImmediate<int>(percent =>
                                          User.RaiseProgress(progDescr,
                                                             percent * add.Count / totSteps)),
                                      remove.Select(instMod => (long)instMod.Files.Count()));
@@ -1139,7 +1139,7 @@ namespace CKAN
                 }
 
                 var addProgress = new ProgressScalePercentsByFileSizes(
-                                      new Progress<int>(percent =>
+                                      new ProgressImmediate<int>(percent =>
                                           User.RaiseProgress(progDescr,
                                                              ((100 * add.Count) + (percent * remove.Count)) / totSteps)),
                                       add.Select(m => m.install_size));
@@ -1612,7 +1612,7 @@ namespace CKAN
             if (!TryGetFileHashMatches(files, registry, Cache,
                                        out Dictionary<FileInfo, List<CkanModule>> matched,
                                        out List<FileInfo> notFound,
-                                       new Progress<int>(p =>
+                                       new ProgressImmediate<int>(p =>
                                            user.RaiseProgress(Properties.Resources.ModuleInstallerImportScanningFiles,
                                                               p))))
             {
@@ -1660,7 +1660,7 @@ namespace CKAN
                 user.RaiseMessage(" ");
                 var description = "";
                 var progress = new ProgressScalePercentsByFileSizes(
-                                   new Progress<int>(p =>
+                                   new ProgressImmediate<int>(p =>
                                        user.RaiseProgress(string.Format(Properties.Resources.ModuleInstallerImporting,
                                                                         description),
                                                           p)),

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -28,7 +28,9 @@ namespace CKAN
     {
         public IUser User { get; set; }
 
-        public event Action<CkanModule>? onReportModInstalled = null;
+        public event Action<CkanModule, long, long>?      InstallProgress;
+        public event Action<InstalledModule, long, long>? RemoveProgress;
+        public event Action<CkanModule>?                  OneComplete;
 
         private static readonly ILog log = LogManager.GetLogger(typeof(ModuleInstaller));
 
@@ -71,7 +73,7 @@ namespace CKAN
                 .First(),
                 userAgent);
 
-            return cache.Store(module, tmp_file, new ProgressImmediate<int>(percent => {}), filename, true);
+            return cache.Store(module, tmp_file, new ProgressImmediate<long>(bytes => {}), filename, true);
         }
 
         /// <summary>
@@ -105,19 +107,6 @@ namespace CKAN
             return full_path;
         }
 
-        /// <summary>
-        /// Makes sure all the specified mods are downloaded.
-        /// </summary>
-        private void DownloadModules(IEnumerable<CkanModule> mods, IDownloader downloader)
-        {
-            var downloads = mods.Where(module => !module.IsMetapackage && !Cache.IsCached(module))
-                                .ToList();
-            if (downloads.Count > 0)
-            {
-                downloader.DownloadModules(downloads);
-            }
-        }
-
         #endregion
 
         #region Installation
@@ -138,7 +127,6 @@ namespace CKAN
                                 IDownloader?                downloader    = null,
                                 bool                        ConfirmPrompt = true)
         {
-            // TODO: Break this up into smaller pieces! It's huge!
             if (modules.Count == 0)
             {
                 User.RaiseProgress(Properties.Resources.ModuleInstallerNothingToInstall, 100);
@@ -149,73 +137,85 @@ namespace CKAN
                                                     instance.game,
                                                     instance.VersionCriteria());
             var modsToInstall = resolver.ModList().ToList();
-            var downloads = new List<CkanModule>();
+            // Alert about attempts to install DLC before downloading or installing anything
+            if (modsToInstall.Any(m => m.IsDLC))
+            {
+                throw new BadCommandKraken(Properties.Resources.ModuleInstallerDLC);
+            }
 
             // Make sure we have enough space to install this stuff
+            var installBytes = modsToInstall.Sum(m => m.install_size);
             CKANPathUtils.CheckFreeSpace(new DirectoryInfo(instance.GameDir()),
-                                         modsToInstall.Select(m => m.install_size)
-                                                      .OfType<long>()
-                                                      .Sum(),
+                                         installBytes,
                                          Properties.Resources.NotEnoughSpaceToInstall);
 
-            // TODO: All this user-stuff should be happening in another method!
-            // We should just be installing mods as a transaction.
-
+            var cached    = new List<CkanModule>();
+            var downloads = new List<CkanModule>();
             User.RaiseMessage(Properties.Resources.ModuleInstallerAboutToInstall);
             User.RaiseMessage("");
-
             foreach (var module in modsToInstall)
             {
                 User.RaiseMessage(" * {0}", Cache.DescribeAvailability(module));
-                // Alert about attempts to install DLC before downloading or installing anything
-                CheckKindInstallationKraken(module);
                 if (!module.IsMetapackage && !Cache.IsMaybeCachedZip(module))
                 {
                     downloads.Add(module);
                 }
+                else
+                {
+                    cached.Add(module);
+                }
             }
-
             if (ConfirmPrompt && !User.RaiseYesNoDialog(Properties.Resources.ModuleInstallerContinuePrompt))
             {
                 throw new CancelledActionKraken(Properties.Resources.ModuleInstallerUserDeclined);
             }
 
+            var downloadBytes = CkanModule.GroupByDownloads(downloads)
+                                          .Sum(grp => grp.First().download_size);
+            var rateCounter = new ByteRateCounter()
+            {
+                Size      = downloadBytes + installBytes,
+                BytesLeft = downloadBytes + installBytes,
+            };
+            rateCounter.Start();
+            long downloadedBytes = 0;
+            long installedBytes  = 0;
             if (downloads.Count > 0)
             {
                 downloader ??= new NetAsyncModulesDownloader(User, Cache, userAgent);
-                downloader.DownloadModules(downloads);
+                downloader.OverallDownloadProgress += brc =>
+                {
+                    downloadedBytes = downloadBytes - brc.BytesLeft;
+                    rateCounter.BytesLeft = downloadBytes - downloadedBytes
+                                          + installBytes  - installedBytes;
+                    User.RaiseProgress(rateCounter);
+                };
             }
-
-            // Make sure we STILL have enough space to install this stuff
-            // now that the downloads have been stored to the cache
-            CKANPathUtils.CheckFreeSpace(new DirectoryInfo(instance.GameDir()),
-                                         modsToInstall.Select(m => m.install_size)
-                                                      .OfType<long>()
-                                                      .Sum(),
-                                         Properties.Resources.NotEnoughSpaceToInstall);
 
             // We're about to install all our mods; so begin our transaction.
             using (var transaction = CkanTransaction.CreateTransactionScope())
             {
-                CkanModule? installing = null;
-                var progress = new ProgressScalePercentsByFileSizes(
-                    new ProgressImmediate<int>(p => User.RaiseProgress(
-                                               string.Format(Properties.Resources.ModuleInstallerInstallingMod,
-                                                             installing),
-                                               // The post-install steps start at 90%,
-                                               // so count up to 85% for installation
-                                               p * 85 / 100)),
-                    modsToInstall.Select(m => m.install_size));
-                for (int i = 0; i < modsToInstall.Count; i++)
+                var gameDir = new DirectoryInfo(instance.GameDir());
+                long modInstallCompletedBytes = 0;
+                foreach (var mod in ModsInDependencyOrder(resolver, cached, downloads, downloader))
                 {
-                    installing = modsToInstall[i];
-                    Install(installing,
-                            resolver.IsAutoInstalled(installing),
+                    // Re-check that there's enough free space in case game dir and cache are on same drive
+                    CKANPathUtils.CheckFreeSpace(gameDir, mod.install_size,
+                                                 Properties.Resources.NotEnoughSpaceToInstall);
+                    Install(mod, resolver.IsAutoInstalled(mod),
                             registry_manager.registry,
                             ref possibleConfigOnlyDirs,
-                            progress);
-                    progress?.NextFile();
+                            new ProgressImmediate<long>(bytes =>
+                            {
+                                InstallProgress?.Invoke(mod, mod.install_size - bytes, mod.install_size);
+                                installedBytes = modInstallCompletedBytes + bytes;
+                                rateCounter.BytesLeft = downloadBytes - downloadedBytes
+                                                      + installBytes  - installedBytes;
+                                User.RaiseProgress(rateCounter);
+                            }));
+                    modInstallCompletedBytes += mod.install_size;
                 }
+                rateCounter.Stop();
 
                 User.RaiseProgress(Properties.Resources.ModuleInstallerUpdatingRegistry, 90);
                 registry_manager.Save(!options.without_enforce_consistency);
@@ -226,6 +226,66 @@ namespace CKAN
 
             EnforceCacheSizeLimit(registry_manager.registry, Cache);
             User.RaiseProgress(Properties.Resources.ModuleInstallerDone, 100);
+        }
+
+        private static IEnumerable<CkanModule> ModsInDependencyOrder(RelationshipResolver    resolver,
+                                                                     ICollection<CkanModule> cached,
+                                                                     ICollection<CkanModule> toDownload,
+                                                                     IDownloader?            downloader)
+
+            => ModsInDependencyOrder(resolver, cached,
+                                     downloader != null && toDownload.Count > 0
+                                         ? downloader.ModulesAsTheyFinish(cached, toDownload)
+                                         : null);
+
+        private static IEnumerable<CkanModule> ModsInDependencyOrder(RelationshipResolver     resolver,
+                                                                     ICollection<CkanModule>  cached,
+                                                                     IEnumerable<CkanModule>? downloading)
+        {
+            var waiting = new HashSet<CkanModule>();
+            var done    = new HashSet<CkanModule>();
+            if (downloading != null)
+            {
+                foreach (var newlyCached in downloading)
+                {
+                    waiting.Add(newlyCached);
+                    foreach (var m in OnePass(resolver, waiting, done))
+                    {
+                        yield return m;
+                    }
+                }
+            }
+            else
+            {
+                waiting.UnionWith(cached);
+                foreach (var m in OnePass(resolver, waiting, done))
+                {
+                    yield return m;
+                }
+            }
+        }
+
+        private static IEnumerable<CkanModule> OnePass(RelationshipResolver resolver,
+                                                       HashSet<CkanModule>  waiting,
+                                                       HashSet<CkanModule>  done)
+        {
+            while (true)
+            {
+                var newlyDone = waiting.Where(m => resolver.ReadyToInstall(m, done))
+                                       .OrderBy(m => m.identifier)
+                                       .ToArray();
+                if (newlyDone.Length == 0)
+                {
+                    // No mods ready to install
+                    break;
+                }
+                foreach (var m in newlyDone)
+                {
+                    waiting.Remove(m);
+                    done.Add(m);
+                    yield return m;
+                }
+            }
         }
 
         /// <summary>
@@ -245,7 +305,7 @@ namespace CKAN
                              bool                 autoInstalled,
                              Registry             registry,
                              ref HashSet<string>? possibleConfigOnlyDirs,
-                             IProgress<int>?      progress)
+                             IProgress<long>?     progress)
         {
             CheckKindInstallationKraken(module);
             var version = registry.InstalledVersion(module.identifier);
@@ -254,7 +314,7 @@ namespace CKAN
             if (version is not null and not UnmanagedModuleVersion)
             {
                 User.RaiseMessage(Properties.Resources.ModuleInstallerAlreadyInstalled,
-                                  module.identifier, version);
+                                  module.name, version);
                 return;
             }
 
@@ -273,6 +333,9 @@ namespace CKAN
                 }
             }
 
+            User.RaiseMessage(Properties.Resources.ModuleInstallerInstallingMod,
+                              module.name);
+
             using (var transaction = CkanTransaction.CreateTransactionScope())
             {
                 // Install all the things!
@@ -289,8 +352,11 @@ namespace CKAN
                 transaction.Complete();
             }
 
+            User.RaiseMessage(Properties.Resources.ModuleInstallerInstalledMod,
+                              module.name);
+
             // Fire our callback that we've installed a module, if we have one.
-            onReportModInstalled?.Invoke(module);
+            OneComplete?.Invoke(module);
         }
 
         /// <summary>
@@ -317,7 +383,7 @@ namespace CKAN
                                            string?              zip_filename,
                                            Registry             registry,
                                            ref HashSet<string>? possibleConfigOnlyDirs,
-                                           IProgress<int>?      moduleProgress)
+                                           IProgress<long>?     moduleProgress)
         {
             var createdPaths = new List<string>();
             if (module.IsMetapackage || zip_filename == null)
@@ -394,16 +460,14 @@ namespace CKAN
                             }
                         }
                     }
-                    var fileProgress = moduleProgress != null
-                        ? new ProgressFilesOffsetsToPercent(moduleProgress,
-                                                            files.Select(f => f.source.Size))
-                        : null;
+                    long installedBytes = 0;
+                    var fileProgress = new ProgressImmediate<long>(bytes => moduleProgress?.Report(installedBytes + bytes));
                     foreach (InstallableFile file in files)
                     {
                         log.DebugFormat("Copying {0}", file.source.Name);
                         var path = CopyZipEntry(zipfile, file.source, file.destination, file.makedir,
                                                 fileProgress);
-                        fileProgress?.NextFile();
+                        installedBytes += file.source.Size;
                         if (path != null)
                         {
                             createdPaths.Add(path);
@@ -803,18 +867,38 @@ namespace CKAN
             using (var transaction = CkanTransaction.CreateTransactionScope())
             {
                 var registry = registry_manager.registry;
-                var progDescr = "";
-                var progress = new ProgressScalePercentsByFileSizes(
-                                   new ProgressImmediate<int>(percent => User.RaiseProgress(progDescr, percent)),
-                                   goners.Select(id => (long?)registry.InstalledModule(id)?.Files.Count()
-                                                                                          ?? 0));
+                long removeBytes = goners.Select(registry.InstalledModule)
+                                         .OfType<InstalledModule>()
+                                         .Sum(m => m.Module.install_size);
+                var rateCounter = new ByteRateCounter()
+                {
+                    Size      = removeBytes,
+                    BytesLeft = removeBytes,
+                };
+                rateCounter.Start();
+
+                long modRemoveCompletedBytes = 0;
                 foreach (string ident in goners)
                 {
-                    progDescr = string.Format(Properties.Resources.ModuleInstallerRemovingMod,
-                                                         registry.InstalledModule(ident)?.Module.ToString()
-                                                                                        ?? ident);
-                    Uninstall(ident, ref possibleConfigOnlyDirs, registry, progress);
-                    progress.NextFile();
+                    if (registry.InstalledModule(ident) is InstalledModule instMod)
+                    {
+                        User.RaiseMessage(Properties.Resources.ModuleInstallerRemovingMod,
+                                          registry.InstalledModule(ident)?.Module.name
+                                                                         ?? ident);
+                        Uninstall(ident, ref possibleConfigOnlyDirs, registry,
+                                  new ProgressImmediate<long>(bytes =>
+                                  {
+                                      RemoveProgress?.Invoke(instMod,
+                                                             instMod.Module.install_size - bytes,
+                                                             instMod.Module.install_size);
+                                      rateCounter.BytesLeft = removeBytes - (modRemoveCompletedBytes + bytes);
+                                      User.RaiseProgress(rateCounter);
+                                  }));
+                        modRemoveCompletedBytes += instMod?.Module.install_size ?? 0;
+                        User.RaiseMessage(Properties.Resources.ModuleInstallerRemovedMod,
+                                          registry.InstalledModule(ident)?.Module.name
+                                                                         ?? ident);
+                    }
                 }
 
                 // Enforce consistency if we're not installing anything,
@@ -837,7 +921,7 @@ namespace CKAN
         private void Uninstall(string               identifier,
                                ref HashSet<string>? possibleConfigOnlyDirs,
                                Registry             registry,
-                               IProgress<int>       progress)
+                               IProgress<long>      progress)
         {
             var file_transaction = new TxFileManager();
 
@@ -860,11 +944,10 @@ namespace CKAN
                 // Files that Windows refused to delete due to locking (probably)
                 var undeletableFiles = new List<string>();
 
-                int i = 0;
+                long bytesDeleted = 0;
                 foreach (string relPath in modFiles)
                 {
                     string absPath = instance.ToAbsoluteGameDir(relPath);
-                    progress?.Report(100 * i++ / modFiles.Length);
 
                     try
                     {
@@ -884,6 +967,8 @@ namespace CKAN
                                 directoriesToDelete.Add(p);
                             }
 
+                            bytesDeleted += new FileInfo(absPath).Length;
+                            progress.Report(bytesDeleted);
                             log.DebugFormat("Removing {0}", relPath);
                             file_transaction.Delete(absPath);
                         }
@@ -1111,50 +1196,92 @@ namespace CKAN
         /// <param name="autoInstalled">true or false for each item in `add`</param>
         /// <param name="remove">Modules to remove</param>
         /// <param name="newModulesAreAutoInstalled">true if newly installed modules should be marked auto-installed, false otherwise</param>
-        private void AddRemove(ref HashSet<string>?         possibleConfigOnlyDirs,
-                               RegistryManager              registry_manager,
-                               ICollection<CkanModule>      add,
-                               ICollection<bool>            autoInstalled,
-                               ICollection<InstalledModule> remove,
-                               bool                         enforceConsistency)
+        private void AddRemove(ref HashSet<string>?          possibleConfigOnlyDirs,
+                               RegistryManager               registry_manager,
+                               RelationshipResolver          resolver,
+                               ICollection<CkanModule>       add,
+                               IDictionary<CkanModule, bool> autoInstalled,
+                               ICollection<InstalledModule>  remove,
+                               IDownloader                   downloader,
+                               bool                          enforceConsistency)
         {
-            // TODO: We should do a consistency check up-front, rather than relying
-            // upon our registry catching inconsistencies at the end.
-
             using (var tx = CkanTransaction.CreateTransactionScope())
             {
-                int totSteps = remove.Count + add.Count;
+                var groups = add.GroupBy(m => m.IsMetapackage || Cache.IsCached(m));
+                var cached = groups.FirstOrDefault(grp => grp.Key)?.ToArray()
+                                                                  ?? Array.Empty<CkanModule>();
+                var toDownload = groups.FirstOrDefault(grp => !grp.Key)?.ToArray()
+                                                                       ?? Array.Empty<CkanModule>();
 
-                string progDescr = "";
-                var rmProgress = new ProgressScalePercentsByFileSizes(
-                                     new ProgressImmediate<int>(percent =>
-                                         User.RaiseProgress(progDescr,
-                                                            percent * add.Count / totSteps)),
-                                     remove.Select(instMod => (long)instMod.Files.Count()));
-                foreach (InstalledModule instMod in remove)
+                long removeBytes     = remove.Sum(m => m.Module.install_size);
+                long removedBytes    = 0;
+                long downloadBytes   = toDownload.Sum(m => m.download_size);
+                long downloadedBytes = 0;
+                long installBytes    = add.Sum(m => m.install_size);
+                long installedBytes  = 0;
+                var rateCounter = new ByteRateCounter()
                 {
-                    progDescr = string.Format(Properties.Resources.ModuleInstallerRemovingMod, instMod.Module);
-                    Uninstall(instMod.Module.identifier, ref possibleConfigOnlyDirs, registry_manager.registry, rmProgress);
-                    rmProgress.NextFile();
+                    Size      = removeBytes + downloadBytes + installBytes,
+                    BytesLeft = removeBytes + downloadBytes + installBytes,
+                };
+                rateCounter.Start();
+
+                downloader.OverallDownloadProgress += brc =>
+                {
+                    downloadedBytes = downloadBytes - brc.BytesLeft;
+                    rateCounter.BytesLeft = removeBytes   - removedBytes
+                                          + downloadBytes - downloadedBytes
+                                          + installBytes  - installedBytes;
+                    User.RaiseProgress(rateCounter);
+                };
+                var toInstall = ModsInDependencyOrder(resolver, cached, toDownload, downloader);
+
+                long modRemoveCompletedBytes = 0;
+                foreach (var instMod in remove)
+                {
+                    Uninstall(instMod.Module.identifier,
+                              ref possibleConfigOnlyDirs,
+                              registry_manager.registry,
+                              new ProgressImmediate<long>(bytes =>
+                              {
+                                  RemoveProgress?.Invoke(instMod,
+                                                         instMod.Module.install_size - bytes,
+                                                         instMod.Module.install_size);
+                                  removedBytes = modRemoveCompletedBytes + bytes;
+                                  rateCounter.BytesLeft = removeBytes   - removedBytes
+                                                        + downloadBytes - downloadedBytes
+                                                        + installBytes  - installedBytes;
+                                  User.RaiseProgress(rateCounter);
+                              }));
+                     modRemoveCompletedBytes += instMod.Module.install_size;
                 }
 
-                var addProgress = new ProgressScalePercentsByFileSizes(
-                                      new ProgressImmediate<int>(percent =>
-                                          User.RaiseProgress(progDescr,
-                                                             ((100 * add.Count) + (percent * remove.Count)) / totSteps)),
-                                      add.Select(m => m.install_size));
-                foreach ((CkanModule module, bool autoInst) in add.Zip(autoInstalled))
+                var gameDir = new DirectoryInfo(instance.GameDir());
+                long modInstallCompletedBytes = 0;
+                foreach (var mod in toInstall)
                 {
-                    progDescr = string.Format(Properties.Resources.ModuleInstallerInstallingMod, module);
-                    var previous = remove?.FirstOrDefault(im => im.Module.identifier == module.identifier);
-                    // For upgrading, new modules are dependencies and should be marked auto-installed,
-                    // for replacing, new modules are the replacements and should not be marked auto-installed
-                    Install(module,
-                            previous?.AutoInstalled ?? autoInst,
+                    CKANPathUtils.CheckFreeSpace(gameDir, mod.install_size,
+                                                 Properties.Resources.NotEnoughSpaceToInstall);
+                    Install(mod,
+                            // For upgrading, new modules are dependencies and should be marked auto-installed,
+                            // for replacing, new modules are the replacements and should not be marked auto-installed
+                            remove?.FirstOrDefault(im => im.Module.identifier == mod.identifier)
+                                  ?.AutoInstalled
+                                  ?? autoInstalled[mod],
                             registry_manager.registry,
                             ref possibleConfigOnlyDirs,
-                            addProgress);
-                    addProgress.NextFile();
+                            new ProgressImmediate<long>(bytes =>
+                            {
+                                InstallProgress?.Invoke(mod,
+                                                        mod.install_size - bytes,
+                                                        mod.install_size);
+                                installedBytes = modInstallCompletedBytes + bytes;
+                                rateCounter.BytesLeft = removeBytes   - removedBytes
+                                                      + downloadBytes - downloadedBytes
+                                                      + installBytes  - installedBytes;
+                                User.RaiseProgress(rateCounter);
+                            }));
+                    modInstallCompletedBytes += mod.install_size;
                 }
 
                 registry_manager.Save(enforceConsistency);
@@ -1169,29 +1296,24 @@ namespace CKAN
         /// Throws ModuleNotFoundKraken if a module is not installed.
         /// </summary>
         public void Upgrade(ICollection<CkanModule> modules,
-                            IDownloader             netAsyncDownloader,
+                            IDownloader             downloader,
                             ref HashSet<string>?    possibleConfigOnlyDirs,
                             RegistryManager         registry_manager,
                             bool                    enforceConsistency   = true,
-                            bool                    resolveRelationships = false,
                             bool                    ConfirmPrompt        = true)
         {
             var registry = registry_manager.registry;
-            var autoInstalled = modules.ToDictionary(m => m, m => true);
 
-            if (resolveRelationships)
-            {
-                var resolver = new RelationshipResolver(
-                    modules,
-                    modules.Select(m => registry.InstalledModule(m.identifier)?.Module)
-                           .OfType<CkanModule>(),
-                    RelationshipResolverOptions.DependsOnlyOpts(),
-                    registry,
-                    instance.game,
-                    instance.VersionCriteria());
-                modules = resolver.ModList().ToArray();
-                autoInstalled = modules.ToDictionary(m => m, resolver.IsAutoInstalled);
-            }
+            var resolver = new RelationshipResolver(
+                modules,
+                modules.Select(m => registry.InstalledModule(m.identifier)?.Module)
+                       .OfType<CkanModule>(),
+                RelationshipResolverOptions.DependsOnlyOpts(),
+                registry,
+                instance.game,
+                instance.VersionCriteria());
+            modules = resolver.ModList().ToArray();
+            var autoInstalled = modules.ToDictionary(m => m, resolver.IsAutoInstalled);
 
             User.RaiseMessage(Properties.Resources.ModuleInstallerAboutToUpgrade);
             User.RaiseMessage("");
@@ -1304,14 +1426,13 @@ namespace CKAN
                 throw new CancelledActionKraken(Properties.Resources.ModuleInstallerUpgradeUserDeclined);
             }
 
-            // Start by making sure we've downloaded everything.
-            DownloadModules(modules, netAsyncDownloader);
-
             AddRemove(ref possibleConfigOnlyDirs,
                       registry_manager,
+                      resolver,
                       modules,
-                      modules.Select(m => autoInstalled[m]).ToArray(),
+                      autoInstalled,
                       to_remove,
+                      downloader,
                       enforceConsistency);
             User.RaiseProgress(Properties.Resources.ModuleInstallerDone, 100);
         }
@@ -1324,7 +1445,7 @@ namespace CKAN
         /// <exception cref="ModuleNotFoundKraken">Thrown if a module that should be replaced is not installed.</exception>
         public void Replace(IEnumerable<ModuleReplacement> replacements,
                             RelationshipResolverOptions    options,
-                            IDownloader                    netAsyncDownloader,
+                            IDownloader                    downloader,
                             ref HashSet<string>?           possibleConfigOnlyDirs,
                             RegistryManager                registry_manager,
                             bool                           enforceConsistency = true)
@@ -1338,13 +1459,10 @@ namespace CKAN
                 modsToInstall.Add(repl.ReplaceWith);
                 log.DebugFormat("We want to install {0} as a replacement for {1}", repl.ReplaceWith.identifier, repl.ToReplace.identifier);
             }
-            // Start by making sure we've downloaded everything.
-            DownloadModules(modsToInstall, netAsyncDownloader);
 
             // Our replacement involves removing the currently installed mods, then
             // adding everything that needs installing (which may involve new mods to
             // satisfy dependencies).
-
 
             // Let's discover what we need to do with each module!
             foreach (ModuleReplacement repl in replacements)
@@ -1406,11 +1524,14 @@ namespace CKAN
             var resolver = new RelationshipResolver(modsToInstall, null, options, registry_manager.registry,
                                                     instance.game, instance.VersionCriteria());
             var resolvedModsToInstall = resolver.ModList().ToList();
+
             AddRemove(ref possibleConfigOnlyDirs,
                       registry_manager,
+                      resolver,
                       resolvedModsToInstall,
-                      resolvedModsToInstall.Select(m => false).ToArray(),
+                      resolvedModsToInstall.ToDictionary(m => m, m => false),
                       modsToRemove,
+                      downloader,
                       enforceConsistency);
             User.RaiseProgress(Properties.Resources.ModuleInstallerDone, 100);
         }
@@ -1659,12 +1780,18 @@ namespace CKAN
                 // Store any new files
                 user.RaiseMessage(" ");
                 var description = "";
-                var progress = new ProgressScalePercentsByFileSizes(
-                                   new ProgressImmediate<int>(p =>
-                                       user.RaiseProgress(string.Format(Properties.Resources.ModuleInstallerImporting,
-                                                                        description),
-                                                          p)),
-                                   toStore.Select(tuple => tuple.File.Length));
+                long installedBytes = 0;
+                var rateCounter = new ByteRateCounter()
+                {
+                    Size      = toStore.Sum(tuple => tuple.File.Length),
+                    BytesLeft = toStore.Sum(tuple => tuple.File.Length),
+                };
+                rateCounter.Start();
+                var progress = new ProgressImmediate<long>(bytes =>
+                {
+                    rateCounter.BytesLeft = rateCounter.Size - (installedBytes + bytes);
+                    user.RaiseProgress(rateCounter);
+                });
                 foreach ((FileInfo fi, CkanModule module) in toStore)
                 {
 
@@ -1675,8 +1802,9 @@ namespace CKAN
                                 move: delete && toStore.Last(tuple => tuple.File == fi).Module == module,
                                 // Skip revalidation because we had to check the hashes to get here!
                                 validate: false);
-                    progress.NextFile();
+                    installedBytes += fi.Length;
                 }
+                rateCounter.Stop();
             }
 
             // Here we have installable containing mods that can be installed, and the importable files have been stored in cache.

--- a/Core/Net/ByteRateCounter.cs
+++ b/Core/Net/ByteRateCounter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Timers;
+
+namespace CKAN
+{
+    public class ByteRateCounter
+    {
+        public ByteRateCounter()
+        {
+            progressTimer.Elapsed += CalculateByteRate;
+        }
+
+        public long Size           { get;         set; }
+        public long BytesLeft      { get;         set; }
+        public long BytesPerSecond { get; private set; }
+
+        public int  Percent
+            => Size > 0 ? (int)(100 * (Size - BytesLeft) / Size) : 0;
+
+        public TimeSpan TimeLeft
+            => BytesPerSecond > 0 ? TimeSpan.FromSeconds(BytesLeft / BytesPerSecond)
+                                  : TimeSpan.MaxValue;
+
+        public string TimeLeftString
+            => TimeLeft switch
+            {
+                {TotalHours:   >1 and var hours} tls
+                    => string.Format(Properties.Resources.ByteRateCounterHoursMinutesSeconds,
+                                     (int)hours, tls.Minutes, tls.Seconds),
+                {TotalMinutes: >1 and var mins}  tls
+                    => string.Format(Properties.Resources.ByteRateCounterMinutesSeconds,
+                                     (int)mins, tls.Seconds),
+                var tls
+                    => string.Format(Properties.Resources.ByteRateCounterSeconds,
+                                     tls.Seconds),
+            };
+
+        public string Summary =>
+            BytesPerSecond > 0
+                ? string.Format(Properties.Resources.ByteRateCounterRateSummary,
+                                CkanModule.FmtSize(BytesPerSecond),
+                                CkanModule.FmtSize(BytesLeft),
+                                TimeLeftString,
+                                Percent)
+                : string.Format(Properties.Resources.ByteRateCounterSummary,
+                                CkanModule.FmtSize(BytesLeft),
+                                Percent);
+
+        public void Start() => progressTimer.Start();
+        public void Stop()  => progressTimer.Stop();
+
+        private void CalculateByteRate(object? sender, ElapsedEventArgs args)
+        {
+            var now                = DateTime.Now;
+            var timerSpan          = now - lastProgressUpdateTime;
+            var startSpan          = now - startedAt;
+            var bytesDownloaded    = Size - BytesLeft;
+            var timerBytesChange   = bytesDownloaded - lastProgressUpdateSize;
+            lastProgressUpdateSize = bytesDownloaded;
+            lastProgressUpdateTime = now;
+
+            var overallRate = bytesDownloaded  / startSpan.TotalSeconds;
+            var timerRate   = timerBytesChange / timerSpan.TotalSeconds;
+            BytesPerSecond  = (long)(0.5 * (overallRate + timerRate));
+        }
+
+        private readonly DateTime startedAt              = DateTime.Now;
+        private          DateTime lastProgressUpdateTime = DateTime.Now;
+        private          long     lastProgressUpdateSize = 0;
+        private readonly Timer    progressTimer          = new Timer(intervalMs);
+        private const    int      intervalMs             = 3000;
+    }
+}

--- a/Core/Net/IDownloader.cs
+++ b/Core/Net/IDownloader.cs
@@ -14,10 +14,12 @@ namespace CKAN
         /// </summary>
         void DownloadModules(IEnumerable<CkanModule> modules);
 
+        public event Action<ByteRateCounter> OverallDownloadProgress;
+
         /// <summary>
         /// Raised when data arrives for a module
         /// </summary>
-        event Action<CkanModule, long, long> Progress;
+        event Action<CkanModule, long, long> DownloadProgress;
 
         /// <summary>
         /// Raised while we are checking that a ZIP is valid
@@ -25,9 +27,17 @@ namespace CKAN
         event Action<CkanModule, long, long> StoreProgress;
 
         /// <summary>
+        /// Raised when one module finishes
+        /// </summary>
+        event Action<CkanModule> OneComplete;
+
+        /// <summary>
         /// Raised when a batch of downloads is all done
         /// </summary>
         event Action AllComplete;
+
+        IEnumerable<CkanModule> ModulesAsTheyFinish(ICollection<CkanModule> cached,
+                                                    ICollection<CkanModule> toDownload);
 
         /// <summary>
         /// Cancel any running downloads.

--- a/Core/Net/NetAsyncDownloader.DownloadTarget.cs
+++ b/Core/Net/NetAsyncDownloader.DownloadTarget.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 
 namespace CKAN
 {
@@ -22,7 +23,8 @@ namespace CKAN
             }
 
             public abstract long CalculateSize();
-            public abstract void DownloadWith(ResumingWebClient wc, Uri url);
+            public abstract void DownloadWith(ResumingWebClient wc, Uri url,
+                                              HashAlgorithm? hasher);
 
             public override string ToString() => string.Join(", ", urls);
         }
@@ -54,9 +56,10 @@ namespace CKAN
                 return size;
             }
 
-            public override void DownloadWith(ResumingWebClient wc, Uri url)
+            public override void DownloadWith(ResumingWebClient wc, Uri url,
+                                              HashAlgorithm? hasher)
             {
-                wc.DownloadFileAsyncWithResume(url, filename);
+                wc.DownloadFileAsyncWithResume(url, filename, hasher);
             }
 
             public override string ToString() => $"{base.ToString()} => {filename}";
@@ -87,9 +90,10 @@ namespace CKAN
                 return size;
             }
 
-            public override void DownloadWith(ResumingWebClient wc, Uri url)
+            public override void DownloadWith(ResumingWebClient wc, Uri url,
+                                              HashAlgorithm? hasher)
             {
-                wc.DownloadFileAsyncWithResume(url, contents);
+                wc.DownloadFileAsyncWithResume(url, contents, hasher);
             }
 
             public void Dispose()

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -24,14 +24,15 @@ namespace CKAN
         /// <summary>
         /// Raised when data arrives for a download
         /// </summary>
-        public event Action<DownloadTarget, long, long>? Progress;
+        public event Action<DownloadTarget, long, long>? TargetProgress;
+        public event Action<ByteRateCounter>?            OverallProgress;
 
         private readonly object dlMutex = new object();
-        // NOTE: Never remove anything from this, because closures have indexes into it!
-        // (Clearing completely after completion is OK)
         private readonly List<DownloadPart> downloads       = new List<DownloadPart>();
         private readonly List<DownloadPart> queuedDownloads = new List<DownloadPart>();
         private int completed_downloads;
+
+        private readonly ByteRateCounter rateCounter = new ByteRateCounter();
 
         // For inter-thread communication
         private volatile bool download_canceled;
@@ -77,7 +78,7 @@ namespace CKAN
         /// Start a new batch of downloads
         /// </summary>
         /// <param name="targets">The downloads to begin</param>
-        public void DownloadAndWait(IList<DownloadTarget> targets)
+        public void DownloadAndWait(ICollection<DownloadTarget> targets)
         {
             lock (dlMutex)
             {
@@ -102,8 +103,12 @@ namespace CKAN
                 Download(targets);
             }
 
+            rateCounter.Start();
+
             log.Debug("Waiting for downloads to finish...");
             complete_or_canceled.WaitOne();
+
+            rateCounter.Stop();
 
             log.Debug("Downloads finished");
 
@@ -211,38 +216,33 @@ namespace CKAN
             {
                 if (!queuedDownloads.Contains(dl))
                 {
-                    log.DebugFormat("Enqueuing download of {0}", string.Join(", ", dl.target.urls));
+                    log.DebugFormat("Enqueuing download of {0}", dl.CurrentUri);
                     // Throttled host already downloading, we will get back to this later
                     queuedDownloads.Add(dl);
                 }
             }
             else
             {
-                log.DebugFormat("Beginning download of {0}", string.Join(", ", dl.target.urls));
+                log.DebugFormat("Beginning download of {0}", dl.CurrentUri);
 
                 lock (dlMutex)
                 {
                     if (!downloads.Contains(dl))
                     {
-                        // We need a new variable for our closure/lambda, hence index = 1+prev max
-                        int index = downloads.Count;
-
                         downloads.Add(dl);
 
                         // Schedule for us to get back progress reports.
-                        dl.Progress += (ProgressPercentage, BytesReceived, TotalBytesToReceive) =>
-                            FileProgressReport(index, BytesReceived, TotalBytesToReceive);
+                        dl.Progress += FileProgressReport;
 
                         // And schedule a notification if we're done (or if something goes wrong)
-                        dl.Done += (sender, args, etag, hash) =>
-                            FileDownloadComplete(index, args.Error, args.Cancelled, etag, hash);
+                        dl.Done += FileDownloadComplete;
                     }
                     queuedDownloads.Remove(dl);
                 }
 
                 // Encode spaces to avoid confusing URL parsers
                 User.RaiseMessage(Properties.Resources.NetAsyncDownloaderDownloading,
-                    dl.CurrentUri.ToString().Replace(" ", "%20"));
+                                  dl.CurrentUri.ToString().Replace(" ", "%20"));
 
                 // Start the download!
                 dl.Download();
@@ -279,65 +279,24 @@ namespace CKAN
         /// <summary>
         /// Generates a download progress report.
         /// </summary>
-        /// <param name="index">Index of the file being downloaded</param>
+        /// <param name="download">The download that progressed</param>
         /// <param name="percent">The percent complete</param>
         /// <param name="bytesDownloaded">The bytes downloaded</param>
         /// <param name="bytesToDownload">The total amount of bytes we expect to download</param>
-        private void FileProgressReport(int index, long bytesDownloaded, long bytesToDownload)
+        private void FileProgressReport(DownloadPart download, long bytesDownloaded, long bytesToDownload)
         {
-            DownloadPart download = downloads[index];
-
-            DateTime now = DateTime.Now;
-            TimeSpan timeSpan = now - download.lastProgressUpdateTime;
-            if (timeSpan.Seconds >= 3.0)
-            {
-                long bytesChange = bytesDownloaded - download.lastProgressUpdateSize;
-                download.lastProgressUpdateSize = bytesDownloaded;
-                download.lastProgressUpdateTime = now;
-                download.bytesPerSecond = bytesChange / timeSpan.Seconds;
-            }
-
-            download.size = bytesToDownload;
+            download.size      = bytesToDownload;
             download.bytesLeft = download.size - bytesDownloaded;
-
-            Progress?.Invoke(download.target, download.bytesLeft, download.size);
-
-            long totalBytesPerSecond = 0;
-            long totalBytesLeft = 0;
-            long totalSize = 0;
+            TargetProgress?.Invoke(download.target, download.bytesLeft, download.size);
 
             lock (dlMutex)
             {
-                foreach (var t in downloads)
-                {
-                    if (t == null)
-                    {
-                        continue;
-                    }
-
-                    if (t.bytesLeft > 0)
-                    {
-                        totalBytesPerSecond += t.bytesPerSecond;
-                    }
-
-                    totalBytesLeft += t.bytesLeft;
-                    totalSize += t.size;
-                }
-                foreach (var dl in queuedDownloads)
-                {
-                    // Somehow managed to get a NullRef for dl here
-                    if (dl == null)
-                    {
-                        continue;
-                    }
-
-                    totalBytesLeft += dl.target.size;
-                    totalSize += dl.target.size;
-                }
+                var queuedSize = queuedDownloads.Sum(dl => dl.target.size);
+                rateCounter.Size      = queuedSize + downloads.Sum(dl => dl.size);
+                rateCounter.BytesLeft = queuedSize + downloads.Sum(dl => dl.bytesLeft);
             }
 
-            int totalPercentage = (int)(((totalSize - totalBytesLeft) * 100) / (totalSize));
-            User.RaiseProgress(totalPercentage, totalBytesPerSecond, totalBytesLeft);
+            OverallProgress?.Invoke(rateCounter);
         }
 
         private void PopFromQueue(string host)
@@ -360,13 +319,12 @@ namespace CKAN
         /// This method gets called back by `WebClient` when a download is completed.
         /// It in turncalls the onCompleted hook when *all* downloads are finished.
         /// </summary>
-        private void FileDownloadComplete(int        index,
-                                          Exception? error,
-                                          bool       canceled,
-                                          string?    etag,
-                                          string     hash)
+        private void FileDownloadComplete(DownloadPart dl,
+                                          Exception?   error,
+                                          bool         canceled,
+                                          string?      etag,
+                                          string       hash)
         {
-            var dl      = downloads[index];
             var doneUri = dl.CurrentUri;
             if (error != null)
             {

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -160,10 +160,10 @@ namespace CKAN
                                                     || m.InternetArchiveDownload == url);
                         User.RaiseMessage(Properties.Resources.NetAsyncDownloaderValidating, module);
                         cache.Store(module, filename,
-                            new Progress<int>(percent => StoreProgress?.Invoke(module, 100 - percent, 100)),
-                            module.StandardName(),
-                            false,
-                            cancelTokenSrc?.Token);
+                                    new ProgressImmediate<int>(percent => StoreProgress?.Invoke(module, 100 - percent, 100)),
+                                    module.StandardName(),
+                                    false,
+                                    cancelTokenSrc?.Token);
                         File.Delete(filename);
                     }
                     catch (InvalidModuleFileKraken kraken)

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -187,8 +187,8 @@ namespace CKAN
                 cancelToken?.ThrowIfCancellationRequested();
 
                 // Check valid CRC
-                if (!ZipValid(path, out string invalidReason, new Progress<int>(percent =>
-                    progress?.Report(percent * zipValidPercent / 100))))
+                if (!ZipValid(path, out string invalidReason,
+                              new ProgressImmediate<int>(percent => progress?.Report(percent * zipValidPercent / 100))))
                 {
                     throw new InvalidModuleFileKraken(module, path, string.Format(
                         Properties.Resources.NetModuleCacheNotValidZIP,

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -186,7 +186,7 @@ namespace CKAN
 
         private void ToStream(Stream netStream, Stream outStream, CancellationToken token)
         {
-            netStream.CopyTo(outStream, new Progress<long>(bytesDownloaded =>
+            netStream.CopyTo(outStream, new ProgressImmediate<long>(bytesDownloaded =>
                 {
                     DownloadProgress?.Invoke((int)(100 * bytesDownloaded / contentLength),
                                              bytesDownloaded, contentLength);

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -121,9 +121,14 @@
   <data name="NetDownloading" xml:space="preserve"><value>Downloading {0}</value></data>
   <data name="NetMissingCertFailed" xml:space="preserve"><value>Failed downloading {0}</value></data>
   <data name="NetInvalidLocation" xml:space="preserve"><value>Invalid URL in Location header: {0}</value></data>
+  <data name="ByteRateCounterRateSummary" xml:space="preserve"><value>{0}/sec - {1} ({2}) left - {3}%</value></data>
+  <data name="ByteRateCounterSummary" xml:space="preserve"><value>{0} left - {1}%</value></data>
+  <data name="ByteRateCounterHoursMinutesSeconds" xml:space="preserve"><value>{0} hrs, {1} min, {2} sec</value></data>
+  <data name="ByteRateCounterMinutesSeconds" xml:space="preserve"><value>{0} min, {1} sec</value></data>
+  <data name="ByteRateCounterSeconds" xml:space="preserve"><value>{0} sec</value></data>
   <data name="NetAsyncDownloaderDownloading" xml:space="preserve"><value>Downloading {0} ...</value></data>
   <data name="NetAsyncDownloaderCancelled" xml:space="preserve"><value>Download cancelled by user</value></data>
-  <data name="NetAsyncDownloaderProgress" xml:space="preserve"><value>{0}/sec - downloading - {1} left</value></data>
+  <data name="NetAsyncDownloaderProgress" xml:space="preserve"><value>{0}/sec - {1} left</value></data>
   <data name="NetAsyncDownloaderTryingFallback" xml:space="preserve"><value>Failed to download "{0}", trying fallback "{1}"</value></data>
   <data name="NetAsyncDownloaderValidating" xml:space="preserve"><value>Finished downloading {0}, validating and storing to cache...</value></data>
   <data name="NetFileCacheCannotFind" xml:space="preserve"><value>Cannot find cache directory: {0}</value></data>
@@ -228,6 +233,7 @@ What would you like to do?</value></data>
   <data name="ModuleInstallerAboutToInstall" xml:space="preserve"><value>About to install:</value></data>
   <data name="ModuleInstallerUserDeclined" xml:space="preserve"><value>User declined install list</value></data>
   <data name="ModuleInstallerInstallingMod" xml:space="preserve"><value>Installing {0}...</value></data>
+  <data name="ModuleInstallerInstalledMod" xml:space="preserve"><value>Finished installing {0}</value></data>
   <data name="ModuleInstallerUpdatingRegistry" xml:space="preserve"><value>Updating registry</value></data>
   <data name="ModuleInstallerCommitting" xml:space="preserve"><value>Committing filesystem changes</value></data>
   <data name="ModuleInstallerRescanning" xml:space="preserve"><value>Rescanning {0}</value></data>
@@ -250,6 +256,7 @@ Overwrite?</value></data>
   <data name="ModuleInstallerContinuePrompt" xml:space="preserve"><value>Continue?</value></data>
   <data name="ModuleInstallerRemoveAborted" xml:space="preserve"><value>Mod removal aborted at user request</value></data>
   <data name="ModuleInstallerRemovingMod" xml:space="preserve"><value>Removing {0}...</value></data>
+  <data name="ModuleInstallerRemovedMod" xml:space="preserve"><value>Finished removing {0}</value></data>
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve"><value>About to upgrade:</value></data>
   <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3} remaining)</value></data>
   <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3})</value></data>

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -537,8 +537,7 @@ namespace CKAN
 
         private bool ValidRecSugReasons(HashSet<CkanModule>                  dependencies,
                                         SelectionReason.RelationshipReason[] recSugReasons)
-            => recSugReasons.OfType<SelectionReason.RelationshipReason>()
-                            .Any(r => dependencies.Contains(r.Parent))
+            => recSugReasons.Any(r => dependencies.Contains(r.Parent))
                && !suppressedRecommenders.Any(rel => recSugReasons.Any(r => r.Parent != null
                                                                             && rel.WithinBounds(r.Parent)));
 

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -429,11 +429,6 @@ namespace CKAN
         /// </summary>
         private void Add(CkanModule module, SelectionReason reason)
         {
-            if (module.IsDLC)
-            {
-                throw new ModuleIsDLCKraken(module);
-            }
-
             log.DebugFormat("Adding {0} {1}", module.identifier, module.version);
 
             if (modlist.TryGetValue(module.identifier, out CkanModule? possibleDup))

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -477,15 +477,14 @@ namespace CKAN
         /// Each mod is after its dependencies and before its reverse dependencies.
         /// </summary>
         public IEnumerable<CkanModule> ModList(bool parallel = true)
-            => modlist.Values
-                      .Distinct()
-                      .AsParallelIf(parallel)
-                      // Put user choices at the bottom; .OrderBy(bool) -> false first
-                      .OrderBy(m => ReasonsFor(m).Any(r => r is SelectionReason.UserRequested))
-                      // Put dependencies before dependers
-                      .ThenByDescending(totalDependers)
-                      // Resolve ties in name order
-                      .ThenBy(m => m.name);
+            => modlist.Values.Distinct()
+                             .AsParallelIf(parallel)
+                             // Put user choices at the bottom; .OrderBy(bool) -> false first
+                             .OrderBy(m => ReasonsFor(m).Any(r => r is SelectionReason.UserRequested))
+                             // Put dependencies before dependers
+                             .ThenByDescending(totalDependers)
+                             // Resolve ties in name order
+                             .ThenBy(m => m.name);
 
         // The more nodes of the reverse-dependency graph we can paint, the higher up in the list it goes
         private int totalDependers(CkanModule module)
@@ -509,7 +508,7 @@ namespace CKAN
             }
         }
 
-        private IEnumerable<CkanModule> allDependers(CkanModule                   module)
+        private IEnumerable<CkanModule> allDependers(CkanModule module)
             => BreadthFirstSearch(Enumerable.Repeat(module, 1),
                                   (searching, found) =>
                                       ReasonsFor(searching).OfType<SelectionReason.RelationshipReason>()
@@ -541,7 +540,7 @@ namespace CKAN
                                                                          .ToArray()))
                              .OrderByDescending(totalDependers);
 
-        private bool ValidRecSugReasons(HashSet<CkanModule>   dependencies,
+        private bool ValidRecSugReasons(HashSet<CkanModule>                  dependencies,
                                         SelectionReason.RelationshipReason[] recSugReasons)
             => recSugReasons.OfType<SelectionReason.RelationshipReason>()
                             .Any(r => dependencies.Contains(r.Parent))

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -481,6 +481,15 @@ namespace CKAN
                              // Resolve ties in name order
                              .ThenBy(m => m.name);
 
+        public bool ReadyToInstall(CkanModule mod, ICollection<CkanModule> installed)
+            => !modlist.Values.Distinct()
+                              .Where(m => m != mod)
+                              .Except(installed)
+                              // Ignore circular dependencies
+                              .Except(allDependers(mod))
+                              .SelectMany(allDependers)
+                              .Contains(mod);
+
         // The more nodes of the reverse-dependency graph we can paint, the higher up in the list it goes
         private int totalDependers(CkanModule module)
             => allDependers(module).Count();

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -171,11 +171,13 @@ namespace CKAN
             => resolved.Any(rr => rr.Key == mod || rr.Value.Any(rrr => rrr.Contains(mod)));
 
         public override bool Unsatisfied()
-            => reason is SelectionReason.Depends && resolved.Count == 0;
+            => reason is SelectionReason.Depends
+               && resolved.Keys.Count(m => !m.IsDLC) == 0;
 
         public override bool Unsatisfied(ICollection<CkanModule> installing)
             => reason is SelectionReason.Depends
-               && !resolved.Any(kvp => AvailableModule.DependsAndConflictsOK(kvp.Key, installing)
+               && !resolved.Any(kvp => !kvp.Key.IsDLC
+                                       && AvailableModule.DependsAndConflictsOK(kvp.Key, installing)
                                        && kvp.Value.All(rr => !rr.Unsatisfied(installing)));
 
         public override string ToString()

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -150,9 +150,12 @@ namespace CKAN
                     providers.ToDictionary(prov => prov,
                                            prov => ResolvedRelationshipsTree.ResolveModule(
                                                        prov, definitelyInstalling, allInstalling, registry, installed, crit,
-                                                       (optRels & OptionalRelationships.AllSuggestions) == 0
-                                                           ? optRels & ~OptionalRelationships.Suggestions
-                                                           : optRels,
+                                                       relationship.suppress_recommendations
+                                                           ? optRels & ~OptionalRelationships.Recommendations
+                                                                     & ~OptionalRelationships.Suggestions
+                                                           : (optRels & OptionalRelationships.AllSuggestions) == 0
+                                                               ? optRels & ~OptionalRelationships.Suggestions
+                                                               : optRels,
                                                        relationshipCache)
                                                        .ToArray()))
         {

--- a/Core/Repositories/ProgressScalePercentsByFileSize.cs
+++ b/Core/Repositories/ProgressScalePercentsByFileSize.cs
@@ -42,6 +42,11 @@ namespace CKAN
             }
         }
 
+        public void StartFile(long size)
+        {
+            sizes[currentIndex] = size;
+        }
+
         /// <summary>
         /// Call this when you move on from one file to the next
         /// </summary>

--- a/Core/Repositories/ProgressScalePercentsByFileSize.cs
+++ b/Core/Repositories/ProgressScalePercentsByFileSize.cs
@@ -33,10 +33,11 @@ namespace CKAN
             {
                 var percent = basePercent + (int)(currentFilePercent * sizes[currentIndex] / totalSize);
                 // Only report each percentage once, to avoid spamming UI calls
-                if (percent > lastPercent)
+                if (percent > lastPercent || lastFile != currentIndex)
                 {
                     percentProgress?.Report(percent);
                     lastPercent = percent;
+                    lastFile    = currentIndex;
                 }
             }
         }
@@ -66,5 +67,6 @@ namespace CKAN
         private          int             currentIndex = 0;
         private          int             basePercent  = 0;
         private          int             lastPercent  = -1;
+        private          int             lastFile     = -1;
     }
 }

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -188,7 +188,7 @@ namespace CKAN
                 // Load them
                 string msg = "";
                 var progress = new ProgressFilesOffsetsToPercent(
-                    new Progress<int>(p => user.RaiseProgress(msg, p)),
+                    new ProgressImmediate<int>(p => user.RaiseProgress(msg, p)),
                     targets.Select(t => t.size));
                 foreach ((var repo, var target) in toUpdate.Zip(targets))
                 {

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -277,7 +277,8 @@ namespace CKAN
 
         private void setETag(NetAsyncDownloader.DownloadTarget target,
                              Exception?                        error,
-                             string?                           etag)
+                             string?                           etag,
+                             string                            sha256)
         {
             var url = target.urls.First();
             if (etag != null)

--- a/Core/User.cs
+++ b/Core/User.cs
@@ -24,7 +24,7 @@ namespace CKAN
                         string message, params object[] args);
 
         void RaiseProgress(string message, int percent);
-        void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft);
+        void RaiseProgress(ByteRateCounter rateCounter);
         void RaiseMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)]
                           string message, params object[] args);
     }
@@ -64,7 +64,7 @@ namespace CKAN
         {
         }
 
-        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        public void RaiseProgress(ByteRateCounter rateCounter)
         {
         }
 

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -227,7 +227,7 @@ namespace CKAN.GUI
             })
             {
                 Tag     = module,
-                Checked = check,
+                Checked = check && !module.IsDLC,
                 Group   = group
             };
 
@@ -266,7 +266,7 @@ namespace CKAN.GUI
             RecommendedModsListView.ItemChecked -= RecommendedModsListView_ItemChecked;
             foreach (ListViewItem item in items)
             {
-                if (item.Checked != check)
+                if (item.Checked != check && NotDLC(item))
                 {
                     item.Checked = check;
                 }
@@ -281,11 +281,16 @@ namespace CKAN.GUI
         {
             CheckAllButton.Enabled = RecommendedModsListView.Items
                                                             .OfType<ListViewItem>()
+                                                            .Where(NotDLC)
                                                             .Any(lvi => !lvi.Checked);
             CheckRecommendationsButton.Enabled = RecommendationsGroup.Items
                                                                      .OfType<ListViewItem>()
+                                                                     .Where(NotDLC)
                                                                      .Any(lvi => !lvi.Checked);
         }
+
+        private bool NotDLC(ListViewItem item)
+            => item.Tag is CkanModule mod && !mod.IsDLC;
 
         private void RecommendedModsCancelButton_Click(object? sender, EventArgs? e)
         {

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -179,23 +179,5 @@ namespace CKAN.GUI
             }
             return base.ProcessCmdKey(ref msg, keyData);
         }
-
-        // https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles
-        private enum WindowStyles : uint
-        {
-            WS_VISIBLE = 0x10000000,
-            WS_CHILD   = 0x40000000,
-            WS_POPUP   = 0x80000000,
-        }
-
-        // https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
-        private enum WindowExStyles : uint
-        {
-            WS_EX_TOPMOST       =        0x8,
-            WS_EX_TOOLWINDOW    =       0x80,
-            WS_EX_CONTROLPARENT =    0x10000,
-            WS_EX_NOACTIVATE    = 0x08000000,
-        }
-
     }
 }

--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -95,14 +95,17 @@ namespace CKAN.GUI
         /// <param name="searches">New searches to add</param>
         public void MergeSearches(List<ModSearch> searches)
         {
-            // Merge inputs once for all editors
-            var merged = searches.Aggregate((search, newSearch) => search.MergedWith(newSearch));
-            foreach (var editor in editors)
+            if (searches.Count > 0)
             {
-                // Combine all new with each existing (old AND new)
-                editor.Search = editor.Search?.MergedWith(merged) ?? merged;
+                // Merge inputs once for all editors
+                var merged = searches.Aggregate((search, newSearch) => search.MergedWith(newSearch));
+                foreach (var editor in editors)
+                {
+                    // Combine all new with each existing (old AND new)
+                    editor.Search = editor.Search?.MergedWith(merged) ?? merged;
+                }
+                Apply();
             }
-            Apply();
         }
 
         private void AddSearchButton_Click(object? sender, EventArgs? e)

--- a/GUI/Controls/LabeledProgressBar.cs
+++ b/GUI/Controls/LabeledProgressBar.cs
@@ -1,0 +1,63 @@
+using System.Drawing;
+using System.Windows.Forms;
+using System.ComponentModel;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
+namespace CKAN.GUI
+{
+    /// <summary>
+    /// https://stackoverflow.com/a/40824778
+    /// </summary>
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
+    public class LabeledProgressBar : ProgressBar
+    {
+        public LabeledProgressBar()
+            : base()
+        {
+            SuspendLayout();
+
+            label = new TransparentLabel()
+            {
+                ForeColor   = SystemColors.ControlText,
+                Dock        = DockStyle.Fill,
+                TextAlign   = ContentAlignment.MiddleCenter,
+                Text        = "",
+            };
+            Controls.Add(label);
+
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        [Bindable(false)]
+        [Browsable(true)]
+        [DefaultValue("")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        // If we use override instead of new, the nullability never matches (!)
+        public new string? Text
+        {
+            get => label.Text;
+            set => label.Text = value;
+        }
+
+        // If we use override instead of new, the nullability never matches (!)
+        public new Font Font
+        {
+            get => label.Font;
+            set => label.Font = value;
+        }
+
+        public ContentAlignment TextAlign
+        {
+            get => label.TextAlign;
+            set => label.TextAlign = value;
+        }
+
+        private readonly TransparentLabel label;
+    }
+}

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1007,6 +1007,18 @@ namespace CKAN.GUI
                         UpdateChangeSetAndConflicts(currentInstance,
                             RegistryManager.Instance(currentInstance, repoData).registry);
                         break;
+
+                    case "IsCached":
+                        row.Visible = mainModList.IsVisible(gmod,
+                                                            currentInstance.Name,
+                                                            currentInstance.game,
+                                                            RegistryManager.Instance(currentInstance, repoData).registry);
+                        if (row.Visible && !ModGrid.Rows.Contains(row))
+                        {
+                            // UpdateFilters only adds visible rows, so we may need to add if newly visible
+                            ModGrid.Rows.Add(row);
+                        }
+                        break;
                 }
             }
         }
@@ -1340,7 +1352,7 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        public void UpdateFilters()
+        private void UpdateFilters()
         {
             Util.Invoke(this, _UpdateFilters);
         }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -455,8 +455,7 @@ namespace CKAN.GUI
 
         private void FilterAllButton_Click(object? sender, EventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.All), merge);
+            Filter(ModList.FilterToSavedSearch(GUIModFilter.All), false);
         }
 
         /// <summary>

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1413,7 +1413,7 @@ namespace CKAN.GUI
 
             repoData.Prepopulate(
                 registry.Repositories.Values.ToList(),
-                new Progress<int>(p => user?.RaiseProgress(
+                new ProgressImmediate<int>(p => user?.RaiseProgress(
                     Properties.Resources.LoadingCachedRepoData, p)));
 
             if (!regMgr.registry.HasAnyAvailable())

--- a/GUI/Controls/TransparentLabel.cs
+++ b/GUI/Controls/TransparentLabel.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
+namespace CKAN.GUI
+{
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
+    public class TransparentLabel : Label
+    {
+        public TransparentLabel()
+        {
+            SetStyle(ControlStyles.SupportsTransparentBackColor
+                     | ControlStyles.ResizeRedraw
+                     | ControlStyles.Opaque
+                     | ControlStyles.AllPaintingInWmPaint,
+                     true);
+            SetStyle(ControlStyles.OptimizedDoubleBuffer, false);
+            BackColor = Color.Transparent;
+        }
+
+        // If we use override instead of new, the nullability never matches (!)
+        public new string? Text
+        {
+            get => base.Text;
+            set
+            {
+                base.Text = value;
+                Parent?.Invalidate(Bounds, false);
+            }
+        }
+
+        // If we use override instead of new, the nullability never matches (!)
+        public new ContentAlignment TextAlign
+        {
+            get => base.TextAlign;
+            set
+            {
+                base.TextAlign = value;
+                Parent?.Invalidate(Bounds, false);
+            }
+        }
+
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                var cp = base.CreateParams;
+                cp.ExStyle |= (int)WindowExStyles.WS_EX_TRANSPARENT;
+                return cp;
+            }
+        }
+
+        protected override void OnMove(EventArgs e)
+        {
+            base.OnMove(e);
+            RecreateHandle();
+        }
+
+        protected override void OnPaintBackground(PaintEventArgs e)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/GUI/Controls/Wait.Designer.cs
+++ b/GUI/Controls/Wait.Designer.cs
@@ -30,76 +30,76 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(Wait));
-            this.TopPanel = new System.Windows.Forms.Panel();
-            this.MessageTextBox = new System.Windows.Forms.TextBox();
-            this.DialogProgressBar = new System.Windows.Forms.ProgressBar();
+            this.VerticalSplitter = new System.Windows.Forms.SplitContainer();
+            this.DialogProgressBar = new CKAN.GUI.LabeledProgressBar();
             this.ProgressBarTable = new System.Windows.Forms.TableLayoutPanel();
             this.LogTextBox = new System.Windows.Forms.TextBox();
             this.BottomButtonPanel = new CKAN.GUI.LeftRightRowPanel();
             this.CancelCurrentActionButton = new System.Windows.Forms.Button();
             this.RetryCurrentActionButton = new System.Windows.Forms.Button();
             this.OkButton = new System.Windows.Forms.Button();
+            this.VerticalSplitter.Panel1.SuspendLayout();
+            this.VerticalSplitter.Panel2.SuspendLayout();
+            this.VerticalSplitter.SuspendLayout();
             this.ProgressBarTable.SuspendLayout();
             this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
-            // TopPanel
+            // VerticalSplitter
             //
-            this.TopPanel.Controls.Add(this.MessageTextBox);
-            this.TopPanel.Controls.Add(this.DialogProgressBar);
-            this.TopPanel.Controls.Add(this.ProgressBarTable);
-            this.TopPanel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.TopPanel.Name = "TopPanel";
-            this.TopPanel.Size = new System.Drawing.Size(500, 85);
+            this.VerticalSplitter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.VerticalSplitter.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.VerticalSplitter.Location = new System.Drawing.Point(0, 35);
+            this.VerticalSplitter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.VerticalSplitter.Name = "VerticalSplitter";
+            this.VerticalSplitter.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.VerticalSplitter.Size = new System.Drawing.Size(500, 500);
+            this.VerticalSplitter.SplitterDistance = 50;
+            this.VerticalSplitter.SplitterWidth = 10;
+            this.VerticalSplitter.TabStop = false;
             //
-            // MessageTextBox
+            // VerticalSplitter.Panel1
             //
-            this.MessageTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.MessageTextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.MessageTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.MessageTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.MessageTextBox.Enabled = false;
-            this.MessageTextBox.Location = new System.Drawing.Point(5, 5);
-            this.MessageTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.MessageTextBox.Multiline = true;
-            this.MessageTextBox.Name = "MessageTextBox";
-            this.MessageTextBox.ReadOnly = true;
-            this.MessageTextBox.Size = new System.Drawing.Size(490, 30);
-            this.MessageTextBox.TabIndex = 0;
-            this.MessageTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            resources.ApplyResources(this.MessageTextBox, "MessageTextBox");
+            this.VerticalSplitter.Panel1.Controls.Add(this.DialogProgressBar);
+            this.VerticalSplitter.Panel1.Controls.Add(this.ProgressBarTable);
+            this.VerticalSplitter.Panel1MinSize = 50;
+            //
+            // VerticalSplitter.Panel2
+            //
+            this.VerticalSplitter.Panel2.Controls.Add(this.LogTextBox);
+            this.VerticalSplitter.Panel2MinSize = 100;
             //
             // DialogProgressBar
             //
             this.DialogProgressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.DialogProgressBar.Location = new System.Drawing.Point(5, 45);
+            this.DialogProgressBar.Location = new System.Drawing.Point(5, 7);
             this.DialogProgressBar.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.DialogProgressBar.Font = new System.Drawing.Font(System.Drawing.SystemFonts.MessageBoxFont.Name, 12, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
             this.DialogProgressBar.Minimum = 0;
             this.DialogProgressBar.Maximum = 100;
             this.DialogProgressBar.Name = "DialogProgressBar";
-            this.DialogProgressBar.Size = new System.Drawing.Size(490, 25);
+            this.DialogProgressBar.Size = new System.Drawing.Size(490, 28);
             this.DialogProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-            this.DialogProgressBar.TabIndex = 1;
+            this.DialogProgressBar.TabIndex = 0;
             //
             // ProgressBarTable
             //
-            this.ProgressBarTable.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ProgressBarTable.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right | System.Windows.Forms.AnchorStyles.Bottom;
             this.ProgressBarTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ProgressBarTable.AutoScroll = true;
+            this.ProgressBarTable.AutoSize = false;
             this.ProgressBarTable.ColumnCount = 2;
             this.ProgressBarTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
             this.ProgressBarTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
-            this.ProgressBarTable.Location = new System.Drawing.Point(0, 70);
+            this.ProgressBarTable.Location = new System.Drawing.Point(0, 40);
             this.ProgressBarTable.Name = "ProgressBarTable";
-            this.ProgressBarTable.Padding = new System.Windows.Forms.Padding(0, 6, 0, 6);
-            this.ProgressBarTable.Size = new System.Drawing.Size(500, 0);
-            this.ProgressBarTable.AutoSize = false;
-            this.ProgressBarTable.AutoScroll = false;
-            this.ProgressBarTable.VerticalScroll.Visible = false;
+            this.ProgressBarTable.Padding = new System.Windows.Forms.Padding(1);
+            this.ProgressBarTable.Size = new System.Drawing.Size(490, 10);
+            this.ProgressBarTable.VerticalScroll.Visible = true;
+            this.ProgressBarTable.VerticalScroll.SmallChange = 22;
             this.ProgressBarTable.HorizontalScroll.Visible = false;
-            this.ProgressBarTable.TabIndex = 0;
+            this.ProgressBarTable.TabIndex = 1;
             //
             // LogTextBox
             //
@@ -107,6 +107,7 @@ namespace CKAN.GUI
             this.LogTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.LogTextBox.Location = new System.Drawing.Point(14, 89);
             this.LogTextBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.LogTextBox.Padding = new System.Windows.Forms.Padding(4);
             this.LogTextBox.Multiline = true;
             this.LogTextBox.Name = "LogTextBox";
             this.LogTextBox.ReadOnly = true;
@@ -160,8 +161,7 @@ namespace CKAN.GUI
             // Wait
             //
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.Controls.Add(this.LogTextBox);
-            this.Controls.Add(this.TopPanel);
+            this.Controls.Add(this.VerticalSplitter);
             this.Controls.Add(this.BottomButtonPanel);
             this.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
             this.Padding = new System.Windows.Forms.Padding(0, 0, 0, 0);
@@ -172,15 +172,18 @@ namespace CKAN.GUI
             this.ProgressBarTable.PerformLayout();
             this.BottomButtonPanel.ResumeLayout(false);
             this.BottomButtonPanel.PerformLayout();
+            this.VerticalSplitter.Panel1.ResumeLayout(false);
+            this.VerticalSplitter.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.VerticalSplitter)).EndInit();
+            this.VerticalSplitter.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
         }
 
         #endregion
 
-        private System.Windows.Forms.Panel TopPanel;
-        private System.Windows.Forms.TextBox MessageTextBox;
-        private System.Windows.Forms.ProgressBar DialogProgressBar;
+        private System.Windows.Forms.SplitContainer VerticalSplitter;
+        private CKAN.GUI.LabeledProgressBar DialogProgressBar;
         private System.Windows.Forms.TableLayoutPanel ProgressBarTable;
         private System.Windows.Forms.TextBox LogTextBox;
         private CKAN.GUI.LeftRightRowPanel BottomButtonPanel;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -186,7 +186,7 @@ namespace CKAN.GUI
                 if (newPath != coreConfig.DownloadCacheDir
                     && manager != null
                     && !manager.TrySetupCache(newPath,
-                                              new Progress<int>(UpdateCacheProgress),
+                                              new ProgressImmediate<int>(UpdateCacheProgress),
                                               out string? failReason))
                 {
                     Util.Invoke(this, () =>

--- a/GUI/Enums/WindowExStyles.cs
+++ b/GUI/Enums/WindowExStyles.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace CKAN.GUI
+{
+    // https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
+    [Flags]
+    public enum WindowExStyles : uint
+    {
+        WS_EX_TOPMOST       =        0x8,
+        WS_EX_TRANSPARENT   =       0x20,
+        WS_EX_TOOLWINDOW    =       0x80,
+        WS_EX_CONTROLPARENT =    0x10000,
+        WS_EX_NOACTIVATE    = 0x08000000,
+    }
+}

--- a/GUI/Enums/WindowStyles.cs
+++ b/GUI/Enums/WindowStyles.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace CKAN.GUI
+{
+    // https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles
+    [Flags]
+    public enum WindowStyles : uint
+    {
+        WS_VISIBLE = 0x10000000,
+        WS_CHILD   = 0x40000000,
+        WS_POPUP   = 0x80000000,
+    }
+}

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -101,15 +101,14 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        public void RaiseProgress(int percent,
-                                  long bytesPerSecond, long bytesLeft)
+        public void RaiseProgress(ByteRateCounter rateCounter)
         {
             Util.Invoke(main, () =>
             {
-                wait.SetMainProgress(percent, bytesPerSecond, bytesLeft);
+                wait.SetMainProgress(rateCounter);
                 statBarProgBar.Value =
                     Math.Max(statBarProgBar.Minimum,
-                        Math.Min(statBarProgBar.Maximum, percent));
+                        Math.Min(statBarProgBar.Maximum, rateCounter.Percent));
                 statBarProgBar.Style = ProgressBarStyle.Continuous;
             });
         }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -47,12 +47,9 @@ namespace CKAN.GUI
                 && Manager?.Cache != null)
             {
                 downloader = new NetAsyncModulesDownloader(currentUser, Manager.Cache, userAgent);
-                downloader.Progress      += Wait.SetModuleProgress;
-                downloader.AllComplete   += Wait.DownloadsComplete;
-                downloader.StoreProgress += (module, remaining, total) =>
-                    Wait.SetProgress(string.Format(Properties.Resources.ValidatingDownload,
-                                                   module),
-                                     remaining, total);
+                downloader.DownloadProgress += OnModDownloading;
+                downloader.StoreProgress    += OnModValidating;
+                downloader.OverallDownloadProgress += currentUser.RaiseProgress;
                 Wait.OnCancel += downloader.CancelDownload;
                 downloader.DownloadModules(new List<CkanModule> { gm.ToCkanModule() });
                 e.Result = e.Argument;

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -133,9 +133,6 @@ namespace CKAN.GUI
         {
             UpdateCachedByDownloads(module);
 
-            // Reapply searches in case is:cached or not:cached is active
-            ManageMods.UpdateFilters();
-
             if (module == null
                 || ModInfo.SelectedModule?.Identifier == module.identifier)
             {

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -71,7 +71,7 @@ namespace CKAN.GUI
                 // We need the old data to alert the user of newly compatible modules after update.
                 repoData.Prepopulate(
                     registry.Repositories.Values.ToList(),
-                    new Progress<int>(p => currentUser.RaiseProgress(Properties.Resources.LoadingCachedRepoData, p)));
+                    new ProgressImmediate<int>(p => currentUser.RaiseProgress(Properties.Resources.LoadingCachedRepoData, p)));
 
                 var versionCriteria = CurrentInstance.VersionCriteria();
                 var oldModules = registry.CompatibleModules(versionCriteria)

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -90,7 +90,7 @@ namespace CKAN.GUI
                         try
                         {
                             bool canceled = false;
-                            var downloader = new NetAsyncDownloader(currentUser, userAgent);
+                            var downloader = new NetAsyncDownloader(currentUser, () => null, userAgent);
                             downloader.Progress += (target, remaining, total) =>
                             {
                                 var repo = repos.Where(r => target.urls.Contains(r.uri))

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -91,11 +91,11 @@ namespace CKAN.GUI
                         {
                             bool canceled = false;
                             var downloader = new NetAsyncDownloader(currentUser, () => null, userAgent);
-                            downloader.Progress += (target, remaining, total) =>
+                            downloader.TargetProgress += (target, remaining, total) =>
                             {
                                 var repo = repos.Where(r => target.urls.Contains(r.uri))
                                                 .FirstOrDefault();
-                                if (repo != null)
+                                if (repo != null && total > 0)
                                 {
                                     Wait.SetProgress(repo.name, remaining, total);
                                 }

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -51,13 +51,10 @@ namespace CKAN.GUI
         /// <param name="description">Message displayed above the DialogProgress bar</param>
         public void FailWaitDialog(string statusMsg, string logMsg, string description)
         {
-            Util.Invoke(statusStrip1, () =>
+            Util.Invoke(this, () =>
             {
                 StatusProgress.Visible = false;
                 currentUser.RaiseMessage("{0}", statusMsg);
-            });
-            Util.Invoke(WaitTabPage, () =>
-            {
                 RecreateDialogs();
                 Wait.Finish();
             });

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -68,7 +68,20 @@ namespace CKAN.GUI
         public string DownloadSize { get; private set; }
         public string InstallSize { get; private set; }
         public int? DownloadCount { get; private set; }
-        public bool IsCached { get; private set; }
+
+        private bool isCached;
+        public bool IsCached
+        {
+            get => isCached;
+            private set
+            {
+                if (value != isCached)
+                {
+                    isCached = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         // These indicate the maximum game version that the maximum available
         // version of this mod can handle. The "Long" version also indicates

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -222,6 +222,8 @@ Are you sure you want to install them? Cancelling will abort the entire installa
   <data name="MainImportFilter" xml:space="preserve"><value>Mods (*.zip)|*.zip</value></data>
   <data name="MainImportWaitTitle" xml:space="preserve"><value>Status log</value></data>
   <data name="MainInstallWaitTitle" xml:space="preserve"><value>Status log</value></data>
+  <data name="MainInstallInstallingMod" xml:space="preserve"><value>Installing {0}</value></data>
+  <data name="MainInstallRemovingMod" xml:space="preserve"><value>Removing {0}</value></data>
   <data name="MainInstallDepNotSatisfied" xml:space="preserve"><value>{0} requires {1} but it is not listed in the index, or not available for your game version.</value></data>
   <data name="MainInstallNotFound" xml:space="preserve"><value>Module {0} required but it is not listed in the index, or not available for your game version.</value></data>
   <data name="MainInstallBadMetadata" xml:space="preserve"><value>Bad metadata detected for module {0}: {1}</value></data>
@@ -299,6 +301,7 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="ModInfoSteamStoreLabel" xml:space="preserve"><value>Steam store:</value></data>
   <data name="ModInfoToolTipReverseRelationships" xml:space="preserve"><value>Ctrl-click or Shift-click to make sticky</value></data>
   <data name="DownloadFailed" xml:space="preserve"><value>Download failed!</value></data>
+  <data name="Downloading" xml:space="preserve"><value>Downloading {0}</value></data>
   <data name="ValidatingDownload" xml:space="preserve"><value>Validating {0}</value></data>
   <data name="MainModListWaitTitle" xml:space="preserve"><value>Loading modules</value></data>
   <data name="MainModListLoadingRegistry" xml:space="preserve"><value>Loading registry...</value></data>

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -276,18 +276,15 @@ namespace CKAN.NetKAN
             Console.Write("\r\n{0}", message);
         }
 
-        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        public void RaiseProgress(ByteRateCounter rateCounter)
         {
             // In headless mode, only print a new message if the percent has changed,
             // to reduce clutter in logs for large downloads
-            if (!Headless || percent != previousPercent)
+            if (!Headless || rateCounter.Percent != previousPercent)
             {
-                var fullMsg = string.Format(Properties.Resources.NetAsyncDownloaderProgress,
-                                            CkanModule.FmtSize(bytesPerSecond),
-                                            CkanModule.FmtSize(bytesLeft));
-                // The \r at the front here causes download messages to *overwrite* each other.
-                Console.Write("\r{0} - {1}%           ", fullMsg, percent);
-                previousPercent = percent;
+                // The \r at the start causes download messages to *overwrite* each other.
+                Console.Write("\r{0}           ", rateCounter.Summary);
+                previousPercent = rateCounter.Percent;
             }
         }
 

--- a/Tests/CapturingUser.cs
+++ b/Tests/CapturingUser.cs
@@ -40,10 +40,10 @@ namespace Tests
             RaisedProgresses.Add(new Tuple<string, int>(message, percent));
         }
 
-        public void RaiseProgress(int percent, long bytesPerSecond, long bytesLeft)
+        public void RaiseProgress(ByteRateCounter rateCounter)
         {
-            RaisedProgresses.Add(new Tuple<string, int>($"{bytesPerSecond} {bytesLeft}",
-                                                        percent));
+            RaisedProgresses.Add(new Tuple<string, int>($"{rateCounter.BytesPerSecond} {rateCounter.BytesLeft}",
+                                                        rateCounter.Percent));
         }
 
         public void RaiseMessage(string message, params object[] args)

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -58,7 +58,7 @@ namespace Tests.Core
             _gameDir = _instance.KSP.GameDir();
             _gameDataDir = _instance.KSP.game.PrimaryModDirectory(_instance.KSP);
             var testModFile = TestData.DogeCoinFlagZip();
-            _manager.Cache?.Store(_testModule!, testModFile, new Progress<int>(percent => {}));
+            _manager.Cache?.Store(_testModule!, testModFile, new Progress<long>(bytes => {}));
             HashSet<string>? possibleConfigOnlyDirs = null;
             _installer.InstallList(
                 new List<CkanModule>() { _testModule! },

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -406,7 +406,7 @@ namespace Tests.Core
 
                 var cache_path = manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
                                                       TestData.DogeCoinFlagZip(),
-                                                      new Progress<int>(percent => {}));
+                                                      new Progress<long>(bytes => {}));
 
                 Assert.IsTrue(manager.Cache?.IsCached(TestData.DogeCoinFlag_101_module()));
                 Assert.IsTrue(File.Exists(cache_path));
@@ -455,7 +455,7 @@ namespace Tests.Core
                 registry.RepositoriesAdd(repo.repo);
                 manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
                                      TestData.DogeCoinFlagZip(),
-                                     new Progress<int>(percent => {}));
+                                     new Progress<long>(bytes => {}));
 
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
@@ -503,7 +503,7 @@ namespace Tests.Core
                 registry.RepositoriesAdd(repo.repo);
                 manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
                                      TestData.DogeCoinFlagZip(),
-                                     new Progress<int>(percent => {}));
+                                     new Progress<long>(bytes => {}));
 
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
@@ -519,7 +519,7 @@ namespace Tests.Core
                 // Install the plugin test mod.
                 manager.Cache?.Store(TestData.DogeCoinPlugin_module(),
                                      TestData.DogeCoinPluginZip(),
-                                     new Progress<int>(percent => {}));
+                                     new Progress<long>(bytes => {}));
 
                 modules.Add(TestData.DogeCoinPlugin_module());
 
@@ -711,7 +711,7 @@ namespace Tests.Core
                     // Copy the zip file to the cache directory.
                     manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
                                          TestData.DogeCoinFlagZip(),
-                                         new Progress<int>(percent => {}));
+                                         new Progress<long>(bytes => {}));
 
                     // Attempt to install it.
                     var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
@@ -970,7 +970,7 @@ namespace Tests.Core
                 // Copy the zip file to the cache directory.
                 manager.Cache?.Store(TestData.DogeCoinFlag_101ZipSlip_module(),
                                      TestData.DogeCoinFlagZipSlipZip(),
-                                     new Progress<int>(percent => {}));
+                                     new Progress<long>(bytes => {}));
 
                 // Attempt to install it.
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101ZipSlip_module() };
@@ -1012,7 +1012,7 @@ namespace Tests.Core
                 // Copy the zip file to the cache directory.
                 manager.Cache?.Store(TestData.DogeCoinFlag_101ZipBomb_module(),
                                      TestData.DogeCoinFlagZipBombZip(),
-                                     new Progress<int>(percent => {}));
+                                     new Progress<long>(bytes => {}));
 
                 // Attempt to install it.
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101ZipBomb_module() };
@@ -1081,7 +1081,7 @@ namespace Tests.Core
 
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
-                manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<int>(percent => {}));
+                manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 var replacement = querier.GetReplacement(replaced.identifier,
                                                          new GameVersionCriteria(new GameVersion(1, 12)))!;
                 installer.Replace(Enumerable.Repeat(replacement, 1),
@@ -1149,7 +1149,7 @@ namespace Tests.Core
 
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
-                manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<int>(percent => {}));
+                manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 var replacement = querier.GetReplacement(replaced.identifier,
                                                          new GameVersionCriteria(new GameVersion(1, 11)));
 
@@ -1307,7 +1307,7 @@ namespace Tests.Core
                     var module = CkanModule.FromJson(m);
                     manager.Cache?.Store(module,
                                          TestData.DogeCoinFlagZip(),
-                                         new Progress<int>(percent => {}));
+                                         new Progress<long>(bytes => {}));
                     if (!querier.IsInstalled(module.identifier, false))
                     {
                         registry.RegisterModule(module,
@@ -1381,7 +1381,7 @@ namespace Tests.Core
                 File.WriteAllText(inst.KSP.ToAbsoluteGameDir(unmanaged),
                                   "Not really a DLL, are we?");
                 regMgr.ScanUnmanagedFiles();
-                manager.Cache?.Store(module, zipPath, new Progress<int>(percent => {}));
+                manager.Cache?.Store(module, zipPath, new Progress<long>(bytes => {}));
 
                 // Act
                 HashSet<string>? possibleConfigOnlyDirs = null;

--- a/Tests/Core/Net/NetAsyncDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncDownloaderTests.cs
@@ -25,7 +25,7 @@ namespace Tests.Core.Net
         public void DownloadAndWait_WithValidFileUrl_SetsTargetSize(string pathWithinTestData)
         {
             // Arrange
-            var downloader = new NetAsyncDownloader(new NullUser());
+            var downloader = new NetAsyncDownloader(new NullUser(), () => null);
             var fromPath   = TestData.DataDir(pathWithinTestData);
             var target     = new NetAsyncDownloader.DownloadTargetFile(new Uri(fromPath),
                                                                        Path.GetTempFileName());
@@ -71,7 +71,7 @@ namespace Tests.Core.Net
         public void DownloadAndWait_WithValidFileUrls_SetsTargetsSize(params string[] pathsWithinTestData)
         {
             // Arrange
-            var downloader = new NetAsyncDownloader(new NullUser());
+            var downloader = new NetAsyncDownloader(new NullUser(), () => null);
             var fromPaths  = pathsWithinTestData.Select(TestData.DataDir).ToArray();
             var targets    = fromPaths.Select(p => new NetAsyncDownloader.DownloadTargetFile(new Uri(p),
                                                                                              Path.GetTempFileName()))
@@ -187,7 +187,7 @@ namespace Tests.Core.Net
             params string[] pathsWithinTestData)
         {
             // Arrange
-            var downloader   = new NetAsyncDownloader(new NullUser());
+            var downloader   = new NetAsyncDownloader(new NullUser(), () => null);
             var fromPaths    = pathsWithinTestData.Select(p => Path.GetFullPath(TestData.DataDir(p))).ToArray();
             var targets      = fromPaths.Select(p => new NetAsyncDownloader.DownloadTargetFile(new Uri(p),
                                                                                                Path.GetTempFileName()))

--- a/Tests/Core/Net/NetModuleCacheTests.cs
+++ b/Tests/Core/Net/NetModuleCacheTests.cs
@@ -50,14 +50,14 @@ namespace Tests.Core
             Assert.Throws<FileNotFoundKraken>(() =>
                 module_cache?.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    "/DoesNotExist.zip", new Progress<int>(percent => {})));
+                    "/DoesNotExist.zip", new Progress<long>(bytes => {})));
 
             // Try to store the LZMA-format DogeCoin zip into a NetModuleCache
             // and expect an InvalidModuleFileKraken
             Assert.Throws<InvalidModuleFileKraken>(() =>
                 module_cache?.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    TestData.DogeCoinFlagZipLZMA, new Progress<int>(percent => {})));
+                    TestData.DogeCoinFlagZipLZMA, new Progress<long>(bytes => {})));
 
             // Try to store the normal DogeCoin zip into a NetModuleCache
             // using the WRONG metadata (file size and hashes)
@@ -65,7 +65,7 @@ namespace Tests.Core
             Assert.Throws<InvalidModuleFileKraken>(() =>
                 module_cache?.Store(
                     TestData.DogeCoinFlag_101_LZMA_module,
-                    TestData.DogeCoinFlagZip(), new Progress<int>(percent => {})));
+                    TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {})));
         }
 
         [Test]

--- a/Tests/Data/TemporaryRepositoryData.cs
+++ b/Tests/Data/TemporaryRepositoryData.cs
@@ -23,7 +23,7 @@ namespace Tests.Data
             if (repos.Length > 0)
             {
                 Manager.Update(repos, new KerbalSpaceProgram(),
-                               false, new NetAsyncDownloader(user), user);
+                               false, new NetAsyncDownloader(user, () => null), user);
             }
         }
 

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -166,7 +166,7 @@ namespace Tests.GUI
                 // Act
 
                 // Install module and set it as pre-installed
-                manager.Cache?.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<int>(percent => {}));
+                manager.Cache?.Store(TestData.DogeCoinFlag_101_module(), TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
                 registry.RegisterModule(anyVersionModule, new List<string>(), instance.KSP, false);
 
                 HashSet<string>? possibleConfigOnlyDirs = null;


### PR DESCRIPTION
## Motivations

- Currently the module installer downloads all of the uncached mods in a changeset before it starts installing anything. It would be more time-efficient to start installing some mods while others are still downloading, when feasible.
- Currently a mod's SHA256 hash is calculated after we finish downloading it, which means we receive all of those bytes over the network, save them to disk, and then load them back from disk into memory to hash them. This can take a while for large files. It would be better to calculate the hash while the download is in progress, since we have to wait for the bytes to come across the network anyway.
- Currently `ckan available` always lists _all_ the available mods. If you have some idea of what you're looking for (e.g., I wanted to list the "OPX" mods for testing), it would be nice to be able to apply a filter.

## Problems

- The GUI progress screen's per-mod progress bars can sometimes get stuck at nearly-complete instead of disappearing when their task finishes
- If you Shift-click the All filter in GUI, an exception is thrown
- Mac OS has a default keybind for <kbd>F10</kbd>, which conflicts with ConsoleUI's use of that key
- If you try to install a mod that recommends a DLC that you don't have installed, you get an error that says "CKAN can't install expansion 'Making History' for you.", even though you're not trying to install it.

## Causes

- The progress bars are driven by `Progress<>` objects, which run code on a thread pool and can be de-allocated before that actually happens if the task that created them finishes
- Shift-clicking All doesn't make sense as an operation because the intersection of a set with All is the same set you started with (n.b., in contrast to the other filters, there is no tooltip advertising this key option), but there is code partially implementing it anyway. This partial implementation passes an empty list to `EditModSearches.MergeSearches`, which expects at least one element.
- The relationship resolver throws an exception if it finds a DLC in its traversal of relationships, but as of #3917, that's how we find recommendations.

## Changes

- Now downloads and installs are performed in parallel. A downloaded mod will only be installed once all of its dependencies have been installed, to preserve the exFAT-friendly timestamp ordering from #3667. For upgrades, the downloads begin in parallel with removals and continue into the installs if they take that long. This should reduce the overall time required for installs and upgrades. Upon a download error or user cancellation, the installs are reverted but any completed downloads remain cached.
  Fixes #3793.
- The progress screen is fairly drastically refactored to be closer to how I imagined it ought to have worked all along:
  - Where previously only the main progress bar showed the rate and percentage in a separate label located above it, now every progress bar shows those details in an internal label
    Known issue: The internal progress bar label is not compatible with "marquee" style progress bars (where instead of reflecting a percentage completion, it just plays an animation). The label is shown for one frame of animation and then disappears. I think this is OK for now since we don't use the labels with marquee style to display actual useful information. This might be something we can address in the future with more messing around with the WinForms APIs.
  - The overall progress bar now combines total progress on all downloads and installs since they are no longer two separate stages
  - Per-mod progress bars don't disappear anymore but instead are scrolled out of view, with the active progress bars kept at the bottom of the list and the pane sized to fit them
  - The user can scroll through the progress bars if they wish and move the splitter that separates them from the log messages box
  - Previously only downloading and validating had per-mod progress bars, but now installing and removing steps also have them
- Now the `Progress<>` objects are replaced with `ProgressImmediate<>` objects that run their callbacks right away instead of in a thread pool, so we no longer lose updates
- Now the progress bar captions show the approximate remaining time, which we compute by dividing the remaining bytes by the average of two rates: the total bytes per second of the download since it started, and the bytes per second over the last three seconds.
  Fixes #4160.
- Now the `ResumingWebClient`'s constructor accepts an optional `HashAlgorithm` parameter. If supplied, it will be used to calculate the hash of the incoming byte stream as received from the server. Upon completion, the resulting hash is propagated outwards to the `NetAsyncModulesDownloader` where it is checked against the mod's hash metadata. This eliminates hashing from the download validation step (but we still need that step for a few things like checking that the file is a valid ZIP, etc.). This should speed up installs a bit.
- Now when a mod recommends a non-installed DLC, the install won't error out, and the DLC will show up in the recommendations list, as intended.
  Tests are created to exercise this and catch future regressions.
  Fixes #4242.
- Now Shift-clicking the All filter works exactly like clicking it normally.
  Fixes #4244.
- Now ConsoleUI supports <kbd>Ctrl+T</kbd> in addition to <kbd>F10</kbd> to open the menu, and the screen tip on Mac is changed from `F10` to `Ctrl+T`.
  Fixes #4248.
- Now `ckan available` supports a globbing pattern (meaning you can use `?` and `*` as wildcards) to filter the list of available mods
