### PR TITLE
Exclude DLLs being upgraded to full modules

### DIFF
--- a/Core/Properties/Resources.fr-FR.resx
+++ b/Core/Properties/Resources.fr-FR.resx
@@ -596,7 +596,7 @@ Pensez à ajouter un jeton d'authentification pour augmenter la limite avant bri
   <data name="KrakenAlreadyRunning" xml:space="preserve">
     <value>Fichier verrou avec un ID de processus actif à {0}
 
-Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu. 
+Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu.
 
 Voulez-vous supprimez ce fichier verrou pour forcer l'accès ?</value>
   </data>
@@ -662,9 +662,6 @@ Libérez de l'espace sur cet appareil ou modifiez vos paramètres pour utiliser 
   </data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve">
     <value>{0} a une dépendance insatisfaite : {1} n'est pas installé</value>
-  </data>
-  <data name="SanityCheckerConflictsWith" xml:space="preserve">
-    <value>{0} est en conflit avec {1}</value>
   </data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve">
     <value>{0} {1} (méta-paquet)</value>

--- a/Core/Properties/Resources.it-IT.resx
+++ b/Core/Properties/Resources.it-IT.resx
@@ -647,9 +647,6 @@ Libera spazio su quel dispositivo o modifica le impostazioni per utilizzare un'a
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve">
     <value>{0} ha una dipendenza non soddisfatta: {1} non è installata</value>
   </data>
-  <data name="SanityCheckerConflictsWith" xml:space="preserve">
-    <value>{0} conflitti con {1}</value>
-  </data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve">
     <value>{0} {1} (metapacchetto)</value>
   </data>

--- a/Core/Properties/Resources.pl-PL.resx
+++ b/Core/Properties/Resources.pl-PL.resx
@@ -618,9 +618,6 @@ Zwolnij miejsce na tym urządzeniu lub zmień ustawienia, aby użyć innej lokal
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve">
     <value>{0} ma niespełnioną zależność: {1} nie jest zainstalowany</value>
   </data>
-  <data name="SanityCheckerConflictsWith" xml:space="preserve">
-    <value>{0} koliduje z {1}</value>
-  </data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve">
     <value>{0} {1} (metapackage)</value>
   </data>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -333,7 +333,6 @@ Free up space on that device or change your settings to use another location.
   <data name="RelationshipResolverDependsReason" xml:space="preserve"><value>Dependency of {0}</value></data>
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>Recommended by {0}</value></data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve"><value>{0} has an unsatisfied dependency: {1} is not installed</value></data>
-  <data name="SanityCheckerConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
   <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (cached)</value></data>
   <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>

--- a/Core/Properties/Resources.ru-RU.resx
+++ b/Core/Properties/Resources.ru-RU.resx
@@ -290,7 +290,6 @@ https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors</value></data>
   <data name="RelationshipResolverDependsReason" xml:space="preserve"><value>Для удовлетворения зависимости {0}</value></data>
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>Рекомендуется {0}</value></data>
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve"><value>{0} имеет неудовлетворённую зависимость: {1} не установлен</value></data>
-  <data name="SanityCheckerConflictsWith" xml:space="preserve"><value>{0} конфликтует с {1}</value></data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (метапакет)</value></data>
   <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (кэшировано)</value></data>
   <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>

--- a/Core/Properties/Resources.zh-CN.resx
+++ b/Core/Properties/Resources.zh-CN.resx
@@ -650,9 +650,6 @@
   <data name="SanityCheckerUnsatisfiedDependency" xml:space="preserve">
     <value>{0} 有一个未满足的依赖项: {1} 未安装</value>
   </data>
-  <data name="SanityCheckerConflictsWith" xml:space="preserve">
-    <value>{0} 与 {1} 冲突</value>
-  </data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve">
     <value>{0} {1} (metapackage)</value>
   </data>

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -142,6 +142,7 @@ namespace CKAN
                              ICollection<CkanModule> definitelyInstalling,
                              ICollection<CkanModule> allInstalling,
                              IRegistryQuerier        registry,
+                             ICollection<string>     dlls,
                              ICollection<CkanModule> installed,
                              GameVersionCriteria     crit,
                              OptionalRelationships   optRels,
@@ -149,7 +150,7 @@ namespace CKAN
              : this(source, relationship, reason,
                     providers.ToDictionary(prov => prov,
                                            prov => ResolvedRelationshipsTree.ResolveModule(
-                                                       prov, definitelyInstalling, allInstalling, registry, installed, crit,
+                                                       prov, definitelyInstalling, allInstalling, registry, dlls, installed, crit,
                                                        relationship.suppress_recommendations
                                                            ? optRels & ~OptionalRelationships.Recommendations
                                                                      & ~OptionalRelationships.Suggestions

--- a/Netkan/Extensions/JObjectExtensions.cs
+++ b/Netkan/Extensions/JObjectExtensions.cs
@@ -81,6 +81,14 @@ namespace CKAN.NetKAN.Extensions
             }
         }
 
+        public static void SafeMerge(this JObject jobject, JObject other)
+        {
+            foreach (var property in other.Properties())
+            {
+                jobject.SafeAdd(property.Name, property.Value);
+            }
+        }
+
         public static JToken? ToJValueOrJArray<T>(this IEnumerable<T?> source) where T: notnull
         {
             var items = source.OfType<T>()


### PR DESCRIPTION
## Problem

If you manully install RPM alongside a CKAN install of Deferred and then try to upgrade RPM to CKAN-managed, it doesn't let you:

![image](https://github.com/user-attachments/assets/645798f9-be4e-4297-9005-63a94722dc00)

## Cause

As of #4067, a DLL can be upgraded to a full module, but the relationship resolver's consistency check still checks conflicts against the pre-upgrade DLL list.

In the case of Deferred, it conflicts with older versions of RPM, but versions can't be checked with DLLs, so the registry starts out in a conflicted state and remains that way despite the planned upgrade to a non-conflicting module.

## Changes

Now the relationship resolver computes a post-install set of DLLs based on the list from the registry minus the identifiers of modules being installed. This allows upgrading a version-specifically-conflicted DLL to a module with a version that doesn't match the conflict. A test is included to catch any future regressions.

Fixes #4225.
