### PR TITLE
Sort dependencies first in modpacks

### DIFF
--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -103,6 +103,7 @@ namespace CKAN.GUI
                         && !module.recommends.Any(rel => rel.ContainsAny(ids))
                         && !module.suggests.Any(rel => rel.ContainsAny(ids));
                 })
+                .OrderBy(kvp => kvp.Key)
                 .Select(kvp => (RelationshipDescriptor) new ModuleRelationshipDescriptor()
                     {
                         name    = kvp.Key,
@@ -141,7 +142,6 @@ namespace CKAN.GUI
             {
                 RelationshipsListView.Items.AddRange(
                     relationships.OfType<ModuleRelationshipDescriptor>()
-                                 .OrderBy(r => r.name)
                                  .Select(r => new ListViewItem(new string[]
                                      {
                                          r.name,

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -100,12 +100,13 @@ namespace CKAN.GUI
                         pb.Text = rateCounter.Summary;
                         if (newVal >= 100)
                         {
+                            var myLbl = progressLabels[label];
                             rateCounter.Stop();
+                            ProgressBarTable.SuspendLayout();
                             for (int row = ProgressBarTable.GetPositionFromControl(pb).Row; row > 0; --row)
                             {
-                                if (ProgressBarTable.GetControlFromPosition(1, row - 1)    is LabeledProgressBar prevPb
-                                    && ProgressBarTable.GetControlFromPosition(0, row)     is Label myLbl
-                                    && ProgressBarTable.GetControlFromPosition(0, row - 1) is Label prevLbl)
+                                if (ProgressBarTable.GetControlFromPosition(0, row - 1) is Label prevLbl
+                                    && ProgressBarTable.GetControlFromPosition(1, row - 1) is LabeledProgressBar prevPb)
                                 {
                                     if (prevPb.Value >= 100)
                                     {
@@ -122,6 +123,7 @@ namespace CKAN.GUI
                                     }
                                 }
                             }
+                            ProgressBarTable.ResumeLayout();
                         }
                     }
                     else


### PR DESCRIPTION
## Motivation

#3499 sorted the relationships in modpacks alphanumerically by identifier (rather than randomly). There have been some problems with this; since the ordering of a changeset matters, sorting alphanumerically means that dependencies might end up later in the changeset than their depending mods, so for instance there might be cases where a user is prompted to choose a mod and is allowed to pick one that will conflict with a dependency of something later in the changeset.

## Changes

Now we use a relationship resolver to sort dependencies before depending mods in modpacks. This way when a new modpack is exported, the ordering will better reflect how the mods should be installed.

Ideally we would also give the user some options for manually reordering mods, but I discovered that WinForms's `ListView` control cannot do that when item groups are in use. It either puts moved `ListViewItem`s in the wrong place or omits them completely, and if we try rebuilding the entire list from scratch, there is no way to restore the scroll position so you can see the mod you just moved. Perhaps something to come back to in the future if we feel like reimplementing the modpack editor with a different underlying control.

### Side fixes

To test this, I tried installing the community lifeboat modpack and found that the scrollbars from #4249 flickered quite a bit. Some calls to `SuspendLayout` and `ResumeLayout` are added to improve this.
