### PR TITLE
Allow installs and removals to be cancelled

### DIFF
--- a/Core/Net/IDownloader.cs
+++ b/Core/Net/IDownloader.cs
@@ -38,10 +38,5 @@ namespace CKAN
 
         IEnumerable<CkanModule> ModulesAsTheyFinish(ICollection<CkanModule> cached,
                                                     ICollection<CkanModule> toDownload);
-
-        /// <summary>
-        /// Cancel any running downloads.
-        /// </summary>
-        void CancelDownload();
     }
 }


### PR DESCRIPTION
## Problem

The GUI progress screen has a Cancel button, but it only works while a download is in progress. If you try to cancel after the downloads are finished but installation is still in progress, the button disables itself and nothing else happens.

## Cause

The downloaders have their own custom `CancelDownload` methods, but the `ModuleInstaller` has nothing equivalent.

## Changes

- Now the downloader classes are refactored to accept `CancellationToken`s in their constructors and throw `CancelledActionKraken` in place of their proprietary APIs. The `CancelledActionKraken` causes the installation transaction to abort, which restores the original state of the game folder.
- `ModuleInstaller` is updated to work the same way and checks the token in between installing or removing files
- The Cancel button now cancels the current `CancellationToken`

This allows the Cancel button to work regardless of which step is currently in progress.
