### PR TITLE
Ignore manually installed duplicates of installed modules

### DIFF
--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -26,8 +26,8 @@ namespace CKAN
         /// <param name="dlc">Collection of installed DLCs</param>
         public CompatibilitySorter(GameVersionCriteria                              crit,
                                    IEnumerable<Dictionary<string, AvailableModule>> available,
-                                   Dictionary<string, HashSet<AvailableModule>>     providers,
-                                   Dictionary<string, InstalledModule>              installed,
+                                   IDictionary<string, HashSet<AvailableModule>>    providers,
+                                   IDictionary<string, InstalledModule>             installed,
                                    ICollection<string>                              dlls,
                                    IDictionary<string, ModuleVersion>               dlc)
         {
@@ -103,9 +103,9 @@ namespace CKAN
             }
         }
 
-        private readonly Dictionary<string, InstalledModule> installed;
-        private readonly ICollection<string>                 dlls;
-        private readonly IDictionary<string, ModuleVersion>  dlc;
+        private readonly IDictionary<string, InstalledModule> installed;
+        private readonly ICollection<string>                  dlls;
+        private readonly IDictionary<string, ModuleVersion>   dlc;
 
         private List<CkanModule>? latestCompatible;
         private List<CkanModule>? latestIncompatible;
@@ -119,8 +119,8 @@ namespace CKAN
         /// Mapping from identifiers to compatible mods providing those identifiers
         /// </returns>
         private static Dictionary<string, HashSet<AvailableModule>> CompatibleProviders(
-            GameVersionCriteria                          crit,
-            Dictionary<string, HashSet<AvailableModule>> providers)
+            GameVersionCriteria                           crit,
+            IDictionary<string, HashSet<AvailableModule>> providers)
             => providers
                 .AsParallel()
                 .Select(kvp => new KeyValuePair<string, HashSet<AvailableModule>>(


### PR DESCRIPTION
## Problem

According to #4256, installing Parallax with CKAN and then Parallax Continued manually causes CKAN to enforce version-specific relationships against the manually installed DLL:

![image](https://github.com/user-attachments/assets/1faa75bf-7108-47b4-ab15-aabd58e700d6)

This is arguably correct behavior, since you _do_ have a manually installed DLL, for which which CKAN _cannot_ programmatically determine a version for comparison with version-specific relationships. But it's opaque and frustrating for users, who just want some way to get these paid mods integrated into the ecosystem.

## Cause

This is speculation because the affected mod is not publicly available and the issue description isn't detailed enough to confirm, but it _sounds_ to me like the manually installed mod is being put in a different path than the CKAN-installed mod.

I say this because if you simply replaced the CKAN-installed files with manually installed ones in the same locations, then CKAN would not even know anything had changed and relationships would match or not exactly the same as if you had just installed with CKAN. Something is giving away the manual changes, and the most likely explanation is that they're in a different path, allowing the DLL to be detected as manually installed.

## Changes

Now if you install a mod with CKAN and then install an extra copy of it manually somewhere else, the manually installed copy will be ignored by CKAN (but not by the game, of course!). This will ensure that version-specific relationships will match based on the CKAN-installed module only, so users of this one paid mod can have a workaround to bypass the non-paid mod's version-specific relationships.

Fixes #4256 (probably).
