### PR TITLE
fix: `NetKAN.schema` not rejecting invalid pattern for `$kref` and `$vref` in VSCode

### DIFF
--- a/NetKAN.schema
+++ b/NetKAN.schema
@@ -42,39 +42,39 @@
             "type": "string",
             "oneOf": [
                 {
-                    "pattern": "^#\/ckan\/spacedock\/[0-9]+$",
+                    "pattern": "^#/ckan/spacedock/[0-9]+$",
                     "description": "Indicates that data should be fetched from SpaceDock"
                 },
                 {
-                    "pattern": "^#\/ckan\/curse\/[A-Za-z0-9_-]+$",
+                    "pattern": "^#/ckan/curse/[A-Za-z0-9_-]+$",
                     "description": "Deprecated format, no longer supported"
                 },
                 {
-                    "pattern": "^#\/ckan\/github\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+(\/asset_match\/.+|\/version_from_asset\/.+)$",
+                    "pattern": "^#/ckan/github/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+(/asset_match/.+|/version_from_asset/.+)?$",
                     "description": "Indicates that data should be fetched from the GitHub user and repo provided"
                 },
                 {
-                    "pattern": "^#\/ckan\/gitlab\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+$",
+                    "pattern": "^#/ckan/gitlab/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$",
                     "description": "Indicates that data should be fetched from the GitLab the user and repo provided"
                 },
                 {
-                    "pattern": "^#\/ckan\/sourceforge\/.+$",
+                    "pattern": "^#/ckan/sourceforge/.+$",
                     "description": "Indicates that data should be fetched from SourceForge using the repo provided"
                 },
                 {
-                    "pattern": "^#\/ckan\/jenkins\/.+$",
+                    "pattern": "^#/ckan/jenkins/.+$",
                     "description": "Indicates that data should be fetched from a Jenkins CI server using the joburl provided"
                 },
                 {
-                    "pattern": "^#\/ckan\/http\/.+$",
+                    "pattern": "^#/ckan/http/.+$",
                     "description": "Indicates data should be fetched from an HTTP server, using the URL provided"
                 },
                 {
-                    "pattern": "^#\/ckan\/ksp-avc\/.+$",
+                    "pattern": "^#/ckan/ksp-avc/.+$",
                     "description": "Indicates that data should be fetched from a KSP-AVC .version file at the URL provided"
                 },
                 {
-                    "pattern": "^#\/ckan\/netkan\/.+$",
+                    "pattern": "^#/ckan/netkan/.+$",
                     "description": "Indicates that data should be fetched from the .netkan file at the given URL"
                 }
             ]
@@ -84,11 +84,11 @@
             "type": "string",
             "oneOf": [
                 {
-                    "pattern": "^#\/ckan\/ksp-avc(\/.*)$",
+                    "pattern": "^#/ckan/ksp-avc(/.*)?$",
                     "description": "Version information should be retrieved from an embedded KSP-AVC .version file inside the downloaded file"
                 },
                 {
-                    "pattern": "^#\/ckan\/space-warp(\/.*)$",
+                    "pattern": "^#/ckan/space-warp(/.*)?$",
                     "description": "Version information should be retrieved from an embedded SpaceWarp swinfo.json file inside the downloaded file"
                 }
             ]

--- a/NetKAN.schema
+++ b/NetKAN.schema
@@ -42,39 +42,39 @@
             "type": "string",
             "oneOf": [
                 {
-                    "pattern": "^#/ckan/spacedock/[0-9]+",
+                    "pattern": "^#\/ckan\/spacedock\/[0-9]+$",
                     "description": "Indicates that data should be fetched from SpaceDock"
                 },
                 {
-                    "pattern": "^#/ckan/curse/[A-Za-z0-9_-]+",
+                    "pattern": "^#\/ckan\/curse\/[A-Za-z0-9_-]+$",
                     "description": "Deprecated format, no longer supported"
                 },
                 {
-                    "pattern": "^#/ckan/github/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+(/asset_match/.+|/version_from_asset/.+)?",
+                    "pattern": "^#\/ckan\/github\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+(\/asset_match\/.+|\/version_from_asset\/.+)$",
                     "description": "Indicates that data should be fetched from the GitHub user and repo provided"
                 },
                 {
-                    "pattern": "^#/ckan/gitlab/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+",
+                    "pattern": "^#\/ckan\/gitlab\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+$",
                     "description": "Indicates that data should be fetched from the GitLab the user and repo provided"
                 },
                 {
-                    "pattern": "^#/ckan/sourceforge/.+",
+                    "pattern": "^#\/ckan\/sourceforge\/.+$",
                     "description": "Indicates that data should be fetched from SourceForge using the repo provided"
                 },
                 {
-                    "pattern": "^#/ckan/jenkins/.+",
+                    "pattern": "^#\/ckan\/jenkins\/.+$",
                     "description": "Indicates that data should be fetched from a Jenkins CI server using the joburl provided"
                 },
                 {
-                    "pattern": "^#/ckan/http/.+",
+                    "pattern": "^#\/ckan\/http\/.+$",
                     "description": "Indicates data should be fetched from an HTTP server, using the URL provided"
                 },
                 {
-                    "pattern": "^#/ckan/ksp-avc/.+",
+                    "pattern": "^#\/ckan\/ksp-avc\/.+$",
                     "description": "Indicates that data should be fetched from a KSP-AVC .version file at the URL provided"
                 },
                 {
-                    "pattern": "^#/ckan/netkan/.+",
+                    "pattern": "^#\/ckan\/netkan\/.+$",
                     "description": "Indicates that data should be fetched from the .netkan file at the given URL"
                 }
             ]
@@ -84,11 +84,11 @@
             "type": "string",
             "oneOf": [
                 {
-                    "pattern": "^#/ckan/ksp-avc(/.*)?",
+                    "pattern": "^#\/ckan\/ksp-avc(\/.*)$",
                     "description": "Version information should be retrieved from an embedded KSP-AVC .version file inside the downloaded file"
                 },
                 {
-                    "pattern": "^#/ckan/space-warp(/.*)?",
+                    "pattern": "^#\/ckan\/space-warp(\/.*)$",
                     "description": "Version information should be retrieved from an embedded SpaceWarp swinfo.json file inside the downloaded file"
                 }
             ]


### PR DESCRIPTION
Optional capture groups allowed invalid patterns like
`"$kref": "#/ckan/github/foo/foo-bar/asset_WARN_match/foo-bar-baz.zip"`
to not result in a warning by VSCode, now they are rejected correctly:

before:
![image](https://github.com/user-attachments/assets/9b990f3d-b072-4aca-8871-e3de0a2b0278)

after:
![image](https://github.com/user-attachments/assets/cfec4457-e923-44d7-87c6-00b4e376421c)

Note that it warns about the spacedock pattern, which is the first of the possible patterns - this unhelpful message is a limitation of VSCode / just this regex approach of JSON schemas in general 🤷‍♂️

Also added escape slashes where needed, which is superfluous for the C# flavor, but required in the JavaScript flavor of regex, just to be safe.