### PR TITLE
Pre-release handling

### DIFF
--- a/Cmdline/Action/Available.cs
+++ b/Cmdline/Action/Available.cs
@@ -16,11 +16,13 @@ namespace CKAN.CmdLine
 
         public int RunCommand(CKAN.GameInstance instance, object raw_options)
         {
-            AvailableOptions opts     = (AvailableOptions)raw_options;
-            IRegistryQuerier registry = RegistryManager.Instance(instance, repoData).registry;
+            AvailableOptions opts = (AvailableOptions)raw_options;
 
-            IEnumerable<CkanModule> compatible = registry
-                .CompatibleModules(instance.VersionCriteria())
+            IEnumerable<CkanModule> compatible = RegistryManager
+                .Instance(instance, repoData)
+                .registry
+                .CompatibleModules(instance.StabilityToleranceConfig,
+                                   instance.VersionCriteria())
                 .Where(m => !m.IsDLC)
                 .OrderBy(m => m.identifier);
 

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -60,7 +60,7 @@ namespace CKAN.CmdLine
                     {
                         HashSet<string>? possibleConfigOnlyDirs = null;
                         installer.InstallList(toInstall,
-                                              new RelationshipResolverOptions(),
+                                              new RelationshipResolverOptions(instance.StabilityToleranceConfig),
                                               regMgr,
                                               ref possibleConfigOnlyDirs,
                                               opts?.NetUserAgent);

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -89,8 +89,9 @@ namespace CKAN.CmdLine
                                                         (options?.allow_incompatible ?? false)
                                                             ? null
                                                             : crit)
-                                                    ?? registry.LatestAvailable(arg, crit,
-                                                                                null, installed)
+                                                    ?? registry.LatestAvailable(arg,
+                                                                                instance.StabilityToleranceConfig,
+                                                                                crit, null, installed)
                                                     ?? registry.InstalledModule(arg)?.Module)
                                      .OfType<CkanModule>()
                                      .ToList();
@@ -102,7 +103,7 @@ namespace CKAN.CmdLine
             }
 
             var installer   = new ModuleInstaller(instance, manager.Cache, user, options?.NetUserAgent);
-            var install_ops = new RelationshipResolverOptions
+            var install_ops = new RelationshipResolverOptions(instance.StabilityToleranceConfig)
             {
                 with_all_suggests              = options?.with_all_suggests ?? false,
                 with_suggests                  = options?.with_suggests ?? false,

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -87,7 +87,9 @@ namespace CKAN.CmdLine
                         {
                             // Check if upgrades are available, and show appropriately.
                             log.DebugFormat("Check if upgrades are available for {0}", mod.Key);
-                            var latest = registry.LatestAvailable(mod.Key, instance.VersionCriteria());
+                            var latest = registry.LatestAvailable(mod.Key,
+                                                                  instance.StabilityToleranceConfig,
+                                                                  instance.VersionCriteria());
                             var current = registry.GetInstalledVersion(mod.Key);
                             var inst = registry.InstalledModule(mod.Key);
 
@@ -103,7 +105,9 @@ namespace CKAN.CmdLine
                                 // Check if mod is replaceable
                                 else if (current.replaced_by != null)
                                 {
-                                    var replacement = registry.GetReplacement(mod.Key, instance.VersionCriteria());
+                                    var replacement = registry.GetReplacement(mod.Key,
+                                                                              instance.StabilityToleranceConfig,
+                                                                              instance.VersionCriteria());
                                     if (replacement != null)
                                     {
                                         // Replaceable!
@@ -120,7 +124,9 @@ namespace CKAN.CmdLine
                                 // Check if mod is replaceable
                                 if (current?.replaced_by != null)
                                 {
-                                    var replacement = registry.GetReplacement(latest.identifier, instance.VersionCriteria());
+                                    var replacement = registry.GetReplacement(latest.identifier,
+                                                                              instance.StabilityToleranceConfig,
+                                                                              instance.VersionCriteria());
                                     if (replacement != null)
                                     {
                                         // Replaceable!

--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -185,7 +185,7 @@ namespace CKAN.CmdLine
             CKAN.GameInstance inst = MainClass.GetGameInstance(manager);
             return RegistryManager.Instance(inst, repoData)
                                   .registry
-                                  .CompatibleModules(inst.VersionCriteria())
+                                  .CompatibleModules(inst.StabilityToleranceConfig, inst.VersionCriteria())
                                   .Where(m => !m.IsDLC)
                                   .Select(m => m.identifier)
                                   .Where(ident => ident.StartsWith(prefix,

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -36,7 +36,7 @@ namespace CKAN.CmdLine
             }
 
             // Prepare options. Can these all be done in the new() somehow?
-            var replace_ops = new RelationshipResolverOptions
+            var replace_ops = new RelationshipResolverOptions(instance.StabilityToleranceConfig)
                 {
                     with_all_suggests  = options.with_all_suggests,
                     with_suggests      = options.with_suggests,
@@ -68,7 +68,9 @@ namespace CKAN.CmdLine
                             log.DebugFormat("Testing {0} {1} for possible replacement", mod.Key, mod.Value);
                             // Check if replacement is available
 
-                            var replacement = registry.GetReplacement(mod.Key, instance.VersionCriteria());
+                            var replacement = registry.GetReplacement(mod.Key,
+                                                                      instance.StabilityToleranceConfig,
+                                                                      instance.VersionCriteria());
                             if (replacement != null)
                             {
                                 // Replaceable
@@ -100,7 +102,9 @@ namespace CKAN.CmdLine
                             try
                             {
                                 // Check if replacement is available
-                                var replacement = registry.GetReplacement(modToReplace.identifier, instance.VersionCriteria());
+                                var replacement = registry.GetReplacement(modToReplace.identifier,
+                                                                          instance.StabilityToleranceConfig,
+                                                                          instance.VersionCriteria());
                                 if (replacement != null)
                                 {
                                     // Replaceable

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -93,7 +93,7 @@ namespace CKAN.CmdLine
     public class RepoPriorityOptions : InstanceSpecificOptions
     {
         [ValueOption(0)] public string? name     { get; set; }
-        [ValueOption(1)] public int    priority { get; set; }
+        [ValueOption(1)] public int     priority { get; set; }
     }
 
     public class RepoDefaultOptions : InstanceSpecificOptions
@@ -459,6 +459,6 @@ namespace CKAN.CmdLine
         private readonly RepositoryDataManager repoData;
         private          IUser?                user;
 
-        private static readonly ILog log = LogManager.GetLogger(typeof (Repo));
+        private static readonly ILog log = LogManager.GetLogger(typeof(Repo));
     }
 }

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -51,7 +51,8 @@ namespace CKAN.CmdLine
 
                 // Module was not installed, look for an exact match in the available modules,
                 // either by "name" (the user-friendly display name) or by identifier
-                var moduleToShow = registry.CompatibleModules(instance.VersionCriteria())
+                var moduleToShow = registry.CompatibleModules(instance.StabilityToleranceConfig,
+                                                              instance.VersionCriteria())
                                            .SingleOrDefault(
                                                  mod => mod.name       == modName
                                                      || mod.identifier == modName);

--- a/Cmdline/Action/Stability.cs
+++ b/Cmdline/Action/Stability.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Autofac;
+using CommandLine;
+using CommandLine.Text;
+
+using CKAN.Extensions;
+
+namespace CKAN.CmdLine
+{
+    public class Stability : ISubCommand
+    {
+        public int RunSubCommand(GameInstanceManager? manager,
+                                 CommonOptions?       opts,
+                                 SubCommandOptions    options)
+        {
+            int exitCode = Exit.OK;
+            Parser.Default.ParseArgumentsStrict(options.options.ToArray(),
+                                                new StabilitySubOptions(),
+                                                (string option, object suboptions) =>
+            {
+                // ParseArgumentsStrict calls us unconditionally, even with bad arguments
+                if (!string.IsNullOrEmpty(option) && suboptions != null)
+                {
+                    CommonOptions options = (CommonOptions)suboptions;
+                    options.Merge(opts);
+                    var user = new ConsoleUser(options.Headless);
+                    manager ??= new GameInstanceManager(user);
+                    exitCode = options.Handle(manager, user);
+                    if (exitCode == Exit.OK)
+                    {
+                        switch (option)
+                        {
+                            case "list":
+                                exitCode = List(MainClass.GetGameInstance(manager),
+                                                user);
+                                break;
+
+                            case "set":
+                                exitCode = Set((StabilitySetOptions)suboptions,
+                                               MainClass.GetGameInstance(manager),
+                                               user);
+                                break;
+
+                            default:
+                                user.RaiseMessage(Properties.Resources.StabilityUnknownCommand,
+                                                  option);
+                                exitCode = Exit.BADOPT;
+                                break;
+                        }
+                    }
+                }
+            }, () => { exitCode = MainClass.AfterHelp(); });
+            return exitCode;
+        }
+
+        private static int List(CKAN.GameInstance instance, IUser user)
+        {
+            var stabilityTolerance = instance.StabilityToleranceConfig;
+            user.RaiseMessage(Properties.Resources.StabilityOverallLabel,
+                              stabilityTolerance.OverallStabilityTolerance);
+            var rows = stabilityTolerance.OverriddenModIdentifiers
+                                         .OrderBy(ident => ident)
+                                         .Select(ident => stabilityTolerance.ModStabilityTolerance(ident)
+                                                          is ReleaseStatus relStat
+                                                              ? Tuple.Create(ident, relStat.ToString())
+                                                              : null)
+                                         .OfType<Tuple<string, string>>()
+                                         .ToArray();
+            if (rows.Length > 0)
+            {
+                var modHeader       = Properties.Resources.StabilityListModHeader;
+                var stabilityHeader = Properties.Resources.StabilityListStabilityHeader;
+                var modWidth       = Enumerable.Repeat(modHeader, 1)
+                                               .Concat(rows.Select(tuple => tuple.Item1))
+                                               .Max(str => str.Length);
+                var stabilityWidth = Enumerable.Repeat(stabilityHeader, 1)
+                                               .Concat(rows.Select(tuple => tuple.Item2))
+                                               .Max(str => str.Length);
+                user.RaiseMessage("");
+                user.RaiseMessage("{0}  {1}", modHeader.PadRight(modWidth),
+                                              stabilityHeader.PadRight(stabilityWidth));
+                user.RaiseMessage("{0}  {1}", new string('-', modWidth),
+                                              new string('-', stabilityWidth));
+                foreach (var (ident, relStat) in rows)
+                {
+                    user.RaiseMessage("{0}  {1}", ident.PadRight(modWidth),
+                                                  relStat.PadRight(stabilityWidth));
+                }
+            }
+            return Exit.OK;
+        }
+
+        private static int Set(StabilitySetOptions opts, CKAN.GameInstance instance, IUser user)
+        {
+            var stabilityTolerance = instance.StabilityToleranceConfig;
+            if (opts.Identifier == null)
+            {
+                if (opts.Stability is ReleaseStatus relStat)
+                {
+                    stabilityTolerance.OverallStabilityTolerance = relStat;
+                }
+                else
+                {
+                    user.RaiseError(Properties.Resources.ArgumentMissing);
+                    PrintUsage(user, "set");
+                    return Exit.BADOPT;
+                }
+            }
+            else
+            {
+                var repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
+                var registry = RegistryManager.Instance(instance, repoData).registry;
+                var idents   = new List<string> { opts.Identifier };
+                Search.AdjustModulesCase(instance, registry, idents);
+                stabilityTolerance.SetModStabilityTolerance(idents[0], opts.Stability);
+            }
+            List(instance, user);
+            return Exit.OK;
+        }
+
+        private static void PrintUsage(IUser user, string verb)
+        {
+            foreach (var h in StabilitySubOptions.GetHelp(verb))
+            {
+                user.RaiseError("{0}", h);
+            }
+        }
+    }
+
+    public class StabilitySubOptions: VerbCommandOptions
+    {
+        [VerbOption("list", HelpText = "Print stability preferences")]
+        public InstanceSpecificOptions? ListOptions { get; set; }
+
+        [VerbOption("set", HelpText = "Change stability preferences")]
+        public StabilitySetOptions? SetOptions { get; set; }
+
+        [HelpVerbOption]
+        public string GetUsage(string verb)
+        {
+            var ht = HelpText.AutoBuild(this, verb);
+            foreach (var h in GetHelp(verb))
+            {
+                ht.AddPreOptionsLine(h);
+            }
+            return ht;
+        }
+
+        public static IEnumerable<string> GetHelp(string verb)
+        {
+            // Add a usage prefix line
+            yield return " ";
+            if (string.IsNullOrEmpty(verb))
+            {
+                yield return $"ckan stability - {Properties.Resources.StabilityHelpSummary}";
+                yield return $"{Properties.Resources.Usage}: ckan stability <{Properties.Resources.Command}> [{Properties.Resources.Options}]";
+            }
+            else
+            {
+                yield return "stability " + verb + " - " + GetDescription(typeof(StabilitySubOptions), verb);
+                switch (verb)
+                {
+                    // Commands with one argument
+                    case "set":
+                        yield return $"{Properties.Resources.Usage}: ckan stability {verb} [{Properties.Resources.Options}] release_status";
+                        break;
+
+                    // Commands with only --flag type options
+                    case "list":
+                    default:
+                        yield return $"{Properties.Resources.Usage}: ckan stability {verb} [{Properties.Resources.Options}]";
+                        break;
+                }
+            }
+        }
+    }
+
+    public class StabilitySetOptions : InstanceSpecificOptions
+    {
+        [Option("mod", HelpText = "Identifier of mod to override")]
+        public string? Identifier { get; set; }
+
+        [ValueOption(0)]
+        public ReleaseStatus? Stability { get; set; }
+    }
+}

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -226,7 +226,7 @@ namespace CKAN.CmdLine
                     // The modules we'll have after upgrading as aggressively as possible
                     var limiters = identsAndVersions.Select(req => CkanModule.FromIDandVersion(registry, req, crit)
                                                                    ?? Utilities.DefaultIfThrows(
-                                                                       () => registry.LatestAvailable(req, crit))
+                                                                       () => registry.LatestAvailable(req, instance.StabilityToleranceConfig, crit))
                                                                    ?? registry.GetInstalledVersion(req))
                                                     .Concat(heldIdents.Select(ident => registry.GetInstalledVersion(ident)))
                                                     .OfType<CkanModule>()

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -115,6 +115,8 @@ namespace CKAN.CmdLine
                         case "filter":
                             return (new Filter()).RunSubCommand(manager, opts, new SubCommandOptions(args));
 
+                        case "stability":
+                            return (new Stability()).RunSubCommand(manager, opts, new SubCommandOptions(args));
                     }
                 }
             }

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -123,6 +123,9 @@ namespace CKAN.CmdLine
         [VerbOption("filter", HelpText = "View or edit installation filters")]
         public FilterSubOptions? Filter { get; set; }
 
+        [VerbOption("stability", HelpText = "View or edit stability settings")]
+        public StabilitySubOptions? Stability { get; set; }
+
         [HelpVerbOption]
         public string GetUsage(string verb)
         {

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -395,6 +395,11 @@ Proceeding with {0} in case it fixes it.</value></data>
   <data name="FilterRemoveGlobalNotFoundError" xml:space="preserve"><value>Global filters not found: {0}</value></data>
   <data name="FilterRemoveInstanceNotFoundError" xml:space="preserve"><value>Instance filters not found: {0}</value></data>
   <data name="FilterHelpSummary" xml:space="preserve"><value>View or edit installation filters</value></data>
+  <data name="StabilityUnknownCommand" xml:space="preserve"><value>Unknown command: stability {0}</value></data>
+  <data name="StabilityHelpSummary" xml:space="preserve"><value>View or edit stability settings</value></data>
+  <data name="StabilityOverallLabel" xml:space="preserve"><value>Overall stability tolerance: {0}</value></data>
+  <data name="StabilityListModHeader" xml:space="preserve"><value>Mod</value></data>
+  <data name="StabilityListStabilityHeader" xml:space="preserve"><value>Override</value></data>
   <data name="CompletionNotAvailable" xml:space="preserve"><value>
 No game instance selected, identifier completion not available.
 Use the `instance default` command to choose an instance.</value></data>

--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -210,7 +210,7 @@ namespace CKAN.ConsoleUI {
                     var regMgr = RegistryManager.Instance(ksp, repoData);
                     repoData.Prepopulate(regMgr.registry.Repositories.Values.ToList(),
                                          progress);
-                    var compat = regMgr.registry.CompatibleModules(ksp.VersionCriteria());
+                    var compat = regMgr.registry.CompatibleModules(ksp.StabilityToleranceConfig, ksp.VersionCriteria());
 
                 } catch (RegistryInUseKraken k) {
 

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -201,6 +201,7 @@
   <data name="InstanceAddExample" xml:space="preserve"><value>Example: {0}</value></data>
   <data name="InstanceAddTitle" xml:space="preserve"><value>Add Game Instance</value></data>
   <data name="InstanceEditTitle" xml:space="preserve"><value>Edit Game Instance</value></data>
+  <data name="InstanceEditStabilityToleranceHeader" xml:space="preserve"><value>Stability tolerance:</value></data>
   <data name="InstanceEditRepoFrameTitle" xml:space="preserve"><value>Mod List Sources</value></data>
   <data name="InstanceEditCompatFrameTitle" xml:space="preserve"><value>Additional Compatible Versions</value></data>
   <data name="InstanceEditRepoIndexHeader" xml:space="preserve"><value>Index</value></data>
@@ -251,6 +252,9 @@ Edit authentication tokens now?</value></data>
   <data name="ModInfoAuthors" xml:space="preserve"><value>By {0}</value></data>
   <data name="ModInfoLicence" xml:space="preserve"><value>Licence:</value></data>
   <data name="ModInfoDownload" xml:space="preserve"><value>Download:</value></data>
+  <data name="ModInfoInstall" xml:space="preserve"><value>Install:</value></data>
+  <data name="ModInfoStabilityToleranceHeader" xml:space="preserve"><value>Mod stability tolerance override:</value></data>
+  <data name="ModInfoStabilityToleranceNull" xml:space="preserve"><value>Do not override</value></data>
   <data name="ModInfoDescriptionFrame" xml:space="preserve"><value>Description</value></data>
   <data name="ModInfoUnavailableWarning" xml:space="preserve"><value>
 NOTE: This mod is installed but no longer available.

--- a/ConsoleUI/ReleaseStatusComboButtons.cs
+++ b/ConsoleUI/ReleaseStatusComboButtons.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+
+using CKAN.Extensions;
+using CKAN.ConsoleUI.Toolkit;
+
+namespace CKAN.ConsoleUI {
+
+    /// <summary>
+    /// Combo buttons for choosing release statuses
+    /// </summary>
+    public class ReleaseStatusComboButtons : ConsoleRadioButtons<ReleaseStatus?>
+    {
+        /// <param name="l">X coordinate of left edge</param>
+        /// <param name="t">Y coordinate of top edge</param>
+        /// <param name="header">Label to show above the list</param>
+        /// <param name="nullValueString">Allow null values if non-null and represent with this string</param>
+        /// <param name="value">Initially selected value</param>
+        public ReleaseStatusComboButtons(int l, int t,
+                                         string         header,
+                                         string?        nullValueString,
+                                         ReleaseStatus? value)
+            : base(l, t,
+                   l + UIWidth + nonNullOptions.Max(rs => baseRenderer(rs)?.Length ?? 0) - 1,
+                   t + nonNullOptions.Length + (nullValueString != null ? 1 : 0),
+                   header,
+                   (nullValueString != null ? nonNullOptions.Prepend(null)
+                                            : nonNullOptions)
+                       .ToArray(),
+                   value)
+        {
+            this.nullValueString = nullValueString;
+        }
+
+        /// <inheritdoc/>
+        protected override string Renderer(ReleaseStatus? rs)
+            => baseRenderer(rs) ?? nullValueString ?? "";
+
+        private static string? baseRenderer(ReleaseStatus? rs)
+            => rs.HasValue ? $"{rs.LocalizeName()} - {rs.LocalizeDescription()}"
+                           : null;
+
+        private readonly string? nullValueString;
+
+        private static readonly ReleaseStatus?[] nonNullOptions =
+            Enum.GetValues(typeof(ReleaseStatus))
+                .OfType<ReleaseStatus>()
+                .OrderBy(relStat => (int)relStat)
+                .OfType<ReleaseStatus?>()
+                .ToArray();
+    }
+}

--- a/ConsoleUI/Toolkit/ConsoleRadioButtons.cs
+++ b/ConsoleUI/Toolkit/ConsoleRadioButtons.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+
+namespace CKAN.ConsoleUI.Toolkit {
+
+    /// <summary>
+    /// A group of radio buttons that let the user choose one of several options
+    /// </summary>
+    /// <typeparam name="RowT">Type of object represented by each option</typeparam>
+    public class ConsoleRadioButtons<RowT> : ScreenObject {
+
+        /// <summary>
+        /// Initialize a radio button group
+        /// </summary>
+        /// <param name="l">X coordinate of left edge</param>
+        /// <param name="t">Y coordinate of top edge</param>
+        /// <param name="r">X coordinate of right edge</param>
+        /// <param name="b">Y coordinate of bottom edge</param>
+        /// <param name="header">Label to show above the list</param>
+        /// <param name="dataList">Values represented by the radio buttons</param>
+        /// <param name="value">Initially selected value</param>
+        public ConsoleRadioButtons(int l, int t, int r, int b,
+                                   string      header,
+                                   IList<RowT> dataList,
+                                   RowT        value)
+            : base(l, t, r, b)
+        {
+            rows          = dataList;
+            selectedRow   = rows.IndexOf(value);
+            this.header   = header;
+        }
+
+        /// <summary>
+        /// Fired when the user picks a different radio button
+        /// </summary>
+        public event Action? SelectionChanged;
+
+        /// <summary>
+        /// Currently selected row's object
+        /// </summary>
+        public RowT Selection => rows[selectedRow];
+
+        /// <summary>
+        /// Handle key bindings for the list box.
+        /// Mostly moving around wiht cursor keys.
+        /// </summary>
+        /// <param name="k">Key the user pressed</param>
+        public override void OnKeyPress(ConsoleKeyInfo k)
+        {
+            switch (k.Key) {
+                case ConsoleKey.UpArrow:
+                    if (selectedRow > 0) {
+                        --selectedRow;
+                        SelectionChanged?.Invoke();
+                    }
+                    break;
+                case ConsoleKey.DownArrow:
+                    if (selectedRow < rows.Count - 1) {
+                        ++selectedRow;
+                        SelectionChanged?.Invoke();
+                    }
+                    break;
+                case ConsoleKey.Home:
+                    selectedRow = 0;
+                    SelectionChanged?.Invoke();
+                    break;
+                case ConsoleKey.End:
+                    selectedRow = rows.Count - 1;
+                    SelectionChanged?.Invoke();
+                    break;
+                case ConsoleKey.Tab:
+                    Blur(!k.Modifiers.HasFlag(ConsoleModifiers.Shift));
+                    break;
+                default:
+                    // Go backwards if k.Modifiers.HasFlag(ConsoleModifiers.Shift)
+                    if (!char.IsControl(k.KeyChar)
+                            && (k.Modifiers | ConsoleModifiers.Shift) == ConsoleModifiers.Shift) {
+
+                        bool forward = !k.Modifiers.HasFlag(ConsoleModifiers.Shift);
+                        // Find first row after current, wrap
+                        int startRow = forward
+                            ? selectedRow + 1
+                            : selectedRow + rows.Count - 1;
+                        for (int i = 0; i < rows.Count; ++i) {
+                            int candidateRow = (forward
+                                ? startRow + i
+                                : startRow + rows.Count - i
+                            ) % rows.Count;
+                            if (nonAlphaNumPrefix.Replace(Renderer(rows[candidateRow]), "")
+                                                 .StartsWith($"{k.KeyChar}",
+                                                             StringComparison.CurrentCultureIgnoreCase)) {
+                                selectedRow = candidateRow;
+                                SelectionChanged?.Invoke();
+                                break;
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Move the screen cursor to the middle the active radio button
+        /// </summary>
+        public override void PlaceCursor()
+        {
+            Console.SetCursorPosition(GetLeft() + 2, GetTop() + selectedRow + 1);
+        }
+
+        /// <inheritdoc/>
+        public override void Draw(ConsoleTheme theme, bool focused)
+        {
+            int l = GetLeft(), r = GetRight(),
+                t = GetTop(),  b = GetBottom(),
+                w = r - l + 1;
+
+            // Prevent selection from running off the end of the list
+            if (selectedRow > rows.Count - 1) {
+                selectedRow = rows.Count - 1;
+            }
+
+            // Ensure selection is not before the top of the list
+            if (selectedRow < 0) {
+                selectedRow = 0;
+            }
+
+            Console.SetCursorPosition(l, t);
+            Console.BackgroundColor = theme.MainBg;
+            Console.ForegroundColor = theme.RadioButtonsHeaderFg;
+            Console.Write(FormatExactWidth(header, w));
+
+            Console.BackgroundColor = theme.RadioButtonsGroupBg;
+            Console.ForegroundColor = theme.RadioButtonsGroupFg;
+            for (int index = 0, y = t + 1; index < rows.Count && y <= b; ++index, ++y) {
+                Console.SetCursorPosition(l, y);
+                Console.Write(" ({0}) {1} ",
+                              index == selectedRow ? Symbols.dot : " ",
+                              FormatExactWidth(Renderer(rows[index]), w - UIWidth));
+            }
+        }
+
+        /// <summary>
+        /// The number of extra characters we draw per line in addition to the value strings
+        /// </summary>
+        protected const int UIWidth = 6;
+
+        /// <summary>
+        /// Generate a display string for a given row
+        /// </summary>
+        /// <param name="row">The row to display</param>
+        /// <returns>A string representing the given row</returns>
+        protected virtual string Renderer(RowT row) => row?.ToString() ?? "";
+
+        private readonly IList<RowT> rows;
+        private          int         selectedRow;
+        private readonly string      header;
+
+        private static readonly Regex nonAlphaNumPrefix =
+            new Regex("^[^a-zA-Z0-9]*",
+                      RegexOptions.Compiled);
+    }
+}

--- a/ConsoleUI/Toolkit/ConsoleTextBox.cs
+++ b/ConsoleUI/Toolkit/ConsoleTextBox.cs
@@ -238,16 +238,36 @@ namespace CKAN.ConsoleUI.Toolkit {
             }
         }
 
-        /// <summary>
-        /// Tell the container we can't receive focus
-        /// </summary>
-        public override bool Focusable() { return false; }
+        /// <inheritdoc/>
+        public override bool Focusable() => needScroll;
 
-        private bool         needScroll = false;
-        private int          prevTextW;
-        private readonly bool         scrollToBottom;
-        private int          topLine;
-        private readonly TextAlign    align;
+        /// <inheritdoc/>
+        public override void PlaceCursor()
+        {
+            Console.SetCursorPosition(GetLeft(), GetTop());
+        }
+
+        /// <inheritdoc/>
+        public override void OnKeyPress(ConsoleKeyInfo k)
+        {
+            switch (k.Key) {
+                case ConsoleKey.Home:      ScrollToTop();    break;
+                case ConsoleKey.End:       ScrollToBottom(); break;
+                case ConsoleKey.PageUp:    ScrollUp();       break;
+                case ConsoleKey.PageDown:  ScrollDown();     break;
+                case ConsoleKey.UpArrow:   ScrollUp(1);      break;
+                case ConsoleKey.DownArrow: ScrollDown(1);    break;
+                case ConsoleKey.Tab:
+                    Blur(!k.Modifiers.HasFlag(ConsoleModifiers.Shift));
+                    break;
+            }
+        }
+
+        private          bool      needScroll = false;
+        private          int       prevTextW;
+        private readonly bool      scrollToBottom;
+        private          int       topLine;
+        private readonly TextAlign align;
         private readonly SynchronizedCollection<string> lines = new SynchronizedCollection<string>();
         private readonly SynchronizedCollection<string> displayLines = new SynchronizedCollection<string>();
         private readonly Func<ConsoleTheme, ConsoleColor>? getBgColor;

--- a/ConsoleUI/Toolkit/ConsoleTheme.cs
+++ b/ConsoleUI/Toolkit/ConsoleTheme.cs
@@ -29,22 +29,22 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Background color for exit screen
         /// </summary>
         public ConsoleColor? ExitOuterBg;
-        
+
         /// <summary>
         /// Background color for info pane of exit screen
         /// </summary>
         public ConsoleColor ExitInnerBg;
-        
+
         /// <summary>
         /// Foreground color for normal text on exit screen
         /// </summary>
         public ConsoleColor ExitNormalFg;
-        
+
         /// <summary>
         /// Foreground color for highlighted text on exit screen
         /// </summary>
         public ConsoleColor ExitHighlightFg;
-        
+
         /// <summary>
         /// Foreground color for links on exit screen
         /// </summary>
@@ -135,6 +135,19 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Foreground for list box selected row
         /// </summary>
         public ConsoleColor ListBoxSelectedFg;
+
+        /// <summary>
+        /// Text color for the label above a radio buttons group
+        /// </summary>
+        public ConsoleColor RadioButtonsHeaderFg;
+        /// <summary>
+        /// Background for radio buttons group
+        /// </summary>
+        public ConsoleColor RadioButtonsGroupBg;
+        /// <summary>
+        /// Foreground for radio buttons group
+        /// </summary>
+        public ConsoleColor RadioButtonsGroupFg;
 
         /// <summary>
         /// Background for scroll bars
@@ -246,7 +259,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// Foreground for important/abnormal box frames
         /// </summary>
         public ConsoleColor AlertFrameFg;
-        
+
         /// <summary>
         /// Available themes
         /// </summary>
@@ -282,6 +295,9 @@ namespace CKAN.ConsoleUI.Toolkit {
                     ListBoxUnselectedFg    = ConsoleColor.Black,
                     ListBoxSelectedBg      = ConsoleColor.DarkGreen,
                     ListBoxSelectedFg      = ConsoleColor.White,
+                    RadioButtonsHeaderFg   = ConsoleColor.Gray,
+                    RadioButtonsGroupBg    = ConsoleColor.DarkCyan,
+                    RadioButtonsGroupFg    = ConsoleColor.Black,
                     ScrollBarBg            = ConsoleColor.DarkBlue,
                     ScrollBarFg            = ConsoleColor.DarkCyan,
                     MenuBg                 = ConsoleColor.Gray,
@@ -340,6 +356,9 @@ namespace CKAN.ConsoleUI.Toolkit {
                     ListBoxUnselectedFg    = ConsoleColor.DarkGreen,
                     ListBoxSelectedBg      = ConsoleColor.Black,
                     ListBoxSelectedFg      = ConsoleColor.Green,
+                    RadioButtonsHeaderFg   = ConsoleColor.DarkGreen,
+                    RadioButtonsGroupBg    = ConsoleColor.Black,
+                    RadioButtonsGroupFg    = ConsoleColor.DarkGreen,
                     ScrollBarBg            = ConsoleColor.Black,
                     ScrollBarFg            = ConsoleColor.DarkGreen,
                     MenuBg                 = ConsoleColor.DarkGreen,

--- a/ConsoleUI/Toolkit/ScreenObject.cs
+++ b/ConsoleUI/Toolkit/ScreenObject.cs
@@ -147,19 +147,19 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <returns>
         /// X coordinate of left edge of dialog
         /// </returns>
-        protected int GetLeft()   { return Formatting.ConvertCoord(left,   Console.WindowWidth);  }
+        protected int GetLeft()   => Formatting.ConvertCoord(left,   Console.WindowWidth);
         /// <returns>
         /// Y coordinate of top edge of dialog
         /// </returns>
-        protected int GetTop()    { return Formatting.ConvertCoord(top,    Console.WindowHeight); }
+        protected int GetTop()    => Formatting.ConvertCoord(top,    Console.WindowHeight);
         /// <returns>
         /// X coordinate of right edge of dialog
         /// </returns>
-        protected int GetRight()  { return Formatting.ConvertCoord(right,  Console.WindowWidth);  }
+        protected int GetRight()  => Formatting.ConvertCoord(right,  Console.WindowWidth);
         /// <returns>
         /// Y coordinate of bottom edge of dialog
         /// </returns>
-        protected int GetBottom() { return Formatting.ConvertCoord(bottom, Console.WindowHeight); }
+        protected int GetBottom() => Formatting.ConvertCoord(bottom, Console.WindowHeight);
 
         /// <summary>
         /// Draw the UI element
@@ -171,7 +171,7 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// <summary>
         /// Return whether the UI element can accept focus
         /// </summary>
-        public virtual bool Focusable() { return true; }
+        public virtual bool Focusable() => true;
         /// <summary>
         /// Place focus based on the UI element's positioning
         /// </summary>

--- a/Core/Configuration/CompatibleGameVersions.cs
+++ b/Core/Configuration/CompatibleGameVersions.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 using Newtonsoft.Json;
 
-namespace CKAN
+namespace CKAN.Configuration
 {
     [JsonConverter(typeof(CompatibleGameVersionsConverter))]
     public class CompatibleGameVersions

--- a/Core/Configuration/IConfiguration.cs
+++ b/Core/Configuration/IConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -71,5 +72,7 @@ namespace CKAN.Configuration
         /// true if user wants to use nightly builds from S3, false to use releases from GitHub
         /// </summary>
         bool? DevBuilds { get; set; }
+
+        event PropertyChangedEventHandler? PropertyChanged;
     }
 }

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +7,7 @@ using System.Linq;
 using System.Runtime.Versioning;
 #endif
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 using Newtonsoft.Json;
 
@@ -69,6 +71,8 @@ namespace CKAN.Configuration
             configFile = newConfig ?? defaultConfigFile;
             LoadConfig();
         }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         // The standard location of the config file. Where this actually points is platform dependent,
         // but it's the same place as the downloads folder. The location can be overwritten with the
@@ -216,6 +220,8 @@ namespace CKAN.Configuration
             {
                 config.GlobalInstallFilters = value;
                 SaveConfig();
+                // Refresh the Contents tab
+                OnPropertyChanged();
             }
         }
 
@@ -240,6 +246,11 @@ namespace CKAN.Configuration
                 config.DevBuilds = value;
                 SaveConfig();
             }
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
         // <summary>

--- a/Core/Configuration/StabilityToleranceConfig.cs
+++ b/Core/Configuration/StabilityToleranceConfig.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+using Newtonsoft.Json;
+
+namespace CKAN.Configuration
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class StabilityToleranceConfig
+    {
+        public StabilityToleranceConfig(string path)
+        {
+            this.path = path;
+            try
+            {
+                JsonConvert.PopulateObject(File.ReadAllText(this.path), this);
+            }
+            catch
+            {
+                // File doesn't exist yet, we can create it at save
+            }
+        }
+
+        public bool Save()
+        {
+            try
+            {
+                File.WriteAllText(path, JsonConvert.SerializeObject(this, Formatting.Indented));
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public ReleaseStatus? ModStabilityTolerance(string identifier)
+            => modStabilityTolerance.TryGetValue(identifier, out ReleaseStatus relStat)
+                   ? relStat
+                   : null;
+
+        public void SetModStabilityTolerance(string identifier, ReleaseStatus? relStat)
+        {
+            if (relStat is ReleaseStatus rs)
+            {
+                modStabilityTolerance[identifier] = rs;
+            }
+            else
+            {
+                modStabilityTolerance.Remove(identifier);
+            }
+            Changed?.Invoke(identifier, relStat);
+            Save();
+        }
+
+        public ReleaseStatus OverallStabilityTolerance
+        {
+            get => overallStabilityTolerance;
+            set
+            {
+                overallStabilityTolerance = value;
+                Save();
+                Changed?.Invoke(null, value);
+            }
+        }
+
+        public ICollection<string> OverriddenModIdentifiers => modStabilityTolerance.Keys;
+
+        public event Action<string?, ReleaseStatus?>? Changed;
+
+        [JsonProperty("overall_stability_tolerance", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(ReleaseStatus.stable)]
+        private ReleaseStatus overallStabilityTolerance = ReleaseStatus.stable;
+
+        [JsonProperty("mod_stability_tolerance", NullValueHandling = NullValueHandling.Ignore)]
+        private readonly SortedDictionary<string, ReleaseStatus> modStabilityTolerance =
+            new SortedDictionary<string, ReleaseStatus>();
+
+        [JsonIgnore]
+        private readonly string path;
+    }
+}

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System.Diagnostics.CodeAnalysis;
+using System.ComponentModel;
+
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -190,6 +192,10 @@ namespace CKAN.Configuration
         /// Not implemented because the Windows registry is deprecated
         /// </summary>
         public bool? DevBuilds { get; set; }
+
+        #pragma warning disable CS0067
+        public event PropertyChangedEventHandler? PropertyChanged;
+        #pragma warning restore CS0067
 
         public static bool DoesRegistryConfigurationExist()
         {

--- a/Core/Converters/JsonReleaseStatusConverter.cs
+++ b/Core/Converters/JsonReleaseStatusConverter.cs
@@ -1,0 +1,27 @@
+using System;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CKAN
+{
+    public class JsonReleaseStatusConverter : StringEnumConverter
+    {
+        public override object? ReadJson(JsonReader     reader,
+                                         Type           objectType,
+                                         object?        existingValue,
+                                         JsonSerializer serializer)
+            => reader.Value?.ToString() switch
+            {
+                "alpha" => ReleaseStatus.development,
+                "beta"  => ReleaseStatus.testing,
+                null    => ReleaseStatus.stable,
+                ""      => throw new JsonException("Empty release_status string"),
+                _       => base.ReadJson(reader, objectType,
+                                         existingValue, serializer),
+            };
+
+        public override bool CanWrite => true;
+        public override bool CanConvert(Type object_type) => false;
+    }
+}

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -11,9 +11,7 @@ namespace CKAN.Extensions
     public static class EnumerableExtensions
     {
         public static ICollection<T> AsCollection<T>(this IEnumerable<T> source)
-            => source == null
-                ? throw new ArgumentNullException(nameof(source))
-                : source is ICollection<T> collection ? collection : source.ToArray();
+            => source is ICollection<T> collection ? collection : source.ToArray();
 
 #if NET45 || NETSTANDARD2_0
 
@@ -23,14 +21,7 @@ namespace CKAN.Extensions
         internal
         #endif
         static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            return new HashSet<T>(source);
-        }
+            => new HashSet<T>(source);
 
         #if NET45
         public
@@ -38,15 +29,8 @@ namespace CKAN.Extensions
         internal
         #endif
         static HashSet<T> ToHashSet<T>(this IEnumerable<T>  source,
-                                              IEqualityComparer<T> comparer)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            return new HashSet<T>(source, comparer);
-        }
+                                       IEqualityComparer<T> comparer)
+            => new HashSet<T>(source, comparer);
 
 #endif
 
@@ -99,21 +83,10 @@ namespace CKAN.Extensions
         }
 
         public static IEnumerable<T> Memoize<T>(this IEnumerable<T> source)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            else if (source is Memoized<T>)
-            {
-                // Already memoized, don't wrap another layer
-                return source;
-            }
-            else
-            {
-                return new Memoized<T>(source);
-            }
-        }
+            => source is Memoized<T>
+                   // Already memoized, don't wrap another layer
+                   ? source
+                   : new Memoized<T>(source);
 
         public static void RemoveWhere<K, V>(this Dictionary<K, V> source,
                                              Func<KeyValuePair<K, V>, bool> predicate) where K: class

--- a/Core/Extensions/I18nExtensions.cs
+++ b/Core/Extensions/I18nExtensions.cs
@@ -8,12 +8,20 @@ namespace CKAN.Extensions
     public static class I18nExtensions
     {
 
-        public static string Localize(this Enum val)
+        public static string LocalizeDescription(this Enum val)
             => val.GetType()
                   ?.GetMember(val.ToString())
                   ?.First()
                    .GetCustomAttribute<DisplayAttribute>()
                   ?.GetDescription()
+                  ?? "";
+
+        public static string LocalizeName(this Enum val)
+            => val.GetType()
+                  ?.GetMember(val.ToString())
+                  ?.First()
+                   .GetCustomAttribute<DisplayAttribute>()
+                  ?.GetName()
                   ?? "";
 
     }

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -11,6 +11,7 @@ using ChinhDo.Transactions.FileManager;
 using log4net;
 using Newtonsoft.Json;
 
+using CKAN.Configuration;
 using CKAN.Games;
 using CKAN.Versioning;
 
@@ -207,6 +208,14 @@ namespace CKAN
         }
 
         private string InstallFiltersFile => Path.Combine(CkanDir(), "install_filters.json");
+
+        public StabilityToleranceConfig StabilityToleranceConfig
+            => stabilityToleranceConfig ??= new StabilityToleranceConfig(StabilityToleranceFile);
+
+        private StabilityToleranceConfig? stabilityToleranceConfig;
+
+        private string StabilityToleranceFile
+            => Path.Combine(CkanDir(), "stability_tolerance.json");
 
         #endregion
 

--- a/Core/Meta.cs
+++ b/Core/Meta.cs
@@ -20,6 +20,11 @@ namespace CKAN
 
         public static readonly ModuleVersion ReleaseVersion = new ModuleVersion(GetVersion());
 
+        public static bool IsNetKAN
+            => Assembly.GetExecutingAssembly()
+                       .GetAssemblyAttribute<AssemblyTitleAttribute>()
+                       .Title.Contains("NetKAN");
+
         public static string GetVersion(VersionFormat format = VersionFormat.Normal)
         {
             var version = Assembly

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -341,4 +341,10 @@ Free up space on that device or change your settings to use another location.
   <data name="ModpackName" xml:space="preserve"><value>installed-{0}</value></data>
   <data name="InstalledModuleToString" xml:space="preserve"><value>{0} (installed {1})</value></data>
   <data name="InstalledModuleToStringAutoInstalled" xml:space="preserve"><value>{0} (installed {1}, auto-installed)</value></data>
+  <data name="ReleaseStatusStableName" xml:space="preserve"><value>Stable</value></data>
+  <data name="ReleaseStatusStableDescription" xml:space="preserve"><value>Normal releases</value></data>
+  <data name="ReleaseStatusTestingName" xml:space="preserve"><value>Testing</value></data>
+  <data name="ReleaseStatusTestingDescription" xml:space="preserve"><value>Pre-releases for adventurous users</value></data>
+  <data name="ReleaseStatusDevelopmentName" xml:space="preserve"><value>Development</value></data>
+  <data name="ReleaseStatusDevelopmentDescription" xml:space="preserve"><value>Bleeding edge unstable</value></data>
 </root>

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using log4net;
 
+using CKAN.Configuration;
 using CKAN.Games;
 using CKAN.Versioning;
 using CKAN.Extensions;
@@ -55,7 +56,9 @@ namespace CKAN
                            .Except(modulesToInstall.Select(m => m.identifier))
                            .ToHashSet();
             resolved = new ResolvedRelationshipsTree(toInst, registry, dlls,
-                                                     installed_modules, versionCrit,
+                                                     installed_modules,
+                                                     options.stability_tolerance ?? new StabilityToleranceConfig(""),
+                                                     versionCrit,
                                                      options.OptionalHandling());
             if (!options.proceed_with_inconsistencies)
             {
@@ -557,7 +560,8 @@ namespace CKAN
         public ParallelQuery<KeyValuePair<CkanModule, HashSet<string>>> Supporters(
             HashSet<CkanModule>     supported,
             IEnumerable<CkanModule> toExclude)
-            => registry.CompatibleModules(versionCrit)
+            => registry.CompatibleModules(options.stability_tolerance ?? new StabilityToleranceConfig(""),
+                                          versionCrit)
                        .Except(toExclude)
                        .AsParallel()
                        // Find installable modules with "supports" relationships

--- a/Core/Relationships/RelationshipResolverOptions.cs
+++ b/Core/Relationships/RelationshipResolverOptions.cs
@@ -1,3 +1,5 @@
+using CKAN.Configuration;
+
 namespace CKAN
 {
     // TODO: It would be lovely to get rid of the `without` fields,
@@ -5,17 +7,22 @@ namespace CKAN
     // cases in their heads.
     public class RelationshipResolverOptions
     {
+        public RelationshipResolverOptions(StabilityToleranceConfig stabTolCfg)
+        {
+            stability_tolerance = stabTolCfg;
+        }
+
         /// <summary>
         /// Default options for relationship resolution.
         /// </summary>
-        public static RelationshipResolverOptions DefaultOpts()
-            => new RelationshipResolverOptions();
+        public static RelationshipResolverOptions DefaultOpts(StabilityToleranceConfig stabTolCfg)
+            => new RelationshipResolverOptions(stabTolCfg);
 
         /// <summary>
         /// Options to install without recommendations.
         /// </summary>
-        public static RelationshipResolverOptions DependsOnlyOpts()
-            => new RelationshipResolverOptions()
+        public static RelationshipResolverOptions DependsOnlyOpts(StabilityToleranceConfig stabTolCfg)
+            => new RelationshipResolverOptions(stabTolCfg)
             {
                 with_recommends   = false,
                 with_suggests     = false,
@@ -27,8 +34,8 @@ namespace CKAN
         /// of anything in the changeset (except when suppress_recommendations==true),
         /// without throwing exceptions, so the calling code can decide what to do about conflicts
         /// </summary>
-        public static RelationshipResolverOptions KitchenSinkOpts()
-            => new RelationshipResolverOptions()
+        public static RelationshipResolverOptions KitchenSinkOpts(StabilityToleranceConfig stabTolCfg)
+            => new RelationshipResolverOptions(stabTolCfg)
             {
                 with_recommends                = true,
                 with_suggests                  = true,
@@ -38,8 +45,8 @@ namespace CKAN
                 get_recommenders               = true,
             };
 
-        public static RelationshipResolverOptions ConflictsOpts()
-            => new RelationshipResolverOptions()
+        public static RelationshipResolverOptions ConflictsOpts(StabilityToleranceConfig stabTolCfg)
+            => new RelationshipResolverOptions(stabTolCfg)
             {
                 without_toomanyprovides_kraken = true,
                 proceed_with_inconsistencies   = true,
@@ -100,6 +107,11 @@ namespace CKAN
         /// ModuleRelationshipDescriptor.suppress_recommendations==true
         /// </summary>
         public bool get_recommenders = false;
+
+        /// <summary>
+        /// The least stable category of mods to allow
+        /// </summary>
+        public StabilityToleranceConfig? stability_tolerance;
 
         public RelationshipResolverOptions OptionsFor(RelationshipDescriptor descr)
             => descr.suppress_recommendations ? WithoutRecommendations() : this;

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 
+using CKAN.Configuration;
 using CKAN.Versioning;
 
 namespace CKAN
@@ -135,22 +136,23 @@ namespace CKAN
         {
         }
 
-        public ResolvedByNew(CkanModule              source,
-                             RelationshipDescriptor  relationship,
-                             SelectionReason         reason,
-                             IEnumerable<CkanModule> providers,
-                             ICollection<CkanModule> definitelyInstalling,
-                             ICollection<CkanModule> allInstalling,
-                             IRegistryQuerier        registry,
-                             ICollection<string>     dlls,
-                             ICollection<CkanModule> installed,
-                             GameVersionCriteria     crit,
-                             OptionalRelationships   optRels,
-                             RelationshipCache       relationshipCache)
+        public ResolvedByNew(CkanModule               source,
+                             RelationshipDescriptor   relationship,
+                             SelectionReason          reason,
+                             IEnumerable<CkanModule>  providers,
+                             ICollection<CkanModule>  definitelyInstalling,
+                             ICollection<CkanModule>  allInstalling,
+                             IRegistryQuerier         registry,
+                             ICollection<string>      dlls,
+                             ICollection<CkanModule>  installed,
+                             StabilityToleranceConfig stabilityTolerance,
+                             GameVersionCriteria      crit,
+                             OptionalRelationships    optRels,
+                             RelationshipCache        relationshipCache)
              : this(source, relationship, reason,
                     providers.ToDictionary(prov => prov,
                                            prov => ResolvedRelationshipsTree.ResolveModule(
-                                                       prov, definitelyInstalling, allInstalling, registry, dlls, installed, crit,
+                                                       prov, definitelyInstalling, allInstalling, registry, dlls, installed, stabilityTolerance, crit,
                                                        relationship.suppress_recommendations
                                                            ? optRels & ~OptionalRelationships.Recommendations
                                                                      & ~OptionalRelationships.Suggestions

--- a/Core/Repositories/ReadProgressStream.cs
+++ b/Core/Repositories/ReadProgressStream.cs
@@ -40,12 +40,6 @@ namespace CKAN
     {
         protected ContainerStream(Stream stream)
         {
-            if (stream == null)
-            {
-                #pragma warning disable IDE0016
-                throw new ArgumentNullException(nameof(stream));
-                #pragma warning restore IDE0016
-            }
             inner = stream;
         }
 

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -116,8 +116,11 @@ namespace CKAN
         [JsonConverter(typeof(JsonRelationshipConverter))]
         public List<RelationshipDescriptor>? recommends;
 
-        [JsonProperty("release_status", Order = 14, NullValueHandling = NullValueHandling.Ignore)]
-        public ReleaseStatus? release_status;
+        [JsonProperty("release_status", Order = 14,
+                      NullValueHandling = NullValueHandling.Ignore,
+                      DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [DefaultValue(ReleaseStatus.stable)]
+        public ReleaseStatus? release_status = ReleaseStatus.stable;
 
         [JsonProperty("resources", Order = 15, NullValueHandling = NullValueHandling.Ignore)]
         public ResourcesDescriptor? resources;
@@ -354,6 +357,15 @@ namespace CKAN
                 throw new BadMetadataKraken(null,
                                             string.Format(Properties.Resources.CkanModuleMissingRequired,
                                                           identifier, "download"));
+            }
+            if (release_status is not (ReleaseStatus.stable
+                                       or ReleaseStatus.development
+                                       or ReleaseStatus.testing))
+            {
+                throw new BadMetadataKraken(
+                    null,
+                    string.Format(Properties.Resources.ReleaseStatusInvalid,
+                                  release_status));
             }
         }
 
@@ -668,7 +680,7 @@ namespace CKAN
         /// Returns true if we support at least spec_version of the CKAN spec.
         /// </summary>
         internal static bool IsSpecSupported(ModuleVersion spec_version)
-            => Meta.ReleaseVersion.IsGreaterThan(spec_version);
+            => Meta.IsNetKAN || Meta.ReleaseVersion.IsGreaterThan(spec_version);
 
         /// <summary>
         /// Returns true if we support the CKAN spec used by this module.

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 
 using Newtonsoft.Json;
 
+using CKAN.Configuration;
 using CKAN.Games;
 using CKAN.Versioning;
 using CKAN.Extensions;
@@ -26,11 +27,13 @@ namespace CKAN
         public abstract bool WithinBounds(CkanModule otherModule);
 
         public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier         registry,
+                                                                     StabilityToleranceConfig stabilityTolerance,
                                                                      GameVersionCriteria?     crit,
                                                                      ICollection<CkanModule>? installed = null,
                                                                      ICollection<CkanModule>? toInstall = null);
 
         public abstract CkanModule? ExactMatch(IRegistryQuerier         registry,
+                                               StabilityToleranceConfig stabilityTolerance,
                                                GameVersionCriteria?     crit,
                                                ICollection<CkanModule>? installed = null,
             ICollection<CkanModule>? toInstall = null);
@@ -146,16 +149,20 @@ namespace CKAN
         }
 
         public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier         registry,
+                                                                     StabilityToleranceConfig stabilityTolerance,
                                                                      GameVersionCriteria?     crit,
                                                                      ICollection<CkanModule>? installed = null,
                                                                      ICollection<CkanModule>? toInstall = null)
-            => registry.LatestAvailableWithProvides(name, crit, this, installed, toInstall);
+            => registry.LatestAvailableWithProvides(name, stabilityTolerance,
+                                                    crit, this, installed, toInstall);
 
         public override CkanModule? ExactMatch(IRegistryQuerier         registry,
+                                               StabilityToleranceConfig stabilityTolerance,
                                                GameVersionCriteria?     crit,
                                                ICollection<CkanModule>? installed = null,
                                                ICollection<CkanModule>? toInstall = null)
-            => Utilities.DefaultIfThrows(() => registry.LatestAvailable(name, crit, this, installed, toInstall));
+            => Utilities.DefaultIfThrows(() => registry.LatestAvailable(name, stabilityTolerance,
+                                                                        crit, this, installed, toInstall));
 
         public override bool Equals(RelationshipDescriptor? other)
             => Equals(other as ModuleRelationshipDescriptor);
@@ -250,16 +257,18 @@ namespace CKAN
         }
 
         public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier         registry,
+                                                                     StabilityToleranceConfig stabilityTolerance,
                                                                      GameVersionCriteria?     crit,
                                                                      ICollection<CkanModule>? installed = null,
                                                                      ICollection<CkanModule>? toInstall = null)
-            => (any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, crit, installed, toInstall))
+            => (any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, stabilityTolerance, crit, installed, toInstall))
                        .Distinct()
                       ?? Enumerable.Empty<CkanModule>())
                       .ToList();
 
         // Exact match is not possible for any_of
         public override CkanModule? ExactMatch(IRegistryQuerier         registry,
+                                               StabilityToleranceConfig stabilityTolerance,
                                                GameVersionCriteria?     crit,
                                                ICollection<CkanModule>? installed = null,
                                                ICollection<CkanModule>? toInstall = null)

--- a/Core/Types/ReleaseStatus.cs
+++ b/Core/Types/ReleaseStatus.cs
@@ -1,61 +1,23 @@
-using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 using Newtonsoft.Json;
 
 namespace CKAN
 {
-    /// <summary>
-    /// A release status, complying to the CKAN spec.
-    /// </summary>
-    [JsonConverter(typeof(JsonSimpleStringConverter))]
-    public class ReleaseStatus
+    [JsonConverter(typeof(JsonReleaseStatusConverter))]
+    public enum ReleaseStatus
     {
-        private static readonly HashSet<string> valid_statuses = new HashSet<string> {
-            "stable", "testing", "development" // Spec 1.0 statuses
-        };
-
-        private readonly string status;
-
-        /// <summary>
-        /// Creates a ReleaseStatus object which compiles to the CKAN spec.
-        /// Throws a BadMetadataKraken if passed a non-compliant string.
-        /// </summary>
-        /// <param name="status">Status.</param>
-        public ReleaseStatus(string? status)
-        {
-            switch (status)
-            {
-                // As per the spec, if the status is null, we assume stable.
-                case null:
-                    status = "stable";
-                    break;
-
-                // For compatibility with older metadata, we map 'alpha' and 'beta'
-                // to 'development' and 'testing'.
-
-                case "alpha":
-                    status = "development";
-                    break;
-
-                case "beta":
-                    status = "testing";
-                    break;
-            }
-
-            if (!valid_statuses.Contains(status))
-            {
-                throw new BadMetadataKraken(
-                    null,
-                    string.Format(Properties.Resources.ReleaseStatusInvalid, status)
-                );
-            }
-
-            this.status = status;
-        }
-
-        public override string ToString()
-        {
-            return status;
-        }
+        [Display(Name         = "ReleaseStatusStableName",
+                 Description  = "ReleaseStatusStableDescription",
+                 ResourceType = typeof(Properties.Resources))]
+        stable      = 0,
+        [Display(Name         = "ReleaseStatusTestingName",
+                 Description  = "ReleaseStatusTestingDescription",
+                 ResourceType = typeof(Properties.Resources))]
+        testing     = 1,
+        [Display(Name         = "ReleaseStatusDevelopmentName",
+                 Description  = "ReleaseStatusDevelopmentDescription",
+                 ResourceType = typeof(Properties.Resources))]
+        development = 2,
     }
 }

--- a/Core/Types/SpecVersionAnalyzer.cs
+++ b/Core/Types/SpecVersionAnalyzer.cs
@@ -14,7 +14,10 @@ namespace CKAN
 
         public static ModuleVersion MinimumSpecVersion(JObject json)
             // Add new stuff at the top, versions in this function should be in descending order
-            => json["download_hash"] is JObject hashes
+            => json.TryGetValue("release_status", out JToken? relStat)
+               && (string?)relStat is string and not "stable" ? v1p36
+
+             : json["download_hash"] is JObject hashes
                && (!hashes.ContainsKey("sha256") || !hashes.ContainsKey("sha1")) ? v1p35
 
              : json["download"] is JArray ? v1p34
@@ -123,5 +126,6 @@ namespace CKAN
         private static readonly ModuleVersion v1p31 = new ModuleVersion("v1.31");
         private static readonly ModuleVersion v1p34 = new ModuleVersion("v1.34");
         private static readonly ModuleVersion v1p35 = new ModuleVersion("v1.35");
+        private static readonly ModuleVersion v1p36 = new ModuleVersion("v1.36");
     }
 }

--- a/Core/Versioning/GameVersion.cs
+++ b/Core/Versioning/GameVersion.cs
@@ -323,13 +323,8 @@ namespace CKAN.Versioning
         /// A <see cref="GameVersion"/> object that is equivalent to the version number specified in the
         /// <see cref="input"/> parameter.
         /// </returns>
-        public static GameVersion Parse(string? input)
+        public static GameVersion Parse(string input)
         {
-            if (input is null)
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
-
             if (TryParse(input, out GameVersion? result) && result is not null)
             {
                 return result;

--- a/Core/Versioning/GameVersionBound.cs
+++ b/Core/Versioning/GameVersionBound.cs
@@ -111,21 +111,11 @@ namespace CKAN.Versioning
         /// </summary>
         /// <param name="versionBounds">The set of <see cref="GameVersionBound"/> objects to compare.</param>
         /// <returns>The lowest value in <see cref="versionBounds"/>.</returns>
-        public static GameVersionBound Lowest(params GameVersionBound?[] versionBounds)
+        public static GameVersionBound Lowest(params GameVersionBound[] versionBounds)
         {
-            if (versionBounds == null)
-            {
-                throw new ArgumentNullException(nameof(versionBounds));
-            }
-
             if (!versionBounds.Any())
             {
                 throw new ArgumentException("Value cannot be empty.", nameof(versionBounds));
-            }
-
-            if (versionBounds.Contains(null))
-            {
-                throw new ArgumentException("Value cannot contain null.", nameof(versionBounds));
             }
 
             return versionBounds.OfType<GameVersionBound>()

--- a/Core/Versioning/ModuleVersion.cs
+++ b/Core/Versioning/ModuleVersion.cs
@@ -591,19 +591,7 @@ namespace CKAN.Versioning
         /// particular instance will be returned.
         /// </remarks>
         public static ModuleVersion Max(ModuleVersion ver1, ModuleVersion ver2)
-        {
-            if (ver1 == null)
-            {
-                throw new ArgumentNullException(nameof(ver1));
-            }
-
-            if (ver2 == null)
-            {
-                throw new ArgumentNullException(nameof(ver2));
-            }
-
-            return ver1.IsGreaterThan(ver2) ? ver1 : ver2;
-        }
+            => ver1.IsGreaterThan(ver2) ? ver1 : ver2;
 
         /// <summary>
         /// Returns the smaller of two <see cref="ModuleVersion"/> objects.
@@ -616,19 +604,7 @@ namespace CKAN.Versioning
         /// particular instance will be returned.
         /// </remarks>
         public static ModuleVersion Min(ModuleVersion ver1, ModuleVersion ver2)
-        {
-            if (ver1 == null)
-            {
-                throw new ArgumentNullException(nameof(ver1));
-            }
-
-            if (ver2 == null)
-            {
-                throw new ArgumentNullException(nameof(ver2));
-            }
-
-            return ver1.IsLessThan(ver2) ? ver1 : ver2;
-        }
+            => ver1.IsLessThan(ver2) ? ver1 : ver2;
 
         /// <summary>
         /// Converts the specified string to a new instance of the <see cref="ModuleVersion"/> class.

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -161,7 +161,7 @@ namespace CKAN.GUI
         public readonly string?      Conflict     = null;
 
         public string Mod         => Change.NameAndStatus ?? "";
-        public string ChangeType  => Change.ChangeType.Localize();
+        public string ChangeType  => Change.ChangeType.LocalizeDescription();
         public string Reasons     { get; private set; }
         public Bitmap DeleteImage => Change.IsRemovable ? EmbeddedImages.textClear ?? EmptyBitmap
                                                         : EmptyBitmap;

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -133,7 +133,8 @@ namespace CKAN.GUI
 
         private void MarkConflicts()
         {
-            if (registry != null && versionCrit != null && game != null)
+            if (registry != null && versionCrit != null && game != null
+                && Main.Instance?.CurrentInstance is GameInstance inst)
             {
                 try
                 {
@@ -145,7 +146,8 @@ namespace CKAN.GUI
                                                .Concat(toInstall)
                                                .Distinct(),
                         toUninstall,
-                        RelationshipResolverOptions.ConflictsOpts(), registry, game, versionCrit);
+                        RelationshipResolverOptions.ConflictsOpts(inst.StabilityToleranceConfig),
+                        registry, game, versionCrit);
                     var conflicts = resolver.ConflictList;
                     foreach (var item in RecommendedModsListView.Items.Cast<ListViewItem>()
                         // Apparently ListView handes AddRange by:

--- a/GUI/Controls/InstallationHistory.cs
+++ b/GUI/Controls/InstallationHistory.cs
@@ -185,21 +185,25 @@ namespace CKAN.GUI
         // Registry.LatestAvailable without exceptions
         private CkanModule? SaneLatestAvail(string identifier)
         {
-            try
+            if (inst != null)
             {
-                return registry?.LatestAvailable(identifier, inst?.VersionCriteria());
-            }
-            catch
-            {
+                var stabilityTolerance = inst.StabilityToleranceConfig;
                 try
                 {
-                    return registry?.LatestAvailable(identifier, null);
+                    return registry?.LatestAvailable(identifier, stabilityTolerance, inst.VersionCriteria());
                 }
                 catch
                 {
-                    return null;
+                    try
+                    {
+                        return registry?.LatestAvailable(identifier, stabilityTolerance, null);
+                    }
+                    catch
+                    {
+                    }
                 }
             }
+            return null;
         }
 
         private void ModsListView_ItemSelectionChanged(object? sender, ListViewItemSelectionChangedEventArgs? e)

--- a/GUI/Controls/LabeledProgressBar.cs
+++ b/GUI/Controls/LabeledProgressBar.cs
@@ -19,7 +19,9 @@ namespace CKAN.GUI
         public LabeledProgressBar()
             : base()
         {
-            SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
+            SetStyle(ControlStyles.OptimizedDoubleBuffer
+                     | ControlStyles.UserPaint,
+                     true);
             Font = SystemFonts.DefaultFont;
             Text = "";
         }
@@ -31,12 +33,12 @@ namespace CKAN.GUI
         [EditorBrowsable(EditorBrowsableState.Always)]
         // If we use override instead of new, the nullability never matches (!)
         public new string Text {
-            get => text;
-            [MemberNotNull(nameof(text), nameof(textSize))]
+            get => base.Text;
+            [MemberNotNull(nameof(textSize))]
             set
             {
-                text     = value;
-                textSize = TextRenderer.MeasureText(text, Font);
+                base.Text = value;
+                textSize  = TextRenderer.MeasureText(Text, Font);
             }
         }
 
@@ -45,18 +47,33 @@ namespace CKAN.GUI
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         // If we use override instead of new, the nullability never matches (!)
-        public new Font Font { get; set; }
+        public new Font Font
+        {
+            get => base.Font;
+            [MemberNotNull(nameof(textSize))]
+            set
+            {
+                base.Font = value;
+                textSize  = TextRenderer.MeasureText(Text, Font);
+            }
+        }
 
         protected override void OnPaint(PaintEventArgs e)
         {
-            base.OnPaint(e);
+            ProgressBarRenderer.DrawHorizontalBar(e.Graphics, ClientRectangle);
+            ProgressBarRenderer.DrawHorizontalChunks(e.Graphics,
+                                                     new Rectangle(ClientRectangle.X,
+                                                                   ClientRectangle.Y,
+                                                                   ClientRectangle.Width
+                                                                       * (Value - Minimum)
+                                                                       / (Maximum - Minimum),
+                                                                   ClientRectangle.Height));
             TextRenderer.DrawText(e.Graphics, Text, Font,
                                   new Point((Width  - textSize.Width)  / 2,
                                             (Height - textSize.Height) / 2),
                                   SystemColors.ControlText);
         }
 
-        private string text;
-        private Size   textSize;
+        private Size textSize;
     }
 }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -967,7 +967,7 @@ namespace CKAN.GUI
             {
                 switch (e?.PropertyName)
                 {
-                    case "SelectedMod":
+                    case nameof(GUIMod.SelectedMod):
                         Util.Invoke(this, () =>
                         {
                             if (row.Cells[Installed.Index] is DataGridViewCheckBoxCell instCell)
@@ -1002,13 +1002,13 @@ namespace CKAN.GUI
                         });
                         break;
 
-                    case "IsAutoInstalled":
+                    case nameof(GUIMod.IsAutoInstalled):
                         // Update the changeset
                         UpdateChangeSetAndConflicts(currentInstance,
                             RegistryManager.Instance(currentInstance, repoData).registry);
                         break;
 
-                    case "IsCached":
+                    case nameof(GUIMod.IsCached):
                         row.Visible = mainModList.IsVisible(gmod,
                                                             currentInstance.Name,
                                                             currentInstance.game,
@@ -2009,10 +2009,11 @@ namespace CKAN.GUI
                        gmod.SelectedMod = ch.targetMod;
                     }
                 }
-                var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, inst.game, gameVersion);
+                var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, inst.game,
+                                                                              inst.StabilityToleranceConfig, gameVersion);
                 full_change_set = tuple.Item1.ToList();
                 new_conflicts = tuple.Item2.ToDictionary(
-                    item => new GUIMod(item.Key, repoData, registry, gameVersion, null,
+                    item => new GUIMod(item.Key, repoData, registry, inst.StabilityToleranceConfig, gameVersion, null,
                                        guiConfig?.HideEpochs ?? false,
                                        guiConfig?.HideV      ?? false),
                     item => item.Value);

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -44,6 +44,7 @@ namespace CKAN.GUI
             this.Contents = new CKAN.GUI.Contents();
             this.VersionsTabPage = new System.Windows.Forms.TabPage();
             this.Versions = new CKAN.GUI.Versions();
+            this.ModInfoTable.SuspendLayout();
             this.SuspendLayout();
             //
             // ModInfoTable
@@ -214,6 +215,8 @@ namespace CKAN.GUI
             this.Padding = new System.Windows.Forms.Padding(0);
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.ModInfoTable.ResumeLayout(false);
+            this.ModInfoTable.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -9,7 +9,6 @@ using Autofac;
 
 using CKAN.Configuration;
 using CKAN.Versioning;
-using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
 {
@@ -40,17 +39,11 @@ namespace CKAN.GUI
                     {
                         ModInfoTabControl.Enabled = true;
                         UpdateHeaderInfo(value, crit);
-                        LoadTab(value);
                     }
+                    LoadTab(value);
                 }
             }
             get => selectedModule;
-        }
-
-        [ForbidGUICalls]
-        public void RefreshModContentsTree()
-        {
-            Contents.RefreshModContentsTree();
         }
 
         public void SwitchTab(string name)
@@ -77,12 +70,15 @@ namespace CKAN.GUI
 
         private GUIMod? selectedModule;
 
-        private void LoadTab(GUIMod gm)
+        private void LoadTab(GUIMod? gm)
         {
             switch (ModInfoTabControl.SelectedTab?.Name)
             {
                 case "MetadataTabPage":
-                    Metadata.UpdateModInfo(gm);
+                    if (gm != null)
+                    {
+                        Metadata.UpdateModInfo(gm);
+                    }
                     break;
 
                 case "ContentTabPage":

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -28,6 +28,7 @@ namespace CKAN.GUI
 
             Util.Invoke(this, () =>
             {
+                MetadataTable.SuspendLayout();
                 MetadataModuleVersionTextBox.Text = gui_module.LatestVersion.ToString();
                 MetadataModuleLicenseTextBox.Text = string.Join(", ", module.license);
 
@@ -35,7 +36,7 @@ namespace CKAN.GUI
 
                 MetadataIdentifierTextBox.Text = module.identifier;
 
-                if (module.release_status == null)
+                if (module.release_status is null or ReleaseStatus.stable)
                 {
                     ReleaseLabel.Visible = false;
                     MetadataModuleReleaseStatusTextBox.Visible = false;
@@ -46,7 +47,7 @@ namespace CKAN.GUI
                     ReleaseLabel.Visible = true;
                     MetadataModuleReleaseStatusTextBox.Visible = true;
                     MetadataTable.LayoutSettings.RowStyles[3].Height = 30;
-                    MetadataModuleReleaseStatusTextBox.Text = module.release_status.ToString();
+                    MetadataModuleReleaseStatusTextBox.Text = module.release_status.LocalizeName();
                 }
 
                 var compatMod = gui_module.LatestCompatibleMod
@@ -90,6 +91,7 @@ namespace CKAN.GUI
                     AddResourceLink(Properties.Resources.ModInfoStoreLabel,                 res.store);
                     AddResourceLink(Properties.Resources.ModInfoSteamStoreLabel,            res.steamstore);
                 }
+                MetadataTable.ResumeLayout();
             });
         }
 
@@ -235,6 +237,7 @@ namespace CKAN.GUI
         {
             if (staticRowCount > 0)
             {
+                MetadataTable.SuspendLayout();
                 var rWidth = RightColumnWidth;
                 for (int row = staticRowCount; row < MetadataTable.RowStyles.Count; ++row)
                 {
@@ -247,6 +250,7 @@ namespace CKAN.GUI
                             LinkLabelStringHeight(link, rWidth));
                     }
                 }
+                MetadataTable.ResumeLayout();
             }
         }
 

--- a/GUI/Controls/ModInfoTabs/Versions.Designer.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.Designer.cs
@@ -30,33 +30,36 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(Versions));
-            this.label1 = new System.Windows.Forms.Label();
+            this.OverallSummaryLabel = new System.Windows.Forms.Label();
             this.VersionsListView = new ThemedListView();
             this.ModVersion = new System.Windows.Forms.ColumnHeader();
             this.CompatibleGameVersion = new System.Windows.Forms.ColumnHeader();
             this.ReleaseDate = new System.Windows.Forms.ColumnHeader();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
+            this.LabelTable = new System.Windows.Forms.TableLayoutPanel();
+            this.LatestCompatibleLabel = new System.Windows.Forms.Label();
+            this.CompatibleLabel = new System.Windows.Forms.Label();
+            this.InstalledLabel = new System.Windows.Forms.Label();
+            this.PrereleaseLabel = new System.Windows.Forms.Label();
+            this.StabilityToleranceLabel = new System.Windows.Forms.Label();
+            this.StabilityToleranceComboBox = new System.Windows.Forms.ComboBox();
+            this.LabelTable.SuspendLayout();
             this.SuspendLayout();
             //
-            // label1
+            // OverallSummaryLabel
             //
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(0, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(183, 13);
-            this.label1.TabIndex = 0;
-            resources.ApplyResources(this.label1, "label1");
+            this.OverallSummaryLabel.AutoSize = true;
+            this.OverallSummaryLabel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.OverallSummaryLabel.Location = new System.Drawing.Point(0, 0);
+            this.OverallSummaryLabel.Margin = new System.Windows.Forms.Padding(0, 0, 0, 6);
+            this.OverallSummaryLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 6);
+            this.OverallSummaryLabel.Name = "OverallSummaryLabel";
+            this.OverallSummaryLabel.Size = new System.Drawing.Size(183, 13);
+            this.OverallSummaryLabel.TabIndex = 0;
+            resources.ApplyResources(this.OverallSummaryLabel, "OverallSummaryLabel");
             //
             // VersionsListView
             //
-            this.VersionsListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.VersionsListView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.VersionsListView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.VersionsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.ModVersion,
@@ -64,13 +67,15 @@ namespace CKAN.GUI
             this.ReleaseDate});
             this.VersionsListView.CheckBoxes = true;
             this.VersionsListView.FullRowSelect = true;
-            this.VersionsListView.Location = new System.Drawing.Point(6, 76);
+            this.VersionsListView.Location = new System.Drawing.Point(6, 95);
             this.VersionsListView.Name = "VersionsListView";
-            this.VersionsListView.Size = new System.Drawing.Size(488, 416);
+            this.VersionsListView.Size = new System.Drawing.Size(488, 397);
             this.VersionsListView.TabIndex = 1;
+            this.VersionsListView.ShowItemToolTips = true;
             this.VersionsListView.UseCompatibleStateImageBehavior = false;
             this.VersionsListView.View = System.Windows.Forms.View.Details;
             this.VersionsListView.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.VersionsListView_ItemCheck);
+            this.VersionsListView.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.VersionsListView_ItemSelectionChanged);
             //
             // ModVersion
             //
@@ -87,93 +92,142 @@ namespace CKAN.GUI
             this.ReleaseDate.Width = 140;
             resources.ApplyResources(this.ReleaseDate, "ReleaseDate");
             //
-            // label2
+            // LabelTable
             //
-            this.label2.AutoSize = true;
-            this.label2.BackColor = System.Drawing.Color.Green;
-            this.label2.ForeColor = System.Drawing.Color.White;
-            this.label2.Location = new System.Drawing.Point(4, 17);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(36, 13);
-            this.label2.TabIndex = 2;
-            resources.ApplyResources(this.label2, "label2");
+            this.LabelTable.AutoSize = true;
+            this.LabelTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.LabelTable.ColumnCount = 1;
+            this.LabelTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.LabelTable.Controls.Add(this.PrereleaseLabel, 0, 0);
+            this.LabelTable.Controls.Add(this.InstalledLabel, 0, 1);
+            this.LabelTable.Controls.Add(this.LatestCompatibleLabel, 0, 2);
+            this.LabelTable.Controls.Add(this.CompatibleLabel, 0, 3);
+            this.LabelTable.Controls.Add(this.StabilityToleranceLabel, 0, 4);
+            this.LabelTable.Controls.Add(this.StabilityToleranceComboBox, 0, 5);
+            this.LabelTable.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.LabelTable.Location = new System.Drawing.Point(0, 0);
+            this.LabelTable.Name = "LabelTable";
+            this.LabelTable.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
+            this.LabelTable.RowCount = 6;
+            this.LabelTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.LabelTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.LabelTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.LabelTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.LabelTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.LabelTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.LabelTable.Size = new System.Drawing.Size(346, 255);
+            this.LabelTable.TabIndex = 0;
             //
-            // label3
+            // LatestCompatibleLabel
             //
-            this.label3.AutoSize = true;
-            this.label3.BackColor = System.Drawing.Color.LightGreen;
-            this.label3.Location = new System.Drawing.Point(4, 36);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(60, 13);
-            this.label3.TabIndex = 3;
-            resources.ApplyResources(this.label3, "label3");
+            this.LatestCompatibleLabel.AutoSize = true;
+            this.LatestCompatibleLabel.BackColor = System.Drawing.Color.Green;
+            this.LatestCompatibleLabel.ForeColor = System.Drawing.Color.White;
+            this.LatestCompatibleLabel.Location = new System.Drawing.Point(0, 17);
+            this.LatestCompatibleLabel.Margin = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            this.LatestCompatibleLabel.Padding = new System.Windows.Forms.Padding(6, 1, 6, 1);
+            this.LatestCompatibleLabel.Name = "LatestCompatibleLabel";
+            this.LatestCompatibleLabel.Size = new System.Drawing.Size(229, 13);
+            this.LatestCompatibleLabel.TabIndex = 5;
+            resources.ApplyResources(this.LatestCompatibleLabel, "LatestCompatibleLabel");
             //
-            // label4
+            // CompatibleLabel
             //
-            this.label4.AutoSize = true;
-            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.label4.Location = new System.Drawing.Point(0, 56);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(32, 13);
-            this.label4.TabIndex = 4;
-            resources.ApplyResources(this.label4, "label4");
+            this.CompatibleLabel.AutoSize = true;
+            this.CompatibleLabel.BackColor = System.Drawing.Color.LightGreen;
+            this.CompatibleLabel.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.CompatibleLabel.Location = new System.Drawing.Point(0, 36);
+            this.CompatibleLabel.Margin = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            this.CompatibleLabel.Padding = new System.Windows.Forms.Padding(6, 1, 6, 1);
+            this.CompatibleLabel.Name = "CompatibleLabel";
+            this.CompatibleLabel.Size = new System.Drawing.Size(180, 13);
+            this.CompatibleLabel.TabIndex = 6;
+            resources.ApplyResources(this.CompatibleLabel, "CompatibleLabel");
             //
-            // label5
+            // InstalledLabel
             //
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(65, 17);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(229, 13);
-            this.label5.TabIndex = 5;
-            resources.ApplyResources(this.label5, "label5");
+            this.InstalledLabel.AutoSize = true;
+            this.InstalledLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 8F, System.Drawing.FontStyle.Bold);
+            this.InstalledLabel.BackColor = System.Drawing.SystemColors.Window;
+            this.InstalledLabel.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.InstalledLabel.Location = new System.Drawing.Point(0, 55);
+            this.InstalledLabel.Margin = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            this.InstalledLabel.Padding = new System.Windows.Forms.Padding(6, 1, 6, 1);
+            this.InstalledLabel.Name = "InstalledLabel";
+            this.InstalledLabel.Size = new System.Drawing.Size(131, 13);
+            this.InstalledLabel.TabIndex = 7;
+            this.InstalledLabel.Visible = false;
+            resources.ApplyResources(this.InstalledLabel, "InstalledLabel");
             //
-            // label6
+            // PrereleaseLabel
             //
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(65, 36);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(180, 13);
-            this.label6.TabIndex = 6;
-            resources.ApplyResources(this.label6, "label6");
+            this.PrereleaseLabel.AutoSize = true;
+            this.PrereleaseLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 8F, System.Drawing.FontStyle.Italic);
+            this.PrereleaseLabel.BackColor = System.Drawing.Color.Gold;
+            this.PrereleaseLabel.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.PrereleaseLabel.Location = new System.Drawing.Point(0, 74);
+            this.PrereleaseLabel.Margin = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            this.PrereleaseLabel.Padding = new System.Windows.Forms.Padding(6, 1, 6, 1);
+            this.PrereleaseLabel.Name = "PrereleaseLabel";
+            this.PrereleaseLabel.Size = new System.Drawing.Size(131, 13);
+            this.PrereleaseLabel.TabIndex = 7;
+            this.PrereleaseLabel.Visible = false;
+            resources.ApplyResources(this.PrereleaseLabel, "PrereleaseLabel");
             //
-            // label7
+            // StabilityToleranceLabel
             //
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(65, 56);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(131, 13);
-            this.label7.TabIndex = 7;
-            resources.ApplyResources(this.label7, "label7");
+            this.StabilityToleranceLabel.AutoSize = true;
+            this.StabilityToleranceLabel.Location = new System.Drawing.Point(0, 146);
+            this.StabilityToleranceLabel.Name = "StabilityToleranceLabel";
+            this.StabilityToleranceLabel.Margin = new System.Windows.Forms.Padding(0, 2, 0, 0);
+            this.StabilityToleranceLabel.Padding = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.StabilityToleranceLabel.Size = new System.Drawing.Size(220, 17);
+            this.StabilityToleranceLabel.TabStop = false;
+            resources.ApplyResources(this.StabilityToleranceLabel, "StabilityToleranceLabel");
+            //
+            // StabilityToleranceComboBox
+            //
+            this.StabilityToleranceComboBox.AutoSize = false;
+            this.StabilityToleranceComboBox.Location = new System.Drawing.Point(0, 146);
+            this.StabilityToleranceComboBox.Margin = new System.Windows.Forms.Padding(0, 1, 0, 1);
+            this.StabilityToleranceComboBox.Padding = new System.Windows.Forms.Padding(0);
+            this.StabilityToleranceComboBox.Name = "StabilityToleranceComboBox";
+            this.StabilityToleranceComboBox.Size = new System.Drawing.Size(220, 17);
+            this.StabilityToleranceComboBox.TabIndex = 8;
+            this.StabilityToleranceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.StabilityToleranceComboBox.SelectionChangeCommitted += new System.EventHandler(this.StabilityToleranceComboBox_SelectionChanged);
+            this.StabilityToleranceComboBox.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.StabilityToleranceComboBox_MouseWheel);
             //
             // Versions
             //
-            this.Controls.Add(this.label7);
-            this.Controls.Add(this.label6);
-            this.Controls.Add(this.label5);
-            this.Controls.Add(this.label4);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.label2);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.VersionsListView);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.OverallSummaryLabel);
+            this.Controls.Add(this.LabelTable);
             this.Name = "Versions";
+            this.Padding = new System.Windows.Forms.Padding(6);
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
+            this.LabelTable.ResumeLayout(false);
+            this.LabelTable.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
 
         #endregion
 
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label OverallSummaryLabel;
         private System.Windows.Forms.ListView VersionsListView;
         private System.Windows.Forms.ColumnHeader ModVersion;
         private System.Windows.Forms.ColumnHeader CompatibleGameVersion;
         private System.Windows.Forms.ColumnHeader ReleaseDate;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.Label label6;
-        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.TableLayoutPanel LabelTable;
+        private System.Windows.Forms.Label LatestCompatibleLabel;
+        private System.Windows.Forms.Label CompatibleLabel;
+        private System.Windows.Forms.Label InstalledLabel;
+        private System.Windows.Forms.Label PrereleaseLabel;
+        private System.Windows.Forms.Label StabilityToleranceLabel;
+        private System.Windows.Forms.ComboBox StabilityToleranceComboBox;
     }
 }

--- a/GUI/Controls/ModInfoTabs/Versions.resx
+++ b/GUI/Controls/ModInfoTabs/Versions.resx
@@ -117,14 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve"><value>All available versions of selected mod</value></data>
+  <data name="OverallSummaryLabel.Text" xml:space="preserve"><value>All available versions of selected mod:</value></data>
   <data name="ModVersion.Text" xml:space="preserve"><value>Mod version</value></data>
   <data name="CompatibleGameVersion.Text" xml:space="preserve"><value>Game versions</value></data>
   <data name="ReleaseDate.Text" xml:space="preserve"><value>Release date</value></data>
-  <data name="label2.Text" xml:space="preserve"><value>Green</value></data>
-  <data name="label3.Text" xml:space="preserve"><value>Light green</value></data>
-  <data name="label4.Text" xml:space="preserve"><value>Bold</value></data>
-  <data name="label5.Text" xml:space="preserve"><value>- latest compatible version (likely to be installed)</value></data>
-  <data name="label6.Text" xml:space="preserve"><value>- version is compatible with your game</value></data>
-  <data name="label7.Text" xml:space="preserve"><value>- currently installed version</value></data>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve"><value>Latest compatible version (likely to be installed)</value></data>
+  <data name="CompatibleLabel.Text" xml:space="preserve"><value>Version is compatible with your game</value></data>
+  <data name="InstalledLabel.Text" xml:space="preserve"><value>Currently installed version</value></data>
+  <data name="PrereleaseLabel.Text" xml:space="preserve"><value>Less stable than stability tolerance setting</value></data>
+  <data name="StabilityToleranceLabel.Text" xml:space="preserve"><value>Mod stability override:</value></data>
 </root>

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -226,16 +226,18 @@ namespace CKAN.GUI
 
         private void ClearProgressBars()
         {
-            ProgressBarTable.Controls.Clear();
-            ProgressBarTable.RowStyles.Clear();
-            progressLabels.Clear();
-            progressBars.Clear();
+            VerticalSplitter.SplitterDistance = emptyHeight;
             foreach (var rc in rateCounters.Values)
             {
                 rc.Stop();
             }
             rateCounters.Clear();
-            VerticalSplitter.SplitterDistance = emptyHeight;
+            ProgressBarTable.SuspendLayout();
+            ProgressBarTable.Controls.Clear();
+            ProgressBarTable.RowStyles.Clear();
+            ProgressBarTable.ResumeLayout();
+            progressLabels.Clear();
+            progressBars.Clear();
         }
 
         [ForbidGUICalls]

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
@@ -37,6 +37,7 @@ namespace CKAN.GUI
             this.AddButton = new System.Windows.Forms.Button();
             this.AcceptChangesButton = new System.Windows.Forms.Button();
             this.CancelChangesButton = new System.Windows.Forms.Button();
+            this.BottomButtonPanel.SuspendLayout();
             this.SuspendLayout();
             //
             // CmdLineGrid
@@ -163,6 +164,8 @@ namespace CKAN.GUI
             this.Padding = new System.Windows.Forms.Padding(8, 8, 8, 0);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
+            this.BottomButtonPanel.ResumeLayout(false);
+            this.BottomButtonPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -50,12 +50,15 @@ namespace CKAN.GUI
 
         private void InstallFiltersDialog_Closing(object? sender, CancelEventArgs? e)
         {
-            var newGlobal = GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+            var newGlobal   = GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
             var newInstance = InstanceFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
             Changed = !globalConfig.GlobalInstallFilters.SequenceEqual(newGlobal)
                       || !instance.InstallFilters.SequenceEqual(newInstance);
-            globalConfig.GlobalInstallFilters = newGlobal;
-            instance.InstallFilters = newInstance;
+            if (Changed)
+            {
+                globalConfig.GlobalInstallFilters = newGlobal;
+                instance.InstallFilters           = newInstance;
+            }
         }
 
         private void AddMiniAVCButton_Click(object? sender, EventArgs? e)

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -85,6 +85,8 @@ namespace CKAN.GUI
             this.HideEpochsCheckbox = new System.Windows.Forms.CheckBox();
             this.HideVCheckbox = new System.Windows.Forms.CheckBox();
             this.AutoSortUpdateCheckBox = new System.Windows.Forms.CheckBox();
+            this.StabilityToleranceLabel = new System.Windows.Forms.Label();
+            this.StabilityToleranceComboBox = new System.Windows.Forms.ComboBox();
             this.RepositoryGroupBox.SuspendLayout();
             this.AuthTokensGroupBox.SuspendLayout();
             this.CacheGroupBox.SuspendLayout();
@@ -546,7 +548,7 @@ namespace CKAN.GUI
             this.BehaviourGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.BehaviourGroupBox.Location = new System.Drawing.Point(12, 310);
             this.BehaviourGroupBox.Name = "BehaviourGroupBox";
-            this.BehaviourGroupBox.Size = new System.Drawing.Size(254, 150);
+            this.BehaviourGroupBox.Size = new System.Drawing.Size(254, 173);
             this.BehaviourGroupBox.TabIndex = 32;
             this.BehaviourGroupBox.TabStop = false;
             resources.ApplyResources(this.BehaviourGroupBox, "BehaviourGroupBox");
@@ -618,15 +620,17 @@ namespace CKAN.GUI
             //
             this.MoreSettingsGroupBox.Controls.Add(this.LanguageSelectionLabel);
             this.MoreSettingsGroupBox.Controls.Add(this.LanguageSelectionComboBox);
-            this.MoreSettingsGroupBox.Controls.Add(this.AutoSortUpdateCheckBox);
             this.MoreSettingsGroupBox.Controls.Add(this.RefreshOnStartupCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.HideEpochsCheckbox);
             this.MoreSettingsGroupBox.Controls.Add(this.HideVCheckbox);
+            this.MoreSettingsGroupBox.Controls.Add(this.AutoSortUpdateCheckBox);
+            this.MoreSettingsGroupBox.Controls.Add(this.StabilityToleranceLabel);
+            this.MoreSettingsGroupBox.Controls.Add(this.StabilityToleranceComboBox);
             this.MoreSettingsGroupBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.MoreSettingsGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.MoreSettingsGroupBox.Location = new System.Drawing.Point(280, 310);
             this.MoreSettingsGroupBox.Name = "MoreSettingsGroupBox";
-            this.MoreSettingsGroupBox.Size = new System.Drawing.Size(476, 150);
+            this.MoreSettingsGroupBox.Size = new System.Drawing.Size(476, 173);
             this.MoreSettingsGroupBox.TabIndex = 39;
             this.MoreSettingsGroupBox.TabStop = false;
             resources.ApplyResources(this.MoreSettingsGroupBox, "MoreSettingsGroupBox");
@@ -697,11 +701,31 @@ namespace CKAN.GUI
             this.AutoSortUpdateCheckBox.CheckedChanged += new System.EventHandler(this.AutoSortUpdateCheckBox_CheckedChanged);
             resources.ApplyResources(this.AutoSortUpdateCheckBox, "AutoSortUpdateCheckBox");
             //
+            // StabilityToleranceLabel
+            //
+            this.StabilityToleranceLabel.AutoSize = true;
+            this.StabilityToleranceLabel.Location = new System.Drawing.Point(12, 146);
+            this.StabilityToleranceLabel.Name = "StabilityToleranceLabel";
+            this.StabilityToleranceLabel.Size = new System.Drawing.Size(220, 17);
+            this.StabilityToleranceLabel.TabStop = false;
+            resources.ApplyResources(this.StabilityToleranceLabel, "StabilityToleranceLabel");
+            //
+            // StabilityToleranceComboBox
+            //
+            this.StabilityToleranceComboBox.AutoSize = true;
+            this.StabilityToleranceComboBox.Location = new System.Drawing.Point(244, 146);
+            this.StabilityToleranceComboBox.Name = "StabilityToleranceComboBox";
+            this.StabilityToleranceComboBox.Size = new System.Drawing.Size(220, 17);
+            this.StabilityToleranceComboBox.TabIndex = 45;
+            this.StabilityToleranceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.StabilityToleranceComboBox.SelectionChangeCommitted += new System.EventHandler(this.StabilityToleranceComboBox_SelectionChanged);
+            this.StabilityToleranceComboBox.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.StabilityToleranceComboBox_MouseWheel);
+            //
             // SettingsDialog
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(768, 470);
+            this.ClientSize = new System.Drawing.Size(768, 493);
             this.Controls.Add(this.RepositoryGroupBox);
             this.Controls.Add(this.AuthTokensGroupBox);
             this.Controls.Add(this.CacheGroupBox);
@@ -788,5 +812,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.CheckBox HideEpochsCheckbox;
         private System.Windows.Forms.CheckBox HideVCheckbox;
         private System.Windows.Forms.CheckBox AutoSortUpdateCheckBox;
+        private System.Windows.Forms.Label StabilityToleranceLabel;
+        private System.Windows.Forms.ComboBox StabilityToleranceComboBox;
     }
 }

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -76,6 +76,7 @@ namespace CKAN.GUI
             UpdateRefreshRate();
 
             UpdateCacheInfo(coreConfig.DownloadCacheDir ?? JsonConfiguration.DefaultDownloadCacheDir);
+            UpdateStabilityToleranceComboBox();
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
@@ -775,6 +776,42 @@ namespace CKAN.GUI
         private void AutoSortUpdateCheckBox_CheckedChanged(object? sender, EventArgs? e)
         {
             guiConfig.AutoSortByUpdate = AutoSortUpdateCheckBox.Checked;
+        }
+
+        private void UpdateStabilityToleranceComboBox()
+        {
+            StabilityToleranceComboBox.Items.Clear();
+            StabilityToleranceComboBox.Items.AddRange(Enum.GetValues(typeof(ReleaseStatus))
+                                                          .OfType<ReleaseStatus>()
+                                                          .OrderBy(relStat => (int)relStat)
+                                                          .Select(relStat => new ReleaseStatusItem(relStat))
+                                                          .ToArray());
+            if (manager?.CurrentInstance != null)
+            {
+                StabilityToleranceComboBox.SelectedIndex = (int)manager.CurrentInstance.StabilityToleranceConfig.OverallStabilityTolerance;
+            }
+        }
+
+        public bool StabilityToleranceChanged { get; private set; } = false;
+
+        private void StabilityToleranceComboBox_MouseWheel(object sender, MouseEventArgs e)
+        {
+            // Don't change values on scroll
+            if (e is HandledMouseEventArgs me)
+            {
+                me.Handled = true;
+            }
+        }
+
+        private void StabilityToleranceComboBox_SelectionChanged(object? sender, EventArgs? e)
+        {
+            if (manager?.CurrentInstance != null
+                && StabilityToleranceComboBox.SelectedItem is ReleaseStatusItem item
+                && item.Value is ReleaseStatus relStat)
+            {
+                manager.CurrentInstance.StabilityToleranceConfig.OverallStabilityTolerance = relStat;
+                StabilityToleranceChanged = true;
+            }
         }
 
         #endregion

--- a/GUI/Dialogs/SettingsDialog.resx
+++ b/GUI/Dialogs/SettingsDialog.resx
@@ -162,6 +162,7 @@
   <data name="HideEpochsCheckbox.Text" xml:space="preserve"><value>Hide epoch numbers in mod list (requires restart)</value></data>
   <data name="HideVCheckbox.Text" xml:space="preserve"><value>Hide "v" in mod list (requires restart)</value></data>
   <data name="AutoSortUpdateCheckBox.Text" xml:space="preserve"><value>Automatically sort by "Update"-column when clicking "Add available updates"</value></data>
+  <data name="StabilityToleranceLabel.Text" xml:space="preserve"><value>Stability tolerance:</value></data>
   <data name="RepoNameHeader.Text" xml:space="preserve"><value>Name</value></data>
   <data name="RepoURLHeader.Text" xml:space="preserve"><value>URL</value></data>
   <data name="AuthHostHeader.Text" xml:space="preserve"><value>Host</value></data>

--- a/GUI/Localization/de-DE/Versions.de-DE.resx
+++ b/GUI/Localization/de-DE/Versions.de-DE.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Alle verfügbaren Versionen der ausgewählten Mod</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Veröffentlichungsdatum</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Grün</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>neueste kompatible Version (wird vermutlich installiert)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Hellgrün</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>kompatible Version</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Fett</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- neueste kompatible Version (wird vermutlich installiert)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- kompatible Version</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- momentan installierte Version</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>momentan installierte Version</value>
   </data>
 </root>

--- a/GUI/Localization/fr-FR/Versions.fr-FR.resx
+++ b/GUI/Localization/fr-FR/Versions.fr-FR.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Toutes les versions disponibles du mod sélectionné</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Date de publication</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Vert</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>version compatible la plus récente (préférence)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Vert clair</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>versions compatibles avec votre jeu</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Gras</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- version compatible la plus récente (préférence)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- versions compatibles avec votre jeu</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- version actuellement installée</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>version actuellement installée</value>
   </data>
 </root>

--- a/GUI/Localization/it-IT/Versions.it-IT.resx
+++ b/GUI/Localization/it-IT/Versions.it-IT.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Tutte le versioni disponibili della mod selezionata</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Data di rilascio</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Verde</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>ultima versione compatibile (che probabilmente sarà installata)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Verde chiaro</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>la versione è compatibile con il gioco</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Grassetto</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- ultima versione compatibile (che probabilmente sarà installata)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- la versione è compatibile con il gioco</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- versione attualmente installata</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>versione attualmente installata</value>
   </data>
 </root>

--- a/GUI/Localization/ja-JP/Versions.ja-JP.resx
+++ b/GUI/Localization/ja-JP/Versions.ja-JP.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>このModの全てのバージョン</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>リリース日時</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>緑</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>最新の対応するバージョン (推奨)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>黄緑</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>現在インストールされているゲームに対応するバージョン</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>太字</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- 最新の対応するバージョン (推奨)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- 現在インストールされているゲームに対応するバージョン</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- 現在インストールされているバージョン</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>現在インストールされているバージョン</value>
   </data>
 </root>

--- a/GUI/Localization/ko-KR/Versions.ko-KR.resx
+++ b/GUI/Localization/ko-KR/Versions.ko-KR.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>선택된 모드의 등록된 버전들</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>출시일</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>녹색</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>호환되는 마지막 버전이에요(설치될 수 있음).</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>연두색</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>이 버전은 게임과 호환돼요.</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>볼드체</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- 호환되는 마지막 버전이에요(설치될 수 있음).</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- 이 버전은 게임과 호환돼요.</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- 지금 설치한 버전이에요.</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>지금 설치한 버전이에요.</value>
   </data>
 </root>

--- a/GUI/Localization/nl-NL/Versions.nl-NL.resx
+++ b/GUI/Localization/nl-NL/Versions.nl-NL.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Alle beschikbare versies van de geselecteerde mod</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Release datum</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Groen</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>nieuwste compatibele versie (waarschijnlijk geïnstalleerd)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Lichtgroen</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>versie is compatibel met je spel</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Dikgedrukt</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- nieuwste compatibele versie (waarschijnlijk geïnstalleerd)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- versie is compatibel met je spel</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- momenteel geïnstalleerde versie</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>momenteel geïnstalleerde versie</value>
   </data>
 </root>

--- a/GUI/Localization/pl-PL/Versions.pl-PL.resx
+++ b/GUI/Localization/pl-PL/Versions.pl-PL.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Wszystkie dostępne wersje wybranej modyfikacji</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Data wydania</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Zielony</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>najnowsza kompatybilna wersja (prawdopodobnie zostanie zainstalowana)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Jasnozielony</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>wersja jest kompatybilna z Twoją grą</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Pogrubiony</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- najnowsza kompatybilna wersja (prawdopodobnie zostanie zainstalowana)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- wersja jest kompatybilna z Twoją grą</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- aktualnie zainstalowana wersja</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>aktualnie zainstalowana wersja</value>
   </data>
 </root>

--- a/GUI/Localization/pt-BR/Versions.pt-BR.resx
+++ b/GUI/Localization/pt-BR/Versions.pt-BR.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Todas as versões disponíveis do mod selecionado</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Data do lançamento</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Verde</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>última versão compativel (a que possívelmente será instalada)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Verde claro</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>versão que é compatível com o seu jogo</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Negrito</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- última versão compativel (a que possívelmente será instalada)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- versão que é compatível com o seu jogo</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- versão instalada atualmente</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>versão instalada atualmente</value>
   </data>
 </root>

--- a/GUI/Localization/ru-RU/Versions.ru-RU.resx
+++ b/GUI/Localization/ru-RU/Versions.ru-RU.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Все доступные версии выбранной модификации</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Дата выпуска</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Зелёный</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>последняя совместимая версия (будет установлена)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Св.-зел.</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>совместима с установленной игрой</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Жирный</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>— последняя совместимая версия (будет установлена)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>— совместима с установленной игрой</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>— текущая установленная версия</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>текущая установленная версия</value>
   </data>
 </root>

--- a/GUI/Localization/tr-TR/Versions.tr-TR.resx
+++ b/GUI/Localization/tr-TR/Versions.tr-TR.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>Seçili modun mevcut tüm sürümleri</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>Yayın tarihi</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Yeşil</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>en son uyumlu sürüm (muhtemelen kurulacak)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Açık yeşil</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>oyununuzla uyumlu sürüm</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Kalın</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- en son uyumlu sürüm (muhtemelen kurulacak)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- oyununuzla uyumlu sürüm</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- şuanda yüklü sürüm</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>şuanda yüklü sürüm</value>
   </data>
 </root>

--- a/GUI/Localization/zh-CN/Versions.zh-CN.resx
+++ b/GUI/Localization/zh-CN/Versions.zh-CN.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="OverallSummaryLabel.Text" xml:space="preserve">
     <value>选中Mod的所有可用版本</value>
   </data>
   <data name="ModVersion.Text" xml:space="preserve">
@@ -129,22 +129,13 @@
   <data name="ReleaseDate.Text" xml:space="preserve">
     <value>发布日期</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>绿色</value>
+  <data name="LatestCompatibleLabel.Text" xml:space="preserve">
+    <value>最新的兼容版本(将会被安装)</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>浅绿色</value>
+  <data name="CompatibleLabel.Text" xml:space="preserve">
+    <value>兼容您的游戏的版本</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>粗体</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>- 最新的兼容版本(将会被安装)</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>- 兼容您的游戏的版本</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>- 当前安装版本</value>
+  <data name="InstalledLabel.Text" xml:space="preserve">
+    <value>当前安装版本</value>
   </data>
 </root>

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -41,22 +41,25 @@ namespace CKAN.GUI
 
         private void Changeset_OnConfirmChanges(List<ModChange> changeset)
         {
-            DisableMainWindow();
-            try
+            if (CurrentInstance != null)
             {
-                Wait.StartWaiting(InstallMods, PostInstallMods, true,
-                    new InstallArgument(
-                        // Only pass along user requested mods, so auto-installed can be determined
-                        changeset.Where(ch => ch.Reasons.Any(r => r is SelectionReason.UserRequested)
-                                              // Include all removes and upgrades
-                                              || ch.ChangeType != GUIModChangeType.Install)
-                                 .ToList(),
-                        RelationshipResolverOptions.DependsOnlyOpts()));
-            }
-            catch (InvalidOperationException)
-            {
-                // Thrown if it's already busy, can happen if the user double-clicks the button. Ignore it.
-                // More thread-safe than checking installWorker.IsBusy beforehand.
+                DisableMainWindow();
+                try
+                {
+                    Wait.StartWaiting(InstallMods, PostInstallMods, true,
+                        new InstallArgument(
+                            // Only pass along user requested mods, so auto-installed can be determined
+                            changeset.Where(ch => ch.Reasons.Any(r => r is SelectionReason.UserRequested)
+                                                  // Include all removes and upgrades
+                                                  || ch.ChangeType != GUIModChangeType.Install)
+                                     .ToList(),
+                            RelationshipResolverOptions.DependsOnlyOpts(CurrentInstance.StabilityToleranceConfig)));
+                }
+                catch (InvalidOperationException)
+                {
+                    // Thrown if it's already busy, can happen if the user double-clicks the button. Ignore it.
+                    // More thread-safe than checking installWorker.IsBusy beforehand.
+                }
             }
         }
     }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -124,19 +124,12 @@ namespace CKAN.GUI
                 Manager.Cache.ModPurged += OnModStoredOrPurged;
             }
             UpdateCachedByDownloads(null);
-            ModInfo.RefreshModContentsTree();
         }
 
         [ForbidGUICalls]
         private void OnModStoredOrPurged(CkanModule? module)
         {
             UpdateCachedByDownloads(module);
-
-            if (module == null
-                || ModInfo.SelectedModule?.Identifier == module.identifier)
-            {
-                ModInfo.RefreshModContentsTree();
-            }
         }
     }
 }

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -27,6 +27,7 @@ namespace CKAN.GUI
                     modules.Select(mod => new ModChange(mod, GUIModChangeType.Install))
                            .ToHashSet(),
                     CurrentInstance.game,
+                    CurrentInstance.StabilityToleranceConfig,
                     CurrentInstance.VersionCriteria());
                 UpdateChangesDialog(tuple.Item1.ToList(), tuple.Item2);
                 tabController.ShowTab("ChangesetTabPage", 1);
@@ -48,6 +49,7 @@ namespace CKAN.GUI
                     ? null
                     : new GUIMod(m, repoData,
                                  RegistryManager.Instance(CurrentInstance, repoData).registry,
+                                 CurrentInstance.StabilityToleranceConfig,
                                  CurrentInstance.VersionCriteria(),
                                  null,
                                  configuration?.HideEpochs ?? false,

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -68,7 +68,7 @@ namespace CKAN.GUI
                             new InstallArgument(
                                 result.Select(mod => new ModChange(mod, GUIModChangeType.Install))
                                       .ToList(),
-                                RelationshipResolverOptions.DependsOnlyOpts()));
+                                RelationshipResolverOptions.DependsOnlyOpts(CurrentInstance.StabilityToleranceConfig)));
                     }
                 }
                 else

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -66,6 +66,7 @@ namespace CKAN.GUI
 
                 // Note the current mods' compatibility for the NewlyCompatible filter
                 var registry = regMgr.registry;
+                var stabilityTolerance = CurrentInstance.StabilityToleranceConfig;
 
                 var cancelTokenSrc = new CancellationTokenSource();
                 Wait.OnCancel += cancelTokenSrc.Cancel;
@@ -78,9 +79,9 @@ namespace CKAN.GUI
                     new ProgressImmediate<int>(p => currentUser.RaiseProgress(Properties.Resources.LoadingCachedRepoData, p)));
 
                 var versionCriteria = CurrentInstance.VersionCriteria();
-                var oldModules = registry.CompatibleModules(versionCriteria)
+                var oldModules = registry.CompatibleModules(stabilityTolerance, versionCriteria)
                                          .ToDictionary(m => m.identifier, m => false);
-                registry.IncompatibleModules(versionCriteria)
+                registry.IncompatibleModules(stabilityTolerance, versionCriteria)
                         .Where(m => !oldModules.ContainsKey(m.identifier))
                         .ToList()
                         .ForEach(m => oldModules.Add(m.identifier, true));

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -163,11 +163,14 @@ namespace CKAN.GUI
             // Check all the upgrade checkboxes
             ManageMods.MarkAllUpdates();
 
-            // Install
-            Wait.StartWaiting(InstallMods, PostInstallMods, true,
-                              new InstallArgument(ManageMods.ComputeUserChangeSet()
-                                                            .ToList(),
-                                                  RelationshipResolverOptions.DependsOnlyOpts()));
+            if (CurrentInstance != null)
+            {
+                // Install
+                Wait.StartWaiting(InstallMods, PostInstallMods, true,
+                                  new InstallArgument(ManageMods.ComputeUserChangeSet()
+                                                                .ToList(),
+                                                      RelationshipResolverOptions.DependsOnlyOpts(CurrentInstance.StabilityToleranceConfig)));
+            }
         }
         #endregion
     }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 #endif
 
+using CKAN.Configuration;
 using CKAN.Versioning;
 
 namespace CKAN.GUI
@@ -131,11 +132,12 @@ namespace CKAN.GUI
         public GUIMod(InstalledModule       instMod,
                       RepositoryDataManager repoDataMgr,
                       IRegistryQuerier      registry,
+                      StabilityToleranceConfig stabilityTolerance,
                       GameVersionCriteria   current_game_version,
                       bool? incompatible,
                       bool  hideEpochs,
                       bool  hideV)
-            : this(instMod.Module, repoDataMgr, registry, current_game_version, incompatible, hideEpochs, hideV)
+            : this(instMod.Module, repoDataMgr, registry, stabilityTolerance, current_game_version, incompatible, hideEpochs, hideV)
         {
             IsInstalled      = true;
             InstalledMod     = instMod;
@@ -159,10 +161,11 @@ namespace CKAN.GUI
         /// <param name="registry">CKAN registry object for current game instance</param>
         /// <param name="current_game_version">Current game version</param>
         /// <param name="incompatible">If true, mark this module as incompatible</param>
-        public GUIMod(CkanModule            mod,
-                      RepositoryDataManager repoDataMgr,
-                      IRegistryQuerier      registry,
-                      GameVersionCriteria   current_game_version,
+        public GUIMod(CkanModule               mod,
+                      RepositoryDataManager    repoDataMgr,
+                      IRegistryQuerier         registry,
+                      StabilityToleranceConfig stabilityTolerance,
+                      GameVersionCriteria      current_game_version,
                       bool? incompatible,
                       bool  hideEpochs,
                       bool  hideV)
@@ -180,7 +183,7 @@ namespace CKAN.GUI
             {
                 try
                 {
-                    LatestCompatibleMod = registry.LatestAvailable(Identifier, current_game_version);
+                    LatestCompatibleMod = registry.LatestAvailable(Identifier, stabilityTolerance, current_game_version);
                     latest_version = LatestCompatibleMod?.version;
                 }
                 catch (ModuleNotFoundKraken)
@@ -199,7 +202,7 @@ namespace CKAN.GUI
 
             try
             {
-                LatestAvailableMod = registry.LatestAvailable(Identifier, null);
+                LatestAvailableMod = registry.LatestAvailable(Identifier, stabilityTolerance, null);
             }
             catch
             { }
@@ -242,7 +245,7 @@ namespace CKAN.GUI
                                            .OfType<char>()
                                            .ToArray());
 
-            HasReplacement = registry.GetReplacement(mod, current_game_version) != null;
+            HasReplacement = registry.GetReplacement(mod, stabilityTolerance, current_game_version) != null;
             DownloadSize   = mod.download_size == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.download_size);
             InstallSize    = mod.install_size  == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.install_size);
 

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -112,7 +112,7 @@ namespace CKAN.GUI
                 : (((maxEnumVal + 1) * Mod.GetHashCode()) + (int)ChangeType);
 
         public override string ToString()
-            => $"{ChangeType.Localize()} {Mod} ({Description})";
+            => $"{ChangeType.LocalizeDescription()} {Mod} ({Description})";
 
         public virtual string? NameAndStatus
             => Main.Instance?.Manager?.Cache?.DescribeAvailability(Mod);

--- a/GUI/Model/ReleaseStatusItem.cs
+++ b/GUI/Model/ReleaseStatusItem.cs
@@ -1,0 +1,17 @@
+using CKAN.Extensions;
+
+namespace CKAN.GUI
+{
+    public class ReleaseStatusItem
+    {
+        public ReleaseStatusItem(ReleaseStatus? value)
+        {
+            Value = value;
+        }
+
+        public readonly ReleaseStatus? Value;
+        public override string ToString()
+            => Value == null ? ""
+                             : $"{Value.LocalizeName()} - {Value.LocalizeDescription()}";
+    }
+}

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -199,6 +199,9 @@ Which build would you like to use?
 This means that CKAN forgot about all your installed mods, but they are still in GameData. You can reinstall them by importing the {2} file.</value></data>
   <data name="MainDeleteLockfileYes" xml:space="preserve"><value>Force</value></data>
   <data name="MainDeleteLockfileNo" xml:space="preserve"><value>Cancel</value></data>
+  <data name="AllModVersionsPrereleasePrompt" xml:space="preserve"><value>{0} has a release status of '{1}', which is less stable than your stability tolerance setting of '{2}'.
+
+Are you sure you want to install it?</value></data>
   <data name="AllModVersionsInstallPrompt" xml:space="preserve"><value>{0} is not supported on your current compatible game versions ({1}) and may not work at all. If you have any problems with it, you should NOT ask its maintainers for help.
 
 Do you really want to install it?</value></data>

--- a/NetKAN.schema
+++ b/NetKAN.schema
@@ -218,6 +218,10 @@
                 "use_source_archive": {
                     "description": "If true, the release's source ZIP will be used instead of an asset",
                     "type": "boolean"
+                },
+                "prereleases": {
+                    "description": "Skip prereleases if false, skip regular releases if true, use both if absent",
+                    "type": "boolean"
                 }
             }
         },

--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -37,8 +37,8 @@ namespace CKAN.NetKAN
         [Option("skip-releases", DefaultValue = "0", HelpText = "Number of releases to skip / index of release to inflate.")]
         public string? SkipReleases { get; set; }
 
-        [Option("prerelease", HelpText = "Index GitHub prereleases")]
-        public bool PreRelease { get; set; }
+        [Option("prerelease", DefaultValue = null, HelpText = "true to get only prereleases from GitHub, false to skip them, omit to get both")]
+        public bool? PreRelease { get; set; }
 
         [Option("overwrite-cache", HelpText = "Overwrite cached files")]
         public bool OverwriteCache { get; set; }

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -31,7 +31,7 @@ namespace CKAN.NetKAN.Processors
                             string? githubToken,
                             string? gitlabToken,
                             string? userAgent,
-                            bool    prerelease,
+                            bool?   prerelease,
                             IGame   game)
         {
             this.outputDir = outputDir;

--- a/Netkan/Properties/AssemblyInfo.cs
+++ b/Netkan/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle ("CKAN-NetKAN")]
-[assembly: AssemblyDescription ("CKAN NetKAN Client")]
+[assembly: AssemblyTitle("CKAN-NetKAN")]
+[assembly: AssemblyDescription("CKAN NetKAN Client")]
 
 [assembly: InternalsVisibleTo("CKAN.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Netkan/Sources/Github/GithubConfig.cs
+++ b/Netkan/Sources/Github/GithubConfig.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace CKAN.NetKAN.Sources.Github
+{
+    internal sealed class GitHubConfig
+    {
+        [JsonProperty("use_source_archive")]
+        public bool UseSourceArchive { get; set; } = false;
+
+        [JsonProperty("prereleases")]
+        public bool? Prereleases { get; set; } = null;
+    }
+}

--- a/Netkan/Sources/Github/GithubRef.cs
+++ b/Netkan/Sources/Github/GithubRef.cs
@@ -16,12 +16,11 @@ namespace CKAN.NetKAN.Sources.Github
         public Regex? Filter           { get; private set; }
         public Regex? VersionFromAsset { get; private set; }
         public bool   UseSourceArchive { get; private set; }
-        public bool   UsePrerelease    { get; private set; }
 
-        public GithubRef(string remoteRefToken, bool useSourceArchive, bool usePrerelease)
-            : this(new RemoteRef(remoteRefToken), useSourceArchive, usePrerelease) { }
+        public GithubRef(string remoteRefToken, bool useSourceArchive)
+            : this(new RemoteRef(remoteRefToken), useSourceArchive) { }
 
-        public GithubRef(RemoteRef remoteRef, bool useSourceArchive, bool usePrerelease)
+        public GithubRef(RemoteRef remoteRef, bool useSourceArchive)
             : base(remoteRef)
         {
             if (remoteRef.Id != null
@@ -41,7 +40,6 @@ namespace CKAN.NetKAN.Sources.Github
                     : null;
 
                 UseSourceArchive = useSourceArchive;
-                UsePrerelease = usePrerelease;
             }
             else
             {

--- a/Netkan/Sources/Github/IGithubApi.cs
+++ b/Netkan/Sources/Github/IGithubApi.cs
@@ -6,8 +6,8 @@ namespace CKAN.NetKAN.Sources.Github
     internal interface IGithubApi
     {
         GithubRepo? GetRepo(GithubRef reference);
-        GithubRelease? GetLatestRelease(GithubRef reference);
-        IEnumerable<GithubRelease> GetAllReleases(GithubRef reference);
+        GithubRelease? GetLatestRelease(GithubRef reference, bool? usePrerelease);
+        IEnumerable<GithubRelease> GetAllReleases(GithubRef reference, bool? usePrerelease);
         List<GithubUser> getOrgMembers(GithubUser organization);
         string? DownloadText(Uri url);
     }

--- a/Netkan/Sources/Spacedock/SDVersion.cs
+++ b/Netkan/Sources/Spacedock/SDVersion.cs
@@ -32,33 +32,22 @@ namespace CKAN.NetKAN.Sources.Spacedock
         /// </summary>
         internal class JsonConvertGameVersion : JsonConverter
         {
-            public override object? ReadJson(
-                JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer
-            )
-            {
-                if (reader.Value == null)
-                {
-                    return null;
-                }
-
-                var raw_version = reader.Value.ToString();
-
-                return GameVersion.Parse(ExpandVersionIfNeeded(raw_version));
-            }
+            public override object? ReadJson(JsonReader     reader,
+                                             Type           objectType,
+                                             object?        existingValue,
+                                             JsonSerializer serializer)
+                => reader.Value?.ToString() is string s
+                       ? GameVersion.Parse(ExpandVersionIfNeeded(s))
+                       : null;
 
             /// <summary>
             /// Actually expand the KSP version. It's way easier to test this than the override. :)
             /// </summary>
-            public static string? ExpandVersionIfNeeded(string? version)
-            {
-                if (Regex.IsMatch(version ?? "", @"^\d+\.\d+$"))
-                {
-                    // Two part string, add our .0
-                    return version + ".0";
-                }
-
-                return version;
-            }
+            public static string ExpandVersionIfNeeded(string version)
+                => Regex.IsMatch(version, @"^\d+\.\d+$")
+                       // Two part string, add our .0
+                       ? version + ".0"
+                       : version;
 
             public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
             {

--- a/Netkan/Transformers/GitlabTransformer.cs
+++ b/Netkan/Transformers/GitlabTransformer.cs
@@ -22,10 +22,6 @@ namespace CKAN.NetKAN.Transformers
         /// <param name="api">Object to use for accessing the GitLab API</param>
         public GitlabTransformer(IGitlabApi api)
         {
-            if (api == null)
-            {
-                throw new ArgumentNullException(nameof(api));
-            }
             this.api = api;
         }
 

--- a/Netkan/Transformers/NetkanTransformer.cs
+++ b/Netkan/Transformers/NetkanTransformer.cs
@@ -30,7 +30,7 @@ namespace CKAN.NetKAN.Transformers
                                  string?        githubToken,
                                  string?        gitlabToken,
                                  string?        userAgent,
-                                 bool           prerelease,
+                                 bool?          prerelease,
                                  IGame          game,
                                  IValidator     validator)
         {

--- a/Netkan/Transformers/StagingTransformer.cs
+++ b/Netkan/Transformers/StagingTransformer.cs
@@ -37,8 +37,8 @@ namespace CKAN.NetKAN.Transformers
             JObject json = metadata.Json();
             var minStr = json["ksp_version_min"] ?? json["ksp_version"];
             var maxStr = json["ksp_version_max"] ?? json["ksp_version"];
-            var minVer = minStr == null ? GameVersion.Any : GameVersion.Parse((string?)minStr);
-            var maxVer = maxStr == null ? GameVersion.Any : GameVersion.Parse((string?)maxStr);
+            var minVer = (string?)minStr is string s1 ? GameVersion.Parse(s1) : GameVersion.Any;
+            var maxVer = (string?)maxStr is string s2 ? GameVersion.Parse(s2) : GameVersion.Any;
             if (currentRelease != null && currentRelease.IntersectWith(new GameVersionRange(minVer, maxVer)) == null)
             {
                 reason = $"Hard-coded game versions not compatible with current release: {GameVersionRange.VersionSpan(game, minVer, maxVer)}\r\nPlease check that they match the forum thread.";

--- a/Netkan/Transformers/VersionedOverrideTransformer.cs
+++ b/Netkan/Transformers/VersionedOverrideTransformer.cs
@@ -160,14 +160,14 @@ namespace CKAN.NetKAN.Transformers
                     {
                         ModuleService.ApplyVersions(
                             metadata,
-                            overrides.ContainsKey("ksp_version")
-                                ? GameVersion.Parse((string?)overrides["ksp_version"])
+                            (string?)overrides["ksp_version"] is string v1
+                                ? GameVersion.Parse(v1)
                                 : null,
-                            overrides.ContainsKey("ksp_version_min")
-                                ? GameVersion.Parse((string?)overrides["ksp_version_min"])
+                            (string?)overrides["ksp_version_min"] is string v2
+                                ? GameVersion.Parse(v2)
                                 : null,
-                            overrides.ContainsKey("ksp_version_max")
-                                ? GameVersion.Parse((string?)overrides["ksp_version_max"])
+                            (string?)overrides["ksp_version_max"] is string v3
+                                ? GameVersion.Parse(v3)
                                 : null
                         );
                         foreach (var p in gameVersionProperties)

--- a/Spec.md
+++ b/Spec.md
@@ -790,6 +790,7 @@ When used, the following fields will be auto-filled if not already present:
 - `resources.x_screenshot`
 - `ksp_version`
 - `release_date`
+- `release_status`
 
 ###### `#/ckan/curse/:cid`
 
@@ -833,6 +834,7 @@ When used, the following fields will be auto-filled if not already present:
 - `resources.repository`
 - `resources.bugtracker`
 - `release_date`
+- `release_status`
 
 Optionally, one of `asset_match` with `:filter_regexp` *or* `version_from_asset` with `:version_regexp` *may* be provided:
 
@@ -852,6 +854,8 @@ An `x_netkan_github` field may be provided to customize how the metadata is fetc
 
 - `use_source_archive` (type: `boolean`) (default: `false`)<br/>
   Specifies that the source ZIP of the repository itself will be used instead of any assets in the release.
+- `prereleases` (type: `boolean`) (default: `null`)<br/>
+  Skip prereleases if `false`, skip regular releases if `true`, use both if absent.
 
 ###### `#/ckan/gitlab/:user/:repo`
 

--- a/Tests/Core/Configuration/FakeConfiguration.cs
+++ b/Tests/Core/Configuration/FakeConfiguration.cs
@@ -1,8 +1,10 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+using CKAN;
 using CKAN.Configuration;
 using CKAN.Games.KerbalSpaceProgram.GameVersionProviders;
 
@@ -12,7 +14,7 @@ namespace Tests.Core.Configuration
 {
     public class FakeConfiguration : IConfiguration, IDisposable
     {
-        public FakeConfiguration(CKAN.GameInstance instance, string autostart)
+        public FakeConfiguration(GameInstance instance, string autostart)
             : this(new List<Tuple<string, string, string>>
                    {
                        new Tuple<string, string, string>("test", instance.GameDir(), "KSP")
@@ -93,7 +95,7 @@ namespace Tests.Core.Configuration
         /// <returns>
         /// Returns
         /// </returns>
-        public void SetRegistryToInstances(SortedList<string, CKAN.GameInstance> instances)
+        public void SetRegistryToInstances(SortedList<string, GameInstance> instances)
         {
             Instances =
                 instances.Select(kvpair => new Tuple<string, string, string>(kvpair.Key, kvpair.Value.GameDir(), "KSP")).ToList();
@@ -152,6 +154,10 @@ namespace Tests.Core.Configuration
         public string?[] PreferredHosts { get; set; } = Array.Empty<string>();
 
         public bool? DevBuilds { get; set; }
+
+        #pragma warning disable CS0067
+        public event PropertyChangedEventHandler? PropertyChanged;
+        #pragma warning restore CS0067
 
         public void Dispose()
         {

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -62,7 +62,7 @@ namespace Tests.Core
             HashSet<string>? possibleConfigOnlyDirs = null;
             _installer.InstallList(
                 new List<CkanModule>() { _testModule! },
-                new RelationshipResolverOptions(),
+                new RelationshipResolverOptions(_instance.KSP.StabilityToleranceConfig),
                 _registryManager,
                 ref possibleConfigOnlyDirs);
         }

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -415,7 +415,7 @@ namespace Tests.Core
                 registry.RepositoriesClear();
                 registry.RepositoriesAdd(repo.repo);
 
-                Assert.AreEqual(1, registry.CompatibleModules(ksp.KSP.VersionCriteria()).Count());
+                Assert.AreEqual(1, registry.CompatibleModules(ksp.KSP.StabilityToleranceConfig, ksp.KSP.VersionCriteria()).Count());
 
                 // Attempt to install it.
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
@@ -423,7 +423,7 @@ namespace Tests.Core
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(),
+                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                  ref possibleConfigOnlyDirs);
 
@@ -461,7 +461,7 @@ namespace Tests.Core
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
-                    .InstallList(modules, new RelationshipResolverOptions(),
+                    .InstallList(modules, new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                  ref possibleConfigOnlyDirs);
 
@@ -510,7 +510,7 @@ namespace Tests.Core
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(),
+                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                  ref possibleConfigOnlyDirs);
 
@@ -525,7 +525,7 @@ namespace Tests.Core
 
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(),
+                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                  ref possibleConfigOnlyDirs);
 
@@ -719,7 +719,7 @@ namespace Tests.Core
                     HashSet<string>? possibleConfigOnlyDirs = null;
                     new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
                         .InstallList(modules,
-                                     new RelationshipResolverOptions(),
+                                     new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                      RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                      ref possibleConfigOnlyDirs);
 
@@ -878,7 +878,7 @@ namespace Tests.Core
 
                 // Act
                 var result = ModuleInstaller.FindRecommendations(inst.KSP,
-                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, crit))
+                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit))
                                                                               .OfType<CkanModule>()
                                                                               .ToHashSet(),
                                                                  new List<CkanModule>(),
@@ -890,7 +890,7 @@ namespace Tests.Core
                 // Assert
                 Assert.IsTrue(result, "Should return something");
                 CollectionAssert.IsNotEmpty(recommendations, "Should return recommendations");
-                CollectionAssert.AreEquivalent(dlcIdents.Select(ident => registry.LatestAvailable(ident, crit)),
+                CollectionAssert.AreEquivalent(dlcIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit)),
                                                recommendations.Keys,
                                                "The DLC should be recommended");
             }
@@ -929,7 +929,7 @@ namespace Tests.Core
 
                 // Act
                 var result = ModuleInstaller.FindRecommendations(inst.KSP,
-                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, crit))
+                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit))
                                                                               .OfType<CkanModule>()
                                                                               .ToHashSet(),
                                                                  new List<CkanModule>(),
@@ -940,7 +940,7 @@ namespace Tests.Core
 
                 // Assert
                 Assert.IsFalse(result, "Should return nothing");
-                foreach (var mod in dlcIdents.Select(ident => registry.LatestAvailable(ident, crit)))
+                foreach (var mod in dlcIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit)))
                 {
                     CollectionAssert.DoesNotContain(recommendations, mod,
                                                     "DLC should not be recommended");
@@ -982,7 +982,7 @@ namespace Tests.Core
                         HashSet<string>? possibleConfigOnlyDirs = null;
                         new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
                             .InstallList(modules,
-                                         new RelationshipResolverOptions(),
+                                         new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                          RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                          ref possibleConfigOnlyDirs);
                     },
@@ -1021,7 +1021,7 @@ namespace Tests.Core
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(),
+                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                  ref possibleConfigOnlyDirs);
             }
@@ -1082,10 +1082,10 @@ namespace Tests.Core
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
                 manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
-                var replacement = querier.GetReplacement(replaced.identifier,
+                var replacement = querier.GetReplacement(replaced.identifier, ksp.KSP.StabilityToleranceConfig,
                                                          new GameVersionCriteria(new GameVersion(1, 12)))!;
                 installer.Replace(Enumerable.Repeat(replacement, 1),
-                                  new RelationshipResolverOptions(),
+                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                   downloader, ref possibleConfigOnlyDirs, regMgr,
                                   false);
 
@@ -1150,7 +1150,7 @@ namespace Tests.Core
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
                 manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), new Progress<long>(bytes => {}));
-                var replacement = querier.GetReplacement(replaced.identifier,
+                var replacement = querier.GetReplacement(replaced.identifier, ksp.KSP.StabilityToleranceConfig,
                                                          new GameVersionCriteria(new GameVersion(1, 11)));
 
                 // Assert
@@ -1326,7 +1326,7 @@ namespace Tests.Core
 
                 // Act
                 installer.Upgrade(upgradeIdentifiers.Select(ident =>
-                                      registry.LatestAvailable(ident, inst.KSP.VersionCriteria()))
+                                      registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, inst.KSP.VersionCriteria()))
                                                     .OfType<CkanModule>()
                                                     .ToArray(),
                                   downloader, ref possibleConfigOnlyDirs, regMgr, false);
@@ -1387,7 +1387,7 @@ namespace Tests.Core
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 new ModuleInstaller(inst.KSP, manager.Cache!, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(),
+                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  regMgr,
                                  ref possibleConfigOnlyDirs);
             }

--- a/Tests/Core/Registry/CompatibilitySorter.cs
+++ b/Tests/Core/Registry/CompatibilitySorter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NUnit.Framework;
 
 using CKAN;
+using CKAN.Configuration;
 using CKAN.Versioning;
 #if NET45
 using CKAN.Extensions;
@@ -86,11 +87,11 @@ namespace Tests.Core.Registry
                                         .GetAvailableModules(Enumerable.Repeat(repo1.repo, 1),
                                                              identifier)
                                         .First()
-                                        .Latest();
+                                        .Latest(ReleaseStatus.stable);
 
                 // Act
                 var sorter = new CompatibilitySorter(
-                    versCrit,
+                    new StabilityToleranceConfig(""), versCrit,
                     repoData.Manager.GetAllAvailDicts(repos),
                     providers, installed, dlls, dlcs);
 

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Tests.Data;
 
 using CKAN;
+using CKAN.Configuration;
 using CKAN.Versioning;
 
 namespace Tests.Core.Registry
@@ -16,6 +17,7 @@ namespace Tests.Core.Registry
     public class RegistryTests
     {
         private string? repoDataDir;
+        private readonly StabilityToleranceConfig stabilityTolerance = new StabilityToleranceConfig("");
 
         private static readonly GameVersionCriteria v0_24_2 = new GameVersionCriteria(GameVersion.Parse("0.24.2"));
         private static readonly GameVersionCriteria v0_25_0 = new GameVersionCriteria(GameVersion.Parse("0.25.0"));
@@ -55,15 +57,15 @@ namespace Tests.Core.Registry
                 var module = registry.GetModuleByVersion(identifier, "0.14");
 
                 // Make sure it's there for 0.24.2
-                Assert.AreEqual(module?.ToString(), registry.LatestAvailable(identifier, v0_24_2)?.ToString());
+                Assert.AreEqual(module?.ToString(), registry.LatestAvailable(identifier, stabilityTolerance, v0_24_2)?.ToString());
 
                 // But not for 0.25.0
-                Assert.IsNull(registry.LatestAvailable(identifier, v0_25_0));
+                Assert.IsNull(registry.LatestAvailable(identifier, stabilityTolerance, v0_25_0));
 
                 // And that we fail if we ask for something we don't know.
                 Assert.Throws<ModuleNotFoundKraken>(delegate
                 {
-                    registry.LatestAvailable("ToTheMun", v0_24_2);
+                    registry.LatestAvailable("ToTheMun", stabilityTolerance, v0_24_2);
                 });
             }
         }
@@ -89,7 +91,7 @@ namespace Tests.Core.Registry
                 var DLCDepender = registry.GetModuleByVersion("DLC-Depender", "1.0.0");
 
                 // Act
-                var avail = registry.CompatibleModules(v0_24_2).OfType<CkanModule?>().ToList();
+                var avail = registry.CompatibleModules(stabilityTolerance, v0_24_2).OfType<CkanModule?>().ToList();
 
                 // Assert
                 Assert.IsFalse(avail.Contains(DLCDepender));
@@ -121,7 +123,7 @@ namespace Tests.Core.Registry
                 var DLCDepender = registry.GetModuleByVersion("DLC-Depender", "1.0.0");
 
                 // Act
-                var avail = registry.CompatibleModules(v0_24_2).OfType<CkanModule?>().ToList();
+                var avail = registry.CompatibleModules(stabilityTolerance, v0_24_2).OfType<CkanModule?>().ToList();
 
                 // Assert
                 Assert.IsTrue(avail.Contains(DLCDepender));
@@ -154,7 +156,7 @@ namespace Tests.Core.Registry
                 var DLCDepender = registry.GetModuleByVersion("DLC-Depender", "1.0.0");
 
                 // Act
-                var avail = registry.CompatibleModules(v0_24_2).OfType<CkanModule?>().ToList();
+                var avail = registry.CompatibleModules(stabilityTolerance, v0_24_2).OfType<CkanModule?>().ToList();
 
                 // Assert
                 Assert.IsTrue(avail.Contains(DLCDepender));
@@ -187,7 +189,7 @@ namespace Tests.Core.Registry
                 var DLCDepender = registry.GetModuleByVersion("DLC-Depender", "1.0.0");
 
                 // Act
-                var avail = registry.CompatibleModules(v0_24_2).OfType<CkanModule?>().ToList();
+                var avail = registry.CompatibleModules(stabilityTolerance, v0_24_2).OfType<CkanModule?>().ToList();
 
                 // Assert
                 Assert.IsFalse(avail.Contains(DLCDepender));
@@ -232,7 +234,7 @@ namespace Tests.Core.Registry
 
                 // Act
                 GameVersionCriteria v173 = new GameVersionCriteria(GameVersion.Parse("1.7.3"));
-                var compat = registry.CompatibleModules(v173).OfType<CkanModule?>().ToList();
+                var compat = registry.CompatibleModules(stabilityTolerance, v173).OfType<CkanModule?>().ToList();
 
                 // Assert
                 Assert.IsFalse(compat.Contains(modFor161));
@@ -271,7 +273,7 @@ namespace Tests.Core.Registry
                 });
 
                 // Act
-                bool has = registry.HasUpdate(mod.identifier, gameInst, new HashSet<string>(), false, out _);
+                bool has = registry.HasUpdate(mod.identifier, stabilityTolerance, gameInst, new HashSet<string>(), false, out _);
 
                 // Assert
                 Assert.IsTrue(has, "Can't upgrade manually installed DLL");
@@ -327,7 +329,7 @@ namespace Tests.Core.Registry
                 GameVersionCriteria crit = new GameVersionCriteria(olderDepMod?.ksp_version);
 
                 // Act
-                bool has = registry.HasUpdate(olderDepMod?.identifier!, gameInst, new HashSet<string>(), false,
+                bool has = registry.HasUpdate(olderDepMod?.identifier!, stabilityTolerance, gameInst, new HashSet<string>(), false,
                                               out _,
                                               registry.InstalledModules
                                                       .Select(im => im.Module)

--- a/Tests/Core/Registry/RegistryLive.cs
+++ b/Tests/Core/Registry/RegistryLive.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Tests.Data;
 
 using CKAN;
+using CKAN.Configuration;
 using CKAN.Versioning;
 
 namespace Tests.Core.Registry
@@ -32,7 +33,7 @@ namespace Tests.Core.Registry
                 registry.RepositoriesAdd(repo);
 
                 var module =
-                    registry.LatestAvailable("AGExt", new GameVersionCriteria(temp_ksp.KSP.Version()));
+                    registry.LatestAvailable("AGExt", new StabilityToleranceConfig(""), new GameVersionCriteria(temp_ksp.KSP.Version()));
 
                 Assert.AreEqual("AGExt", module?.identifier);
                 Assert.AreEqual("1.24a", module?.version.ToString());

--- a/Tests/Core/Repositories/RepositoryDataManagerTests.cs
+++ b/Tests/Core/Repositories/RepositoryDataManagerTests.cs
@@ -25,7 +25,7 @@ namespace Tests.Core.Repositories
                 // Act
                 var versions = repoData.Manager.GetAvailableModules(Enumerable.Repeat(testRepo, 1),
                                                                     "FerramAerospaceResearch")
-                                               .Select(am => am.Latest(crit)?.version.ToString())
+                                               .Select(am => am.Latest(ReleaseStatus.stable, crit)?.version.ToString())
                                                .ToArray();
 
                 // Assert
@@ -47,7 +47,7 @@ namespace Tests.Core.Repositories
                 // Act
                 var versions = repoData.Manager.GetAvailableModules(Enumerable.Repeat(testRepo, 1),
                                                                     "FerramAerospaceResearch")
-                                               .Select(am => am.Latest(crit)?.version.ToString())
+                                               .Select(am => am.Latest(ReleaseStatus.stable, crit)?.version.ToString())
                                                .ToArray();
 
                 // Assert

--- a/Tests/Core/Types/ReleaseStatus.cs
+++ b/Tests/Core/Types/ReleaseStatus.cs
@@ -1,4 +1,5 @@
 using CKAN;
+
 using NUnit.Framework;
 
 namespace Tests.Core.Types
@@ -6,46 +7,74 @@ namespace Tests.Core.Types
     [TestFixture]
     public class ReleaseStatus
     {
-
-        // These get used by our tests, but we have to disable 'used only once' (0414)
-        // to stop the compiler from giving us warnings.
-        #pragma warning disable 0414, IDE0052
-
-        private static readonly string[] GoodStatuses = {
-            "stable", "testing", "development"
-        };
-
-        private static readonly string[] BadStatuses = {
-            "cheese", "some thing I wrote last night" , "",
-            "yo dawg I heard you like tests",
-            "42"
-        };
-
-        #pragma warning restore 0414, IDE0052
-
-        [Test][TestCaseSource("GoodStatuses")]
-        public void ReleaseGood(string status)
+        [TestCase("stable"),
+         TestCase("testing"),
+         TestCase("development"),
+         TestCase("alpha", "development"),
+         TestCase("beta",  "testing")]
+        public void Deserialize_GoodString_DoesNotThrow(string  status,
+                                                        string? aliasValue = null)
         {
-            var release = new CKAN.ReleaseStatus(status);
-            Assert.IsInstanceOf<CKAN.ReleaseStatus>(release);
-            Assert.AreEqual(status, release.ToString());
+            Assert.DoesNotThrow(() =>
+            {
+                var module = CkanModule.FromJson(
+                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                        $@"{{
+                            ""identifier"": ""aMod"",
+                            ""release_status"": ""{status}""
+                        }}"));
+                Assert.AreEqual(aliasValue ?? status,
+                                module.release_status.ToString());
+            });
         }
 
-        [Test][TestCaseSource("BadStatuses")]
-        public void ReleaseBad(string status)
+        [TestCase("cheese"),
+         TestCase("some thing I wrote last night"),
+         TestCase(""),
+         TestCase("yo dawg I heard you like tests"),
+         TestCase("42")]
+        public void Deserialize_BadString_Throws(string status)
         {
             Assert.Throws<BadMetadataKraken>(delegate
             {
-                new CKAN.ReleaseStatus(status);
+                var module = CkanModule.FromJson(
+                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                        $@"{{
+                            ""identifier"": ""aMod"",
+                            ""release_status"": ""{status}""
+                        }}"));
             });
         }
 
         [Test]
-        public void Null()
+        public void Deserialize_Absent_DoesNotThrow()
         {
-            // According to the spec, no release status means "stable".
-            var release = new CKAN.ReleaseStatus(null);
-            Assert.AreEqual("stable", release.ToString());
+            // According to the spec, no release status means "stable"
+            Assert.DoesNotThrow(() =>
+            {
+                var module = CkanModule.FromJson(
+                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                        $@"{{
+                            ""identifier"": ""aMod""
+                        }}"));
+                Assert.AreEqual("stable", module.release_status.ToString());
+            });
+        }
+
+        [Test]
+        public void Deserialize_NullOrEmpty_DoesNotThrow()
+        {
+            // According to the spec, no release status means "stable"
+            Assert.DoesNotThrow(() =>
+            {
+                var module = CkanModule.FromJson(
+                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                        $@"{{
+                            ""identifier"": ""aMod"",
+                            ""release_status"": null
+                        }}"));
+                Assert.AreEqual("stable", module.release_status.ToString());
+            });
         }
     }
 }

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -22,6 +22,7 @@ namespace Tests.GUI
     [TestFixture]
     public class GUIModTests
     {
+
         [Test]
         public void NewGuiModsAreNotSelectedForUpgrade()
         {
@@ -38,7 +39,7 @@ namespace Tests.GUI
                 var registry = new Registry(repoData.Manager, repo.repo);
                 var ckan_mod = registry.GetModuleByVersion("kOS", "0.14");
 
-                var mod = new GUIMod(ckan_mod!, repoData.Manager, registry, manager.CurrentInstance.VersionCriteria(),
+                var mod = new GUIMod(ckan_mod!, repoData.Manager, registry, manager.CurrentInstance.StabilityToleranceConfig, manager.CurrentInstance.VersionCriteria(),
                                      null, false, false);
                 Assert.True(mod.SelectedMod == mod.InstalledMod?.Module);
             }
@@ -67,7 +68,7 @@ namespace Tests.GUI
                     var upgradeableGroups = registry.CheckUpgradeable(tidy.KSP,
                                                                       new HashSet<string>());
 
-                    var mod = new GUIMod(old_version, repoData.Manager, registry, tidy.KSP.VersionCriteria(),
+                    var mod = new GUIMod(old_version, repoData.Manager, registry, tidy.KSP.StabilityToleranceConfig, tidy.KSP.VersionCriteria(),
                                          null, false, false)
                     {
                         HasUpdate = upgradeableGroups[true].Any(m => m.identifier == old_version.identifier),
@@ -108,7 +109,7 @@ namespace Tests.GUI
                 var prevVersion = registry.GetModuleByVersion("OutOfOrderMod", "1.1.0");
 
                 // Act
-                GUIMod m = new GUIMod(mainVersion!, repoData.Manager, registry, tidy.KSP.VersionCriteria(),
+                GUIMod m = new GUIMod(mainVersion!, repoData.Manager, registry, tidy.KSP.StabilityToleranceConfig, tidy.KSP.VersionCriteria(),
                                       null, false, false);
 
                 // Assert

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -50,7 +50,7 @@ namespace Tests.NetKAN.Sources.Github
             var sut = new GithubApi(new CachingHttpService(_cache!));
 
             // Act
-            var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test", false, false));
+            var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test", false), false);
 
             // Assert
             Assert.IsNotNull(githubRelease?.Author);

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -28,7 +28,7 @@ namespace Tests.NetKAN.Transformers
                     HtmlUrl = "https://github.com/ExampleAccount/ExampleProject"
                 });
 
-            mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>()))
+            mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>(), false))
                 .Returns(new GithubRelease(
                     "ExampleProject",
                     new ModuleVersion("1.0"),
@@ -42,7 +42,7 @@ namespace Tests.NetKAN.Transformers
                     }
                 ));
 
-            mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>()))
+            mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>(), false))
                 .Returns(new GithubRelease[] {
                     new GithubRelease(
                         "ExampleProject",
@@ -137,7 +137,7 @@ namespace Tests.NetKAN.Transformers
                     HtmlUrl = "https://github.com/jrodrigv/DestructionEffects"
                 });
 
-            mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>()))
+            mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>(), false))
                 .Returns(new GithubRelease(
                     "DestructionEffects",
                     new ModuleVersion("v1.8,0"),
@@ -151,7 +151,7 @@ namespace Tests.NetKAN.Transformers
                     }
                 ));
 
-            mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>()))
+            mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>(), false))
                 .Returns(new GithubRelease[] { new GithubRelease(
                     "DestructionEffects",
                     new ModuleVersion("v1.8,0"),


### PR DESCRIPTION
## Motivation

@JonnyOThan wants to make prereleases of RPM and FreeIva available to CKAN users on an opt-in basis.

Currently the inflator just ignores prereleases, so they aren't added to the default metadata repo at all.

## Problems

Bugs encountered during dev:

- The "Install:" label in ConsoleUI's mod info screen was not internationalized
- The labeled progress bar fix for Mono from #4255 broke it on Windows; no text is shown

## Causes

- The labeled progress bar's `OnPaint` method never runs on Windows, so the text never gets drawn!

## Changes

- Now `ReleaseStatus` is changed from a rich class containing a `string` to an `enum` with integer values and `Display` attributes for each option
  - `JsonReleaseStatusConverter` is created to migrate `alpha` to `development` and `beta` to `testing`
- Now a `CKAN.Configuration.StabilityToleranceConfig` class is created to hold JSON-serializable data representing an overall `Release` status plus per-mod overrides
  - `RelationshipResolverOptions` now requires one of these and provides it to the relationship resolver code that needs it to pick modules; from there it is passed layer-by-layer to `AvailableModules.Latest` which actually applies the filter
  - `CompatibleGameVersions` is moved to the `Configuration` folder and the `CKAN.Configuration` namespace
- Now `GameInstance.StabilityToleranceConfig` represents such an object for each game instance, saved to `<game root>/CKAN/stability_tolerance.json`
- `JsonConfiguration` now raises a `PropertyChanged` event when the system level install filters are changed
  - GUI's Version tab now listens for this event and no longer needs `Main` to tell it to refresh after the install filters window closes
- Now Netkan's `--prerelease` option is changed from boolean to nullable boolean, so the options are:
  - `true`: Inflate only prereleases (same as before)
  - `false`: Inflate only **non**-prereleases (same as before, also the old default)
  - `null` (omitted, therefore the new default): Inflate both
- `x_netkan_github` may now contain a `prereleases` flag with the same values and effects as above, in case we need to override this behavior for an individual mod
- Now if the GitHub transformer inflates a prerelease, it sets `release_status` to `testing`
- Now if the SpaceDock transformer inflates a release whose version string contains "alpha", "beta", or "pre", it sets `release_status` to `testing`
- Now for a mod to be considered installable, its `release_status` has to be as stable as the configured stability tolerance
  - The old client never filters on `release_status`, which will become a problem once we start indexing prereleases. Therefore the spec version analyzer is updated to set `spec_version` to `v1.36` for any module with a `release_status` other than `stable`, which will ensure that they will be hidden by the old client
  - The inflator can't handle future spec versions, even though it is always the cutting edge code and it makes sense to pregenerate metadata in anticipation of future releases. To account for this, `Meta.IsNetKAN` is now created to return `true` from inside Netkan and `false` in the client, which we then use to turn off spec version validation
- Multi-hosted mods are likely to upload their prereleases to just one host, so the `Generated 2 modules but only 1 requested` check is relaxed for prereleases
  - To make this work, we now mix the non-`x_netkan` properties of the sections of a netkan before inflation. In the near term this will mean we no longer need to put `install:` under both the GitHub and SpaceDock sections.
- Now CmdLine has new commands `ckan stability list` and `ckan stability set` to show and edit the new settings; `set --mod` can be used to set mod overrides
- Now the "Install:" label in ConsoleUI's mod info screen is internationalized
- Now ConsoleUI has a `ConsoleComboButtons` control representing a group of radio buttons, and a derived class `ReleaseStatsComboButtons` using it to represent choosing a value from `ReleaseStatus`, which is added to the instance edit and mod info screens
  - Since the radio buttons in the mod info screen can accept focus, so can the other text boxes if they have enough contents to be scrolled
- Now a combobox dropdown control is added to GUI's settings dialog to represent the instance-level setting and the Versions tab to represent the per-mod override
- Now the labeled progress bar control sets the `UserPaint` style to make `OnPaint` run, where it uses `ProgressBarRenderer` to draw the progress bar before it draws the text, which hopefully will work everywhere
- Some missing `SuspendLayout`, `ResumeLayout`, and `PerformLayout` calls are added to GUI, which fixes a few UI glitches and reduces some flickering
- The Versions tab no longer highlights the selected row, because this uselessly conceals the row color
- The Versions tab's legend is now moved to the bottom, just above the stability override combobox
  - The legend now only shows the installed version label if the mod is installed
  - The legend now shows a label for pre-releases if there is one in the current mod

Fixes #4159.
