### PR TITLE
Exclude dependencies in the changeset from supported by list

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1623,8 +1623,8 @@ namespace CKAN
 
             var opts = RelationshipResolverOptions.DependsOnlyOpts();
             supporters = resolver.Supporters(recommenders,
-                                             toInstall.Concat(recommendations.Keys)
-                                                      .Concat(suggestions.Keys))
+                                             recommenders.Concat(recommendations.Keys)
+                                                         .Concat(suggestions.Keys))
                                  .Where(kvp => CanInstall(toInstall.Append(kvp.Key).ToList(),
                                                           opts, registry, instance.game, crit))
                                  .ToDictionary();


### PR DESCRIPTION
## Problem

If you install `BoringCrewServices`, `KSPCommunityPartModules` will be listed as a dependency in the changeset, but also as optional in the "Supported By" list. It doesn't make sense for it to be in both places.

Reported by @SofieBrink and @AlexSkylark in Discord.

## Causes

- `BoringCrewServices` depends on `KSPCommunityPartModules`, which adds the latter to the changeset as a dependency
- `KSPCommunityPartModules` supports `BoringCrewServices`, which adds the former to the "Supported By" list
- The relationship resolver currently excludes only the mods that you directly selected from the "Supported By" list, not their dependencies (probably because this relationship structure doesn't actually make sense)

## Changes

Now `ModuleInstaller.FindRecommendations` passes `recommenders` to `RelationshipResolver.Supporters` instead of `toInstall`. This will exclude dependencies of the selected mods from the "Supported By" list.
