### PR TITLE
Include `supports` relationship in `ckan show`

### DIFF
--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -217,7 +217,7 @@ namespace CKAN.CmdLine
                 {
                     user.RaiseMessage("");
                     user.RaiseMessage(Properties.Resources.ShowDependsHeader);
-                    foreach (RelationshipDescriptor dep in module.depends)
+                    foreach (var dep in module.depends)
                     {
                         user.RaiseMessage("  - {0}", RelationshipToPrintableString(dep));
                     }
@@ -227,9 +227,9 @@ namespace CKAN.CmdLine
                 {
                     user.RaiseMessage("");
                     user.RaiseMessage(Properties.Resources.ShowRecommendsHeader);
-                    foreach (RelationshipDescriptor dep in module.recommends)
+                    foreach (var rec in module.recommends)
                     {
-                        user.RaiseMessage("  - {0}", RelationshipToPrintableString(dep));
+                        user.RaiseMessage("  - {0}", RelationshipToPrintableString(rec));
                     }
                 }
 
@@ -237,9 +237,19 @@ namespace CKAN.CmdLine
                 {
                     user.RaiseMessage("");
                     user.RaiseMessage(Properties.Resources.ShowSuggestsHeader);
-                    foreach (RelationshipDescriptor dep in module.suggests)
+                    foreach (var sug in module.suggests)
                     {
-                        user.RaiseMessage("  - {0}", RelationshipToPrintableString(dep));
+                        user.RaiseMessage("  - {0}", RelationshipToPrintableString(sug));
+                    }
+                }
+
+                if (module.supports != null && module.supports.Count > 0)
+                {
+                    user.RaiseMessage("");
+                    user.RaiseMessage(Properties.Resources.ShowSupportsHeader);
+                    foreach (var sup in module.supports)
+                    {
+                        user.RaiseMessage("  - {0}", RelationshipToPrintableString(sup));
                     }
                 }
 
@@ -247,7 +257,7 @@ namespace CKAN.CmdLine
                 {
                     user.RaiseMessage("");
                     user.RaiseMessage(Properties.Resources.ShowProvidesHeader);
-                    foreach (string prov in module.provides)
+                    foreach (var prov in module.provides)
                     {
                         user.RaiseMessage("  - {0}", prov);
                     }

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -345,6 +345,7 @@ Try `ckan list` for a list of installed mods.</value></data>
   <data name="ShowDependsHeader" xml:space="preserve"><value>Depends:</value></data>
   <data name="ShowRecommendsHeader" xml:space="preserve"><value>Recommends:</value></data>
   <data name="ShowSuggestsHeader" xml:space="preserve"><value>Suggests:</value></data>
+  <data name="ShowSupportsHeader" xml:space="preserve"><value>Supports:</value></data>
   <data name="ShowProvidesHeader" xml:space="preserve"><value>Provides:</value></data>
   <data name="ShowResourcesHeader" xml:space="preserve"><value>Resources:</value></data>
   <data name="ShowHomePage" xml:space="preserve"><value>  Home page:	{0}</value></data>


### PR DESCRIPTION
## Motivation

`ckan show` lists a module's relationships, except for `supports`. It would be good to see them all.

## Changes

Now a new "Supports:" section appears with the `supports` relationships.
