### PR TITLE
Handle raw GitHub URLs containing refs/heads/

### DIFF
--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -40,7 +40,7 @@ namespace CKAN.NetKAN.Sources.Github
 
         // https://raw.githubusercontent.com/<OWNER>/<REPO>/<BRANCH>/<PATH>
         private static readonly Regex githubUserContentUrlRegex =
-            new Regex(@"^/(?<owner>[^/]+)/(?<repo>[^/]+)/(?<branch>[^/]+)/(?<path>.+)$",
+            new Regex(@"^/(?<owner>[^/]+)/(?<repo>[^/]+)/(refs/heads/)?(?<branch>[^/]+)/(?<path>.+)$",
                       RegexOptions.Compiled);
 
         public GithubApi(IHttpService http, string? oauthToken = null)
@@ -115,7 +115,8 @@ namespace CKAN.NetKAN.Sources.Github
                                       out string? ghBranch,
                                       out string? ghPath))
             {
-                Log.Info("Found GitHub URL, retrieving with API");
+                Log.InfoFormat("Found GitHub URL, retrieving with API: {0} {1} {2} {3}",
+                               ghOwner, ghRepo, ghBranch, ghPath);
                 return Call(
                     $"repos/{ghOwner}/{ghRepo}/contents/{ghPath}?ref={ghBranch}",
                     rawMediaType);


### PR DESCRIPTION
## Problem

`HideEmptyFilters` currently has an inflation warning about failing to download a remote version file that most definitely exists.

## Cause

Once upon a time, if you clicked the "raw" link in GitHub, it took you to a URL like this:

- <https://raw.githubusercontent.com/HebaruSan/Astrogator/master/GameData/Astrogator/Astrogator.version>

Now it does this instead:

- <https://raw.githubusercontent.com/AlexSkylark/HideEmptyFilters/refs/heads/main/GameData/HideEmptyFilters/HideEmptyFilters.version>

Note the extra `refs/heads/` substring that's been added. `GithubApi.TryGetGithubPath` tries to parse GitHub URLs in order to access the same files via the GitHub API, and this new substring messes up the existing parsing. It thinks the branch is called `refs` and that the file's path starts with `heads/main`. When these erroneous strings are passed to the API, the retrieval fails.

## Changes

Now `GithubApi.TryGetGitHubPath` skips `refs/heads/` if it is present in a URL. This allows it to get the correct branch, and therefore also download the file successfully, which fixes the 404.

FYI to @AlexSkylark.
