### PR TITLE
Fix exception when the same module is in multiple repos

### DIFF
--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -26,7 +26,7 @@ namespace CKAN
         /// <param name="dlc">Collection of installed DLCs</param>
         public CompatibilitySorter(GameVersionCriteria                              crit,
                                    IEnumerable<Dictionary<string, AvailableModule>> available,
-                                   IDictionary<string, HashSet<AvailableModule>>    providers,
+                                   IDictionary<string, AvailableModule[]>           providers,
                                    IDictionary<string, InstalledModule>             installed,
                                    ICollection<string>                              dlls,
                                    IDictionary<string, ModuleVersion>               dlc)
@@ -119,8 +119,8 @@ namespace CKAN
         /// Mapping from identifiers to compatible mods providing those identifiers
         /// </returns>
         private static Dictionary<string, HashSet<AvailableModule>> CompatibleProviders(
-            GameVersionCriteria                           crit,
-            IDictionary<string, HashSet<AvailableModule>> providers)
+            GameVersionCriteria                    crit,
+            IDictionary<string, AvailableModule[]> providers)
             => providers
                 .AsParallel()
                 .Select(kvp => new KeyValuePair<string, HashSet<AvailableModule>>(

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -173,7 +173,7 @@ namespace CKAN
 
         public override bool Unsatisfied()
             => reason is SelectionReason.Depends
-               && resolved.Keys.Count(m => !m.IsDLC) == 0;
+               && !resolved.Keys.Any(m => !m.IsDLC);
 
         public override bool Unsatisfied(ICollection<CkanModule> installing)
             => reason is SelectionReason.Depends

--- a/Tests/Core/Registry/CompatibilitySorter.cs
+++ b/Tests/Core/Registry/CompatibilitySorter.cs
@@ -78,7 +78,7 @@ namespace Tests.Core.Registry
                                         .GetAllAvailableModules(repos)
                                         .GroupBy(am => am.AllAvailable().First().identifier)
                                         .ToDictionary(grp => grp.Key,
-                                                      grp => grp.ToHashSet());
+                                                      grp => grp.ToArray());
                 var installed = new Dictionary<string, InstalledModule>();
                 var dlls      = new Dictionary<string, string>().Keys;
                 var dlcs      = new Dictionary<string, ModuleVersion>();


### PR DESCRIPTION
## Problem

KSP-CKAN/NetKAN#10303 is throwing:

```
Unhandled Exception:
  System.ArgumentException: An item with the same key has already been added. Key: RSSOrigin-TopoRevampTextures16k v1.1.2
    at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x0015a] in <d636f104d58046fd9b195699bcb1a744>:0 
    at System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00000] in <d636f104d58046fd9b195699bcb1a744>:0 
    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.List`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector, System.Collections.Generic.IEqualityComparer`1[T] comparer) [0x0002d] in <69ada62907b24213a012734531df1db1>:0 
    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector, System.Collections.Generic.IEqualityComparer`1[T] comparer) [0x00067] in <69ada62907b24213a012734531df1db1>:0 
    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector) [0x00000] in <69ada62907b24213a012734531df1db1>:0 
    at CKAN.ResolvedByNew..ctor (CKAN.CkanModule source, CKAN.RelationshipDescriptor relationship, CKAN.SelectionReason reason, System.Collections.Generic.IEnumerable`1[T] providers, System.Collections.Generic.ICollection`1[T] definitelyInstalling, System.Collections.Generic.ICollection`1[T] allInstalling, CKAN.IRegistryQuerier registry, System.Collections.Generic.ICollection`1[T] dlls, System.Collections.Generic.ICollection`1[T] installed, CKAN.Versioning.GameVersionCriteria crit, CKAN.OptionalRelationships optRels, System.Collections.Concurrent.ConcurrentDictionary`2[TKey,TValue] relationshipCache) [0x0004d] in <dc3376c212ad46a191d66621f410eae2>:0 
```

## Cause

This exception indicates that `Registry.LatestAvailableWithProvides` returned multiple copies of `RSSOrigin-TopoRevampTextures16k`, which would have happened because it's present in both the default repo and the custom repo that the validator uses for the freshly inflated replacement modules. It should only return the one with the higher repo priority.

## Changes

- Now the value type of the provides index is changed from `HashSet` to array to preserve the priority ordering of the source repos
- Now `Registry.LatestAvailableWithProvides` calls `Distinct` to filter duplicates out of its returned list
