### PR TITLE
Create workflow to bounce the Inflators

### DIFF
--- a/.github/actions/netkan/action.yml
+++ b/.github/actions/netkan/action.yml
@@ -1,0 +1,26 @@
+name: NetKAN
+description: Run commands in the NetKAN container
+
+inputs:
+  AWS_ACCESS_KEY_ID:
+    description: Credentials for AWS
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    description: Credentials for AWS
+    required: true
+  AWS_DEFAULT_REGION:
+    description: Region for AWS
+    required: true
+  args:
+    description: The command to run
+    required: true
+
+runs:
+  using: docker
+  image: kspckan/netkan
+  env:
+    AWS_ACCESS_KEY_ID:     ${{ inputs.AWS_ACCESS_KEY_ID     }}
+    AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+    AWS_DEFAULT_REGION:    ${{ inputs.AWS_DEFAULT_REGION    }}
+  args:
+    - ${{ input.args }}

--- a/.github/workflows/bounce.yml
+++ b/.github/workflows/bounce.yml
@@ -1,0 +1,21 @@
+name: Bounce the Inflators
+on:
+  workflow_dispatch:
+
+jobs:
+  bounce:
+    strategy:
+      matrix:
+        game:
+          - Ksp
+          - Ksp2
+    name: Bounce the ${{ matrix.game }} Inflator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run NetKAN redeploy command for ${{ matrix.game }}
+        uses: ./.github/actions/netkan
+        with:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID     }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION:    us-west-2
+          args: redeploy-service --cluster NetKANCluster --service-name Inflator${{ matrix.game }}


### PR DESCRIPTION
## Motivation

The Inflators have been freezing up a bit recently. While we're still investigating why, it would be nice to have an easy way to reboot them that doesn't require recompiling and signing everything, as re-running the deploy workflow does.

## Changes

Now a new bounce job can be run from the workflows list, which uses a games matrix to start two jobs in parallel, which use a new action to run a given command in the `kspckan/netkan` container. This should allow us to run just the redeploy commands easily.
