### PR TITLE
Let dev builds use future spec versions

### DIFF
--- a/ConsoleUI/AuthTokenListScreen.cs
+++ b/ConsoleUI/AuthTokenListScreen.cs
@@ -82,7 +82,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/ConsoleUI/DeleteDirectoriesScreen.cs
+++ b/ConsoleUI/DeleteDirectoriesScreen.cs
@@ -122,7 +122,7 @@ namespace CKAN.ConsoleUI {
         /// <summary>
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
-        protected override string LeftHeader() => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+        protected override string LeftHeader() => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Show the Delete Directories header

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -142,7 +142,7 @@ namespace CKAN.ConsoleUI {
         /// <summary>
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
-        protected override string LeftHeader() => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+        protected override string LeftHeader() => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/ConsoleUI/ExitScreen.cs
+++ b/ConsoleUI/ExitScreen.cs
@@ -49,8 +49,8 @@ namespace CKAN.ConsoleUI {
             Console.Clear();
 
             // Specially formatted snippets
-            var ckanPiece = new FancyLinePiece(Meta.GetProductName(), theme.ExitInnerBg, theme.ExitHighlightFg);
-            var ckanVersionPiece = new FancyLinePiece($"{Meta.GetProductName()} {Meta.GetVersion()}", theme.ExitInnerBg, theme.ExitHighlightFg);
+            var ckanPiece = new FancyLinePiece(Meta.ProductName, theme.ExitInnerBg, theme.ExitHighlightFg);
+            var ckanVersionPiece = new FancyLinePiece($"{Meta.ProductName} {Meta.GetVersion()}", theme.ExitInnerBg, theme.ExitHighlightFg);
             var releaseLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/releases/latest", theme.ExitInnerBg, theme.ExitLinkFg);
             var issuesLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/issues", theme.ExitInnerBg, theme.ExitLinkFg);
             var authorsLinkPiece = new FancyLinePiece("https://github.com/KSP-CKAN/CKAN/graphs/contributors", theme.ExitInnerBg, theme.ExitLinkFg);

--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -168,7 +168,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/ConsoleUI/GameInstanceScreen.cs
+++ b/ConsoleUI/GameInstanceScreen.cs
@@ -56,7 +56,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Return whether the fields currently are valid.

--- a/ConsoleUI/InstallFiltersScreen.cs
+++ b/ConsoleUI/InstallFiltersScreen.cs
@@ -98,7 +98,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -226,7 +226,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -381,7 +381,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/ConsoleUI/ProgressScreen.cs
+++ b/ConsoleUI/ProgressScreen.cs
@@ -46,7 +46,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in upper left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description of what we're doing in top center

--- a/ConsoleUI/RepoScreen.cs
+++ b/ConsoleUI/RepoScreen.cs
@@ -80,7 +80,7 @@ namespace CKAN.ConsoleUI {
         /// Put CKAN 1.25.5 in top left corner
         /// </summary>
         protected override string LeftHeader()
-            => $"{Meta.GetProductName()} {Meta.GetVersion()}";
+            => $"{Meta.ProductName} {Meta.GetVersion()}";
 
         /// <summary>
         /// Put description in top center

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -15,7 +15,7 @@ namespace CKAN
         /// </summary>
         public static readonly string AppDataPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            Meta.GetProductName());
+            Meta.ProductName);
 
         private static readonly ILog log = LogManager.GetLogger(typeof(CKANPathUtils));
 

--- a/Core/Meta.cs
+++ b/Core/Meta.cs
@@ -1,7 +1,8 @@
-using System;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
+using CKAN.Extensions;
 using CKAN.Versioning;
 
 namespace CKAN
@@ -13,37 +14,40 @@ namespace CKAN
         /// so we don't have to embed that string in many places
         /// </summary>
         /// <returns>"CKAN"</returns>
-        public static string GetProductName()
-            => Assembly.GetExecutingAssembly()
-                       .GetAssemblyAttribute<AssemblyProductAttribute>()
-                       .Product;
+        public static readonly string ProductName =
+            Assembly.GetExecutingAssembly()
+                    .GetAssemblyAttribute<AssemblyProductAttribute>()
+                    .Product;
 
         public static readonly ModuleVersion ReleaseVersion = new ModuleVersion(GetVersion());
 
-        public static bool IsNetKAN
-            => Assembly.GetExecutingAssembly()
-                       .GetAssemblyAttribute<AssemblyTitleAttribute>()
-                       .Title.Contains("NetKAN");
+        public static readonly ModuleVersion SpecVersion =
+            // A dev build always has an odd patch version, and
+            // an odd number always ends with an odd digit in base 10
+            new Regex(@"^(?<prefix>v\d+\.)(?<minor>\d+)\.\d*[13579]\.")
+                .TryMatch(ReleaseVersion.ToString(), out Match? m)
+                && int.TryParse(m.Groups["minor"].Value, out int minor)
+                ? new ModuleVersion($"{m.Groups["prefix"]}{minor + 1}.999")
+                : ReleaseVersion;
+
+        public static readonly bool IsNetKAN =
+            Assembly.GetExecutingAssembly()
+                    .GetAssemblyAttribute<AssemblyTitleAttribute>()
+                    .Title.Contains("NetKAN");
 
         public static string GetVersion(VersionFormat format = VersionFormat.Normal)
-        {
-            var version = Assembly
-                .GetExecutingAssembly()
-                .GetAssemblyAttribute<AssemblyInformationalVersionAttribute>()
-                .InformationalVersion;
-
-            switch (format)
+            => "v" + (format switch
             {
-                case VersionFormat.Normal:
-                    return "v" + Assembly.GetExecutingAssembly()
-                                         .GetAssemblyAttribute<AssemblyFileVersionAttribute>()
-                                         .Version;
-                case VersionFormat.Full:
-                    return $"v{version}";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(format), format, null);
-            }
-        }
+                VersionFormat.Full =>
+                    Assembly.GetExecutingAssembly()
+                            .GetAssemblyAttribute<AssemblyInformationalVersionAttribute>()
+                            .InformationalVersion,
+
+                VersionFormat.Normal or _ =>
+                    Assembly.GetExecutingAssembly()
+                            .GetAssemblyAttribute<AssemblyFileVersionAttribute>()
+                            .Version,
+            });
 
         private static T GetAssemblyAttribute<T>(this Assembly assembly)
             => (T)assembly.GetCustomAttributes(typeof(T), false)

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -680,7 +680,7 @@ namespace CKAN
         /// Returns true if we support at least spec_version of the CKAN spec.
         /// </summary>
         internal static bool IsSpecSupported(ModuleVersion spec_version)
-            => Meta.IsNetKAN || Meta.ReleaseVersion.IsGreaterThan(spec_version);
+            => Meta.IsNetKAN || Meta.SpecVersion.IsGreaterThan(spec_version);
 
         /// <summary>
         /// Returns true if we support the CKAN spec used by this module.

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -142,8 +142,8 @@ namespace CKAN.GUI
             // Set the window name and class for X11
             if (Platform.IsX11)
             {
-                HandleCreated += (sender, e) => X11.SetWMClass(Meta.GetProductName(),
-                                                               Meta.GetProductName(), Handle);
+                HandleCreated += (sender, e) => X11.SetWMClass(Meta.ProductName,
+                                                               Meta.ProductName, Handle);
             }
 
             currentUser = new GUIUser(this, Wait, StatusLabel, StatusProgress);
@@ -427,8 +427,8 @@ namespace CKAN.GUI
 
             Util.Invoke(this, () =>
             {
-                Text = $"{Meta.GetProductName()} {Meta.GetVersion()} - {CurrentInstance.game.ShortName} {CurrentInstance.Version()}    --    {Platform.FormatPath(CurrentInstance.GameDir())}";
-                minimizeNotifyIcon.Text = $"{Meta.GetProductName()} - {CurrentInstance.Name}";
+                Text = $"{Meta.ProductName} {Meta.GetVersion()} - {CurrentInstance.game.ShortName} {CurrentInstance.Version()}    --    {Platform.FormatPath(CurrentInstance.GameDir())}";
+                minimizeNotifyIcon.Text = $"{Meta.ProductName} - {CurrentInstance.Name}";
                 UpdateStatusBar();
             });
 


### PR DESCRIPTION
## Background

The `spec_version` metadata property defines the earliest version of the CKAN client that can properly handle a given module. As of #4155 it is populated programmatically based on analysis of the fields that are present or absent in a module. The CKAN client ignores modules with "future" spec versions indicating that it can't handle them properly.

When we add a new feature, it goes into the dev build immediately. So at any stage of development, all of the next release's functionality is already present in the dev build. But dev builds have a version that corresponds to the same spec version as the current release (but with an odd patch version), so they'll ignore modules with higher spec versions that they can in fact handle properly.

## Motivation

#4260 updated the spec version analyzer to use `v1.36` for modules with `release_status` set to something other than `stable`, to hide them from old clients. This has also hidden them from the dev build, which means it cannot be used for piloting the pre-release functionality from that PR. This defeats the purpose of having dev builds with respect to such changes.

## Changes

- Now `Meta.SpecVersion` is a static readonly field that represents the next highest minor version for dev builds and is the same as `Meta.ReleaseVersion` otherwise (thanks to regex magic)
- Now `CkanModule.IsSpecSupported` compares modules' spec versions to `Meta.SpecVersion` instead of `Meta.ReleaseVersion`
- Now `Meta.GetProductName()` is replaced by a static readonly field `Meta.ProductName` so we don't have to keep recalculating its value with reflection
- Now `Meta.IsNetKAN` is a static readonly field so we don't have to keep recalculating its value with reflection
