### PR TITLE
Draw progress bar when ProgressBarRenderer.IsSupported is false

### DIFF
--- a/GUI/Controls/LabeledProgressBar.cs
+++ b/GUI/Controls/LabeledProgressBar.cs
@@ -60,14 +60,31 @@ namespace CKAN.GUI
 
         protected override void OnPaint(PaintEventArgs e)
         {
-            ProgressBarRenderer.DrawHorizontalBar(e.Graphics, ClientRectangle);
-            ProgressBarRenderer.DrawHorizontalChunks(e.Graphics,
-                                                     new Rectangle(ClientRectangle.X,
-                                                                   ClientRectangle.Y,
-                                                                   ClientRectangle.Width
-                                                                       * (Value - Minimum)
+            if (ProgressBarRenderer.IsSupported)
+            {
+                ProgressBarRenderer.DrawHorizontalBar(e.Graphics, ClientRectangle);
+                ProgressBarRenderer.DrawHorizontalChunks(e.Graphics,
+                                                         new Rectangle(ClientRectangle.X,
+                                                                       ClientRectangle.Y,
+                                                                       ClientRectangle.Width * (Value   - Minimum)
+                                                                                             / (Maximum - Minimum),
+                                                                       ClientRectangle.Height));
+            }
+            else
+            {
+                const int borderWidth = 1;
+                var innerRect = Rectangle.Inflate(ClientRectangle, -2 * borderWidth,
+                                                                   -2 * borderWidth);
+                innerRect.Offset(borderWidth, borderWidth);
+                e.Graphics.DrawRectangle(SystemPens.ControlDark, ClientRectangle);
+                e.Graphics.FillRectangle(SystemBrushes.Control, innerRect);
+                e.Graphics.FillRectangle(SystemBrushes.Highlight,
+                                         new Rectangle(innerRect.X,
+                                                       innerRect.Y,
+                                                       innerRect.Width * (Value   - Minimum)
                                                                        / (Maximum - Minimum),
-                                                                   ClientRectangle.Height));
+                                                       innerRect.Height));
+            }
             TextRenderer.DrawText(e.Graphics, Text, Font,
                                   new Point((Width  - textSize.Width)  / 2,
                                             (Height - textSize.Height) / 2),

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -402,7 +402,7 @@ namespace CKAN.GUI
                 // so we have to re-enforce the filter ourselves
                 var chosen  = Path.GetFileName(dlg.FileName);
                 var allowed = manager.AllInstanceAnchorFiles;
-                if (!allowed.Contains(chosen))
+                if (!allowed.Contains(chosen, Platform.PathComparer))
                 {
                     e.Cancel = true;
                     user.RaiseError(Properties.Resources.ManageGameInstancesInvalidFileSelected,


### PR DESCRIPTION
## Problem

After #4255, my Ubuntu VM still had problems rendering `LabeledProgressBar`. An exception was thrown and the progress bar appeared as a white background with a red X on it.

## Cause

`ProgressBarRenderer` has a boolean `IsSupported` property which is set based on the capabilities and configuration of the host system. If false, then the class's drawing methods throw exceptions instead of drawing. It must have been true on my main Ubuntu system, but it's clearly false in my VM.

## Changes

Now if `ProgressBarRenderer.IsSupported` is false, we draw it with the `PaintEventArgs.Graphics` object instead of `ProgressBarRenderer`.
