### PR TITLE
Optimize label searches and handle spaces in names

### DIFF
--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -135,10 +135,10 @@ namespace CKAN.GUI
                         }
                         break;
                 }
-                if (Main.Instance?.CurrentInstance != null)
+                if (Main.Instance?.CurrentInstance is GameInstance inst)
                 {
                     // Sync the search boxes immediately
-                    currentSearch = ModSearch.Parse(FilterCombinedTextBox.Text);
+                    currentSearch = ModSearch.Parse(inst, FilterCombinedTextBox.Text);
                 }
                 SearchToEditor();
             }

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -45,6 +45,7 @@ namespace CKAN.GUI
 
         public ModSearch CurrentSearch()
             => new ModSearch(
+                Main.Instance!.CurrentInstance!,
                 FilterByNameTextBox.Text,
                 FilterByAuthorTextBox.Text.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries).ToList(),
                 FilterByDescriptionTextBox.Text,

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -391,73 +391,73 @@ namespace CKAN.GUI
         {
             var clicked = sender as ToolStripMenuItem;
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Tag, clicked?.Tag as ModuleTag, null), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Tag, clicked?.Tag as ModuleTag, null), merge);
         }
 
         private void customFilterButton_Click(object? sender, EventArgs? e)
         {
             var clicked = sender as ToolStripMenuItem;
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null, clicked?.Tag as ModuleLabel), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.CustomLabel, null, clicked?.Tag as ModuleLabel), merge);
         }
 
         private void FilterCompatibleButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Compatible), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Compatible), merge);
         }
 
         private void FilterInstalledButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Installed), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Installed), merge);
         }
 
         private void FilterInstalledUpdateButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.InstalledUpdateAvailable), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.InstalledUpdateAvailable), merge);
         }
 
         private void FilterReplaceableButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Replaceable), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Replaceable), merge);
         }
 
         private void FilterCachedButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Cached), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Cached), merge);
         }
 
         private void FilterUncachedButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Uncached), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Uncached), merge);
         }
 
         private void FilterNewButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.NewInRepository), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.NewInRepository), merge);
         }
 
         private void FilterNotInstalledButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.NotInstalled), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.NotInstalled), merge);
         }
 
         private void FilterIncompatibleButton_Click(object? sender, EventArgs? e)
         {
             var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.Incompatible), merge);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Incompatible), merge);
         }
 
         private void FilterAllButton_Click(object? sender, EventArgs? e)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.All), false);
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.All), false);
         }
 
         /// <summary>
@@ -470,7 +470,7 @@ namespace CKAN.GUI
             if (currentInstance != null)
             {
                 var searches = search.Values
-                                     .Select(s => ModSearch.Parse(s))
+                                     .Select(s => ModSearch.Parse(currentInstance!, s))
                                      .OfType<ModSearch>()
                                      .ToList();
 
@@ -1503,25 +1503,25 @@ namespace CKAN.GUI
             Util.Invoke(menuStrip2, () =>
             {
                 FilterCompatibleButton.Text = string.Format(Properties.Resources.MainModListCompatible,
-                    mainModList.CountModsByFilter(GUIModFilter.Compatible));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.Compatible));
                 FilterInstalledButton.Text = string.Format(Properties.Resources.MainModListInstalled,
-                    mainModList.CountModsByFilter(GUIModFilter.Installed));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.Installed));
                 FilterInstalledUpdateButton.Text = string.Format(Properties.Resources.MainModListUpgradeable,
-                    mainModList.CountModsByFilter(GUIModFilter.InstalledUpdateAvailable));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.InstalledUpdateAvailable));
                 FilterReplaceableButton.Text = string.Format(Properties.Resources.MainModListReplaceable,
-                    mainModList.CountModsByFilter(GUIModFilter.Replaceable));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.Replaceable));
                 FilterCachedButton.Text = string.Format(Properties.Resources.MainModListCached,
-                    mainModList.CountModsByFilter(GUIModFilter.Cached));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.Cached));
                 FilterUncachedButton.Text = string.Format(Properties.Resources.MainModListUncached,
-                    mainModList.CountModsByFilter(GUIModFilter.Uncached));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.Uncached));
                 FilterNewButton.Text = string.Format(Properties.Resources.MainModListNewlyCompatible,
-                    mainModList.CountModsByFilter(GUIModFilter.NewInRepository));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.NewInRepository));
                 FilterNotInstalledButton.Text = string.Format(Properties.Resources.MainModListNotInstalled,
-                    mainModList.CountModsByFilter(GUIModFilter.NotInstalled));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.NotInstalled));
                 FilterIncompatibleButton.Text = string.Format(Properties.Resources.MainModListIncompatible,
-                    mainModList.CountModsByFilter(GUIModFilter.Incompatible));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.Incompatible));
                 FilterAllButton.Text = string.Format(Properties.Resources.MainModListAll,
-                    mainModList.CountModsByFilter(GUIModFilter.All));
+                    mainModList.CountModsByFilter(currentInstance, GUIModFilter.All));
 
                 UpdateAllToolButton.Enabled = has_unheld_updates;
             });
@@ -1853,7 +1853,7 @@ namespace CKAN.GUI
 
         private void hiddenTagsLabelsLinkList_LabelClicked(ModuleLabel label, bool merge)
         {
-            Filter(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel, null, label),
+            Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.CustomLabel, null, label),
                    merge);
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -294,16 +294,18 @@ namespace CKAN.GUI
             if (currentInstance != null)
             {
                 FilterLabelsToolButton.DropDownItems.Clear();
-                foreach (ModuleLabel mlbl in ModuleLabelList.ModuleLabels.LabelsFor(currentInstance.Name))
-                {
-                    FilterLabelsToolButton.DropDownItems.Add(new ToolStripMenuItem(
-                        $"{mlbl.Name} ({mlbl.ModuleCount(currentInstance.game)})",
-                        null, customFilterButton_Click)
-                    {
-                        Tag         = mlbl,
-                        ToolTipText = Properties.Resources.FilterLinkToolTip,
-                    });
-                }
+                FilterLabelsToolButton.DropDownItems.AddRange(
+                    ModuleLabelList.ModuleLabels
+                                   .LabelsFor(currentInstance.Name)
+                                   .Select(mlbl => new ToolStripMenuItem(
+                                                       $"{mlbl.Name} ({mlbl.ModuleCount(currentInstance.game)})",
+                                                       null, customFilterButton_Click)
+                                                   {
+                                                       Tag         = mlbl,
+                                                       BackColor   = mlbl.Color ?? Color.Transparent,
+                                                       ToolTipText = Properties.Resources.FilterLinkToolTip,
+                                                   })
+                                   .ToArray());
             }
         }
 

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -185,12 +185,14 @@ namespace CKAN.GUI
 
 
         private void tagsLabelsLinkList_TagClicked(ModuleTag tag, bool merge)
-            => OnChangeFilter?.Invoke(ModList.FilterToSavedSearch(GUIModFilter.Tag,
+            => OnChangeFilter?.Invoke(ModList.FilterToSavedSearch(Main.Instance!.CurrentInstance!,
+                                                                  GUIModFilter.Tag,
                                                                   tag, null),
                                       merge);
 
         private void tagsLabelsLinkList_LabelClicked(ModuleLabel label, bool merge)
-            => OnChangeFilter?.Invoke(ModList.FilterToSavedSearch(GUIModFilter.CustomLabel,
+            => OnChangeFilter?.Invoke(ModList.FilterToSavedSearch(Main.Instance!.CurrentInstance!,
+                                                                  GUIModFilter.CustomLabel,
                                                                   null, label),
                                       merge);
 

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -132,7 +132,8 @@ namespace CKAN.GUI
                     new SavedSearch()
                     {
                         Name   = string.Format(Properties.Resources.AuthorSearchName, author),
-                        Values = Enumerable.Repeat(ModSearch.FromAuthors(Enumerable.Repeat(author, 1)).Combined, 1)
+                        Values = Enumerable.Repeat(ModSearch.FromAuthors(Main.Instance!.CurrentInstance!,
+                                                   Enumerable.Repeat(author, 1)).Combined, 1)
                                            .OfType<string>()
                                            .ToList(),
                     },

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -666,6 +666,7 @@ namespace CKAN.GUI
                     // Fall back to old setting
                     ManageMods.Filter(
                         ModList.FilterToSavedSearch(
+                            CurrentInstance,
                             (GUIModFilter)configuration.ActiveFilter,
                             configuration.TagFilter == null
                                 ? null
@@ -678,7 +679,7 @@ namespace CKAN.GUI
                 }
                 else
                 {
-                    var searches = def.Select(s => ModSearch.Parse(s))
+                    var searches = def.Select(s => ModSearch.Parse(CurrentInstance, s))
                                       .OfType<ModSearch>()
                                       .ToList();
                     ManageMods.SetSearches(searches);

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -55,17 +55,20 @@ namespace CKAN.GUI
 
         private void UpdateTrayInfo()
         {
-            var count = ManageMods.mainModList.CountModsByFilter(GUIModFilter.InstalledUpdateAvailable);
-
-            if (count == 0)
+            if (CurrentInstance != null)
             {
-                updatesToolStripMenuItem.Enabled = false;
-                updatesToolStripMenuItem.Text = Properties.Resources.MainTrayNoUpdates;
-            }
-            else
-            {
-                updatesToolStripMenuItem.Enabled = true;
-                updatesToolStripMenuItem.Text = string.Format(Properties.Resources.MainTrayUpdatesAvailable, count);
+                var count = ManageMods.mainModList.CountModsByFilter(CurrentInstance,
+                                                                     GUIModFilter.InstalledUpdateAvailable);
+                if (count == 0)
+                {
+                    updatesToolStripMenuItem.Enabled = false;
+                    updatesToolStripMenuItem.Text = Properties.Resources.MainTrayNoUpdates;
+                }
+                else
+                {
+                    updatesToolStripMenuItem.Enabled = true;
+                    updatesToolStripMenuItem.Text = string.Format(Properties.Resources.MainTrayUpdatesAvailable, count);
+                }
             }
             toolStripSeparator4.Visible = true;
             updatesToolStripMenuItem.Visible = true;

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -103,13 +103,14 @@ namespace CKAN.GUI
             return "";
         }
 
-        public static SavedSearch FilterToSavedSearch(GUIModFilter filter,
+        public static SavedSearch FilterToSavedSearch(GameInstance instance,
+                                                      GUIModFilter filter,
                                                       ModuleTag?   tag   = null,
                                                       ModuleLabel? label = null)
             => new SavedSearch()
             {
                 Name   = FilterName(filter, tag, label),
-                Values = new List<string>() { new ModSearch(filter, tag, label).Combined ?? "" },
+                Values = new List<string>() { new ModSearch(instance, filter, tag, label).Combined ?? "" },
             };
 
         private static RelationshipResolverOptions conflictOptions(StabilityToleranceConfig stabilityTolerance)
@@ -277,8 +278,8 @@ namespace CKAN.GUI
         public int CountModsBySearches(List<ModSearch> searches)
             => Modules.Count(mod => searches?.Any(s => s?.Matches(mod) ?? true) ?? true);
 
-        public int CountModsByFilter(GUIModFilter filter)
-            => CountModsBySearches(new List<ModSearch>() { new ModSearch(filter, null, null) });
+        public int CountModsByFilter(GameInstance inst, GUIModFilter filter)
+            => CountModsBySearches(new List<ModSearch>() { new ModSearch(inst, filter, null, null) });
 
         /// <summary>
         /// Constructs the mod list suitable for display to the user.

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -69,8 +69,11 @@ namespace Tests.GUI
         [TestCaseSource("GetFilters")]
         public void CountModsByFilter_EmptyModList_ReturnsZero(GUIModFilter filter)
         {
-            var item = new ModList();
-            Assert.That(item.CountModsByFilter(filter), Is.EqualTo(0));
+            using (var tidy = new DisposableKSP())
+            {
+                var item = new ModList();
+                Assert.That(item.CountModsByFilter(tidy.KSP, filter), Is.EqualTo(0));
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Problem

If you make a label with spaces in its name and apply it to some mods, filtering by that label finds no mods.

Reported by Discord user TEMPEST.

## Cause

The search syntax uses spaces to separate parts of the search, so `label:Name With Spaces` is changed to `label:NameWithSpaces`, but the label checking logic wasn't accounting for this.

## Changes

- Now the label checking logic removes spaces from a label name before checking whether it matches the query
- The repetitive parts of label searches (translating names to label objects, checking for negation) are now precalculated once, which should give such searches a tiny performance boost
- Now the Filters &rarr; Labels menu shows the label colors like the right click menu does
  ![image](https://github.com/user-attachments/assets/f5aa9a4d-c40d-48e9-96db-706843151df8)

