### PR TITLE
Restore default version support for SpaceDock

### DIFF
--- a/Netkan/Sources/Spacedock/SpacedockMod.cs
+++ b/Netkan/Sources/Spacedock/SpacedockMod.cs
@@ -20,22 +20,13 @@ namespace CKAN.NetKAN.Sources.Spacedock
         [JsonProperty] public Uri?             background;
 
         public SDVersion Latest()
-        {
-            // The version we want is specified by `default_version_id`, it's not just
-            // the latest. See GH #214. Thanks to @Starstrider42 for spotting this.
-
-            var latest =
-                from release in versions
-                where release.id == default_version_id
-                select release
-            ;
-
-            // There should only ever be one.
-            return latest.First();
-        }
+            => All().First();
 
         public IEnumerable<SDVersion> All()
-            => versions ?? Enumerable.Empty<SDVersion>();
+            // The version we want is specified by `default_version_id`, it's not just
+            // the latest. See GH #214. Thanks to @Starstrider42 for spotting this.
+            => versions?.OrderByDescending(v => v.id == default_version_id)
+                       ?? Enumerable.Empty<SDVersion>();
 
         /// <summary>
         /// Returns the path to the mod's home on SpaceDock


### PR DESCRIPTION
## Problem

BeyondJool currently has this inflation error:

> No files found matching find="BeyondJool" to install!

## Cause

There's a 1-MB dummy download with a version of `TEST (do not use)` sitting at the top of the list of releases:

- <https://spacedock.info/mod/3682/Beyond%20Jool#changelog>

The inflator is downloading this and discovering that it doesn't contain the mod, even though the "Set as default" button was used on SpaceDock to mark the previous download. This most likely broke when we added the `--releases` and `--skip-releases` options to Netkan because support for the default release flag was only in `SpacedockMod.Latest`, which is no longer used because it only returns one version.

## Changes

Now the default release setting is used to sort the releases from SpaceDock, so it will determine which release gets inflated. If we inflate multiple releases, the others will be checked after the default.
