### PR TITLE
Don't raise inflation errors for single-hosted prereleases of multi-hosted mods

### DIFF
--- a/Netkan/CmdLineOptions.cs
+++ b/Netkan/CmdLineOptions.cs
@@ -46,8 +46,11 @@ namespace CKAN.NetKAN
         [Option("queues", HelpText = "Input,Output queue names for Queue Inflator mode")]
         public string? Queues { get; set; }
 
-        [Option("highest-version", HelpText = "Highest known version for auto-epoching")]
+        [Option("highest-version", HelpText = "Highest known non-prerelease version for auto-epoching")]
         public string? HighestVersion { get; set; }
+
+        [Option("highest-version-prerelease", HelpText = "Highest known prerelease version for auto-epoching")]
+        public string? HighestVersionPrerelease { get; set; }
 
         [Option("validate-ckan", HelpText = "Name of .ckan file to check for errors")]
         public string? ValidateCkan { get; set; }

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -152,6 +152,12 @@ namespace CKAN.NetKAN.Processors
                 highVer = new ModuleVersion(highVerAttr.StringValue);
             }
 
+            ModuleVersion? highVerPre = null;
+            if (msg.MessageAttributes.TryGetValue("HighestVersionPrerelease", out MessageAttributeValue? highVerPreAttr))
+            {
+                highVerPre = new ModuleVersion(highVerPreAttr.StringValue);
+            }
+
             log.InfoFormat("Inflating {0}", netkans.First().Identifier);
             IEnumerable<Metadata>? ckans = null;
             bool    caught        = false;
@@ -159,6 +165,7 @@ namespace CKAN.NetKAN.Processors
             var     opts          = new TransformOptions(releases,
                                                          null,
                                                          highVer,
+                                                         highVerPre,
                                                          netkans.First().Staged,
                                                          netkans.First().StagingReason);
             try

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -109,6 +109,7 @@ namespace CKAN.NetKAN
                                 ParseReleases(Options.Releases),
                                 ParseSkipReleases(Options.SkipReleases),
                                 ParseHighestVersion(Options.HighestVersion),
+                                ParseHighestVersion(Options.HighestVersionPrerelease),
                                 netkans.First().Staged,
                                 netkans.First().StagingReason))
                         .ToArray();

--- a/Netkan/Transformers/EpochTransformer.cs
+++ b/Netkan/Transformers/EpochTransformer.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
+
 using log4net;
 using Newtonsoft.Json.Linq;
+
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 
@@ -29,7 +32,7 @@ namespace CKAN.NetKAN.Transformers
 
                 if (uint.TryParse(epoch.ToString(), out uint epochNumber))
                 {
-                    //Implicit if zero. No need to add
+                    // Implicit if zero. No need to add
                     if (epochNumber != 0)
                     {
                         json["version"] = epochNumber + ":" + json["version"];
@@ -43,40 +46,62 @@ namespace CKAN.NetKAN.Transformers
                 }
             }
 
-            if (json.TryGetValue("x_netkan_allow_out_of_order", out JToken? allowOOO) && (bool)allowOOO)
+            if (json.TryGetValue("x_netkan_allow_out_of_order", out JToken? allowOOO)
+                && (bool)allowOOO)
             {
                 Log.Debug("Out of order versions enabled in netkan, skipping OOO check");
             }
-            else if (opts?.HighestVersion != null && (string?)json["version"] is string v)
+            else if (opts != null
+                     && (string?)json["version"] is string v
+                     && (metadata.Prerelease
+                             ? new ModuleVersion?[]
+                               {
+                                   opts.HighestVersionPrerelease,
+                                   opts.HighestVersion,
+                               }
+                             : new ModuleVersion?[]
+                               {
+                                   opts.HighestVersion,
+                               })
+                            .OfType<ModuleVersion>()
+                            .Max()
+                        is ModuleVersion highest)
             {
-                // Ensure we are greater or equal to the previous max
-                ModuleVersion startV = new ModuleVersion(v);
-                ModuleVersion currentV = startV;
-                while (currentV < opts.HighestVersion)
-                {
-                    Log.DebugFormat("Auto-epoching out of order version: {0} < {1}",
-                        currentV, opts.HighestVersion);
-                    // Increment epoch if too small
-                    currentV = currentV.IncrementEpoch();
-                }
-                if (!opts.HighestVersion.EpochEquals(currentV)
-                    && startV < opts.HighestVersion && opts.HighestVersion < currentV)
-                {
-                    if (opts.FlakyAPI)
-                    {
-                        throw new Kraken($"Out-of-order version found on unreliable server: {startV} < {opts.HighestVersion} < {currentV}");
-                    }
-                    else
-                    {
-                        // New file, tell the Indexer to be careful
-                        opts.Staged = true;
-                        opts.StagingReasons.Add($"Auto-epoching out of order version: {startV} < {opts.HighestVersion} < {currentV}");
-                    }
-                }
-                json["version"] = currentV.ToString();
+                json["version"] = CheckOutOfOrder(opts, highest,
+                                                  new ModuleVersion(v))
+                                      .ToString();
             }
 
             yield return new Metadata(json);
+        }
+
+        private static ModuleVersion CheckOutOfOrder(TransformOptions opts,
+                                                     ModuleVersion    highest,
+                                                     ModuleVersion    start)
+        {
+            // Ensure we are greater or equal to the previous max
+            ModuleVersion current = start;
+            while (current < highest)
+            {
+                Log.DebugFormat("Auto-epoching out of order version: {0} < {1}",
+                                current, highest);
+                // Increment epoch if too small
+                current = current.IncrementEpoch();
+            }
+            if (!highest.EpochEquals(current) && start < highest && highest < current)
+            {
+                if (opts.FlakyAPI)
+                {
+                    throw new Kraken($"Out-of-order version found on unreliable server: {start} < {highest} < {current}");
+                }
+                else
+                {
+                    // New file, tell the Indexer to be careful
+                    opts.Staged = true;
+                    opts.StagingReasons.Add($"Auto-epoching out of order version: {start} < {highest} < {current}");
+                }
+            }
+            return current;
         }
     }
 }

--- a/Netkan/Transformers/ITransformer.cs
+++ b/Netkan/Transformers/ITransformer.cs
@@ -9,14 +9,16 @@ namespace CKAN.NetKAN.Transformers
         public TransformOptions(int?           releases,
                                 int?           skipReleases,
                                 ModuleVersion? highVer,
+                                ModuleVersion? highVerPre,
                                 bool           staged,
                                 string?        stagingReason)
         {
-            Releases       = releases;
-            SkipReleases   = skipReleases;
-            HighestVersion = highVer;
-            Staged         = staged;
-            StagingReasons = new List<string>();
+            Releases                 = releases;
+            SkipReleases             = skipReleases;
+            HighestVersion           = highVer;
+            HighestVersionPrerelease = highVerPre;
+            Staged                   = staged;
+            StagingReasons           = new List<string>();
             if (stagingReason != null && !string.IsNullOrEmpty(stagingReason))
             {
                 StagingReasons.Add(stagingReason);
@@ -26,6 +28,7 @@ namespace CKAN.NetKAN.Transformers
         public readonly int?           Releases;
         public readonly int?           SkipReleases;
         public readonly ModuleVersion? HighestVersion;
+        public readonly ModuleVersion? HighestVersionPrerelease;
         public          bool           Staged;
         public readonly List<string>   StagingReasons;
         public          bool           FlakyAPI = false;

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -11,7 +11,7 @@ namespace Tests.NetKAN
     [TestFixture]
     public class MainClassTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test]
         public void FixVersionStringsUnharmed()

--- a/Tests/NetKAN/NetkanOverride.cs
+++ b/Tests/NetKAN/NetkanOverride.cs
@@ -13,7 +13,7 @@ namespace Tests.NetKAN
     public class NetkanOverride
     {
         private JObject? such_metadata;
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [SetUp]
         public void Setup()

--- a/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcKrefTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcKrefTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test,
             TestCase(

--- a/Tests/NetKAN/Transformers/AvcTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/AvcTransformerTests.cs
@@ -18,7 +18,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class AvcTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
         private readonly IGame game = new KerbalSpaceProgram();
 
         [Test]

--- a/Tests/NetKAN/Transformers/CurseTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/CurseTransformerTests.cs
@@ -12,7 +12,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class CurseTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/DownloadAttributeTransformerTests.cs
@@ -11,7 +11,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class DownloadAttributeTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test]
         [Category("Cache")]

--- a/Tests/NetKAN/Transformers/EpochTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/EpochTransformerTests.cs
@@ -10,33 +10,56 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class EpochTransformerTests
     {
-        [Test,
-            TestCase("1.1",     null,    "1.1"),
-            TestCase("1.1",    "1.1",    "1.1"),
-            TestCase("1.1",    "1.2",  "1:1.1"),
-            TestCase("1.1",  "5:1.1",  "5:1.1"),
-            TestCase("1.1",  "5:1.2",  "6:1.1"),
-            TestCase("0.7",   "0.65",  "1:0.7"),
-            TestCase("2.5",   "v2.4",  "1:2.5"),
-            TestCase("2.5",   "V2.4",  "1:2.5"),
-            TestCase("v2.5", "vV2.4", "1:v2.5"),
+        [
+            TestCase("1.1",     null,   null, false,    "1.1", false),
+            TestCase("1.1",     null,   null,  true,    "1.1", false),
+            TestCase("1.1",    "1.1",   null, false,    "1.1", false),
+            TestCase("1.1",    "1.2",   null, false,  "1:1.1", true),
+            TestCase("1.1",  "5:1.1",   null, false,  "5:1.1", false),
+            TestCase("1.1",  "5:1.2",   null, false,  "6:1.1", true),
+            TestCase("0.7",   "0.65",   null, false,  "1:0.7", true),
+            TestCase("2.5",   "v2.4",   null, false,  "1:2.5", true),
+            TestCase("2.5",   "V2.4",   null, false,  "1:2.5", true),
+            TestCase("v2.5", "vV2.4",   null, false, "1:v2.5", true),
+
+            // Non-prerelease with a prerelease on another host
+            TestCase("1.0",    "1.0",  "2.0", false,    "1.0", false),
+            // Prerelease with no normal releases
+            TestCase("1.0",     null,  "1.0",  true,    "1.0", false),
+            // Updating a prerelease to a normal release
+            TestCase("2.0",    "1.0",  "2.0", false,    "2.0", false),
+            // Prerelease needing an epoch boost
+            TestCase("2.0",    "1.0",  "3.0",  true,  "1:2.0", true),
+            // The previous prerelease is old
+            TestCase("1.5",    "2.0",  "1.0",  true,  "1:1.5", true),
         ]
-        public void Transform_WithHighVersionParam_MatchesExpected(string version, string highVer, string expected)
+        public void Transform_WithHighVersionParam_MatchesExpected(string  version,
+                                                                   string? highVer,
+                                                                   string? highVerPre,
+                                                                   bool    prerelease,
+                                                                   string  expected,
+                                                                   bool    staged)
         {
             // Arrange
             var json = new JObject()
             {
-                { "spec_version", "v1.4"       },
-                { "identifier",   "AwesomeMod" },
-                { "version",      version      },
+                { "spec_version",   "v1.4"          },
+                { "identifier",     "AwesomeMod"    },
+                { "version",        version         },
+                { "release_status", prerelease
+                                        ? "testing"
+                                        : "stable"  },
             };
             ITransformer     sut  = new EpochTransformer();
             TransformOptions opts = new TransformOptions(
                 1,
                 null,
-                string.IsNullOrEmpty(highVer)
+                highVer is null or ""
                     ? null
                     : new ModuleVersion(highVer),
+                highVerPre is null or ""
+                    ? null
+                    : new ModuleVersion(highVerPre),
                 false,
                 null
             );
@@ -47,6 +70,7 @@ namespace Tests.NetKAN.Transformers
 
             // Assert
             Assert.AreEqual(expected, (string?)transformedJson["version"]);
+            Assert.AreEqual(staged,   opts.Staged);
         }
     }
 }

--- a/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GeneratedByTransformerTests.cs
@@ -9,7 +9,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GeneratedByTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test]
         public void AddsGeneratedByProperty()

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -14,7 +14,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class GithubTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         private Mock<IGithubApi>? apiMockUp;
 
@@ -192,7 +192,7 @@ namespace Tests.NetKAN.Transformers
             // Act
             var results = sut.Transform(
                 new Metadata(json),
-                new TransformOptions(2, null, null, false, null)
+                new TransformOptions(2, null, null, null, false, null)
             );
             var transformedJsons = results.Select(result => result.Json()).ToArray();
 
@@ -230,7 +230,7 @@ namespace Tests.NetKAN.Transformers
             // Act
             var results = sut.Transform(
                 new Metadata(json),
-                new TransformOptions(1, 3, null, false, null)
+                new TransformOptions(1, 3, null, null, false, null)
             );
             var transformedJsons = results.Select(result => result.Json()).ToArray();
 
@@ -268,7 +268,7 @@ namespace Tests.NetKAN.Transformers
             // Act
             var results = sut.Transform(
                 new Metadata(json),
-                new TransformOptions(2, 1, null, false, null)
+                new TransformOptions(2, 1, null, null, false, null)
             ).ToArray();
 
             // Assert

--- a/Tests/NetKAN/Transformers/HttpTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/HttpTransformerTests.cs
@@ -9,7 +9,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class HttpTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [TestCase("#/ckan/github/foo/bar")]
         [TestCase("#/ckan/netkan/http://awesomemod.example/awesomemod.netkan")]

--- a/Tests/NetKAN/Transformers/InstallSizeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InstallSizeTransformerTests.cs
@@ -38,6 +38,6 @@ namespace Tests.NetKAN.Transformers
             Assert.AreEqual(52291, (int?)transformedJson["install_size"]);
         }
 
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
     }
 }

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -15,7 +15,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class InternalCkanTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test]
         public void AddsMissingProperties()

--- a/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/MetaNetkanTransformerTests.cs
@@ -15,7 +15,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class MetaNetkanTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -15,7 +15,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class SpacedockTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]

--- a/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/StripNetkanMetadataTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class StripNetkanMetadataTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [TestCaseSource("StripNetkanMetadataTestCaseSource")]
         public void StripNetkanMetadata(string json, string expected)

--- a/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/VersionEditTransformerTests.cs
@@ -10,7 +10,7 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class VersionEditTransformerTests
     {
-        private readonly TransformOptions opts = new TransformOptions(1, null, null, false, null);
+        private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test]
         public void DoesNothingWhenNoMatch()


### PR DESCRIPTION
## Motivation

Prereleases currently get indexed, and then in subsequent passes an inflation error `Out-of-order version found on unreliable server` occurs because only one host has the prerelease, and that host's latest release appears to be out of order by comparison.

## Changes

Now the Inflator has a `--highest-version-prerelease` parameter and supports a `HighestVersionPrerelease` message attribute (to be populated by KSP-CKAN/NetKAN-Infra#352) that can specify the version of the latest prerelease separately from the regular releases. When we check for out-of-order versions, regular releases are only compared to other regular releases, and prereleases are compared to both.

Once both PRs are merged, the inflation errors associated with prereleases should drop off, which is important for minimizing the re-downloading of modules.
