### PR TITLE
Stop trying to get remote version files from the forum

### DIFF
--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -88,10 +88,17 @@ namespace CKAN.NetKAN.Transformers
 
                         try
                         {
-                            if ((_github?.DownloadText(remoteUri)
-                                ?? _http.DownloadText(remoteUri)) is string remoteJson
-                                && JsonConvert.DeserializeObject<AvcVersion>(remoteJson) is AvcVersion remoteAvc
-                                && avc.version.CompareTo(remoteAvc.version) == 0)
+                            if (BadHosts.Contains(remoteUri.Host))
+                            {
+                                Log.WarnFormat("AVC host does not contain version files: {0}",
+                                               remoteUri.Host);
+                            }
+                            else if ((_github?.DownloadText(remoteUri)
+                                      ?? _http.DownloadText(remoteUri))
+                                     is string remoteJson
+                                     && JsonConvert.DeserializeObject<AvcVersion>(remoteJson)
+                                        is AvcVersion remoteAvc
+                                     && avc.version.Equals(remoteAvc.version))
                             {
                                 // Local AVC and Remote AVC describe the same version, prefer
                                 Log.Info("Remote AVC version file describes same version as local AVC version file, using it preferentially.");
@@ -161,5 +168,10 @@ namespace CKAN.NetKAN.Transformers
 
             return Net.GetRawUri(remoteUri);
         }
+
+        private static readonly HashSet<string> BadHosts = new HashSet<string>()
+        {
+            "forum.kerbalspaceprogram.com",
+        };
     }
 }


### PR DESCRIPTION
## Problem

Some mods' version files have a `URL` pointing to `forum.kerbalspaceprogram.com`. Now that the forum is unreliable, this sometimes causes timeouts, and the inflation warnings toggle back and forth between network errors and parsing errors.

Even when the URL is retrieved successfully, it's a waste of time and bandwidth because the forum can never contain a remote version file.

## Changes

Now version files with a `URL` on the forum emit a warning and move on rather than trying to retrieve the URL.
