### PR TITLE
Small performance tweaks for DLL scanning

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -939,7 +939,7 @@ namespace CKAN
             {
                 EnlistWithTransaction();
                 InvalidateInstalledCaches();
-                installed_dlls = new Dictionary<string, string>(unregistered);
+                installed_dlls = unregistered;
                 return true;
             }
             return false;


### PR DESCRIPTION
## Motivation

A user drove-by the CKAN Discord to complain loudly about load times. No actionable information was shared, but it did remind me that I'd seen delays during the DLL scanning step with a lot of mods installed.

A code audit didn't reveal any major inefficiencies, but I did spot several minor ones.

## Changes

- Now `Registry.SetDlls` no longer makes an extra copy of the `installed_dlls` dictionary
- Now `IGame.StockFoders` is only called once per scanning pass rather than once per DLL, which was a potential source of slowness because it allocates an array
- Now we append `/` to each stock folder once per scanning pass rather than once per DLL
- Now the stock folders check skips stock folders that aren't inside the per-game equivalents of GameData

Together, these changes eliminate some unnecessary work that was being done during DLL scanning, but I don't expect it to be significant enough to be noticeable. The scan's run time would still have to be dominated by disk I/O on all but the fastest drives.
