### PR TITLE
Fix broken version label in About dialog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       unsigned-artifact-id: ${{ steps.upload-unsigned-artifact.outputs.artifact-id }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/build.yml
   test-build:
     needs: build-debug
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install runtime dependencies

--- a/GUI/Controls/ModInfoTabs/Metadata.cs
+++ b/GUI/Controls/ModInfoTabs/Metadata.cs
@@ -153,10 +153,10 @@ namespace CKAN.GUI
         {
             if (sender is LinkLabel lbl)
             {
-                switch (e?.KeyCode)
+                switch (e)
                 {
-                    case Keys.Apps:
-                        Util.LinkContextMenu(lbl.Text);
+                    case {KeyCode: Keys.Apps}:
+                        Util.LinkContextMenu(lbl.Text, lbl);
                         e.Handled = true;
                         break;
                 }

--- a/GUI/Dialogs/AboutDialog.Designer.cs
+++ b/GUI/Dialogs/AboutDialog.Designer.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Windows.Forms;
-
 namespace CKAN.GUI
 {
     partial class AboutDialog
@@ -48,6 +45,7 @@ namespace CKAN.GUI
             //
             // projectNameLabel
             //
+            this.projectNameLabel.AutoSize = true;
             this.projectNameLabel.Location = new System.Drawing.Point(6, 5);
             this.projectNameLabel.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.projectNameLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -59,6 +57,7 @@ namespace CKAN.GUI
             //
             // versionLabel
             //
+            this.versionLabel.AutoSize = true;
             this.versionLabel.Location = new System.Drawing.Point(6, 25);
             this.versionLabel.Name = "versionLabel";
             this.versionLabel.Size = new System.Drawing.Size(100, 13);
@@ -68,6 +67,7 @@ namespace CKAN.GUI
             //
             // licenseLabel
             //
+            this.licenseLabel.AutoSize = true;
             this.licenseLabel.Location = new System.Drawing.Point(6, 55);
             this.licenseLabel.Name = "licenseLabel";
             this.licenseLabel.Size = new System.Drawing.Size(100, 13);
@@ -77,10 +77,12 @@ namespace CKAN.GUI
             //
             // licenseLinkLabel
             //
+            this.licenseLinkLabel.AutoSize = true;
             this.licenseLinkLabel.Location = new System.Drawing.Point(110, 55);
             this.licenseLinkLabel.Name = "licenseLinkLabel";
             this.licenseLinkLabel.Text = "https://github.com/KSP-CKAN/CKAN/blob/master/LICENSE.md";
             this.licenseLinkLabel.LinkArea = new System.Windows.Forms.LinkArea(0, 56);
+            this.licenseLinkLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
             this.licenseLinkLabel.Size = new System.Drawing.Size(380, 13);
             this.licenseLinkLabel.TabIndex = 1;
             this.licenseLinkLabel.TabStop = true;
@@ -91,6 +93,7 @@ namespace CKAN.GUI
             //
             // authorsLabel
             //
+            this.authorsLabel.AutoSize = true;
             this.authorsLabel.Location = new System.Drawing.Point(6, 75);
             this.authorsLabel.Name = "authorsLabel";
             this.authorsLabel.Size = new System.Drawing.Size(100, 13);
@@ -100,10 +103,12 @@ namespace CKAN.GUI
             //
             // authorsLinkLabel
             //
+            this.authorsLinkLabel.AutoSize = true;
             this.authorsLinkLabel.Location = new System.Drawing.Point(110, 75);
             this.authorsLinkLabel.Name = "authorsLinkLabel";
             this.authorsLinkLabel.Text = "https://github.com/KSP-CKAN/CKAN/graphs/contributors";
             this.authorsLinkLabel.LinkArea = new System.Windows.Forms.LinkArea(0, 52);
+            this.authorsLinkLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
             this.authorsLinkLabel.Size = new System.Drawing.Size(380, 13);
             this.authorsLinkLabel.TabIndex = 2;
             this.authorsLinkLabel.TabStop = true;
@@ -113,6 +118,7 @@ namespace CKAN.GUI
             //
             // sourceLabel
             //
+            this.sourceLabel.AutoSize = true;
             this.sourceLabel.Location = new System.Drawing.Point(6, 95);
             this.sourceLabel.Name = "sourceLabel";
             this.sourceLabel.Size = new System.Drawing.Size(100, 13);
@@ -122,10 +128,12 @@ namespace CKAN.GUI
             //
             // sourceLinkLabel
             //
+            this.sourceLinkLabel.AutoSize = true;
             this.sourceLinkLabel.Location = new System.Drawing.Point(110, 95);
             this.sourceLinkLabel.Name = "sourceLinkLabel";
             this.sourceLinkLabel.Text = "https://github.com/KSP-CKAN/CKAN/";
             this.sourceLinkLabel.LinkArea = new System.Windows.Forms.LinkArea(0, 33);
+            this.sourceLinkLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
             this.sourceLinkLabel.Size = new System.Drawing.Size(380, 13);
             this.sourceLinkLabel.TabIndex = 3;
             this.sourceLinkLabel.TabStop = true;
@@ -135,6 +143,7 @@ namespace CKAN.GUI
             //
             // forumthreadLabel
             //
+            this.forumthreadLabel.AutoSize = true;
             this.forumthreadLabel.Location = new System.Drawing.Point(6, 115);
             this.forumthreadLabel.Name = "forumthreadLinkLabel";
             this.forumthreadLabel.Size = new System.Drawing.Size(100, 13);
@@ -144,10 +153,12 @@ namespace CKAN.GUI
             //
             // forumthreadLinkLabel
             //
+            this.forumthreadLinkLabel.AutoSize = true;
             this.forumthreadLinkLabel.Location = new System.Drawing.Point(110, 115);
             this.forumthreadLinkLabel.Name = "forumthreadLinkLabel";
             this.forumthreadLinkLabel.Text = "http://forum.kerbalspaceprogram.com/index.php?/topic/197082-ckan";
             this.forumthreadLinkLabel.LinkArea = new System.Windows.Forms.LinkArea(0, 64);
+            this.forumthreadLinkLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
             this.forumthreadLinkLabel.Size = new System.Drawing.Size(380, 13);
             this.forumthreadLinkLabel.TabIndex = 4;
             this.forumthreadLinkLabel.TabStop = true;
@@ -158,6 +169,7 @@ namespace CKAN.GUI
             //
             // homepageLabel
             //
+            this.homepageLabel.AutoSize = true;
             this.homepageLabel.Location = new System.Drawing.Point(6, 135);
             this.homepageLabel.Name = "homepageLinkLabel";
             this.homepageLabel.Size = new System.Drawing.Size(100, 13);
@@ -167,10 +179,12 @@ namespace CKAN.GUI
             //
             // homepageLinkLabel
             //
+            this.homepageLinkLabel.AutoSize = true;
             this.homepageLinkLabel.Location = new System.Drawing.Point(110, 135);
             this.homepageLinkLabel.Name = "homepageLinkLabel";
             this.homepageLinkLabel.Text = "http://ksp-ckan.space";
             this.homepageLinkLabel.LinkArea = new System.Windows.Forms.LinkArea(0, 21);
+            this.homepageLinkLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
             this.homepageLinkLabel.Size = new System.Drawing.Size(380, 13);
             this.homepageLinkLabel.TabIndex = 5;
             this.homepageLinkLabel.TabStop = true;
@@ -197,9 +211,11 @@ namespace CKAN.GUI
             this.Controls.Add(this.homepageLinkLabel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = EmbeddedImages.AppIcon;
+            this.KeyPreview = true;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "AboutDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             resources.ApplyResources(this, "$this");
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/GUI/Dialogs/AboutDialog.cs
+++ b/GUI/Dialogs/AboutDialog.cs
@@ -14,7 +14,6 @@ namespace CKAN.GUI
         {
             InitializeComponent();
             ApplyFormCompatibilityFixes();
-            StartPosition = FormStartPosition.CenterScreen;
             versionLabel.Text = string.Format(Properties.Resources.AboutDialogLabel2Text, Meta.GetVersion());
         }
 
@@ -30,10 +29,10 @@ namespace CKAN.GUI
         {
             if (sender is LinkLabel l)
             {
-                switch (e?.KeyCode)
+                switch (e)
                 {
-                    case Keys.Apps:
-                        Util.LinkContextMenu(l.Text);
+                    case {KeyCode: Keys.Apps}:
+                        Util.LinkContextMenu(l.Text, l);
                         e.Handled = true;
                         break;
                 }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -162,7 +162,7 @@ namespace CKAN.GUI
             OnCacheChanged(null);
 
             tabController = new TabController(MainTabControl);
-            tabController.ShowTab("ManageModsTabPage");
+            tabController.ShowTab(ManageModsTabPage.Name);
 
             // Disable the modinfo controls until a mod has been choosen. This has an effect if the modlist is empty.
             ActiveModInfo = null;
@@ -235,7 +235,7 @@ namespace CKAN.GUI
         {
             actuallyVisible = true;
 
-            tabController.RenameTab("WaitTabPage", Properties.Resources.MainLoadingGameInstance);
+            tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainLoadingGameInstance);
             ShowWaitDialog();
             DisableMainWindow();
             Wait.StartWaiting(
@@ -898,7 +898,7 @@ namespace CKAN.GUI
                 UpdateChangesDialog(toInstall.Select(m => new ModChange(m, GUIModChangeType.Install))
                                              .ToList(),
                                     null);
-                tabController.ShowTab("ChangesetTabPage", 1);
+                tabController.ShowTab(ChangesetTabPage.Name, 1);
             }
         }
 
@@ -992,7 +992,7 @@ namespace CKAN.GUI
         {
             if (changeset != null && changeset.Count != 0)
             {
-                tabController.ShowTab("ChangesetTabPage", 1, false);
+                tabController.ShowTab(ChangesetTabPage.Name, 1, false);
                 UpdateChangesDialog(
                     changeset,
                     conflicts.ToDictionary(item => item.Key.ToCkanModule(),
@@ -1001,7 +1001,7 @@ namespace CKAN.GUI
             }
             else
             {
-                tabController.HideTab("ChangesetTabPage");
+                tabController.HideTab(ChangesetTabPage.Name);
                 auditRecommendationsMenuItem.Enabled = true;
             }
         }
@@ -1153,12 +1153,12 @@ namespace CKAN.GUI
             UpdateChangesDialog(changeset,
                                 conflicts?.ToDictionary(item => item.Key.ToCkanModule(),
                                                         item => item.Value));
-            tabController.ShowTab("ChangesetTabPage", 1);
+            tabController.ShowTab(ChangesetTabPage.Name, 1);
         }
 
         private void RefreshModList(bool allowAutoUpdate, Dictionary<string, bool>? oldModules = null)
         {
-            tabController.RenameTab("WaitTabPage", Properties.Resources.MainModListWaitTitle);
+            tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainModListWaitTitle);
             ShowWaitDialog();
             DisableMainWindow();
             ActiveModInfo = null;

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -82,7 +82,7 @@ namespace CKAN.GUI
         {
             ShowWaitDialog();
             DisableMainWindow();
-            tabController.RenameTab("WaitTabPage", Properties.Resources.MainUpgradingWaitTitle);
+            tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainUpgradingWaitTitle);
             var mainConfig = ServiceLocator.Container.Resolve<IConfiguration>();
             var update = updater.GetUpdate(mainConfig.DevBuilds ?? false, userAgent);
             Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo,

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -36,7 +36,7 @@ namespace CKAN.GUI
             {
                 ManageMods.ClearChangeSet();
             }
-            tabController.ShowTab("ManageModsTabPage");
+            tabController.ShowTab(ManageModsTabPage.Name);
         }
 
         private void Changeset_OnConfirmChanges(List<ModChange> changeset)

--- a/GUI/Main/MainExport.cs
+++ b/GUI/Main/MainExport.cs
@@ -26,14 +26,14 @@ namespace CKAN.GUI
                 Task.Factory.StartNew(() =>
                 {
                     currentUser.RaiseMessage("");
-                    tabController.ShowTab("EditModpackTabPage", 2);
+                    tabController.ShowTab(EditModpackTabPage.Name, 2);
                     DisableMainWindow();
                     var mgr = RegistryManager.Instance(CurrentInstance, repoData);
                     EditModpack.LoadModule(mgr.GenerateModpack(false, true), mgr.registry);
                     // This will block till the user is done
                     EditModpack.Wait(currentUser);
-                    tabController.ShowTab("ManageModsTabPage");
-                    tabController.HideTab("EditModpackTabPage");
+                    tabController.ShowTab(ManageModsTabPage.Name);
+                    tabController.HideTab(EditModpackTabPage.Name);
                     EnableMainWindow();
                 });
             }

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -13,7 +13,7 @@ namespace CKAN.GUI
             if (CurrentInstance != null && configuration != null)
             {
                 InstallationHistory.LoadHistory(CurrentInstance, configuration, repoData);
-                tabController.ShowTab("InstallationHistoryTabPage", 2);
+                tabController.ShowTab(InstallationHistoryTabPage.Name, 2);
             }
         }
 
@@ -30,15 +30,15 @@ namespace CKAN.GUI
                     CurrentInstance.StabilityToleranceConfig,
                     CurrentInstance.VersionCriteria());
                 UpdateChangesDialog(tuple.Item1.ToList(), tuple.Item2);
-                tabController.ShowTab("ChangesetTabPage", 1);
+                tabController.ShowTab(ChangesetTabPage.Name, 1);
             }
         }
 
         private void InstallationHistory_Done()
         {
             UpdateStatusBar();
-            tabController.ShowTab("ManageModsTabPage");
-            tabController.HideTab("InstallationHistoryTabPage");
+            tabController.ShowTab(ManageModsTabPage.Name);
+            tabController.HideTab(InstallationHistoryTabPage.Name);
         }
 
         private void InstallationHistory_OnSelectedModuleChanged(CkanModule m)

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -36,7 +36,7 @@ namespace CKAN.GUI
                         && dlg.FileNames.Length > 0)
                 {
                     // Show WaitTabPage (status page) and lock it.
-                    tabController.RenameTab("WaitTabPage", Properties.Resources.MainImportWaitTitle);
+                    tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainImportWaitTitle);
                     ShowWaitDialog();
                     DisableMainWindow();
                     Wait.StartWaiting(

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -167,7 +167,7 @@ namespace CKAN.GUI
                         out Dictionary<CkanModule, List<string>> suggestions,
                         out Dictionary<CkanModule, HashSet<string>> supporters))
                     {
-                        tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
+                        tabController.ShowTab(ChooseRecommendedModsTabPage.Name, 3);
                         ChooseRecommendedMods.LoadRecommendations(
                             registry, toInstall, toUninstall,
                             CurrentInstance.VersionCriteria(), Manager.Cache,
@@ -181,7 +181,7 @@ namespace CKAN.GUI
                         Util.Invoke(this, () => UseWaitCursor = false);
                         var result = ChooseRecommendedMods.Wait();
                         tabController.SetTabLock(false);
-                        tabController.HideTab("ChooseRecommendedModsTabPage");
+                        tabController.HideTab(ChooseRecommendedModsTabPage.Name);
                         if (result == null)
                         {
                             e.Result = new InstallResult(false, changes);
@@ -204,7 +204,7 @@ namespace CKAN.GUI
                 Util.Invoke(this, () =>
                 {
                     // Need to be on the GUI thread to get the translated string
-                    tabController.RenameTab("WaitTabPage", Properties.Resources.MainInstallWaitTitle);
+                    tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainInstallWaitTitle);
                 });
                 tabController.SetTabLock(true);
 
@@ -302,7 +302,7 @@ namespace CKAN.GUI
                         catch (TooManyModsProvideKraken k)
                         {
                             // Prompt user to choose which mod to use
-                            tabController.ShowTab("ChooseProvidedModsTabPage", 3);
+                            tabController.ShowTab(ChooseProvidedModsTabPage.Name, 3);
                             Util.Invoke(this, () => StatusProgress.Visible = false);
                             var repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
                             ChooseProvidedMods.LoadProviders(
@@ -318,13 +318,13 @@ namespace CKAN.GUI
                             var chosen = ChooseProvidedMods.Wait();
                             // Close the selection prompt
                             tabController.SetTabLock(false);
-                            tabController.HideTab("ChooseProvidedModsTabPage");
+                            tabController.HideTab(ChooseProvidedModsTabPage.Name);
                             if (chosen != null)
                             {
                                 // User picked a mod, queue it up for installation
                                 toInstall.Add(chosen);
                                 // DON'T return so we can loop around and try the above InstallList call again
-                                tabController.ShowTab("WaitTabPage");
+                                tabController.ShowTab(WaitTabPage.Name);
                                 Util.Invoke(this, () => StatusProgress.Visible = true);
                             }
                             else
@@ -356,7 +356,7 @@ namespace CKAN.GUI
                 if (possibleConfigOnlyDirs.Count > 0)
                 {
                     Util.Invoke(this, () => StatusLabel.ToolTipText = StatusLabel.Text = "");
-                    tabController.ShowTab("DeleteDirectoriesTabPage", 4);
+                    tabController.ShowTab(DeleteDirectoriesTabPage.Name, 4);
                     tabController.SetTabLock(true);
 
                     DeleteDirectories.LoadDirs(CurrentInstance, possibleConfigOnlyDirs);
@@ -377,8 +377,8 @@ namespace CKAN.GUI
                         }
                     }
 
-                    tabController.ShowTab("WaitTabPage");
-                    tabController.HideTab("DeleteDirectoriesTabPage");
+                    tabController.ShowTab(WaitTabPage.Name);
+                    tabController.HideTab(DeleteDirectoriesTabPage.Name);
                     tabController.SetTabLock(false);
                 }
             }

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -50,7 +50,7 @@ namespace CKAN.GUI
                     out Dictionary<CkanModule, List<string>> suggestions,
                     out Dictionary<CkanModule, HashSet<string>> supporters))
                 {
-                    tabController.ShowTab("ChooseRecommendedModsTabPage", 3);
+                    tabController.ShowTab(ChooseRecommendedModsTabPage.Name, 3);
                     ChooseRecommendedMods.LoadRecommendations(
                         registry, new List<CkanModule>(), new HashSet<CkanModule>(),
                         versionCriteria, Manager.Cache,
@@ -61,7 +61,7 @@ namespace CKAN.GUI
                         configuration,
                         recommendations, suggestions, supporters);
                     var result = ChooseRecommendedMods.Wait();
-                    tabController.HideTab("ChooseRecommendedModsTabPage");
+                    tabController.HideTab(ChooseRecommendedModsTabPage.Name);
                     if (result != null && result.Count != 0)
                     {
                         Wait.StartWaiting(InstallMods, PostInstallMods, true,

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -34,7 +34,7 @@ namespace CKAN.GUI
 
         public void UpdateRepo(bool forceFullRefresh = false, bool refreshWithoutChanges = false)
         {
-            tabController.RenameTab("WaitTabPage", Properties.Resources.MainRepoWaitTitle);
+            tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainRepoWaitTitle);
 
             try
             {

--- a/GUI/Main/MainTime.cs
+++ b/GUI/Main/MainTime.cs
@@ -10,15 +10,15 @@ namespace CKAN.GUI
         private void viewPlayTimeStripMenuItem_Click(object? sender, EventArgs? e)
         {
             PlayTime.loadAllPlayTime(Manager);
-            tabController.ShowTab("PlayTimeTabPage", 2);
+            tabController.ShowTab(PlayTimeTabPage.Name, 2);
             DisableMainWindow();
         }
 
         private void PlayTime_Done()
         {
             UpdateStatusBar();
-            tabController.ShowTab("ManageModsTabPage");
-            tabController.HideTab("PlayTimeTabPage");
+            tabController.ShowTab(ManageModsTabPage.Name);
+            tabController.HideTab(PlayTimeTabPage.Name);
             EnableMainWindow();
         }
     }

--- a/GUI/Main/MainUnmanaged.cs
+++ b/GUI/Main/MainUnmanaged.cs
@@ -12,15 +12,15 @@ namespace CKAN.GUI
             if (Manager.CurrentInstance != null)
             {
                 UnmanagedFiles.LoadFiles(Manager.CurrentInstance, repoData, currentUser);
-                tabController.ShowTab("UnmanagedFilesTabPage", 2);
+                tabController.ShowTab(UnmanagedFilesTabPage.Name, 2);
             }
         }
 
         private void UnmanagedFiles_Done()
         {
             UpdateStatusBar();
-            tabController.ShowTab("ManageModsTabPage");
-            tabController.HideTab("UnmanagedFilesTabPage");
+            tabController.ShowTab(ManageModsTabPage.Name);
+            tabController.HideTab(UnmanagedFilesTabPage.Name);
         }
     }
 }

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -20,7 +20,7 @@ namespace CKAN.GUI
         {
             Util.Invoke(this, () =>
             {
-                tabController.ShowTab("WaitTabPage", 2);
+                tabController.ShowTab(WaitTabPage.Name, 2);
                 StatusProgress.Value = 0;
                 StatusProgress.Style = ProgressBarStyle.Marquee;
                 StatusProgress.Visible = true;
@@ -34,8 +34,8 @@ namespace CKAN.GUI
                 Wait.Finish();
                 RecreateDialogs();
 
-                tabController.HideTab("WaitTabPage");
-                tabController.SetActiveTab("ManageModsTabPage");
+                tabController.HideTab(WaitTabPage.Name);
+                tabController.SetActiveTab(ManageModsTabPage.Name);
 
                 StatusProgress.Value = 0;
                 StatusProgress.Style = ProgressBarStyle.Continuous;
@@ -65,7 +65,7 @@ namespace CKAN.GUI
         public void Wait_OnRetry()
         {
             EnableMainWindow();
-            tabController.ShowTab("ChangesetTabPage", 1);
+            tabController.ShowTab(ChangesetTabPage.Name, 1);
         }
 
         public void Wait_OnOk()

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 using Timer = System.Windows.Forms.Timer;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
@@ -131,21 +131,31 @@ namespace CKAN.GUI
         }
 
         /// <summary>
+        /// Show a link right-click menu under a control,
+        /// meant for keyboard access
+        /// </summary>
+        /// <param name="url">The URL of the link</param>
+        /// <param name="c">The menu will be shown below the bottom of this control</param>
+        public static void LinkContextMenu(string url, Control c)
+            => LinkContextMenu(url, c.PointToScreen(new Point(0, c.Height)));
+
+        /// <summary>
         /// Show a context menu when the user right clicks a link
         /// </summary>
         /// <param name="url">The URL of the link</param>
-        public static void LinkContextMenu(string url)
+        /// <param name="where">Screen coordinates for the menu</param>
+        public static void LinkContextMenu(string url, Point? where = null)
         {
-            ToolStripMenuItem copyLink = new ToolStripMenuItem(Properties.Resources.UtilCopyLink);
-            copyLink.Click += new EventHandler((sender, ev) => Clipboard.SetText(url));
+            var copyLink = new ToolStripMenuItem(Properties.Resources.UtilCopyLink);
+            copyLink.Click += (sender, ev) => Clipboard.SetText(url);
 
-            ContextMenuStrip menu = new ContextMenuStrip();
+            var menu = new ContextMenuStrip();
             if (Platform.IsMono)
             {
                 menu.Renderer = new FlatToolStripRenderer();
             }
             menu.Items.Add(copyLink);
-            menu.Show(Cursor.Position);
+            menu.Show(where ?? Cursor.Position);
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

The About dialog's version label no longer shows the version:

![image](https://github.com/user-attachments/assets/d04abdc3-9da0-4e3e-a328-9442256707df)

## Cause

The labels on the About form all have hard coded sizes and are not auto-sized, and the version string is longer than it used to be (build number was added), so the version label is wrapping and then being truncated vertically.

## Changes

- Now all the of the About dialog's labels have `AutoSize = true`, so they'll always show their full contents
- Now if you press the menu key while focused on a link label, the menu will appear under the link label instead of at the mouse cursor

Fixes #4276.
