### PR TITLE
Set unicode-aware locale in containers

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -4,6 +4,9 @@ FROM ubuntu:22.04 AS base
 # Don't prompt for time zone
 ENV DEBIAN_FRONTEND noninteractive
 
+# Properly handle Unicode
+ENV LANG C.utf-8
+
 # Put user-installed Python code in path
 ENV PATH "$PATH:/root/.local/bin"
 

--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -3,6 +3,9 @@ FROM ubuntu:22.04
 # Don't prompt for time zone
 ENV DEBIAN_FRONTEND noninteractive
 
+# Properly handle Unicode
+ENV LANG C.utf-8
+
 # Set up Mono's APT repo
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg \


### PR DESCRIPTION
## Problem

The metadata for Skopos has `??` in the abstract where non-ASCII characters are provided by the GitHub API:

- <https://api.github.com/repos/mockingbirdnest/Skopos>
- <https://github.com/KSP-CKAN/CKAN-meta/blob/master/Skopos/Skopos-v1.0.1.0.ckan>

Notably, this does not happen for me locally.

## Cause

The `LANG` environment variable is not set in the Inflator's container, so unicode characters are not handled properly. I have it set to `en_US.utf-8`, the latter part of which enables unicode.

## Changes

Now our `Dockerfile`s set `LANG` to `C.utf-8` to enable unicode support. This is also the value used in the bot's Python-based containers. This causes UTF-8 strings from the GitHub API to be faithfully recorded into the metadata.

Fixes #4288.
