### PR TITLE
Spacedock transformer: remove version string -> release_status parsing

### DIFF
--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -114,12 +114,6 @@ namespace CKAN.NetKAN.Transformers
                              var sdLicense                  => sdLicense,
                          });
 
-            if (ver?.ToLower() is string lowerV
-                && preReleaseSubstrings.Any(substr => lowerV.Contains(substr)))
-            {
-                json.SafeAdd("release_status", "testing");
-            }
-
             // Make sure resources exist.
             if (json["resources"] == null)
             {
@@ -196,10 +190,5 @@ namespace CKAN.NetKAN.Transformers
         private static readonly Regex githubUrlPathPattern =
             new Regex("^/(?<owner>[^/]+)/(?<repo>[^/]+)",
                       RegexOptions.Compiled);
-
-        private static readonly string[] preReleaseSubstrings = new string[]
-        {
-            "pre", "alpha", "beta",
-        };
     }
 }


### PR DESCRIPTION
Prior to https://github.com/KSP-CKAN/CKAN/pull/4260, the release_status field was purely for user information and did not affect which versions CKAN would index or install.  The PR changed that (and we had already removed the release_status from existing netkans).  In order to prevent older clients from installing pre-release versions, these versions are now marked with spec_version 1.36.

The above PR also added a bit of logic that parsed the version string from mods hosted on spacedock; setting their release_status to "testing" if it has one of the strings "alpha," "beta," "pre."

This led to some trouble, even for older clients.  Versions of mods that are hosted on spacedock that used to be installable no longer are (some of these had their last release years ago).  Also since non-latest versions don't get re-inflated, this leads to the older ckan clients installing the second-newest version from spacedock even if it's also labeled "beta."  This happened to kopernicus expansion continueder, and it's especially unfortunate because the 2nd-newest version has a bug that makes it completely broken (which is what led me to discover this in the first place).  HebaruSan also applied the "testing" status to that release, but then this has the effect of making the mod not visible at all to the older ckan client, which is creating new issues of users needing support when they try to install mods that depend on kopernicus expansion.

lengthy discussion here: https://discord.com/channels/601452466017665040/601459946684547095/1333492865220739214