### PR TITLE
Handle GitHub API rate limit errors appropriately

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -213,9 +213,9 @@ namespace CKAN.CmdLine
                     user.RaiseError("{0}", kraken.ToString());
                     return Exit.ERROR;
                 }
-                catch (DownloadThrottledKraken kraken)
+                catch (RequestThrottledKraken kraken)
                 {
-                    user.RaiseError("{0}", kraken.ToString());
+                    user.RaiseError("{0}", kraken.Message);
                     user.RaiseMessage(Properties.Resources.InstallTryAuthToken, kraken.infoUrl);
                     return Exit.ERROR;
                 }

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -139,8 +139,8 @@ namespace CKAN.ConsoleUI {
                             RaiseError("{0}", ex.ToString());
                         } catch (ModuleDownloadErrorsKraken ex) {
                             RaiseError("{0}", ex.ToString());
-                        } catch (DownloadThrottledKraken ex) {
-                            if (RaiseYesNoDialog(string.Format(Properties.Resources.InstallAuthTokenPrompt, ex.ToString()))) {
+                        } catch (RequestThrottledKraken ex) {
+                            if (RaiseYesNoDialog(string.Format(Properties.Resources.InstallAuthTokenPrompt, ex.Message))) {
                                 if (ex.infoUrl != null) {
                                     ModInfoScreen.LaunchURL(theme, ex.infoUrl);
                                 }

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -170,9 +170,9 @@ namespace CKAN
                                                      && url.IsAbsoluteUri
                                                      && Net.ThrottledHosts.TryGetValue(url.Host, out Uri? infoUrl)
                                                      && infoUrl is not null
-                                                         ? new DownloadThrottledKraken(url, infoUrl)
+                                                         ? new RequestThrottledKraken(url, infoUrl, wex)
                                                          : null)
-                                      .OfType<DownloadThrottledKraken>()
+                                      .OfType<RequestThrottledKraken>()
                                       .FirstOrDefault();
             if (throttled is not null)
             {

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -302,8 +302,7 @@ If the game is still running, close it and try again. Otherwise check the permis
 Consult this page for help:
 {0}</value></data>
   <data name="KrakenMissingCertificateNotUnix" xml:space="preserve"><value>Oh no! Our download failed with a certificate error!</value></data>
-  <data name="KrakenDownloadThrottled" xml:space="preserve"><value>Download from {0} was throttled.
-Consider adding an authentication token to increase the throttling limit.</value></data>
+  <data name="KrakenDownloadThrottled" xml:space="preserve"><value>Request to {0} throttled</value></data>
   <data name="KrakenAlreadyRunning" xml:space="preserve"><value>Lock file with live process ID found at:
 {0}
 

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -489,8 +489,8 @@ namespace CKAN.GUI
                         currentUser.RaiseMessage("{0}", exc.ToString());
                         break;
 
-                    case DownloadThrottledKraken exc:
-                        string msg = exc.ToString();
+                    case RequestThrottledKraken exc:
+                        string msg = exc.Message;
                         currentUser.RaiseMessage("{0}", msg);
                         if (configuration != null && CurrentInstance != null
                             && YesNoDialog(string.Format(Properties.Resources.MainInstallOpenSettingsPrompt, msg),

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 using Amazon.SQS;
 using Amazon.SQS.Model;
@@ -181,6 +182,13 @@ namespace CKAN.NetKAN.Processors
                 // error CS1631: Cannot yield a value in the body of a catch clause
                 caught        = true;
                 caughtMessage = e.Message;
+                if (e is RequestThrottledKraken k && k.retryTime is DateTime dt)
+                {
+                    // Let the API credits recharge
+                    var span = dt.Subtract(DateTime.UtcNow);
+                    caughtMessage += $"; sleeping {span}";
+                    Thread.Sleep(span);
+                }
             }
             if (caught)
             {

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -49,14 +49,13 @@ namespace CKAN.NetKAN
                 if (!string.IsNullOrEmpty(Options.ValidateCkan))
                 {
                     var ckan = new Metadata(JObject.Parse(File.ReadAllText(Options.ValidateCkan)));
-                    var inf = new Inflator(
-                        Options.CacheDir,
-                        Options.OverwriteCache,
-                        Options.GitHubToken,
-                        Options.GitLabToken,
-                        Options.NetUserAgent,
-                        Options.PreRelease,
-                        game);
+                    var inf = new Inflator(Options.CacheDir,
+                                           Options.OverwriteCache,
+                                           Options.GitHubToken,
+                                           Options.GitLabToken,
+                                           Options.NetUserAgent,
+                                           Options.PreRelease,
+                                           game);
                     inf.ValidateCkan(ckan);
                     Console.WriteLine(QueueHandler.serializeCkan(
                         PropertySortTransformer.SortProperties(ckan)));
@@ -72,17 +71,16 @@ namespace CKAN.NetKAN
                     && array[0] is var input
                     && array[1] is var output)
                 {
-                    var qh = new QueueHandler(
-                        input,
-                        output,
-                        Options.CacheDir,
-                        Options.OutputDir,
-                        Options.OverwriteCache,
-                        Options.GitHubToken,
-                        Options.GitLabToken,
-                        Options.NetUserAgent,
-                        Options.PreRelease,
-                        game);
+                    var qh = new QueueHandler(input,
+                                              output,
+                                              Options.CacheDir,
+                                              Options.OutputDir,
+                                              Options.OverwriteCache,
+                                              Options.GitHubToken,
+                                              Options.GitLabToken,
+                                              Options.NetUserAgent,
+                                              Options.PreRelease,
+                                              game);
                     qh.Process();
                     return ExitOk;
                 }
@@ -94,14 +92,13 @@ namespace CKAN.NetKAN
                     var netkans = ReadNetkans(Options);
                     Log.Info("Finished reading input");
 
-                    var inf = new Inflator(
-                        Options.CacheDir,
-                        Options.OverwriteCache,
-                        Options.GitHubToken,
-                        Options.GitLabToken,
-                        Options.NetUserAgent,
-                        Options.PreRelease,
-                        game);
+                    var inf = new Inflator(Options.CacheDir,
+                                           Options.OverwriteCache,
+                                           Options.GitHubToken,
+                                           Options.GitLabToken,
+                                           Options.NetUserAgent,
+                                           Options.PreRelease,
+                                           game);
                     var ckans = inf.Inflate(
                             Options.File,
                             netkans,
@@ -177,7 +174,8 @@ namespace CKAN.NetKAN
 
         private static Metadata[] ReadNetkans(CmdLineOptions Options)
         {
-            if (!Options.File?.EndsWith(".netkan") ?? false)
+            if (!Options.File?.EndsWith(".netkan", StringComparison.OrdinalIgnoreCase)
+                             ?? false)
             {
                 Log.WarnFormat("Input is not a .netkan file");
             }

--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -181,9 +181,12 @@ namespace CKAN.NetKAN.Sources.Github
             catch (WebException k)
             {
                 if (((HttpWebResponse?)k.Response)?.StatusCode == HttpStatusCode.Forbidden
-                    && k.Response.Headers["X-RateLimit-Remaining"] == "0")
+                    && k.Response.Headers["X-RateLimit-Remaining"] == "0"
+                    && Net.ThrottledHosts.TryGetValue(url.Host, out Uri? infoUrl)
+                    && infoUrl is not null)
                 {
-                    throw new Kraken($"GitHub API rate limit exceeded: {path}");
+                    throw new RequestThrottledKraken(url, infoUrl, k,
+                                                     $"GitHub API rate limit exceeded: {path}");
                 }
                 throw;
             }

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -153,9 +153,14 @@ namespace CKAN.NetKAN.Transformers
                         }
                     }
                 }
+                catch (RequestThrottledKraken)
+                {
+                    // Treat rate limiting as a real error to avoid temporary metadata degradation
+                    throw;
+                }
                 catch
                 {
-                    // Just give up, it's fine
+                    // Just give up, invalid URLs are fine
                 }
             }
             TryAddResourceURL(metadata.Identifier, resourcesJson, "repository", sdMod.source_code);


### PR DESCRIPTION
## Motivation

The bot has occasionally hit the GitHub API rate limit recently. When this happens, it keeps querying over and over regardless:

![image](https://github.com/user-attachments/assets/68728d89-ae81-433a-b5f6-ea36af8ad5b3)

... which isn't what we're supposed to do:

<https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#handle-rate-limit-errors-appropriately>

![image](https://github.com/user-attachments/assets/472edcce-31bf-45fc-bbd8-77221321753c)

## Changes

Now if we get a rate limiting response from the GitHub API, we pause inflation for the time it requests and log that time span in the current mod's inflation error. This should allow the rate limit budget to recharge and keep us safer from being banned.

### Known limitations

Due to how the logging works, the messages about pausing will only appear _after_ the pause occurs. The Discord messages are sent by the Infra Python code, which receives them from AWS queue messages, which are batched in groups of 10. So if the third mod of a batch of 10 hits the limit, we'll pause for however long, then continue with mods 4–10 and finally send the message that alerts us to the pause.

I looked for a way around this, but did not find one. Maybe we can figure it out in the future.
