### PR TITLE
Handle paths without DriveInfo

### DIFF
--- a/Cmdline/Action/AuthToken.cs
+++ b/Cmdline/Action/AuthToken.cs
@@ -33,7 +33,7 @@ namespace CKAN.CmdLine
             string[] args     = unparsed.options.ToArray();
             int      exitCode = Exit.OK;
 
-            Parser.Default.ParseArgumentsStrict(args, new AuthTokenSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(args, new AuthTokenSubOptions(), (option, suboptions) =>
             {
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
                 {

--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -251,11 +251,20 @@ namespace CKAN.CmdLine
         {
             if (manager?.Cache != null)
             {
-                manager.Cache.GetSizeInfo(out int fileCount, out long bytes, out long bytesFree);
-                user?.RaiseMessage(Properties.Resources.CacheInfo,
-                                   fileCount,
-                                   CkanModule.FmtSize(bytes),
-                                   CkanModule.FmtSize(bytesFree));
+                manager.Cache.GetSizeInfo(out int fileCount, out long bytes, out long? bytesFree);
+                if (bytesFree.HasValue)
+                {
+                    user?.RaiseMessage(Properties.Resources.CacheInfo,
+                                       fileCount,
+                                       CkanModule.FmtSize(bytes),
+                                       CkanModule.FmtSize(bytesFree.Value));
+                }
+                else
+                {
+                    user?.RaiseMessage(Properties.Resources.CacheInfoFreeSpaceUnknown,
+                                       fileCount,
+                                       CkanModule.FmtSize(bytes));
+                }
             }
         }
 

--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -108,7 +108,7 @@ namespace CKAN.CmdLine
 
             int exitCode = Exit.OK;
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new CacheSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(args, new CacheSubOptions(), (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)

--- a/Cmdline/Action/Compat.cs
+++ b/Cmdline/Action/Compat.cs
@@ -99,7 +99,7 @@ namespace CKAN.CmdLine
         {
             var exitCode = Exit.OK;
 
-            Parser.Default.ParseArgumentsStrict(options.options.ToArray(), new CompatSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(options.options.ToArray(), new CompatSubOptions(), (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)

--- a/Cmdline/Action/Filter.cs
+++ b/Cmdline/Action/Filter.cs
@@ -35,7 +35,7 @@ namespace CKAN.CmdLine
             string[] args = unparsed.options.ToArray();
             int exitCode = Exit.OK;
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new FilterSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(args, new FilterSubOptions(), (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)

--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -181,7 +181,7 @@ namespace CKAN.CmdLine
 
             int exitCode = Exit.OK;
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new InstanceSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(args, new InstanceSubOptions(), (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -35,7 +35,7 @@ namespace CKAN.CmdLine
             string[] args = unparsed.options.ToArray();
             int exitCode = Exit.OK;
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new MarkSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(args, new MarkSubOptions(), (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -58,7 +58,7 @@ namespace CKAN.CmdLine
         {
             int exitCode = Exit.OK;
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(unparsed.options.ToArray(), new RepairSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(unparsed.options.ToArray(), new RepairSubOptions(), (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -137,7 +137,7 @@ namespace CKAN.CmdLine
             int exitCode = Exit.OK;
 
             // Parse and process our sub-verbs
-            Parser.Default.ParseArgumentsStrict(args, new RepoSubOptions(), (string option, object suboptions) =>
+            Parser.Default.ParseArgumentsStrict(args, new RepoSubOptions(), (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)
@@ -200,8 +200,7 @@ namespace CKAN.CmdLine
                         is RepositoryList repoList)
                 {
                     var maxNameLen = repoList.repositories
-                                             .Select(r => r.name.Length)
-                                             .Max();
+                                             .Max(r => r.name.Length);
                     foreach (var repository in repoList.repositories)
                     {
                         user?.RaiseMessage("  {0}: {1}",

--- a/Cmdline/Action/Stability.cs
+++ b/Cmdline/Action/Stability.cs
@@ -19,7 +19,7 @@ namespace CKAN.CmdLine
             int exitCode = Exit.OK;
             Parser.Default.ParseArgumentsStrict(options.options.ToArray(),
                                                 new StabilitySubOptions(),
-                                                (string option, object suboptions) =>
+                                                (option, suboptions) =>
             {
                 // ParseArgumentsStrict calls us unconditionally, even with bad arguments
                 if (!string.IsNullOrEmpty(option) && suboptions != null)

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -172,6 +172,7 @@ If you must run as an administrator, the `--asroot` parameter will bypass this c
   <data name="CacheResetFailed" xml:space="preserve"><value>Can't reset cache path: {0}</value></data>
   <data name="CacheUnlimited" xml:space="preserve"><value>Unlimited</value></data>
   <data name="CacheInfo" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>
+  <data name="CacheInfoFreeSpaceUnknown" xml:space="preserve"><value>{0} files, {1}, free space unknown</value></data>
   <data name="CompareSame" xml:space="preserve"><value>"{0}" and "{1}" are the same versions.</value></data>
   <data name="CompareLower" xml:space="preserve"><value>"{0}" is lower than "{1}".</value></data>
   <data name="CompareHigher" xml:space="preserve"><value>"{0}" is higher than "{1}".</value></data>

--- a/ConsoleUI/AuthTokenAddDialog.cs
+++ b/ConsoleUI/AuthTokenAddDialog.cs
@@ -57,10 +57,11 @@ namespace CKAN.ConsoleUI {
             AddObject(tokenEntry);
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object sender) => false);
+            AddBinding(Keys.Escape, sender => false);
 
             AddTip(Properties.Resources.Enter, Properties.Resources.Accept, validKey);
-            AddBinding(Keys.Enter, (object sender) => {
+            AddBinding(Keys.Enter, sender =>
+            {
                 if (validKey()) {
                     ServiceLocator.Container.Resolve<IConfiguration>().SetAuthToken(hostEntry.Value, tokenEntry.Value);
                     return false;

--- a/ConsoleUI/AuthTokenListScreen.cs
+++ b/ConsoleUI/AuthTokenListScreen.cs
@@ -36,10 +36,10 @@ namespace CKAN.ConsoleUI {
                 new List<ConsoleListBoxColumn<string>>() {
                     new ConsoleListBoxColumn<string>(
                         Properties.Resources.AuthTokenListHostHeader,
-                        (string s) => s, null, 20),
+                        s => s, null, 20),
                     new ConsoleListBoxColumn<string>(
                         Properties.Resources.AuthTokenListTokenHeader,
-                        (string s) => {
+                        s => {
                             return ServiceLocator.Container.Resolve<IConfiguration>().TryGetAuthToken(s, out string? token)
                                 ? token
                                 : Properties.Resources.AuthTokenListMissingToken;
@@ -57,10 +57,11 @@ namespace CKAN.ConsoleUI {
             ));
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Back);
-            AddBinding(Keys.Escape, (object sender) => false);
+            AddBinding(Keys.Escape, sender => false);
 
             tokenList.AddTip("A", Properties.Resources.Add);
-            tokenList.AddBinding(Keys.A, (object sender) => {
+            tokenList.AddBinding(Keys.A, sender =>
+            {
                 var ad = new AuthTokenAddDialog(theme);
                 ad.Run();
                 DrawBackground();
@@ -69,7 +70,8 @@ namespace CKAN.ConsoleUI {
             });
 
             tokenList.AddTip("R", Properties.Resources.Remove, () => tokenList.Selection != null);
-            tokenList.AddBinding(Keys.R, (object sender) => {
+            tokenList.AddBinding(Keys.R, sender =>
+            {
                 if (tokenList.Selection != null) {
                     ServiceLocator.Container.Resolve<IConfiguration>().SetAuthToken(tokenList.Selection, null);
                     tokenList.SetData(new List<string>(ServiceLocator.Container.Resolve<IConfiguration>().GetAuthTokenHosts()));

--- a/ConsoleUI/CompatibleVersionDialog.cs
+++ b/ConsoleUI/CompatibleVersionDialog.cs
@@ -39,7 +39,8 @@ namespace CKAN.ConsoleUI {
             );
             AddObject(choices);
             choices.AddTip(Properties.Resources.Enter, Properties.Resources.CompatibleVersionsListAcceptTip);
-            choices.AddBinding(Keys.Enter, (object sender) => {
+            choices.AddBinding(Keys.Enter, sender =>
+            {
                 choice = choices.Selection;
                 return false;
             });
@@ -51,7 +52,8 @@ namespace CKAN.ConsoleUI {
             };
             AddObject(manualEntry);
             manualEntry.AddTip(Properties.Resources.Enter, Properties.Resources.CompatibleVersionsEntryAcceptTip, () => GameVersion.TryParse(manualEntry.Value, out choice));
-            manualEntry.AddBinding(Keys.Enter, (object sender) => {
+            manualEntry.AddBinding(Keys.Enter, sender =>
+            {
                 if (GameVersion.TryParse(manualEntry.Value, out choice)) {
                     // Good value, done running
                     return false;
@@ -62,7 +64,8 @@ namespace CKAN.ConsoleUI {
             });
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object StronglyTypedResourceBuilder) => {
+            AddBinding(Keys.Escape, StronglyTypedResourceBuilder =>
+            {
                 choice = null;
                 return false;
             });

--- a/ConsoleUI/DeleteDirectoriesScreen.cs
+++ b/ConsoleUI/DeleteDirectoriesScreen.cs
@@ -51,7 +51,8 @@ namespace CKAN.ConsoleUI {
             directories.AddTip("D", Properties.Resources.DeleteDirectoriesDeleteDirTip,
                                () => directories.Selection is not null
                                      && !toDelete.Contains(directories.Selection));
-            directories.AddBinding(Keys.D, (object sender) => {
+            directories.AddBinding(Keys.D, sender =>
+            {
                 if (directories.Selection is not null)
                 {
                     toDelete.Add(directories.Selection);
@@ -61,7 +62,8 @@ namespace CKAN.ConsoleUI {
             directories.AddTip("K", Properties.Resources.DeleteDirectoriesKeepDirTip,
                                () => directories.Selection is not null
                                      && toDelete.Contains(directories.Selection));
-            directories.AddBinding(Keys.K, (object sender) => {
+            directories.AddBinding(Keys.K, sender =>
+            {
                 if (directories.Selection is not null)
                 {
                     toDelete.Remove(directories.Selection);
@@ -90,10 +92,11 @@ namespace CKAN.ConsoleUI {
                    Properties.Resources.DeleteDirectoriesCancelTip);
             AddBinding(Keys.Escape,
                        // Discard changes
-                       (object sender) => false);
+                       sender => false);
 
             AddTip("F9", Properties.Resources.DeleteDirectoriesApplyTip);
-            AddBinding(Keys.F9, (object sender) => {
+            AddBinding(Keys.F9, sender =>
+            {
                 foreach (var d in toDelete) {
                     try {
                         Directory.Delete(d, true);

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -62,24 +62,25 @@ namespace CKAN.ConsoleUI {
                 new List<ConsoleListBoxColumn<Dependency>>() {
                     new ConsoleListBoxColumn<Dependency>(
                         Properties.Resources.RecommendationsInstallHeader,
-                        (Dependency d) => StatusSymbol(d.module),
+                        d => StatusSymbol(d.module),
                         null,
                         7),
                     new ConsoleListBoxColumn<Dependency>(
                         Properties.Resources.RecommendationsNameHeader,
-                        (Dependency d) => d.module.ToString(),
+                        d => d.module.ToString(),
                         null,
                         null),
                     new ConsoleListBoxColumn<Dependency>(
                         Properties.Resources.RecommendationsSourcesHeader,
-                        (Dependency d) => string.Join(", ", d.dependents),
+                        d => string.Join(", ", d.dependents),
                         null,
                         42)
                 },
                 1, 0, ListSortDirection.Descending
             );
             dependencyList.AddTip("+", Properties.Resources.Toggle);
-            dependencyList.AddBinding(Keys.Plus, (object sender) => {
+            dependencyList.AddBinding(Keys.Plus, sender =>
+            {
                 if (dependencyList.Selection?.module is CkanModule mod
                     && (accepted.Contains(mod) || TryWithoutConflicts(accepted.Append(mod)))) {
                     ChangePlan.toggleContains(accepted, mod);
@@ -88,7 +89,8 @@ namespace CKAN.ConsoleUI {
             });
 
             dependencyList.AddTip($"{Properties.Resources.Ctrl}+A", Properties.Resources.SelectAll);
-            dependencyList.AddBinding(Keys.CtrlA, (object sender) => {
+            dependencyList.AddBinding(Keys.CtrlA, sender =>
+            {
                 if (TryWithoutConflicts(dependencies.Keys)) {
                     foreach (var kvp in dependencies) {
                         if (!accepted.Contains(kvp.Key)) {
@@ -100,13 +102,15 @@ namespace CKAN.ConsoleUI {
             });
 
             dependencyList.AddTip($"{Properties.Resources.Ctrl}+D", Properties.Resources.DeselectAll, () => accepted.Count > 0);
-            dependencyList.AddBinding(Keys.CtrlD, (object sender) => {
+            dependencyList.AddBinding(Keys.CtrlD, sender =>
+            {
                 accepted.Clear();
                 return true;
             });
 
             dependencyList.AddTip(Properties.Resources.Enter, Properties.Resources.Details);
-            dependencyList.AddBinding(Keys.Enter, (object sender) => {
+            dependencyList.AddBinding(Keys.Enter, sender =>
+            {
                 if (dependencyList.Selection != null) {
                     LaunchSubScreen(new ModInfoScreen(theme, manager, instance, reg, userAgent, plan,
                                                              dependencyList.Selection.module,
@@ -119,14 +123,16 @@ namespace CKAN.ConsoleUI {
             AddObject(dependencyList);
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object sender) => {
+            AddBinding(Keys.Escape, sender =>
+            {
                 // Add everything to rejected
                 rejected.UnionWith(dependencies.Keys.Select(m => m.identifier));
                 return false;
             });
 
             AddTip("F9", Properties.Resources.Accept);
-            AddBinding(Keys.F9, (object sender) => {
+            AddBinding(Keys.F9, sender =>
+            {
                 if (TryWithoutConflicts(accepted)) {
                     plan.Install.UnionWith(accepted);
                     // Add the rest to rejected

--- a/ConsoleUI/DownloadImportDialog.cs
+++ b/ConsoleUI/DownloadImportDialog.cs
@@ -41,7 +41,7 @@ namespace CKAN.ConsoleUI {
                     Properties.Resources.ImportProgressTitle,
                     Properties.Resources.ImportProgressMessage);
                 ps.Run(() => ModuleInstaller.ImportFiles(files, ps,
-                                                         (CkanModule mod) => cp.Install.Add(mod),
+                                                         mod => cp.Install.Add(mod),
                                                          RegistryManager.Instance(gameInst, repoData).registry,
                                                          gameInst, cache));
             }

--- a/ConsoleUI/GameInstanceEditScreen.cs
+++ b/ConsoleUI/GameInstanceEditScreen.cs
@@ -89,13 +89,15 @@ namespace CKAN.ConsoleUI {
                 );
                 AddObject(repoList);
                 repoList.AddTip("A", Properties.Resources.Add);
-                repoList.AddBinding(Keys.A, (object sender) => {
+                repoList.AddBinding(Keys.A, sender =>
+                {
                     LaunchSubScreen(new RepoAddScreen(theme, instance.game, repoEditList, userAgent));
                     repoList.SetData(new List<Repository>(repoEditList.Values));
                     return true;
                 });
                 repoList.AddTip("R", Properties.Resources.Remove);
-                repoList.AddBinding(Keys.R, (object sender) => {
+                repoList.AddBinding(Keys.R, sender =>
+                {
                     if (repoList.Selection is Repository repo)
                     {
                         int oldPrio = repo.priority;
@@ -111,7 +113,8 @@ namespace CKAN.ConsoleUI {
                     return true;
                 });
                 repoList.AddTip("E", Properties.Resources.Edit);
-                repoList.AddBinding(Keys.E, (object sender) => {
+                repoList.AddBinding(Keys.E, sender =>
+                {
                     if (repoList.Selection is Repository repo)
                     {
                         LaunchSubScreen(new RepoEditScreen(theme, instance.game, repoEditList, repo, userAgent));
@@ -120,7 +123,8 @@ namespace CKAN.ConsoleUI {
                     return true;
                 });
                 repoList.AddTip("-", Properties.Resources.Up);
-                repoList.AddBinding(Keys.Minus, (object sender) => {
+                repoList.AddBinding(Keys.Minus, sender =>
+                {
                     if (repoList.Selection is Repository repo)
                     {
                         if (repo.priority > 0) {
@@ -136,7 +140,8 @@ namespace CKAN.ConsoleUI {
                     return true;
                 });
                 repoList.AddTip("+", Properties.Resources.Down);
-                repoList.AddBinding(Keys.Plus, (object sender) => {
+                repoList.AddBinding(Keys.Plus, sender =>
+                {
                     if (repoList.Selection is Repository repo)
                     {
                         var next = SortedDictFind(repoEditList,
@@ -165,7 +170,8 @@ namespace CKAN.ConsoleUI {
                 AddObject(compatList);
 
                 compatList.AddTip("A", Properties.Resources.Add);
-                compatList.AddBinding(Keys.A, (object sender) => {
+                compatList.AddBinding(Keys.A, sender =>
+                {
                     CompatibleVersionDialog vd = new CompatibleVersionDialog(theme, instance.game);
                     var newVersion = vd.Run();
                     DrawBackground();
@@ -176,7 +182,8 @@ namespace CKAN.ConsoleUI {
                     return true;
                 });
                 compatList.AddTip("R", Properties.Resources.Remove, () => compatList.Selection != null);
-                compatList.AddBinding(Keys.R, (object sender) => {
+                compatList.AddBinding(Keys.R, sender =>
+                {
                     if (compatList.Selection is GameVersion gv)
                     {
                         compatEditList.Remove(gv);

--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -71,15 +71,16 @@ namespace CKAN.ConsoleUI {
 
             if (first) {
                 AddTip($"{Properties.Resources.Ctrl}+Q", Properties.Resources.Quit);
-                AddBinding(Keys.AltX,  (object sender) => false);
-                AddBinding(Keys.CtrlQ, (object sender) => false);
+                AddBinding(Keys.AltX,  sender => false);
+                AddBinding(Keys.CtrlQ, sender => false);
             } else {
                 AddTip(Properties.Resources.Esc, Properties.Resources.Quit);
-                AddBinding(Keys.Escape, (object sender) => false);
+                AddBinding(Keys.Escape, sender => false);
             }
 
             AddTip(Properties.Resources.Enter, Properties.Resources.Select);
-            AddBinding(Keys.Enter, (object sender) => {
+            AddBinding(Keys.Enter, sender =>
+            {
                 if (instanceList.Selection is GameInstance inst)
                 {
                     var d = new ConsoleMessageDialog(theme, string.Format(Properties.Resources.InstanceListLoadingInstance,
@@ -87,7 +88,7 @@ namespace CKAN.ConsoleUI {
                                                      new List<string>());
 
                     if (TryGetInstance(theme, inst, repoData,
-                                       (ConsoleTheme th) => { d.Run(() => {}); },
+                                       th => { d.Run(() => {}); },
                                        null)) {
                         try {
                             manager.SetCurrentInstance(inst.Name);
@@ -105,13 +106,15 @@ namespace CKAN.ConsoleUI {
             });
 
             instanceList.AddTip("A", Properties.Resources.Add);
-            instanceList.AddBinding(Keys.A, (object sender) => {
+            instanceList.AddBinding(Keys.A, sender =>
+            {
                 LaunchSubScreen(new GameInstanceAddScreen(theme, manager));
                 instanceList.SetData(manager.Instances.Values);
                 return true;
             });
             instanceList.AddTip("R", Properties.Resources.Remove);
-            instanceList.AddBinding(Keys.R, (object sender) => {
+            instanceList.AddBinding(Keys.R, sender =>
+            {
                 if (instanceList.Selection is GameInstance inst)
                 {
                     manager.RemoveInstance(inst.Name);
@@ -120,7 +123,8 @@ namespace CKAN.ConsoleUI {
                 return true;
             });
             instanceList.AddTip("E", Properties.Resources.Edit);
-            instanceList.AddBinding(Keys.E, (object sender) => {
+            instanceList.AddBinding(Keys.E, sender =>
+            {
                 if (instanceList.Selection is GameInstance inst)
                 {
                     var d = new ConsoleMessageDialog(
@@ -128,7 +132,7 @@ namespace CKAN.ConsoleUI {
                         string.Format(Properties.Resources.InstanceListLoadingInstance, inst.Name),
                         new List<string>());
                     TryGetInstance(theme, inst, repoData,
-                                   (ConsoleTheme th) => { d.Run(() => {}); },
+                                   th => { d.Run(() => {}); },
                                    null);
                     // Still launch the screen even if the load fails,
                     // because you need to be able to fix the name/path.
@@ -138,7 +142,8 @@ namespace CKAN.ConsoleUI {
             });
 
             instanceList.AddTip("D", Properties.Resources.InstanceListDefaultToggle);
-            instanceList.AddBinding(Keys.D, (object sender) => {
+            instanceList.AddBinding(Keys.D, sender =>
+            {
                 if (instanceList.Selection is GameInstance inst)
                 {
                     string name = inst.Name;

--- a/ConsoleUI/GameInstanceScreen.cs
+++ b/ConsoleUI/GameInstanceScreen.cs
@@ -22,7 +22,8 @@ namespace CKAN.ConsoleUI {
             manager = mgr;
 
             AddTip("F2", Properties.Resources.Accept);
-            AddBinding(Keys.F2, (object sender) => {
+            AddBinding(Keys.F2, sender =>
+            {
                 if (Valid()) {
                     Save();
                     // Close screen
@@ -34,7 +35,8 @@ namespace CKAN.ConsoleUI {
             });
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object sender) => {
+            AddBinding(Keys.Escape, sender =>
+            {
                 // Discard changes
                 return false;
             });

--- a/ConsoleUI/InstallFilterAddDialog.cs
+++ b/ConsoleUI/InstallFilterAddDialog.cs
@@ -28,13 +28,15 @@ namespace CKAN.ConsoleUI {
             };
             AddObject(manualEntry);
             manualEntry.AddTip(Properties.Resources.Enter, Properties.Resources.FilterAddAcceptTip);
-            manualEntry.AddBinding(Keys.Enter, (object sender) => {
+            manualEntry.AddBinding(Keys.Enter, sender =>
+            {
                 choice = manualEntry.Value;
                 return false;
             });
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object sender) => {
+            AddBinding(Keys.Escape, sender =>
+            {
                 choice = null;
                 return false;
             });

--- a/ConsoleUI/InstallFiltersScreen.cs
+++ b/ConsoleUI/InstallFiltersScreen.cs
@@ -27,13 +27,15 @@ namespace CKAN.ConsoleUI {
             instanceFilters = instance.InstallFilters.ToList();
 
             AddTip("F2", Properties.Resources.Accept);
-            AddBinding(Keys.F2, (object sender) => {
+            AddBinding(Keys.F2, sender =>
+            {
                 Save();
                 // Close screen
                 return false;
             });
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object sender) => {
+            AddBinding(Keys.Escape, sender =>
+            {
                 // Discard changes
                 return false;
             });
@@ -60,12 +62,14 @@ namespace CKAN.ConsoleUI {
             );
             AddObject(globalList);
             globalList.AddTip("A", Properties.Resources.Add);
-            globalList.AddBinding(Keys.A, (object sender) => {
+            globalList.AddBinding(Keys.A, sender =>
+            {
                 AddFilter(theme, globalList, globalFilters);
                 return true;
             });
             globalList.AddTip("R", Properties.Resources.Remove);
-            globalList.AddBinding(Keys.R, (object sender) => {
+            globalList.AddBinding(Keys.R, sender =>
+            {
                 RemoveFilter(globalList, globalFilters);
                 return true;
             });
@@ -83,12 +87,14 @@ namespace CKAN.ConsoleUI {
             );
             AddObject(instanceList);
             instanceList.AddTip("A", Properties.Resources.Add);
-            instanceList.AddBinding(Keys.A, (object sender) => {
+            instanceList.AddBinding(Keys.A, sender =>
+            {
                 AddFilter(theme, instanceList, instanceFilters);
                 return true;
             });
             instanceList.AddTip("R", Properties.Resources.Remove);
-            instanceList.AddBinding(Keys.R, (object sender) => {
+            instanceList.AddBinding(Keys.R, sender =>
+            {
                 RemoveFilter(instanceList, instanceFilters);
                 return true;
             });

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -157,7 +157,7 @@ namespace CKAN.ConsoleUI {
                                 ex.Message,
                                 Properties.Resources.InstallTooManyModsNameHeader,
                                 ex.modules,
-                                (CkanModule mod) => mod.ToString()
+                                mod => mod.ToString()
                             );
                             var chosen = ch.Run();
                             DrawBackground();

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -145,12 +145,13 @@ namespace CKAN.ConsoleUI {
             }
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Back);
-            AddBinding(Keys.Escape, (object sender) => false);
+            AddBinding(Keys.Escape, sender => false);
 
             AddTip($"{Properties.Resources.Ctrl}+D", Properties.Resources.ModInfoDownloadToCache,
                 () => manager.Cache != null && !manager.Cache.IsMaybeCachedZip(mod) && !mod.IsDLC
             );
-            AddBinding(Keys.CtrlD, (object sender) => {
+            AddBinding(Keys.CtrlD, sender =>
+            {
                 if (!mod.IsDLC) {
                     Download();
                 }

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -82,7 +82,7 @@ namespace CKAN.ConsoleUI {
                         12),
                 },
                 1, 0, ListSortDirection.Descending,
-                (CkanModule m, string filter) => {
+                (m, filter) => {
                     // Search for author
                     if (filter.StartsWith("@")) {
                         string authorFilt = filter[1..];
@@ -149,7 +149,7 @@ namespace CKAN.ConsoleUI {
                     ? Properties.Resources.ModListSearchFocusedGhostText
                     : Properties.Resources.ModListSearchUnfocusedGhostText
             };
-            searchBox.OnChange += (ConsoleField sender, string newValue) => {
+            searchBox.OnChange += (sender, newValue) => {
                 moduleList.FilterString = newValue;
             };
 
@@ -167,34 +167,39 @@ namespace CKAN.ConsoleUI {
             AddObject(searchBox);
             AddObject(moduleList);
 
-            AddBinding(Keys.CtrlP, (object sender) => PlayGame());
-            AddBinding(Keys.CtrlQ, (object sender) => false);
-            AddBinding(Keys.AltX,  (object sender) => false);
-            AddBinding(Keys.F1,    (object sender) => Help());
-            AddBinding(Keys.AltH,  (object sender) => Help());
-            AddBinding(Keys.F5,    (object sender) => UpdateRegistry());
-            AddBinding(Keys.CtrlR, (object sender) => UpdateRegistry());
-            AddBinding(Keys.CtrlU, (object sender) => UpgradeAll());
+            AddBinding(Keys.CtrlP, sender => PlayGame());
+            AddBinding(Keys.CtrlQ, sender => false);
+            AddBinding(Keys.AltX,  sender => false);
+            AddBinding(Keys.F1,    sender => Help());
+            AddBinding(Keys.AltH,  sender => Help());
+            AddBinding(Keys.F5,    sender => UpdateRegistry());
+            AddBinding(Keys.CtrlR, sender => UpdateRegistry());
+            AddBinding(Keys.CtrlU, sender => UpgradeAll());
 
             // Now a bunch of convenience shortcuts so you don't get stuck in the search box
-            searchBox.AddBinding(Keys.PageUp, (object sender) => {
+            searchBox.AddBinding(Keys.PageUp, sender =>
+            {
                 SetFocus(moduleList);
                 return true;
             });
-            searchBox.AddBinding(Keys.PageDown, (object sender) => {
+            searchBox.AddBinding(Keys.PageDown, sender =>
+            {
                 SetFocus(moduleList);
                 return true;
             });
-            searchBox.AddBinding(Keys.Enter, (object sender) => {
+            searchBox.AddBinding(Keys.Enter, sender =>
+            {
                 SetFocus(moduleList);
                 return true;
             });
 
-            moduleList.AddBinding(Keys.CtrlF, (object sender) => {
+            moduleList.AddBinding(Keys.CtrlF, sender =>
+            {
                 SetFocus(searchBox);
                 return true;
             });
-            moduleList.AddBinding(Keys.Escape, (object sender) => {
+            moduleList.AddBinding(Keys.Escape, sender =>
+            {
                 searchBox.Clear();
                 return true;
             });
@@ -202,7 +207,8 @@ namespace CKAN.ConsoleUI {
             moduleList.AddTip(Properties.Resources.Enter, Properties.Resources.Details,
                 () => moduleList.Selection != null
             );
-            moduleList.AddBinding(Keys.Enter, (object sender) => {
+            moduleList.AddBinding(Keys.Enter, sender =>
+            {
                 if (moduleList.Selection != null && manager.CurrentInstance != null) {
                     LaunchSubScreen(new ModInfoScreen(theme, manager, manager.CurrentInstance, registry, userAgent,
                                                       plan, moduleList.Selection, upgradeableGroups?[true], debug));
@@ -227,7 +233,8 @@ namespace CKAN.ConsoleUI {
                                                  manager.CurrentInstance.StabilityToleranceConfig,
                                                  manager.CurrentInstance.VersionCriteria()) != null
             );
-            moduleList.AddBinding(Keys.Plus, (object sender) => {
+            moduleList.AddBinding(Keys.Plus, sender =>
+            {
                 if (moduleList.Selection != null && !moduleList.Selection.IsDLC && manager.CurrentInstance != null) {
                     if (!registry.IsInstalled(moduleList.Selection.identifier, false)) {
                         plan.ToggleInstall(moduleList.Selection);
@@ -248,7 +255,8 @@ namespace CKAN.ConsoleUI {
                     && registry.IsInstalled(moduleList.Selection.identifier, false)
                     && !registry.IsAutodetected(moduleList.Selection.identifier)
             );
-            moduleList.AddBinding(Keys.Minus, (object sender) => {
+            moduleList.AddBinding(Keys.Minus, sender =>
+            {
                 if (moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && registry.IsInstalled(moduleList.Selection.identifier, false)
                     && !registry.IsAutodetected(moduleList.Selection.identifier)) {
@@ -265,7 +273,8 @@ namespace CKAN.ConsoleUI {
                 () => moduleList.Selection != null && !moduleList.Selection.IsDLC
                     && (registry.InstalledModule(moduleList.Selection.identifier)?.AutoInstalled ?? false)
             );
-            moduleList.AddBinding(Keys.F8, (object sender) => {
+            moduleList.AddBinding(Keys.F8, sender =>
+            {
                 if (moduleList.Selection is CkanModule m)
                 {
                     var im = registry.InstalledModule(m.identifier);
@@ -278,7 +287,8 @@ namespace CKAN.ConsoleUI {
             });
 
             AddTip("F9", Properties.Resources.ModListApplyChangesTip, plan.NonEmpty);
-            AddBinding(Keys.F9, (object sender) => {
+            AddBinding(Keys.F9, sender =>
+            {
                 ApplyChanges();
                 return true;
             });
@@ -298,7 +308,8 @@ namespace CKAN.ConsoleUI {
                         :              string.Format(Properties.Resources.ModListUpdatedDaysAgo, days);
                 },
                 null,
-                (ConsoleTheme th) => {
+                th =>
+                {
                     return timeSinceUpdate < RepositoryDataManager.TimeTillStale     ? th.RegistryUpToDate
                         :  timeSinceUpdate < RepositoryDataManager.TimeTillVeryStale ? th.RegistryStale
                         :                                                              th.RegistryVeryStale;

--- a/ConsoleUI/ProgressScreen.cs
+++ b/ConsoleUI/ProgressScreen.cs
@@ -79,11 +79,13 @@ namespace CKAN.ConsoleUI {
                 TextAlign.Center,
                 -Console.WindowHeight / 2
             );
-            d.AddBinding(Keys.Y, (object sender) => {
+            d.AddBinding(Keys.Y, sender =>
+            {
                 d.PressButton(0);
                 return false;
             });
-            d.AddBinding(Keys.N, (object sender) => {
+            d.AddBinding(Keys.N, sender =>
+            {
                 d.PressButton(1);
                 return false;
             });

--- a/ConsoleUI/RepoScreen.cs
+++ b/ConsoleUI/RepoScreen.cs
@@ -43,7 +43,8 @@ namespace CKAN.ConsoleUI {
             AddObject(url);
 
             AddTip("F2", Properties.Resources.Accept);
-            AddBinding(Keys.F2, (object sender) => {
+            AddBinding(Keys.F2, sender =>
+            {
                 if (Valid()) {
                     Save();
                     return false;
@@ -53,7 +54,7 @@ namespace CKAN.ConsoleUI {
             });
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object sender) => false);
+            AddBinding(Keys.Escape, sender => false);
 
             // mainMenu = list of default options
             mainMenu = (RepositoryList.DefaultRepositories(game, userAgent) is RepositoryList repoList)

--- a/ConsoleUI/SplashScreen.cs
+++ b/ConsoleUI/SplashScreen.cs
@@ -31,7 +31,7 @@ namespace CKAN.ConsoleUI {
             GameInstance? ksp = manager.CurrentInstance ?? manager.GetPreferredInstance();
             if (ksp != null
                 && !GameInstanceListScreen.TryGetInstance(theme, ksp, repoData,
-                                                          (ConsoleTheme th) => Draw(th, false),
+                                                          th => Draw(th, false),
                                                           new ProgressImmediate<int>(p => drawProgressBar(theme, 22, 20, p)))) {
                 Console.ResetColor();
                 Console.Clear();

--- a/ConsoleUI/Toolkit/ConsoleChoiceDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleChoiceDialog.cs
@@ -56,12 +56,14 @@ namespace CKAN.ConsoleUI.Toolkit {
             );
 
             choices.AddTip(Properties.Resources.Enter, Properties.Resources.Accept);
-            choices.AddBinding(Keys.Enter, (object sender) => {
+            choices.AddBinding(Keys.Enter, sender =>
+            {
                 return false;
             });
 
             choices.AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            choices.AddBinding(Keys.Escape, (object sender) => {
+            choices.AddBinding(Keys.Escape, sender =>
+            {
                 cancelled = true;
                 return false;
             });

--- a/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleFileMultiSelectDialog.cs
@@ -83,7 +83,7 @@ namespace CKAN.ConsoleUI.Toolkit {
                         9),
                     new ConsoleListBoxColumn<FileSystemInfo>(
                         Properties.Resources.FileSelectTimestampHeader,
-                        (FileSystemInfo fi) => fi.LastWriteTime.ToString("yyyy-MM-dd"),
+                        fi => fi.LastWriteTime.ToString("yyyy-MM-dd"),
                         (a, b) => a.LastWriteTime.CompareTo(b.LastWriteTime),
                         10)
                 },
@@ -92,13 +92,15 @@ namespace CKAN.ConsoleUI.Toolkit {
             AddObject(fileList);
 
             AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
-            AddBinding(Keys.Escape, (object sender) => {
+            AddBinding(Keys.Escape, sender =>
+            {
                 chosenFiles.Clear();
                 return false;
             });
 
             AddTip(ConsoleScreen.MainMenuKeyTip, Properties.Resources.Sort);
-            AddBinding(ConsoleScreen.MainMenuKeys, (object sender) => {
+            AddBinding(ConsoleScreen.MainMenuKeys, sender =>
+            {
                 fileList.SortMenu().Run(theme, right - 2, top + 2);
                 DrawBackground();
                 return true;
@@ -106,11 +108,12 @@ namespace CKAN.ConsoleUI.Toolkit {
 
             AddTip(Properties.Resources.Enter, Properties.Resources.FileSelectChangeDirectory, () => fileList.Selection != null &&  isDir(fileList.Selection));
             AddTip(Properties.Resources.Enter, Properties.Resources.FileSelectSelect,          () => fileList.Selection != null && !isDir(fileList.Selection));
-            AddBinding(Keys.Enter, (object sender) => selectRow());
-            AddBinding(Keys.Space, (object sender) => selectRow());
+            AddBinding(Keys.Enter, sender => selectRow());
+            AddBinding(Keys.Space, sender => selectRow());
 
             AddTip($"{Properties.Resources.Ctrl}+A", Properties.Resources.SelectAll);
-            AddBinding(Keys.CtrlA, (object sender) => {
+            AddBinding(Keys.CtrlA, sender =>
+            {
                 foreach (FileSystemInfo fi in contents) {
                     if (!isDir(fi)) {
                         if (fi is FileInfo file)
@@ -123,7 +126,8 @@ namespace CKAN.ConsoleUI.Toolkit {
             });
 
             AddTip($"{Properties.Resources.Ctrl}+D", Properties.Resources.DeselectAll, () => chosenFiles.Count > 0);
-            AddBinding(Keys.CtrlD, (object sender) => {
+            AddBinding(Keys.CtrlD, sender =>
+            {
                 if (chosenFiles.Count > 0) {
                     chosenFiles.Clear();
                 }
@@ -131,7 +135,7 @@ namespace CKAN.ConsoleUI.Toolkit {
             });
 
             AddTip("F9", acceptTip, () => chosenFiles.Count > 0);
-            AddBinding(Keys.F9, (object sender) => false);
+            AddBinding(Keys.F9, sender => false);
         }
 
         private bool selectRow()

--- a/ConsoleUI/Toolkit/ConsoleListBox.cs
+++ b/ConsoleUI/Toolkit/ConsoleListBox.cs
@@ -142,8 +142,7 @@ namespace CKAN.ConsoleUI.Toolkit {
             }
 
             var remainingWidth = contentR - l - 1
-                                 - columns.Select(col => col.Width ?? 0)
-                                          .Sum()
+                                 - columns.Sum(col => col.Width ?? 0)
                                  - (padding.Length * (columns.Count - 1));
             var autoWidthCount = columns.Count(col => !col.Width.HasValue);
             var autoWidth = autoWidthCount > 0 && remainingWidth > 0

--- a/ConsoleUI/Toolkit/ConsoleScreen.cs
+++ b/ConsoleUI/Toolkit/ConsoleScreen.cs
@@ -22,7 +22,8 @@ namespace CKAN.ConsoleUI.Toolkit {
                 MainMenuKeyTip, MenuTip(),
                 () => mainMenu != null
             );
-            AddBinding(MainMenuKeys, (object sender) => {
+            AddBinding(MainMenuKeys, sender =>
+            {
                 bool val = true;
                 if (mainMenu != null) {
                     DrawSelectedHamburger();
@@ -111,11 +112,13 @@ namespace CKAN.ConsoleUI.Toolkit {
                     Properties.Resources.Yes,
                     Properties.Resources.No
                 });
-            d.AddBinding(Keys.Y, (object sender) => {
+            d.AddBinding(Keys.Y, sender =>
+            {
                 d.PressButton(0);
                 return false;
             });
-            d.AddBinding(Keys.N, (object sender) => {
+            d.AddBinding(Keys.N, sender =>
+            {
                 d.PressButton(1);
                 return false;
             });

--- a/ConsoleUI/Toolkit/ConsoleTextBox.cs
+++ b/ConsoleUI/Toolkit/ConsoleTextBox.cs
@@ -180,58 +180,70 @@ namespace CKAN.ConsoleUI.Toolkit {
         public void AddScrollBindings(ScreenContainer cont, ConsoleTheme theme, bool drawMore = false)
         {
             if (drawMore) {
-                cont.AddBinding(Keys.Home,      (object sender) => {
+                cont.AddBinding(Keys.Home,      sender =>
+                {
                     ScrollToTop();
                     Draw(theme, false);
                     return true;
                 });
-                cont.AddBinding(Keys.End,       (object sender) => {
+                cont.AddBinding(Keys.End,       sender =>
+                {
                     ScrollToBottom();
                     Draw(theme, false);
                     return true;
                 });
-                cont.AddBinding(Keys.PageUp,    (object sender) => {
+                cont.AddBinding(Keys.PageUp,    sender =>
+                {
                     ScrollUp();
                     Draw(theme, false);
                     return true;
                 });
-                cont.AddBinding(Keys.PageDown,  (object sender) => {
+                cont.AddBinding(Keys.PageDown,  sender =>
+                {
                     ScrollDown();
                     Draw(theme, false);
                     return true;
                 });
-                cont.AddBinding(Keys.UpArrow,   (object sender) => {
+                cont.AddBinding(Keys.UpArrow,   sender =>
+                {
                     ScrollUp(1);
                     Draw(theme, false);
                     return true;
                 });
-                cont.AddBinding(Keys.DownArrow, (object sender) => {
+                cont.AddBinding(Keys.DownArrow, sender =>
+                {
                     ScrollDown(1);
                     Draw(theme, false);
                     return true;
                 });
             } else {
-                cont.AddBinding(Keys.Home,      (object sender) => {
+                cont.AddBinding(Keys.Home,      sender =>
+                {
                     ScrollToTop();
                     return true;
                 });
-                cont.AddBinding(Keys.End,       (object sender) => {
+                cont.AddBinding(Keys.End,       sender =>
+                {
                     ScrollToBottom();
                     return true;
                 });
-                cont.AddBinding(Keys.PageUp,    (object sender) => {
+                cont.AddBinding(Keys.PageUp,    sender =>
+                {
                     ScrollUp();
                     return true;
                 });
-                cont.AddBinding(Keys.PageDown,  (object sender) => {
+                cont.AddBinding(Keys.PageDown,  sender =>
+                {
                     ScrollDown();
                     return true;
                 });
-                cont.AddBinding(Keys.UpArrow,   (object sender) => {
+                cont.AddBinding(Keys.UpArrow,   sender =>
+                {
                     ScrollUp(1);
                     return true;
                 });
-                cont.AddBinding(Keys.DownArrow, (object sender) => {
+                cont.AddBinding(Keys.DownArrow, sender =>
+                {
                     ScrollDown(1);
                     return true;
                 });

--- a/ConsoleUI/Toolkit/ScreenContainer.cs
+++ b/ConsoleUI/Toolkit/ScreenContainer.cs
@@ -15,7 +15,8 @@ namespace CKAN.ConsoleUI.Toolkit {
         protected ScreenContainer(ConsoleTheme theme)
         {
             this.theme = theme;
-            AddBinding(Keys.CtrlL, (object sender) => {
+            AddBinding(Keys.CtrlL, sender =>
+            {
                 // Just redraw everything and keep running
                 DrawBackground();
                 return true;

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -79,7 +79,7 @@ namespace CKAN
             }
 
             // Strip off the root, then remove any slashes at the beginning
-            return path.Remove(0, root.Length).TrimStart('/');
+            return path[root.Length..].TrimStart('/');
         }
 
         /// <summary>

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -118,9 +118,9 @@ namespace CKAN
                                           long          bytesToStore,
                                           string        errorDescription)
         {
-            if (bytesToStore > 0)
+            if (bytesToStore > 0
+                && where.GetDrive()?.AvailableFreeSpace is long bytesFree)
             {
-                var bytesFree = where.GetDrive().AvailableFreeSpace;
                 if (bytesToStore > bytesFree) {
                     throw new NotEnoughSpaceKraken(errorDescription, where,
                                                    bytesFree, bytesToStore);

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -14,8 +14,8 @@ namespace CKAN.Extensions
         /// </summary>
         /// <param name="dir">Any DirectoryInfo object</param>
         /// <returns>The DriveInfo associated with this directory, if any, else null</returns>
-        public static DriveInfo GetDrive(this DirectoryInfo dir)
-            => new DriveInfo(dir.FullName);
+        public static DriveInfo? GetDrive(this DirectoryInfo dir)
+            => Utilities.DefaultIfThrows(() => new DriveInfo(dir.FullName));
 
         /// <summary>
         /// A version of Stream.CopyTo with progress updates.

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -13,7 +13,6 @@ using CKAN.Versioning;
 using CKAN.Configuration;
 using CKAN.Games;
 using CKAN.Games.KerbalSpaceProgram;
-using CKAN.Extensions;
 using CKAN.Games.KerbalSpaceProgram.GameVersionProviders;
 
 namespace CKAN
@@ -615,23 +614,24 @@ namespace CKAN
                 }
                 else
                 {
-                    // Make sure we can access it
-                    var bytesFree = new DirectoryInfo(path).GetDrive().AvailableFreeSpace;
                     Cache = new NetModuleCache(this, path);
                     Configuration.DownloadCacheDir = path;
                 }
                 if (origPath != null && origCache != null)
                 {
                     origCache.GetSizeInfo(out _, out long oldNumBytes, out _);
-                    Cache.GetSizeInfo(out _, out _, out long bytesFree);
+                    Cache.GetSizeInfo(out _, out _, out long? bytesFree);
 
                     if (oldNumBytes > 0)
                     {
                         switch (User.RaiseSelectionDialog(
-                                    string.Format(Properties.Resources.GameInstanceManagerCacheMigrationPrompt,
-                                                  CkanModule.FmtSize(oldNumBytes),
-                                                  CkanModule.FmtSize(bytesFree)),
-                                    oldNumBytes < bytesFree ? 0 : 2,
+                                    bytesFree.HasValue
+                                        ? string.Format(Properties.Resources.GameInstanceManagerCacheMigrationPrompt,
+                                                        CkanModule.FmtSize(oldNumBytes),
+                                                        CkanModule.FmtSize(bytesFree.Value))
+                                        : string.Format(Properties.Resources.GameInstanceManagerCacheMigrationPromptFreeSpaceUnknown,
+                                                        CkanModule.FmtSize(oldNumBytes)),
+                                    oldNumBytes < (bytesFree ?? 0) ? 0 : 2,
                                     Properties.Resources.GameInstanceManagerCacheMigrationMove,
                                     Properties.Resources.GameInstanceManagerCacheMigrationDelete,
                                     Properties.Resources.GameInstanceManagerCacheMigrationOpen,

--- a/Core/Net/IDownloader.cs
+++ b/Core/Net/IDownloader.cs
@@ -14,7 +14,7 @@ namespace CKAN
         /// </summary>
         void DownloadModules(IEnumerable<CkanModule> modules);
 
-        public event Action<ByteRateCounter> OverallDownloadProgress;
+        event Action<ByteRateCounter> OverallDownloadProgress;
 
         /// <summary>
         /// Raised when data arrives for a module

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -84,8 +84,7 @@ namespace CKAN
                                          .ToHashSet();
             var moduleGroups = CkanModule.GroupByDownloads(modules);
             // Make sure we have enough space to download and cache
-            cache.CheckFreeSpace(moduleGroups.Select(grp => grp.First().download_size)
-                                             .Sum());
+            cache.CheckFreeSpace(moduleGroups.Sum(grp => grp.First().download_size));
             // Add all the requested modules
             this.modules.AddRange(moduleGroups.SelectMany(grp => grp));
 

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -69,9 +69,6 @@ namespace CKAN
             }
             inProgressPath = new DirectoryInfo(Path.Combine(path, "downloading"));
 
-            // Make sure we can access it
-            var bytesFree = cachePath.GetDrive().AvailableFreeSpace;
-
             // Establish a watch on our cache. This means we can cache the directory contents,
             // and discard that cache if we spot changes.
             watcher = new FileSystemWatcher(cachePath.FullName, "*.zip")
@@ -257,9 +254,9 @@ namespace CKAN
         /// <param name="numFiles">Output parameter set to number of files in cache</param>
         /// <param name="numBytes">Output parameter set to number of bytes in cache</param>
         /// <param name="bytesFree">Output parameter set to number of bytes free</param>
-        public void GetSizeInfo(out int numFiles, out long numBytes, out long bytesFree)
+        public void GetSizeInfo(out int numFiles, out long numBytes, out long? bytesFree)
         {
-            bytesFree = cachePath.GetDrive().AvailableFreeSpace;
+            bytesFree = cachePath.GetDrive()?.AvailableFreeSpace;
             (numFiles, numBytes) = Enumerable.Repeat(cachePath, 1)
                                              .Concat(legacyDirs())
                                              .Select(GetDirSizeInfo)
@@ -292,7 +289,7 @@ namespace CKAN
 
         public void EnforceSizeLimit(long bytes, Registry registry)
         {
-            GetSizeInfo(out int numFiles, out long curBytes, out long _);
+            GetSizeInfo(out int numFiles, out long curBytes, out _);
             if (curBytes > bytes)
             {
                 // This object will let us determine whether a module is compatible with any of our instances

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -85,7 +85,7 @@ namespace CKAN
         public string? GetCachedFilename(CkanModule m)
             => m.download?.Select(dlUri => cache.GetCachedFilename(dlUri, m.release_date))
                           .FirstOrDefault(filename => filename != null);
-        public void GetSizeInfo(out int numFiles, out long numBytes, out long bytesFree)
+        public void GetSizeInfo(out int numFiles, out long numBytes, out long? bytesFree)
         {
             cache.GetSizeInfo(out numFiles, out numBytes, out bytesFree);
         }

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -235,7 +235,7 @@ namespace CKAN
                         long onePercent = new FileInfo(filename).Length / 100;
                         // Perform CRC and other checks
                         if (zip.TestArchive(true, TestStrategy.FindFirstError,
-                            (TestStatus st, string msg) =>
+                            (st, msg) =>
                             {
                                 // This delegate is called as TestArchive proceeds through its
                                 // steps, both routine and abnormal.

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -212,6 +212,8 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="GameInstanceManagerSelectGamePrompt" xml:space="preserve"><value>Please select the game that is installed at {0}</value></data>
   <data name="GameInstanceManagerCacheMigrationPrompt" xml:space="preserve"><value>Old cache folder contains {0}. New cache folder has {1} free.
 What would you like to do?</value></data>
+  <data name="GameInstanceManagerCacheMigrationPromptFreeSpaceUnknown" xml:space="preserve"><value>Old cache folder contains {0}. New cache folder has unknown free space.
+What would you like to do?</value></data>
   <data name="GameInstanceManagerCacheMigrationMove" xml:space="preserve"><value>Move old cached files to new cache folder</value></data>
   <data name="GameInstanceManagerCacheMigrationDelete" xml:space="preserve"><value>Delete cached files</value></data>
   <data name="GameInstanceManagerCacheMigrationOpen" xml:space="preserve"><value>Open old and new cache folders in file browsers</value></data>

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -215,8 +215,7 @@ namespace CKAN
                 // Can't get later than Any, so no need for more complex logic
                 return realVersions?.LastOrDefault()
                                    // This is needed for when we have no real versions loaded, such as tests
-                                   ?? module_version.Values.Select(m => m.LatestCompatibleGameVersion())
-                                                           .Max()
+                                   ?? module_version.Values.Max(m => m.LatestCompatibleGameVersion())
                                    ?? module_version.Values.Last().LatestCompatibleGameVersion();
             }
             // Find the range with the highest upper bound
@@ -226,8 +225,7 @@ namespace CKAN
                                                               : best);
             return realVersions?.LastOrDefault(bestRange.Contains)
                                // This is needed for when we have no real versions loaded, such as tests
-                               ?? module_version.Values.Select(m => m.LatestCompatibleGameVersion())
-                                                       .Max()
+                               ?? module_version.Values.Max(m => m.LatestCompatibleGameVersion())
                                ?? module_version.Values.Last().LatestCompatibleGameVersion();
         }
 

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -142,7 +142,7 @@ namespace CKAN
         // Select only paths within subdir, prune prefixes
         private static IEnumerable<string> SubPaths(string parent, string[] paths)
             => paths.Where(p => p.StartsWith($"{parent}/", Platform.PathComparison))
-                    .Select(p => p.Remove(0, parent.Length + 1));
+                    .Select(p => p[(parent.Length + 1)..]);
 
         /// <summary>
         /// Launch a URL. For YEARS this was done by Process.Start in a

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -105,9 +105,9 @@ namespace CKAN.GUI
                 {
                     try
                     {
-                        manager.Cache.GetSizeInfo(out int  cacheFileCount,
-                                                  out long cacheSize,
-                                                  out long cacheFreeSpace);
+                        manager.Cache.GetSizeInfo(out int   cacheFileCount,
+                                                  out long  cacheSize,
+                                                  out long? cacheFreeSpace);
 
                         Util.Invoke(this, () =>
                         {
@@ -116,10 +116,14 @@ namespace CKAN.GUI
                                 // Show setting in MiB
                                 CacheLimit.Text = (coreConfig.CacheSizeLimit.Value / 1024 / 1024).ToString();
                             }
-                            CacheSummary.Text = string.Format(Properties.Resources.SettingsDialogSummmary,
-                                                              cacheFileCount,
-                                                              CkanModule.FmtSize(cacheSize),
-                                                              CkanModule.FmtSize(cacheFreeSpace));
+                            CacheSummary.Text = cacheFreeSpace.HasValue
+                                ? string.Format(Properties.Resources.SettingsDialogSummmary,
+                                                cacheFileCount,
+                                                CkanModule.FmtSize(cacheSize),
+                                                CkanModule.FmtSize(cacheFreeSpace.Value))
+                                : string.Format(Properties.Resources.SettingsDialogSummmaryFreeSpaceUnknown,
+                                                cacheFileCount,
+                                                CkanModule.FmtSize(cacheSize));
                             CacheSummary.ForeColor   = SystemColors.ControlText;
                             OpenCacheButton.Enabled  = true;
                             ClearCacheButton.Enabled = (cacheSize > 0);

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -47,7 +47,7 @@ namespace CKAN.GUI
                                 e.Result = ModuleInstaller.ImportFiles(
                                     GetFiles(dlg.FileNames),
                                     currentUser,
-                                    (CkanModule mod) =>
+                                    mod =>
                                     {
                                         if (ManageMods.mainModList
                                                       .full_list_of_mod_rows

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -97,8 +97,7 @@ namespace CKAN.GUI
                             var downloader = new NetAsyncDownloader(currentUser, () => null, userAgent);
                             downloader.TargetProgress += (target, remaining, total) =>
                             {
-                                var repo = repos.Where(r => target.urls.Contains(r.uri))
-                                                .FirstOrDefault();
+                                var repo = repos.FirstOrDefault(r => target.urls.Contains(r.uri));
                                 if (repo != null && total > 0)
                                 {
                                     Wait.SetProgress(repo.name, remaining, total);

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -309,7 +309,7 @@ namespace CKAN.GUI
             item.DefaultCellStyle.BackColor = GetRowBackground(mod, false, instanceName, game);
             item.DefaultCellStyle.SelectionBackColor = SelectionBlend(item.DefaultCellStyle.BackColor);
 
-            var myChange = changes?.FindLast((ModChange ch) => ch.Mod.Equals(mod));
+            var myChange = changes?.FindLast(ch => ch.Mod.Equals(mod));
 
             var selecting = mod.IsAutodetected
                 ? new DataGridViewTextBoxCell()

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -371,6 +371,7 @@ Find the folder where your game is installed and choose one of these files:
   <data name="SettingsToolTipOpenCacheButton" xml:space="preserve"><value>Browse the cache folder</value></data>
   <data name="SettingsToolTipClearCacheButton" xml:space="preserve"><value>Delete files from the cache</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>
+  <data name="SettingsDialogSummmaryFreeSpaceUnknown" xml:space="preserve"><value>{0} files, {1}, free space unknown</value></data>
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Invalid path: {0}</value></data>
   <data name="SettingsDialogCacheDescrip" xml:space="preserve"><value>Choose a folder for storing CKAN's mod downloads:</value></data>
   <data name="SettingsDialogDeleteConfirm" xml:space="preserve"><value>Do you really want to delete {0} cached files, freeing {1}?</value></data>

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -272,7 +272,7 @@ namespace CKAN.GUI
                 doneFunc(receivedFrom, received);
             };
 
-            return (object? sender, EventT evt) =>
+            return (sender, evt) =>
             {
                 if (!abortFunc(sender, evt))
                 {

--- a/Netkan/Transformers/InstallSizeTransformer.cs
+++ b/Netkan/Transformers/InstallSizeTransformer.cs
@@ -29,8 +29,7 @@ namespace CKAN.NetKAN.Transformers
                 ZipFile    zip = new ZipFile(_http.DownloadModule(metadata));
                 GameInstance inst = new GameInstance(_game, "/", "dummy", new NullUser());
                 json["install_size"] = _moduleService.FileSources(mod, zip, inst)
-                                                     .Select(ze => ze.Size)
-                                                     .Sum();
+                                                     .Sum(ze => ze.Size);
                 yield return new Metadata(json);
             }
             else


### PR DESCRIPTION
## Problem

On a Linux system with a ZFS root filesystem, trying to use a ZFS filesystem for the download cache or the game folder throws `Argumentexception`s in `DriveInfo`'s constructor, which then breaks lots of other things:

![image](https://github.com/user-attachments/assets/bcdd645c-4fd7-4b23-864f-4214d6349604)

## Cause

`DriveInfo` is supposed to represent the partition associated with the given path, but Mono can only find it if the device's path starts with a `/` character in the listing in `/etc/mtab`. ZFS filesystems instead use devices starting with `rpool/`, so they're ignored (see discussion in #4251 for investigation with source code excerpts). If the root is also ZFS, then _no_ device is found, and `ArgumentException` is thrown.

## Changes

Now if this exception is thrown, we catch it and give up on trying to figure out that path's free space. This should allow ZFS filesystems to be used, but without the protections afforded by checking the free space before installation.

Fixes #4251.
