### PR TITLE
Treat throttled remote version file as inflation error

### DIFF
--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -111,6 +111,11 @@ namespace CKAN.NetKAN.Transformers
                                 remoteUri, e.Message);
                             Log.Debug(e);
                         }
+                        catch (RequestThrottledKraken)
+                        {
+                            // Treat rate limiting as a real error to avoid temporary metadata degradation
+                            throw;
+                        }
                         catch (Exception e)
                         {
                             Log.WarnFormat("Error fetching remote version file {0}: {1}", remoteUri, e.Message);


### PR DESCRIPTION
## Motivation

If the GitHub API returns a throttling error when we request a remote version file, a warning is logged:

![image](https://github.com/user-attachments/assets/25b6d3a7-ac4f-4b21-90a6-6065d76ae3f1)

... and the inflation proceeds without the remote version file, which can cause temporary inaccurate metadata if the remote version file has been updated since release.

Other web errors must be treated as warnings in case the URL itself is invalid, but throttling can also happen for valid URLs.

## Changes

Now if a request for a remote version file is throttled, it will be treated as an error instead of a warning, so we won't temporarily inflate a mod with partial info.

#4299 did this for repo info requests for SpaceDock mods, but I got sidetracked with all the other stuff and forgot to document it.
