### PR TITLE
Make versions tab non-interactive inside install flow

### DIFF
--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -70,6 +70,7 @@ namespace CKAN.GUI
         private static GameInstance?        currentInstance => Main.Instance?.CurrentInstance;
         private static GameInstanceManager? manager         => Main.Instance?.Manager;
         private static IUser?               user            => Main.Instance?.currentUser;
+        private static bool                 interactive     => !Main.Instance?.Waiting ?? false;
 
         private readonly RepositoryDataManager    repoData;
         private          GUIMod?                  visibleGuiModule;
@@ -171,7 +172,7 @@ namespace CKAN.GUI
 
         private void UpdateSelection()
         {
-            if (visibleGuiModule != null)
+            if (visibleGuiModule != null && interactive)
             {
                 bool prevIgnore = ignoreItemCheck;
                 ignoreItemCheck = true;
@@ -256,7 +257,7 @@ namespace CKAN.GUI
                     {
                         toRet.BackColor = PrereleaseLabel.BackColor;
                     }
-                    if (module.Equals(gmod.SelectedMod))
+                    if (module.Equals(gmod.SelectedMod) && interactive)
                     {
                         toRet.Checked = true;
                     }
@@ -322,6 +323,8 @@ namespace CKAN.GUI
         {
             if (currentInstance != null)
             {
+                StabilityToleranceLabel.Visible = interactive;
+                StabilityToleranceComboBox.Visible = interactive;
                 // checkInstallable needs this to stop background threads on switch to another mod
                 cancelTokenSrc     = new CancellationTokenSource();
                 var startingModule = gmod;
@@ -342,7 +345,7 @@ namespace CKAN.GUI
                     if (startingModule.Equals(visibleGuiModule))
                     {
                         // Only show checkboxes for non-DLC modules
-                        VersionsListView.CheckBoxes = !gmod.ToModule().IsDLC;
+                        VersionsListView.CheckBoxes = interactive && !gmod.ToModule().IsDLC;
                         ignoreItemCheck = true;
                         VersionsListView.Items.AddRange(items);
                         VersionsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
@@ -359,7 +362,7 @@ namespace CKAN.GUI
 
         private void UpdateStabilityToleranceComboBox(GUIMod gmod)
         {
-            if (currentInstance != null)
+            if (currentInstance != null && interactive)
             {
                 StabilityToleranceComboBox.Items.Clear();
                 StabilityToleranceComboBox.Items.AddRange(

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -43,6 +43,8 @@ namespace CKAN.GUI
         public event Action? OnCancel;
         public event Action? OnOk;
 
+        public bool Busy => bgWorker.IsBusy;
+
         #pragma warning disable IDE0027
 
         public bool RetryEnabled

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -38,6 +38,7 @@ namespace CKAN.GUI
         private readonly RepositoryDataManager repoData;
         private readonly string? userAgent;
         private readonly AutoUpdate updater = new AutoUpdate();
+        public bool Waiting => Wait.Busy;
 
         // Stuff we set when the game instance changes
         public GUIConfiguration? configuration;


### PR DESCRIPTION
## Problem

The Versions tab is available on the recommendations screen, but the checkboxes don't do anything, and the stability override dropdown throws an exception:

```
System.InvalidOperationException: This BackgroundWorker is currently busy and cannot run multiple tasks concurrently.
   at System.ComponentModel.BackgroundWorker.RunWorkerAsync(Object argument)
   at CKAN.GUI.Main.RefreshModList(Boolean allowAutoUpdate, Dictionary`2 oldModules)
   at CKAN.GUI.Main.StabilityToleranceConfig_Changed(String identifier, Nullable`1 relStat)
   at CKAN.Configuration.StabilityToleranceConfig.SetModStabilityTolerance(String identifier, Nullable`1 relStat)
   at CKAN.GUI.Versions.StabilityToleranceComboBox_SelectionChanged(Object sender, EventArgs e)
   at System.Windows.Forms.ComboBox.OnSelectionChangeCommitted(EventArgs e)
   at System.Windows.Forms.ComboBox.OnSelectionChangeCommittedInternal(EventArgs e)
   at System.Windows.Forms.ComboBox.WmReflectCommand(Message& m)
   at System.Windows.Forms.ComboBox.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Cause

These interactive UI elements are only available because the rest of mod info is potentially useful in evaluating recommended mods to install. The dropdown needs to force an update of the mod list (in case changing it makes some mods newly installable or uninstallable), which requires using the progress screen, which is already doing something else while the install flow is active.

## Changes

Now the Versions tab's checkboxes and dropdown are hidden on the recommendations screen.

Fixes #4290.
