### PR TITLE
Guard rail for clicking refresh with refresh already in progress

### DIFF
--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -31,12 +31,15 @@ namespace CKAN.GUI
                                  bool                                          cancelable,
                                  object?                                       param)
         {
-            bgLogic   = mainWork;
-            postLogic = postWork;
-            Reset(cancelable);
-            ClearLog();
-            RetryEnabled = false;
-            bgWorker.RunWorkerAsync(param);
+            if (!Busy)
+            {
+                bgLogic   = mainWork;
+                postLogic = postWork;
+                Reset(cancelable);
+                ClearLog();
+                RetryEnabled = false;
+                bgWorker.RunWorkerAsync(param);
+            }
         }
 
         public event Action? OnRetry;

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -217,9 +217,9 @@ namespace CKAN.GUI
                         break;
                 }
             }
-            else if (e?.Result is(RepositoryDataManager.UpdateResult updateResult,
-                                  Dictionary<string, bool>           oldModules,
-                                  bool                               refreshWithoutChanges))
+            else if (e?.Result is (RepositoryDataManager.UpdateResult updateResult,
+                                   Dictionary<string, bool>           oldModules,
+                                   bool                               refreshWithoutChanges))
             {
                 switch (updateResult)
                 {

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -344,12 +344,14 @@ If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/
   <data name="MainRepoAutoRefreshPrompt" xml:space="preserve"><value>Would you like CKAN to refresh the mod list automatically every time it is loaded?
 
 You can refresh the mod list manually with the Refresh button at the top, and you can change this setting later in the Settings. If you disable automatic refreshes, it's a good idea to refresh every few days.</value></data>
-  <data name="MainRepoBalloonTipDetails" xml:space="preserve"><value>{0} update(s) available</value></data>
-  <data name="MainRepoBalloonTipTooltip" xml:space="preserve"><value>Click to upgrade</value></data>
+  <data name="MainRepoBalloonTipDetails" xml:space="preserve"><value>Updates available: {0}
+
+Click to install...</value></data>
+  <data name="MainRepoBalloonTipTooltip" xml:space="preserve"><value>Click to install updates</value></data>
   <data name="MainTrayIconResume" xml:space="preserve"><value>Resume</value></data>
   <data name="MainTrayIconPause" xml:space="preserve"><value>Pause</value></data>
   <data name="MainTrayNoUpdates" xml:space="preserve"><value>No available updates</value></data>
-  <data name="MainTrayUpdatesAvailable" xml:space="preserve"><value>{0} available update(s)</value></data>
+  <data name="MainTrayUpdatesAvailable" xml:space="preserve"><value>Updates available: {0}</value></data>
   <data name="MainWaitPleaseWait" xml:space="preserve"><value>Please wait</value></data>
   <data name="MainWaitDone" xml:space="preserve"><value>All done!</value></data>
   <data name="ManageGameInstancesNotValid" xml:space="preserve"><value>Directory {0} is not a valid game directory.</value></data>


### PR DESCRIPTION
## Problem

CKAN's tray icon has a notification that pops up after a refresh when there are updatable mods. Clicking this begins installation of those updates.

If you do this while an update or install is already in progress, an exception is thrown:

```
System.InvalidOperationException: This BackgroundWorker is currently busy and cannot run multiple tasks concurrently.
   at System.ComponentModel.BackgroundWorker.RunWorkerAsync(Object argument)
   at CKAN.GUI.Main.minimizeNotifyIcon_BalloonTipClicked(Object sender, EventArgs e)
   at System.Windows.Forms.NotifyIcon.OnBalloonTipClicked()
   at System.Windows.Forms.NotifyIcon.WndProc(Message& msg)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Cause

Similar to #4302, when the progress screen is already busy doing something, it can't be interrupted to do a refresh instead / in addition.

## Changes

- Now if the progress screen is already busy, attempting to start another refresh will do nothing, so the exception won't be thrown.
- The English text of the notification is slightly re-worded to hopefully make it easier to understand.
  ![image](https://github.com/user-attachments/assets/c4331086-fbde-4612-ab1e-c644c97a8386)


Fixes #4295.
