### PR TITLE
Checkboxes to copy more dirs when cloning instances

### DIFF
--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -243,6 +243,7 @@ namespace CKAN
         /// <param name="existingInstance">The KSP instance to clone.</param>
         /// <param name="newName">The name for the new instance.</param>
         /// <param name="newPath">The path where the new instance should be located.</param>
+        /// <param name="shareStockFolders">True to make junctions or symlinks to stock folders instead of copying</param>
         /// <exception cref="InstanceNameTakenKraken">Thrown if the instance name is already in use.</exception>
         /// <exception cref="NotKSPDirKraken">Thrown by AddInstance() if created instance is not valid, e.g. if something went wrong with copying.</exception>
         /// <exception cref="DirectoryNotFoundKraken">Thrown by CopyDirectory() if directory doesn't exist. Should never be thrown here.</exception>
@@ -251,6 +252,30 @@ namespace CKAN
         public void CloneInstance(GameInstance existingInstance,
                                   string       newName,
                                   string       newPath,
+                                  bool         shareStockFolders = false)
+        {
+            CloneInstance(existingInstance, newName, newPath,
+                          existingInstance.game.LeaveEmptyInClones,
+                          shareStockFolders);
+        }
+
+        /// <summary>
+        /// Clones an existing KSP installation.
+        /// </summary>
+        /// <param name="existingInstance">The KSP instance to clone.</param>
+        /// <param name="newName">The name for the new instance.</param>
+        /// <param name="newPath">The path where the new instance should be located.</param>
+        /// <param name="leaveEmpty">Dirs whose contents should not be copied</param>
+        /// <param name="shareStockFolders">True to make junctions or symlinks to stock folders instead of copying</param>
+        /// <exception cref="InstanceNameTakenKraken">Thrown if the instance name is already in use.</exception>
+        /// <exception cref="NotKSPDirKraken">Thrown by AddInstance() if created instance is not valid, e.g. if something went wrong with copying.</exception>
+        /// <exception cref="DirectoryNotFoundKraken">Thrown by CopyDirectory() if directory doesn't exist. Should never be thrown here.</exception>
+        /// <exception cref="PathErrorKraken">Thrown by CopyDirectory() if the target folder already exists and is not empty.</exception>
+        /// <exception cref="IOException">Thrown by CopyDirectory() if something goes wrong during the process.</exception>
+        public void CloneInstance(GameInstance existingInstance,
+                                  string       newName,
+                                  string       newPath,
+                                  string[]     leaveEmpty,
                                   bool         shareStockFolders = false)
         {
             if (HasInstance(newName))
@@ -267,7 +292,7 @@ namespace CKAN
             Utilities.CopyDirectory(existingInstance.GameDir(), newPath,
                                     shareStockFolders ? existingInstance.game.StockFolders
                                                       : Array.Empty<string>(),
-                                    existingInstance.game.LeaveEmptyInClones);
+                                    leaveEmpty);
 
             // Add the new instance to the config
             AddInstance(new GameInstance(existingInstance.game, newPath, newName, User));

--- a/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
@@ -44,6 +44,9 @@ namespace CKAN.GUI
             this.checkBoxSetAsDefault = new System.Windows.Forms.CheckBox();
             this.checkBoxSwitchInstance = new System.Windows.Forms.CheckBox();
             this.checkBoxShareStock = new System.Windows.Forms.CheckBox();
+            this.OptionalPathsLabel = new System.Windows.Forms.Label();
+            this.OptionalPathsListView = new ThemedListView();
+            this.PathHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.buttonOK = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.progressBar = new System.Windows.Forms.ProgressBar();
@@ -196,10 +199,39 @@ namespace CKAN.GUI
             this.checkBoxShareStock.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.checkBoxShareStock, "checkBoxShareStock");
             //
+            // OptionalPathsLabel
+            //
+            this.OptionalPathsLabel.AutoSize = true;
+            this.OptionalPathsLabel.Location = new System.Drawing.Point(12, 234);
+            this.OptionalPathsLabel.Name = "OptionalPathsLabel";
+            this.OptionalPathsLabel.Size = new System.Drawing.Size(131, 13);
+            this.OptionalPathsLabel.TabIndex = 22;
+            resources.ApplyResources(this.OptionalPathsLabel, "OptionalPathsLabel");
+            //
+            // OptionalPathsListView
+            //
+            this.OptionalPathsListView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.OptionalPathsListView.CheckBoxes = true;
+            this.OptionalPathsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.PathHeader});
+            this.OptionalPathsListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.OptionalPathsListView.Location = new System.Drawing.Point(181, 234);
+            this.OptionalPathsListView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.OptionalPathsListView.Name = "OptionalPathsListView";
+            this.OptionalPathsListView.Size = new System.Drawing.Size(218, 120);
+            this.OptionalPathsListView.TabIndex = 23;
+            this.OptionalPathsListView.UseCompatibleStateImageBehavior = false;
+            this.OptionalPathsListView.View = System.Windows.Forms.View.Details;
+            //
+            // PathHeader
+            //
+            this.PathHeader.Width = 180;
+            resources.ApplyResources(this.PathHeader, "PathHeader");
+            //
             // buttonOK
             //
             this.buttonOK.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.buttonOK.Location = new System.Drawing.Point(256, 230);
+            this.buttonOK.Location = new System.Drawing.Point(256, 360);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 22;
@@ -210,7 +242,7 @@ namespace CKAN.GUI
             // buttonCancel
             //
             this.buttonCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.buttonCancel.Location = new System.Drawing.Point(337, 230);
+            this.buttonCancel.Location = new System.Drawing.Point(337, 360);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 23;
@@ -235,7 +267,7 @@ namespace CKAN.GUI
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(424, 265);
+            this.ClientSize = new System.Drawing.Size(424, 395);
             this.Controls.Add(this.labelOldInstance);
             this.Controls.Add(this.comboBoxKnownInstance);
             this.Controls.Add(this.labelOldPath);
@@ -245,6 +277,8 @@ namespace CKAN.GUI
             this.Controls.Add(this.buttonPathBrowser);
             this.Controls.Add(this.checkBoxSwitchInstance);
             this.Controls.Add(this.checkBoxShareStock);
+            this.Controls.Add(this.OptionalPathsLabel);
+            this.Controls.Add(this.OptionalPathsListView);
             this.Controls.Add(this.textBoxNewPath);
             this.Controls.Add(this.labelNewPath);
             this.Controls.Add(this.checkBoxSetAsDefault);
@@ -284,6 +318,9 @@ namespace CKAN.GUI
         private System.Windows.Forms.CheckBox checkBoxSetAsDefault;
         private System.Windows.Forms.CheckBox checkBoxSwitchInstance;
         private System.Windows.Forms.CheckBox checkBoxShareStock;
+        private System.Windows.Forms.Label OptionalPathsLabel;
+        private System.Windows.Forms.ListView OptionalPathsListView;
+        private System.Windows.Forms.ColumnHeader PathHeader;
         private System.Windows.Forms.Button buttonOK;
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.FolderBrowserDialog folderBrowserDialogNewPath;

--- a/GUI/Dialogs/CloneGameInstanceDialog.resx
+++ b/GUI/Dialogs/CloneGameInstanceDialog.resx
@@ -126,6 +126,8 @@
   <data name="checkBoxSetAsDefault.Text" xml:space="preserve"><value>Set new instance as default</value></data>
   <data name="checkBoxSwitchInstance.Text" xml:space="preserve"><value>Switch to new instance</value></data>
   <data name="checkBoxShareStock.Text" xml:space="preserve"><value>Share stock files</value></data>
+  <data name="OptionalPathsLabel.Text" xml:space="preserve"><value>Optional paths to copy:</value></data>
+  <data name="PathHeader.Text" xml:space="preserve"><value>Optional paths</value></data>
   <data name="buttonOK.Text" xml:space="preserve"><value>Clone</value></data>
   <data name="buttonCancel.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Clone Game Instance</value></data>


### PR DESCRIPTION
## Motivation

In #4129, instance cloning was updated to generate smaller clones by no longer copying the contents of folders that typically have an instance-specific meaning, such as `saves` and `screenshots`.

@linuxgurugamer would like the option to copy some of those dirs anyway.

## Changes

Now the clone instance dialog has a list of checkboxes for the optional paths. If you leave them unchecked (the default), they won't be copied. If you check them, they will be copied.

![image](https://github.com/user-attachments/assets/735a7996-364b-4403-a79a-af4a4ed50e4e)

Fixes #4298.
