### PR TITLE
Exclude release author bots from authors list

### DIFF
--- a/Netkan/Sources/Github/GithubRef.cs
+++ b/Netkan/Sources/Github/GithubRef.cs
@@ -13,7 +13,7 @@ namespace CKAN.NetKAN.Sources.Github
         public string Account          { get; private set; }
         public string Project          { get; private set; }
         public string Repository       { get; private set; }
-        public Regex? Filter           { get; private set; }
+        public Regex  Filter           { get; private set; }
         public Regex? VersionFromAsset { get; private set; }
         public bool   UseSourceArchive { get; private set; }
 
@@ -46,5 +46,9 @@ namespace CKAN.NetKAN.Sources.Github
                 throw new Kraken(string.Format(@"Could not parse reference: ""{0}""", remoteRef));
             }
         }
+
+        public bool FilterMatches(GithubReleaseAsset asset)
+            => asset.Name is string name && Filter.IsMatch(name);
+
     }
 }

--- a/Netkan/Sources/Github/GithubRelease.cs
+++ b/Netkan/Sources/Github/GithubRelease.cs
@@ -1,54 +1,31 @@
 using System;
-using System.Linq;
-using System.Collections.Generic;
+using System.ComponentModel;
 
-using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 using CKAN.Versioning;
 
 namespace CKAN.NetKAN.Sources.Github
 {
-    internal sealed class GithubRelease
+    public sealed class GithubRelease
     {
-        public readonly string?                   Author;
-        public readonly ModuleVersion?            Tag;
-        public readonly List<GithubReleaseAsset>? Assets;
-        public readonly bool                      PreRelease;
-        public readonly DateTime?                 PublishedAt;
+        [JsonProperty("author")]
+        public GithubUser? Author { get; set; }
 
-        public GithubRelease(GithubRef reference, JToken json)
-        {
-            PreRelease  = (bool?)json["prerelease"] ?? false;
-            Tag         = (string?)json["tag_name"] is string s ? new ModuleVersion(s) : null;
-            if (Tag == null)
-            {
-                throw new Kraken("GitHub release missing tag!");
-            }
-            Author      = (string?)json["author"]?["login"];
-            PublishedAt = (DateTime?)json["published_at"];
-            Assets      = reference.UseSourceArchive
-                          && (string?)json["zipball_url"] is string sourceZIP
-                ? new List<GithubReleaseAsset> {
-                      new GithubReleaseAsset(Tag.ToString(), new Uri(sourceZIP), PublishedAt),
-                  }
-                : (JArray?)json["assets"] is JArray assets
-                  && reference.Filter != null
-                      ? assets.Select(asset => (string?)asset["name"] is string name
-                                            && reference.Filter.IsMatch(name)
-                                            && (string?)asset["browser_download_url"] is string url
-                                            && (DateTime?)asset["updated_at"] is DateTime updated
-                                                ? new GithubReleaseAsset(name, new Uri(url), updated)
-                                                : null)
-                              .OfType<GithubReleaseAsset>()
-                              .ToList()
-                      : new List<GithubReleaseAsset>();
-        }
+        [JsonProperty("tag_name")]
+        public ModuleVersion? Tag { get; set; }
 
-        public GithubRelease(string author, ModuleVersion tag, List<GithubReleaseAsset> assets)
-        {
-            Author = author;
-            Tag    = tag;
-            Assets = assets;
-        }
+        [JsonProperty("assets")]
+        public GithubReleaseAsset[]? Assets { get; set; }
+
+        [JsonProperty("zipball_url")]
+        public Uri? SourceArchive { get; set; }
+
+        [JsonProperty("published_at")]
+        public DateTime? PublishedAt { get; set; }
+
+        [JsonProperty("prerelease")]
+        [DefaultValue(false)]
+        public bool PreRelease { get; set; } = false;
     }
 }

--- a/Netkan/Sources/Github/GithubReleaseAsset.cs
+++ b/Netkan/Sources/Github/GithubReleaseAsset.cs
@@ -1,18 +1,21 @@
 using System;
 
+using Newtonsoft.Json;
+
 namespace CKAN.NetKAN.Sources.Github
 {
     public sealed class GithubReleaseAsset
     {
-        public string    Name     { get; }
-        public Uri       Download { get; }
-        public DateTime? Updated  { get; }
+        [JsonProperty("name")]
+        public string? Name { get; set; }
 
-        public GithubReleaseAsset(string name, Uri download, DateTime? updated)
-        {
-            Name     = name;
-            Download = download;
-            Updated  = updated;
-        }
+        [JsonProperty("browser_download_url")]
+        public Uri? Download { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime? Updated { get; set; }
+
+        [JsonProperty("uploader")]
+        public GithubUser? Uploader { get; set; }
     }
 }

--- a/Netkan/Sources/Github/GithubRepo.cs
+++ b/Netkan/Sources/Github/GithubRepo.cs
@@ -53,6 +53,13 @@ namespace CKAN.NetKAN.Sources.Github
         public string? Login { get; set; }
 
         [JsonProperty("type")]
-        public string? Type { get; set; }
+        public GithubUserType? Type { get; set; } = GithubUserType.User;
+    }
+
+    public enum GithubUserType
+    {
+        User,
+        Organization,
+        Bot,
     }
 }

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -1,9 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Sources.Github;
@@ -29,71 +30,79 @@ namespace Tests.NetKAN.Transformers
                 });
 
             mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>(), false))
-                .Returns(new GithubRelease(
-                    "ExampleProject",
-                    new ModuleVersion("1.0"),
-                    new List<GithubReleaseAsset>
-                    {
-                        new GithubReleaseAsset(
-                            "download",
-                            new Uri("http://github.example/download"),
-                            null
-                        )
-                    }
-                ));
+                .Returns(new GithubRelease()
+                         {
+                             Author = new GithubUser() { Login = "ExampleProject" },
+                             Tag    = new ModuleVersion("1.0"),
+                             Assets = new GithubReleaseAsset[]
+                                      {
+                                          new GithubReleaseAsset()
+                                          {
+                                              Name     = "download.zip",
+                                              Download = new Uri("http://github.example/download")
+                                          },
+                                      },
+                         });
 
             mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>(), false))
                 .Returns(new GithubRelease[] {
-                    new GithubRelease(
-                        "ExampleProject",
-                        new ModuleVersion("1.0"),
-                        new List<GithubReleaseAsset>
-                        {
-                            new GithubReleaseAsset(
-                                "download",
-                                new Uri("http://github.example/download/1.0"),
-                                null
-                            )
-                        }
-                    ),
-                    new GithubRelease("ExampleProject",
-                        new ModuleVersion("1.1"),
-                        new List<GithubReleaseAsset>
-                        {
-                            new GithubReleaseAsset(
-                                "download",
-                                new Uri("http://github.example/download/1.1"),
-                                null
-                            )
-                        }
-                    ),
-                    new GithubRelease("ExampleProject",
-                        new ModuleVersion("1.2"),
-                        new List<GithubReleaseAsset>
-                        {
-                            new GithubReleaseAsset(
-                                "ExampleProject_1.2-1.8.1.zip",
-                                new Uri("http://github.example/download/1.2/ExampleProject_1.2-1.8.1.zip"),
-                                null
-                            )
-                        }
-                    ),
-                    new GithubRelease("ExampleProject",
-                        new ModuleVersion("1.3"),
-                        new List<GithubReleaseAsset>
-                        {
-                            new GithubReleaseAsset(
-                                "ExampleProject_1.2-1.8.1.zip",
-                                new Uri("http://github.example/download/1.2/ExampleProject_1.2-1.8.1.zip"),
-                                null
-                            ),
-                            new GithubReleaseAsset(
-                                "ExampleProject_1.2-1.9.1.zip",
-                                new Uri("http://github.example/download/1.2/ExampleProject_1.2-1.9.1.zip"),
-                                null
-                            )
-                        }
-                    ),
+                    new GithubRelease()
+                    {
+                         Author = new GithubUser() { Login = "ExampleProject" },
+                         Tag    = new ModuleVersion("1.0"),
+                         Assets = new GithubReleaseAsset[]
+                                  {
+                                      new GithubReleaseAsset()
+                                      {
+                                          Name     = "download.zip",
+                                          Download = new Uri("http://github.example/download/1.0"),
+                                      },
+                                  },
+                    },
+                    new GithubRelease()
+                    {
+                         Author = new GithubUser() { Login = "ExampleProject" },
+                         Tag    = new ModuleVersion("1.1"),
+                         Assets = new GithubReleaseAsset[]
+                                  {
+                                      new GithubReleaseAsset()
+                                      {
+                                          Name     = "download.zip",
+                                          Download = new Uri("http://github.example/download/1.1"),
+                                      },
+                                  },
+                    },
+                    new GithubRelease()
+                    {
+                         Author = new GithubUser() { Login = "ExampleProject" },
+                         Tag    = new ModuleVersion("1.2"),
+                         Assets = new GithubReleaseAsset[]
+                                  {
+                                      new GithubReleaseAsset()
+                                      {
+                                          Name     = "ExampleProject_1.2-1.8.1.zip",
+                                          Download = new Uri("http://github.example/download/1.2/ExampleProject_1.2-1.8.1.zip"),
+                                      },
+                                  },
+                    },
+                    new GithubRelease()
+                    {
+                         Author = new GithubUser() { Login = "ExampleProject" },
+                         Tag    = new ModuleVersion("1.3"),
+                         Assets = new GithubReleaseAsset[]
+                                  {
+                                      new GithubReleaseAsset()
+                                      {
+                                          Name     = "ExampleProject_1.2-1.8.1.zip",
+                                          Download = new Uri("http://github.example/download/1.2/ExampleProject_1.2-1.8.1.zip"),
+                                      },
+                                      new GithubReleaseAsset()
+                                      {
+                                          Name     = "ExampleProject_1.2-1.9.1.zip",
+                                          Download = new Uri("http://github.example/download/1.2/ExampleProject_1.2-1.9.1.zip"),
+                                      }
+                                  },
+                    },
                 });
 
             apiMockUp = mApi;
@@ -138,32 +147,37 @@ namespace Tests.NetKAN.Transformers
                 });
 
             mApi.Setup(i => i.GetLatestRelease(It.IsAny<GithubRef>(), false))
-                .Returns(new GithubRelease(
-                    "DestructionEffects",
-                    new ModuleVersion("v1.8,0"),
-                    new List<GithubReleaseAsset>
-                    {
-                        new GithubReleaseAsset(
-                            "DestructionEffects.1.8.0_0412018.zip",
-                            new Uri("https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip"),
-                            null
-                        )
-                    }
-                ));
+                .Returns(new GithubRelease()
+                         {
+                             Author = new GithubUser() { Login = "DestructionEffects" },
+                             Tag    = new ModuleVersion("v1.8,0"),
+                             Assets = new GithubReleaseAsset[]
+                                      {
+                                          new GithubReleaseAsset()
+                                          {
+                                              Name = "DestructionEffects.1.8.0_0412018.zip",
+                                              Download = new Uri("https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip"),
+                                          }
+                                      },
+                         });
 
             mApi.Setup(i => i.GetAllReleases(It.IsAny<GithubRef>(), false))
-                .Returns(new GithubRelease[] { new GithubRelease(
-                    "DestructionEffects",
-                    new ModuleVersion("v1.8,0"),
-                    new List<GithubReleaseAsset>
-                    {
-                        new GithubReleaseAsset(
-                            "DestructionEffects.1.8.0_0412018.zip",
-                            new Uri("https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip"),
-                            null
-                        )
-                    }
-                )});
+                .Returns(new GithubRelease[]
+                         {
+                             new GithubRelease()
+                             {
+                                 Author = new GithubUser() { Login = "DestructionEffects" },
+                                 Tag    = new ModuleVersion("v1.8,0"),
+                                 Assets = new GithubReleaseAsset[]
+                                          {
+                                              new GithubReleaseAsset()
+                                              {
+                                                  Name = "DestructionEffects.1.8.0_0412018.zip",
+                                                  Download = new Uri("https://github.com/jrodrigv/DestructionEffects/releases/download/v1.8%2C0/DestructionEffects.1.8.0_0412018.zip"),
+                                              },
+                                          },
+                             },
+                         });
 
             ITransformer sut = new GithubTransformer(mApi.Object, false);
 


### PR DESCRIPTION
## Problem

If a GitHub release is created by a bot (which can happen when automated tools are used, see KSPModdingLibs/KSPBuildTools#47), the bot is added to the list of authors.

## Cause

We have logic to filter out bot users already, but it's only applied when we retrieve members of orgs.

## Changes

Now the user filter is applied to all users retrieved from GitHub, including release creators.

Fixes #4317.
