### PR TITLE
Find releases past all-filtered-out pages on GitHub

### DIFF
--- a/Netkan/Sources/Github/GithubApi.cs
+++ b/Netkan/Sources/Github/GithubApi.cs
@@ -71,23 +71,21 @@ namespace CKAN.NetKAN.Sources.Github
                     break;
                 }
                 Log.Debug("Parsing JSON...");
-                var ghReleases = JsonConvert.DeserializeObject<GithubRelease[]>(json)
-                                            ?.Where(ghRel => ReleaseTypeMatches(usePrerelease, ghRel.PreRelease)
-                                                             // Skip releases without assets
-                                                             && (reference.UseSourceArchive
-                                                                 || (ghRel.Assets != null
-                                                                     && ghRel.Assets.Any(reference.FilterMatches))))
-                                             // Insurance against GitHub returning them in the wrong order
-                                             .OrderByDescending(ghRel => ghRel.PublishedAt)
-                                             .ToArray()
-                                            ?? Array.Empty<GithubRelease>();
-                if (ghReleases.Length < 1)
+                var releases = JsonConvert.DeserializeObject<GithubRelease[]>(json)
+                               ?? Array.Empty<GithubRelease>();
+                if (releases.Length < 1)
                 {
                     // That's all folks!
                     break;
                 }
 
-                foreach (var ghRel in ghReleases)
+                foreach (var ghRel in releases.Where(r => ReleaseTypeMatches(usePrerelease, r.PreRelease)
+                                                          // Skip releases without assets
+                                                          && (reference.UseSourceArchive
+                                                              || (r.Assets != null
+                                                                  && r.Assets.Any(reference.FilterMatches))))
+                                              // Insurance against GitHub returning them in the wrong order
+                                              .OrderByDescending(r => r.PublishedAt))
                 {
                     yield return ghRel;
                 }

--- a/Netkan/Sources/Github/GithubRelease.cs
+++ b/Netkan/Sources/Github/GithubRelease.cs
@@ -27,5 +27,17 @@ namespace CKAN.NetKAN.Sources.Github
         [JsonProperty("prerelease")]
         [DefaultValue(false)]
         public bool PreRelease { get; set; } = false;
+
+        [JsonIgnore]
+        public GithubReleaseAsset? SourceArchiveAsset
+            => Tag is ModuleVersion ver
+                   ? new GithubReleaseAsset()
+                     {
+                         Name     = ver.ToString(),
+                         Download = SourceArchive,
+                         Updated  = PublishedAt,
+                         Uploader = Author,
+                     }
+                   : null;
     }
 }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -69,18 +69,13 @@ namespace CKAN.NetKAN.Transformers
                 bool returnedAny = false;
                 foreach (var rel in releases)
                 {
-                    if (ghRef.UseSourceArchive && rel.Tag != null)
+                    if (ghRef.UseSourceArchive
+                        && rel.Tag != null
+                        && rel.SourceArchiveAsset is GithubReleaseAsset srcAsset)
                     {
                         returnedAny = true;
                         yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel,
-                                                  new GithubReleaseAsset()
-                                                  {
-                                                      Name     = rel.Tag.ToString(),
-                                                      Download = rel.SourceArchive,
-                                                      Updated  = rel.PublishedAt,
-                                                      Uploader = rel.Author,
-                                                  },
-                                                  rel.Tag.ToString());
+                                                  srcAsset, rel.Tag.ToString());
                     }
                     else if (ghRef.VersionFromAsset != null && rel.Assets != null)
                     {


### PR DESCRIPTION
## Problem

If a netkan has an `asset_match` that filters out the entire first page of releases on GitHub, then releases on later pages won't be found.

At the moment this only affects RP-0, which last had a matching release (starting with `v1`) six pages (19 months) ago:

- <https://github.com/KSP-RO/RP-1/releases?page=6>

(We might want to freeze that one anyway, if it's never going to have another release and is costing us 6 API hits per inflation...)

## Cause

#4318 refactored the GitHub API to make a `GithubRelease` object accurately reflect the upstream data instead of processing it, which required moving the filtering logic from `GithubRelease`'s constructor to `GithubApi.GetAllReleases`. In the process, the empty-page check was moved after the filtering instead of before, so the loop stopped at the first all-filtered-out page.

## Changes

Now the empty-page check happens before the filtering.
