### PR TITLE
Disable Play button while playing game

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -413,14 +413,21 @@ namespace CKAN
                         EnableRaisingEvents = true
                     };
 
+                    var isSteam = SteamLibrary.IsSteamCmdLine(command);
                     p.Exited += (sender, e) =>
                     {
-                        playTime?.Stop(CkanDir());
+                        if (!isSteam)
+                        {
+                            playTime?.Stop(CkanDir());
+                        }
                         onExit?.Invoke();
                     };
 
                     p.Start();
-                    playTime?.Start();
+                    if (!isSteam)
+                    {
+                        playTime?.Start();
+                    }
                 }
                 catch (Exception exception)
                 {

--- a/Core/SteamLibrary.cs
+++ b/Core/SteamLibrary.cs
@@ -68,6 +68,9 @@ namespace CKAN
 
         public readonly GameBase[] Games;
 
+        public static bool IsSteamCmdLine(string command)
+            => command.StartsWith("steam://", StringComparison.InvariantCultureIgnoreCase);
+
         private static string LibraryFoldersConfigPath(string libraryPath)
             => Path.Combine(libraryPath, "config", "libraryfolders.vdf");
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -1144,7 +1144,11 @@ namespace CKAN.GUI
                 }
 
                 CurrentInstance.PlayGame(command ?? configuration.CommandLines.First(),
-                                         UpdateStatusBar);
+                                         () =>
+                                         {
+                                             ManageMods.OnGameExit();
+                                             UpdateStatusBar();
+                                         });
             }
         }
 

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -483,6 +483,7 @@ If unchecked, only mods in the pack will be installed.</value></data>
   <data name="ModSearchReplaceableSuffix" xml:space="preserve"><value>replaceable</value></data>
   <data name="EditModSearchTooltipExpandButton" xml:space="preserve"><value>Expand or collapse the detailed search fields (Ctrl-Shift-F)</value></data>
   <data name="EditModSearchesTooltipAddSearchButton" xml:space="preserve"><value>Combine a new search with your current searches</value></data>
+  <data name="ManageModsPlaying" xml:space="preserve"><value>Playing...</value></data>
   <data name="ManageModsSteamPlayTimeYesTooltip" xml:space="preserve"><value>(will count play time in Steam)</value></data>
   <data name="ManageModsSteamPlayTimeNoTooltip" xml:space="preserve"><value>(will NOT count play time in Steam)</value></data>
   <data name="ManageModsInstallAllCheckboxTooltip" xml:space="preserve"><value>Uncheck to uninstall all mods, check to clear change set</value></data>


### PR DESCRIPTION
## Motivation

@Clayell has requested some sort of visual feedback when the Play button has been clicked due to fear of accidentally clicking twice.

## Changes

Now if you click Play, the button is disabled and its caption changes to "Playing...":

![image](https://github.com/user-attachments/assets/9fbf9711-9dfd-4da0-a1bd-2d4c0711a8d7)

When the game exits, the caption resets and the button is re-enabled.

Fixes #4286.

### Known limitations

It turns out that the `steam://` commands don't notify us at all when they exit, so if we applied this new "Playing..." behavior to them, the Play button would remain in that state forever. Since that's bad, clicking a Steam command will not change the Play button at all, as it was before.

### Side fixes

In line with the above, the in-CKAN play time counting from #3543 now excludes `steam://` commands, since it can't be accurate without finding out when the game has closed. This should be fine because users of those commands can look at Steam's own play time tracking instead.
