### PR TITLE
Document the `x_netkan_trust_version_file` property

### DIFF
--- a/NetKAN.schema
+++ b/NetKAN.schema
@@ -93,6 +93,10 @@
                 }
             ]
         },
+        "x_netkan_trust_version_file": {
+            "description": "If true (and $vref is set), set the version property to the VERSION specified in the .version file",
+            "type": "boolean"
+        },
         "x_netkan_epoch": {
             "description": "Specifies a minimum epoch number manually in the version field",
             "type": "integer"

--- a/Spec.md
+++ b/Spec.md
@@ -1075,6 +1075,17 @@ When used, the following fields are auto-generated:
 - `version`
 - `resources.remote-swinfo` (if the `version_check` property is present in the `swinfo.json` file)
 
+##### `x_netkan_trust_version_file`
+
+If true (and `$vref` is set), then the `version` property will be set to the value specified in the `VERSION` property of the mod's `.version` file, overriding the value from the host server. This is mostly useful when we need to index a mod that lacks its own standalone download but instead exists only as a bundled mod inside another mod's download.
+
+An example `.netkan` excerpt:
+
+```yaml
+$vref: '#/ckan/ksp-avc'
+x_netkan_trust_version_file: true
+```
+
 ##### `x_netkan_epoch`
 
 The `x_netkan_epoch` field is used to specify a minimum `epoch` number manually in the `version` field. Its value should be


### PR DESCRIPTION
## Problems

- #2406 added support for `x_netkan_trust_version_file` in netkans, but didn't add it to the spec
- Consequently, #4254 left it out of the .netkan schema

## Changes

Now this property is documented in the spec and the .netkan schema.
