### PR TITLE
Allow adding already installed mod if metadata changed

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -440,11 +440,22 @@ namespace CKAN
 
             if (modlist.TryGetValue(module.identifier, out CkanModule? possibleDup))
             {
-                if (possibleDup?.identifier == module.identifier)
+                if (possibleDup.identifier == module.identifier)
                 {
-                    // We should never add the same module twice!
-                    log.ErrorFormat("Assertion failed: Adding {0} twice in relationship resolution", module.identifier);
-                    throw new ArgumentException("Already contains module: " + module.identifier);
+                    if (possibleDup.version == module.version
+                        && !possibleDup.MetadataEquals(module))
+                    {
+                        // If the version is the same and the metadata changed,
+                        // queue this up as a reinstall (remove the old version)
+                        reasons.Remove(possibleDup);
+                        modlist.Remove(possibleDup.identifier);
+                    }
+                    else
+                    {
+                        // We should never add the same module twice!
+                        log.ErrorFormat("Assertion failed: Adding {0} twice in relationship resolution", module.identifier);
+                        throw new ArgumentException("Already contains module: " + module.identifier);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Problem

If you install the pre KSP-CKAN/NetKAN#10405 versions of `RocketSoundEnhancement` and `RocketSoundEnhancement-Config-Default`, then refresh your registry with the metadata after that PR, the Update checkbox appears for you to reinstall those mods, but checking it just for `RocketSoundEnhancement` throws an exception:

```
System.ArgumentException: Already contains module: RocketSoundEnhancement-Config-Default
   at CKAN.RelationshipResolver.Add(CkanModule module, SelectionReason reason)
   at CKAN.RelationshipResolver.ResolveStanza(List`1 stanza, SelectionReason reason, RelationshipResolverOptions options, Boolean soft_resolve, IEnumerable`1 old_stanza)
   at CKAN.RelationshipResolver.Resolve(CkanModule module, RelationshipResolverOptions options, IEnumerable`1 old_stanza)
   at CKAN.RelationshipResolver.ResolveStanza(List`1 stanza, SelectionReason reason, RelationshipResolverOptions options, Boolean soft_resolve, IEnumerable`1 old_stanza)
   at CKAN.RelationshipResolver.Resolve(CkanModule module, RelationshipResolverOptions options, IEnumerable`1 old_stanza)
   at CKAN.RelationshipResolver.AddModulesToInstall(CkanModule[] modules)
   at CKAN.RelationshipResolver..ctor(IEnumerable`1 modulesToInstall, IEnumerable`1 modulesToRemove, RelationshipResolverOptions options, IRegistryQuerier registry, IGame game, GameVersionCriteria versionCrit)
   at CKAN.IRegistryQuerierHelpers.FindRemovableAutoInstalled(IRegistryQuerier querier, List`1 installedModules, IGame game, StabilityToleranceConfig stabilityTolerance, GameVersionCriteria crit)
   at CKAN.GUI.ModList.ComputeFullChangeSetFromUserChangeSet(IRegistryQuerier registry, HashSet`1 changeSet, IGame game, StabilityToleranceConfig stabilityTolerance, GameVersionCriteria version)
   at CKAN.GUI.ManageMods.UpdateChangeSetAndConflicts(GameInstance inst, IRegistryQuerier registry)
   at CKAN.GUI.ManageMods.ModGrid_CellValueChanged(Object sender, DataGridViewCellEventArgs e)
   at System.Windows.Forms.DataGridView.OnCellValueChanged(DataGridViewCellEventArgs e)
   at System.Windows.Forms.DataGridViewCell.SetValue(Int32 rowIndex, Object value)
   at System.Windows.Forms.DataGridView.PushFormattedValue(DataGridViewCell& dataGridViewCurrentCell, Object formattedValue, Exception& exception)
   at System.Windows.Forms.DataGridView.CommitEdit(DataGridViewCell& dataGridViewCurrentCell, DataGridViewDataErrorContexts context, DataGridViewValidateCellInternal validateCell, Boolean fireCellLeave, Boolean fireCellEnter, Boolean fireRowLeave, Boolean fireRowEnter, Boolean fireLeave)
   at System.Windows.Forms.DataGridView.CommitEdit(DataGridViewDataErrorContexts context)
   at CKAN.GUI.ManageMods.ModGrid_CurrentCellDirtyStateChanged(Object sender, EventArgs e)
   at System.Windows.Forms.DataGridView.OnCurrentCellDirtyStateChanged(EventArgs e)
   at System.Windows.Forms.DataGridView.set_IsCurrentCellDirtyInternal(Boolean value)
   at System.Windows.Forms.DataGridView.NotifyCurrentCellDirty(Boolean dirty)
   at System.Windows.Forms.DataGridViewCheckBoxCell.OnCommonContentClick(DataGridViewCellEventArgs e)
   at System.Windows.Forms.DataGridView.OnCellContentClick(DataGridViewCellEventArgs e)
   at System.Windows.Forms.DataGridView.OnCommonCellContentClick(Int32 columnIndex, Int32 rowIndex, Boolean doubleClick)
   at System.Windows.Forms.DataGridViewCell.OnMouseUpInternal(DataGridViewCellMouseEventArgs e)
   at System.Windows.Forms.DataGridView.OnCellMouseUp(DataGridViewCellMouseEventArgs e)
   at System.Windows.Forms.DataGridView.OnMouseUp(MouseEventArgs e)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Cause

The relationship resolver starts out with the config module that we already have installed. When it tries to resolve the `RocketSoundEnhancement-Config` dependency, the installed module doesn't provide it, but the new one does. So it tries to add the new one, which it detects as an attempt to add a duplicate module.

## Changes

Now if the relationship resolver stumbles upon a repeated identifier, it checks whether the modules' versions also match up, and whether the metadata has changed. If so, then the new module replaces the old one in the resolver. This narrowly carved exception to the previous rule should facilitate reinstalled (it worked for me!) without breaking anything else.

Fixes #4336.
