### PR TITLE
Generate more plugins folders in fake KSP2 instances

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -266,6 +266,28 @@ namespace CKAN.Extensions
                                     return hc;
                                 },
                                 hc => hc.ToHashCode());
+
+        /// <summary>
+        /// Accumulate a sequence of values based on a seed value and a function,
+        /// similar to Aggregate but including intermediate values
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="source">Input sequence</param>
+        /// <param name="seed">First intermediate value, not included in return sequence</param>
+        /// <param name="func">Function to transform a previous result and a next input sequence element into the next result</param>
+        /// <returns></returns>
+        public static IEnumerable<TResult> Accumulate<TSource, TResult>(this IEnumerable<TSource>       source,
+                                                                        TResult                         seed,
+                                                                        Func<TResult, TSource, TResult> func)
+        {
+            var result = seed;
+            foreach (var item in source)
+            {
+                result = func(result, item);
+                yield return result;
+            }
+        }
     }
 
     /// <summary>

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -13,6 +13,7 @@ using Mono.Cecil;
 
 using CKAN.DLC;
 using CKAN.Versioning;
+using CKAN.Extensions;
 
 namespace CKAN.Games.KerbalSpaceProgram2
 {
@@ -92,10 +93,13 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public void RebuildSubdirectories(string absGameRoot)
         {
-            var path = Path.Combine(absGameRoot, DataDir);
-            if (!Directory.Exists(path))
+            // Create the plugin path used by Planety
+            foreach (var path in PluginsPieces.Accumulate(absGameRoot, Path.Combine))
             {
-                Directory.CreateDirectory(path);
+                if (!Directory.Exists(path))
+                {
+                    Directory.CreateDirectory(path);
+                }
             }
         }
 
@@ -233,6 +237,8 @@ namespace CKAN.Games.KerbalSpaceProgram2
         public Uri ModSupportURL => new Uri("https://forum.kerbalspaceprogram.com/forum/137-ksp2-technical-support-pc-modded-installs/");
 
         private const string DataDir = "KSP2_x64_Data";
+
+        private static readonly string[] PluginsPieces = { DataDir, "Plugins", "x86_64" };
 
         // Key: Allowed value of install_to
         // Value: Relative path


### PR DESCRIPTION
## Problem

KSP-CKAN/KSP2-NetKAN#190 is failing with this error:

```
Error: 9321 [1] ERROR CKAN.CmdLine.ConsoleUser (null) - Could not find a part of the path "/game-instance/KSP2_x64_Data/Plugins/x86_64/zlib.dll".
```

However, if I save the generated metadata to a .ckan file locally, it installs without problems.

## Cause

Fake instances have `KSP2_x64_Data` but not the full `KSP2_x64_Data\Plugins\x86_64` hierarchy that the full game has, so the installer can't put files there.

## Changes

Now we generate `KSP2_x64_Data\Plugins\x86_64` fully so fake KSP2 instances will be more faithful to real ones, and Planety might be able to pass the tests.
