### PR TITLE
Don't save registry.json at instance creation

### DIFF
--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -374,8 +374,8 @@ namespace CKAN
         {
         }
 
-        public static Registry Empty()
-            => new Registry(null,
+        public static Registry Empty(RepositoryDataManager repoData)
+            => new Registry(repoData,
                             new Dictionary<string, InstalledModule>(),
                             new Dictionary<string, string>(),
                             new Dictionary<string, string>(),

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -16,7 +16,7 @@ namespace Tests.Core
     /// Tests the AddParentDirectories method in CKAN.ModuleInstaller
     /// </summary>
     [TestFixture]
-    public class ModuleInstallerDirTest
+    public class ModuleInstallerDirTests
     {
         private GameInstanceManager? _manager;
         private DisposableKSP?       _instance;

--- a/Tests/Core/Net/NetFileCacheTests.cs
+++ b/Tests/Core/Net/NetFileCacheTests.cs
@@ -160,33 +160,41 @@ namespace Tests.Core
         [Test]
         public void EnforceSizeLimit_UnderLimit_FileRetained()
         {
-            // Arrange
-            CKAN.Registry registry = CKAN.Registry.Empty();
-            long fileSize = new FileInfo(TestData.DogeCoinFlagZip()).Length;
+            var user = new NullUser();
+            using (var repoData = new TemporaryRepositoryData(user))
+            {
+                // Arrange
+                CKAN.Registry registry = CKAN.Registry.Empty(repoData.Manager);
+                long fileSize = new FileInfo(TestData.DogeCoinFlagZip()).Length;
 
-            // Act
-            Uri url = new Uri("http://kitte.nz/");
-            cache?.Store(url, TestData.DogeCoinFlagZip());
-            cache?.EnforceSizeLimit(fileSize + 100, registry);
+                // Act
+                Uri url = new Uri("http://kitte.nz/");
+                cache?.Store(url, TestData.DogeCoinFlagZip());
+                cache?.EnforceSizeLimit(fileSize + 100, registry);
 
-            // Assert
-            Assert.IsTrue(cache?.IsCached(url));
+                // Assert
+                Assert.IsTrue(cache?.IsCached(url));
+            }
         }
 
         [Test]
         public void EnforceSizeLimit_OverLimit_FileRemoved()
         {
-            // Arrange
-            CKAN.Registry registry = CKAN.Registry.Empty();
-            long fileSize = new FileInfo(TestData.DogeCoinFlagZip()).Length;
+            var user = new NullUser();
+            using (var repoData = new TemporaryRepositoryData(user))
+            {
+                // Arrange
+                CKAN.Registry registry = CKAN.Registry.Empty(repoData.Manager);
+                long fileSize = new FileInfo(TestData.DogeCoinFlagZip()).Length;
 
-            // Act
-            Uri url = new Uri("http://kitte.nz/");
-            cache?.Store(url, TestData.DogeCoinFlagZip());
-            cache?.EnforceSizeLimit(fileSize - 100, registry);
+                // Act
+                Uri url = new Uri("http://kitte.nz/");
+                cache?.Store(url, TestData.DogeCoinFlagZip());
+                cache?.EnforceSizeLimit(fileSize - 100, registry);
 
-            // Assert
-            Assert.IsFalse(cache?.IsCached(url));
+                // Assert
+                Assert.IsFalse(cache?.IsCached(url));
+            }
         }
 
         #pragma warning disable IDE0051

--- a/Tests/Core/Registry/RegistryManager.cs
+++ b/Tests/Core/Registry/RegistryManager.cs
@@ -79,7 +79,9 @@ namespace Tests.Core.Registry
                 var lockPath = Path.Combine(gameInst.KSP.CkanDir(), "registry.locked");
 
                 // Act / Assert
-                RegistryManager.Instance(gameInst.KSP, repoData.Manager);
+                var mgr = RegistryManager.Instance(gameInst.KSP, repoData.Manager);
+                Assert.IsFalse(File.Exists(jsonPath));
+                mgr.Save();
                 Assert.IsTrue(File.Exists(jsonPath));
                 Assert.IsTrue(File.Exists(lockPath));
                 RegistryManager.DisposeInstance(gameInst.KSP);

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -39,10 +39,14 @@ namespace Tests.Core.Relationships
         [Test]
         public void Constructor_WithoutModules_AlwaysReturns()
         {
-            var registry = CKAN.Registry.Empty();
-            options = RelationshipResolverOptions.DefaultOpts(stabilityTolerance);
-            Assert.DoesNotThrow(() => new RelationshipResolver(new List<CkanModule>(),
-                null, options, registry, game, crit));
+            var user = new NullUser();
+            using (var repoData = new TemporaryRepositoryData(user))
+            {
+                var registry = CKAN.Registry.Empty(repoData.Manager);
+                options = RelationshipResolverOptions.DefaultOpts(stabilityTolerance);
+                Assert.DoesNotThrow(() => new RelationshipResolver(new List<CkanModule>(),
+                    null, options, registry, game, crit));
+            }
         }
 
         [Test]
@@ -1043,9 +1047,11 @@ namespace Tests.Core.Relationships
         [Test]
         public void AutodetectedCanSatisfyRelationships()
         {
+            var user = new NullUser();
+            using (var repoData = new TemporaryRepositoryData(user))
             using (var ksp = new DisposableKSP())
             {
-                var registry = CKAN.Registry.Empty();
+                var registry = CKAN.Registry.Empty(repoData.Manager);
                 registry.SetDlls(new Dictionary<string, string>()
                 {
                     {

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -30,9 +30,11 @@ namespace Tests.GUI
         public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var item = new ModList();
+            var user = new NullUser();
+            using (var repoData = new TemporaryRepositoryData(user))
             using (var tidy = new DisposableKSP())
             {
-                Assert.That(item.ComputeUserChangeSet(Registry.Empty(), crit, tidy.KSP, null, null), Is.Empty);
+                Assert.That(item.ComputeUserChangeSet(Registry.Empty(repoData.Manager), crit, tidy.KSP, null, null), Is.Empty);
             }
         }
 
@@ -225,7 +227,7 @@ namespace Tests.GUI
                     {
                         // Install the "other" module
                         installer.InstallList(
-                            modList.ComputeUserChangeSet(Registry.Empty(), crit, inst2.KSP, null, null).Select(change => change.Mod).ToList(),
+                            modList.ComputeUserChangeSet(Registry.Empty(repoData.Manager), crit, inst2.KSP, null, null).Select(change => change.Mod).ToList(),
                             new RelationshipResolverOptions(inst2.KSP.StabilityToleranceConfig),
                             registryManager,
                             ref possibleConfigOnlyDirs,


### PR DESCRIPTION
## Motivation

When a new game instance is added, an empty `Registry` object is created, saved to `registry.json`, then immediately loaded from that file. Serializing an object that contains no useful data, saving it to disk, then loading it back from disk and deserializing it, is wasteful of CPU, disk throughput, and time.

## Problem

One user reported an exception after adding an instance on a Mac in ConsoleUI:

```
System.IO.IOException: Sharing violation on path /volumes/tf-256/ksp files/ksp modded/CKAN/registry.json
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x0019e] in <207d12884485488d9288cc8cbf474289>:0 
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options) [0x00000] in <207d12884485488d9288cc8cbf474289>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions)
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize) [0x00055] in <207d12884485488d9288cc8cbf474289>:0 
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks) [0x00000] in <207d12884485488d9288cc8cbf474289>:0 
  at (wrapper remoting-invoke-with-check) System.IO.StreamReader..ctor(string,System.Text.Encoding,bool)
  at System.IO.File.InternalReadAllText (System.String path, System.Text.Encoding encoding) [0x00000] in <207d12884485488d9288cc8cbf474289>:0 
  at System.IO.File.ReadAllText (System.String path) [0x0002c] in <207d12884485488d9288cc8cbf474289>:0 
  at CKAN.RegistryManager.Load (CKAN.RepositoryDataManager repoData) [0x00035] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.RegistryManager.LoadOrCreate (CKAN.RepositoryDataManager repoData) [0x000be] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.RegistryManager..ctor (System.String path, CKAN.GameInstance inst, CKAN.RepositoryDataManager repoData) [0x00067] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.RegistryManager.Instance (CKAN.GameInstance inst, CKAN.RepositoryDataManager repoData) [0x00024] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.ConsoleUI.ConsoleCKAN..ctor (CKAN.GameInstanceManager mgr, System.String themeName, System.String userAgent, System.Boolean debug) [0x0009b] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.ConsoleUI.ConsoleUI.Main_ (CKAN.GameInstanceManager manager, System.String themeName, System.String userAgent, System.Boolean debug) [0x00005] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.CmdLine.MainClass.ConsoleUi (CKAN.GameInstanceManager manager, CKAN.CmdLine.ConsoleUIOptions opts) [0x00039] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.CmdLine.MainClass.RunSimpleAction (CKAN.CmdLine.Options cmdline, CKAN.CmdLine.CommonOptions options, System.String[] args, CKAN.IUser user, CKAN.GameInstanceManager manager) [0x002aa] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.CmdLine.MainClass.Execute (CKAN.GameInstanceManager manager, CKAN.CmdLine.CommonOptions opts, System.String[] args) [0x002b9] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
  at CKAN.CmdLine.MainClass.Main (System.String[] args) [0x000e9] in <e7a11ea66e094dd1a3ac6d97032c8cd9>:0 
```

A search for that error suggests it may have something to do with conflicts between open file handles:

<https://stackoverflow.com/questions/59562067/system-io-ioexception-sharing-violation-on-path>

Based on that, maybe the handle used to create the file is somehow still active on this user's Mac when the file handle to read the file back in is created.

## Changes

Now when `registry.json` doesn't exist, we simply generate an empty `Registry` object in memory without serializing it, saving it, loading it, and deserializing it. The file will be created if/when we have meaningful changes to save.

Fixes #4309 (because the call stack is no longer possible).
