### PR TITLE
Fix ckan version command and update copyrights

### DIFF
--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -34,7 +34,7 @@
                    System.Text.RegularExpressions.RegexOptions.Singleline))</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>The CKAN Authors</Authors>
-    <Copyright>Copyright © CKAN Authors 2014–2024</Copyright>
+    <Copyright>Copyright © CKAN Authors 2014–2025</Copyright>
     <PackageTags>KerbalSpaceProgram Mods</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("CKAN")]
 [assembly: AssemblyCompany("CKAN Contributors")]
-[assembly: AssemblyCopyright("Copyright © 2014–2024")]
+[assembly: AssemblyCopyright("Copyright © 2014–2025")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -78,7 +78,7 @@ public partial class BuildContext : FrostingContext
                 version.Minor,
                 version.Patch,
                 version.PreRelease,
-                commitDate.ToString("yy") + commitDate.DayOfYear.ToString("000"));
+                "." + commitDate.ToString("yy") + commitDate.DayOfYear.ToString("000"));
         }
 
         return version;

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -96,9 +96,9 @@ public sealed class GenerateGlobalAssemblyVersionInfoTask : FrostingTask<BuildCo
             {
                 Version = $"{version.Major}.{version.Minor}",
                 FileVersion = version.HasMeta
-                    ? $"{version.Major}.{version.Minor}.{version.Patch}.{version.Meta}"
+                    ? $"{version.Major}.{version.Minor}.{version.Patch}{version.Meta}"
                     : $"{version.Major}.{version.Minor}.{version.Patch}",
-                InformationalVersion = version.ToString()
+                InformationalVersion = version.ToString(),
             });
     }
 }

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: http://webchat.esper.net/?channels=ckan
 Source: https://github.com/KSP-CKAN/CKAN/
 
 Files: *
-Copyright: 2014-2024, the Comprehensive Kerbal Archive Network (CKAN) Authors:
+Copyright: 2014-2025, the Comprehensive Kerbal Archive Network (CKAN) Authors:
     https://github.com/KSP-CKAN/CKAN/graphs/contributors
 Comment: You can use the CKAN and its associated files under the MIT license,
     reproduced below. This includes the right to sublicense under compatible


### PR DESCRIPTION
## Problem

The `ckan version` and `ckan help` commands are missing a `.` when they print the version:

```
$ ckan version
v1.36.125098
```

That should read `v1.36.1.25098`. You can tell because the first two digits of the last piece are supposed to represent the year.

## Cause

These commands call `Meta.GetVersion(VersionFormat.Full)`, which returns the `InformationalVersion` assembly attribute:

https://github.com/KSP-CKAN/CKAN/blob/c50b77f11c6805dd6ffa9d6d8c09ccabc00c4731/Core/Meta.cs#L41-L44

This is generated based on Cake's `SemVersion.ToString()`:

https://github.com/KSP-CKAN/CKAN/blob/c50b77f11c6805dd6ffa9d6d8c09ccabc00c4731/build/Program.cs#L92-L102

Which returns `Major.Minor.PatchMeta`, with no delimiter betwen `Patch` and `Meta`:

https://github.com/cake-build/cake/blob/d6c0cc3a0eb5a1432566a9c1db2399d48ff89ad7/src/Cake.Common/SemanticVersion.cs#L306-L315

`Meta` is the last piece here, which we set to the final piece with no delimiter:

https://github.com/KSP-CKAN/CKAN/blob/c50b77f11c6805dd6ffa9d6d8c09ccabc00c4731/build/BuildContext.cs#L77-L81

So the patch and build numbers just get mashed together.

## Changes

- Now the `Meta` part of that `SemVersion` starts with a `.` so the `InformationalVersion` will be correct.
- All of the copyright dates are updated from 2024 to 2025.
