### PR TITLE
Exclude internal .ckan files from `install_size`

### DIFF
--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -408,8 +408,7 @@ namespace CKAN
                                         instF.destination != null
                                         && instF.destination.Contains(filt))
                                     // Skip the file if it's a ckan file, these should never be copied to GameData
-                                    && !instF.source.Name.EndsWith(
-                                        ".ckan", StringComparison.InvariantCultureIgnoreCase))
+                                    && !IsInternalCkan(instF.source))
                     .ToList();
 
                 try
@@ -500,6 +499,9 @@ namespace CKAN
             }
             return createdPaths;
         }
+
+        public static bool IsInternalCkan(ZipEntry ze)
+            => ze.Name.EndsWith(".ckan", StringComparison.OrdinalIgnoreCase);
 
         #region File overwrites
 

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -64,7 +64,7 @@ namespace CKAN.NetKAN.Services
                         .Select(instF => instF.source)
                     // Find embedded .ckan files anywhere in the ZIP
                     : zip.OfType<ZipEntry>()
-                         .Where(entry => entry.Name.EndsWith(".ckan", StringComparison.InvariantCultureIgnoreCase)))
+                         .Where(ModuleInstaller.IsInternalCkan))
                 .Select(entry => DeserializeFromStream(
                                     zip.GetInputStream(entry)))
                 .FirstOrDefault();

--- a/Netkan/Transformers/InstallSizeTransformer.cs
+++ b/Netkan/Transformers/InstallSizeTransformer.cs
@@ -29,6 +29,7 @@ namespace CKAN.NetKAN.Transformers
                 ZipFile    zip = new ZipFile(_http.DownloadModule(metadata));
                 GameInstance inst = new GameInstance(_game, "/", "dummy", new NullUser());
                 json["install_size"] = _moduleService.FileSources(mod, zip, inst)
+                                                     .Where(ze => !ModuleInstaller.IsInternalCkan(ze))
                                                      .Sum(ze => ze.Size);
                 yield return new Metadata(json);
             }

--- a/Tests/NetKAN/Transformers/InstallSizeTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InstallSizeTransformerTests.cs
@@ -35,7 +35,7 @@ namespace Tests.NetKAN.Transformers
             var transformedJson = result.Json();
 
             // Assert
-            Assert.AreEqual(52291, (int?)transformedJson["install_size"]);
+            Assert.AreEqual(52043, (int?)transformedJson["install_size"]);
         }
 
         private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);


### PR DESCRIPTION
## Problem

Some time ago, I noticed that when installing KerbalChangelog, its progress bar would get stuck at 99%, which pins it toward the bottom of the progress bar list as everything else completes and scrolls by.

## Cause

Staring at the progress bar, I noticed that it said there were 96 bytes remaining to install. Checking the mod's ZIP, there's a 96-byte .ckan file!

Internal .ckan files are excluded from installation here:

https://github.com/KSP-CKAN/CKAN/blob/4eab9d89857ccc355554404e1e71512390be69fa/Core/ModuleInstaller.cs#L407-L412

But Netkan needs to be able to see them, so they're not filtered out of the core ZIP contents listing code used by `InstallSizeTransfomer`, which therefore includes them in the `install_size` property. So the installer thinks KerbalChangelog is 96 bytes larger than it actually is, and the progress bar waits forever for those 96 bytes to finish.

## Changes

Now `install_size` excludes internal .ckan files. This will result in a small wave of metadata updates, after which the affected mods will reach 100% completion when installing.
