### PR TITLE
Add a test to catch usage of replaced controls

### DIFF
--- a/GUI/Controls/ChooseProvidedMods.Designer.cs
+++ b/GUI/Controls/ChooseProvidedMods.Designer.cs
@@ -134,7 +134,7 @@ namespace CKAN.GUI
         #endregion
 
         private System.Windows.Forms.Label ChooseProvidedModsLabel;
-        private System.Windows.Forms.ListView ChooseProvidedModsListView;
+        private CKAN.GUI.ThemedListView ChooseProvidedModsListView;
         private System.Windows.Forms.ColumnHeader modNameColumnHeader;
         private System.Windows.Forms.ColumnHeader modDescriptionColumnHeader;
         private CKAN.GUI.LeftRightRowPanel BottomButtonPanel;

--- a/GUI/Controls/ChooseRecommendedMods.Designer.cs
+++ b/GUI/Controls/ChooseRecommendedMods.Designer.cs
@@ -244,7 +244,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem CheckAllButton;
         private System.Windows.Forms.ToolStripMenuItem CheckRecommendationsButton;
         private System.Windows.Forms.Label RecommendedDialogLabel;
-        private System.Windows.Forms.ListView RecommendedModsListView;
+        private CKAN.GUI.ThemedListView RecommendedModsListView;
         private System.Windows.Forms.ListViewGroup RecommendationsGroup;
         private System.Windows.Forms.ListViewGroup SuggestionsGroup;
         private System.Windows.Forms.ListViewGroup SupportedByGroup;

--- a/GUI/Controls/DeleteDirectories.Designer.cs
+++ b/GUI/Controls/DeleteDirectories.Designer.cs
@@ -194,9 +194,9 @@ namespace CKAN.GUI
 
         private System.Windows.Forms.Label ExplanationLabel;
         private CKAN.GUI.UsableSplitContainer Splitter;
-        private System.Windows.Forms.ListView DirectoriesListView;
+        private CKAN.GUI.ThemedListView DirectoriesListView;
         private System.Windows.Forms.ColumnHeader DirectoryColumn;
-        private System.Windows.Forms.ListView ContentsListView;
+        private CKAN.GUI.ThemedListView ContentsListView;
         private System.Windows.Forms.ColumnHeader FileColumn;
         private System.Windows.Forms.ListViewItem SelectDirPrompt;
         private CKAN.GUI.LeftRightRowPanel BottomButtonPanel;

--- a/GUI/Controls/DeleteDirectories.Designer.cs
+++ b/GUI/Controls/DeleteDirectories.Designer.cs
@@ -31,7 +31,7 @@ namespace CKAN.GUI
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(DeleteDirectories));
             this.ExplanationLabel = new System.Windows.Forms.Label();
-            this.Splitter = new System.Windows.Forms.SplitContainer();
+            this.Splitter = new CKAN.GUI.UsableSplitContainer();
             this.DirectoriesListView = new ThemedListView();
             this.DirectoryColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ContentsListView = new ThemedListView();
@@ -193,7 +193,7 @@ namespace CKAN.GUI
         #endregion
 
         private System.Windows.Forms.Label ExplanationLabel;
-        private System.Windows.Forms.SplitContainer Splitter;
+        private CKAN.GUI.UsableSplitContainer Splitter;
         private System.Windows.Forms.ListView DirectoriesListView;
         private System.Windows.Forms.ColumnHeader DirectoryColumn;
         private System.Windows.Forms.ListView ContentsListView;

--- a/GUI/Controls/EditModpack.Designer.cs
+++ b/GUI/Controls/EditModpack.Designer.cs
@@ -458,7 +458,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ComboBox LicenseComboBox;
         private System.Windows.Forms.CheckBox IncludeVersionsCheckbox;
         private System.Windows.Forms.CheckBox IncludeOptRelsCheckbox;
-        private System.Windows.Forms.ListView RelationshipsListView;
+        private CKAN.GUI.ThemedListView RelationshipsListView;
         private System.Windows.Forms.ColumnHeader ModNameColumn;
         private System.Windows.Forms.ColumnHeader ModVersionColumn;
         private System.Windows.Forms.ColumnHeader ModAbstractColumn;

--- a/GUI/Controls/InstallationHistory.Designer.cs
+++ b/GUI/Controls/InstallationHistory.Designer.cs
@@ -33,7 +33,7 @@ namespace CKAN.GUI
             this.ToolTip = new System.Windows.Forms.ToolTip();
             this.Toolbar = new System.Windows.Forms.MenuStrip();
             this.InstallButton = new System.Windows.Forms.ToolStripMenuItem();
-            this.Splitter = new System.Windows.Forms.SplitContainer();
+            this.Splitter = new CKAN.GUI.UsableSplitContainer();
             this.HistoryListView = new ThemedListView();
             this.TimestampColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ModsListView = new ThemedListView();
@@ -227,7 +227,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.MenuStrip Toolbar;
         private System.Windows.Forms.ToolStripMenuItem InstallButton;
-        private System.Windows.Forms.SplitContainer Splitter;
+        private CKAN.GUI.UsableSplitContainer Splitter;
         private System.Windows.Forms.ListView HistoryListView;
         private System.Windows.Forms.ColumnHeader TimestampColumn;
         private System.Windows.Forms.ListView ModsListView;

--- a/GUI/Controls/InstallationHistory.Designer.cs
+++ b/GUI/Controls/InstallationHistory.Designer.cs
@@ -228,9 +228,9 @@ namespace CKAN.GUI
         private System.Windows.Forms.MenuStrip Toolbar;
         private System.Windows.Forms.ToolStripMenuItem InstallButton;
         private CKAN.GUI.UsableSplitContainer Splitter;
-        private System.Windows.Forms.ListView HistoryListView;
+        private CKAN.GUI.ThemedListView HistoryListView;
         private System.Windows.Forms.ColumnHeader TimestampColumn;
-        private System.Windows.Forms.ListView ModsListView;
+        private CKAN.GUI.ThemedListView ModsListView;
         private System.Windows.Forms.ListViewGroup NotInstalledGroup;
         private System.Windows.Forms.ListViewGroup InstalledGroup;
         private System.Windows.Forms.ColumnHeader NameColumn;

--- a/GUI/Controls/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo.Designer.cs
@@ -252,7 +252,7 @@ namespace CKAN.GUI
         private CKAN.GUI.TagsLabelsLinkList tagsLabelsLinkList;
         private System.Windows.Forms.Label MetadataModuleAbstractLabel;
         private CKAN.GUI.TransparentTextBox MetadataModuleDescriptionTextBox;
-        private System.Windows.Forms.TabControl ModInfoTabControl;
+        private CKAN.GUI.ThemedTabControl ModInfoTabControl;
         private System.Windows.Forms.TabPage MetadataTabPage;
         private CKAN.GUI.Metadata Metadata;
         private System.Windows.Forms.TabPage RelationshipTabPage;

--- a/GUI/Controls/ModInfoTabs/Versions.Designer.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.Designer.cs
@@ -218,7 +218,7 @@ namespace CKAN.GUI
         #endregion
 
         private System.Windows.Forms.Label OverallSummaryLabel;
-        private System.Windows.Forms.ListView VersionsListView;
+        private CKAN.GUI.ThemedListView VersionsListView;
         private System.Windows.Forms.ColumnHeader ModVersion;
         private System.Windows.Forms.ColumnHeader CompatibleGameVersion;
         private System.Windows.Forms.ColumnHeader ReleaseDate;

--- a/GUI/Controls/UsableSplitContainer.cs
+++ b/GUI/Controls/UsableSplitContainer.cs
@@ -1,0 +1,48 @@
+using System.Windows.Forms;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
+namespace CKAN.GUI
+{
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
+    public class UsableSplitContainer : SplitContainer
+    {
+        public new int SplitterDistance
+        {
+            get => base.SplitterDistance;
+
+            // SplitContainer throws exceptions if the PanelMinSize limits are exceeded
+            // rather than simply obeying them.  Here we fix that.
+            set
+            {
+                try
+                {
+                    base.SplitterDistance =
+                        // Ensure the value respects Panel1MinSize
+                        value < Panel1MinSize
+                            ? Panel1MinSize
+                            // Ensure the value respects Panel2MinSize
+                            : Orientation switch
+                            {
+                                Orientation.Horizontal =>
+                                    value > Height - SplitterWidth - Panel2MinSize
+                                        ? Height - SplitterWidth - Panel2MinSize
+                                        : value,
+                                Orientation.Vertical or _ =>
+                                    value > Width - SplitterWidth - Panel2MinSize
+                                        ? Width - SplitterWidth - Panel2MinSize
+                                        : value,
+                            };
+                            // If both can't be respected, just let it throw and discard
+                }
+                catch
+                {
+                    // Suppress any exceptions
+                }
+            }
+        }
+    }
+}

--- a/GUI/Controls/Wait.Designer.cs
+++ b/GUI/Controls/Wait.Designer.cs
@@ -30,7 +30,7 @@ namespace CKAN.GUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(Wait));
-            this.VerticalSplitter = new System.Windows.Forms.SplitContainer();
+            this.VerticalSplitter = new CKAN.GUI.UsableSplitContainer();
             this.DialogProgressBar = new CKAN.GUI.LabeledProgressBar();
             this.ProgressBarTable = new System.Windows.Forms.TableLayoutPanel();
             this.LogTextBox = new System.Windows.Forms.TextBox();
@@ -183,7 +183,7 @@ namespace CKAN.GUI
 
         #endregion
 
-        private System.Windows.Forms.SplitContainer VerticalSplitter;
+        private CKAN.GUI.UsableSplitContainer VerticalSplitter;
         private CKAN.GUI.LabeledProgressBar DialogProgressBar;
         private System.Windows.Forms.TableLayoutPanel ProgressBarTable;
         private System.Windows.Forms.TextBox LogTextBox;

--- a/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
@@ -49,7 +49,7 @@ namespace CKAN.GUI
             this.PathHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.buttonOK = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
-            this.progressBar = new System.Windows.Forms.ProgressBar();
+            this.progressBar = new CKAN.GUI.LabeledProgressBar();
             this.folderBrowserDialogNewPath = new System.Windows.Forms.FolderBrowserDialog();
             this.SuspendLayout();
             //
@@ -327,11 +327,11 @@ namespace CKAN.GUI
         private System.Windows.Forms.CheckBox checkBoxSwitchInstance;
         private System.Windows.Forms.CheckBox checkBoxShareStock;
         private System.Windows.Forms.Label OptionalPathsLabel;
-        private System.Windows.Forms.ListView OptionalPathsListView;
+        private CKAN.GUI.ThemedListView OptionalPathsListView;
         private System.Windows.Forms.ColumnHeader PathHeader;
         private System.Windows.Forms.Button buttonOK;
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.FolderBrowserDialog folderBrowserDialogNewPath;
-        private System.Windows.Forms.ProgressBar progressBar;
+        private CKAN.GUI.LabeledProgressBar progressBar;
     }
 }

--- a/GUI/Dialogs/EditLabelsDialog.Designer.cs
+++ b/GUI/Dialogs/EditLabelsDialog.Designer.cs
@@ -33,7 +33,7 @@ namespace CKAN.GUI
             this.ToolTip = new System.Windows.Forms.ToolTip();
             this.TopButtonPanel = new CKAN.GUI.LeftRightRowPanel();
             this.CreateButton = new System.Windows.Forms.Button();
-            this.Splitter = new System.Windows.Forms.SplitContainer();
+            this.Splitter = new CKAN.GUI.UsableSplitContainer();
             this.LabelSelectionTree = new System.Windows.Forms.TreeView();
             this.SelectOrCreateLabel = new System.Windows.Forms.Label();
             this.EditDetailsPanel = new System.Windows.Forms.Panel();
@@ -416,7 +416,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolTip ToolTip;
         private CKAN.GUI.LeftRightRowPanel TopButtonPanel;
         private System.Windows.Forms.Button CreateButton;
-        private System.Windows.Forms.SplitContainer Splitter;
+        private CKAN.GUI.UsableSplitContainer Splitter;
         private System.Windows.Forms.TreeView LabelSelectionTree;
         private System.Windows.Forms.Label SelectOrCreateLabel;
         private System.Windows.Forms.Panel EditDetailsPanel;

--- a/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
@@ -251,7 +251,7 @@ namespace CKAN.GUI
 
         #endregion
 
-        private System.Windows.Forms.ListView GameInstancesListView;
+        private CKAN.GUI.ThemedListView GameInstancesListView;
         private System.Windows.Forms.ColumnHeader GameInstallName;
         private System.Windows.Forms.ColumnHeader Game;
         private System.Windows.Forms.ColumnHeader GameInstallVersion;

--- a/GUI/Dialogs/NewRepoDialog.Designer.cs
+++ b/GUI/Dialogs/NewRepoDialog.Designer.cs
@@ -183,7 +183,7 @@ namespace CKAN.GUI
         #endregion
 
         private System.Windows.Forms.GroupBox RepositoryGroupBox;
-        private System.Windows.Forms.ListView ReposListBox;
+        private CKAN.GUI.ThemedListView ReposListBox;
         private System.Windows.Forms.ColumnHeader RepoNameHeader;
         private System.Windows.Forms.ColumnHeader RepoURLHeader;
         private System.Windows.Forms.Label RepoNameLabel;

--- a/GUI/Dialogs/PreferredHostsDialog.Designer.cs
+++ b/GUI/Dialogs/PreferredHostsDialog.Designer.cs
@@ -32,7 +32,7 @@ namespace CKAN.GUI
             System.ComponentModel.ComponentResourceManager resources = new SingleAssemblyComponentResourceManager(typeof(PreferredHostsDialog));
             this.ToolTip = new System.Windows.Forms.ToolTip();
             this.ExplanationLabel = new System.Windows.Forms.Label();
-            this.Splitter = new System.Windows.Forms.SplitContainer();
+            this.Splitter = new CKAN.GUI.UsableSplitContainer();
             this.AvailableHostsLabel = new System.Windows.Forms.Label();
             this.AvailableHostsListBox = new System.Windows.Forms.ListBox();
             this.MoveRightButton = new System.Windows.Forms.Button();
@@ -223,7 +223,7 @@ namespace CKAN.GUI
 
         private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.Label ExplanationLabel;
-        private System.Windows.Forms.SplitContainer Splitter;
+        private CKAN.GUI.UsableSplitContainer Splitter;
         private System.Windows.Forms.Label AvailableHostsLabel;
         private System.Windows.Forms.ListBox AvailableHostsListBox;
         private System.Windows.Forms.Button MoveRightButton;

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -61,7 +61,7 @@ namespace CKAN.GUI
             this.PurgeAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ResetCacheButton = new System.Windows.Forms.Button();
             this.OpenCacheButton = new System.Windows.Forms.Button();
-            this.MoveCacheProgressBar = new System.Windows.Forms.ProgressBar();
+            this.MoveCacheProgressBar = new CKAN.GUI.LabeledProgressBar();
             this.AutoUpdateGroupBox = new System.Windows.Forms.GroupBox();
             this.LocalVersionPreLabel = new System.Windows.Forms.Label();
             this.LocalVersionLabel = new System.Windows.Forms.Label();
@@ -759,7 +759,7 @@ namespace CKAN.GUI
 
         private System.Windows.Forms.ToolTip ToolTip;
         private System.Windows.Forms.GroupBox RepositoryGroupBox;
-        private System.Windows.Forms.ListView ReposListBox;
+        private CKAN.GUI.ThemedListView ReposListBox;
         private System.Windows.Forms.ColumnHeader RepoNameHeader;
         private System.Windows.Forms.ColumnHeader RepoURLHeader;
         private System.Windows.Forms.Button NewRepoButton;
@@ -767,7 +767,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.Button DownRepoButton;
         private System.Windows.Forms.Button DeleteRepoButton;
         private System.Windows.Forms.GroupBox AuthTokensGroupBox;
-        private System.Windows.Forms.ListView AuthTokensListBox;
+        private CKAN.GUI.ThemedListView AuthTokensListBox;
         private System.Windows.Forms.ColumnHeader AuthHostHeader;
         private System.Windows.Forms.ColumnHeader AuthTokenHeader;
         private System.Windows.Forms.Button NewAuthTokenButton;
@@ -788,7 +788,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem PurgeAllMenuItem;
         private System.Windows.Forms.Button ResetCacheButton;
         private System.Windows.Forms.Button OpenCacheButton;
-        private System.Windows.Forms.ProgressBar MoveCacheProgressBar;
+        private CKAN.GUI.LabeledProgressBar MoveCacheProgressBar;
         private System.Windows.Forms.GroupBox AutoUpdateGroupBox;
         private System.Windows.Forms.Label LocalVersionPreLabel;
         private System.Windows.Forms.Label LocalVersionLabel;

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -58,7 +58,7 @@ namespace CKAN.GUI
             this.reportMetadataIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.splitContainer1 = new CKAN.GUI.UsableSplitContainer();
             this.LabelsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.modListToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.tagFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
@@ -918,7 +918,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem reportMetadataIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.StatusStrip statusStrip1;
-        private System.Windows.Forms.SplitContainer splitContainer1;
+        private CKAN.GUI.UsableSplitContainer splitContainer1;
         private System.Windows.Forms.ToolStripSeparator modListToolStripSeparator;
         private System.Windows.Forms.ToolStripSeparator tagFilterToolStripSeparator;
         private System.Windows.Forms.ToolStripSeparator untaggedFilterToolStripSeparator;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -193,15 +193,7 @@ namespace CKAN.GUI
 
             Util.Invoke(this, () => Text = $"CKAN {Meta.GetVersion()}");
 
-            try
-            {
-                // splitContainer1.SplitterDistance = configuration.PanelPosition;
-            }
-            catch
-            {
-                // SplitContainer is mis-designed to throw exceptions
-                // if the min/max limits are exceeded rather than simply obeying them.
-            }
+            splitContainer1.SplitterDistance = configuration.PanelPosition;
 
             log.Info("GUI started");
             base.OnLoad(e);

--- a/Tests/GUI/DeprecatedControlTests.cs
+++ b/Tests/GUI/DeprecatedControlTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Mono.Cecil;
+using NUnit.Framework;
+
+namespace Tests.GUI
+{
+    [TestFixture]
+    public class DeprecatedControlTests
+    {
+        [Test]
+        public void GUIAssemblyModule_BadControls_NotUsed()
+        {
+            // Arrange
+            var mainModule = ModuleDefinition.ReadModule(Assembly.GetAssembly(typeof(CKAN.GUI.Main))!
+                                                                 .Location);
+
+            // Act
+            var badMembers = mainModule.Types
+                                       .Where(NotAbsolved)
+                                       .SelectMany(t => t.Fields
+                                                         .Where(BadMember)
+                                                         .Select(f => (t, f)))
+                                       .ToArray();
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                foreach (var (type, field) in badMembers)
+                {
+                    Assert.Fail($"Deprecated control {field.FieldType.FullName} in {type.Name}.{field.Name}, use {DeprecatedControls[field.FieldType.FullName]} instead.");
+                }
+            });
+        }
+
+        private static bool NotAbsolved(TypeDefinition type)
+            => !AbsolvedSinners.Contains(type.FullName);
+
+        // These classes are allowed to reference deprecated controls as a way of
+        // using our inheriting controls through standard interfaces
+        private static readonly HashSet<string> AbsolvedSinners = new HashSet<string>
+        {
+            "CKAN.GUI.TabController",
+        };
+
+        private static bool BadMember(FieldDefinition field)
+            => DeprecatedControls.Keys.Contains(field.FieldType.FullName);
+
+        // We have made replacements for these controls
+        private static readonly Dictionary<string, string> DeprecatedControls = new Dictionary<string, string>
+        {
+            { "System.Windows.Forms.SplitContainer", "CKAN.GUI.UsableSplitContainer" },
+            { "System.Windows.Forms.TabControl",     "CKAN.GUI.ThemedTabControl"     },
+            { "System.Windows.Forms.ListView",       "CKAN.GUI.ThemedListView"       },
+            { "System.Windows.Forms.ProgressBar",    "CKAN.GUI.LabeledProgressBar"   },
+        };
+    }
+}


### PR DESCRIPTION
## Problem

Discord user Jaxx reported an exception during repo updating.

## Cause

Setting `SplitContainer.SplitterDistance` can cause an exception to be thrown if either its `Panel1MinSize` or `Panel2MinSize` constraints are violated by the new value. (Which means all usages of this property require `try`/`catch` blocks. Why Microsoft thought this would ever be desirable is beyond me.) Based on the exception text, that must be happening somewhere.

When part of a download is received, the `NetAsyncDownloader` raises its `TargetProgress` event, which triggers updates of the per-download progress bars in GUI. As part of this, the splitter in the progress tab can be moved downwards to ensure all of the active progress bars are visible. When all downloads are finished, we reset the splitter to its original position.

Therefore, we must be in a situation where either the `Panel1MinSize` or the `Panel2MinSize` of the progress tab is being violated by a new splitter position in response to a download progress event for a repository. Maybe the window is really small. Maybe there are too few or too many downloads. Maybe font scaling is messing with how the constraints work. Whatever the cause, the last thing we want is an exception.

## Changes

- Now a new `UsableSplitContainer` class is created inheriting from `SplitContainer` but with a `SplitterDistance` implementation that never throws exceptions.
- All current usages of `SplitContainer` are migrated to `UsableSplitContainer`.
- A test is added to ensure we don't use the underlying `SplitContainer` by itself anymore, along with several other controls for which we previously created similar replacements.
- #4316 accidentally disabled restoration of the mod info splitter position on startup. Now it's back.
