### PR TITLE
Generate and tidy up XML docs for Core

### DIFF
--- a/Core/AutoUpdate/AutoUpdate.cs
+++ b/Core/AutoUpdate/AutoUpdate.cs
@@ -46,6 +46,9 @@ namespace CKAN
         /// and then launches the helper allowing us to upgrade.
         /// </summary>
         /// <param name="launchCKANAfterUpdate">If set to <c>true</c> launch CKAN after update.</param>
+        /// <param name="userAgent">The user agent to use for the request.</param>
+        /// <param name="devBuild">If set to <c>true</c> use the dev build.</param>
+        /// <param name="user">The user to use for the request.</param>
         public void StartUpdateProcess(bool launchCKANAfterUpdate, string? userAgent, bool devBuild, IUser? user = null)
         {
             var pid = Process.GetCurrentProcess().Id;

--- a/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
+++ b/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
@@ -18,7 +18,8 @@ namespace CKAN
         /// <summary>
         /// Initialize the Object
         /// </summary>
-        /// <param name="json">JSON representation of release</param>
+        /// <param name="releaseJson">JSON representation of release</param>
+        /// <param name="userAgent">User agent to use for the request</param>
         public GitHubReleaseCkanUpdate(GitHubReleaseInfo? releaseJson = null, string? userAgent = null)
         {
             if (releaseJson == null)

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -18,9 +18,10 @@
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>SYSLIB0050,IDE0090</WarningsNotAsErrors>
-    <NoWarn>IDE1006</NoWarn>
+    <NoWarn>IDE1006,CS1591</NoWarn>
     <TargetFrameworks>netstandard2.0;net48;net8.0</TargetFrameworks>
     <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>

--- a/Core/Exporters/IExporter.cs
+++ b/Core/Exporters/IExporter.cs
@@ -10,6 +10,7 @@ namespace CKAN.Exporters
         /// <summary>
         /// Export installed mods.
         /// </summary>
+        /// <param name="manager">The registry manager to use for exporting.</param>
         /// <param name="registry">The registry of mods to be exported.</param>
         /// <param name="stream">The output stream to be written to.</param>
         void Export(RegistryManager manager, IRegistryQuerier registry, Stream stream);

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -24,6 +24,8 @@ namespace CKAN.Extensions
         /// <param name="dest">Stream to which to copy</param>
         /// <param name="progress">Callback to notify as we traverse the input, called with count of bytes received</param>
         /// <param name="idleInterval">Maximum timespand to elapse between progress updates, will synthesize extra updates as needed</param>
+        /// <param name="hasher">Hash algorithm to use, if any</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
         public static void CopyTo(this Stream       src,
                                   Stream            dest,
                                   IProgress<long>   progress,

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -620,6 +620,7 @@ namespace CKAN
         /// Switch to using a download cache in a new location
         /// </summary>
         /// <param name="path">Location of folder for new cache</param>
+        /// <param name="progress">Progress object to report progress to</param>
         /// <param name="failureReason">Contains a human readable failure message if the setup failed</param>
         /// <returns>
         /// true if successful, false otherwise

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -95,8 +95,9 @@ namespace CKAN.Games.KerbalSpaceProgram
         /// <summary>
         /// Checks the path against a list of reserved game directories
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
+        /// <param name="inst">Game instance we're checking</param>
+        /// <param name="path">Path to check</param>
+        /// <returns>True if reserved, false otherwise</returns>
         public bool IsReservedDirectory(GameInstance inst, string path)
             => path == inst.GameDir() || path == inst.CkanDir()
             || path == PrimaryModDirectory(inst)
@@ -323,6 +324,7 @@ namespace CKAN.Games.KerbalSpaceProgram
         /// otherwise return the array as-is.
         /// </summary>
         /// <param name="args">Command line parameters to check</param>
+        /// <param name="installedVersion">The installed game version</param>
         /// <param name="crashyKspRange">Game versions that should not use this parameter</param>
         /// <param name="parameter">The parameter to remove on version match</param>
         /// <returns>

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -82,8 +82,9 @@ namespace CKAN.Games.KerbalSpaceProgram2
         /// <summary>
         /// Checks the path against a list of reserved game directories
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
+        /// <param name="inst">Game instance we're checking</param>
+        /// <param name="path">Path to check</param>
+        /// <returns>True if reserved, false otherwise</returns>
         public bool IsReservedDirectory(GameInstance inst, string path)
             => path == inst.GameDir()
                || path == inst.CkanDir()

--- a/Core/ModuleImporter.cs
+++ b/Core/ModuleImporter.cs
@@ -24,6 +24,9 @@ namespace CKAN
         /// <param name="files">Set of files to import</param>
         /// <param name="user">Object for user interaction</param>
         /// <param name="installMod">Function to call to mark a mod for installation</param>
+        /// <param name="registry">Registry to use for version checking</param>
+        /// <param name="instance">Game instance to use for version checking</param>
+        /// <param name="Cache">Cache to use for storing files</param>
         /// <param name="allowDelete">True to ask user whether to delete imported files, false to leave the files as is</param>
         public static bool ImportFiles(HashSet<FileInfo>  files,
                                        IUser              user,

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -509,7 +509,9 @@ namespace CKAN
         /// Find files in the given list that are already installed and unowned.
         /// Note, this compares files on demand; Memoize for performance!
         /// </summary>
+        /// <param name="zip">Zip file that we are installing from</param>
         /// <param name="files">Files that we want to install for a module</param>
+        /// <param name="registry">Registry to check for file ownership</param>
         /// <returns>
         /// List of pairs: Key = file, Value = true if identical, false if different
         /// </returns>
@@ -929,6 +931,8 @@ namespace CKAN
         /// </summary>
         /// <param name="identifier">Identifier of module to uninstall</param>
         /// <param name="possibleConfigOnlyDirs">Directories that the user might want to remove after uninstall</param>
+        /// <param name="registry">Registry to use</param>
+        /// <param name="progress">Progress to report</param>
         private void Uninstall(string               identifier,
                                ref HashSet<string>? possibleConfigOnlyDirs,
                                Registry             registry,
@@ -1208,10 +1212,14 @@ namespace CKAN
         /// No relationships will be processed.
         /// This *will* save the registry.
         /// </summary>
+        /// <param name="possibleConfigOnlyDirs">Directories that the user might want to remove after uninstall</param>
+        /// <param name="registry_manager">Registry to use</param>
+        /// <param name="resolver">Relationship resolver to use</param>
         /// <param name="add">Modules to add</param>
         /// <param name="autoInstalled">true or false for each item in `add`</param>
         /// <param name="remove">Modules to remove</param>
-        /// <param name="newModulesAreAutoInstalled">true if newly installed modules should be marked auto-installed, false otherwise</param>
+        /// <param name="downloader">Downloader to use</param>
+        /// <param name="enforceConsistency">Whether to enforce consistency</param>
         private void AddRemove(ref HashSet<string>?          possibleConfigOnlyDirs,
                                RegistryManager               registry_manager,
                                RelationshipResolver          resolver,
@@ -1563,8 +1571,10 @@ namespace CKAN
         /// <summary>
         /// Looks for optional related modules that could be installed alongside the given modules
         /// </summary>
+        /// <param name="instance">Game instance to use</param>
         /// <param name="sourceModules">Modules to check for relationships</param>
         /// <param name="toInstall">Modules already being installed, to be omitted from search</param>
+        /// <param name="registry">Registry to use</param>
         /// <param name="recommendations">Modules that are recommended to install</param>
         /// <param name="suggestions">Modules that are suggested to install</param>
         /// <param name="supporters">Modules that support other modules we're installing</param>
@@ -1641,6 +1651,8 @@ namespace CKAN
         /// <param name="opts">Installer options</param>
         /// <param name="toInstall">Mods we want to install</param>
         /// <param name="registry">Registry of instance into which we want to install</param>
+        /// <param name="game">Game instance</param>
+        /// <param name="crit">Game version criteria</param>
         /// <returns>
         /// True if it's possible to install these mods, false otherwise
         /// </returns>

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -171,6 +171,7 @@ namespace CKAN
         /// Download a string from a URL
         /// </summary>
         /// <param name="url">URL to download from</param>
+        /// <param name="userAgent">User agent to send with the request</param>
         /// <param name="authToken">An authentication token sent with the "Authorization" header.
         ///                         Attempted to be looked up from the configuraiton if not specified</param>
         /// <param name="mimeType">A mime type sent with the "Accept" header</param>

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -272,7 +272,6 @@ namespace CKAN
         /// Generates a download progress report.
         /// </summary>
         /// <param name="download">The download that progressed</param>
-        /// <param name="percent">The percent complete</param>
         /// <param name="bytesDownloaded">The bytes downloaded</param>
         /// <param name="bytesToDownload">The total amount of bytes we expect to download</param>
         private void FileProgressReport(DownloadPart download, long bytesDownloaded, long bytesToDownload)

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -75,7 +75,7 @@ namespace CKAN
                     : $"{first.download_content_type};q=1.0,{defaultMimeType};q=0.9");
 
         /// <summary>
-        /// <see cref="IDownloader.DownloadModules(NetFileCache, IEnumerable{CkanModule})"/>
+        /// <see cref="IDownloader.DownloadModules"/>
         /// </summary>
         public void DownloadModules(IEnumerable<CkanModule> modules)
         {

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -46,6 +46,7 @@ namespace CKAN
         /// Initialize a cache given a GameInstanceManager
         /// </summary>
         /// <param name="mgr">GameInstanceManager object containing the Instances that might have old caches</param>
+        /// <param name="path">Location of folder to use for caching</param>
         public NetFileCache(GameInstanceManager mgr, string path)
             : this(path)
         {
@@ -517,6 +518,7 @@ namespace CKAN
         /// May throw an IOException if disk is full!
         /// </summary>
         /// <param name="fromDir">Path from which to move files</param>
+        /// <param name="percentProgress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
         public void MoveFrom(DirectoryInfo  fromDir,
                              IProgress<int> percentProgress)
         {
@@ -604,6 +606,7 @@ namespace CKAN
         /// </summary>
         /// <param name="filePath">Path to file to examine</param>
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
         /// <returns>
         /// SHA1 hash, in all-caps hexadecimal format
         /// </returns>
@@ -617,6 +620,7 @@ namespace CKAN
         /// </summary>
         /// <param name="filePath">Path to file to examine</param>
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
         /// <returns>
         /// SHA256 hash, in all-caps hexadecimal format
         /// </returns>
@@ -629,7 +633,11 @@ namespace CKAN
         /// Calculate the hash of a file
         /// </summary>
         /// <param name="filePath">Path to file to examine</param>
+        /// <param name="hashSuffix">Suffix to use for the hash file</param>
+        /// <param name="cache">Cache to use for storing the hash</param>
+        /// <param name="getHashAlgo">Function to get the hash algorithm</param>
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
         /// <returns>
         /// Hash, in all-caps hexadecimal format
         /// </returns>

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -29,6 +29,7 @@ namespace CKAN
         /// Initialize the cache
         /// </summary>
         /// <param name="mgr">GameInstanceManager containing instances that might have legacy caches</param>
+        /// <param name="path">Path to directory to use as the cache</param>
         public NetModuleCache(GameInstanceManager mgr, string path)
         {
             cache = new NetFileCache(mgr, path);
@@ -126,6 +127,7 @@ namespace CKAN
         /// </summary>
         /// <param name="filePath">Path to file to examine</param>
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
         /// <returns>
         /// SHA1 hash, in all-caps hexadecimal format
         /// </returns>
@@ -137,6 +139,7 @@ namespace CKAN
         /// </summary>
         /// <param name="filePath">Path to file to examine</param>
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
         /// <returns>
         /// SHA256 hash, in all-caps hexadecimal format
         /// </returns>
@@ -152,6 +155,8 @@ namespace CKAN
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
         /// <param name="description">Description of the file</param>
         /// <param name="move">True to move the file, false to copy</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
+        /// <param name="validate">True to validate the file, false to skip validation</param>
         /// <returns>
         /// Name of the new file in the cache
         /// </returns>

--- a/Core/Net/RedirectingTimeoutWebClient.cs
+++ b/Core/Net/RedirectingTimeoutWebClient.cs
@@ -22,6 +22,7 @@ namespace CKAN
         /// <summary>
         /// Initialize our special web client
         /// </summary>
+        /// <param name="userAgent">User agent string to send with the request</param>
         /// <param name="timeout">Timeout for the request in milliseconds, defaulting to 100 000 (=100 seconds)</param>
         /// <param name="mimeType">A mime type sent with the "Accept" header</param>
         public RedirectingTimeoutWebClient(string userAgent,

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -24,6 +24,7 @@ namespace CKAN
         /// </summary>
         /// <param name="url">What to download</param>
         /// <param name="path">Where to save it</param>
+        /// <param name="hasher">Hash algorithm to use, or null</param>
         public void DownloadFileAsyncWithResume(Uri url, string path, HashAlgorithm? hasher)
         {
             this.hasher = hasher;

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -20,9 +20,11 @@ namespace CKAN
         /// <summary>
         /// Initialize the sorter and partition the mods.
         /// </summary>
+        /// <param name="stabilityTolerance">The least stable category of modules to consider</param>
         /// <param name="crit">Versions to be considered compatible</param>
         /// <param name="available">Collection of mods from registry</param>
         /// <param name="providers">Dictionary mapping every identifier to the modules providing it</param>
+        /// <param name="installed">Collection of installed mods</param>
         /// <param name="dlls">Collection of found dlls</param>
         /// <param name="dlc">Collection of installed DLCs</param>
         public CompatibilitySorter(StabilityToleranceConfig                         stabilityTolerance,

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -54,6 +54,7 @@ namespace CKAN
         /// <summary>
         /// Returns the max game version that is compatible with the given mod.
         /// </summary>
+        /// <param name="realVersions">List of game versions to check against</param>
         /// <param name="identifier">Name of mod to check</param>
         GameVersion? LatestCompatibleGameVersion(List<GameVersion> realVersions, string identifier);
 
@@ -131,6 +132,7 @@ namespace CKAN
         ///     If the mod was autodetected (but present), a version of type `DllVersion` is returned.
         ///     If the mod is provided by another mod (ie, virtual) a type of ProvidesVersion is returned.
         /// </summary>
+        /// <param name="identifier">Identifier of mod</param>
         /// <param name="with_provides">If set to false will not check for provided versions.</param>
         /// <returns>The version of the mod or null if not found</returns>
         ModuleVersion? InstalledVersion(string identifier, bool with_provides = true);
@@ -139,6 +141,7 @@ namespace CKAN
         /// Check whether any versions of this mod are installable (including dependencies) on the given game versions
         /// </summary>
         /// <param name="identifier">Identifier of mod</param>
+        /// <param name="stabilityTolerance">Stability tolerance for the game instance</param>
         /// <param name="crit">Game versions</param>
         /// <returns>true if any version is recursively compatible, false otherwise</returns>
         bool IdentifierCompatible(string identifier, StabilityToleranceConfig stabilityTolerance, GameVersionCriteria crit);
@@ -353,6 +356,8 @@ namespace CKAN
         /// Generate a string describing the range of game versions
         /// compatible with the given module.
         /// </summary>
+        /// <param name="querier">A registry</param>
+        /// <param name="game">Game to represent</param>
         /// <param name="identifier">Mod name to findDependencyShallow</param>
         /// <returns>
         /// String describing range of compatible game versions.
@@ -464,9 +469,10 @@ namespace CKAN
         /// Find auto-installed modules that have no depending modules
         /// or only auto-installed depending modules.
         /// </summary>
+        /// <param name="querier">A registry</param>
         /// <param name="installedModules">The modules currently installed</param>
-        /// <param name="dlls">The DLLs that are manually installed</param>
-        /// <param name="dlc">The DLCs that are installed</param>
+        /// <param name="game">The registry's game instance</param>
+        /// <param name="stabilityTolerance">Stability tolerance for the game instance</param>
         /// <param name="crit">Version criteria for resolving relationships</param>
         /// <returns>
         /// Sequence of removable auto-installed modules, if any

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -575,6 +575,7 @@ namespace CKAN
         /// Partition all CkanModules in available_modules into
         /// compatible and incompatible groups.
         /// </summary>
+        /// <param name="stabilityTolerance">Stability tolerance to determine compatibility</param>
         /// <param name="versCrit">Version criteria to determine compatibility</param>
         public CompatibilitySorter SetCompatibleVersion(StabilityToleranceConfig stabilityTolerance,
                                                         GameVersionCriteria      versCrit)
@@ -625,6 +626,7 @@ namespace CKAN
         /// Quicker than checking CompatibleModules for one identifier.
         /// </summary>
         /// <param name="identifier">Identifier of mod</param>
+        /// <param name="stabilityTolerance">Stability tolerance to determine compatibility</param>
         /// <param name="crit">Game versions</param>
         /// <returns>true if any version is recursively compatible, false otherwise</returns>
         public bool IdentifierCompatible(string                   identifier,
@@ -700,6 +702,7 @@ namespace CKAN
         /// <summary>
         /// Return the latest game version compatible with the given mod.
         /// </summary>
+        /// <param name="realVersions">Game versions to check against</param>
         /// <param name="identifier">Name of mod to check</param>
         public GameVersion? LatestCompatibleGameVersion(List<GameVersion> realVersions,
                                                         string            identifier)
@@ -1112,6 +1115,7 @@ namespace CKAN
         /// <param name="origInstalled">Modules that are already installed, MUST include the FULL changeset if installing mods</param>
         /// <param name="dlls">Installed DLLs</param>
         /// <param name="dlc">Installed DLCs</param>
+        /// <param name="satisfiedFilter">Optional filter to apply to the dependencies</param>
         /// <returns>List of modules whose dependencies are about to be or already removed.</returns>
         public static IEnumerable<string> FindReverseDependencies(
             ICollection<string>                 modulesToRemove,

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -106,9 +106,9 @@ namespace CKAN
         /// <summary>
         /// Releases all resource used by the <see cref="RegistryManager"/> object.
         /// </summary>
-        /// <remarks>Call <see cref="Dispose"/> when you are finished using the <see cref="RegistryManager"/>. The
-        /// <see cref="Dispose"/> method leaves the <see cref="RegistryManager"/> in an unusable state. After
-        /// calling <see cref="Dispose"/>, you must release all references to the <see cref="RegistryManager"/> so
+        /// <remarks>Call <see cref="Dispose()"/> when you are finished using the <see cref="RegistryManager"/>. The
+        /// <see cref="Dispose()"/> method leaves the <see cref="RegistryManager"/> in an unusable state. After
+        /// calling <see cref="Dispose()"/>, you must release all references to the <see cref="RegistryManager"/> so
         /// the garbage collector can reclaim the memory that the <see cref="RegistryManager"/> was occupying.</remarks>
         public void Dispose()
         {

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -28,6 +28,7 @@ namespace CKAN
         /// <param name="modulesToRemove">Modules to remove</param>
         /// <param name="options">Options for the RelationshipResolver</param>
         /// <param name="registry">CKAN registry object for current game instance</param>
+        /// <param name="game">The game to mention in error messages</param>
         /// <param name="versionCrit">The current game version criteria to consider</param>
         public RelationshipResolver(IEnumerable<CkanModule>     modulesToInstall,
                                     IEnumerable<CkanModule>?    modulesToRemove,

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -96,6 +96,7 @@ namespace CKAN
         /// <summary>
         /// Return the most recent release of a module with a optional ksp version to target and a RelationshipDescriptor to satisfy.
         /// </summary>
+        /// <param name="stabilityTolerance">Stability tolerance that the module must match.</param>
         /// <param name="ksp_version">If not null only consider mods which match this ksp version.</param>
         /// <param name="relationship">If not null only consider mods which satisfy the RelationshipDescriptor.</param>
         /// <param name="installed">Modules that are already installed</param>

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -87,6 +87,7 @@ namespace CKAN
         /// <param name="counts">Download counts from this repo</param>
         /// <param name="versions">Game versions in this repo</param>
         /// <param name="repos">Contents of repositories.json in this repo</param>
+        /// <param name="unsupportedSpec">true if any module we found requires a newer client version, false otherwise</param>
         public RepositoryData(IEnumerable<CkanModule>?       modules,
                               SortedDictionary<string, int>? counts,
                               IEnumerable<GameVersion>?      versions,

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -89,7 +89,7 @@ namespace CKAN
         /// Load the cached data for the given repos, WITHOUT any network calls
         /// </summary>
         /// <param name="repos">Repositories for which to load data</param>
-        /// <param name="progress">Progress object for reporting percentage complete</param>
+        /// <param name="percentProgress">Progress object for reporting percentage complete</param>
         public void Prepopulate(List<Repository> repos, IProgress<int>? percentProgress)
         {
             // Look up the sizes of repos that have uncached files
@@ -140,6 +140,7 @@ namespace CKAN
         /// <param name="skipETags">True to force downloading regardless of the etags, false to skip if no changes on remote</param>
         /// <param name="downloader">The object that will do the actual downloading for us</param>
         /// <param name="user">Object for reporting messages and progress to the UI</param>
+        /// <param name="userAgent">User agent string to send with the request</param>
         /// <returns>Updated if we changed any of the available modules, NoChanges if already up to date</returns>
         public UpdateResult Update(Repository[]       repos,
                                    IGame              game,

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -220,7 +220,7 @@ namespace CKAN
         /// <param name="spec_version">The version of the spec obeyed by this module</param>
         /// <param name="identifier">This module's machine-readable identifier</param>
         /// <param name="name">This module's user-visible display name</param>
-        /// <param name="@abstract">Short description of this module</param>
+        /// <param name="abstract">Short description of this module</param>
         /// <param name="description">Long description of this module</param>
         /// <param name="author">Authors of this module</param>
         /// <param name="license">Licenses of this module</param>
@@ -414,7 +414,7 @@ namespace CKAN
         /// Returns the latest compatible or installed module if no version has been given.
         /// </summary>
         /// <param name="registry">CKAN registry object for current game instance</param>
-        /// <param name="name">The identifier or identifier=version of the module</param>
+        /// <param name="mod">The identifier or identifier=version of the module</param>
         /// <param name="ksp_version">The current KSP version criteria to consider</param>
         /// <returns>A CkanModule</returns>
         /// <exception cref="ModuleNotFoundKraken">Thrown if no matching module could be found</exception>

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -106,6 +106,9 @@ namespace CKAN
         /// Initialize the exception representing failed dependency resolution
         /// </summary>
         /// <param name="unsatisfied">List of chain of relationships with last one unsatisfied</param>
+        /// <param name="registry">Registry to use for formatting</param>
+        /// <param name="game">Game to use for formatting</param>
+        /// <param name="resolved">Resolved relationships tree</param>
         /// <param name="innerException">Originating exception parameter for base class</param>
         public DependenciesNotSatisfiedKraken(ICollection<ResolvedRelationship[]> unsatisfied,
                                               IRegistryQuerier                    registry,
@@ -536,7 +539,7 @@ namespace CKAN
         /// Release the kraken
         /// </summary>
         /// <param name="module">Module to check against path</param>
-        /// <param name="Path">Path to the file to check against module</param>
+        /// <param name="path">Path to the file to check against module</param>
         /// <param name="reason">Human-readable description of the problem</param>
         public InvalidModuleFileKraken(CkanModule module, string path, string? reason = null)
             : base(reason)

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -139,10 +139,10 @@ namespace CKAN
         /// <summary>
         /// Compare two install stanzas
         /// </summary>
-        /// <param name="other">The other stanza for comparison</param>
+        /// <param name="otherStanza">The other stanza for comparison</param>
         /// <returns>
         /// True if they're equivalent, false if they're different.
-        /// IEquatable<> uses this for more efficient comparisons.
+        /// IEquatable&lt;&gt; uses this for more efficient comparisons.
         /// </returns>
         public bool Equals(ModuleInstallDescriptor? otherStanza)
         {
@@ -477,8 +477,10 @@ namespace CKAN
         /// EX: "kOS-1.1/GameData/kOS", "kOS-1.1/GameData/kOS/Plugins/kOS.dll", "GameData" will be transformed
         /// to "GameData/kOS/Plugins/kOS.dll"
         /// </summary>
+        /// <param name="game">The game to use for reserved paths</param>
         /// <param name="outputName">The name of the file to transform</param>
         /// <param name="installDir">The installation dir where the file should end up with</param>
+        /// <param name="as">The name to use for the file</param>
         /// <returns>The output name</returns>
         internal string TransformOutputName(IGame game, string outputName, string installDir, string? @as)
         {

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -122,6 +122,7 @@ namespace CKAN
         /// <param name="modules">Sequence of modules to consider</param>
         /// <param name="dlls">Sequence of DLLs to consider</param>
         /// <param name="dlc">DLC to consider</param>
+        /// <param name="matched">The first module that matched, if any</param>
         /// <returns>
         /// true if any of the modules match this descriptor, false otherwise.
         /// </returns>

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -54,6 +54,7 @@ namespace CKAN
         /// <param name="sourceDirPath">Source directory path</param>
         /// <param name="destDirPath">Destination directory path</param>
         /// <param name="subFolderRelPathsToSymlink">Relative subdirs that should be symlinked to the originals instead of copied</param>
+        /// <param name="subFolderRelPathsToLeaveEmpty">Relative subdirs that should be left empty</param>
         public static void CopyDirectory(string   sourceDirPath,
                                          string   destDirPath,
                                          string[] subFolderRelPathsToSymlink,

--- a/Core/Versioning/GameVersion.cs
+++ b/Core/Versioning/GameVersion.cs
@@ -323,7 +323,7 @@ namespace CKAN.Versioning
         /// <param name="input">A string that contains a version number to convert.</param>
         /// <returns>
         /// A <see cref="GameVersion"/> object that is equivalent to the version number specified in the
-        /// <see cref="input"/> parameter.
+        /// input parameter.
         /// </returns>
         public static GameVersion Parse(string input)
         {
@@ -346,10 +346,10 @@ namespace CKAN.Versioning
         /// </param>
         /// <param name="result">
         /// When this method returns <c>true</c>, contains the <see cref="GameVersion"/> equivalent of the number that
-        /// is contained in <see cref="input"/>. When this method returns <c>false</c>, the value is unspecified.
+        /// is contained in input. When this method returns <c>false</c>, the value is unspecified.
         /// </param>
         /// <returns>
-        /// <c>true</c> if the <see cref="input"/> parameter was converted successfully; otherwise, <c>false</c>.
+        /// <c>true</c> if the input parameter was converted successfully; otherwise, <c>false</c>.
         /// </returns>
         public static bool TryParse(string? input,
                                     [NotNullWhen(returnValue: true)] out GameVersion? result)
@@ -489,7 +489,8 @@ namespace CKAN.Versioning
         /// Needs at least a Major and Minor (doesn't make sense else).
         /// </summary>
         /// <returns>A complete GameVersion object</returns>
-        /// <param name="user">A IUser instance, to raise the corresponding dialog.</param>
+        /// <param name="game">The game whose versions are to be selected</param>
+        /// <param name="user">A IUser instance, to raise the corresponding dialog</param>
         public GameVersion RaiseVersionSelectionDialog(IGame game, IUser? user)
         {
             if (IsFullyDefined && InBuildMap(game))
@@ -722,7 +723,7 @@ namespace CKAN.Versioning
         /// </param>
         /// <returns>
         /// <c>true</c> if every component of the current <see cref="GameVersion"/> matches the corresponding component
-        /// of the <see cref="obj"/> parameter; otherwise, <c>false</c>.
+        /// of the obj parameter; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals(GameVersion? obj)
             => obj is not null
@@ -740,9 +741,9 @@ namespace CKAN.Versioning
         /// An object to compare with the current <see cref="GameVersion"/> object, or <c>null</c>.
         /// </param>
         /// <returns>
-        /// <c>true</c> if the current <see cref="GameVersion"/> object and <see cref="obj"/> are both
+        /// <c>true</c> if the current <see cref="GameVersion"/> object and obj are both
         /// <see cref="GameVersion"/> objects and every component of the current <see cref="GameVersion"/> object
-        /// matches the corresponding component of <see cref="obj"/>; otherwise, <c>false</c>.
+        /// matches the corresponding component of obj; otherwise, <c>false</c>.
         /// </returns>
         public override bool Equals(object? obj)
             => obj is not null
@@ -765,7 +766,7 @@ namespace CKAN.Versioning
         /// </summary>
         /// <param name="v1">The first <see cref="GameVersion"/> object.</param>
         /// <param name="v2">The second <see cref="GameVersion"/> object.</param>
-        /// <returns><c>true</c> if <see cref="v1"/> equals <see cref="v2"/>; otherwise, <c>false</c>.</returns>
+        /// <returns><c>true</c> if v1 equals v2; otherwise, <c>false</c>.</returns>
         public static bool operator ==(GameVersion? v1, GameVersion? v2)
             => Equals(v1, v2);
 
@@ -775,7 +776,7 @@ namespace CKAN.Versioning
         /// <param name="v1">The first <see cref="GameVersion"/> object.</param>
         /// <param name="v2">The second <see cref="GameVersion"/> object.</param>
         /// <returns>
-        /// <c>true</c> if <see cref="v1"/> does not equal <see cref="v2"/>; otherwise, <c>false</c>.
+        /// <c>true</c> if v1 does not equal v2; otherwise, <c>false</c>.
         /// </returns>
         public static bool operator !=(GameVersion? v1, GameVersion? v2)
             => !Equals(v1, v2);
@@ -798,20 +799,20 @@ namespace CKAN.Versioning
         /// <item>
         /// <term>Less than zero</term>
         /// <description>
-        /// The current <see cref="GameVersion"/> object is a version before <see cref="obj"/>.
+        /// The current <see cref="GameVersion"/> object is a version before obj.
         /// </description>
         /// </item>
         /// <item>
         /// <term>Zero</term>
         /// <description>
-        /// The current <see cref="GameVersion"/> object is the same version as <see cref="obj"/>.
+        /// The current <see cref="GameVersion"/> object is the same version as obj.
         /// </description>
         /// </item>
         /// <item>
         /// <term>Greater than zero</term>
         /// <description>
         /// <para>
-        /// The current <see cref="GameVersion"/> object is a version subsequent to <see cref="obj"/>.
+        /// The current <see cref="GameVersion"/> object is a version subsequent to obj.
         /// </para>
         /// </description>
         /// </item>
@@ -851,20 +852,20 @@ namespace CKAN.Versioning
         /// <item>
         /// <term>Less than zero</term>
         /// <description>
-        /// The current <see cref="GameVersion"/> object is a version before <see cref="other"/>.
+        /// The current <see cref="GameVersion"/> object is a version before other.
         /// </description>
         /// </item>
         /// <item>
         /// <term>Zero</term>
         /// <description>
-        /// The current <see cref="GameVersion"/> object is the same version as <see cref="other"/>.
+        /// The current <see cref="GameVersion"/> object is the same version as other.
         /// </description>
         /// </item>
         /// <item>
         /// <term>Greater than zero</term>
         /// <description>
         /// <para>
-        /// The current <see cref="GameVersion"/> object is a version subsequent to <see cref="other"/>.
+        /// The current <see cref="GameVersion"/> object is a version subsequent to other.
         /// </para>
         /// </description>
         /// </item>
@@ -912,7 +913,7 @@ namespace CKAN.Versioning
         /// <param name="left">The first <see cref="GameVersion"/> object.</param>
         /// <param name="right">The second <see cref="GameVersion"/> object.</param>
         /// <returns>
-        /// <c>true</c> if <see cref="left"/> is less than <see cref="right"/>; otherwise, <c>flase</c>.
+        /// <c>true</c> if left is less than right; otherwise, <c>false</c>.
         /// </returns>
         public static bool operator <(GameVersion left, GameVersion right)
             => left.CompareTo(right) < 0;
@@ -924,7 +925,7 @@ namespace CKAN.Versioning
         /// <param name="left">The first <see cref="GameVersion"/> object.</param>
         /// <param name="right">The second <see cref="GameVersion"/> object.</param>
         /// <returns>
-        /// <c>true</c> if <see cref="left"/> is greater than <see cref="right"/>; otherwise, <c>flase</c>.
+        /// <c>true</c> if left is greater than right; otherwise, <c>false</c>.
         /// </returns>
         public static bool operator >(GameVersion left, GameVersion right)
             => left.CompareTo(right) > 0;
@@ -936,7 +937,7 @@ namespace CKAN.Versioning
         /// <param name="left">The first <see cref="GameVersion"/> object.</param>
         /// <param name="right">The second <see cref="GameVersion"/> object.</param>
         /// <returns>
-        /// <c>true</c> if <see cref="left"/> is less than or equal to <see cref="right"/>; otherwise, <c>flase</c>.
+        /// <c>true</c> if left is less than or equal to right; otherwise, <c>false</c>.
         /// </returns>
         public static bool operator <=(GameVersion left, GameVersion right)
             => left.CompareTo(right) <= 0;
@@ -948,7 +949,7 @@ namespace CKAN.Versioning
         /// <param name="left">The first <see cref="GameVersion"/> object.</param>
         /// <param name="right">The second <see cref="GameVersion"/> object.</param>
         /// <returns>
-        /// <c>true</c> if <see cref="left"/> is greater than or equal to <see cref="right"/>; otherwise, <c>flase</c>.
+        /// <c>true</c> if left is greater than or equal to right; otherwise, <c>false</c>.
         /// </returns>
         public static bool operator >=(GameVersion left, GameVersion right)
             => left.CompareTo(right) >= 0;

--- a/Core/Versioning/GameVersionBound.cs
+++ b/Core/Versioning/GameVersionBound.cs
@@ -110,7 +110,7 @@ namespace CKAN.Versioning
         /// tie inclusive bounds are treated as both lower and higher than equivalent exclusive bounds.
         /// </summary>
         /// <param name="versionBounds">The set of <see cref="GameVersionBound"/> objects to compare.</param>
-        /// <returns>The lowest value in <see cref="versionBounds"/>.</returns>
+        /// <returns>The lowest value in versionBounds.</returns>
         public static GameVersionBound Lowest(params GameVersionBound[] versionBounds)
         {
             if (!versionBounds.Any())
@@ -131,7 +131,7 @@ namespace CKAN.Versioning
         /// tie inclusive bounds are treated as both lower and higher than equivalent exclusive bounds.
         /// </summary>
         /// <param name="versionBounds">The set of <see cref="GameVersionBound"/> objects to compare.</param>
-        /// <returns>The highest value in <see cref="versionBounds"/>.</returns>
+        /// <returns>The highest value in versionBounds.</returns>
         public static GameVersionBound Highest(params GameVersionBound?[] versionBounds)
         {
             if (versionBounds.Length == 0)

--- a/Core/Versioning/GameVersionRange.cs
+++ b/Core/Versioning/GameVersionRange.cs
@@ -97,6 +97,7 @@ namespace CKAN.Versioning
         /// Generate a string describing a range of KSP versions.
         /// May be bounded or unbounded on either side.
         /// </summary>
+        /// <param name="game">The game to which the version range applies</param>
         /// <param name="minKsp">Lowest version in the range</param>
         /// <param name="maxKsp">Highest version in the range</param>
         /// <returns>


### PR DESCRIPTION
## Motivation

Discord user Lewis has been coding against CKAN Core via the Nuget package. He has requested XML documentation be added to the package.

## Changes

- Now `GenerateDocumentationFile` is enabled for `CKAN-core.csproj` (the other projects aren't included in the .nupkg file)
- The `CS1591` warning for missing documentation is turned off so we don't have 3000+ new warnings every time we compile.
- Assorted instances of other documentation related errors are fixed

This way, the next release will have XML docs embedded in the .nupkg.
