### PR TITLE
Mod file deduplication across game instances

### DIFF
--- a/Cmdline/Action/Deduplicate.cs
+++ b/Cmdline/Action/Deduplicate.cs
@@ -1,0 +1,42 @@
+using log4net;
+
+using CKAN.IO;
+
+namespace CKAN.CmdLine
+{
+    public class Deduplicate : ICommand
+    {
+        public Deduplicate(GameInstanceManager mgr, RepositoryDataManager repoData, IUser user)
+        {
+            manager       = mgr;
+            this.repoData = repoData;
+            this.user     = user;
+        }
+
+        public int RunCommand(CKAN.GameInstance instance, object rawOptions)
+        {
+            log.Debug("Deduplicating...");
+            user.RaiseMessage(Properties.Resources.ScanningForDuplicates);
+            var deduper = new InstalledFilesDeduplicator(manager.Instances.Values, repoData);
+            try
+            {
+                deduper.DeduplicateAll(user);
+                log.Debug("Deduplication done.");
+            }
+            catch (CancelledActionKraken)
+            {
+                // Cancelled by user, do nothing.
+                log.Debug("Deduplication cancelled.");
+            }
+            return Exit.OK;
+        }
+
+        private readonly GameInstanceManager   manager;
+        private readonly RepositoryDataManager repoData;
+        private readonly IUser                 user;
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(Deduplicate));
+    }
+
+    internal class DeduplicateOptions : CommonOptions { }
+}

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using CommandLine;
 using log4net;
 
+using CKAN.IO;
+
 namespace CKAN.CmdLine
 {
     /// <summary>

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -65,6 +65,9 @@ namespace CKAN.CmdLine
                                               new RelationshipResolverOptions(instance.StabilityToleranceConfig),
                                               regMgr,
                                               ref possibleConfigOnlyDirs,
+                                              new InstalledFilesDeduplicator(instance,
+                                                                             manager.Instances.Values,
+                                                                             repoData),
                                               opts?.NetUserAgent);
                     }
                     return Exit.OK;

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using CommandLine;
 using log4net;
 
+using CKAN.Versioning;
+
 namespace CKAN.CmdLine
 {
     public class Install : ICommand

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using CommandLine;
 using log4net;
 
+using CKAN.IO;
 using CKAN.Versioning;
 
 namespace CKAN.CmdLine

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -123,7 +123,11 @@ namespace CKAN.CmdLine
                 {
                     HashSet<string>? possibleConfigOnlyDirs = null;
                     installer.InstallList(modules, install_ops, regMgr,
-                                          ref possibleConfigOnlyDirs, options?.NetUserAgent);
+                                          ref possibleConfigOnlyDirs,
+                                          new InstalledFilesDeduplicator(instance,
+                                                                         manager.Instances.Values,
+                                                                         repoData),
+                                          options?.NetUserAgent);
                     user.RaiseMessage("");
                     done = true;
                 }

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -6,6 +6,8 @@ using System.Text.RegularExpressions;
 using CommandLine;
 using log4net;
 
+using CKAN.IO;
+
 namespace CKAN.CmdLine
 {
     public class Remove : ICommand

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -165,7 +165,10 @@ namespace CKAN.CmdLine
                         .Replace(to_replace, replace_ops,
                                  new NetAsyncModulesDownloader(user, manager.Cache, options.NetUserAgent),
                                  ref possibleConfigOnlyDirs,
-                                 regMgr);
+                                 regMgr,
+                                 new InstalledFilesDeduplicator(instance,
+                                                                manager.Instances.Values,
+                                                                repoData));
                     user.RaiseMessage("");
                 }
                 catch (DependenciesNotSatisfiedKraken ex)

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using CommandLine;
 using log4net;
 
+using CKAN.IO;
 using CKAN.Versioning;
 
 namespace CKAN.CmdLine

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -6,6 +6,7 @@ using System.Transactions;
 using CommandLine;
 using Autofac;
 
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.Configuration;
 

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -15,6 +15,8 @@ using Autofac;
 using log4net;
 using log4net.Core;
 
+using CKAN.Versioning;
+
 namespace CKAN.CmdLine
 {
     internal class MainClass

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -265,6 +265,9 @@ namespace CKAN.CmdLine
                     case "clean":
                         return Clean(manager.Cache);
 
+                    case "dedup":
+                        return new Deduplicate(manager, repoData, user).RunCommand(GetGameInstance(manager), cmdline.options);
+
                     case "compare":
                         return (new Compare(user)).RunCommand(cmdline.options);
 

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -90,6 +90,9 @@ namespace CKAN.CmdLine
         [VerbOption("clean", HelpText = "Clean away downloaded files from the cache")]
         public CleanOptions? Clean { get; set; }
 
+        [VerbOption("dedup", HelpText = "Find mod files that exist in multiple game instances and replace all but one of each group with hard links")]
+        public DeduplicateOptions? Deduplicate { get; set; }
+
         [VerbOption("repair", HelpText = "Attempt various automatic repairs")]
         public RepairSubOptions? Repair { get; set; }
 
@@ -188,6 +191,7 @@ namespace CKAN.CmdLine
                     case "update":
                     case "scan":
                     case "clean":
+                    case "dedup":
                     case "version":
                     default:
                         yield return $"{Properties.Resources.Usage}: ckan {verb} [{Properties.Resources.Options}]";

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -404,4 +404,5 @@ Proceeding with {0} in case it fixes it.</value></data>
   <data name="CompletionNotAvailable" xml:space="preserve"><value>
 No game instance selected, identifier completion not available.
 Use the `instance default` command to choose an instance.</value></data>
+  <data name="ScanningForDuplicates" xml:space="preserve"><value>Scanning for duplicate installed files...</value></data>
 </root>

--- a/ConsoleUI/DeleteDirectoriesScreen.cs
+++ b/ConsoleUI/DeleteDirectoriesScreen.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.IO;
 using System.Collections.Generic;
 
+using CKAN.IO;
 using CKAN.ConsoleUI.Toolkit;
 
 namespace CKAN.ConsoleUI {

--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.ConsoleUI.Toolkit;
 

--- a/ConsoleUI/DownloadImportDialog.cs
+++ b/ConsoleUI/DownloadImportDialog.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
+using CKAN.IO;
 using CKAN.ConsoleUI.Toolkit;
 
 namespace CKAN.ConsoleUI {

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -78,6 +78,10 @@ namespace CKAN.ConsoleUI {
 
                             HashSet<string>? possibleConfigOnlyDirs = null;
 
+                            if (manager.Instances.Count > 0)
+                            {
+                                RaiseMessage(Properties.Resources.InstallDeduplicateScanning);
+                            }
                             var deduper = new InstalledFilesDeduplicator(manager.CurrentInstance,
                                                                          manager.Instances.Values,
                                                                          repoData);

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -4,6 +4,7 @@ using System.Transactions;
 using System.Collections.Generic;
 using System.Linq;
 
+using CKAN.IO;
 using CKAN.Configuration;
 using CKAN.ConsoleUI.Toolkit;
 

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -205,7 +205,8 @@ namespace CKAN.ConsoleUI {
 
         private void OnModInstalled(CkanModule mod)
         {
-            RaiseMessage(Properties.Resources.InstallModInstalled, Symbols.checkmark, mod.name, ModuleInstaller.StripEpoch(mod.version));
+            RaiseMessage(Properties.Resources.InstallModInstalled,
+                         Symbols.checkmark, mod.name, mod.version.StripEpoch());
         }
 
         private IEnumerable<ModuleReplacement> AllReplacements(IEnumerable<string> identifiers)

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -78,6 +78,10 @@ namespace CKAN.ConsoleUI {
 
                             HashSet<string>? possibleConfigOnlyDirs = null;
 
+                            var deduper = new InstalledFilesDeduplicator(manager.CurrentInstance,
+                                                                         manager.Instances.Values,
+                                                                         repoData);
+
                             ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this, userAgent);
                             inst.OneComplete += OnModInstalled;
                             if (plan.Remove.Count > 0) {
@@ -97,7 +101,8 @@ namespace CKAN.ConsoleUI {
                                                                                           plan.Install))
                                                              ?? m)
                                                 .ToArray();
-                                inst.InstallList(iList, resolvOpts(stabilityTolerance), regMgr, ref possibleConfigOnlyDirs, userAgent, dl);
+                                inst.InstallList(iList, resolvOpts(stabilityTolerance), regMgr,
+                                                 ref possibleConfigOnlyDirs, deduper, userAgent, dl);
                                 plan.Install.Clear();
                             }
                             if (plan.Upgrade.Count > 0) {
@@ -108,11 +113,12 @@ namespace CKAN.ConsoleUI {
                                                                           .Keys
                                                                           .Except(plan.Upgrade)
                                                                           .ToHashSet());
-                                inst.Upgrade(upgGroups[true], dl, ref possibleConfigOnlyDirs, regMgr);
+                                inst.Upgrade(upgGroups[true], dl, ref possibleConfigOnlyDirs, regMgr, deduper);
                                 plan.Upgrade.Clear();
                             }
                             if (plan.Replace.Count > 0) {
-                                inst.Replace(AllReplacements(plan.Replace), resolvOpts(stabilityTolerance), dl, ref possibleConfigOnlyDirs, regMgr, true);
+                                inst.Replace(AllReplacements(plan.Replace), resolvOpts(stabilityTolerance), dl,
+                                             ref possibleConfigOnlyDirs, regMgr, deduper, true);
                             }
 
                             trans.Complete();

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
+using CKAN.IO;
 using CKAN.Configuration;
 using CKAN.Versioning;
 using CKAN.ConsoleUI.Toolkit;

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -509,8 +509,8 @@ namespace CKAN.ConsoleUI {
                 AddObject(new ConsoleLabel(
                     l + 2, t + 1, r - 2,
                     () => minMod == maxMod
-                        ? $"{ModuleInstaller.WithAndWithoutEpoch(minMod?.ToString() ?? "???")}"
-                        : $"{ModuleInstaller.WithAndWithoutEpoch(minMod?.ToString() ?? "???")} - {ModuleInstaller.WithAndWithoutEpoch(maxMod?.ToString() ?? "???")}",
+                        ? $"{minMod?.WithAndWithoutEpoch() ?? "???"}"
+                        : $"{minMod?.WithAndWithoutEpoch() ?? "???"} - {maxMod?.WithAndWithoutEpoch() ?? "???"}",
                     null,
                     color
                 ));

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -61,7 +61,7 @@ namespace CKAN.ConsoleUI {
                         null, null),
                     new ConsoleListBoxColumn<CkanModule>(
                         Properties.Resources.ModListVersionHeader,
-                        m => ModuleInstaller.StripEpoch(m.version?.ToString() ?? ""),
+                        m => m.version?.StripEpoch() ?? "",
                         (a, b) => a.version.CompareTo(b.version),
                         10),
                     new ConsoleListBoxColumn<CkanModule>(

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -11,6 +11,7 @@ using CKAN.Extensions;
 using CKAN.Games;
 using CKAN.Configuration;
 using CKAN.Versioning;
+using CKAN.IO;
 
 namespace CKAN.ConsoleUI {
 
@@ -370,6 +371,9 @@ namespace CKAN.ConsoleUI {
                 new ConsoleMenuOption(Properties.Resources.ModListFilterMenu, "",
                     Properties.Resources.ModListFilterMenuTip,
                     true, EditInstallFilters),
+                new ConsoleMenuOption(Properties.Resources.ModListDeduplicateInstalledFilesMenu, "",
+                    Properties.Resources.ModListDeduplicateInstalledFilesMenuTip,
+                    true, DeduplicateInstalledFiles),
                 null,
                 new ConsoleMenuOption(Properties.Resources.ModListHelpMenu, helpKey,
                     Properties.Resources.ModListHelpMenuTip,
@@ -624,6 +628,29 @@ namespace CKAN.ConsoleUI {
                     ServiceLocator.Container.Resolve<IConfiguration>(),
                     manager.CurrentInstance));
             }
+            return true;
+        }
+
+        private bool DeduplicateInstalledFiles()
+        {
+            var ps = new ProgressScreen(theme,
+                                        Properties.Resources.ModListDeduplicateInstalledFilesProgressTitle,
+                                        Properties.Resources.ModListDeduplicateInstalledFilesProgressMessage);
+            ps.Run(() =>
+            {
+                ps.RaiseMessage(Properties.Resources.ModListDeduplicateInstalledFilesScanning);
+                var deduper = new InstalledFilesDeduplicator(manager.Instances.Values, repoData);
+                try
+                {
+                    deduper.DeduplicateAll(ps);
+                    ps.RaiseMessage(Properties.Resources.SplashPressAnyKey);
+                    Console.ReadKey(true);
+                }
+                catch (CancelledActionKraken)
+                {
+                    // User cancelled, do nothing.
+                }
+            });
             return true;
         }
 

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -239,6 +239,7 @@ Edit authentication tokens now?</value></data>
 {1}</value></data>
   <data name="InstallNotInstalled" xml:space="preserve"><value>{0} is not installed, can't remove</value></data>
   <data name="InstallModInstalled" xml:space="preserve"><value>{0} Successfully installed {1} {2}</value></data>
+  <data name="InstallDeduplicateScanning" xml:space="preserve"><value>Checking other game instances for possible duplicate installed files...</value></data>
   <data name="DeleteDirectoriesHeader" xml:space="preserve"><value>Delete Directories</value></data>
   <data name="DeleteDirectoriesHelpLabel" xml:space="preserve"><value>Warning, some folders have been left behind because CKAN does not know whether it is safe to delete their remaining files. Keeping these folders may break other mods! If you do not need these files, deleting them is recommended.</value></data>
   <data name="DeleteDirectoriesFoldersHeader" xml:space="preserve"><value>Directories</value></data>
@@ -360,6 +361,11 @@ If you uninstall it, CKAN will not be able to re-install it.</value></data>
   <data name="ModListAuthTokenMenuTip" xml:space="preserve"><value>Edit authentication tokens sent to download servers</value></data>
   <data name="ModListFilterMenu" xml:space="preserve"><value>Installation filters...</value></data>
   <data name="ModListFilterMenuTip" xml:space="preserve"><value>Edit list of files and folders to exclude from installation</value></data>
+  <data name="ModListDeduplicateInstalledFilesMenu" xml:space="preserve"><value>Deduplicate installed files...</value></data>
+  <data name="ModListDeduplicateInstalledFilesMenuTip" xml:space="preserve"><value>Search game instances for multiple copies of the same file and consolidate duplicates with hard links</value></data>
+  <data name="ModListDeduplicateInstalledFilesProgressTitle" xml:space="preserve"><value>Deduplicating Installed Files</value></data>
+  <data name="ModListDeduplicateInstalledFilesProgressMessage" xml:space="preserve"><value>Scanning instances for duplicates...</value></data>
+  <data name="ModListDeduplicateInstalledFilesScanning" xml:space="preserve"><value>Scanning instances for duplicates...</value></data>
   <data name="ModListHelpMenu" xml:space="preserve"><value>Help</value></data>
   <data name="ModListHelpMenuTip" xml:space="preserve"><value>Tips &amp; tricks</value></data>
   <data name="ModListQuitMenu" xml:space="preserve"><value>Quit</value></data>

--- a/Core/CKANPathUtils.cs
+++ b/Core/CKANPathUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text.RegularExpressions;
 
 using log4net;
 
@@ -27,30 +26,6 @@ namespace CKAN
         public static string NormalizePath(string path)
             => path.Length < 2 ? path.Replace('\\', '/')
                                : path.Replace('\\', '/').TrimEnd('/');
-
-        /// <summary>
-        /// Gets the last path element. Ex: /a/b/c returns c
-        /// </summary>
-        /// <returns>The last path element.</returns>
-        /// <param name="path">The path to process.</param>
-        public static string GetLastPathElement(string path)
-            => Regex.Replace(NormalizePath(path), @"^.*/", "");
-
-        /// <summary>
-        /// Gets the leading path elements. Ex: /a/b/c returns /a/b
-        ///
-        /// Returns empty string if there is no leading path. (Eg: "Example.dll" -> "");
-        /// </summary>
-        /// <returns>The leading path elements.</returns>
-        /// <param name="path">The path to process.</param>
-        public static string GetLeadingPathElements(string path)
-        {
-            path = NormalizePath(path);
-
-            return Regex.IsMatch(path, "/")
-                ? Regex.Replace(path, @"(^.*)/.+", "$1")
-                : string.Empty;
-        }
 
         /// <summary>
         /// Converts a path to one relative to the root provided.

--- a/Core/Configuration/JsonConfiguration.cs
+++ b/Core/Configuration/JsonConfiguration.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 
 using Newtonsoft.Json;
 
+using CKAN.IO;
 using CKAN.Games.KerbalSpaceProgram;
 
 namespace CKAN.Configuration

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -9,6 +9,8 @@ using System.ComponentModel;
 using System.Runtime.Versioning;
 #endif
 
+using CKAN.IO;
+
 namespace CKAN.Configuration
 {
     // DEPRECATED: We now use a JSON configuration file. This still exists to facilitate migration.

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -81,6 +81,19 @@ namespace CKAN.Extensions
             => seq1.Zip(seq2, func).SelectMany(seqs => seqs);
 
         /// <summary>
+        /// Zip a sequence with a sequence generated from the first sequence using the given function
+        /// </summary>
+        /// <typeparam name="T">Source sequence type</typeparam>
+        /// <typeparam name="V">Type of elements returned by func</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="func">Function to generate values of second sequence given source</param>
+        /// <returns>Sequence of tuples containing pairs from each sequence</returns>
+        public static IEnumerable<(T First, V Second)> ZipBy<T, V>(this IEnumerable<T> source, Func<IEnumerable<T>, IEnumerable<V>> func)
+            => source.ToArray() is T[] array
+                   ? array.Zip(func(array))
+                   : Enumerable.Empty<(T First, V Second)>();
+
+        /// <summary>
         /// Generate a sequence from a linked list
         /// </summary>
         /// <param name="start">The first node</param>

--- a/Core/Extensions/Polyfills.cs
+++ b/Core/Extensions/Polyfills.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
-
 #if !NET8_0_OR_GREATER
+using System.Collections.Generic;
 
 namespace System.Linq
 {
@@ -63,8 +62,8 @@ namespace System.Linq
         /// <param name="seq1">The first sequence</param>
         /// <param name="seq2">The second sequence</param>
         /// <returns>Sequence of pairs of one element from seq1 and one from seq2</returns>
-        public static IEnumerable<Tuple<T1, T2>> Zip<T1, T2>(this IEnumerable<T1> seq1, IEnumerable<T2> seq2)
-            => seq1.Zip(seq2, (item1, item2) => new Tuple<T1, T2>(item1, item2));
+        public static IEnumerable<(T1 First, T2 Second)> Zip<T1, T2>(this IEnumerable<T1> seq1, IEnumerable<T2> seq2)
+            => seq1.Zip(seq2, (First, Second) => (First, Second));
 
         #endif
     }

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -11,6 +11,7 @@ using ChinhDo.Transactions.FileManager;
 using log4net;
 using Newtonsoft.Json;
 
+using CKAN.IO;
 using CKAN.Configuration;
 using CKAN.Games;
 using CKAN.Versioning;

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -9,6 +9,7 @@ using Autofac;
 using ChinhDo.Transactions.FileManager;
 using log4net;
 
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.Configuration;
 using CKAN.Games;

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using Newtonsoft.Json.Linq;
 
+using CKAN.IO;
 using CKAN.DLC;
 using CKAN.Versioning;
 

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -10,6 +10,7 @@ using log4net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+using CKAN.IO;
 using CKAN.DLC;
 using CKAN.Games.KerbalSpaceProgram.GameVersionProviders;
 using CKAN.Games.KerbalSpaceProgram.DLC;

--- a/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildMap.cs
+++ b/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildMap.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using log4net;
 using Newtonsoft.Json;
 
+using CKAN.IO;
 using CKAN.Versioning;
 
 namespace CKAN.Games.KerbalSpaceProgram.GameVersionProviders

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Mono.Cecil;
 
+using CKAN.IO;
 using CKAN.DLC;
 using CKAN.Versioning;
 using CKAN.Extensions;

--- a/Core/IO/CKANPathUtils.cs
+++ b/Core/IO/CKANPathUtils.cs
@@ -5,7 +5,7 @@ using log4net;
 
 using CKAN.Extensions;
 
-namespace CKAN
+namespace CKAN.IO
 {
     public static class CKANPathUtils
     {

--- a/Core/IO/DirectoryLink.cs
+++ b/Core/IO/DirectoryLink.cs
@@ -8,12 +8,12 @@ using Microsoft.Win32.SafeHandles;
 
 using ChinhDo.Transactions.FileManager;
 
-namespace CKAN
+namespace CKAN.IO
 {
     /// <summary>
     /// Junctions on Windows, symbolic links on Unix
     /// </summary>
-    public static class DirectoryLink
+    internal static class DirectoryLink
     {
         public static void Create(string target, string link, TxFileManager txMgr)
         {

--- a/Core/IO/FileIdentifier.cs
+++ b/Core/IO/FileIdentifier.cs
@@ -5,7 +5,7 @@ using ICSharpCode.SharpZipLib.GZip;
 
 using CKAN.Extensions;
 
-namespace CKAN
+namespace CKAN.IO
 {
     public static class FileIdentifier
     {

--- a/Core/IO/HardLink.cs
+++ b/Core/IO/HardLink.cs
@@ -1,0 +1,276 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
+using FileMode = System.IO.FileMode;
+
+using ChinhDo.Transactions.FileManager;
+using log4net;
+
+namespace CKAN.IO
+{
+    /// <summary>
+    /// This class provides methods for creating hard links to files.
+    /// It also provides methods to retrieve information relevant to hard links,
+    /// such as the device identifier, hard link target identifier, and link count of a file.
+    /// </summary>
+    internal static class HardLink
+    {
+        /// <summary>
+        /// Create a hard link to a file.
+        /// This will throw an exception if the hard link cannot be created (e.g., if the paths are on different volumes).
+        /// </summary>
+        /// <param name="target">The original file</param>
+        /// <param name="linkPath">The place where we want to make a link or copy</param>
+        /// <exception cref="Kraken">Thrown if can't make a hard link</exception>
+        public static void Create(string target, string linkPath)
+        {
+            log.DebugFormat("Creating hard link from {0} to {1}...", target, linkPath);
+            if (!CreateImpl(target, linkPath))
+            {
+                throw new Kraken(Platform.IsWindows
+                    ? $"Failed to create hard link from {target} to {linkPath}: {Marshal.GetLastWin32Error()}"
+                    : $"Failed to create hard link from {target} to {linkPath}.");
+            }
+        }
+
+        /// <summary>
+        /// Create a hard link to a file.
+        /// If the hard link cannot be created (e.g., if the paths are on different volumes), copy the file instead.
+        /// </summary>
+        /// <param name="target">The original file</param>
+        /// <param name="linkPath">The place where we want to make a link or copy</param>
+        /// <param name="file_transaction">Transaction in case we need to roll back</param>
+        public static void CreateOrCopy(string        target,
+                                        string        linkPath,
+                                        TxFileManager file_transaction)
+        {
+            log.DebugFormat("Creating hard link or copy from {0} to {1}...", target, linkPath);
+            if (!CreateImpl(target, linkPath))
+            {
+                // If we can't create a hard link (e.g., if the paths are on separate volumes), copy instead
+                file_transaction.Copy(target, linkPath, false);
+            }
+        }
+
+        private static bool CreateImpl(string target, string linkPath)
+            => Platform.IsWindows ? CreateHardLink(linkPath, target, IntPtr.Zero)
+                                  : link(target, linkPath) == 0;
+
+        [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool CreateHardLink(string lpFileName,
+                                                  string lpExistingFileName,
+                                                  IntPtr lpSecurityAttributes);
+
+        [DllImport("libc")]
+        private static extern int link(string oldpath, string newpath);
+
+        /// <summary>
+        /// Get the device identifiers of files or directories.
+        /// This is a unique identifier for the filesystem.
+        /// Files on different devices cannot be hard-linked to each other.
+        /// </summary>
+        /// <param name="paths">The files' paths</param>
+        /// <returns>Sequence of long integers representing the device/volume if found, otherwise null</returns>
+        public static IEnumerable<ulong?> GetDeviceIdentifiers(IEnumerable<string> paths)
+            => Platform.IsWindows
+                   ? paths.Select(path => GetFileInformation(path,
+                                                             out BY_HANDLE_FILE_INFORMATION fileInfo)
+                                              ? (ulong?)fileInfo.VolumeSerialNumber
+                                              : null)
+                   : (Platform.IsUnix || Platform.IsMac)
+                         ? RunStat(paths, StatArg.DeviceID)
+                               .Select(v => v.FirstOrDefault())
+                         : Enumerable.Empty<ulong?>();
+
+        /// <summary>
+        /// Get the identifiers of files.
+        /// This is a unique identifier for the file on the filesystem.
+        /// Files with the same identifier are hard links to the same file.
+        /// On Windows, it is a combination of the volume serial number and the file index.
+        /// On Unix-like systems, it is a combination of the device ID and the inode number.
+        /// </summary>
+        /// <param name="paths">The files' paths</param>
+        /// <returns>Sequence of 128-bit values representing the files if found, otherwise null</returns>
+        public static IEnumerable<Guid?> GetFileIdentifiers(IEnumerable<string> paths)
+            => Platform.IsWindows
+                   ? paths.Select(path => GetFileInformation(path,
+                                                             out BY_HANDLE_FILE_INFORMATION fileInfo)
+                                              ? (Guid?)new Guid(BitConverter.GetBytes((ulong)fileInfo.VolumeSerialNumber)
+                                                          .Concat(BitConverter.GetBytes(fileInfo.FileIndexHigh))
+                                                          .Concat(BitConverter.GetBytes(fileInfo.FileIndexLow))
+                                                          .ToArray())
+                                              : null)
+                   : (Platform.IsUnix || Platform.IsMac)
+                         ? RunStat(paths, StatArg.DeviceID, StatArg.InodeNumber)
+                               .Select(v => (Guid?)new Guid(v.SelectMany(val => BitConverter.GetBytes(val ?? 0L))
+                                                             .ToArray()))
+                         : Enumerable.Empty<Guid?>();
+
+        /// <summary>
+        /// Get the number of hard links to files' contents, including themselves.
+        /// This is the number of directory entries that point to the file.
+        /// </summary>
+        /// <param name="paths">The files' paths</param>
+        /// <returns>Sequence of number of links if found, otherwise null</returns>
+        public static IEnumerable<ulong?> GetLinkCounts(IEnumerable<string> paths)
+            => Platform.IsWindows
+                   ? paths.Select(path => GetFileInformation(path,
+                                                             out BY_HANDLE_FILE_INFORMATION fileInfo)
+                                              ? (ulong?)fileInfo.NumberOfLinks
+                                              : null)
+                   : (Platform.IsUnix || Platform.IsMac)
+                         ? RunStat(paths, StatArg.HardLinkCount)
+                               .Select(v => v.FirstOrDefault())
+                         : Enumerable.Empty<ulong?>();
+
+        private static bool GetFileInformation(string path,
+                                               out BY_HANDLE_FILE_INFORMATION FileInformation)
+        {
+            var h = CreateFile(path, 0, 0, IntPtr.Zero,
+                               FileMode.Open, BackupSemantics, IntPtr.Zero);
+            if (!h.IsInvalid)
+            {
+                var val = GetFileInformationByHandle(h, out FileInformation);
+                h.Close();
+                return val;
+            }
+            FileInformation = default;
+            return false;
+        }
+
+        private enum StatArg
+        {
+            DeviceID,
+            InodeNumber,
+            HardLinkCount,
+        }
+
+        /// <summary>
+        /// Get the device ID, inode number, or hard link count of files
+        /// using the stat command on Unix.
+        /// We use the stat command because struct stat's byte layout
+        /// is not guaranteed to be the same across different Unix-like systems.
+        /// It handles multiple file at once to reduce the number of processes we start.
+        /// </summary>
+        /// <param name="paths">The files to inspect</param>
+        /// <param name="what">The info to get</param>
+        /// <returns>Values returned by stat if any, else null</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the what arg isn't valid</exception>
+        private static IEnumerable<ulong?[]> RunStat(IEnumerable<string> paths,
+                                                     params StatArg[]    what)
+        {
+            var fmt = string.Join(" ", what.Select(w => w switch
+            {
+                StatArg.DeviceID      => "%d",
+                StatArg.InodeNumber   => "%i",
+                StatArg.HardLinkCount => "%h",
+                _                     => throw new ArgumentOutOfRangeException(nameof(what),
+                                                                               what, "Invalid stat arg"),
+            }));
+            foreach (var pathsString in LimitedStringJoins(paths.Select(p => $"\"{p}\""),
+                                                           " ", STAT_ARG_MAX))
+            {
+                if (Process.Start(new ProcessStartInfo("stat", $"-c '{fmt}' {pathsString}")
+                                  {
+                                      UseShellExecute        = false,
+                                      RedirectStandardOutput = true,
+                                      RedirectStandardError  = true,
+                                      CreateNoWindow         = true,
+                                  })
+                    is Process proc)
+                {
+                    while (!proc.StandardOutput.EndOfStream)
+                    {
+                        yield return proc.StandardOutput
+                                         .ReadLine()
+                                         ?.Trim()
+                                          .Split(' ')
+                                          .Select(s => ulong.TryParse(s, out ulong val)
+                                                           ? (ulong?)val
+                                                           : null)
+                                          .ToArray()
+                                         ?? Array.Empty<ulong?>();
+                    }
+                    proc.WaitForExit();
+                }
+            }
+        }
+
+        private static IEnumerable<string> LimitedStringJoins(IEnumerable<string> strings,
+                                                              string              separator,
+                                                              long                maxLength)
+        {
+            var current = "";
+            foreach (var str in strings)
+            {
+                if (current.Length + separator.Length + str.Length > maxLength)
+                {
+                    yield return current;
+                    current = "";
+                }
+                current += current.Length > 0 ? separator + str
+                                              : str;
+            }
+            if (current.Length > 0)
+            {
+                yield return current;
+            }
+        }
+
+        private static long STAT_ARG_MAX => sysconf(_SC_ARG_MAX)
+                                            - POSIX_HEADROOM
+                                            - "-c %d %i %h ".Length;
+
+        /// <summary>
+        /// xargs says POSIX requires 2048 bytes of headroom for environment variables.
+        /// </summary>
+        private const long POSIX_HEADROOM = 2048;
+
+        /// <summary>
+        /// POSIX defines this as a C enum without a specific value,
+        /// so of course it is different on every platform.
+        /// </summary>
+        private static readonly int _SC_ARG_MAX = Platform.IsMac ? 1 : 0;
+
+        [DllImport("libc")]
+        private static extern long sysconf(int name);
+
+
+        private const uint BackupSemantics = 0x02000000u;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern SafeFileHandle CreateFile([MarshalAs(UnmanagedType.LPTStr)] string    filename,
+                                                        [MarshalAs(UnmanagedType.U4)]     uint      access,
+                                                        [MarshalAs(UnmanagedType.U4)]     FileShare share,
+                                                        IntPtr securityAttributes,
+                                                        [MarshalAs(UnmanagedType.U4)]     FileMode  creationDisposition,
+                                                        [MarshalAs(UnmanagedType.U4)]     uint      flagsAndAttributes,
+                                                        IntPtr templateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool GetFileInformationByHandle(SafeFileHandle                 hFile,
+                                                              out BY_HANDLE_FILE_INFORMATION FileInformation);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        private struct BY_HANDLE_FILE_INFORMATION
+        {
+            public uint     FileAttributes;
+            public FILETIME CreationTime;
+            public FILETIME LastAccessTime;
+            public FILETIME LastWriteTime;
+            public uint     VolumeSerialNumber;
+            public uint     FileSizeHigh;
+            public uint     FileSizeLow;
+            public uint     NumberOfLinks;
+            public uint     FileIndexHigh;
+            public uint     FileIndexLow;
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(HardLink));
+    }
+}

--- a/Core/IO/InstalledFilesDeduplicator.cs
+++ b/Core/IO/InstalledFilesDeduplicator.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+
+using ChinhDo.Transactions.FileManager;
+using log4net;
+
+using CKAN.Versioning;
+using CKAN.Extensions;
+
+namespace CKAN.IO
+{
+    // This type represents the mapping of installed files across multiple game instances.
+    // We use it to simplify the type of InstalledWhere, since the outer dictionary is grouped by volume.
+    using NestedDict = Dictionary<(string identifier, ModuleVersion version),
+                                  (GameInstance instance, InstalledModule instMod)[]>;
+
+    /// <summary>
+    /// Provides services for deduplicating installed files across multiple game instances.
+    /// </summary>
+    public class InstalledFilesDeduplicator
+    {
+        /// <summary>
+        /// Creates a new instance of the InstalledFilesDeduplicator class.
+        /// This constructor is used when no destination instance is specified,
+        /// which is intended for deduplicating files across all instances.
+        /// </summary>
+        /// <param name="instances">Full list of instances that might already have the files we need</param>
+        /// <param name="repoData">RepositoryDataManager needed to instantiate registries</param>
+        public InstalledFilesDeduplicator(IEnumerable<GameInstance> instances,
+                                          RepositoryDataManager     repoData)
+        {
+            log.DebugFormat("Checking for duplicate installed files from {0}...",
+                            string.Join(", ", instances.Select(inst => inst.Name)));
+            InstalledWhere = instances.Where(inst => Directory.Exists(inst.GameDir()))
+                                      .ZipBy(goodInsts => HardLink.GetDeviceIdentifiers(goodInsts.Select(inst => inst.GameDir())))
+                                      .GroupBy(tuple => tuple.Second ?? 0UL,
+                                               tuple => tuple.First)
+                                      .ToDictionary(grp => grp.Key,
+                                                    grp => GetInstalledDict(repoData, grp));
+            log.Debug("Done checking for duplicate installed files.");
+        }
+
+        /// <summary>
+        /// Get single dictionary of all installed modules grouped by (identifier, version)
+        /// and containing the instances where they are installed.
+        /// </summary>/param>
+        /// <param name="repoData">RepositoryDataManager needed to instantiate registries</param>
+        /// <param name="instances">Sequence of instances that share a volume</param>
+        /// <returns>Dictionary representing this group's installed files, grouped by mod</returns>
+        private static NestedDict GetInstalledDict(RepositoryDataManager     repoData,
+                                                   IEnumerable<GameInstance> instances)
+            => instances.SelectMany(inst => RegistryManager.ReadOnlyRegistry(inst, repoData)
+                                                           ?.InstalledModules
+                                                            .Select(im => (instance: inst, instMod: im))
+                                                           ?? Enumerable.Empty<(GameInstance instance, InstalledModule instMod)>())
+                        .GroupBy(tuple => (tuple.instMod.identifier,
+                                           tuple.instMod.Module.version),
+                                 tuple => (tuple.instance,
+                                           tuple.instMod))
+                        .ToDictionary(grp => grp.Key,
+                                      grp => grp.ToArray());
+
+        /// <summary>
+        /// Creates a new instance of the InstalledFilesDeduplicator class.
+        /// This constructor is used when the destination instance is specified,
+        /// which is intended for installing new files.
+        /// </summary>
+        /// <param name="destinationInstance">The instance where we want to deduplicate files</param>
+        /// <param name="instances">Full list of instances that might already have the files we need</param>
+        /// <param name="repoData">RepositoryDataManager needed to instantiate registries</param>
+        public InstalledFilesDeduplicator(GameInstance              destinationInstance,
+                                          IEnumerable<GameInstance> instances,
+                                          RepositoryDataManager     repoData)
+            : this(HardLink.GetDeviceIdentifiers(instances.Prepend(destinationInstance)
+                                                          .Select(inst => inst.GameDir())).ToArray()
+                   is ulong?[] devIds
+                       ? instances.Zip(devIds.Skip(1))
+                                  .Where(tuple => tuple.First != destinationInstance
+                                                  && tuple.Second == devIds[0])
+                                  .Select(tuple => tuple.First)
+                                  .Where(inst => inst.game == destinationInstance.game)
+                       : Enumerable.Empty<GameInstance>(),
+                   repoData)
+        {
+        }
+
+        /// <summary>
+        /// Returns a dictionary of all installed files for a given module, from all instances, grouped by file name.
+        /// Only files larger than 128 KiB are included.
+        /// The dictionary contains the relative path as the key and an array of absolute paths as the value.
+        /// </summary>
+        /// <param name="identifier">Identifier of the module</param>
+        /// <param name="version">Version of the module</param>
+        /// <returns>Mapping from relative path to array of absolute paths</returns>
+        public Dictionary<string, string[]> ModuleCandidateDuplicates(string        identifier,
+                                                                      ModuleVersion version)
+            => InstalledWhere.Values
+                             .SelectMany(dict => (dict.TryGetValue((identifier, version),
+                                                                   out (GameInstance instance, InstalledModule instMod)[]? sources)
+                                                     ? sources.SelectMany(DupEntries)
+                                                     : Enumerable.Empty<(string relPath, string absPath)>()))
+                             .GroupBy(tuple => tuple.relPath,
+                                      tuple => tuple.absPath)
+                             .ToDictionary(grp => grp.Key,
+                                           grp => grp.ToArray());
+
+        /// <summary>
+        /// Reduces the disk space used by all game instances
+        /// by replacing duplicate installed files with hard links.
+        /// Only files larger than 128 KiB are considered for deduplication.
+        /// The method will prompt the user for confirmation before proceeding.
+        /// </summary>
+        /// <param name="user">Handler for messaging and interaction</param>
+        public void DeduplicateAll(IUser user)
+        {
+            log.Debug("Grouping duplicate installed files...");
+            var fileGroups = InstalledWhere.Values
+                                           .SelectMany(dict => dict.Values
+                                                                   .Where(dups => dups.Length > 1)
+                                                                   .SelectMany(GetDuplicateGroups))
+                                           .ToArray();
+            log.DebugFormat("Got {0} duplicate installed file groups...", fileGroups.Length);
+            if (fileGroups.Length > 0)
+            {
+                var dupCount  = fileGroups.Sum(grp => grp.Count() - 1);
+                var dupSize   = fileGroups.Sum(grp => grp.Skip(1)
+                                                         .Sum(absPath => new FileInfo(absPath).Length));
+                int doneCount = 0;
+                if (log.IsDebugEnabled)
+                {
+                    log.DebugFormat("Found duplicate installed files:");
+                    log.DebugFormat("{0}", string.Join(Environment.NewLine,
+                                                       fileGroups.SelectMany(grp => grp)));
+                }
+                if (user.RaiseYesNoDialog(string.Format(Properties.Resources.FoundDuplicatesConfirmation,
+                                                        dupCount)))
+                {
+                    log.DebugFormat("Deduplicating all...");
+                    using (var tx = CkanTransaction.CreateTransactionScope())
+                    {
+                        var file_transaction = new TxFileManager();
+                        foreach (var grp in fileGroups)
+                        {
+                            var target = grp.First();
+                            foreach (var linkPath in grp.Skip(1))
+                            {
+                                file_transaction.Delete(linkPath);
+                                // If this fails (e.g., if the files are on different volumes), it throws,
+                                // the transaction is aborted, and all changes are reverted.
+                                HardLink.Create(target, linkPath);
+                                ++doneCount;
+                            }
+                            user.RaiseProgress(string.Format(Properties.Resources.DeduplicatedRelPath,
+                                                             grp.Count() - 1,
+                                                             Platform.FormatPath(grp.Key)),
+                                               100 * doneCount / dupCount);
+                        }
+                    }
+                    user.RaiseMessage(Properties.Resources.DoneDeduplicatingFiles,
+                                      CkanModule.FmtSize(dupSize));
+                }
+                else
+                {
+                    throw new CancelledActionKraken();
+                }
+            }
+            else
+            {
+                user.RaiseMessage(Properties.Resources.NoDuplicatesFound);
+            }
+        }
+
+        private static IEnumerable<IGrouping<string, string>> GetDuplicateGroups((GameInstance instance, InstalledModule instMod)[] tuples)
+            => tuples.SelectMany(DupEntries)
+                     .ZipBy(tuples => HardLink.GetFileIdentifiers(tuples.Select(tuple => tuple.absPath)))
+                     .DistinctBy(tuple => tuple.Second)
+                     .Select(tuple => tuple.First)
+                     .ZipBy(tuples => HardLink.GetLinkCounts(tuples.Select(tuple => tuple.absPath)))
+                     .OrderByDescending(tuple => tuple.Second)
+                     .Select(tuple => tuple.First)
+                     .GroupBy(tuple => tuple.relPath,
+                              tuple => tuple.absPath)
+                     .Where(grp => grp.Count() > 1);
+
+        public static void CreateOrCopy(FileInfo      target,
+                                        string        linkPath,
+                                        TxFileManager file_transaction)
+        {
+            if (target.Length >= MinDedupFileSize)
+            {
+                // If >=128KiB, try making a hard link, then fall back to copying if it fails
+                log.DebugFormat("Creating a hard link from {0} to {1}...", target, linkPath);
+                HardLink.CreateOrCopy(target.FullName, linkPath, file_transaction);
+            }
+            else
+            {
+                // If <128KiB, just copy the file
+                log.DebugFormat("Copying from {0} to {1}...", target, linkPath);
+                file_transaction.Copy(target.FullName, linkPath, false);
+            }
+        }
+
+        /// <summary>
+        /// Minimum file size for deduplication.
+        /// Files smaller than this are not considered for deduplication.
+        /// The idea is that deduplicating is most effective for larger files,
+        /// and smaller files are more likely to be edited by the user after installation.
+        /// </summary>
+        private const long MinDedupFileSize = 128 * 1024;
+
+        /// <summary>
+        /// Returns sequence of tuples containing the relative path and absolute path of files installed
+        /// for an instance and module.
+        /// Intended for other code to check for duplicates.
+        /// </summary>
+        /// <param name="instance">Game instance for getting absolute paths</param>
+        /// <param name="instMod">Instaleld module to check for duplicate installed files</param>
+        /// <returns>Sequence of relpath, abspath pairs</returns>
+        private static IEnumerable<(string relPath, string absPath)> DupEntries(GameInstance instance, InstalledModule instMod)
+            => instMod.Files.Select(relPath => (relPath,
+                                                absPath: instance.ToAbsoluteGameDir(relPath)))
+                            .Where(tuple => File.Exists(tuple.absPath)
+                                            && new FileInfo(tuple.absPath).Length >= MinDedupFileSize);
+
+        /// <summary>
+        /// Same as above but accepts a tuple.
+        /// </summary>
+        /// <param name="tuple">Game instance and installed module</param>
+        /// <returns>Sequence of relpath, abspath pairs</returns>
+        private static IEnumerable<(string relPath, string absPath)> DupEntries((GameInstance instance, InstalledModule instMod) tuple)
+            => DupEntries(tuple.instance, tuple.instMod);
+
+        /// <summary>
+        /// All installed modules for all instances, grouped by volume, then by (identifier, version).
+        /// The value is an array of tuples containing the instance and the installed module.
+        /// </summary>
+        private readonly Dictionary<ulong, NestedDict> InstalledWhere;
+
+        private static readonly ILog log = LogManager.GetLogger(typeof(InstalledFilesDeduplicator));
+    }
+}

--- a/Core/IO/ModuleImporter.cs
+++ b/Core/IO/ModuleImporter.cs
@@ -13,7 +13,7 @@ using CKAN.Versioning;
 using CKAN.Avc;
 using CKAN.SpaceWarp;
 
-namespace CKAN
+namespace CKAN.IO
 {
     public static class ModuleImporter
     {

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -130,6 +130,7 @@ namespace CKAN.IO
                                 RelationshipResolverOptions options,
                                 RegistryManager             registry_manager,
                                 ref HashSet<string>?        possibleConfigOnlyDirs,
+                                InstalledFilesDeduplicator? deduper       = null,
                                 string?                     userAgent     = null,
                                 IDownloader?                downloader    = null,
                                 bool                        ConfirmPrompt = true)
@@ -210,6 +211,7 @@ namespace CKAN.IO
                                                  Properties.Resources.NotEnoughSpaceToInstall);
                     Install(mod, resolver.IsAutoInstalled(mod),
                             registry_manager.registry,
+                            deduper?.ModuleCandidateDuplicates(mod.identifier, mod.version),
                             ref possibleConfigOnlyDirs,
                             new ProgressImmediate<long>(bytes =>
                             {
@@ -307,11 +309,12 @@ namespace CKAN.IO
         ///
         /// TODO: The name of this and InstallModule() need to be made more distinctive.
         /// </summary>
-        private void Install(CkanModule           module,
-                             bool                 autoInstalled,
-                             Registry             registry,
-                             ref HashSet<string>? possibleConfigOnlyDirs,
-                             IProgress<long>?     progress)
+        private void Install(CkanModule                    module,
+                             bool                          autoInstalled,
+                             Registry                      registry,
+                             Dictionary<string, string[]>? candidateDuplicates,
+                             ref HashSet<string>?          possibleConfigOnlyDirs,
+                             IProgress<long>?              progress)
         {
             CheckKindInstallationKraken(module);
             var version = registry.InstalledVersion(module.identifier);
@@ -345,7 +348,7 @@ namespace CKAN.IO
             using (var transaction = CkanTransaction.CreateTransactionScope())
             {
                 // Install all the things!
-                var files = InstallModule(module, filename, registry,
+                var files = InstallModule(module, filename, registry, candidateDuplicates,
                                           ref possibleConfigOnlyDirs, progress);
 
                 // Register our module and its files.
@@ -385,11 +388,12 @@ namespace CKAN.IO
         /// Propagates a CancelledActionKraken if the user decides not to overwite unowned files.
         /// Propagates a FileExistsKraken if we were going to overwrite a file.
         /// </summary>
-        private List<string> InstallModule(CkanModule           module,
-                                           string?              zip_filename,
-                                           Registry             registry,
-                                           ref HashSet<string>? possibleConfigOnlyDirs,
-                                           IProgress<long>?     moduleProgress)
+        private List<string> InstallModule(CkanModule                    module,
+                                           string?                       zip_filename,
+                                           Registry                      registry,
+                                           Dictionary<string, string[]>? candidateDuplicates,
+                                           ref HashSet<string>?          possibleConfigOnlyDirs,
+                                           IProgress<long>?              moduleProgress)
         {
             var createdPaths = new List<string>();
             if (module.IsMetapackage || zip_filename == null)
@@ -474,8 +478,13 @@ namespace CKAN.IO
                             throw new CancelledActionKraken();
                         }
                         log.DebugFormat("Copying {0}", file.source.Name);
-                        var path = CopyZipEntry(zipfile, file.source, file.destination, file.makedir,
-                                                fileProgress);
+                        var path = InstallFile(zipfile, file.source, file.destination, file.makedir,
+                                               (candidateDuplicates != null
+                                                && candidateDuplicates.TryGetValue(instance.ToRelativeGameDir(file.destination),
+                                                                                 out string[]? duplicates))
+                                                   ? duplicates
+                                                   : Array.Empty<string>(),
+                                               fileProgress);
                         installedBytes += file.source.Size;
                         if (path != null)
                         {
@@ -727,11 +736,12 @@ namespace CKAN.IO
         /// Path of file or directory that was created.
         /// May differ from the input fullPath!
         /// </returns>
-        internal static string? CopyZipEntry(ZipFile          zipfile,
-                                             ZipEntry         entry,
-                                             string           fullPath,
-                                             bool             makeDirs,
-                                             IProgress<long>? progress)
+        internal static string? InstallFile(ZipFile          zipfile,
+                                            ZipEntry         entry,
+                                            string           fullPath,
+                                            bool             makeDirs,
+                                            string[]         candidateDuplicates,
+                                            IProgress<long>? progress)
         {
             var file_transaction = new TxFileManager();
 
@@ -774,6 +784,20 @@ namespace CKAN.IO
                 // overwite files, as it ensures deletion on rollback.
                 file_transaction.Snapshot(fullPath);
 
+                // Try making hard links if already installed in another instance (faster, less space)
+                foreach (var installedSource in candidateDuplicates)
+                {
+                    try
+                    {
+                        HardLink.Create(installedSource, fullPath);
+                        return fullPath;
+                    }
+                    catch
+                    {
+                        // If hard link creation fails, try more hard links, or copy if none work
+                    }
+                }
+
                 try
                 {
                     // It's a file! Prepare the streams
@@ -792,7 +816,7 @@ namespace CKAN.IO
                                              progress?.Report(e.Processed);
                                          },
                                          UnzipProgressInterval,
-                                         entry, "CopyZipEntry");
+                                         entry, "InstallFile");
                     }
                 }
                 catch (DirectoryNotFoundException ex)
@@ -1219,6 +1243,7 @@ namespace CKAN.IO
         /// <param name="autoInstalled">true or false for each item in `add`</param>
         /// <param name="remove">Modules to remove</param>
         /// <param name="downloader">Downloader to use</param>
+        /// <param name="deduper">Deduplicator to use</param>
         /// <param name="enforceConsistency">Whether to enforce consistency</param>
         private void AddRemove(ref HashSet<string>?          possibleConfigOnlyDirs,
                                RegistryManager               registry_manager,
@@ -1227,7 +1252,8 @@ namespace CKAN.IO
                                IDictionary<CkanModule, bool> autoInstalled,
                                ICollection<InstalledModule>  remove,
                                IDownloader                   downloader,
-                               bool                          enforceConsistency)
+                               bool                          enforceConsistency,
+                               InstalledFilesDeduplicator?   deduper = null)
         {
             using (var tx = CkanTransaction.CreateTransactionScope())
             {
@@ -1293,6 +1319,7 @@ namespace CKAN.IO
                                   ?.AutoInstalled
                                   ?? autoInstalled[mod],
                             registry_manager.registry,
+                            deduper?.ModuleCandidateDuplicates(mod.identifier, mod.version),
                             ref possibleConfigOnlyDirs,
                             new ProgressImmediate<long>(bytes =>
                             {
@@ -1319,12 +1346,13 @@ namespace CKAN.IO
         /// Will *re-install* or *downgrade* (with a warning) as well as upgrade.
         /// Throws ModuleNotFoundKraken if a module is not installed.
         /// </summary>
-        public void Upgrade(ICollection<CkanModule> modules,
-                            IDownloader             downloader,
-                            ref HashSet<string>?    possibleConfigOnlyDirs,
-                            RegistryManager         registry_manager,
-                            bool                    enforceConsistency   = true,
-                            bool                    ConfirmPrompt        = true)
+        public void Upgrade(ICollection<CkanModule>     modules,
+                            IDownloader                 downloader,
+                            ref HashSet<string>?        possibleConfigOnlyDirs,
+                            RegistryManager             registry_manager,
+                            InstalledFilesDeduplicator? deduper            = null,
+                            bool                        enforceConsistency = true,
+                            bool                        ConfirmPrompt      = true)
         {
             var registry = registry_manager.registry;
 
@@ -1455,7 +1483,8 @@ namespace CKAN.IO
                       autoInstalled,
                       to_remove,
                       downloader,
-                      enforceConsistency);
+                      enforceConsistency,
+                      deduper);
             User.RaiseProgress(Properties.Resources.ModuleInstallerDone, 100);
         }
 
@@ -1470,6 +1499,7 @@ namespace CKAN.IO
                             IDownloader                    downloader,
                             ref HashSet<string>?           possibleConfigOnlyDirs,
                             RegistryManager                registry_manager,
+                            InstalledFilesDeduplicator?    deduper = null,
                             bool                           enforceConsistency = true)
         {
             replacements = replacements.Memoize();
@@ -1554,7 +1584,8 @@ namespace CKAN.IO
                       resolvedModsToInstall.ToDictionary(m => m, m => false),
                       modsToRemove,
                       downloader,
-                      enforceConsistency);
+                      enforceConsistency,
+                      deduper);
             User.RaiseProgress(Properties.Resources.ModuleInstallerDone, 100);
         }
 

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
@@ -14,9 +15,8 @@ using CKAN.Extensions;
 using CKAN.Versioning;
 using CKAN.Configuration;
 using CKAN.Games;
-using System.Threading;
 
-namespace CKAN
+namespace CKAN.IO
 {
     public struct InstallableFile
     {

--- a/Core/IO/SteamLibrary.cs
+++ b/Core/IO/SteamLibrary.cs
@@ -3,12 +3,13 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
+
 using log4net;
 using ValveKeyValue;
 
 using CKAN.Extensions;
 
-namespace CKAN
+namespace CKAN.IO
 {
     public class SteamLibrary
     {

--- a/Core/ModuleInstaller.cs
+++ b/Core/ModuleInstaller.cs
@@ -1719,45 +1719,5 @@ namespace CKAN
                 Cache.EnforceSizeLimit(winReg.CacheSizeLimit.Value, registry);
             }
         }
-
-        /// <summary>
-        /// Remove prepending v V. Version_ etc
-        /// </summary>
-        public static string StripV(string version)
-            => Regex.Match(version, @"^(?<num>\d\:)?[vV]+(ersion)?[_.]*(?<ver>\d.*)$") is Match match
-               && match.Success
-                   ? match.Groups["num"].Value + match.Groups["ver"].Value
-                   : version;
-
-        /// <summary>
-        /// Returns a version string shorn of any leading epoch as delimited by a single colon
-        /// </summary>
-        /// <param name="version">A version that might contain an epoch</param>
-        public static string StripEpoch(ModuleVersion version)
-            => StripEpoch(version.ToString());
-
-        /// <summary>
-        /// Returns a version string shorn of any leading epoch as delimited by a single colon
-        /// </summary>
-        /// <param name="version">A version string that might contain an epoch</param>
-        public static string StripEpoch(string version)
-            // If our version number starts with a string of digits, followed by
-            // a colon, and then has no more colons, we're probably safe to assume
-            // the first string of digits is an epoch
-            => epochMatch.IsMatch(version)
-                ? epochReplace.Replace(version, @"$2")
-                : version;
-
-        /// <summary>
-        /// As above, but includes the original in parentheses
-        /// </summary>
-        /// <param name="version">A version string that might contain an epoch</param>
-        public static string WithAndWithoutEpoch(string version)
-            => epochMatch.IsMatch(version)
-                ? $"{epochReplace.Replace(version, @"$2")} ({version})"
-                : version;
-
-        private static readonly Regex epochMatch   = new Regex(@"^[0-9][0-9]*:[^:]+$", RegexOptions.Compiled);
-        private static readonly Regex epochReplace = new Regex(@"^([^:]+):([^:]+)$",   RegexOptions.Compiled);
     }
 }

--- a/Core/Net/NetAsyncDownloader.DownloadPart.cs
+++ b/Core/Net/NetAsyncDownloader.DownloadPart.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Security.Cryptography;
 
 using Autofac;
@@ -43,7 +44,7 @@ namespace CKAN
                 triedDownloads = 0;
             }
 
-            public void Download()
+            public void Download(CancellationToken? cancelToken = default)
             {
                 var url = CurrentUri;
                 ResetAgent();
@@ -63,7 +64,8 @@ namespace CKAN
                     {
                         Progress?.Invoke(this, 0, size);
                     }
-                    target.DownloadWith(agent, url, hasher);
+                    target.DownloadWith(agent, url, hasher,
+                                        cancelToken);
                 }
             }
 

--- a/Core/Net/NetAsyncDownloader.DownloadTarget.cs
+++ b/Core/Net/NetAsyncDownloader.DownloadTarget.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Threading;
 using System.Security.Cryptography;
 
 namespace CKAN
@@ -24,7 +25,8 @@ namespace CKAN
 
             public abstract long CalculateSize();
             public abstract void DownloadWith(ResumingWebClient wc, Uri url,
-                                              HashAlgorithm? hasher);
+                                              HashAlgorithm? hasher,
+                                              CancellationToken? cancelToken = default);
 
             public override string ToString() => string.Join(", ", urls);
         }
@@ -57,9 +59,10 @@ namespace CKAN
             }
 
             public override void DownloadWith(ResumingWebClient wc, Uri url,
-                                              HashAlgorithm? hasher)
+                                              HashAlgorithm? hasher,
+                                              CancellationToken? cancelToken = default)
             {
-                wc.DownloadFileAsyncWithResume(url, filename, hasher);
+                wc.DownloadFileAsyncWithResume(url, filename, size, hasher, cancelToken);
             }
 
             public override string ToString() => $"{base.ToString()} => {filename}";
@@ -91,7 +94,8 @@ namespace CKAN
             }
 
             public override void DownloadWith(ResumingWebClient wc, Uri url,
-                                              HashAlgorithm? hasher)
+                                              HashAlgorithm? hasher,
+                                              CancellationToken? cancelToken = default)
             {
                 wc.DownloadFileAsyncWithResume(url, contents, hasher);
             }

--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -237,7 +237,7 @@ namespace CKAN
                                   dl.CurrentUri.ToString().Replace(" ", "%20"));
 
                 // Start the download!
-                dl.Download();
+                dl.Download(cancelToken);
             }
         }
 

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -14,6 +14,7 @@ using System.Security.Permissions;
 using log4net;
 using ChinhDo.Transactions.FileManager;
 
+using CKAN.IO;
 using CKAN.Extensions;
 using CKAN.Versioning;
 

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 
 using ICSharpCode.SharpZipLib.Zip;
 
+using CKAN.IO;
+
 namespace CKAN
 {
     /// <summary>

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -189,7 +189,7 @@ namespace CKAN
                 cancelToken?.ThrowIfCancellationRequested();
 
                 // Check valid CRC
-                if (!ZipValid(path, out string invalidReason, progress))
+                if (!ZipValid(path, out string invalidReason, progress, cancelToken))
                 {
                     throw new InvalidModuleFileKraken(
                         module, path,
@@ -220,12 +220,14 @@ namespace CKAN
         /// <param name="filename">Path to zip file to check</param>
         /// <param name="invalidReason">Description of problem with the file</param>
         /// <param name="progress">Callback to notify as we traverse the input, called with percentages from 0 to 100</param>
+        /// <param name="cancelToken">Cancellation token to cancel the operation</param>
         /// <returns>
         /// True if valid, false otherwise. See invalidReason param for explanation.
         /// </returns>
-        public static bool ZipValid(string           filename,
-                                    out string       invalidReason,
-                                    IProgress<long>? progress)
+        public static bool ZipValid(string             filename,
+                                    out string         invalidReason,
+                                    IProgress<long>?   progress,
+                                    CancellationToken? cancelToken = default)
         {
             try
             {
@@ -242,6 +244,7 @@ namespace CKAN
                         if (zip.TestArchive(true, TestStrategy.FindFirstError,
                             (st, msg) =>
                             {
+                                cancelToken?.ThrowIfCancellationRequested();
                                 // This delegate is called as TestArchive proceeds through its
                                 // steps, both routine and abnormal.
                                 // The second parameter is non-null if an error occurred.

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -348,4 +348,8 @@ Free up space on that device or change your settings to use another location.
   <data name="ReleaseStatusTestingDescription" xml:space="preserve"><value>Pre-releases for adventurous users</value></data>
   <data name="ReleaseStatusDevelopmentName" xml:space="preserve"><value>Development</value></data>
   <data name="ReleaseStatusDevelopmentDescription" xml:space="preserve"><value>Bleeding edge unstable</value></data>
+  <data name="FoundDuplicatesConfirmation" xml:space="preserve"><value>Found {0} duplicate installed files. De-duplicate?</value></data>
+  <data name="DeduplicatedRelPath" xml:space="preserve"><value>Deduplicated {0} copies of {1}</value></data>
+  <data name="DoneDeduplicatingFiles" xml:space="preserve"><value>Deduplication complete. Space saved: {0}</value></data>
+  <data name="NoDuplicatesFound" xml:space="preserve"><value>No duplicate installed files found.</value></data>
 </root>

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 
+using CKAN.IO;
 using Newtonsoft.Json;
 
 namespace CKAN

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -11,6 +11,7 @@ using Autofac;
 using Newtonsoft.Json;
 using log4net;
 
+using CKAN.IO;
 using CKAN.Configuration;
 using CKAN.Extensions;
 using CKAN.Versioning;

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1097,6 +1097,10 @@ namespace CKAN
                 ? InstalledModule(fileOwner)
                 : null;
 
+        public IEnumerable<(string relPath, InstalledModule owner)> InstalledFileInfo()
+            => installed_files.Select(kvp => (kvp.Key, InstalledModule(kvp.Value)))
+                              .OfType<(string, InstalledModule)>();
+
         /// <summary>
         /// <see cref="IRegistryQuerier.CheckSanity"/>
         /// </summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -799,7 +799,6 @@ namespace CKAN
                                                             ICollection<CkanModule>? toInstall    = null)
             => ((providers ?? BuildProvidesIndex())
                     is Dictionary<string, AvailableModule[]> allProvs
-                && Repositories.Values.ToArray() is Repository[] repos
                 && allProvs.TryGetValue(identifier, out AvailableModule[]? provs)
                     // For each AvailableModule, we want the latest one matching our constraints
                     ? provs.Select(am => am.Latest(stabilityTolerance, gameVersion, relationship, installed, toInstall))
@@ -807,7 +806,7 @@ namespace CKAN
                            .Where(m => m.ProvidesList.Contains(identifier))
                            .Distinct()
                            // Put the most popular one on top
-                           .OrderByDescending(m => repoDataMgr?.GetDownloadCount(repos, m.identifier)
+                           .OrderByDescending(m => repoDataMgr?.GetDownloadCount(Repositories.Values, m.identifier)
                                                               ?? 0)
                     // Nothing provides this
                     : Enumerable.Empty<CkanModule>())

--- a/Core/Registry/Tags/ModuleTagList.cs
+++ b/Core/Registry/Tags/ModuleTagList.cs
@@ -2,6 +2,8 @@ using System.IO;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
+using CKAN.IO;
+
 namespace CKAN
 {
     public class ModuleTagList

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -14,6 +14,7 @@ using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
 using log4net;
 
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.Games;
 

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using ChinhDo.Transactions.FileManager;
 using log4net;
 
+using CKAN.IO;
 using CKAN.Extensions;
 using CKAN.Games;
 

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json;
 
+using CKAN.IO;
 using CKAN.Games;
 
 [assembly: InternalsVisibleTo("CKAN.Tests")]

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -107,7 +107,9 @@ namespace CKAN
                     continue;
                 }
 
-                file_transaction.Copy(file.FullName, Path.Combine(destDirPath, file.Name), false);
+                InstalledFilesDeduplicator.CreateOrCopy(file,
+                                                        Path.Combine(destDirPath, file.Name),
+                                                        file_transaction);
             }
 
             // Create all first level subdirectories

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using ChinhDo.Transactions.FileManager;
 using log4net;
 
+using CKAN.IO;
+
 namespace CKAN
 {
     public static class Utilities

--- a/Core/Versioning/VersionFormat.cs
+++ b/Core/Versioning/VersionFormat.cs
@@ -1,4 +1,4 @@
-namespace CKAN
+namespace CKAN.Versioning
 {
     public enum VersionFormat
     {

--- a/GUI/Controls/DeleteDirectories.cs
+++ b/GUI/Controls/DeleteDirectories.cs
@@ -9,6 +9,7 @@ using System.Runtime.Versioning;
 #endif
 using System.Diagnostics.CodeAnalysis;
 
+using CKAN.IO;
 using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -94,7 +94,7 @@ namespace CKAN.GUI
         public event Action<string>?  RaiseError;
         public event Action<string>?  SetStatusBar;
         public event Action?          ClearStatusBar;
-        public event Action<string?>? LaunchGame;
+        public event Action<string>?  LaunchGame;
         public event Action?          EditCommandLines;
 
         public readonly ModList mainModList;
@@ -634,14 +634,15 @@ namespace CKAN.GUI
 
         private void LaunchGameToolStripMenuItem_Click(object? sender, EventArgs? e)
         {
-            if (sender is ToolStripMenuItem menuItem)
+            if (sender is ToolStripMenuItem menuItem
+                && (menuItem.Tag as string
+                    ?? guiConfig?.CommandLines.First()) is string cmd)
             {
-                if (menuItem.Tag is string cmd
-                    && !SteamLibrary.IsSteamCmdLine(cmd))
+                if (!SteamLibrary.IsSteamCmdLine(cmd))
                 {
                     SetPlayButtonActiveInactive(true);
                 }
-                LaunchGame?.Invoke(menuItem.Tag as string);
+                LaunchGame?.Invoke(cmd);
             }
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -11,6 +11,7 @@ using System.Runtime.Versioning;
 using Autofac;
 using log4net;
 
+using CKAN.IO;
 using CKAN.Extensions;
 using CKAN.GUI.Attributes;
 

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -11,6 +11,7 @@ using System.Runtime.Versioning;
 
 using Autofac;
 
+using CKAN.IO;
 using CKAN.Configuration;
 using CKAN.GUI.Attributes;
 

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -13,6 +13,7 @@ using System.Runtime.Versioning;
 
 using Autofac;
 
+using CKAN.IO;
 using CKAN.Games;
 using CKAN.Extensions;
 using CKAN.Versioning;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -229,6 +229,8 @@ namespace CKAN.GUI
             {
                 MoveCacheProgressBar.Visible = true;
                 MoveCacheProgressBar.Value = percent;
+                MoveCacheProgressBar.Text = string.Format(Properties.Resources.SettingsDialogCacheProgress,
+                                                          percent);
             });
         }
 

--- a/GUI/Extensions/WinFormsExtensions.cs
+++ b/GUI/Extensions/WinFormsExtensions.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using System.Windows.Forms;
+
+namespace CKAN.GUI
+{
+    public static class WinFormsExtensions
+    {
+        /// <summary>
+        /// GetControlFromPosition returns null if Control.Visible == false.
+        /// This doesn't.
+        /// </summary>
+        /// <param name="panel">The table to inspect</param>
+        /// <param name="column">The column of the control to retrieve</param>
+        /// <param name="row">the row of the control to retrieve</param>
+        /// <returns>The control at the given cell of the table</returns>
+        public static Control? GetControlFromPositionEvenIfInvisible(this TableLayoutPanel panel,
+                                                                     int                   column,
+                                                                     int                   row)
+            => panel.Controls.OfType<Control>()
+                             .FirstOrDefault(ctl => panel.GetPositionFromControl(ctl)
+                                                    is TableLayoutPanelCellPosition pos
+                                                    && pos.Column == column
+                                                    && pos.Row    == row);
+    }
+}

--- a/GUI/Labels/ModuleLabelList.cs
+++ b/GUI/Labels/ModuleLabelList.cs
@@ -7,6 +7,8 @@ using System.Runtime.Serialization;
 
 using Newtonsoft.Json;
 
+using CKAN.IO;
+
 namespace CKAN.GUI
 {
     [JsonObject(MemberSerialization.OptIn)]

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -40,6 +40,7 @@ namespace CKAN.GUI
             this.exportModPackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.importDownloadsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deduplicateToolstripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.auditRecommendationsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ExitToolButton = new System.Windows.Forms.ToolStripMenuItem();
@@ -153,6 +154,7 @@ namespace CKAN.GUI
             this.installationHistoryStripMenuItem,
             this.installFromckanToolStripMenuItem,
             this.importDownloadsToolStripMenuItem,
+            this.deduplicateToolstripMenuItem,
             this.toolStripSeparator2,
             this.exportModListToolStripMenuItem,
             this.exportModPackToolStripMenuItem,
@@ -218,6 +220,13 @@ namespace CKAN.GUI
             this.importDownloadsToolStripMenuItem.Size = new System.Drawing.Size(281, 30);
             this.importDownloadsToolStripMenuItem.Click += new System.EventHandler(this.importDownloadsToolStripMenuItem_Click);
             resources.ApplyResources(this.importDownloadsToolStripMenuItem, "importDownloadsToolStripMenuItem");
+            //
+            // deduplicateToolstripMenuItem
+            //
+            this.deduplicateToolstripMenuItem.Name = "deduplicateToolstripMenuItem";
+            this.deduplicateToolstripMenuItem.Size = new System.Drawing.Size(281, 30);
+            this.deduplicateToolstripMenuItem.Click += new System.EventHandler(this.deduplicateToolstripMenuItem_Click);
+            resources.ApplyResources(this.deduplicateToolstripMenuItem, "deduplicateToolstripMenuItem");
             //
             // toolStripSeparator3
             //
@@ -900,6 +909,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem exportModPackToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem importDownloadsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deduplicateToolstripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripMenuItem auditRecommendationsMenuItem;
         private System.Windows.Forms.ToolStripMenuItem ExitToolButton;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -14,6 +14,7 @@ using System.Runtime.Versioning;
 using log4net;
 using Autofac;
 
+using CKAN.IO;
 using CKAN.Extensions;
 using CKAN.Versioning;
 using CKAN.GUI.Attributes;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -1097,12 +1097,15 @@ namespace CKAN.GUI
 
         private void openGameToolStripMenuItem_Click(object? sender, EventArgs? e)
         {
-            LaunchGame();
+            if (configuration != null)
+            {
+                LaunchGame(configuration.CommandLines.First());
+            }
         }
 
-        private void LaunchGame(string? command = null)
+        private void LaunchGame(string command)
         {
-            if (CurrentInstance != null && configuration != null)
+            if (CurrentInstance != null)
             {
                 var registry = RegistryManager.Instance(CurrentInstance, repoData).registry;
                 var suppressedIdentifiers = CurrentInstance.GetSuppressedCompatWarningIdentifiers;
@@ -1135,7 +1138,7 @@ namespace CKAN.GUI
                     }
                 }
 
-                CurrentInstance.PlayGame(command ?? configuration.CommandLines.First(),
+                CurrentInstance.PlayGame(command,
                                          () =>
                                          {
                                              ManageMods.OnGameExit();

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -122,23 +122,34 @@
   </metadata>
   <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>&amp;File</value></data>
   <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>&amp;Manage game instances</value></data>
+  <data name="manageGameInstancesMenuItem.ToolTipText" xml:space="preserve"><value>Add, clone, or switch to other game instances</value></data>
   <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Open game directory</value></data>
   <data name="installationHistoryStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;history...</value></data>
+  <data name="installationHistoryStripMenuItem.ToolTipText" xml:space="preserve"><value>Browse history of which mods were installed in the past</value></data>
   <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Install from .ckan...</value></data>
+  <data name="installFromckanToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Choose a .ckan file containing metadata for a module and install it</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
+  <data name="importDownloadsToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Choose ZIP files downloaded outside of CKAN and put them in the cache for installation</value></data>
   <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list (cannot be re-imported)...</value></data>
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Export modpack (can be re-imported)...</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Audit &amp;recommendations</value></data>
+  <data name="auditRecommendationsMenuItem.ToolTipText" xml:space="preserve"><value>Review recommendations and suggestions of all installed mods</value></data>
   <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play &amp;time...</value></data>
+  <data name="viewPlayTimeStripMenuItem.ToolTipText" xml:space="preserve"><value>See and edit how long you've played each game instance</value></data>
   <data name="viewUnmanagedFilesStripMenuItem.Text" xml:space="preserve"><value>&amp;Unmanaged files...</value></data>
+  <data name="viewUnmanagedFilesStripMenuItem.ToolTipText" xml:space="preserve"><value>List files in this game instance that weren't installed by CKAN</value></data>
   <data name="ExitToolButton.Text" xml:space="preserve"><value>E&amp;xit</value></data>
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Settings</value></data>
   <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;settings</value></data>
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Game command lines</value></data>
+  <data name="GameCommandlineToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Configure how to run this game instance</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Compatible game versions</value></data>
+  <data name="compatibleGameVersionsToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Chose game versions to consider compatible for purposes of determining which mods are compatible</value></data>
   <data name="preferredHostsToolStripMenuItem.Text" xml:space="preserve"><value>Preferred &amp;hosts</value></data>
+  <data name="preferredHostsToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Configure the priority of download servers</value></data>
   <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;filters</value></data>
+  <data name="installFiltersToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Prevent some mod files from being installed</value></data>
   <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Plugins</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Help</value></data>
   <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;user guide</value></data>

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -130,6 +130,8 @@
   <data name="installFromckanToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Choose a .ckan file containing metadata for a module and install it</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
   <data name="importDownloadsToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Choose ZIP files downloaded outside of CKAN and put them in the cache for installation</value></data>
+  <data name="deduplicateToolstripMenuItem.Text" xml:space="preserve"><value>Deduplicate installed files...</value></data>
+  <data name="deduplicateToolstripMenuItem.ToolTipText" xml:space="preserve"><value>Scan installed files from all game instances and share the ones that can be shared</value></data>
   <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list (cannot be re-imported)...</value></data>
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Export modpack (can be re-imported)...</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -123,19 +123,23 @@
   <data name="fileToolStripMenuItem.Text" xml:space="preserve"><value>&amp;File</value></data>
   <data name="manageGameInstancesMenuItem.Text" xml:space="preserve"><value>&amp;Manage game instances</value></data>
   <data name="openGameDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Open game directory</value></data>
+  <data name="installationHistoryStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;history...</value></data>
   <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Install from .ckan...</value></data>
+  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
   <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list (cannot be re-imported)...</value></data>
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Export modpack (can be re-imported)...</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Audit &amp;recommendations</value></data>
+  <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play &amp;time...</value></data>
+  <data name="viewUnmanagedFilesStripMenuItem.Text" xml:space="preserve"><value>&amp;Unmanaged files...</value></data>
   <data name="ExitToolButton.Text" xml:space="preserve"><value>E&amp;xit</value></data>
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Settings</value></data>
   <data name="cKANSettingsToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;settings</value></data>
-  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Plugins</value></data>
-  <data name="preferredHostsToolStripMenuItem.Text" xml:space="preserve"><value>Preferred &amp;hosts</value></data>
-  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;filters</value></data>
   <data name="GameCommandlineToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Game command lines</value></data>
   <data name="compatibleGameVersionsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Compatible game versions</value></data>
+  <data name="preferredHostsToolStripMenuItem.Text" xml:space="preserve"><value>Preferred &amp;hosts</value></data>
+  <data name="installFiltersToolStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;filters</value></data>
+  <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Plugins</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Help</value></data>
   <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;user guide</value></data>
   <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;Discord</value></data>
@@ -143,6 +147,14 @@
   <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN &amp;client</value></data>
   <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod &amp;metadata</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>&amp;About</value></data>
+  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
+  <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Refresh</value></data>
+  <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Pause</value></data>
+  <data name="openCKANToolStripMenuItem.Text" xml:space="preserve"><value>Open CKAN</value></data>
+  <data name="openGameToolStripMenuItem.Text" xml:space="preserve"><value>Launch Game</value></data>
+  <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Open Game Directory</value></data>
+  <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Settings</value></data>
+  <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quit</value></data>
   <data name="ManageModsTabPage.Text" xml:space="preserve"><value>Manage Mods</value></data>
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Changeset</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Status Log</value></data>
@@ -153,15 +165,4 @@
   <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Edit Modpack</value></data>
   <data name="UnmanagedFilesTabPage.Text" xml:space="preserve"><value>Unmanaged Files</value></data>
   <data name="InstallationHistoryTabPage.Text" xml:space="preserve"><value>Installation History</value></data>
-  <data name="minimizeNotifyIcon.Text" xml:space="preserve"><value>CKAN</value></data>
-  <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Refresh</value></data>
-  <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Pause</value></data>
-  <data name="openCKANToolStripMenuItem.Text" xml:space="preserve"><value>Open CKAN</value></data>
-  <data name="openGameToolStripMenuItem.Text" xml:space="preserve"><value>Launch Game</value></data>
-  <data name="openGameDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>Open Game Directory</value></data>
-  <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Settings</value></data>
-  <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Quit</value></data>
-  <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play &amp;time...</value></data>
-  <data name="viewUnmanagedFilesStripMenuItem.Text" xml:space="preserve"><value>&amp;Unmanaged files...</value></data>
-  <data name="installationHistoryStripMenuItem.Text" xml:space="preserve"><value>Installation &amp;history...</value></data>
 </root>

--- a/GUI/Main/MainDeduplicate.cs
+++ b/GUI/Main/MainDeduplicate.cs
@@ -1,0 +1,46 @@
+using System;
+
+using CKAN.IO;
+
+namespace CKAN.GUI
+{
+    public partial class Main
+    {
+        private void deduplicateToolstripMenuItem_Click(object? sender, EventArgs? evt)
+        {
+            // Show WaitTabPage (status page) and lock it.
+            tabController.RenameTab(WaitTabPage.Name,
+                                    Properties.Resources.MainDeduplicateWaitTitle);
+            ShowWaitDialog();
+            DisableMainWindow();
+            Wait.StartWaiting(
+                (sender, e) =>
+                {
+                    if (e != null)
+                    {
+                        currentUser.RaiseMessage(Properties.Resources.MainDeduplicateScanning);
+                        var deduper = new InstalledFilesDeduplicator(Manager.Instances.Values,
+                                                                     repoData);
+                        deduper.DeduplicateAll(currentUser);
+                        e.Result = true;
+                    }
+                },
+                (sender, e) =>
+                {
+                    switch (e?.Error)
+                    {
+                        case CancelledActionKraken:
+                            HideWaitDialog();
+                            break;
+                        case Exception exc:
+                            currentUser.RaiseMessage("{0}", exc.Message);
+                            break;
+                    }
+                    Wait.Finish();
+                    EnableMainWindow();
+                },
+                false,
+                null);
+        }
+    }
+}

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Linq;
 
+using CKAN.IO;
+
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
 

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -11,6 +11,7 @@ using System.Runtime.Versioning;
 
 using Autofac;
 
+using CKAN.IO;
 using CKAN.Extensions;
 using CKAN.GUI.Attributes;
 using CKAN.Configuration;

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -214,6 +214,10 @@ namespace CKAN.GUI
                 downloader.DownloadProgress += OnModDownloading;
                 downloader.StoreProgress    += OnModValidating;
 
+                var deduper = new InstalledFilesDeduplicator(CurrentInstance,
+                                                             Manager.Instances.Values,
+                                                             repoData);
+
                 HashSet<string>? possibleConfigOnlyDirs = null;
 
                 // Treat whole changeset as atomic
@@ -235,12 +239,14 @@ namespace CKAN.GUI
                             }
                             if (!canceled && toInstall.Count > 0)
                             {
-                                installer.InstallList(toInstall, options, registry_manager, ref possibleConfigOnlyDirs, userAgent, downloader, false);
+                                installer.InstallList(toInstall, options, registry_manager, ref possibleConfigOnlyDirs,
+                                                      deduper, userAgent, downloader, false);
                                 toInstall.Clear();
                             }
                             if (!canceled && toUpgrade.Count > 0)
                             {
-                                installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager, true, false);
+                                installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager,
+                                                  deduper, true, false);
                                 toUpgrade.Clear();
                             }
                             if (canceled)

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -214,6 +214,10 @@ namespace CKAN.GUI
                 downloader.DownloadProgress += OnModDownloading;
                 downloader.StoreProgress    += OnModValidating;
 
+                if (Manager.Instances.Count > 1)
+                {
+                    currentUser.RaiseMessage(Properties.Resources.MainInstallDeduplicateScanning);
+                }
                 var deduper = new InstalledFilesDeduplicator(CurrentInstance,
                                                              Manager.Instances.Values,
                                                              repoData);

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using System.Threading.Tasks;
 using System.Linq;
 
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.GUI.Attributes;
 

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -429,18 +429,6 @@ namespace CKAN.GUI
 
         private const float selectionAlpha = 0.4f;
 
-        /// <summary>
-        /// Returns a version string shorn of any leading epoch as delimited by a single colon
-        /// </summary>
-        public string StripEpoch(string version)
-            // If our version number starts with a string of digits, followed by
-            // a colon, and then has no more colons, we're probably safe to assume
-            // the first string of digits is an epoch
-            => ContainsEpoch.IsMatch(version) ? RemoveEpoch.Replace(version, @"$2") : version;
-
-        private static readonly Regex ContainsEpoch = new Regex(@"^[0-9][0-9]*:[^:]+$", RegexOptions.Compiled);
-        private static readonly Regex RemoveEpoch   = new Regex(@"^([^:]+):([^:]+)$",   RegexOptions.Compiled);
-
         private static IEnumerable<ModChange> rowChanges(IRegistryQuerier    registry,
                                                          DataGridViewRow     row,
                                                          DataGridViewColumn? upgradeCol,

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -530,4 +530,7 @@ This action cannot be undone!</value></data>
   <data name="PreferredHostsTooltipMoveUp" xml:space="preserve"><value>Make selected host higher priority</value></data>
   <data name="PreferredHostsTooltipMoveDown" xml:space="preserve"><value>Make selected host lower priority</value></data>
   <data name="SelectionDialogDefault" xml:space="preserve"><value>{0} (DEFAULT)</value></data>
+  <data name="MainInstallDeduplicateScanning" xml:space="preserve"><value>Checking other game instances for possible duplicate installed files...</value></data>
+  <data name="MainDeduplicateWaitTitle" xml:space="preserve"><value>Duplicating Installed Files</value></data>
+  <data name="MainDeduplicateScanning" xml:space="preserve"><value>Scanning for duplicate installed files...</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -373,6 +373,7 @@ Find the folder where your game is installed and choose one of these files:
   <data name="SettingsToolTipResetCacheButton" xml:space="preserve"><value>Use the default download cache folder </value></data>
   <data name="SettingsToolTipOpenCacheButton" xml:space="preserve"><value>Browse the cache folder</value></data>
   <data name="SettingsToolTipClearCacheButton" xml:space="preserve"><value>Delete files from the cache</value></data>
+  <data name="SettingsDialogCacheProgress" xml:space="preserve"><value>Moving... ({0}%)</value></data>
   <data name="SettingsDialogSummmary" xml:space="preserve"><value>{0} files, {1}, {2} free</value></data>
   <data name="SettingsDialogSummmaryFreeSpaceUnknown" xml:space="preserve"><value>{0} files, {1}, free space unknown</value></data>
   <data name="SettingsDialogSummaryInvalid" xml:space="preserve"><value>Invalid path: {0}</value></data>

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -4,6 +4,7 @@ using System.IO;
 
 using log4net;
 
+using CKAN.IO;
 using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Services

--- a/Netkan/Services/FileService.cs
+++ b/Netkan/Services/FileService.cs
@@ -1,5 +1,7 @@
 using System.IO;
 
+using CKAN.IO;
+
 namespace CKAN.NetKAN.Services
 {
     internal sealed class FileService : IFileService

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json.Linq;
 
+using CKAN.IO;
 using CKAN.Avc;
 using CKAN.SpaceWarp;
 using CKAN.NetKAN.Sources.Github;

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -9,6 +9,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+using CKAN.IO;
 using CKAN.Extensions;
 using CKAN.Avc;
 using CKAN.SpaceWarp;

--- a/Netkan/Transformers/InstallSizeTransformer.cs
+++ b/Netkan/Transformers/InstallSizeTransformer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using ICSharpCode.SharpZipLib.Zip;
 
+using CKAN.IO;
 using CKAN.NetKAN.Model;
 using CKAN.NetKAN.Services;
 using CKAN.Games;

--- a/Netkan/Validators/InstallValidator.cs
+++ b/Netkan/Validators/InstallValidator.cs
@@ -2,6 +2,7 @@ using System.Linq;
 
 using Newtonsoft.Json.Linq;
 
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.NetKAN.Model;
 

--- a/Tests/Core/CKANPathUtils.cs
+++ b/Tests/Core/CKANPathUtils.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 
 using CKAN;
+using CKAN.IO;
 
 namespace Tests.Core
 {

--- a/Tests/Core/CKANPathUtils.cs
+++ b/Tests/Core/CKANPathUtils.cs
@@ -1,5 +1,6 @@
-using CKAN;
 using NUnit.Framework;
+
+using CKAN;
 
 namespace Tests.Core
 {
@@ -15,30 +16,6 @@ namespace Tests.Core
             Assert.AreEqual("a/b/c", CKANPathUtils.NormalizePath("a/b\\c"), "No starting slash");
             Assert.AreEqual("/a/b/c", CKANPathUtils.NormalizePath("\\a/b\\c\\"), "Trailing slash");
             Assert.AreEqual("SPACE", CKANPathUtils.NormalizePath("SPACE"), "All upper-case, no slashes");
-        }
-
-        [Test]
-        public void GetLastPathElement()
-        {
-            Assert.AreEqual("c", CKANPathUtils.GetLastPathElement("/a/b/c"), "Simple case");
-            Assert.AreEqual("c", CKANPathUtils.GetLastPathElement("\\a\\b\\c"), "With other slashes");
-            Assert.AreEqual("c", CKANPathUtils.GetLastPathElement("\\a/b\\c"), "With mixed slashes");
-            Assert.AreEqual("c", CKANPathUtils.GetLastPathElement("a/b\\c"), "No starting slash");
-            Assert.AreEqual("c", CKANPathUtils.GetLastPathElement("\\a/b\\c\\"), "Trailing slash");
-            Assert.AreEqual("kOS", CKANPathUtils.GetLastPathElement("GameData/kOS"), "Real world test");
-            Assert.AreEqual("buckethead", CKANPathUtils.GetLastPathElement("buckethead"), "No slashes at all");
-        }
-
-        [Test]
-        public void GetLeadingPathElements()
-        {
-            Assert.AreEqual("/a/b", CKANPathUtils.GetLeadingPathElements("/a/b/c"), "Simple case");
-            Assert.AreEqual("/a/b", CKANPathUtils.GetLeadingPathElements("\\a\\b\\c"), "With other slashes");
-            Assert.AreEqual("/a/b", CKANPathUtils.GetLeadingPathElements("\\a/b\\c"), "With mixed slashes");
-            Assert.AreEqual("a/b", CKANPathUtils.GetLeadingPathElements("a/b\\c"), "No starting slash");
-            Assert.AreEqual("/a/b", CKANPathUtils.GetLeadingPathElements("\\a/b\\c\\"), "Trailing slash");
-
-            Assert.IsEmpty(CKANPathUtils.GetLeadingPathElements("ModuleManager.2.5.1.dll"));
         }
 
         [Test]

--- a/Tests/Core/FileIdentifier.cs
+++ b/Tests/Core/FileIdentifier.cs
@@ -6,6 +6,7 @@ using ICSharpCode.SharpZipLib.Tar;
 using NUnit.Framework;
 
 using CKAN;
+using CKAN.IO;
 
 using Tests.Data;
 

--- a/Tests/Core/GameInstance.cs
+++ b/Tests/Core/GameInstance.cs
@@ -4,6 +4,7 @@ using System.IO;
 using NUnit.Framework;
 
 using CKAN;
+using CKAN.IO;
 using CKAN.Games.KerbalSpaceProgram;
 
 using Tests.Data;

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -10,6 +10,8 @@ using CKAN;
 using Tests.Core.Configuration;
 using Tests.Data;
 
+using CKAN.IO;
+
 namespace Tests.Core
 {
     /// <summary>

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -9,6 +9,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 
 using CKAN;
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.Games.KerbalSpaceProgram;
 

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -267,7 +267,7 @@ namespace Tests.Core
         // GH #205, make sure we write in *binary*, not text.
         public void BinaryNotText_205()
         {
-            // Use CopyZipEntry (via CopyDogeFromZip) and make sure it
+            // Use InstallFile (via CopyDogeFromZip) and make sure it
             // comes out the right size.
             string tmpfile = CopyDogeFromZip();
             long size = new FileInfo(tmpfile).Length;
@@ -285,7 +285,7 @@ namespace Tests.Core
         }
 
         [Test]
-        // Make sure when we roll-back a transaction, files written with CopyZipEntry go
+        // Make sure when we roll-back a transaction, files written with InstallFile go
         // back to their pre-transaction state.
         public void FileSysRollBack()
         {
@@ -313,7 +313,7 @@ namespace Tests.Core
 
                 Assert.Throws<FileExistsKraken>(delegate
                 {
-                    ModuleInstaller.CopyZipEntry(zipfile, entry, tmpfile, false, null);
+                    ModuleInstaller.InstallFile(zipfile, entry, tmpfile, false, Array.Empty<string>(), null);
                 });
 
                 // Cleanup
@@ -351,7 +351,7 @@ namespace Tests.Core
 
             // We have to delete our temporary file, as CZE refuses to overwrite; huzzah!
             File.Delete(tmpfile);
-            ModuleInstaller.CopyZipEntry(zipfile, entry, tmpfile, false, null);
+            ModuleInstaller.InstallFile(zipfile, entry, tmpfile, false, Array.Empty<string>(), null);
 
             return tmpfile;
         }
@@ -1087,7 +1087,7 @@ namespace Tests.Core
                                                          new GameVersionCriteria(new GameVersion(1, 12)))!;
                 installer.Replace(Enumerable.Repeat(replacement, 1),
                                   new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                  downloader, ref possibleConfigOnlyDirs, regMgr,
+                                  downloader, ref possibleConfigOnlyDirs, regMgr, null,
                                   false);
 
                 // Assert
@@ -1330,7 +1330,7 @@ namespace Tests.Core
                                       registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, inst.KSP.VersionCriteria()))
                                                     .OfType<CkanModule>()
                                                     .ToArray(),
-                                  downloader, ref possibleConfigOnlyDirs, regMgr, false);
+                                  downloader, ref possibleConfigOnlyDirs, regMgr, null, false);
 
                 // Assert
                 CollectionAssert.AreEquivalent(correctRemainingIdentifiers,

--- a/Tests/Core/Utilities.cs
+++ b/Tests/Core/Utilities.cs
@@ -3,8 +3,10 @@ using System.IO;
 
 using NUnit.Framework;
 
-using Tests.Data;
 using CKAN;
+using CKAN.IO;
+
+using Tests.Data;
 
 namespace Tests.Core
 {

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -184,7 +184,7 @@ namespace Tests.GUI
                     new RelationshipResolverOptions(instance.KSP.StabilityToleranceConfig),
                     registryManager,
                     ref possibleConfigOnlyDirs,
-                    null,
+                    null, null,
                     downloader);
 
                 // TODO: Refactor the column header code to allow mocking of the GUI without creating columns
@@ -232,7 +232,7 @@ namespace Tests.GUI
                             new RelationshipResolverOptions(inst2.KSP.StabilityToleranceConfig),
                             registryManager,
                             ref possibleConfigOnlyDirs,
-                            null,
+                            null, null,
                             downloader);
 
                         // Now we need to sort

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -13,6 +13,7 @@ using Tests.Core.Configuration;
 using Tests.Data;
 
 using CKAN;
+using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.GUI;
 


### PR DESCRIPTION
## Motivation

- Some mods install very large files, in some cases consuming multiple GiB. If you install such mods in multiple game instances, they consume a lot of space.
- In addition, unpacking such gigantic files takes a long time, which slows down the install process.

## Changes

- A new `HardLink` class provides a wrapper around Windows- and Unix-specific operations for dealing with each platform's hard links.
- A new `InstalledFilesDeduplicator` class builds on top of `HardLink` to handle detection and replacement of duplicated installed mod files.
- Now when you install or update mods, we first scan the registries of every game instance for the same game on the same disk volume into which you're installing. If any of them contain a copy of a file we're installing from the same version of the same mod, CKAN will create a hard link to the existing file instead of extracting it from the ZIP. This will be faster and consume less disk space.
- To facilitate "catch-up" of existing installs, you can have CKAN scan all of your game instances and replace duplicate installed files files with hard links:
  - CmdLine provides a `ckan dedup` command
  - ConsoleUI has a "Deduplicate installed files..." option in its F10 menu that opens the progress screen and runs the same code as `ckan dedup`
  - GUI has a "Deduplicate installed files..." option in its File menu that opens the progress tab and runs the same code as `ckan dedup`
- When you clone an instance, we attempt to hard link the files instead of copying, if the disk volumes are the same.

There are some exclusions and limitations:

- Since small files may be config files that the user may customize, and the benefit of this feature is primarily for large files, files smaller than 128 KiB will be extracted and installed (or copied) as normal rather than being hard-linked. This way, the user will not unexpectedly affect other game instances by editing config files.
- Only files installed by CKAN will be hard-linked, because we know the mod version. Manually installed files will not be touched. Users desiring such are invited to pursue non-CKAN solutions such as using a deduplicating filesystem like ZFS on Linux.

Fixes #4284.

### Side fixes

- The top progress bar in the GUI progress tab could get stuck there if it was still in progress while the ones below completed.
  Now the progress bar positioning logic is reworked to ensure it is moved down below the completed progress bars.
- If you tried to cancel an install while a download was being validated, the cancellation only took effect at the very end, after validation was completed, leaving a full-size download in your in-progress cache folder waiting to be revalidated again.
  Now the cancellation takes effect immediately.
- If you had a very large download in your in-progress cache folder, the SHA256 hashing that normally is done on the fly during downloads needs to be re-done and may take a while, but there are no status updates, so you can't see that it's working.
  Now the "Downloading" progress bar is shown to track this (not optimal, but the best feasible option for now).
- The "Playing..." caption from #4330 only took effect if you clicked in the dropdown, because it relied on the menu item's `Tag` property, which isn't set on the main button.
  Now it works for the main button as well.
  Fixes #4356.

### Minor stuff

- Two unused functions, `GetLastPathElement` and `GetLeadingPathElements`, are removed from `CKANPathUtils`, and so are their tests.
- `ModuleInstaller.StripV` and `ModuleInstaller.StripEpoch` are moved to `ModuleVersion` because they operate solely on that type. Some duplicated logic for this in GUI now shares the implementation in Core.
- `VersionFormat` is moved to the `Versioning` namespace and folder because it is about versioning.
- The single-argument `Zip` polyfill for `net48` and `netstandard2.0` now returns a `ValueTuple` 
instead of `Tuple` for consistency with the official `net8.0` implementation. This is probably slightly faster.
- An unnecessary call to `ToArray` in `Registry.LatestAvailableWithProvides` is removed to keep this core workhorse function optimized.
- Existing disk- and file-related classes are moved into the `CKAN.IO` namespace and the `Core/IO` folder.
- Some existing items items in the GUI main menu with short names and complex functionality that can use clarification now have tooltips.
- Now the progress bar in the settings dialog for migrating cache files shows the percent complete as it goes.
