### PR TITLE
Make global install filters and presets game-specific

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Restore cache for _build/test/cache
+        uses: actions/cache@v4
+        with:
+          path: _build/test/cache
+          key: build-test-cache
       - name: Install runtime dependencies
         run: sudo apt-get install -y xvfb
       - name: Download out artifact

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -2,9 +2,11 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
+using Autofac;
 using CommandLine;
 using log4net;
 
+using CKAN.Configuration;
 using CKAN.IO;
 
 namespace CKAN.CmdLine
@@ -53,7 +55,8 @@ namespace CKAN.CmdLine
                 {
                     log.InfoFormat("Importing {0} files", toImport.Count);
                     var toInstall = new List<CkanModule>();
-                    var installer = new ModuleInstaller(instance, manager.Cache, user);
+                    var installer = new ModuleInstaller(instance, manager.Cache,
+                                                        ServiceLocator.Container.Resolve<IConfiguration>(), user);
                     var regMgr    = RegistryManager.Instance(instance, repoData);
                     ModuleImporter.ImportFiles(toImport, user, toInstall.Add,
                                                regMgr.registry, instance, manager.Cache,

--- a/Cmdline/Action/Import.cs
+++ b/Cmdline/Action/Import.cs
@@ -53,7 +53,7 @@ namespace CKAN.CmdLine
                 {
                     log.InfoFormat("Importing {0} files", toImport.Count);
                     var toInstall = new List<CkanModule>();
-                    var installer = new ModuleInstaller(instance, manager.Cache, user, opts?.NetUserAgent);
+                    var installer = new ModuleInstaller(instance, manager.Cache, user);
                     var regMgr    = RegistryManager.Instance(instance, repoData);
                     ModuleImporter.ImportFiles(toImport, user, toInstall.Add,
                                                regMgr.registry, instance, manager.Cache,

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -3,9 +3,11 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 
+using Autofac;
 using CommandLine;
 using log4net;
 
+using CKAN.Configuration;
 using CKAN.IO;
 using CKAN.Versioning;
 
@@ -105,7 +107,8 @@ namespace CKAN.CmdLine
                 return Exit.ERROR;
             }
 
-            var installer   = new ModuleInstaller(instance, manager.Cache, user);
+            var installer   = new ModuleInstaller(instance, manager.Cache,
+                                                  ServiceLocator.Container.Resolve<IConfiguration>(), user);
             var install_ops = new RelationshipResolverOptions(instance.StabilityToleranceConfig)
             {
                 with_all_suggests              = options?.with_all_suggests ?? false,

--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -105,7 +105,7 @@ namespace CKAN.CmdLine
                 return Exit.ERROR;
             }
 
-            var installer   = new ModuleInstaller(instance, manager.Cache, user, options?.NetUserAgent);
+            var installer   = new ModuleInstaller(instance, manager.Cache, user);
             var install_ops = new RelationshipResolverOptions(instance.StabilityToleranceConfig)
             {
                 with_all_suggests              = options?.with_all_suggests ?? false,

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -81,7 +81,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string>? possibleConfigOnlyDirs = null;
-                    var installer = new ModuleInstaller(instance, manager.Cache, user, options.NetUserAgent);
+                    var installer = new ModuleInstaller(instance, manager.Cache, user);
                     Search.AdjustModulesCase(instance, regMgr.registry, options.modules);
                     installer.UninstallList(options.modules, ref possibleConfigOnlyDirs, regMgr);
                     user.RaiseMessage("");

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
+using Autofac;
 using CommandLine;
 using log4net;
 
+using CKAN.Configuration;
 using CKAN.IO;
 
 namespace CKAN.CmdLine
@@ -81,7 +83,8 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string>? possibleConfigOnlyDirs = null;
-                    var installer = new ModuleInstaller(instance, manager.Cache, user);
+                    var installer = new ModuleInstaller(instance, manager.Cache,
+                                                        ServiceLocator.Container.Resolve<IConfiguration>(), user);
                     Search.AdjustModulesCase(instance, regMgr.registry, options.modules);
                     installer.UninstallList(options.modules, ref possibleConfigOnlyDirs, regMgr);
                     user.RaiseMessage("");

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 
+using Autofac;
 using CommandLine;
 using log4net;
 
+using CKAN.Configuration;
 using CKAN.IO;
 using CKAN.Versioning;
 
@@ -161,7 +163,8 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string>? possibleConfigOnlyDirs = null;
-                    new ModuleInstaller(instance, manager.Cache, user)
+                    new ModuleInstaller(instance, manager.Cache,
+                                        ServiceLocator.Container.Resolve<IConfiguration>(), user)
                         .Replace(to_replace, replace_ops,
                                  new NetAsyncModulesDownloader(user, manager.Cache, options.NetUserAgent),
                                  ref possibleConfigOnlyDirs,

--- a/Cmdline/Action/Replace.cs
+++ b/Cmdline/Action/Replace.cs
@@ -161,7 +161,7 @@ namespace CKAN.CmdLine
                 try
                 {
                     HashSet<string>? possibleConfigOnlyDirs = null;
-                    new ModuleInstaller(instance, manager.Cache, user, options.NetUserAgent)
+                    new ModuleInstaller(instance, manager.Cache, user)
                         .Replace(to_replace, replace_ops,
                                  new NetAsyncModulesDownloader(user, manager.Cache, options.NetUserAgent),
                                  ref possibleConfigOnlyDirs,

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -296,7 +296,7 @@ namespace CKAN.CmdLine
                                            Action<CkanModule>    addUserChoiceCallback)
         {
             using (TransactionScope transact = CkanTransaction.CreateTransactionScope()) {
-                var installer  = new ModuleInstaller(instance, cache, user, userAgent);
+                var installer  = new ModuleInstaller(instance, cache, user);
                 var downloader = new NetAsyncModulesDownloader(user, cache, userAgent);
                 var regMgr     = RegistryManager.Instance(instance, repoData);
                 HashSet<string>? possibleConfigOnlyDirs = null;

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -296,7 +296,8 @@ namespace CKAN.CmdLine
                                            Action<CkanModule>    addUserChoiceCallback)
         {
             using (TransactionScope transact = CkanTransaction.CreateTransactionScope()) {
-                var installer  = new ModuleInstaller(instance, cache, user);
+                var installer  = new ModuleInstaller(instance, cache,
+                                                     ServiceLocator.Container.Resolve<IConfiguration>(), user);
                 var downloader = new NetAsyncModulesDownloader(user, cache, userAgent);
                 var regMgr     = RegistryManager.Instance(instance, repoData);
                 HashSet<string>? possibleConfigOnlyDirs = null;

--- a/Cmdline/Properties/Resources.resx
+++ b/Cmdline/Properties/Resources.resx
@@ -389,12 +389,13 @@ Try `ckan list` for a list of installed mods.</value></data>
   <data name="ScanPreliminaryInconsistent" xml:space="preserve"><value>Preliminary scanning shows that the install is in a inconsistent state.
 Use ckan.exe scan for more details
 Proceeding with {0} in case it fixes it.</value></data>
-  <data name="FilterListGlobalHeader" xml:space="preserve"><value>Global filters:</value></data>
-  <data name="FilterListInstanceHeader" xml:space="preserve"><value>Instance filters:</value></data>
+  <data name="FilterListGlobalHeader" xml:space="preserve"><value>Global filters for {0}:</value></data>
+  <data name="FilterListInstanceHeader" xml:space="preserve"><value>Instance filters for {0}:</value></data>
   <data name="FilterAddGlobalDuplicateError" xml:space="preserve"><value>Global filters already set: {0}</value></data>
   <data name="FilterAddInstanceDuplicateError" xml:space="preserve"><value>Instance filters already set: {0}</value></data>
   <data name="FilterRemoveGlobalNotFoundError" xml:space="preserve"><value>Global filters not found: {0}</value></data>
   <data name="FilterRemoveInstanceNotFoundError" xml:space="preserve"><value>Instance filters not found: {0}</value></data>
+  <data name="FilterGameNotFoundError" xml:space="preserve"><value>Game {0} not found! Try one of: {1}</value></data>
   <data name="FilterHelpSummary" xml:space="preserve"><value>View or edit installation filters</value></data>
   <data name="StabilityUnknownCommand" xml:space="preserve"><value>Unknown command: stability {0}</value></data>
   <data name="StabilityHelpSummary" xml:space="preserve"><value>View or edit stability settings</value></data>

--- a/ConsoleUI/InstallFiltersScreen.cs
+++ b/ConsoleUI/InstallFiltersScreen.cs
@@ -23,7 +23,7 @@ namespace CKAN.ConsoleUI {
         {
             this.globalConfig = globalConfig;
             this.instance     = instance;
-            globalFilters   = globalConfig.GlobalInstallFilters.ToList();
+            globalFilters   = globalConfig.GetGlobalInstallFilters(instance.game).ToList();
             instanceFilters = instance.InstallFilters.ToList();
 
             AddTip("F2", Properties.Resources.Accept);
@@ -53,7 +53,8 @@ namespace CKAN.ConsoleUI {
                 globalFilters,
                 new List<ConsoleListBoxColumn<string>>() {
                     new ConsoleListBoxColumn<string>(
-                        Properties.Resources.FiltersGlobalHeader,
+                        string.Format(Properties.Resources.FiltersGlobalHeader,
+                                      instance.game.ShortName),
                         f => f,
                         null,
                         null)
@@ -143,8 +144,8 @@ namespace CKAN.ConsoleUI {
 
         private void Save()
         {
-            globalConfig.GlobalInstallFilters = globalFilters.ToArray();
-            instance.InstallFilters           = instanceFilters.ToArray();
+            globalConfig.SetGlobalInstallFilters(instance.game, globalFilters.ToArray());
+            instance.InstallFilters = instanceFilters.ToArray();
         }
 
         private readonly IConfiguration globalConfig;

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -4,6 +4,8 @@ using System.Transactions;
 using System.Collections.Generic;
 using System.Linq;
 
+using Autofac;
+
 using CKAN.IO;
 using CKAN.Configuration;
 using CKAN.ConsoleUI.Toolkit;
@@ -86,7 +88,9 @@ namespace CKAN.ConsoleUI {
                                                                          manager.Instances.Values,
                                                                          repoData);
 
-                            ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this);
+                            ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache,
+                                                                       ServiceLocator.Container.Resolve<IConfiguration>(),
+                                                                       this);
                             inst.OneComplete += OnModInstalled;
                             if (plan.Remove.Count > 0) {
                                 inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr, true, new List<CkanModule>(plan.Install));

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -86,7 +86,7 @@ namespace CKAN.ConsoleUI {
                                                                          manager.Instances.Values,
                                                                          repoData);
 
-                            ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this, userAgent);
+                            ModuleInstaller inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, this);
                             inst.OneComplete += OnModInstalled;
                             if (plan.Remove.Count > 0) {
                                 inst.UninstallList(plan.Remove, ref possibleConfigOnlyDirs, regMgr, true, new List<CkanModule>(plan.Install));

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -589,7 +589,7 @@ namespace CKAN.ConsoleUI {
             {
                 var ps   = new ProgressScreen(theme, string.Format(Properties.Resources.ModInfoDownloading, mod.identifier));
                 var dl   = new NetAsyncModulesDownloader(ps, manager.Cache, userAgent);
-                var inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, ps, userAgent);
+                var inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, ps);
                 LaunchSubScreen(
                     ps,
                     () => {

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
+using Autofac;
+
 using CKAN.IO;
 using CKAN.Configuration;
 using CKAN.Versioning;
@@ -589,7 +591,8 @@ namespace CKAN.ConsoleUI {
             {
                 var ps   = new ProgressScreen(theme, string.Format(Properties.Resources.ModInfoDownloading, mod.identifier));
                 var dl   = new NetAsyncModulesDownloader(ps, manager.Cache, userAgent);
-                var inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache, ps);
+                var inst = new ModuleInstaller(manager.CurrentInstance, manager.Cache,
+                                               ServiceLocator.Container.Resolve<IConfiguration>(), ps);
                 LaunchSubScreen(
                     ps,
                     () => {

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -405,7 +405,7 @@ If you uninstall it, CKAN will not be able to re-install it.</value></data>
   <data name="FiltersTitle" xml:space="preserve"><value>Installation Filters</value></data>
   <data name="FiltersAddMiniAVCMenu" xml:space="preserve"><value>Add MiniAVC</value></data>
   <data name="FiltersAddMiniAVCMenuTip" xml:space="preserve"><value>Prevent MiniAVC from being installed</value></data>
-  <data name="FiltersGlobalHeader" xml:space="preserve"><value>Global Filters</value></data>
+  <data name="FiltersGlobalHeader" xml:space="preserve"><value>Global Filters for {0}</value></data>
   <data name="FiltersInstanceHeader" xml:space="preserve"><value>Instance Filters</value></data>
   <data name="FilterAddGhostText" xml:space="preserve"><value>&lt;Enter a filter&gt;</value></data>
   <data name="FilterAddAcceptTip" xml:space="preserve"><value>Accept value</value></data>

--- a/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
+++ b/Core/AutoUpdate/GithubReleaseCkanUpdate.cs
@@ -26,7 +26,8 @@ namespace CKAN
             {
                 var coreConfig = ServiceLocator.Container.Resolve<IConfiguration>();
                 var token = coreConfig.TryGetAuthToken(latestCKANReleaseApiUrl.Host, out string? t)
-                    ? t : null;
+                                ? t
+                                : Environment.GetEnvironmentVariable("GITHUB_TOKEN");
                 releaseJson = Net.DownloadText(latestCKANReleaseApiUrl, userAgent, token) is string content
                               ? JsonConvert.DeserializeObject<GitHubReleaseInfo>(content)
                               : null;

--- a/Core/Configuration/IConfiguration.cs
+++ b/Core/Configuration/IConfiguration.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
+using CKAN.Games;
+
 namespace CKAN.Configuration
 {
     public interface IConfiguration
@@ -60,7 +62,8 @@ namespace CKAN.Configuration
         /// <summary>
         /// Paths that should be excluded from all installations
         /// </summary>
-        string[] GlobalInstallFilters { get; set; }
+        string[] GetGlobalInstallFilters(IGame game);
+        void SetGlobalInstallFilters(IGame game, string[] value);
 
         /// <summary>
         /// List of hosts in order of priority when there are multiple URLs to choose from.

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -10,6 +10,7 @@ using System.Runtime.Versioning;
 #endif
 
 using CKAN.IO;
+using CKAN.Games;
 
 namespace CKAN.Configuration
 {
@@ -179,7 +180,11 @@ namespace CKAN.Configuration
         /// <summary>
         /// Not implemented because the Windows registry is deprecated
         /// </summary>
-        public string[] GlobalInstallFilters { get; set; } = Array.Empty<string>();
+        public string[] GetGlobalInstallFilters(IGame game) => Array.Empty<string>();
+        /// <summary>
+        /// Not implemented because the Windows registry is deprecated
+        /// </summary>
+        public void SetGlobalInstallFilters(IGame game, string[] value) { }
 
         /// <summary>
         /// Not implemented because the Windows registry is deprecated

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -37,6 +37,7 @@ namespace CKAN.Games
         string[]       DefaultCommandLines(SteamLibrary steamLib, DirectoryInfo path);
         string[]       AdjustCommandLine(string[] args, GameVersion? installedVersion);
         IDlcDetector[] DlcDetectors { get; }
+        IDictionary<string, string[]> InstallFilterPresets { get; }
 
         // Which versions exist and which is present?
         void              RefreshVersions(string? userAgent);

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -172,6 +172,28 @@ namespace CKAN.Games.KerbalSpaceProgram
             new MakingHistoryDlcDetector(),
         };
 
+        public IDictionary<string, string[]> InstallFilterPresets =>
+            new SortedDictionary<string, string[]>()
+            {
+                {
+                    "MiniAVC",
+                    new string[]
+                    {
+                        "/MiniAVC.dll",
+                        "/MiniAVC.xml",
+                        "/LICENSE-MiniAVC.txt",
+                    }
+                },
+                {
+                    "MiniAVC2-V2",
+                    new string[]
+                    {
+                        "/MiniAVC-V2.dll",
+                        "/MiniAVC-V2.dll.mdb",
+                    }
+                },
+            };
+
         public void RefreshVersions(string? userAgent)
         {
             ServiceLocator.Container.Resolve<IKspBuildMap>().Refresh(userAgent);

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -127,6 +127,9 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public IDlcDetector[] DlcDetectors => Array.Empty<IDlcDetector>();
 
+        public IDictionary<string, string[]> InstallFilterPresets =>
+            new Dictionary<string, string[]>();
+
         private static readonly Uri BuildMapUri =
             new Uri("https://raw.githubusercontent.com/KSP-CKAN/KSP2-CKAN-meta/main/builds.json");
         private static readonly string cachedBuildMapPath =

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -334,7 +334,7 @@ namespace CKAN.IO
             }
             using (ZipFile zipfile = new ZipFile(zip_filename))
             {
-                var filters = config.GlobalInstallFilters
+                var filters = config.GetGlobalInstallFilters(instance.game)
                                     .Concat(instance.InstallFilters)
                                     .ToHashSet();
                 var files = FindInstallableFiles(module, zipfile, instance)

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -36,84 +36,23 @@ namespace CKAN.IO
 
         private readonly GameInstance      instance;
         private readonly NetModuleCache    Cache;
-        private readonly string?           userAgent;
         private readonly CancellationToken cancelToken;
 
         // Constructor
         public ModuleInstaller(GameInstance      inst,
                                NetModuleCache    cache,
                                IUser             user,
-                               string?           userAgent   = null,
                                CancellationToken cancelToken = default)
         {
             User     = user;
             Cache    = cache;
             instance = inst;
-            this.userAgent = userAgent;
+            User        = user;
             this.cancelToken = cancelToken;
             log.DebugFormat("Creating ModuleInstaller for {0}", instance.GameDir());
         }
 
-        #region Downloading
 
-        /// <summary>
-        /// Downloads the given mod to the cache. Returns the filename it was saved to.
-        /// </summary>
-        public string Download(CkanModule module, string filename)
-        {
-            User.RaiseProgress(string.Format(Properties.Resources.ModuleInstallerDownloading, module.download), 0);
-            return Download(module, filename, userAgent, Cache);
-        }
-
-        /// <summary>
-        /// Downloads the given mod to the cache. Returns the filename it was saved to.
-        /// </summary>
-        public static string Download(CkanModule module, string filename, string? userAgent, NetModuleCache cache)
-        {
-            log.Info("Downloading " + filename);
-
-            string tmp_file = Net.Download((module.download ?? Enumerable.Empty<Uri>())
-                .OrderBy(u => u,
-                         new PreferredHostUriComparer(
-                             ServiceLocator.Container.Resolve<IConfiguration>().PreferredHosts))
-                .First(),
-                userAgent);
-
-            return cache.Store(module, tmp_file, new ProgressImmediate<long>(bytes => {}), filename, true);
-        }
-
-        /// <summary>
-        /// Returns the path to a cached copy of a module if it exists, or downloads
-        /// and returns the downloaded copy otherwise.
-        ///
-        /// If no filename is provided, the module's standard name will be used.
-        /// Checks the CKAN cache first.
-        /// </summary>
-        public string CachedOrDownload(CkanModule module, string? filename = null)
-            => CachedOrDownload(module, userAgent, Cache, filename);
-
-        /// <summary>
-        /// Returns the path to a cached copy of a module if it exists, or downloads
-        /// and returns the downloaded copy otherwise.
-        ///
-        /// If no filename is provided, the module's standard name will be used.
-        /// Chcecks provided cache first.
-        /// </summary>
-        public static string CachedOrDownload(CkanModule module, string? userAgent, NetModuleCache cache, string? filename = null)
-        {
-            filename ??= CkanModule.StandardName(module.identifier, module.version);
-
-            var full_path = cache.GetCachedFilename(module);
-            if (full_path == null)
-            {
-                return Download(module, filename, userAgent, cache);
-            }
-
-            log.DebugFormat("Using {0} (cached)", filename);
-            return full_path;
-        }
-
-        #endregion
 
         #region Installation
 

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using ICSharpCode.SharpZipLib.Zip;
 
 using CKAN.IO;
+using CKAN.Configuration;
 
 namespace CKAN
 {
@@ -106,23 +107,25 @@ namespace CKAN
                 ? null
                 : cache.GetInProgressFileName(m.download, m.StandardName());
 
-        private static string DescribeUncachedAvailability(CkanModule m, FileInfo? fi)
+        private static string DescribeUncachedAvailability(IConfiguration config,
+                                                           CkanModule     m,
+                                                           FileInfo?      fi)
             => (fi?.Exists ?? false)
                 ? string.Format(Properties.Resources.NetModuleCacheModuleResuming,
                     m.name, m.version,
-                    string.Join(", ", ModuleInstaller.PrioritizedHosts(m.download)),
+                    string.Join(", ", ModuleInstaller.PrioritizedHosts(config, m.download)),
                     CkanModule.FmtSize(m.download_size - fi.Length))
                 : string.Format(Properties.Resources.NetModuleCacheModuleHostSize,
                     m.name, m.version,
-                    string.Join(", ", ModuleInstaller.PrioritizedHosts(m.download)),
+                    string.Join(", ", ModuleInstaller.PrioritizedHosts(config, m.download)),
                     CkanModule.FmtSize(m.download_size));
 
-        public string DescribeAvailability(CkanModule m)
+        public string DescribeAvailability(IConfiguration config, CkanModule m)
             => m.IsMetapackage
                 ? string.Format(Properties.Resources.NetModuleCacheMetapackage, m.name, m.version)
                 : IsMaybeCachedZip(m)
                     ? string.Format(Properties.Resources.NetModuleCacheModuleCached, m.name, m.version)
-                    : DescribeUncachedAvailability(m, GetInProgressFileName(m));
+                    : DescribeUncachedAvailability(config, m, GetInProgressFileName(m));
 
         /// <summary>
         /// Calculate the SHA1 hash of a file

--- a/Core/Properties/Resources.de-DE.resx
+++ b/Core/Properties/Resources.de-DE.resx
@@ -119,4 +119,7 @@
   </resheader>
   <data name="RelationshipResolverUserReason" xml:space="preserve"><value>Neue Mod-Installation ausgewählt vom Nutzer</value></data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (Metapacket)</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoriten</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Versteckt</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Zurückgehalten</value></data>
 </root>

--- a/Core/Properties/Resources.en-US.resx
+++ b/Core/Properties/Resources.en-US.resx
@@ -119,4 +119,5 @@
   </resheader>
   <data name="CkanModuleDeserialisationError" xml:space="preserve"><value>JSON deserialization error: {0}</value></data>
   <data name="LicenceInvalid" xml:space="preserve"><value>The license {0} is invalid</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
 </root>

--- a/Core/Properties/Resources.fr-FR.resx
+++ b/Core/Properties/Resources.fr-FR.resx
@@ -766,4 +766,13 @@ Libérez de l'espace sur cet appareil ou modifiez vos paramètres pour utiliser 
   <data name="NoDuplicatesFound" xml:space="preserve">
     <value>Aucun fichier installé redondant trouvé.</value>
   </data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve">
+    <value>Favoris</value>
+  </data>
+  <data name="ModuleLabelListHidden" xml:space="preserve">
+    <value>Caché</value>
+  </data>
+  <data name="ModuleLabelListHeld" xml:space="preserve">
+    <value>Gelé</value>
+  </data>
 </root>

--- a/Core/Properties/Resources.it-IT.resx
+++ b/Core/Properties/Resources.it-IT.resx
@@ -670,4 +670,13 @@ Libera spazio su quel dispositivo o modifica le impostazioni per utilizzare un'a
   <data name="ModpackName" xml:space="preserve">
     <value>installata-{0}</value>
   </data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve">
+    <value>Preferiti</value>
+  </data>
+  <data name="ModuleLabelListHidden" xml:space="preserve">
+    <value>Nascosto</value>
+  </data>
+  <data name="ModuleLabelListHeld" xml:space="preserve">
+    <value>Mantenuta</value>
+  </data>
 </root>

--- a/Core/Properties/Resources.ja-JP.resx
+++ b/Core/Properties/Resources.ja-JP.resx
@@ -120,4 +120,7 @@
   <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (メタパッケージ)</value></data>
   <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (キャッシュ済)</value></data>
   <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>お気に入り</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>非表示</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>保持</value></data>
 </root>

--- a/Core/Properties/Resources.ko-KR.resx
+++ b/Core/Properties/Resources.ko-KR.resx
@@ -120,4 +120,7 @@
   <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (메타패키지)</value></data>
   <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (캐시됨)</value></data>
   <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>즐겨찾기</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>숨겨짐</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>유지</value></data>
 </root>

--- a/Core/Properties/Resources.pl-PL.resx
+++ b/Core/Properties/Resources.pl-PL.resx
@@ -641,4 +641,13 @@ Zwolnij miejsce na tym urządzeniu lub zmień ustawienia, aby użyć innej lokal
   <data name="ModpackName" xml:space="preserve">
     <value>zainstalowano-{0}</value>
   </data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve">
+    <value>Ulubione</value>
+  </data>
+  <data name="ModuleLabelListHidden" xml:space="preserve">
+    <value>Ukryte</value>
+  </data>
+  <data name="ModuleLabelListHeld" xml:space="preserve">
+    <value>Trzymane</value>
+  </data>
 </root>

--- a/Core/Properties/Resources.pt-BR.resx
+++ b/Core/Properties/Resources.pt-BR.resx
@@ -121,4 +121,7 @@
   <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (metapackage)</value></data>
   <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (Em cache)</value></data>
   <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoritos</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Oculto</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Mantido</value></data>
 </root>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -352,4 +352,7 @@ Free up space on that device or change your settings to use another location.
   <data name="DeduplicatedRelPath" xml:space="preserve"><value>Deduplicated {0} copies of {1}</value></data>
   <data name="DoneDeduplicatingFiles" xml:space="preserve"><value>Deduplication complete. Space saved: {0}</value></data>
   <data name="NoDuplicatesFound" xml:space="preserve"><value>No duplicate installed files found.</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favourites</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Hidden</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Held</value></data>
 </root>

--- a/Core/Properties/Resources.ru-RU.resx
+++ b/Core/Properties/Resources.ru-RU.resx
@@ -298,4 +298,7 @@ https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors</value></data>
   <data name="NetModuleCacheMetapackage" xml:space="preserve"><value>{0} {1} (метапакет)</value></data>
   <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (кэшировано)</value></data>
   <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Избранные</value></data>
+  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Скрытые</value></data>
+  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Без обновления</value></data>
 </root>

--- a/Core/Properties/Resources.zh-CN.resx
+++ b/Core/Properties/Resources.zh-CN.resx
@@ -673,4 +673,13 @@
   <data name="ModpackName" xml:space="preserve">
     <value>已安装-{0}</value>
   </data>
+  <data name="ModuleLabelListFavourites" xml:space="preserve">
+    <value>收藏</value>
+  </data>
+  <data name="ModuleLabelListHidden" xml:space="preserve">
+    <value>隐藏</value>
+  </data>
+  <data name="ModuleLabelListHeld" xml:space="preserve">
+    <value>已使用</value>
+  </data>
 </root>

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -255,7 +255,7 @@ namespace CKAN
                                                                           HashSet<string>?      ignoreMissingIdents = null)
         {
             var filters = ServiceLocator.Container.Resolve<IConfiguration>()
-                                                  .GlobalInstallFilters
+                                                  .GetGlobalInstallFilters(instance.game)
                                                   .Concat(instance.InstallFilters)
                                                   .ToHashSet();
             // Get the absolute latest versions ignoring restrictions,
@@ -296,7 +296,7 @@ namespace CKAN
                                                                           HashSet<string>?      ignoreMissingIdents = null)
         {
             filters ??= ServiceLocator.Container.Resolve<IConfiguration>()
-                                                .GlobalInstallFilters
+                                                .GetGlobalInstallFilters(instance.game)
                                                 .Concat(instance.InstallFilters)
                                                 .ToHashSet();
             // Use those as the installed modules

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -51,7 +51,10 @@ namespace CKAN
 
         // We require our constructor to be private so we can
         // enforce this being an instance (via Instance() above)
-        private RegistryManager(string path, GameInstance inst, RepositoryDataManager repoData)
+        private RegistryManager(string                  path,
+                                GameInstance            inst,
+                                RepositoryDataManager   repoData,
+                                ICollection<Repository> initialRepositories)
         {
             gameInstance = inst;
 
@@ -67,7 +70,7 @@ namespace CKAN
 
             try
             {
-                Load(repoData);
+                Load(repoData, initialRepositories);
             }
             catch
             {
@@ -268,13 +271,16 @@ namespace CKAN
         /// Returns an instance of the registry manager for the game instance.
         /// The file `registry.json` is assumed.
         /// </summary>
-        public static RegistryManager Instance(GameInstance inst, RepositoryDataManager repoData)
+        public static RegistryManager Instance(GameInstance             inst,
+                                               RepositoryDataManager    repoData,
+                                               ICollection<Repository>? repositories = null)
         {
             string directory = inst.CkanDir();
             if (!registryCache.ContainsKey(directory))
             {
                 log.DebugFormat("Preparing to load registry at {0}", directory);
-                registryCache[directory] = new RegistryManager(directory, inst, repoData);
+                registryCache[directory] = new RegistryManager(directory, inst, repoData,
+                                                               repositories ?? Array.Empty<Repository>());
             }
 
             return registryCache[directory];
@@ -302,7 +308,8 @@ namespace CKAN
         }
 
         [MemberNotNull(nameof(registry))]
-        private void Load(RepositoryDataManager repoData)
+        private void Load(RepositoryDataManager   repoData,
+                          ICollection<Repository> repositories)
         {
             try
             {
@@ -311,7 +318,7 @@ namespace CKAN
             }
             catch (IOException exc) when (exc is FileNotFoundException or DirectoryNotFoundException)
             {
-                Create(repoData);
+                Create(repoData, repositories);
             }
             catch (JsonException exc)
             {
@@ -320,7 +327,7 @@ namespace CKAN
                 log.ErrorFormat("{0} is corrupted, archiving to {1}: {2}",
                     path, previousCorruptedPath, previousCorruptedMessage);
                 File.Move(path, previousCorruptedPath);
-                Create(repoData);
+                Create(repoData, repositories);
             }
             catch (Exception ex)
             {
@@ -336,7 +343,8 @@ namespace CKAN
                                                    ? regMgr.registry
                                                    : LoadRegistry(inst, repoData));
 
-        private static Registry LoadRegistry(GameInstance inst, RepositoryDataManager repoData)
+        private static Registry LoadRegistry(GameInstance            inst,
+                                             RepositoryDataManager   repoData)
         {
             var path = Path.Combine(inst.CkanDir(), "registry.json");
             log.DebugFormat("Trying to load registry from {0}", path);
@@ -360,10 +368,11 @@ namespace CKAN
                };
 
         [MemberNotNull(nameof(registry))]
-        private void Create(RepositoryDataManager repoData)
+        private void Create(RepositoryDataManager   repoData,
+                            IEnumerable<Repository> repositories)
         {
             log.InfoFormat("Creating new CKAN registry at {0}", path);
-            registry = Registry.Empty(repoData);
+            registry = new Registry(repoData, repositories);
             AscertainDefaultRepo();
             ScanUnmanagedFiles();
         }

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -373,10 +373,10 @@ namespace CKAN
             if (registry.Repositories.Count == 0)
             {
                 log.InfoFormat("Fabricating repository: {0}", gameInstance.game.DefaultRepositoryURL);
-                var name = $"{gameInstance.game.ShortName}-{Repository.default_ckan_repo_name}";
+                var repo = Repository.DefaultGameRepo(gameInstance.game);
                 registry.RepositoriesSet(new SortedDictionary<string, Repository>
                 {
-                    { name, new Repository(name, gameInstance.game.DefaultRepositoryURL) }
+                    { repo.name, repo }
                 });
             }
         }

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -143,7 +143,7 @@ namespace CKAN
                 long fileSize = new FileInfo(path).Length;
                 log.DebugFormat("Trying to load repository data from {0}", path);
                 // Ain't OOP grand?!
-                using (var stream = File.Open(path, FileMode.Open))
+                using (var stream = File.OpenRead(path))
                 using (var progressStream = new ReadProgressStream(
                     stream,
                     progress == null

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -156,8 +156,7 @@ namespace CKAN
 
             // Check if any ETags have changed, quit if not
             user.RaiseProgress(Properties.Resources.NetRepoCheckingForUpdates, 0);
-            var toUpdate = repos.DefaultIfEmpty(Repository.DefaultGameRepo(game))
-                                .DistinctBy(r => r.uri)
+            var toUpdate = repos.DistinctBy(r => r.uri)
                                 .Where(r => r.uri != null
                                             && (r.uri.IsFile
                                                 || skipETags

--- a/Core/Types/Labels/ModuleLabel.cs
+++ b/Core/Types/Labels/ModuleLabel.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 using CKAN.Games;
 
-namespace CKAN.GUI
+namespace CKAN
 {
     [JsonObject(MemberSerialization.OptIn)]
     [JsonConverter(typeof(ModuleIdentifiersRenamedConverter))]
@@ -104,6 +104,7 @@ namespace CKAN.GUI
         /// <summary>
         /// Add a module to this label's group
         /// </summary>
+        /// <param name="game">The game for which to add this identifier</param>
         /// <param name="identifier">The identifier of the module to add</param>
         public void Add(IGame game, string identifier)
         {
@@ -120,6 +121,7 @@ namespace CKAN.GUI
         /// <summary>
         /// Remove a module from this label's group
         /// </summary>
+        /// <param name="game">The game for which to remove this identifier</param>
         /// <param name="identifier">The identifier of the module to remove</param>
         public void Remove(IGame game, string identifier)
         {

--- a/Core/Types/Labels/ModuleLabelList.cs
+++ b/Core/Types/Labels/ModuleLabelList.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 using CKAN.IO;
 
-namespace CKAN.GUI
+namespace CKAN
 {
     [JsonObject(MemberSerialization.OptIn)]
     public class ModuleLabelList

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using System.Runtime.Versioning;
 #endif
 
+using CKAN.Configuration;
 using CKAN.GUI.Attributes;
 
 namespace CKAN.GUI
@@ -22,7 +23,10 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        public void LoadProviders(string message, List<CkanModule> modules, NetModuleCache cache)
+        public void LoadProviders(string           message,
+                                  List<CkanModule> modules,
+                                  NetModuleCache   cache,
+                                  IConfiguration   config)
         {
             Util.Invoke(this, () =>
             {
@@ -34,7 +38,7 @@ namespace CKAN.GUI
                 ChooseProvidedModsListView.Items.AddRange(modules
                     .Select((module, index) => new ListViewItem(new string[]
                     {
-                        cache.DescribeAvailability(module),
+                        cache.DescribeAvailability(config, module),
                         module.@abstract
                     })
                     {

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -11,6 +11,7 @@ using System.Runtime.Versioning;
 using Autofac;
 using log4net;
 
+using CKAN.Configuration;
 using CKAN.IO;
 using CKAN.Extensions;
 using CKAN.GUI.Attributes;
@@ -1350,7 +1351,8 @@ namespace CKAN.GUI
                                    registry.GetModuleByVersion(module.identifier,
                                                                module.version)
                                            ?? module,
-                                   true, false)
+                                   true, false,
+                                   ServiceLocator.Container.Resolve<IConfiguration>())
                 }, null);
             }
         }

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -143,7 +143,7 @@ namespace CKAN.GUI
                 if (manager?.CurrentInstance is GameInstance inst)
                 {
                     var filters = ServiceLocator.Container.Resolve<IConfiguration>()
-                                                          .GlobalInstallFilters
+                                                          .GetGlobalInstallFilters(inst.game)
                                                           .Concat(inst.InstallFilters)
                                                           .ToHashSet();
                     ContentTabPage.ImageKey = ModuleLabels.IgnoreMissingIdentifiers(inst)

--- a/GUI/Controls/ModInfoTabs/Contents.cs
+++ b/GUI/Controls/ModInfoTabs/Contents.cs
@@ -138,7 +138,7 @@ namespace CKAN.GUI
         {
             switch (e?.PropertyName)
             {
-                case nameof(IConfiguration.GlobalInstallFilters):
+                case nameof(IConfiguration.GetGlobalInstallFilters):
                     RefreshModContentsTree();
                     break;
             }
@@ -206,7 +206,8 @@ namespace CKAN.GUI
                         UseWaitCursor = true;
                         Task.Factory.StartNew(() =>
                         {
-                            var filters = ServiceLocator.Container.Resolve<IConfiguration>().GlobalInstallFilters
+                            var filters = ServiceLocator.Container.Resolve<IConfiguration>()
+                                                                  .GetGlobalInstallFilters(inst.game)
                                                                   .Concat(inst.InstallFilters)
                                                                   .ToHashSet();
                             var tuples = (instMod != null

--- a/GUI/Dialogs/InstallFiltersDialog.Designer.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.Designer.cs
@@ -34,7 +34,6 @@ namespace CKAN.GUI
             this.InstanceFiltersGroupBox = new System.Windows.Forms.GroupBox();
             this.GlobalFiltersTextBox = new System.Windows.Forms.TextBox();
             this.InstanceFiltersTextBox = new System.Windows.Forms.TextBox();
-            this.AddMiniAVCButton = new System.Windows.Forms.Button();
             this.WarningLabel = new System.Windows.Forms.Label();
             this.GlobalFiltersGroupBox.SuspendLayout();
             this.InstanceFiltersGroupBox.SuspendLayout();
@@ -44,7 +43,6 @@ namespace CKAN.GUI
             //
             this.GlobalFiltersGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.GlobalFiltersGroupBox.Controls.Add(this.AddMiniAVCButton);
             this.GlobalFiltersGroupBox.Controls.Add(this.GlobalFiltersTextBox);
             this.GlobalFiltersGroupBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.GlobalFiltersGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
@@ -81,20 +79,6 @@ namespace CKAN.GUI
             this.GlobalFiltersTextBox.Size = new System.Drawing.Size(219, 147);
             this.GlobalFiltersTextBox.TabIndex = 1;
             resources.ApplyResources(this.GlobalFiltersTextBox, "GlobalFiltersTextBox");
-            //
-            // AddMiniAVCButton
-            //
-            this.AddMiniAVCButton.AutoSize = true;
-            this.AddMiniAVCButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
-            this.AddMiniAVCButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.AddMiniAVCButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.AddMiniAVCButton.Location = new System.Drawing.Point(231, 17);
-            this.AddMiniAVCButton.Name = "AddMiniAVCButton";
-            this.AddMiniAVCButton.Size = new System.Drawing.Size(124, 23);
-            this.AddMiniAVCButton.TabIndex = 2;
-            this.AddMiniAVCButton.UseVisualStyleBackColor = true;
-            this.AddMiniAVCButton.Click += new System.EventHandler(this.AddMiniAVCButton_Click);
-            resources.ApplyResources(this.AddMiniAVCButton, "AddMiniAVCButton");
             //
             // InstanceFiltersTextBox
             //
@@ -148,7 +132,6 @@ namespace CKAN.GUI
 
         private System.Windows.Forms.GroupBox GlobalFiltersGroupBox;
         private System.Windows.Forms.GroupBox InstanceFiltersGroupBox;
-        private System.Windows.Forms.Button AddMiniAVCButton;
         private System.Windows.Forms.TextBox GlobalFiltersTextBox;
         private System.Windows.Forms.TextBox InstanceFiltersTextBox;
         private System.Windows.Forms.Label WarningLabel;

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel;
+using System.Drawing;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
@@ -20,6 +22,28 @@ namespace CKAN.GUI
             InitializeComponent();
             this.globalConfig = globalConfig;
             this.instance     = instance;
+            presets           = instance.game.InstallFilterPresets;
+            const int hPadding = 6;
+            int top = 17;
+            foreach ((string name, string[] filters) in presets)
+            {
+                var btn = new Button()
+                {
+                    AutoSize                = true,
+                    AutoSizeMode            = AutoSizeMode.GrowOnly,
+                    Anchor                  = AnchorStyles.Top | AnchorStyles.Right,
+                    FlatStyle               = FlatStyle.Flat,
+                    Location                = new Point(GlobalFiltersTextBox.Right + hPadding, top),
+                    Size                    = new Size(GlobalFiltersGroupBox.Width - GlobalFiltersTextBox.Right - 2 * hPadding, 23),
+                    Text                    = string.Format(Properties.Resources.InstallFiltersAddPreset,
+                                                            name),
+                    Tag                     = name,
+                    UseVisualStyleBackColor = true,
+                };
+                btn.Click += AddMiniAVCButton_Click;
+                GlobalFiltersGroupBox.Controls.Add(btn);
+                top += btn.Height * 4 / 3;
+            }
         }
 
         public bool Changed { get; private set; } = false;
@@ -63,27 +87,24 @@ namespace CKAN.GUI
 
         private void AddMiniAVCButton_Click(object? sender, EventArgs? e)
         {
-            GlobalFiltersTextBox.Text = string.Join(Environment.NewLine,
-                GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries)
-                    .Concat(miniAVC)
-                    .Distinct());
+            if (sender is Button b
+                && b.Tag is string presetName
+                && presets.TryGetValue(presetName, out string[]? filters))
+            {
+                GlobalFiltersTextBox.Text = string.Join(Environment.NewLine,
+                    GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries)
+                        .Concat(filters)
+                        .Distinct());
+            }
         }
 
-        private readonly IConfiguration globalConfig;
-        private readonly GameInstance   instance;
+        private readonly IConfiguration                globalConfig;
+        private readonly GameInstance                  instance;
+        private readonly IDictionary<string, string[]> presets;
 
         private static readonly string[] delimiters = new string[]
         {
             Environment.NewLine
-        };
-
-        private static readonly string[] miniAVC = new string[]
-        {
-            "MiniAVC.dll",
-            "MiniAVC.xml",
-            "LICENSE-MiniAVC.txt",
-            "MiniAVC-V2.dll",
-            "MiniAVC-V2.dll.mdb",
         };
     }
 }

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -25,6 +25,8 @@ namespace CKAN.GUI
             presets           = instance.game.InstallFilterPresets;
             const int hPadding = 6;
             int top = 17;
+            GlobalFiltersGroupBox.Text = string.Format(Properties.Resources.InstallFiltersGlobalFiltersForGame,
+                                                       instance.game.ShortName);
             foreach ((string name, string[] filters) in presets)
             {
                 var btn = new Button()
@@ -66,7 +68,7 @@ namespace CKAN.GUI
 
         private void InstallFiltersDialog_Load(object? sender, EventArgs? e)
         {
-            GlobalFiltersTextBox.Text = string.Join(Environment.NewLine, globalConfig.GlobalInstallFilters);
+            GlobalFiltersTextBox.Text = string.Join(Environment.NewLine, globalConfig.GetGlobalInstallFilters(instance.game));
             InstanceFiltersTextBox.Text = string.Join(Environment.NewLine, instance.InstallFilters);
             GlobalFiltersTextBox.DeselectAll();
             InstanceFiltersTextBox.DeselectAll();
@@ -76,11 +78,11 @@ namespace CKAN.GUI
         {
             var newGlobal   = GlobalFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
             var newInstance = InstanceFiltersTextBox.Text.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
-            Changed = !globalConfig.GlobalInstallFilters.SequenceEqual(newGlobal)
+            Changed = !globalConfig.GetGlobalInstallFilters(instance.game).SequenceEqual(newGlobal)
                       || !instance.InstallFilters.SequenceEqual(newInstance);
             if (Changed)
             {
-                globalConfig.GlobalInstallFilters = newGlobal;
+                globalConfig.SetGlobalInstallFilters(instance.game, newGlobal);
                 instance.InstallFilters           = newInstance;
             }
         }

--- a/GUI/Dialogs/InstallFiltersDialog.resx
+++ b/GUI/Dialogs/InstallFiltersDialog.resx
@@ -119,7 +119,6 @@
   </resheader>
   <data name="GlobalFiltersGroupBox.Text" xml:space="preserve"><value>Global Filters</value></data>
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve"><value>Instance Filters</value></data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve"><value>Add MiniAVC</value></data>
   <data name="WarningLabel.Text" xml:space="preserve"><value>NOTE: Changes to the install filters only take effect on future mod installations; already installed files are unaffected.</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Install Filters</value></data>
 </root>

--- a/GUI/Extensions/WinFormsExtensions.cs
+++ b/GUI/Extensions/WinFormsExtensions.cs
@@ -1,8 +1,14 @@
 using System.Linq;
 using System.Windows.Forms;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
 
 namespace CKAN.GUI
 {
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
     public static class WinFormsExtensions
     {
         /// <summary>

--- a/GUI/Localization/de-DE/InstallFiltersDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/InstallFiltersDialog.de-DE.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>Instanz-spezifische Filter</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>MiniAVC hinzufügen</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>HINWEIS: Änderungen an den Filtern wirken sich erst auf zukünftige Modinstallationen aus; bereits installierte Dateien bleiben bestehen.</value>
   </data>

--- a/GUI/Localization/fr-FR/InstallFiltersDialog.fr-FR.resx
+++ b/GUI/Localization/fr-FR/InstallFiltersDialog.fr-FR.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>Filtres de l'Instance</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>Ajouter MiniAVC</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>NOTE : Les changements de filtres prendront effet lors de l'installation des prochains mods ; les fichiers déjà présents ne sont pas affectés.</value>
   </data>

--- a/GUI/Localization/fr-FR/Main.fr-FR.resx
+++ b/GUI/Localization/fr-FR/Main.fr-FR.resx
@@ -162,9 +162,6 @@
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Sauver le modpack dans un fichier (peut être réimporté)...</value>
   </data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Importer des &amp;mods téléchargés...</value>
-  </data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve">
     <value>Voir les &amp;recommandations</value>
   </data>

--- a/GUI/Localization/it-IT/InstallFiltersDialog.it-IT.resx
+++ b/GUI/Localization/it-IT/InstallFiltersDialog.it-IT.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>Filtri Dell'Istanza</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>Aggiungi MiniAVC</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>NOTA: le modifiche ai filtri di installazione hanno effetto solo sulle future installazioni di mod; i file già installati non subiranno alcuna modifica.</value>
   </data>

--- a/GUI/Localization/ko-KR/InstallFiltersDialog.ko-KR.resx
+++ b/GUI/Localization/ko-KR/InstallFiltersDialog.ko-KR.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>인스턴스 한정 필터</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>MiniAVC 추가</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>참고: 설치 필터를 바꾸면 나중의 모드 설치에만 적용돼요. 현재 모드들은 영향을 받지 않아요.</value>
   </data>

--- a/GUI/Localization/nl-NL/InstallFiltersDialog.nl-NL.resx
+++ b/GUI/Localization/nl-NL/InstallFiltersDialog.nl-NL.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>Instantiemap</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>Voeg MiniAVC toe</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>OPMERKING: Wijzigingen in de installatie filters hebben alleen effect op toekomstige mod installaties; al geïnstalleerde bestanden worden niet beïnvloed.</value>
   </data>

--- a/GUI/Localization/pl-PL/InstallFiltersDialog.pl-PL.resx
+++ b/GUI/Localization/pl-PL/InstallFiltersDialog.pl-PL.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>Filtry instalacji gry</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>Dodaj MiniAVC</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>UWAGA: Zmiany filtrów instalacyjnych zadziałają tylko dla następnych instalacji modów; już zainstalowane pliki pozostaną bez zmian.</value>
   </data>

--- a/GUI/Localization/pt-BR/InstallFiltersDialog.pt-BR.resx
+++ b/GUI/Localization/pt-BR/InstallFiltersDialog.pt-BR.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>Filtros da Instância</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>Adicionar MiniAVC</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>NOTA: Alterações nos filtros de instalação só têm efeito em futuras instalações de mods; arquivos já instalados não são afetados.</value>
   </data>

--- a/GUI/Localization/ru-RU/InstallFiltersDialog.ru-RU.resx
+++ b/GUI/Localization/ru-RU/InstallFiltersDialog.ru-RU.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>Фильтры сборки</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>Добавить MiniAVC</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>ВАЖНО: Изменения фильтров установки вступят в силу при последующих установках модификаций; установленные файлы не затрагиваются.</value>
   </data>

--- a/GUI/Localization/zh-CN/InstallFiltersDialog.zh-CN.resx
+++ b/GUI/Localization/zh-CN/InstallFiltersDialog.zh-CN.resx
@@ -123,9 +123,6 @@
   <data name="InstanceFiltersGroupBox.Text" xml:space="preserve">
     <value>对此游戏实例的过滤</value>
   </data>
-  <data name="AddMiniAVCButton.Text" xml:space="preserve">
-    <value>过滤 MiniAVC</value>
-  </data>
   <data name="WarningLabel.Text" xml:space="preserve">
     <value>注意：修改安装过滤内容仅会对未来Mod的安装生效；已安装的文件不受影响。</value>
   </data>

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -889,7 +889,8 @@ namespace CKAN.GUI
                                Properties.Resources.AllModVersionsInstallYes,
                                Properties.Resources.AllModVersionsInstallNo))
             {
-                UpdateChangesDialog(toInstall.Select(m => new ModChange(m, GUIModChangeType.Install))
+                UpdateChangesDialog(toInstall.Select(m => new ModChange(m, GUIModChangeType.Install,
+                                                                        ServiceLocator.Container.Resolve<IConfiguration>()))
                                              .ToList(),
                                     null);
                 tabController.ShowTab(ChangesetTabPage.Name, 1);

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Linq;
 
+using Autofac;
+
+using CKAN.Configuration;
+
 // Don't warn if we use our own obsolete properties
 #pragma warning disable 0618
 
@@ -24,7 +28,8 @@ namespace CKAN.GUI
                 InstallationHistory_Done();
                 var tuple = ManageMods.mainModList.ComputeFullChangeSetFromUserChangeSet(
                     RegistryManager.Instance(CurrentInstance, repoData).registry,
-                    modules.Select(mod => new ModChange(mod, GUIModChangeType.Install))
+                    modules.Select(mod => new ModChange(mod, GUIModChangeType.Install,
+                                                        ServiceLocator.Container.Resolve<IConfiguration>()))
                            .ToHashSet(),
                     CurrentInstance.game,
                     CurrentInstance.StabilityToleranceConfig,

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -58,10 +58,12 @@ namespace CKAN.GUI
                         if (installed != null)
                         {
                             // Already installed, remove it first
-                            userChangeSet.Add(new ModChange(installed.Module, GUIModChangeType.Remove));
+                            userChangeSet.Add(new ModChange(installed.Module, GUIModChangeType.Remove,
+                                                            ServiceLocator.Container.Resolve<IConfiguration>()));
                         }
                         // Install the selected mod
-                        userChangeSet.Add(new ModChange(module, GUIModChangeType.Install));
+                        userChangeSet.Add(new ModChange(module, GUIModChangeType.Install,
+                                                        ServiceLocator.Container.Resolve<IConfiguration>()));
                     }
                     if (userChangeSet.Count > 0)
                     {
@@ -98,8 +100,9 @@ namespace CKAN.GUI
                 var registry_manager = RegistryManager.Instance(CurrentInstance, repoData);
                 var registry = registry_manager.registry;
                 var stabilityTolerance = CurrentInstance.StabilityToleranceConfig;
-                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser,
-                                                    cancelTokenSrc.Token);
+                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache,
+                                                    ServiceLocator.Container.Resolve<IConfiguration>(),
+                                                    currentUser, cancelTokenSrc.Token);
                 // Avoid accumulating multiple event handlers
                 installer.OneComplete     -= OnModInstalled;
                 installer.InstallProgress -= OnModInstalling;
@@ -166,7 +169,8 @@ namespace CKAN.GUI
                         registry,
                         out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
                         out Dictionary<CkanModule, List<string>> suggestions,
-                        out Dictionary<CkanModule, HashSet<string>> supporters))
+                        out Dictionary<CkanModule, HashSet<string>> supporters)
+                        && configuration != null)
                     {
                         tabController.ShowTab(ChooseRecommendedModsTabPage.Name, 3);
                         ChooseRecommendedMods.LoadRecommendations(
@@ -176,6 +180,7 @@ namespace CKAN.GUI
                             ModuleLabelList.ModuleLabels
                                            .LabelsFor(CurrentInstance.Name)
                                            .ToList(),
+                            ServiceLocator.Container.Resolve<IConfiguration>(),
                             configuration,
                             recommendations, suggestions, supporters);
                         tabController.SetTabLock(true);
@@ -324,7 +329,8 @@ namespace CKAN.GUI
                                          .ThenByDescending(m => m.identifier == k.requested)
                                          .ThenBy(m => m.name)
                                          .ToList(),
-                                Manager.Cache);
+                                Manager.Cache,
+                                ServiceLocator.Container.Resolve<IConfiguration>());
                             tabController.SetTabLock(true);
                             var chosen = ChooseProvidedMods.Wait();
                             // Close the selection prompt

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -98,7 +98,7 @@ namespace CKAN.GUI
                 var registry_manager = RegistryManager.Instance(CurrentInstance, repoData);
                 var registry = registry_manager.registry;
                 var stabilityTolerance = CurrentInstance.StabilityToleranceConfig;
-                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser, userAgent,
+                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser,
                                                     cancelTokenSrc.Token);
                 // Avoid accumulating multiple event handlers
                 installer.OneComplete     -= OnModInstalled;

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -41,7 +41,7 @@ namespace CKAN.GUI
         {
             if (CurrentInstance != null && Manager.Cache != null)
             {
-                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser, userAgent);
+                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser);
                 if (ModuleInstaller.FindRecommendations(
                     CurrentInstance,
                     registry.InstalledModules.Select(im => im.Module).ToHashSet(),

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -4,6 +4,9 @@ using System.Windows.Forms;
 using System.Threading.Tasks;
 using System.Linq;
 
+using Autofac;
+
+using CKAN.Configuration;
 using CKAN.IO;
 using CKAN.Versioning;
 using CKAN.GUI.Attributes;
@@ -41,15 +44,18 @@ namespace CKAN.GUI
         {
             if (CurrentInstance != null && Manager.Cache != null)
             {
-                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache, currentUser);
+                var installer = new ModuleInstaller(CurrentInstance, Manager.Cache,
+                                                    ServiceLocator.Container.Resolve<IConfiguration>(),
+                                                    currentUser);
                 if (ModuleInstaller.FindRecommendations(
-                    CurrentInstance,
-                    registry.InstalledModules.Select(im => im.Module).ToHashSet(),
-                    new List<CkanModule>(),
-                    registry,
-                    out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
-                    out Dictionary<CkanModule, List<string>> suggestions,
-                    out Dictionary<CkanModule, HashSet<string>> supporters))
+                        CurrentInstance,
+                        registry.InstalledModules.Select(im => im.Module).ToHashSet(),
+                        new List<CkanModule>(),
+                        registry,
+                        out Dictionary<CkanModule, Tuple<bool, List<string>>> recommendations,
+                        out Dictionary<CkanModule, List<string>> suggestions,
+                        out Dictionary<CkanModule, HashSet<string>> supporters)
+                    && configuration != null)
                 {
                     tabController.ShowTab(ChooseRecommendedModsTabPage.Name, 3);
                     ChooseRecommendedMods.LoadRecommendations(
@@ -59,6 +65,7 @@ namespace CKAN.GUI
                         ModuleLabelList.ModuleLabels
                                        .LabelsFor(CurrentInstance.Name)
                                        .ToList(),
+                        ServiceLocator.Container.Resolve<IConfiguration>(),
                         configuration,
                         recommendations, suggestions, supporters);
                     var result = ChooseRecommendedMods.Wait();
@@ -67,7 +74,8 @@ namespace CKAN.GUI
                     {
                         Wait.StartWaiting(InstallMods, PostInstallMods, true,
                             new InstallArgument(
-                                result.Select(mod => new ModChange(mod, GUIModChangeType.Install))
+                                result.Select(mod => new ModChange(mod, GUIModChangeType.Install,
+                                                                   ServiceLocator.Container.Resolve<IConfiguration>()))
                                       .ToList(),
                                 RelationshipResolverOptions.DependsOnlyOpts(CurrentInstance.StabilityToleranceConfig)));
                     }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -8,6 +8,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 #endif
 
+using Autofac;
+
 using CKAN.Configuration;
 using CKAN.Versioning;
 
@@ -313,7 +315,8 @@ namespace CKAN.GUI
         {
             if (replaceChecked)
             {
-                yield return new ModChange(Mod, GUIModChangeType.Replace);
+                yield return new ModChange(Mod, GUIModChangeType.Replace,
+                                           ServiceLocator.Container.Resolve<IConfiguration>());
             }
             else if (!(SelectedMod?.Equals(InstalledMod?.Module)
                        ?? InstalledMod?.Module?.Equals(SelectedMod)
@@ -327,17 +330,20 @@ namespace CKAN.GUI
                     yield return new ModUpgrade(Mod,
                                                 GUIModChangeType.Update,
                                                 SelectedMod,
-                                                false, false);
+                                                false, false,
+                                                ServiceLocator.Container.Resolve<IConfiguration>());
                 }
                 else
                 {
                     if (InstalledMod != null)
                     {
-                        yield return new ModChange(InstalledMod.Module!, GUIModChangeType.Remove);
+                        yield return new ModChange(InstalledMod.Module!, GUIModChangeType.Remove,
+                                                   ServiceLocator.Container.Resolve<IConfiguration>());
                     }
                     if (SelectedMod != null)
                     {
-                        yield return new ModChange(SelectedMod, GUIModChangeType.Install);
+                        yield return new ModChange(SelectedMod, GUIModChangeType.Install,
+                                                   ServiceLocator.Container.Resolve<IConfiguration>());
                     }
                 }
             }
@@ -347,7 +353,8 @@ namespace CKAN.GUI
                 yield return new ModUpgrade(Mod,
                                             GUIModChangeType.Update,
                                             SelectedMod,
-                                            false, metadataChanged);
+                                            false, metadataChanged,
+                                            ServiceLocator.Container.Resolve<IConfiguration>());
             }
         }
 

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -3,7 +3,6 @@ using System.Drawing;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -140,7 +140,8 @@ namespace CKAN.GUI
                                          .OfType<ModuleReplacement>()
                                          .GroupBy(repl => repl.ReplaceWith)
                                          .Select(grp => new ModChange(grp.Key, GUIModChangeType.Install,
-                                                                      grp.Select(repl => new SelectionReason.Replacement(repl.ToReplace))))
+                                                                      grp.Select(repl => new SelectionReason.Replacement(repl.ToReplace)),
+                                                                      ServiceLocator.Container.Resolve<IConfiguration>()))
                                          .ToHashSet());
 
             foreach (var change in changeSet)
@@ -192,7 +193,8 @@ namespace CKAN.GUI
                         is CkanModule modByVer)
                 {
                     changeSet.Add(new ModChange(modByVer, GUIModChangeType.Remove,
-                                                new SelectionReason.DependencyRemoved()));
+                                                new SelectionReason.DependencyRemoved(),
+                                                ServiceLocator.Container.Resolve<IConfiguration>()));
                     modules_to_remove.Add(modByVer);
                 }
             }
@@ -200,7 +202,8 @@ namespace CKAN.GUI
             foreach (var im in registry.FindRemovableAutoInstalled(
                 InstalledAfterChanges(registry, changeSet).ToList(), game, stabilityTolerance, version))
             {
-                changeSet.Add(new ModChange(im.Module, GUIModChangeType.Remove, new SelectionReason.NoLongerUsed()));
+                changeSet.Add(new ModChange(im.Module, GUIModChangeType.Remove, new SelectionReason.NoLongerUsed(),
+                                            ServiceLocator.Container.Resolve<IConfiguration>()));
                 modules_to_remove.Add(im.Module);
             }
 
@@ -218,7 +221,8 @@ namespace CKAN.GUI
                          .Union(resolver.ModList()
                                         // Changeset already contains changes for these
                                         .Except(extraInstalls)
-                                        .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonsFor(m)))),
+                                        .Select(m => new ModChange(m, GUIModChangeType.Install, resolver.ReasonsFor(m),
+                                                                   ServiceLocator.Container.Resolve<IConfiguration>()))),
                 resolver.ConflictList,
                 resolver.ConflictDescriptions.ToList());
         }
@@ -499,7 +503,8 @@ namespace CKAN.GUI
                     registry.FindRemovableAutoInstalled(registry.InstalledModules.ToList(), instance.game, instance.StabilityToleranceConfig, crit)
                         .Select(im => new ModChange(
                             im.Module, GUIModChangeType.Remove,
-                            new SelectionReason.NoLongerUsed()))))
+                            new SelectionReason.NoLongerUsed(),
+                            ServiceLocator.Container.Resolve<IConfiguration>()))))
                 .ToHashSet();
         }
 

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -383,4 +383,5 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="RelationshipTypeSuggests" xml:space="preserve"><value>Vorschlag</value></data>
   <data name="RelationshipTypeSupports" xml:space="preserve"><value>Unterstützt</value></data>
   <data name="RelationshipTypeConflicts" xml:space="preserve"><value>Konflikt</value></data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>{0} hinzufügen</value></data>
 </root>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -328,9 +328,6 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Linkadresse kopieren</value></data>
   <data name="StatusInstanceLabelTextWithPlayTime" xml:space="preserve"><value>Spielinstanz: {0} ({1} {2}, {3}h gespielt)</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Spielinstanz: {0} ({1} {2})</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoriten</value></data>
-  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Versteckt</value></data>
-  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Zurückgehalten</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Möchtest du {0} wirklich löschen? Das kann nicht mehr rückgängig gemacht werden!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Änderungen speichern?</value></data>

--- a/GUI/Properties/Resources.en-US.resx
+++ b/GUI/Properties/Resources.en-US.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favorites</value></data>
   <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The license for this modpack</value></data>
   <data name="ModInfoLicenseLabel" xml:space="preserve"><value>License:</value></data>
 </root>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -828,15 +828,6 @@ Voulez-vous autoriser à faire cela ? Si vous cliquez non, vous ne verrez plus
   <data name="StatusInstanceLabelText" xml:space="preserve">
     <value>Instance de jeu : {0} ({1} {2})</value>
   </data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve">
-    <value>Favoris</value>
-  </data>
-  <data name="ModuleLabelListHidden" xml:space="preserve">
-    <value>Caché</value>
-  </data>
-  <data name="ModuleLabelListHeld" xml:space="preserve">
-    <value>Gelé</value>
-  </data>
   <data name="ModuleLabelListGlobal" xml:space="preserve">
     <value>Global</value>
   </data>

--- a/GUI/Properties/Resources.fr-FR.resx
+++ b/GUI/Properties/Resources.fr-FR.resx
@@ -1194,4 +1194,5 @@ Cette action est irréversible !</value>
   <data name="MainDeduplicateScanning" xml:space="preserve">
     <value>Recherche des fichiers installés redondants...</value>
   </data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Ajouter {0}</value></data>
 </root>

--- a/GUI/Properties/Resources.it-IT.resx
+++ b/GUI/Properties/Resources.it-IT.resx
@@ -691,15 +691,6 @@ Vuoi consentire a CKAN di farlo? Se fai clic su no, non vedrai più questo messa
   <data name="StatusInstanceLabelText" xml:space="preserve">
     <value>Istanza di gioco: {0} ({1} {2})</value>
   </data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve">
-    <value>Preferiti</value>
-  </data>
-  <data name="ModuleLabelListHidden" xml:space="preserve">
-    <value>Nascosto</value>
-  </data>
-  <data name="ModuleLabelListHeld" xml:space="preserve">
-    <value>Mantenuta</value>
-  </data>
   <data name="ModuleLabelListGlobal" xml:space="preserve">
     <value>Globale</value>
   </data>

--- a/GUI/Properties/Resources.it-IT.resx
+++ b/GUI/Properties/Resources.it-IT.resx
@@ -949,4 +949,5 @@ Vuoi consentire a CKAN di farlo? Se fai clic su no, non vedrai più questo messa
     <value>Clicca per cercare
 Ctrl-clic o Shift-click per combinare con la ricerca corrente</value>
   </data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Aggiungi {0}</value></data>
 </root>

--- a/GUI/Properties/Resources.ja-JP.resx
+++ b/GUI/Properties/Resources.ja-JP.resx
@@ -328,9 +328,6 @@ CKAN バージョン   : {3}</value></data>
 CKANにこの動作をする許可を与えますか？ いいえをクリックした場合はこのメッセージは再び表示されません。</value></data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Copy link address</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>ゲームインスタンス: {0} ({1} {2})</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>お気に入り</value></data>
-  <data name="ModuleLabelListHidden" xml:space="preserve"><value>非表示</value></data>
-  <data name="ModuleLabelListHeld" xml:space="preserve"><value>保持</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>グローバル</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>本当に {0}を消去しますか？ この操作は取消できません！</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>変更を保存しますか？</value></data>

--- a/GUI/Properties/Resources.ko-KR.resx
+++ b/GUI/Properties/Resources.ko-KR.resx
@@ -403,4 +403,5 @@ CKAN에게 이것을 허용할 건가요? 아니요를 누르면 이 메세지�
   <data name="RelationshipTypeSuggests" xml:space="preserve"><value>제안</value></data>
   <data name="RelationshipTypeSupports" xml:space="preserve"><value>지원함</value></data>
   <data name="RelationshipTypeConflicts" xml:space="preserve"><value>충돌함</value></data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>{0} 추가</value></data>
 </root>

--- a/GUI/Properties/Resources.ko-KR.resx
+++ b/GUI/Properties/Resources.ko-KR.resx
@@ -330,9 +330,6 @@ CKAN에게 이것을 허용할 건가요? 아니요를 누르면 이 메세지�
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;링크 주소 복사</value></data>
   <data name="StatusInstanceLabelTextWithPlayTime" xml:space="preserve"><value>게임 인스턴스: {0} ({1} {2}, {3}시간 플레이)</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>게임 인스턴스: {0} ({1} {2})</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>즐겨찾기</value></data>
-  <data name="ModuleLabelListHidden" xml:space="preserve"><value>숨겨짐</value></data>
-  <data name="ModuleLabelListHeld" xml:space="preserve"><value>유지</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>전역</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>정말로 {0}을 지울까요? 다시는 되돌릴 수 없어요!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>변경점을 저장할까요?</value></data>

--- a/GUI/Properties/Resources.nl-NL.resx
+++ b/GUI/Properties/Resources.nl-NL.resx
@@ -117,4 +117,5 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Voeg {0} toe</value></data>
 </root>

--- a/GUI/Properties/Resources.pl-PL.resx
+++ b/GUI/Properties/Resources.pl-PL.resx
@@ -983,4 +983,5 @@ Kliknij razem z Ctrl lub Shift, aby połączyć z bieżącym wyszukiwaniem</valu
   <data name="PreferredHostsTooltipMoveDown">
     <value>Ustaw zaznaczonego hosta jako niższy priorytet</value>
   </data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Dodaj {0}</value></data>
 </root>

--- a/GUI/Properties/Resources.pl-PL.resx
+++ b/GUI/Properties/Resources.pl-PL.resx
@@ -710,15 +710,6 @@ Czy chcesz zezwolić na to CKAN-owi? Jeśli klikniesz nie, nie zobaczysz tej wia
   <data name="StatusInstanceLabelText" xml:space="preserve">
     <value>Instalacja gry: {0} ({1} {2})</value>
   </data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve">
-    <value>Ulubione</value>
-  </data>
-  <data name="ModuleLabelListHidden" xml:space="preserve">
-    <value>Ukryte</value>
-  </data>
-  <data name="ModuleLabelListHeld" xml:space="preserve">
-    <value>Trzymane</value>
-  </data>
   <data name="ModuleLabelListGlobal" xml:space="preserve">
     <value>Globalne</value>
   </data>

--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -376,4 +376,5 @@ Você deseja permitir que o CKAN faça isso? Se você clicar em Não, você não
   <data name="RelationshipTypeSuggests" xml:space="preserve"><value>Sugere</value></data>
   <data name="RelationshipTypeSupports" xml:space="preserve"><value>Suporta</value></data>
   <data name="RelationshipTypeConflicts" xml:space="preserve"><value>Conflita</value></data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Adicionar {0}</value></data>
 </root>

--- a/GUI/Properties/Resources.pt-BR.resx
+++ b/GUI/Properties/Resources.pt-BR.resx
@@ -321,9 +321,6 @@ Não é possível atualizar automaticamente, pois o ckan.exe é somente leitura 
 Você deseja permitir que o CKAN faça isso? Se você clicar em Não, você não verá esta mensagem novamente.</value></data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Copiar endereço do link</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Instância do jogo: {0} ({1} {2})</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoritos</value></data>
-  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Oculto</value></data>
-  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Mantido</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Você tem certeza de que quer deletar {0}? Esta ação não pode ser desfeita!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Salvar alterações?</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -399,9 +399,6 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Copy link address</value></data>
   <data name="StatusInstanceLabelTextWithPlayTime" xml:space="preserve"><value>Game instance: {0} ({1} {2}, played {3}h)</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Game instance: {0} ({1} {2})</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favourites</value></data>
-  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Hidden</value></data>
-  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Held</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Are you sure you want to delete {0}? This can't be undone!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Save changes?</value></data>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -531,4 +531,5 @@ This action cannot be undone!</value></data>
   <data name="MainDeduplicateWaitTitle" xml:space="preserve"><value>Duplicating Installed Files</value></data>
   <data name="MainDeduplicateScanning" xml:space="preserve"><value>Scanning for duplicate installed files...</value></data>
   <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Add {0}</value></data>
+  <data name="InstallFiltersGlobalFiltersForGame" xml:space="preserve"><value>Global Filters for {0}</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -530,4 +530,5 @@ This action cannot be undone!</value></data>
   <data name="MainInstallDeduplicateScanning" xml:space="preserve"><value>Checking other game instances for possible duplicate installed files...</value></data>
   <data name="MainDeduplicateWaitTitle" xml:space="preserve"><value>Duplicating Installed Files</value></data>
   <data name="MainDeduplicateScanning" xml:space="preserve"><value>Scanning for duplicate installed files...</value></data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Add {0}</value></data>
 </root>

--- a/GUI/Properties/Resources.ru-RU.resx
+++ b/GUI/Properties/Resources.ru-RU.resx
@@ -332,9 +332,6 @@ https://github.com/KSP-CKAN/NetKAN/issues/new/choose
 Хотите ли вы разрешить CKAN это делать? При выборе «Нет» вы не увидите это сообщение снова.</value></data>
   <data name="UtilCopyLink" xml:space="preserve"><value>&amp;Скопировать адрес ссылки</value></data>
   <data name="StatusInstanceLabelText" xml:space="preserve"><value>Сборка игры: {0} ({1} {2})</value></data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Избранные</value></data>
-  <data name="ModuleLabelListHidden" xml:space="preserve"><value>Скрытые</value></data>
-  <data name="ModuleLabelListHeld" xml:space="preserve"><value>Без обновления</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Глобальные</value></data>
   <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Вы уверены, что хотите удалить {0}? Это действие не может быть отменено!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Сохранить изменения?</value></data>

--- a/GUI/Properties/Resources.ru-RU.resx
+++ b/GUI/Properties/Resources.ru-RU.resx
@@ -402,4 +402,5 @@ https://github.com/KSP-CKAN/NetKAN/issues/new/choose
   <data name="RelationshipTypeSuggests" xml:space="preserve"><value>Предлагать</value></data>
   <data name="RelationshipTypeSupports" xml:space="preserve"><value>Поддерживает</value></data>
   <data name="RelationshipTypeConflicts" xml:space="preserve"><value>Конфликтует с</value></data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>Добавить {0}</value></data>
 </root>

--- a/GUI/Properties/Resources.zh-CN.resx
+++ b/GUI/Properties/Resources.zh-CN.resx
@@ -782,15 +782,6 @@ CKAN Version(CKAN版本)   : {3}</value>
   <data name="StatusInstanceLabelText" xml:space="preserve">
     <value>游戏实例: {0} ({1} {2})</value>
   </data>
-  <data name="ModuleLabelListFavourites" xml:space="preserve">
-    <value>收藏</value>
-  </data>
-  <data name="ModuleLabelListHidden" xml:space="preserve">
-    <value>隐藏</value>
-  </data>
-  <data name="ModuleLabelListHeld" xml:space="preserve">
-    <value>已使用</value>
-  </data>
   <data name="ModuleLabelListGlobal" xml:space="preserve">
     <value>全局</value>
   </data>

--- a/GUI/Properties/Resources.zh-CN.resx
+++ b/GUI/Properties/Resources.zh-CN.resx
@@ -1133,4 +1133,5 @@ Ctrl-单击或Shift-单击以合并当前搜索</value>
   <data name="PreferredHostsTooltipMoveDown" xml:space="preserve">
     <value>降低所选服务器的优先级</value>
   </data>
+  <data name="InstallFiltersAddPreset" xml:space="preserve"><value>过滤 {0}</value></data>
 </root>

--- a/Tests/Core/Configuration/FakeConfiguration.cs
+++ b/Tests/Core/Configuration/FakeConfiguration.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 using CKAN;
 using CKAN.Configuration;
+using CKAN.Games;
 using CKAN.Games.KerbalSpaceProgram.GameVersionProviders;
 
 using Tests.Data;
@@ -149,7 +150,17 @@ namespace Tests.Core.Configuration
             }
         }
 
-        public string[] GlobalInstallFilters { get; set; } = Array.Empty<string>();
+        private readonly IDictionary<string, string[]> globalInstallFilters = new Dictionary<string, string[]>();
+
+        public string[] GetGlobalInstallFilters(IGame game)
+            => globalInstallFilters.TryGetValue(game.ShortName, out string[]? value)
+                   ? value
+                   : Array.Empty<string>();
+
+        public void SetGlobalInstallFilters(IGame game, string[] value)
+        {
+            globalInstallFilters[game.ShortName] = value;
+        }
 
         public string?[] PreferredHosts { get; set; } = Array.Empty<string>();
 

--- a/Tests/Core/ModuleInstallerDirTest.cs
+++ b/Tests/Core/ModuleInstallerDirTest.cs
@@ -55,7 +55,7 @@ namespace Tests.Core
             _testModule = _registry.GetModuleByVersion("DogeCoinFlag", "1.01");
             Assert.IsNotNull(_testModule, "DogeCoinFlag 1.01 should exist");
 
-            _installer = new ModuleInstaller(_instance.KSP, _manager.Cache!, _nullUser);
+            _installer = new ModuleInstaller(_instance.KSP, _manager.Cache!, _config, _nullUser);
 
             _gameDir = _instance.KSP.GameDir();
             _gameDataDir = _instance.KSP.game.PrimaryModDirectory(_instance.KSP);

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -63,11 +63,11 @@ namespace Tests.Core
         }
 
         // Test data: different ways to install the same file.
-        private static CkanModule[] doge_mods =
-            {
-                TestData.DogeCoinFlag_101_module(),
-                TestData.DogeCoinFlag_101_module_find()
-            };
+        private static readonly CkanModule[] doge_mods =
+        {
+            TestData.DogeCoinFlag_101_module(),
+            TestData.DogeCoinFlag_101_module_find()
+        };
 
         [Test]
         [TestCaseSource(nameof(doge_mods))]
@@ -98,7 +98,7 @@ namespace Tests.Core
 
         [Test]
         [TestCaseSource(nameof(doge_mods))]
-        public void FindInstallableFilesWithKSP(CkanModule mod)
+        public void FindInstallableFiles_WithKSP(CkanModule mod)
         {
             using (var tidy = new DisposableKSP())
             {
@@ -117,18 +117,18 @@ namespace Tests.Core
         // Even though they're not necessarily all spec-valid, we should accept them
         // nonetheless.
         private static readonly string[] SuchPaths =
-            {
-                "GameData/SuchTest",
-                "GameData/SuchTest/",
-                "GameData\\SuchTest",
-                "GameData\\SuchTest\\",
-                "GameData\\SuchTest/",
-                "GameData/SuchTest\\"
-            };
+        {
+            "GameData/SuchTest",
+            "GameData/SuchTest/",
+            "GameData\\SuchTest",
+            "GameData\\SuchTest\\",
+            "GameData\\SuchTest/",
+            "GameData/SuchTest\\"
+        };
 
         [Test]
         [TestCaseSource(nameof(SuchPaths))]
-        public void FindInstallableFilesWithBonusPath(string path)
+        public void FindInstallableFiles_WithBonusPath(string path)
         {
             var dogemod = TestData.DogeCoinFlag_101_module();
             dogemod.install![0].install_to = path;
@@ -190,7 +190,7 @@ namespace Tests.Core
         [Test]
         [TestCaseSource(nameof(doge_mods))]
         // Make sure all our filters work.
-        public void FindInstallableFilesWithFilter(CkanModule mod)
+        public void FindInstallableFiles_WithFilter(CkanModule mod)
         {
             string extra_doge = TestData.DogeCoinFlagZipWithExtras();
 
@@ -222,7 +222,7 @@ namespace Tests.Core
         }
 
         [Test]
-        public void No_Installable_Files()
+        public void FindInstallableFiles_NoInstallableFiles()
         {
             // This tests GH #93
 
@@ -247,7 +247,7 @@ namespace Tests.Core
 
         [Test]
         [TestCaseSource(nameof(BadTargets))]
-        public void FindInstallableFilesWithBadTarget(string location)
+        public void FindInstallableFiles_WithBadTarget(string location)
         {
             // This install location? It shouldn't be valid.
             var dogemod = TestData.DogeCoinFlag_101_module();
@@ -257,6 +257,38 @@ namespace Tests.Core
             {
                 ModuleInstaller.FindInstallableFiles(dogemod, TestData.DogeCoinFlagZip(), ksp.KSP);
             });
+        }
+
+        [Test]
+        public void FindInstallableFiles_ZipSlip_Throws()
+        {
+            // Arrange
+            // Create a ZIP file with an entry that tries to exploit Zip Slip
+            var zip = ZipFile.Create(new MemoryStream());
+            zip.BeginUpdate();
+            zip.AddDirectory("AwesomeMod");
+            zip.Add(new ZipEntry("AwesomeMod/../../../outside.txt") { Size = 0, CompressedSize = 0 });
+            zip.CommitUpdate();
+            // Create a mod that would install the top folder of that path
+            var mod = CkanModule.FromJson(@"
+                {
+                    ""spec_version"": 1,
+                    ""identifier"": ""AwesomeMod"",
+                    ""author"": ""AwesomeModder"",
+                    ""version"": ""1.0.0"",
+                    ""download"": ""https://awesomemod.example/AwesomeMod.zip""
+                }");
+
+            // Act / Assert
+            Assert.Throws<BadInstallLocationKraken>(
+                delegate
+                {
+                    using (var ksp = new DisposableKSP())
+                    {
+                        var contents = ModuleInstaller.FindInstallableFiles(mod, zip, ksp.KSP);
+                    }
+                },
+                "Kraken should be thrown if ZIP file attempts to exploit Zip Slip vulnerability");
         }
 
         [Test]
@@ -355,10 +387,10 @@ namespace Tests.Core
         [Test]
         public void UninstallModNotFound()
         {
-            using (var tidy = new DisposableKSP())
-            using (var config = new FakeConfiguration(tidy.KSP, tidy.KSP.Name))
+            using (var tidy     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(tidy.KSP, tidy.KSP.Name))
             using (var repoData = new TemporaryRepositoryData(nullUser))
-            using (var manager = new GameInstanceManager(nullUser, config)
+            using (var manager  = new GameInstanceManager(nullUser, config)
                 {
                     CurrentInstance = tidy.KSP
                 })
@@ -384,11 +416,11 @@ namespace Tests.Core
             string mod_file_name = "DogeCoinFlag/Flags/dogecoin.png";
 
             // Create a new disposable KSP instance to run the test on.
-            using (var repo = new TemporaryRepository(TestData.DogeCoinFlag_101()))
+            using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp = new DisposableKSP())
-            using (var config = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-            using (var manager = new GameInstanceManager(nullUser, config)
+            using (var ksp      = new DisposableKSP())
+            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var manager  = new GameInstanceManager(nullUser, config)
                 {
                     CurrentInstance = ksp.KSP
                 })
@@ -435,11 +467,11 @@ namespace Tests.Core
             const string mod_file_name = "DogeCoinFlag/Flags/dogecoin.png";
 
             // Create a new disposable KSP instance to run the test on.
-            using (var repo = new TemporaryRepository(TestData.DogeCoinFlag_101()))
+            using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp = new DisposableKSP())
-            using (var config = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-            using (var manager = new GameInstanceManager(nullUser, config)
+            using (var ksp      = new DisposableKSP())
+            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var manager  = new GameInstanceManager(nullUser, config)
                 {
                     CurrentInstance = ksp.KSP
                 })
@@ -481,13 +513,13 @@ namespace Tests.Core
         {
             const string emptyFolderName = "DogeCoinFlag";
 
-            using (var repo = new TemporaryRepository(TestData.DogeCoinFlag_101(),
+            using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101(),
                                                       TestData.DogeCoinPlugin()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             // Create a new disposable KSP instance to run the test on.
-            using (var ksp = new DisposableKSP())
-            using (var config = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-            using (var manager = new GameInstanceManager(new NullUser(), config)
+            using (var ksp      = new DisposableKSP())
+            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var manager  = new GameInstanceManager(new NullUser(), config)
                 {
                     CurrentInstance = ksp.KSP
                 })
@@ -645,7 +677,7 @@ namespace Tests.Core
                                                                   string[] correctNotRemovable)
         {
             // Arrange
-            using (var inst = new DisposableKSP())
+            using (var inst     = new DisposableKSP())
             using (var repoData = new TemporaryRepositoryData(nullUser))
             {
                 var game     = new KerbalSpaceProgram();
@@ -670,12 +702,12 @@ namespace Tests.Core
 
                 // Act
                 ModuleInstaller.GroupFilesByRemovable(relRoot,
-                                                           registry,
-                                                           Array.Empty<string>(),
-                                                           game,
-                                                           relPaths,
-                                                           out string[] removable,
-                                                           out string[] notRemovable);
+                                                      registry,
+                                                      Array.Empty<string>(),
+                                                      game,
+                                                      relPaths,
+                                                      out string[] removable,
+                                                      out string[] notRemovable);
 
                 // Assert
                 Assert.AreEqual(correctRemovable,    removable);
@@ -691,11 +723,11 @@ namespace Tests.Core
             for (int i = 0; i < 5; i++)
             {
                 // Create a new disposable KSP instance to run the test on.
-                using (var repo = new TemporaryRepository(TestData.DogeCoinFlag_101()))
+                using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101()))
                 using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-                using (var ksp = new DisposableKSP())
-                using (var config = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-                using (var manager = new GameInstanceManager(nullUser, config)
+                using (var ksp      = new DisposableKSP())
+                using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+                using (var manager  = new GameInstanceManager(nullUser, config)
                     {
                         CurrentInstance = ksp.KSP
                     })
@@ -812,38 +844,6 @@ namespace Tests.Core
             }
         }
 
-        [Test]
-        public void FindInstallableFiles_ZipSlip_Throws()
-        {
-            // Arrange
-            // Create a ZIP file with an entry that tries to exploit Zip Slip
-            var zip = ZipFile.Create(new MemoryStream());
-            zip.BeginUpdate();
-            zip.AddDirectory("AwesomeMod");
-            zip.Add(new ZipEntry("AwesomeMod/../../../outside.txt") { Size = 0, CompressedSize = 0 });
-            zip.CommitUpdate();
-            // Create a mod that would install the top folder of that path
-            var mod = CkanModule.FromJson(@"
-                {
-                    ""spec_version"": 1,
-                    ""identifier"": ""AwesomeMod"",
-                    ""author"": ""AwesomeModder"",
-                    ""version"": ""1.0.0"",
-                    ""download"": ""https://awesomemod.example/AwesomeMod.zip""
-                }");
-
-            // Act / Assert
-            Assert.Throws<BadInstallLocationKraken>(
-                delegate
-                {
-                    using (var ksp = new DisposableKSP())
-                    {
-                        var contents = ModuleInstaller.FindInstallableFiles(mod, zip, ksp.KSP);
-                    }
-                },
-                "Kraken should be thrown if ZIP file attempts to exploit Zip Slip vulnerability");
-        }
-
         [Test,
          TestCase(new string[] {
                       @"{
@@ -949,11 +949,11 @@ namespace Tests.Core
         public void InstallList_RealZipSlip_Throws()
         {
             // Arrange
-            using (var repo = new TemporaryRepository(TestData.DogeCoinFlag_101ZipSlip()))
+            using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101ZipSlip()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp = new DisposableKSP())
-            using (var config = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-            using (var manager = new GameInstanceManager(nullUser, config)
+            using (var ksp      = new DisposableKSP())
+            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var manager  = new GameInstanceManager(nullUser, config)
                 {
                     CurrentInstance = ksp.KSP
                 })
@@ -991,11 +991,11 @@ namespace Tests.Core
         public void InstallList_RealZipBomb_DoesNotThrow()
         {
             // Arrange
-            using (var repo = new TemporaryRepository(TestData.DogeCoinFlag_101ZipBomb()))
+            using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101ZipBomb()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp = new DisposableKSP())
-            using (var config = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-            using (var manager = new GameInstanceManager(nullUser, config)
+            using (var ksp      = new DisposableKSP())
+            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var manager  = new GameInstanceManager(nullUser, config)
                 {
                     CurrentInstance = ksp.KSP
                 })
@@ -1058,8 +1058,8 @@ namespace Tests.Core
                     ]
                 }"))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var config = new FakeConfiguration(inst.KSP, inst.KSP.Name))
-            using (var manager = new GameInstanceManager(nullUser, config)
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager  = new GameInstanceManager(nullUser, config)
                 {
                     CurrentInstance = inst.KSP
                 })
@@ -1127,8 +1127,8 @@ namespace Tests.Core
                     ]
                 }"))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var config = new FakeConfiguration(inst.KSP, inst.KSP.Name))
-            using (var manager = new GameInstanceManager(nullUser, config)
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager  = new GameInstanceManager(nullUser, config)
                 {
                     CurrentInstance = inst.KSP
                 })
@@ -1203,7 +1203,7 @@ namespace Tests.Core
                 {
                     CurrentInstance = inst.KSP
                 })
-            using (var repo = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
+            using (var repo     = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             {
                 var installer = new ModuleInstaller(inst.KSP, manager.Cache!, nullUser);
@@ -1286,7 +1286,7 @@ namespace Tests.Core
                 {
                     CurrentInstance = inst.KSP
                 })
-            using (var repo = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
+            using (var repo     = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             {
                 var installer  = new ModuleInstaller(inst.KSP, manager.Cache!, nullUser);

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -399,7 +399,7 @@ namespace Tests.Core
                 {
                     HashSet<string>? possibleConfigOnlyDirs = null;
                     // This should throw, as our tidy KSP has no mods installed.
-                    new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
+                    new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                         .UninstallList(new List<string> {"Foo"},
                                        ref possibleConfigOnlyDirs,
                                        RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
@@ -450,7 +450,7 @@ namespace Tests.Core
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
+                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
@@ -489,7 +489,7 @@ namespace Tests.Core
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
+                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .InstallList(modules, new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
                                  ref possibleConfigOnlyDirs);
@@ -498,7 +498,7 @@ namespace Tests.Core
                 Assert.IsTrue(File.Exists(mod_file_path));
 
                 // Attempt to uninstall it.
-                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
+                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .UninstallList(modules.Select(m => m.identifier),
                                    ref possibleConfigOnlyDirs,
                                    RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
@@ -537,7 +537,7 @@ namespace Tests.Core
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
+                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
@@ -552,7 +552,7 @@ namespace Tests.Core
 
                 modules.Add(TestData.DogeCoinPlugin_module());
 
-                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
+                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
@@ -568,7 +568,7 @@ namespace Tests.Core
                 modules.Add(TestData.DogeCoinFlag_101_module());
                 modules.Add(TestData.DogeCoinPlugin_module());
 
-                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, nullUser)
+                new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .UninstallList(modules.Select(m => m.identifier),
                                    ref possibleConfigOnlyDirs,
                                    RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
@@ -746,7 +746,7 @@ namespace Tests.Core
                     var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                     HashSet<string>? possibleConfigOnlyDirs = null;
-                    new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
+                    new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                         .InstallList(modules,
                                      new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                      RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
@@ -977,7 +977,7 @@ namespace Tests.Core
                     delegate
                     {
                         HashSet<string>? possibleConfigOnlyDirs = null;
-                        new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
+                        new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                             .InstallList(modules,
                                          new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                          RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
@@ -1016,7 +1016,7 @@ namespace Tests.Core
 
                 // Act / Assert
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(ksp.KSP, manager.Cache!, nullUser)
+                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
@@ -1072,7 +1072,7 @@ namespace Tests.Core
                 Assert.IsNotNull(replaced, "Replaced module should exist");
                 var replacer = registry.GetModuleByVersion("replacer", "1.0");
                 Assert.IsNotNull(replacer, "Replacer module should exist");
-                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, nullUser);
+                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache!);
 
@@ -1141,7 +1141,7 @@ namespace Tests.Core
                 Assert.IsNotNull(replaced, "Replaced module should exist");
                 var replacer = registry.GetModuleByVersion("replacer", "1.0");
                 Assert.IsNotNull(replacer, "Replacer module should exist");
-                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, nullUser);
+                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache!);
 
                 // Act
@@ -1206,7 +1206,7 @@ namespace Tests.Core
             using (var repo     = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             {
-                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, nullUser);
+                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 var regMgr    = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager);
                 var registry  = regMgr.registry;
                 var possibleConfigOnlyDirs = new HashSet<string>();
@@ -1289,7 +1289,7 @@ namespace Tests.Core
             using (var repo     = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             {
-                var installer  = new ModuleInstaller(inst.KSP, manager.Cache!, nullUser);
+                var installer  = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache!);
                 var regMgr     = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager);
                 var registry   = regMgr.registry;
@@ -1374,7 +1374,7 @@ namespace Tests.Core
                                                          repoData.Manager);
                 var module    = CkanModule.FromJson(moduleJson);
                 var modules   = new List<CkanModule> { module };
-                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, nullUser);
+                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 File.WriteAllText(inst.KSP.ToAbsoluteGameDir(unmanaged),
                                   "Not really a DLL, are we?");
                 regMgr.ScanUnmanagedFiles();
@@ -1382,7 +1382,7 @@ namespace Tests.Core
 
                 // Act
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(inst.KSP, manager.Cache!, nullUser)
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
                                  regMgr,

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -1028,18 +1028,17 @@ namespace Tests.Core
         public void InstallList_KSP1InstallFilterPresets_InstallsZeroMiniAVCWithoutMiniAVC()
         {
             // Arrange
-            using (var inst   = new DisposableKSP())
-            using (var config = new FakeConfiguration(inst.KSP, inst.KSP.Name)
-                {
-                    GlobalInstallFilters = inst.KSP.game.InstallFilterPresets
-                                                        .SelectMany(kvp => kvp.Value)
-                                                        .ToArray(),
-                })
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var repo     = new TemporaryRepository())
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
+                config.SetGlobalInstallFilters(inst.KSP.game,
+                                               inst.KSP.game.InstallFilterPresets
+                                                            .SelectMany(kvp => kvp.Value)
+                                                            .ToArray());
                 // The tests for different targets can run in parallel,
                 // so they don't share a cache nicely
                 const string targetFramework =

--- a/Tests/Core/ModuleInstallerTests.cs
+++ b/Tests/Core/ModuleInstallerTests.cs
@@ -394,6 +394,7 @@ namespace Tests.Core
                 {
                     CurrentInstance = tidy.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(tidy.KSP, repoData.Manager))
             {
                 Assert.Throws<ModNotInstalledKraken>(delegate
                 {
@@ -401,8 +402,7 @@ namespace Tests.Core
                     // This should throw, as our tidy KSP has no mods installed.
                     new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                         .UninstallList(new List<string> {"Foo"},
-                                       ref possibleConfigOnlyDirs,
-                                       RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
+                                       ref possibleConfigOnlyDirs, regMgr);
                 });
 
                 // I weep even more.
@@ -424,6 +424,8 @@ namespace Tests.Core
                 {
                     CurrentInstance = ksp.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 // Make sure the mod is not installed.
                 string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);
@@ -440,7 +442,7 @@ namespace Tests.Core
                 Assert.IsTrue(manager.Cache?.IsCached(TestData.DogeCoinFlag_101_module()));
                 Assert.IsTrue(File.Exists(cache_path));
 
-                var registry = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager).registry;
+                var registry = regMgr.registry;
                 registry.RepositoriesClear();
                 registry.RepositoriesAdd(repo.repo);
 
@@ -453,7 +455,7 @@ namespace Tests.Core
                 new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                 RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
+                                 regMgr,
                                  ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
@@ -475,11 +477,13 @@ namespace Tests.Core
                 {
                     CurrentInstance = ksp.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);
 
                 // Install the test mod.
-                var registry = RegistryManager.Instance(ksp.KSP, repoData.Manager).registry;
+                var registry = regMgr.registry;
                 registry.RepositoriesClear();
                 registry.RepositoriesAdd(repo.repo);
                 manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
@@ -491,8 +495,7 @@ namespace Tests.Core
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .InstallList(modules, new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                 RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
-                                 ref possibleConfigOnlyDirs);
+                                 regMgr, ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
@@ -500,8 +503,7 @@ namespace Tests.Core
                 // Attempt to uninstall it.
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .UninstallList(modules.Select(m => m.identifier),
-                                   ref possibleConfigOnlyDirs,
-                                   RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
+                                   ref possibleConfigOnlyDirs, regMgr);
 
                 // Check that the module is not installed.
                 Assert.IsFalse(File.Exists(mod_file_path));
@@ -523,11 +525,13 @@ namespace Tests.Core
                 {
                     CurrentInstance = ksp.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 string directoryPath = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), emptyFolderName);
 
                 // Install the base test mod.
-                var registry = RegistryManager.Instance(ksp.KSP, repoData.Manager).registry;
+                var registry = regMgr.registry;
                 registry.RepositoriesClear();
                 registry.RepositoriesAdd(repo.repo);
                 manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
@@ -540,8 +544,7 @@ namespace Tests.Core
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                 RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
-                                 ref possibleConfigOnlyDirs);
+                                 regMgr, ref possibleConfigOnlyDirs);
 
                 modules.Clear();
 
@@ -555,8 +558,7 @@ namespace Tests.Core
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                 RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
-                                 ref possibleConfigOnlyDirs);
+                                 regMgr, ref possibleConfigOnlyDirs);
 
                 modules.Clear();
 
@@ -570,8 +572,7 @@ namespace Tests.Core
 
                 new ModuleInstaller(manager.CurrentInstance, manager.Cache!, config, nullUser)
                     .UninstallList(modules.Select(m => m.identifier),
-                                   ref possibleConfigOnlyDirs,
-                                   RegistryManager.Instance(manager.CurrentInstance, repoData.Manager));
+                                   ref possibleConfigOnlyDirs, regMgr);
 
                 // Check that the directory has been deleted.
                 Assert.IsFalse(Directory.Exists(directoryPath));
@@ -731,8 +732,9 @@ namespace Tests.Core
                     {
                         CurrentInstance = ksp.KSP
                     })
+                using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                                                               new Repository[] { repo.repo }))
                 {
-                    var regMgr = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager);
                     var registry = regMgr.registry;
                     registry.RepositoriesClear();
                     registry.RepositoriesAdd(repo.repo);
@@ -749,8 +751,7 @@ namespace Tests.Core
                     new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                         .InstallList(modules,
                                      new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                     RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
-                                     ref possibleConfigOnlyDirs);
+                                     regMgr, ref possibleConfigOnlyDirs);
 
                     // Check that the module is installed.
                     Assert.IsTrue(File.Exists(Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP),
@@ -957,10 +958,10 @@ namespace Tests.Core
                 {
                     CurrentInstance = ksp.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
-                var registry = RegistryManager.Instance(manager.CurrentInstance,
-                                                        repoData.Manager)
-                                              .registry;
+                var registry = regMgr.registry;
                 registry.RepositoriesClear();
                 registry.RepositoriesAdd(repo.repo);
 
@@ -980,8 +981,7 @@ namespace Tests.Core
                         new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                             .InstallList(modules,
                                          new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                         RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
-                                         ref possibleConfigOnlyDirs);
+                                         regMgr, ref possibleConfigOnlyDirs);
                     },
                     "Kraken should be thrown if ZIP file attempts to exploit Zip Slip vulnerability");
             }
@@ -999,10 +999,10 @@ namespace Tests.Core
                 {
                     CurrentInstance = ksp.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
-                var registry = RegistryManager.Instance(manager.CurrentInstance,
-                                                        repoData.Manager)
-                                              .registry;
+                var registry = regMgr.registry;
                 registry.RepositoriesClear();
                 registry.RepositoriesAdd(repo.repo);
 
@@ -1019,8 +1019,7 @@ namespace Tests.Core
                 new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
-                                 RegistryManager.Instance(manager.CurrentInstance, repoData.Manager),
-                                 ref possibleConfigOnlyDirs);
+                                 regMgr, ref possibleConfigOnlyDirs);
             }
         }
 
@@ -1063,11 +1062,11 @@ namespace Tests.Core
                 {
                     CurrentInstance = inst.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
-                var regMgr = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager);
                 var registry = regMgr.registry;
                 IRegistryQuerier querier = registry;
-                registry.RepositoriesAdd(repo.repo);
                 var replaced = registry.GetModuleByVersion("replaced", "1.0")!;
                 Assert.IsNotNull(replaced, "Replaced module should exist");
                 var replacer = registry.GetModuleByVersion("replacer", "1.0");
@@ -1132,11 +1131,11 @@ namespace Tests.Core
                 {
                     CurrentInstance = inst.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
-                var regMgr = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager);
                 var registry = regMgr.registry;
                 IRegistryQuerier querier = registry;
-                registry.RepositoriesAdd(repo.repo);
                 var replaced = registry.GetModuleByVersion("replaced", "1.0")!;
                 Assert.IsNotNull(replaced, "Replaced module should exist");
                 var replacer = registry.GetModuleByVersion("replacer", "1.0");
@@ -1205,9 +1204,10 @@ namespace Tests.Core
                 })
             using (var repo     = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
-                var regMgr    = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager);
                 var registry  = regMgr.registry;
                 var possibleConfigOnlyDirs = new HashSet<string>();
                 foreach (var m in regularMods)
@@ -1288,10 +1288,11 @@ namespace Tests.Core
                 })
             using (var repo     = new TemporaryRepository(regularMods.Concat(autoInstMods).ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 var installer  = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache!);
-                var regMgr     = RegistryManager.Instance(manager.CurrentInstance, repoData.Manager);
                 var registry   = regMgr.registry;
                 registry.RepositoriesSet(new SortedDictionary<string, Repository>()
                 {
@@ -1369,9 +1370,9 @@ namespace Tests.Core
                 {
                     CurrentInstance = inst.KSP
                 })
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
-                var regMgr    = RegistryManager.Instance(manager.CurrentInstance,
-                                                         repoData.Manager);
                 var module    = CkanModule.FromJson(moduleJson);
                 var modules   = new List<CkanModule> { module };
                 var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -205,9 +205,11 @@ namespace Tests.Core.Registry
         {
             // Arrange
             using (var instance = new DisposableKSP())
-            using (var repoData = new TemporaryRepositoryData(new NullUser()))
+            using (var repo     = new TemporaryRepository())
+            using (var repoData = new TemporaryRepositoryData(new NullUser(), repo.repo))
             {
-                using (var manager = RegistryManager.Instance(instance.KSP, repoData.Manager))
+                using (var manager = RegistryManager.Instance(instance.KSP, repoData.Manager,
+                                                              new Repository[] { repo.repo }))
                 {
                     // Act
                     manager.registry.SetDlcs(new Dictionary<string, UnmanagedModuleVersion>()
@@ -217,7 +219,8 @@ namespace Tests.Core.Registry
                     });
                     manager.Save();
                 }
-                using (var manager = RegistryManager.Instance(instance.KSP, repoData.Manager))
+                using (var manager = RegistryManager.Instance(instance.KSP, repoData.Manager,
+                                                              new Repository[] { repo.repo }))
                 {
                     // Assert
                     CollectionAssert.IsSupersetOf(manager.registry.InstalledDlc.Keys,

--- a/Tests/Core/Registry/RegistryLive.cs
+++ b/Tests/Core/Registry/RegistryLive.cs
@@ -27,13 +27,12 @@ namespace Tests.Core.Registry
             {
                 { repo, RepositoryData.FromJson(TestData.TestRepository(), null)! },
             }))
+            using (var regMgr = RegistryManager.Instance(temp_ksp.KSP, repoData.Manager,
+                                                         new Repository[] { repo }))
             {
-                var registry = RegistryManager.Instance(temp_ksp.KSP, repoData.Manager).registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo);
-
-                var module =
-                    registry.LatestAvailable("AGExt", new StabilityToleranceConfig(""), new GameVersionCriteria(temp_ksp.KSP.Version()));
+                var registry = regMgr.registry;
+                var module = registry.LatestAvailable("AGExt", new StabilityToleranceConfig(""),
+                                                               new GameVersionCriteria(temp_ksp.KSP.Version()));
 
                 Assert.AreEqual("AGExt", module?.identifier);
                 Assert.AreEqual("1.24a", module?.version.ToString());

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -169,7 +169,7 @@ namespace Tests.GUI
                 Assert.IsNotNull(anyVersionModule, "DogeCoinFlag 1.01 should exist");
                 var modList = new ModList();
                 var listGui = new DataGridView();
-                var installer = new ModuleInstaller(instance.KSP, manager.Cache!, manager.User);
+                var installer = new ModuleInstaller(instance.KSP, manager.Cache!, config, manager.User);
                 var downloader = new NetAsyncModulesDownloader(user, manager.Cache!);
 
                 // Act

--- a/Tests/GUI/ResourcesTests.cs
+++ b/Tests/GUI/ResourcesTests.cs
@@ -90,8 +90,9 @@ namespace Tests.GUI
         // The types to test
         private static IEnumerable<Type> DialogsAndControls =>
             Assembly.GetAssembly(typeof(CKAN.GUI.Main))
-                    .GetTypes()
-                    .Where(t => !t.IsAbstract && baseTypesToCheck.Any(t.IsSubclassOf));
+                    ?.GetTypes()
+                     .Where(t => !t.IsAbstract && baseTypesToCheck.Any(t.IsSubclassOf))
+                    ?? Enumerable.Empty<Type>();
 
         private static readonly Type[] baseTypesToCheck = new Type[]
         {

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -49,7 +49,8 @@ namespace Tests.NetKAN.Sources.Github
         public void GetsLatestReleaseCorrectly()
         {
             // Arrange
-            var sut = new GithubApi(new CachingHttpService(_cache!));
+            var sut = new GithubApi(new CachingHttpService(_cache!),
+                                    Environment.GetEnvironmentVariable("GITHUB_TOKEN"));
 
             // Act
             var githubRelease = sut.GetLatestRelease(new GithubRef("#/ckan/github/KSP-CKAN/Test", false), false);


### PR DESCRIPTION
## Motivation

- @linuxgurugamer pointed out that the install filter preset to block MiniAVC also blocks `ZeroMiniAVC.dll`, which is unnecessary for CKAN-installed mods because the filter itself blocks MiniAVC, but could be desirable for purging files from manually-installed mods.
- The global install filter applies across all games, but each game has completely different mods and file naming conventions, so it doesn't make sense to treat them the same.
  - Similarly, the MiniAVC button appears even if you're using KSP2, which 
- @doinkythederp's work on a new Mac GUI proceeds apace, and one of the screenshots reminded me that `ModuleLabel` and `ModuleLabelList` live exclusively in GUI but would be useful for other GUIs.

## Changes

- Now the MiniAVC preset's file paths have `/` added to the front so they won't match parts of other file names
  - Furthermore, MiniAVC v1 and MiniAVC v2 are broken out into separate preset buttons in case users only want to block one or the other.
  - A test is added to confirm that the install filter presets for KSP1 do not prevent `ZeroMinIAVC.dll` from being installed.
    Since ZeroMiniAVC and MiniAVC are both GPL-3.0, and the CKAN repo is MIT, we download the mods during the test and cache them in `_build/test/cache/<target framework>` (the target framework is included to avoid problems with the test clobbering itself when running in parallel for different frameworks). This directory will be cached by the GitHub workflows to reduce network traffic.
- Now each game has its own global install filter. Any values users currently have will be copied to both games at load, and will be edited separately thereafter.
  - This also applies to the preset buttons. Currently the MiniAVC button appears for KSP1 and nothing appears for KSP2; we can add presets for KSP2 later if a common use case arises.
- `ModuleLabel` and `ModuleLabelList` are moved from GUI to Core.

### Side fixes

- #3458 was developed on Linux and left in two compile errors that only occurs on Windows for net8.0.
  Now they're fixed.
- Some of the tests make API calls out to GitHub, so if you run them too much, you can get throttled.
  Now we can set the `GITHUB_TOKEN` environment variable to a GitHub API auth token to solve this.
- The `RegistryLive` test can fail on Windows if our three target platforms attempt to run it simultaneously, because a `FIle.Open` call in `RepositoryData` holds an exclusive lock.
  Now that call uses `OpenRead` instead.
- Since 4a6df2113d61c139357dd3c5bfe2b823b137ebc6, loading the registry can throw this exception:
  ```
  System.ArgumentException: An item with the same key has already been added.
     at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
     at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
     at CKAN.SingleAssemblyResourceManager.InternalGetResourceSet(CultureInfo culture, Boolean createIfNotExists, Boolean tryParents)
     at System.Resources.ResourceManager.GetString(String name, CultureInfo culture)
     at CKAN.Properties.Resources.get_UnmanagedModuleVersionKnown()
     at CKAN.Versioning.UnmanagedModuleVersion..ctor(String version)
     at CKAN.CkanModule.DeSerialisationFixes(StreamingContext like_i_could_care)
  ```
  The loading of `CkanModules` from `registry.json` is parallelized for performance, and the construction of a `CkanModule` for a DLC requires creating an `UnmanagedModuleVersion`, the constructor of which accesses an i18n resource, which is loaded on the fly and cached by `SingleAssemblyResourceManager`. If two DLC `CkanModules` are loaded in parallel, they can end up loading the same resource set simultaneously in different threads and attempting to store both sets to the cache, which throws a duplicate key exception.
  Now `SingleAssemblyResourceManager` uses `lock` to control access to its resource set cache so this won't happen.
- `ModuleInstaller.Download` and `ModuleInstaller.CachedOrDownload` are not used, so now they're removed.
  These functions were the only reason `ModuleInstaller`'s constructor needed a user agent, so that parameter is also removed.
- A translated French string was duplicated at some point. Now the duplicate is removed.
- The locally cached file for the `KSP-Default` repository is checked many times when the tests are run, even though in most cases we're not even trying to use that repo.
  Now the actual correct repo to used is passed all the way into the registry during tests, which pre-empts the attempt to check if `KSP-Default` is cached. In addition, `RegistryManager`s used in tests will now be `Dispose`d when done, which will ensure that the global in-process cache of `RegistryManagers` doesn't grow without bound.
- `ModuleInstaller` grabbed a reference to the `JsonConfiguration` internally, global-variable style, which made it impossible to override those settings in tests.
  Now the configuration is a parameter instead of being acquired sneakily, so tests can control the settings used for the test.
- `RegistryManager.AscertainDefaultRepo` duplicated some logic from `Repository.DefaultGameRepo`.
  Now the former calls the latter instead.
