### PR TITLE
Detect future registry versions

### DIFF
--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -165,6 +165,9 @@ Install the `mono-complete` package or equivalent for your operating system.</va
   <data name="RegistryManagerDirectoryNotFound" xml:space="preserve"><value>Can't find a directory in {0}</value></data>
   <data name="RegistryManagerExportFilenamePrefix" xml:space="preserve"><value>installed</value></data>
   <data name="RegistryManagerDefaultModpackAbstract" xml:space="preserve"><value>A list of modules installed on the {0} KSP instance</value></data>
+  <data name="RegistryManagerRegistryVersionNotSupported" xml:space="preserve"><value>This version of CKAN is too old to load:
+{0}
+Update CKAN to load this game instance.</value></data>
   <data name="CkanModuleDeserialisationError" xml:space="preserve"><value>JSON deserialisation error: {0}</value></data>
   <data name="CkanModuleUnsupportedSpec" xml:space="preserve"><value>{0} requires CKAN {1}, we can't read it.</value></data>
   <data name="CkanModuleMissingRequired" xml:space="preserve"><value>{0} missing required field {1}</value></data>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -163,6 +163,14 @@ namespace CKAN
         [OnDeserialized]
         private void DeSerialisationFixes(StreamingContext context)
         {
+            if (registry_version > LATEST_REGISTRY_VERSION)
+            {
+                throw new RegistryVersionNotSupportedKraken(
+                    registry_version,
+                    string.Format(Properties.Resources.RegistryManagerRegistryVersionNotSupported,
+                                  "registry.json"));
+            }
+
             // Our context is our game instance.
             var ksp = context.Context as GameInstance;
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -200,10 +200,10 @@ namespace CKAN
     {
         public readonly int requestVersion;
 
-        public RegistryVersionNotSupportedKraken(int v, string? reason = null, Exception? innerException = null)
-            : base(reason, innerException)
+        public RegistryVersionNotSupportedKraken(int badVersion, string reason)
+            : base(reason)
         {
-            requestVersion = v;
+            requestVersion = badVersion;
         }
     }
 

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="IndexRange" Version="1.0.3" />
+    <PackageReference Include="StringSyntaxAttribute" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <Reference Include="System" />

--- a/GUI/Dialogs/AskUserForAutoUpdatesDialog.Designer.cs
+++ b/GUI/Dialogs/AskUserForAutoUpdatesDialog.Designer.cs
@@ -44,9 +44,10 @@ namespace CKAN.GUI
             //
             // YesButton
             //
+            this.YesButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.YesButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.YesButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.YesButton.Location = new System.Drawing.Point(401, 44);
+            this.YesButton.Location = new System.Drawing.Point(401, 64);
             this.YesButton.Name = "YesButton";
             this.YesButton.Size = new System.Drawing.Size(149, 23);
             this.YesButton.TabIndex = 1;
@@ -55,8 +56,9 @@ namespace CKAN.GUI
             //
             // NoButton
             //
+            this.NoButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.NoButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.NoButton.Location = new System.Drawing.Point(323, 44);
+            this.NoButton.Location = new System.Drawing.Point(323, 64);
             this.NoButton.Size = new System.Drawing.Size(72, 23);
             this.NoButton.DialogResult = System.Windows.Forms.DialogResult.No;
             this.NoButton.Name = "NoButton";
@@ -66,9 +68,9 @@ namespace CKAN.GUI
             //
             // AskUserForAutoUpdatesDialog
             //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(562, 79);
+            this.ClientSize = new System.Drawing.Size(562, 100);
             this.Controls.Add(this.NoButton);
             this.Controls.Add(this.YesButton);
             this.Controls.Add(this.autoCheckLabel);

--- a/GUI/Dialogs/ErrorDialog.Designer.cs
+++ b/GUI/Dialogs/ErrorDialog.Designer.cs
@@ -74,7 +74,7 @@ namespace CKAN.GUI
             //
             // ErrorDialog
             //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 160);
             this.ControlBox = true;

--- a/GUI/Dialogs/ErrorDialog.cs
+++ b/GUI/Dialogs/ErrorDialog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using System.Windows.Forms;
+using System.Diagnostics.CodeAnalysis;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -22,7 +23,9 @@ namespace CKAN.GUI
         }
 
         [ForbidGUICalls]
-        public void ShowErrorDialog(Main mainForm, string text, params object[] args)
+        public void ShowErrorDialog(Main mainForm,
+                                    [StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+                                    string text, params object[] args)
         {
             Util.Invoke(mainForm, () =>
             {


### PR DESCRIPTION
## Background

`Registry.registry_version` was created to track changes in the format of the registry:

| `registry_version` | Effects
| -- | -- |
| 0 | The keys of `installed_files` will be renormalized after deserialization (see 1de77dd50bc606e9cd8467688a44c1e780a86b2c and #177)
| 0 or 1 | The identifier `001ControlLock` will be migrated to `ControlLock` in `installed_modules` (see #980) |
| 2 | No effect, but corresponds to when `license` became an array (see #1132) |

The current max version is 3, and it hasn't been changed in almost ten years.

## Motivation

If we do change the value of this property again in the future, it would be good for the registry to check it and react appropriately if it indicates a later version of the registry that we can't parse. Currently it does nothing.

## Changes

Now if `registry_version` is greater than `LATEST_REGISTRY_VERSION` (which you can test by just editing `registry.json` and changing the `3` to `4`), `RegistryVersionNotSupportedKraken` is thrown after deserialization. `RegistryManager.LoadRegistry` then strips off the `TargetInvocationException` wrapper, and `RegistryManager.Load` substitutes a kraken with the proper full path to `registry.json`. That exception is then caught in `Main.OnShown` if the registry was loaded at startup or `Main.manageGameInstancesMenuItem_Click` if it was loaded later, and an error popup is shown, after which the user will be prompted to update to a newer CKAN client automatically if there is one, as in #4026.

Fixes #1130.

### Side fixes

- `ErrorDialog.ShowErrorDialog` uses its `text` param as a format string, but it didn't have the `StringSyntax` attribute.
  Now it does.
- The auto update prompt dialog and the error dialog had some visual mal-alignments.
  Now they're fixed.
