### PR TITLE
Show download errors popup for downloads from Contents tab

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -147,9 +147,13 @@ namespace CKAN
             }
 
             // Check to see if we've had any errors. If so, then release the kraken!
-            var exceptions = downloads.Select(dl => dl.error != null
-                                                        ? new KeyValuePair<DownloadTarget, Exception>(dl.target, dl.error)
-                                                        : (KeyValuePair<DownloadTarget, Exception>?)null)
+            var exceptions = downloads.SelectMany(dl => dl.error switch
+                                                        {
+                                                            DownloadErrorsKraken dlKrak => dlKrak.Exceptions,
+                                                            Exception => Enumerable.Repeat(
+                                                                new KeyValuePair<DownloadTarget, Exception>(dl.target, dl.error), 1),
+                                                            null => Enumerable.Empty<KeyValuePair<DownloadTarget, Exception>>(),
+                                                        })
                                       .OfType<KeyValuePair<DownloadTarget, Exception>>()
                                       .ToList();
 

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -212,7 +212,7 @@ namespace CKAN
                             OneComplete?.Invoke(m);
                         }
                     }
-                    catch (InvalidModuleFileKraken kraken)
+                    catch (InvalidModuleFileKraken)
                     {
                         if (module != null)
                         {
@@ -223,7 +223,7 @@ namespace CKAN
                         File.Delete(filename);
 
                         // Tell downloader there is a problem with this file
-                        throw new DownloadErrorsKraken(target, kraken);
+                        throw;
                     }
                     catch (OperationCanceledException exc)
                     {


### PR DESCRIPTION
## Motivation

- While investigating #930, I noticed that the validation error for KopernicusTech's old Dropbox link was being printed to the log instead of popping up the failed downloads popup. That turned out to be because I was downloading from the Contents tab, where it's not implemented.
- Furthermore, that same error was showing the text for a `DownloadErrorsKraken` where it should have been getting to the point of the mismatched hash. Turns out that's because that's what the module downloader throws when `Cache.Store` throws `InvalidModuleKraken`.

## Changes

- Now if a download from the Contents tab fails, the failed downloads popup will appear.
- Now we re-throw the same exception when `Cache.Store` fails, so the message will be normal.
  - In case there are any other instances of this left or added in the future, the downloader now detects when a download is directly associated with a `DownloadErrorsKraken` and extracts the original source exceptions when constructing the new `DownloadErrorsKraken` representing the whole group of downloads.
