### PR TITLE
Propagate exceptions from downloader task

### DIFF
--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -139,7 +139,15 @@ namespace CKAN
                 yield return m;
             }
             blockingQueue.Dispose();
-            if (dlTask.Exception is AggregateException { InnerException: Exception exc })
+            try
+            {
+                dlTask.Wait();
+                if (dlTask.Exception is AggregateException { InnerException: Exception exc })
+                {
+                    throw exc;
+                }
+            }
+            catch (AggregateException agExc) when (agExc.InnerException is Exception exc)
             {
                 throw exc;
             }
@@ -155,6 +163,10 @@ namespace CKAN
                                               {
                                                   blockingQueue.CompleteAdding();
                                                   OneComplete -= oneComplete;
+                                                  if (t.Exception is AggregateException { InnerException: Exception exc })
+                                                  {
+                                                      throw exc;
+                                                  }
                                               }),
                     blockingQueue);
         }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -229,13 +229,13 @@ namespace CKAN.GUI
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
 
-                // Treat whole changeset as atomic
-                using (TransactionScope transaction = CkanTransaction.CreateTransactionScope())
+                // Checks if all actions were successful
+                // Uninstall/installs/upgrades until every list is empty
+                // If the queue is NOT empty, resolvedAllProvidedMods is false until the action is done
+                for (bool resolvedAllProvidedMods = false; !resolvedAllProvidedMods;)
                 {
-                    // Checks if all actions were successful
-                    // Uninstall/installs/upgrades until every list is empty
-                    // If the queue is NOT empty, resolvedAllProvidedMods is false until the action is done
-                    for (bool resolvedAllProvidedMods = false; !resolvedAllProvidedMods;)
+                    // Treat whole changeset as atomic
+                    using (TransactionScope transaction = CkanTransaction.CreateTransactionScope())
                     {
                         try
                         {
@@ -263,6 +263,7 @@ namespace CKAN.GUI
                                 e.Result = new InstallResult(false, changes);
                                 throw new CancelledActionKraken();
                             }
+                            transaction.Complete();
                             resolvedAllProvidedMods = true;
                         }
                         catch (ModuleDownloadErrorsKraken k)
@@ -351,7 +352,6 @@ namespace CKAN.GUI
                             }
                         }
                     }
-                    transaction.Complete();
                 }
                 HandlePossibleConfigOnlyDirs(registry, possibleConfigOnlyDirs);
                 e.Result = new InstallResult(true, changes);


### PR DESCRIPTION
## Problem

The download errors popup seems to be missing in action from the GUI install flow again.

## Cause

You would think that throwing an exception in a `Task` would save that exception to `Task.Exception.InnerException` so you could inspect and handle it. But you would be wrong; our exceptions were getting lost in two ways:

- The `ContinueWith` call receives the main task as its parameter and apparently needs to re-throw its `Exception.InnerException` to avoid losing it
- That exception still isn't actually set to the main `Task.Exception`, possibly because `Task.Wait` hasn't been called to finalize everything

## Changes

- Now the `ContinueWith` call re-throws the inner exception from the main task, if any
- Now `NetAsyncModulesDownloader.ModulesAsTheyFinish` calls `Task.Wait` to finalize the downloader task. On some versions of .NET, this re-throws the exception from `ContinueWith`, so a new `catch` block extracts and re-throws the `InnerException`. 
- After that, I started getting some confusing errors `System.Transactions.TransactionAbortedException: The transaction has aborted.`, which I do not think could be correct, but the scope of the main GUI installation transaction is adjusted to work around this.
