### PR TITLE
Fix upgrading with conflicts between old and new dependencies

### DIFF
--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -273,7 +273,7 @@ namespace CKAN.IO
             }
 
             User.RaiseMessage(Properties.Resources.ModuleInstallerInstallingMod,
-                              module.name);
+                              $"{module.name} {module.version}");
 
             using (var transaction = CkanTransaction.CreateTransactionScope())
             {
@@ -292,7 +292,7 @@ namespace CKAN.IO
             }
 
             User.RaiseMessage(Properties.Resources.ModuleInstallerInstalledMod,
-                              module.name);
+                              $"{module.name} {module.version}");
 
             // Fire our callback that we've installed a module, if we have one.
             OneComplete?.Invoke(module);
@@ -848,9 +848,6 @@ namespace CKAN.IO
                 {
                     if (registry.InstalledModule(ident) is InstalledModule instMod)
                     {
-                        User.RaiseMessage(Properties.Resources.ModuleInstallerRemovingMod,
-                                          registry.InstalledModule(ident)?.Module.name
-                                                                         ?? ident);
                         Uninstall(ident, ref possibleConfigOnlyDirs, registry,
                                   new ProgressImmediate<long>(bytes =>
                                   {
@@ -861,9 +858,6 @@ namespace CKAN.IO
                                       User.RaiseProgress(rateCounter);
                                   }));
                         modRemoveCompletedBytes += instMod?.Module.install_size ?? 0;
-                        User.RaiseMessage(Properties.Resources.ModuleInstallerRemovedMod,
-                                          registry.InstalledModule(ident)?.Module.name
-                                                                         ?? ident);
                     }
                 }
 
@@ -902,6 +896,8 @@ namespace CKAN.IO
                     log.ErrorFormat("Trying to uninstall {0} but it's not installed", identifier);
                     throw new ModNotInstalledKraken(identifier);
                 }
+                User.RaiseMessage(Properties.Resources.ModuleInstallerRemovingMod,
+                                  $"{instMod.Module.name} {instMod.Module.version}");
 
                 // Walk our registry to find all files for this mod.
                 var modFiles = instMod.Files.ToArray();
@@ -1065,6 +1061,8 @@ namespace CKAN.IO
                 }
                 log.InfoFormat("Removed {0}", identifier);
                 transaction.Complete();
+                User.RaiseMessage(Properties.Resources.ModuleInstallerRemovedMod,
+                                  $"{instMod.Module.name} {instMod.Module.version}");
             }
         }
 
@@ -1317,22 +1315,22 @@ namespace CKAN.IO
                         if (inProgressFile.Exists)
                         {
                             User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingResuming,
-                                module.name, module.version,
-                                string.Join(", ", PrioritizedHosts(config, module.download)),
-                                CkanModule.FmtSize(module.download_size - inProgressFile.Length));
+                                              module.name, module.version,
+                                              string.Join(", ", PrioritizedHosts(config, module.download)),
+                                              CkanModule.FmtSize(module.download_size - inProgressFile.Length));
                         }
                         else
                         {
                             User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingUncached,
-                                module.name, module.version,
-                                string.Join(", ", PrioritizedHosts(config, module.download)),
-                                CkanModule.FmtSize(module.download_size));
+                                              module.name, module.version,
+                                              string.Join(", ", PrioritizedHosts(config, module.download)),
+                                              CkanModule.FmtSize(module.download_size));
                         }
                     }
                     else
                     {
                         User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingCached,
-                            module.name, module.version);
+                                          module.name, module.version);
                     }
                 }
                 else
@@ -1344,12 +1342,12 @@ namespace CKAN.IO
                     if (installed.version.IsEqualTo(module.version))
                     {
                         User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeReinstalling,
-                            module.name, module.version);
+                                          module.name, module.version);
                     }
                     else if (installed.version.IsGreaterThan(module.version))
                     {
                         User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeDowngrading,
-                            module.name, installed.version, module.version);
+                                          module.name, installed.version, module.version);
                     }
                     else
                     {
@@ -1359,22 +1357,22 @@ namespace CKAN.IO
                             if (inProgressFile.Exists)
                             {
                                 User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingResuming,
-                                    module.name, installed.version, module.version,
-                                    string.Join(", ", PrioritizedHosts(config, module.download)),
-                                    CkanModule.FmtSize(module.download_size - inProgressFile.Length));
+                                                  module.name, installed.version, module.version,
+                                                  string.Join(", ", PrioritizedHosts(config, module.download)),
+                                                  CkanModule.FmtSize(module.download_size - inProgressFile.Length));
                             }
                             else
                             {
                                 User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingUncached,
-                                    module.name, installed.version, module.version,
-                                    string.Join(", ", PrioritizedHosts(config, module.download)),
-                                    CkanModule.FmtSize(module.download_size));
+                                                  module.name, installed.version, module.version,
+                                                  string.Join(", ", PrioritizedHosts(config, module.download)),
+                                                  CkanModule.FmtSize(module.download_size));
                             }
                         }
                         else
                         {
                             User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingCached,
-                                module.name, installed.version, module.version);
+                                              module.name, installed.version, module.version);
                         }
                     }
                 }

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -784,10 +784,9 @@ namespace CKAN.IO
                 throw new ModNotInstalledKraken(mod);
             }
 
-            var instDlc = mods
-                .Select(registry_manager.registry.InstalledModule)
-                .OfType<InstalledModule>()
-                .FirstOrDefault(m => m.Module.IsDLC);
+            var instDlc = mods.Select(registry_manager.registry.InstalledModule)
+                              .OfType<InstalledModule>()
+                              .FirstOrDefault(m => m.Module.IsDLC);
             if (instDlc != null)
             {
                 throw new ModuleIsDLCKraken(instDlc.Module);

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -798,20 +798,20 @@ namespace CKAN.IO
                     mods.Except(installing?.Select(m => m.identifier) ?? Array.Empty<string>())
                         .ToList(),
                     installing))
-                .ToList();
+                .ToArray();
 
             var goners = revdep.Union(
                     registry_manager.registry.FindRemovableAutoInstalled(
                         registry_manager.registry.InstalledModules
                             .Where(im => !revdep.Contains(im.identifier))
-                            .Concat(installing?.Select(m => new InstalledModule(null, m, Array.Empty<string>(), false)) ?? Array.Empty<InstalledModule>())
-                            .ToList(),
+                            .ToArray(),
+                        installing ?? new List<CkanModule>(),
                         instance.game, instance.StabilityToleranceConfig, instance.VersionCriteria())
                     .Select(im => im.identifier))
-                .ToList();
+                .ToArray();
 
             // If there is nothing to uninstall, skip out.
-            if (goners.Count == 0)
+            if (goners.Length == 0)
             {
                 return;
             }
@@ -1386,11 +1386,11 @@ namespace CKAN.IO
                     // Conjure the future state of the installed modules list after upgrading
                     registry.InstalledModules
                             .Where(im => !removingIdents.Contains(im.identifier))
-                            .Concat(modules.Select(m => new InstalledModule(null, m, Array.Empty<string>(), false)))
-                            .ToList(),
+                            .ToArray(),
+                    modules,
                     instance.game, instance.StabilityToleranceConfig, instance.VersionCriteria())
-                .ToList();
-            if (autoRemoving.Count > 0)
+                .ToArray();
+            if (autoRemoving.Length > 0)
             {
                 foreach (var im in autoRemoving)
                 {

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -833,10 +833,10 @@ namespace CKAN
         /// Register the supplied module as having been installed, thereby keeping
         /// track of its metadata and files.
         /// </summary>
-        public void RegisterModule(CkanModule   mod,
-                                   List<string> absoluteFiles,
-                                   GameInstance inst,
-                                   bool         autoInstalled)
+        public void RegisterModule(CkanModule          mod,
+                                   ICollection<string> absoluteFiles,
+                                   GameInstance        inst,
+                                   bool                autoInstalled)
         {
             log.DebugFormat("Registering module {0}", mod);
             EnlistWithTransaction();
@@ -1220,8 +1220,8 @@ namespace CKAN
         /// Return modules which are dependent on the modules passed in or modules in the return list
         /// </summary>
         public IEnumerable<string> FindReverseDependencies(
-                List<string>                        modulesToRemove,
-                List<CkanModule>?                   modulesToInstall = null,
+                ICollection<string>                 modulesToRemove,
+                ICollection<CkanModule>?            modulesToInstall = null,
                 Func<RelationshipDescriptor, bool>? satisfiedFilter  = null)
             => FindReverseDependencies(modulesToRemove, modulesToInstall,
                                        installed_modules.Values.Select(im => im.Module)

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -16,9 +16,6 @@ namespace CKAN
     /// <summary>
     /// Resolves relationships between mods. Primarily used to satisfy missing dependencies and to check for conflicts on proposed installs.
     /// </summary>
-    /// <remarks>
-    /// All constructors start with currently installed modules, to remove <see cref="RemoveModsFromInstalledList" />
-    /// </remarks>
     public class RelationshipResolver
     {
         /// <summary>
@@ -44,6 +41,7 @@ namespace CKAN
 
             installed_modules = registry.InstalledModules
                                         .Select(i_module => i_module.Module)
+                                        .Except(modulesToRemove ?? Enumerable.Empty<CkanModule>())
                                         .ToHashSet();
             var installed_relationship = new SelectionReason.Installed();
             foreach (var module in installed_modules)
@@ -74,10 +72,6 @@ namespace CKAN
                 }
             }
 
-            if (modulesToRemove != null)
-            {
-                RemoveModsFromInstalledList(modulesToRemove);
-            }
             AddModulesToInstall(toInst);
         }
 
@@ -143,20 +137,6 @@ namespace CKAN
                 conflicts.AddRange(k.Conflicts.Select(tuple => new ModPair(tuple.Item1, tuple.Item3))
                                               .Where(pair => !conflicts.Contains(pair))
                                               .ToArray());
-            }
-        }
-
-        /// <summary>
-        /// Removes mods from the list of installed modules. Intended to be used for cases
-        /// in which the mod is to be un-installed.
-        /// </summary>
-        /// <param name="mods">The mods to remove.</param>
-        private void RemoveModsFromInstalledList(IEnumerable<CkanModule> mods)
-        {
-            foreach (var module in mods)
-            {
-                installed_modules.Remove(module);
-                conflicts.RemoveAll(kvp => module.Equals(kvp.Key) || module.Equals(kvp.Value));
             }
         }
 

--- a/Core/Versioning/UnmanagedModuleVersion.cs
+++ b/Core/Versioning/UnmanagedModuleVersion.cs
@@ -1,8 +1,13 @@
+using System;
+
+using Newtonsoft.Json;
+
 namespace CKAN.Versioning
 {
     /// <summary>
     /// Represents the version of a module that is not managed by CKAN.
     /// </summary>
+    [JsonConverter(typeof(JsonUnmanagedModuleVersionConverter))]
     public sealed class UnmanagedModuleVersion : ModuleVersion
     {
         private readonly string _string;
@@ -12,13 +17,38 @@ namespace CKAN.Versioning
         // HACK: Hardcoding a value of "0" for autodetected DLLs preserves previous behavior.
         public UnmanagedModuleVersion(string? version) : base(version ?? "0")
         {
-            IsUnknownVersion = version == null;
-            _string = version == null
-                ? Properties.Resources.UnmanagedModuleVersionUnknown
-                : string.Format(Properties.Resources.UnmanagedModuleVersionKnown, version);
+            OriginalString = version;
+            IsUnknownVersion = OriginalString == null;
+            _string = OriginalString == null
+                          ? Properties.Resources.UnmanagedModuleVersionUnknown
+                          : string.Format(Properties.Resources.UnmanagedModuleVersionKnown,
+                                          OriginalString);
         }
+
+        public readonly string? OriginalString;
 
         public override string ToString()
             => _string;
+    }
+
+    public class JsonUnmanagedModuleVersionConverter : JsonConverter
+    {
+        public override object? ReadJson(JsonReader     reader,
+                                         Type           objectType,
+                                         object?        existingValue,
+                                         JsonSerializer serializer)
+            => Activator.CreateInstance(objectType, reader.Value?.ToString());
+
+        public override void WriteJson(JsonWriter     writer,
+                                       object?        value,
+                                       JsonSerializer serializer)
+        {
+            writer.WriteValue(value is UnmanagedModuleVersion unm
+                                  ? unm.OriginalString
+                                  : value?.ToString());
+        }
+
+        // Explicit conversions only, please.
+        public override bool CanConvert(Type objectType) => false;
     }
 }

--- a/GUI/Controls/ModInfoTabs/Versions.Designer.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.Designer.cs
@@ -75,6 +75,7 @@ namespace CKAN.GUI
             this.VersionsListView.UseCompatibleStateImageBehavior = false;
             this.VersionsListView.View = System.Windows.Forms.View.Details;
             this.VersionsListView.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.VersionsListView_ItemCheck);
+            this.VersionsListView.Resize += new System.EventHandler(this.VersionsListView_OnResize);
             this.VersionsListView.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.VersionsListView_ItemSelectionChanged);
             //
             // ModVersion

--- a/GUI/Controls/ModInfoTabs/Versions.cs
+++ b/GUI/Controls/ModInfoTabs/Versions.cs
@@ -361,6 +361,14 @@ namespace CKAN.GUI
             }
         }
 
+        private void VersionsListView_OnResize(object sender, EventArgs e)
+        {
+            VersionsListView.BeginUpdate();
+            VersionsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+            VersionsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+            VersionsListView.EndUpdate();
+        }
+
         private void UpdateStabilityToleranceComboBox(GUIMod gmod)
         {
             if (currentInstance != null && interactive)

--- a/GUI/Localization/fr-FR/Main.fr-FR.resx
+++ b/GUI/Localization/fr-FR/Main.fr-FR.resx
@@ -162,9 +162,6 @@
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Sauver le modpack dans un fichier (peut être réimporté)...</value>
   </data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Importer des &amp;mods téléchargés...</value>
-  </data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve">
     <value>Voir les &amp;recommandations</value>
   </data>

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -134,7 +134,6 @@
   <data name="deduplicateToolstripMenuItem.ToolTipText" xml:space="preserve"><value>Scan installed files from all game instances and share the ones that can be shared</value></data>
   <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Save installed mod list (cannot be re-imported)...</value></data>
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Export modpack (can be re-imported)...</value></data>
-  <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Import &amp;downloaded mods...</value></data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Audit &amp;recommendations</value></data>
   <data name="auditRecommendationsMenuItem.ToolTipText" xml:space="preserve"><value>Review recommendations and suggestions of all installed mods</value></data>
   <data name="viewPlayTimeStripMenuItem.Text" xml:space="preserve"><value>Play &amp;time...</value></data>

--- a/Tests/Core/Net/NetAsyncDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncDownloaderTests.cs
@@ -121,7 +121,7 @@ namespace Tests.Core.Net
                      "DogeCoinFlag-1.01-LZMA.zip",
                      "DogeCoinFlag-1.01-avc.zip",
                      "DogeCoinFlag-extra-files.zip"),
-            // Last URL is bad
+            // A URL in the middle is bad
             TestCase("gh221.zip",
                      "ModuleManager-2.5.1.zip",
                      "ZipWithUnicodeChars.zip",
@@ -136,7 +136,7 @@ namespace Tests.Core.Net
                      "DogeCoinFlag-1.01-LZMA.zip",
                      "DogeCoinFlag-1.01-avc.zip",
                      "DogeCoinFlag-extra-files.zip"),
-            // A URL in the middle is bad
+            // Last URL is bad
             TestCase("gh221.zip",
                      "ModuleManager-2.5.1.zip",
                      "ZipWithUnicodeChars.zip",
@@ -152,33 +152,33 @@ namespace Tests.Core.Net
                      "DogeCoinFlag-extra-files.zip",
                      "DoesNotExist.zip"),
             // Every other URL is bad
-            TestCase("DoesNotExist.zip",
+            TestCase("DoesNotExist1.zip",
                      "gh221.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist2.zip",
                      "ModuleManager-2.5.1.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist3.zip",
                      "ZipWithUnicodeChars.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist4.zip",
                      "DogeCoinPlugin.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist5.zip",
                      "DogeCoinFlag-1.01-corrupt.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist6.zip",
                      "CKAN-meta-testkan.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist7.zip",
                      "ZipWithBadChars.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist8.zip",
                      "DogeCoinFlag-1.01-no-dir-entries.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist9.zip",
                      "DogeTokenFlag-1.01.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist10.zip",
                      "DogeCoinFlag-1.01.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist11.zip",
                      "DogeCoinFlag-1.01-LZMA.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist12.zip",
                      "DogeCoinFlag-1.01-avc.zip",
-                     "DoesNotExist.zip",
+                     "DoesNotExist13.zip",
                      "DogeCoinFlag-extra-files.zip",
-                     "DoesNotExist.zip"),
+                     "DoesNotExist14.zip"),
         ]
         public void DownloadAndWait_WithSomeInvalidUrls_ThrowsDownloadErrorsKraken(
             params string[] pathsWithinTestData)
@@ -190,10 +190,8 @@ namespace Tests.Core.Net
                                                                                                Path.GetTempFileName()))
                                         .ToArray();
             var badTargets   = targets.Zip(fromPaths)
-                                      #pragma warning disable IDE0033
-                                      .Where(tuple => !File.Exists(tuple.Item2))
-                                      .Select(tuple => tuple.Item1)
-                                      #pragma warning restore IDE0033
+                                      .Where(tuple => !File.Exists(tuple.Second))
+                                      .Select(tuple => tuple.First)
                                       .ToArray();
             var validTargets = targets.Except(badTargets);
 

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -463,30 +463,7 @@ namespace Tests.Core.Registry
             // Arrange
             var user = new NullUser();
             using (var gameInstWrapper = new DisposableKSP())
-            using (var repo = new TemporaryRepository(
-                                @"{
-                                    ""identifier"": ""OuterPlanetsMod"",
-                                    ""version"":    ""1.0"",
-                                    ""download"":   ""https://github.com/"",
-                                    ""depends"":    [ { ""name"": ""KopernicusTech"" } ]
-                                }",
-                                @"{
-                                    ""identifier"": ""OuterPlanetsMod"",
-                                    ""version"":    ""2.0"",
-                                    ""download"":   ""https://github.com/"",
-                                    ""depends"":    [ { ""name"": ""Kopernicus"" } ]
-                                }",
-                                @"{
-                                    ""identifier"": ""KopernicusTech"",
-                                    ""version"":    ""1.0"",
-                                    ""download"":   ""https://github.com/"",
-                                    ""conflicts"":  [ { ""name"": ""Kopernicus"" } ]
-                                }",
-                                @"{
-                                    ""identifier"": ""Kopernicus"",
-                                    ""version"":    ""1.0"",
-                                    ""download"":   ""https://github.com/""
-                                }"))
+            using (var repo = new TemporaryRepository(TestData.OuterPlanetsLibraryMetadata))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);

--- a/Tests/Data/TemporaryDirectory.cs
+++ b/Tests/Data/TemporaryDirectory.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace Tests.Data
+{
+    public class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory(DirectoryInfo path)
+        {
+            Path = path;
+            Directory.CreateDirectory(Path.FullName);
+        }
+
+        public TemporaryDirectory(string path)
+            : this(new DirectoryInfo(path))
+        {
+        }
+
+        public TemporaryDirectory()
+            : this(TestData.NewTempDir())
+        {
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path.FullName, true);
+            GC.SuppressFinalize(this);
+        }
+
+        public readonly DirectoryInfo Path;
+    }
+}

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -873,6 +873,54 @@ namespace Tests.Data
                 }
               }
             }";
+
+        public static readonly string[] OuterPlanetsLibraryMetadata = new string[]
+        {
+            @"{
+                ""identifier"": ""OuterPlanetsMod"",
+                ""name"":       ""OuterPlanetsMod"",
+                ""version"":    ""1.0"",
+                ""download"":   ""https://github.com/"",
+                ""depends"":    [ { ""name"": ""KopernicusTech"" } ],
+                ""install"":    [ { ""find"":       ""DogeCoinFlag"",
+                                    ""install_to"": ""GameData/OuterPlanetsMod1"" } ]
+            }",
+            @"{
+                ""identifier"": ""OuterPlanetsMod"",
+                ""name"":       ""OuterPlanetsMod"",
+                ""version"":    ""2.0"",
+                ""download"":   ""https://github.com/"",
+                ""depends"":    [ { ""name"": ""Kopernicus"" } ],
+                ""install"":    [ { ""find"":       ""DogeCoinFlag"",
+                                    ""install_to"": ""GameData/OuterPlanetsMod2"" } ]
+            }",
+            @"{
+                ""identifier"": ""KopernicusTech"",
+                ""name"":       ""KopernicusTech"",
+                ""version"":    ""1.0"",
+                ""download"":   ""https://github.com/"",
+                ""conflicts"":  [ { ""name"": ""Kopernicus"" } ],
+                ""install"":    [ { ""find"":       ""DogeCoinFlag"",
+                                    ""install_to"": ""GameData/KopernicusTech"" } ]
+            }",
+            @"{
+                ""identifier"": ""Kopernicus"",
+                ""name"":       ""Kopernicus"",
+                ""version"":    ""1.0"",
+                ""download"":   ""https://github.com/"",
+                ""depends"":    [ { ""name"": ""ModularFlightIntegrator"" } ],
+                ""install"":    [ { ""find"":       ""DogeCoinFlag"",
+                                    ""install_to"": ""GameData/Kopernicus"" } ]
+            }",
+            @"{
+                ""identifier"": ""ModularFlightIntegrator"",
+                ""name"":       ""ModularFlightIntegrator"",
+                ""version"":    ""1.0"",
+                ""download"":   ""https://github.com/"",
+                ""install"":    [ { ""find"":       ""DogeCoinFlag"",
+                                    ""install_to"": ""GameData/ModularFlightIntegrator"" } ]
+            }",
+        };
     }
 
     public class RandomModuleGenerator

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -273,6 +273,11 @@ public sealed class PrepareSignPathTask : FrostingTask<BuildContext>
 [IsDependentOn(typeof(TestOnlyTask))]
 public sealed class TestTask : FrostingTask<BuildContext>;
 
+[TaskName("Test-UnitTests")]
+[IsDependentOn(typeof(BuildTask))]
+[IsDependentOn(typeof(TestUnitTestsOnlyTask))]
+public sealed class TestUnitTestsTask : FrostingTask<BuildContext>;
+
 [TaskName("Test+Only")]
 [TaskDescription("Run tests without compiling.")]
 [IsDependentOn(typeof(TestExecutablesOnlyTask))]


### PR DESCRIPTION
## Problems

If you install OuterPlanetsMod 1.6.5, KopernicusTech is automatically installed as a dependency. If you then try to upgrade to the latest OuterPlanetsMod, KopernicusTech's conflict with Kopernicus causes an `InconsistentKraken` to be thrown that prevents the upgrade from finishing.

## Changes

- Now the `RelationshipResolver` no longer passes modules that are to be removed to the `ResolvedRelationshipsTree`, which would have caused them to be treated as if they were not being removed.
- Now `IRegistryQuerier.FindRemovableAutoInstalled` has a separate `installing` parameter that it passes to `Registry.FindReverseDependencies` so the relationships of installing modules won't be treated as "broken" if they're not satisfied, which would have prevented some installable modules from being treated as installable.
- Now `IRegistryQuerier.FindRemovableAutoInstalled` uses a new `RelationshipResolver` to generate the changeset for each potentially uninstallable mod, rather than using the same changeset for all of them.
- Now `ModuleInstaller.Upgrade` checks for autoremovability before it generates its final changeset rather than after, to ensure autoremovable mods with conflicts don't block other changes
- A test is added to catch any future regressions of this fix in `IRegistryQuerier.FindRemovableAutoInstalled`
- A test is also added to catch regressions in `ckan upgrade`

Fixes #930 (just shy of its tenth birthday).

### Other stuff

- Now upgrading will print messages about the modules it removes
- Now installing and upgrading will include the module versions in their log messages
- `./build.sh test-unittests` and `.\build.ps1 test-unittets` now run the tests without repacking the exes, to make it easier to re-test entire branches full of commits with `git rebase -x "pwsh build.ps1 test-unittests" master`
- Some duplicate i18n resources are removed
- Serializing an `UnmanagedModuleVersion` will now use the original string without `(unmanaged)` after it, so we don't end up with an endlessly accumulating list of `(unmanaged) (unmanaged) (unmanaged) (unmanaged)` suffixes
- The table columns on the Versions tab now auto-resize when the table is resized
- A test is added to catch regressions of #4367
