### PR TITLE
Fix reinstalls, use read-only collections

### DIFF
--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -32,7 +32,7 @@ namespace CKAN
                                    IEnumerable<Dictionary<string, AvailableModule>> available,
                                    IDictionary<string, AvailableModule[]>           providers,
                                    IDictionary<string, InstalledModule>             installed,
-                                   ICollection<string>                              dlls,
+                                   IReadOnlyCollection<string>                      dlls,
                                    IDictionary<string, UnmanagedModuleVersion>      dlc)
         {
             StabilityTolerance = stabilityTolerance;
@@ -114,7 +114,7 @@ namespace CKAN
         }
 
         private readonly IDictionary<string, InstalledModule>        installed;
-        private readonly ICollection<string>                         dlls;
+        private readonly IReadOnlyCollection<string>                 dlls;
         private readonly IDictionary<string, UnmanagedModuleVersion> dlc;
 
         private List<CkanModule>? latestCompatible;

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -19,7 +19,7 @@ namespace CKAN
     {
         ReadOnlyDictionary<string, Repository>      Repositories     { get; }
         IEnumerable<InstalledModule>                InstalledModules { get; }
-        ICollection<string>                         InstalledDlls    { get; }
+        IReadOnlyCollection<string>                 InstalledDlls    { get; }
         IDictionary<string, UnmanagedModuleVersion> InstalledDlc     { get; }
 
         /// <summary>
@@ -44,12 +44,12 @@ namespace CKAN
         /// If no ksp_version is provided, the latest module for *any* KSP version is returned.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
-        CkanModule? LatestAvailable(string                   identifier,
-                                    StabilityToleranceConfig stabilityTolerance,
-                                    GameVersionCriteria?     ksp_version,
-                                    RelationshipDescriptor?  relationship_descriptor = null,
-                                    ICollection<CkanModule>? installed               = null,
-                                    ICollection<CkanModule>? toInstall               = null);
+        CkanModule? LatestAvailable(string                           identifier,
+                                    StabilityToleranceConfig         stabilityTolerance,
+                                    GameVersionCriteria?             ksp_version,
+                                    RelationshipDescriptor?          relationship_descriptor = null,
+                                    IReadOnlyCollection<CkanModule>? installed               = null,
+                                    IReadOnlyCollection<CkanModule>? toInstall               = null);
 
         /// <summary>
         /// Returns the max game version that is compatible with the given mod.
@@ -73,12 +73,12 @@ namespace CKAN
         /// Returns an empty list if nothing is available for our system, which includes if no such module exists.
         /// If no KSP version is provided, the latest module for *any* KSP version is given.
         /// </summary>
-        List<CkanModule> LatestAvailableWithProvides(string                   identifier,
-                                                     StabilityToleranceConfig stabilityTolerance,
-                                                     GameVersionCriteria?     ksp_version,
-                                                     RelationshipDescriptor?  relationship_descriptor = null,
-                                                     ICollection<CkanModule>? installed               = null,
-                                                     ICollection<CkanModule>? toInstall               = null);
+        List<CkanModule> LatestAvailableWithProvides(string                           identifier,
+                                                     StabilityToleranceConfig         stabilityTolerance,
+                                                     GameVersionCriteria?             ksp_version,
+                                                     RelationshipDescriptor?          relationship_descriptor = null,
+                                                     IReadOnlyCollection<CkanModule>? installed               = null,
+                                                     IReadOnlyCollection<CkanModule>? toInstall               = null);
 
         /// <summary>
         /// Checks the sanity of the registry, to ensure that all dependencies are met,
@@ -90,8 +90,8 @@ namespace CKAN
         /// <summary>
         /// Finds and returns all modules that could not exist without the listed modules installed, including themselves.
         /// </summary>
-        IEnumerable<string> FindReverseDependencies(ICollection<string>                 modulesToRemove,
-                                                    ICollection<CkanModule>?            modulesToInstall = null,
+        IEnumerable<string> FindReverseDependencies(IReadOnlyCollection<string>         modulesToRemove,
+                                                    IReadOnlyCollection<CkanModule>?    modulesToInstall = null,
                                                     Func<RelationshipDescriptor, bool>? satisfiedFilter  = null);
 
         /// <summary>
@@ -186,14 +186,14 @@ namespace CKAN
         /// <param name="checkMissingFiles">If true, check if any of the files or directories are missing</param>
         /// <param name="latestMod">The latest mod if an update is available</param>
         /// <param name="installed">The installed modules to check against</param>
-        public static bool HasUpdate(this IRegistryQuerier    querier,
-                                     string                   identifier,
-                                     StabilityToleranceConfig stabilityTolerance,
-                                     GameInstance?            instance,
-                                     HashSet<string>          filters,
-                                     bool                     checkMissingFiles,
-                                     out CkanModule?          latestMod,
-                                     ICollection<CkanModule>? installed = null)
+        public static bool HasUpdate(this IRegistryQuerier            querier,
+                                     string                           identifier,
+                                     StabilityToleranceConfig         stabilityTolerance,
+                                     GameInstance?                    instance,
+                                     HashSet<string>                  filters,
+                                     bool                             checkMissingFiles,
+                                     out CkanModule?                  latestMod,
+                                     IReadOnlyCollection<CkanModule>? installed = null)
         {
             // Check if it's installed (including manually!)
             var instVer = querier.InstalledVersion(identifier);
@@ -479,12 +479,12 @@ namespace CKAN
         /// Sequence of removable auto-installed modules, if any
         /// </returns>
         public static IEnumerable<InstalledModule> FindRemovableAutoInstalled(
-            this IRegistryQuerier        querier,
-            ICollection<InstalledModule> installed,
-            ICollection<CkanModule>      installing,
-            IGame                        game,
-            StabilityToleranceConfig     stabilityTolerance,
-            GameVersionCriteria          crit)
+            this IRegistryQuerier                querier,
+            IReadOnlyCollection<InstalledModule> installed,
+            IReadOnlyCollection<CkanModule>      installing,
+            IGame                                game,
+            StabilityToleranceConfig             stabilityTolerance,
+            GameVersionCriteria                  crit)
         {
             log.DebugFormat("Finding removable autoInstalled for: {0}",
                             string.Join(", ", installed.Select(im => im.identifier)));

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -119,7 +119,7 @@ namespace CKAN
         /// <summary>
         /// Returns the names of installed DLLs.
         /// </summary>
-        [JsonIgnore] public ICollection<string> InstalledDlls
+        [JsonIgnore] public IReadOnlyCollection<string> InstalledDlls
             => installed_dlls.Keys;
 
         /// <summary>
@@ -666,12 +666,12 @@ namespace CKAN
         /// <summary>
         /// <see cref="IRegistryQuerier.LatestAvailable" />
         /// </summary>
-        public CkanModule? LatestAvailable(string                   identifier,
-                                           StabilityToleranceConfig stabilityTolerance,
-                                           GameVersionCriteria?     gameVersion,
-                                           RelationshipDescriptor?  relationshipDescriptor = null,
-                                           ICollection<CkanModule>? installed              = null,
-                                           ICollection<CkanModule>? toInstall              = null)
+        public CkanModule? LatestAvailable(string                           identifier,
+                                           StabilityToleranceConfig         stabilityTolerance,
+                                           GameVersionCriteria?             gameVersion,
+                                           RelationshipDescriptor?          relationshipDescriptor = null,
+                                           IReadOnlyCollection<CkanModule>? installed              = null,
+                                           IReadOnlyCollection<CkanModule>? toInstall              = null)
             => getAvail(identifier)?.Select(am => am.Latest(stabilityTolerance, gameVersion, relationshipDescriptor,
                                                             installed, toInstall))
                                     .OfType<CkanModule>()
@@ -806,12 +806,12 @@ namespace CKAN
         /// <summary>
         /// <see cref="IRegistryQuerier.LatestAvailableWithProvides" />
         /// </summary>
-        public List<CkanModule> LatestAvailableWithProvides(string                   identifier,
-                                                            StabilityToleranceConfig stabilityTolerance,
-                                                            GameVersionCriteria?     gameVersion,
-                                                            RelationshipDescriptor?  relationship = null,
-                                                            ICollection<CkanModule>? installed    = null,
-                                                            ICollection<CkanModule>? toInstall    = null)
+        public List<CkanModule> LatestAvailableWithProvides(string                           identifier,
+                                                            StabilityToleranceConfig         stabilityTolerance,
+                                                            GameVersionCriteria?             gameVersion,
+                                                            RelationshipDescriptor?          relationship = null,
+                                                            IReadOnlyCollection<CkanModule>? installed    = null,
+                                                            IReadOnlyCollection<CkanModule>? toInstall    = null)
             => ((providers ?? BuildProvidesIndex())
                     is Dictionary<string, AvailableModule[]> allProvs
                 && allProvs.TryGetValue(identifier, out AvailableModule[]? provs)
@@ -1136,10 +1136,10 @@ namespace CKAN
         /// <param name="satisfiedFilter">Optional filter to apply to the dependencies</param>
         /// <returns>List of modules whose dependencies are about to be or already removed.</returns>
         public static IEnumerable<string> FindReverseDependencies(
-            ICollection<string>                         modulesToRemove,
-            ICollection<CkanModule>?                    modulesToInstall,
-            ICollection<CkanModule>                     origInstalled,
-            ICollection<string>                         dlls,
+            IReadOnlyCollection<string>                 modulesToRemove,
+            IReadOnlyCollection<CkanModule>?            modulesToInstall,
+            IReadOnlyCollection<CkanModule>             origInstalled,
+            IReadOnlyCollection<string>                 dlls,
             IDictionary<string, UnmanagedModuleVersion> dlc,
             Func<RelationshipDescriptor, bool>?         satisfiedFilter = null)
         {
@@ -1220,8 +1220,8 @@ namespace CKAN
         /// Return modules which are dependent on the modules passed in or modules in the return list
         /// </summary>
         public IEnumerable<string> FindReverseDependencies(
-                ICollection<string>                 modulesToRemove,
-                ICollection<CkanModule>?            modulesToInstall = null,
+                IReadOnlyCollection<string>         modulesToRemove,
+                IReadOnlyCollection<CkanModule>?    modulesToInstall = null,
                 Func<RelationshipDescriptor, bool>? satisfiedFilter  = null)
             => FindReverseDependencies(modulesToRemove, modulesToInstall,
                                        installed_modules.Values.Select(im => im.Module)

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -31,7 +31,7 @@ namespace CKAN
         public virtual bool Unsatisfied()
             => false;
 
-        public virtual bool Unsatisfied(ICollection<CkanModule> installing)
+        public virtual bool Unsatisfied(IReadOnlyCollection<CkanModule> installing)
             => false;
 
         public override string ToString()
@@ -136,19 +136,19 @@ namespace CKAN
         {
         }
 
-        public ResolvedByNew(CkanModule               source,
-                             RelationshipDescriptor   relationship,
-                             SelectionReason          reason,
-                             IEnumerable<CkanModule>  providers,
-                             ICollection<CkanModule>  definitelyInstalling,
-                             ICollection<CkanModule>  allInstalling,
-                             IRegistryQuerier         registry,
-                             ICollection<string>      dlls,
-                             ICollection<CkanModule>  installed,
-                             StabilityToleranceConfig stabilityTolerance,
-                             GameVersionCriteria      crit,
-                             OptionalRelationships    optRels,
-                             RelationshipCache        relationshipCache)
+        public ResolvedByNew(CkanModule                      source,
+                             RelationshipDescriptor          relationship,
+                             SelectionReason                 reason,
+                             IEnumerable<CkanModule>         providers,
+                             IReadOnlyCollection<CkanModule> definitelyInstalling,
+                             IReadOnlyCollection<CkanModule> allInstalling,
+                             IRegistryQuerier                registry,
+                             IReadOnlyCollection<string>     dlls,
+                             IReadOnlyCollection<CkanModule> installed,
+                             StabilityToleranceConfig        stabilityTolerance,
+                             GameVersionCriteria             crit,
+                             OptionalRelationships           optRels,
+                             RelationshipCache               relationshipCache)
              : this(source, relationship, reason,
                     providers.ToDictionary(prov => prov,
                                            prov => ResolvedRelationshipsTree.ResolveModule(
@@ -177,7 +177,7 @@ namespace CKAN
             => reason is SelectionReason.Depends
                && !resolved.Keys.Any(m => !m.IsDLC);
 
-        public override bool Unsatisfied(ICollection<CkanModule> installing)
+        public override bool Unsatisfied(IReadOnlyCollection<CkanModule> installing)
             => reason is SelectionReason.Depends
                && !resolved.Any(kvp => !kvp.Key.IsDLC
                                        && AvailableModule.DependsAndConflictsOK(kvp.Key, installing)

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -22,27 +22,27 @@ namespace CKAN
 
     public class ResolvedRelationshipsTree
     {
-        public ResolvedRelationshipsTree(ICollection<CkanModule>  modules,
-                                         IRegistryQuerier         registry,
-                                         ICollection<string>      dlls,
-                                         ICollection<CkanModule>  installed,
-                                         StabilityToleranceConfig stabilityTolerance,
-                                         GameVersionCriteria      crit,
-                                         OptionalRelationships    optRels)
+        public ResolvedRelationshipsTree(IReadOnlyCollection<CkanModule> modules,
+                                         IRegistryQuerier                registry,
+                                         IReadOnlyCollection<string>     dlls,
+                                         IReadOnlyCollection<CkanModule> installed,
+                                         StabilityToleranceConfig        stabilityTolerance,
+                                         GameVersionCriteria             crit,
+                                         OptionalRelationships           optRels)
         {
             resolved = ResolveManyCached(modules, registry, dlls, installed, stabilityTolerance, crit, optRels, relationshipCache).ToArray();
         }
 
-        public static IEnumerable<ResolvedRelationship> ResolveModule(CkanModule               module,
-                                                                      ICollection<CkanModule>  definitelyInstalling,
-                                                                      ICollection<CkanModule>  allInstalling,
-                                                                      IRegistryQuerier         registry,
-                                                                      ICollection<string>      dlls,
-                                                                      ICollection<CkanModule>  installed,
-                                                                      StabilityToleranceConfig stabilityTolerance,
-                                                                      GameVersionCriteria      crit,
-                                                                      OptionalRelationships    optRels,
-                                                                      RelationshipCache        relationshipCache)
+        public static IEnumerable<ResolvedRelationship> ResolveModule(CkanModule                      module,
+                                                                      IReadOnlyCollection<CkanModule> definitelyInstalling,
+                                                                      IReadOnlyCollection<CkanModule> allInstalling,
+                                                                      IRegistryQuerier                registry,
+                                                                      IReadOnlyCollection<string>     dlls,
+                                                                      IReadOnlyCollection<CkanModule> installed,
+                                                                      StabilityToleranceConfig        stabilityTolerance,
+                                                                      GameVersionCriteria             crit,
+                                                                      OptionalRelationships           optRels,
+                                                                      RelationshipCache               relationshipCache)
             => ResolveRelationships(module, module.depends, new SelectionReason.Depends(module),
                                     definitelyInstalling, allInstalling, registry, dlls, installed, stabilityTolerance, crit, optRels, relationshipCache)
                 .Concat((optRels & OptionalRelationships.Recommendations) == 0
@@ -91,8 +91,8 @@ namespace CKAN
             return Enumerable.Empty<ResolvedRelationship[]>();
         }
 
-        public IEnumerable<CkanModule> Candidates(RelationshipDescriptor  rel,
-                                                  ICollection<CkanModule> installing)
+        public IEnumerable<CkanModule> Candidates(RelationshipDescriptor          rel,
+                                                  IReadOnlyCollection<CkanModule> installing)
             => relationshipCache.TryGetValue(rel, out ResolvedRelationship? rr)
                && rr is ResolvedByNew resRel
                    ? resRel.resolved
@@ -105,46 +105,46 @@ namespace CKAN
             => string.Join(Environment.NewLine,
                            resolved.Select(rr => rr.ToString()));
 
-        private static IEnumerable<ResolvedRelationship> ResolveManyCached(ICollection<CkanModule>  modules,
-                                                                           IRegistryQuerier         registry,
-                                                                           ICollection<string>      dlls,
-                                                                           ICollection<CkanModule>  installed,
-                                                                           StabilityToleranceConfig stabilityTolerance,
-                                                                           GameVersionCriteria      crit,
-                                                                           OptionalRelationships    optRels,
-                                                                           RelationshipCache        relationshipCache)
+        private static IEnumerable<ResolvedRelationship> ResolveManyCached(IReadOnlyCollection<CkanModule> modules,
+                                                                           IRegistryQuerier                registry,
+                                                                           IReadOnlyCollection<string>     dlls,
+                                                                           IReadOnlyCollection<CkanModule> installed,
+                                                                           StabilityToleranceConfig        stabilityTolerance,
+                                                                           GameVersionCriteria             crit,
+                                                                           OptionalRelationships           optRels,
+                                                                           RelationshipCache               relationshipCache)
             => modules.SelectMany(m => ResolveModule(m, modules, modules, registry, dlls, installed, stabilityTolerance, crit, optRels,
                                                      relationshipCache));
 
-        private static IEnumerable<ResolvedRelationship> ResolveRelationships(CkanModule                    module,
-                                                                              List<RelationshipDescriptor>? relationships,
-                                                                              SelectionReason               reason,
-                                                                              ICollection<CkanModule>       definitelyInstalling,
-                                                                              ICollection<CkanModule>       allInstalling,
-                                                                              IRegistryQuerier              registry,
-                                                                              ICollection<string>           dlls,
-                                                                              ICollection<CkanModule>       installed,
-                                                                              StabilityToleranceConfig      stabilityTolerance,
-                                                                              GameVersionCriteria           crit,
-                                                                              OptionalRelationships         optRels,
-                                                                              RelationshipCache             relationshipCache)
+        private static IEnumerable<ResolvedRelationship> ResolveRelationships(CkanModule                      module,
+                                                                              List<RelationshipDescriptor>?   relationships,
+                                                                              SelectionReason                 reason,
+                                                                              IReadOnlyCollection<CkanModule> definitelyInstalling,
+                                                                              IReadOnlyCollection<CkanModule> allInstalling,
+                                                                              IRegistryQuerier                registry,
+                                                                              IReadOnlyCollection<string>     dlls,
+                                                                              IReadOnlyCollection<CkanModule> installed,
+                                                                              StabilityToleranceConfig        stabilityTolerance,
+                                                                              GameVersionCriteria             crit,
+                                                                              OptionalRelationships           optRels,
+                                                                              RelationshipCache               relationshipCache)
             => relationships?.Select(dep => Resolve(module, dep, reason,
                                                     definitelyInstalling, allInstalling, registry, dlls, installed,
                                                     stabilityTolerance, crit, optRels, relationshipCache))
                             ?? Enumerable.Empty<ResolvedRelationship>();
 
-        private static ResolvedRelationship Resolve(CkanModule               source,
-                                                    RelationshipDescriptor   relationship,
-                                                    SelectionReason          reason,
-                                                    ICollection<CkanModule>  definitelyInstalling,
-                                                    ICollection<CkanModule>  allInstalling,
-                                                    IRegistryQuerier         registry,
-                                                    ICollection<string>      dlls,
-                                                    ICollection<CkanModule>  installed,
-                                                    StabilityToleranceConfig stabilityTolerance,
-                                                    GameVersionCriteria      crit,
-                                                    OptionalRelationships    optRels,
-                                                    RelationshipCache        relationshipCache)
+        private static ResolvedRelationship Resolve(CkanModule                      source,
+                                                    RelationshipDescriptor          relationship,
+                                                    SelectionReason                 reason,
+                                                    IReadOnlyCollection<CkanModule> definitelyInstalling,
+                                                    IReadOnlyCollection<CkanModule> allInstalling,
+                                                    IRegistryQuerier                registry,
+                                                    IReadOnlyCollection<string>     dlls,
+                                                    IReadOnlyCollection<CkanModule> installed,
+                                                    StabilityToleranceConfig        stabilityTolerance,
+                                                    GameVersionCriteria             crit,
+                                                    OptionalRelationships           optRels,
+                                                    RelationshipCache               relationshipCache)
             => relationshipCache.TryGetValue(relationship,
                                              out ResolvedRelationship? cachedRel)
                 ? cachedRel.WithSource(source, reason)

--- a/Core/Relationships/SanityChecker.cs
+++ b/Core/Relationships/SanityChecker.cs
@@ -20,7 +20,7 @@ namespace CKAN
         /// Does nothing if the modules can happily co-exist.
         /// </summary>
         public static void EnforceConsistency(IEnumerable<CkanModule>                     modules,
-                                              ICollection<string>                         dlls,
+                                              IReadOnlyCollection<string>                 dlls,
                                               IDictionary<string, UnmanagedModuleVersion> dlc)
         {
             if (!CheckConsistency(modules, dlls, dlc,
@@ -36,13 +36,13 @@ namespace CKAN
         /// This is only used by tests!
         /// </summary>
         public static bool IsConsistent(IEnumerable<CkanModule>                     modules,
-                                        ICollection<string>                         dlls,
+                                        IReadOnlyCollection<string>                 dlls,
                                         IDictionary<string, UnmanagedModuleVersion> dlc)
             => CheckConsistency(modules, dlls, dlc,
                                 out var _, out var _);
 
         private static bool CheckConsistency(IEnumerable<CkanModule>                             modules,
-                                             ICollection<string>                                 dlls,
+                                             IReadOnlyCollection<string>                         dlls,
                                              IDictionary<string, UnmanagedModuleVersion>         dlc,
                                              out List<Tuple<CkanModule, RelationshipDescriptor>> UnmetDepends,
                                              out modRelList                                      Conflicts)
@@ -64,8 +64,8 @@ namespace CKAN
         /// Each Key is the depending module, and each Value is the relationship.
         /// </returns>
         public static IEnumerable<Tuple<CkanModule, RelationshipDescriptor>> FindUnsatisfiedDepends(
-                ICollection<CkanModule>                     modules,
-                ICollection<string>?                        dlls,
+                IReadOnlyCollection<CkanModule>             modules,
+                IReadOnlyCollection<string>?                dlls,
                 IDictionary<string, UnmanagedModuleVersion> dlc)
             => modules.SelectMany(m => (m.depends ?? Enumerable.Empty<RelationshipDescriptor>())
                                          .Where(dep => !dep.MatchesAny(modules, dlls, dlc))
@@ -82,7 +82,7 @@ namespace CKAN
         /// Each Key is the depending module, and each Value is the relationship.
         /// </returns>
         private static modRelList FindConflicting(List<CkanModule>                            modules,
-                                                  ICollection<string>                         dlls,
+                                                  IReadOnlyCollection<string>                 dlls,
                                                   IDictionary<string, UnmanagedModuleVersion> dlc)
             => modules.Where(m => m.conflicts != null)
                       .SelectMany(m => FindConflictingWith(
@@ -94,7 +94,7 @@ namespace CKAN
 
         private static IEnumerable<modRelPair> FindConflictingWith(CkanModule                                  module,
                                                                    List<CkanModule>                            otherMods,
-                                                                   ICollection<string>                         dlls,
+                                                                   IReadOnlyCollection<string>                 dlls,
                                                                    IDictionary<string, UnmanagedModuleVersion> dlc)
             => module.conflicts?.Select(rel => rel.MatchesAny(otherMods, dlls, dlc, out CkanModule?            other)
                                                    ? new modRelPair(module, rel, other)

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -102,20 +102,20 @@ namespace CKAN
         /// <param name="installed">Modules that are already installed</param>
         /// <param name="toInstall">Modules that are planned to be installed</param>
         /// <returns></returns>
-        public CkanModule? Latest(StabilityToleranceConfig stabilityTolerance,
-                                  GameVersionCriteria?     ksp_version  = null,
-                                  RelationshipDescriptor?  relationship = null,
-                                  ICollection<CkanModule>? installed    = null,
-                                  ICollection<CkanModule>? toInstall    = null)
+        public CkanModule? Latest(StabilityToleranceConfig         stabilityTolerance,
+                                  GameVersionCriteria?             ksp_version  = null,
+                                  RelationshipDescriptor?          relationship = null,
+                                  IReadOnlyCollection<CkanModule>? installed    = null,
+                                  IReadOnlyCollection<CkanModule>? toInstall    = null)
             => Latest(stabilityTolerance.ModStabilityTolerance(identifier)
                       ?? stabilityTolerance.OverallStabilityTolerance,
                       ksp_version, relationship, installed, toInstall);
 
-        public CkanModule? Latest(ReleaseStatus            stabilityTolerance,
-                                  GameVersionCriteria?     ksp_version  = null,
-                                  RelationshipDescriptor?  relationship = null,
-                                  ICollection<CkanModule>? installed    = null,
-                                  ICollection<CkanModule>? toInstall    = null)
+        public CkanModule? Latest(ReleaseStatus                    stabilityTolerance,
+                                  GameVersionCriteria?             ksp_version  = null,
+                                  RelationshipDescriptor?          relationship = null,
+                                  IReadOnlyCollection<CkanModule>? installed    = null,
+                                  IReadOnlyCollection<CkanModule>? toInstall    = null)
         {
             var modules = module_version.Values
                                         .Where(m => m.release_status <= stabilityTolerance)
@@ -139,8 +139,8 @@ namespace CKAN
             return modules.FirstOrDefault();
         }
 
-        public static bool DependsAndConflictsOK(CkanModule              module,
-                                                 ICollection<CkanModule> others)
+        public static bool DependsAndConflictsOK(CkanModule                      module,
+                                                 IReadOnlyCollection<CkanModule> others)
         {
             if (module.depends != null)
             {

--- a/Core/Types/RelationshipDescriptor.cs
+++ b/Core/Types/RelationshipDescriptor.cs
@@ -14,29 +14,29 @@ namespace CKAN
 {
     public abstract class RelationshipDescriptor : IEquatable<RelationshipDescriptor>
     {
-        public bool MatchesAny(ICollection<CkanModule>                      modules,
-                               ICollection<string>?                         dlls,
+        public bool MatchesAny(IReadOnlyCollection<CkanModule>              modules,
+                               IReadOnlyCollection<string>?                 dlls,
                                IDictionary<string, UnmanagedModuleVersion>? dlc)
             => MatchesAny(modules, dlls, dlc, out CkanModule? _);
 
-        public abstract bool MatchesAny(ICollection<CkanModule>                      modules,
-                                        ICollection<string>?                         dlls,
+        public abstract bool MatchesAny(IReadOnlyCollection<CkanModule>              modules,
+                                        IReadOnlyCollection<string>?                 dlls,
                                         IDictionary<string, UnmanagedModuleVersion>? dlc,
                                         out CkanModule?                              matched);
 
         public abstract bool WithinBounds(CkanModule otherModule);
 
-        public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier         registry,
-                                                                     StabilityToleranceConfig stabilityTolerance,
-                                                                     GameVersionCriteria?     crit,
-                                                                     ICollection<CkanModule>? installed = null,
-                                                                     ICollection<CkanModule>? toInstall = null);
+        public abstract List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier                 registry,
+                                                                     StabilityToleranceConfig         stabilityTolerance,
+                                                                     GameVersionCriteria?             crit,
+                                                                     IReadOnlyCollection<CkanModule>? installed = null,
+                                                                     IReadOnlyCollection<CkanModule>? toInstall = null);
 
-        public abstract CkanModule? ExactMatch(IRegistryQuerier         registry,
-                                               StabilityToleranceConfig stabilityTolerance,
-                                               GameVersionCriteria?     crit,
-                                               ICollection<CkanModule>? installed = null,
-            ICollection<CkanModule>? toInstall = null);
+        public abstract CkanModule? ExactMatch(IRegistryQuerier                 registry,
+                                               StabilityToleranceConfig         stabilityTolerance,
+                                               GameVersionCriteria?             crit,
+                                               IReadOnlyCollection<CkanModule>? installed = null,
+                                               IReadOnlyCollection<CkanModule>? toInstall = null);
 
         public override bool Equals(object? other)
             => Equals(other as RelationshipDescriptor);
@@ -126,8 +126,8 @@ namespace CKAN
         /// <returns>
         /// true if any of the modules match this descriptor, false otherwise.
         /// </returns>
-        public override bool MatchesAny(ICollection<CkanModule>                      modules,
-                                        ICollection<string>?                         dlls,
+        public override bool MatchesAny(IReadOnlyCollection<CkanModule>              modules,
+                                        IReadOnlyCollection<string>?                 dlls,
                                         IDictionary<string, UnmanagedModuleVersion>? dlc,
                                         out CkanModule?                              matched)
         {
@@ -149,19 +149,19 @@ namespace CKAN
                                && WithinBounds(dlcVer);
         }
 
-        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier         registry,
-                                                                     StabilityToleranceConfig stabilityTolerance,
-                                                                     GameVersionCriteria?     crit,
-                                                                     ICollection<CkanModule>? installed = null,
-                                                                     ICollection<CkanModule>? toInstall = null)
+        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier                 registry,
+                                                                     StabilityToleranceConfig         stabilityTolerance,
+                                                                     GameVersionCriteria?             crit,
+                                                                     IReadOnlyCollection<CkanModule>? installed = null,
+                                                                     IReadOnlyCollection<CkanModule>? toInstall = null)
             => registry.LatestAvailableWithProvides(name, stabilityTolerance,
                                                     crit, this, installed, toInstall);
 
-        public override CkanModule? ExactMatch(IRegistryQuerier         registry,
-                                               StabilityToleranceConfig stabilityTolerance,
-                                               GameVersionCriteria?     crit,
-                                               ICollection<CkanModule>? installed = null,
-                                               ICollection<CkanModule>? toInstall = null)
+        public override CkanModule? ExactMatch(IRegistryQuerier                 registry,
+                                               StabilityToleranceConfig         stabilityTolerance,
+                                               GameVersionCriteria?             crit,
+                                               IReadOnlyCollection<CkanModule>? installed = null,
+                                               IReadOnlyCollection<CkanModule>? toInstall = null)
             => Utilities.DefaultIfThrows(() => registry.LatestAvailable(name, stabilityTolerance,
                                                                         crit, this, installed, toInstall));
 
@@ -244,8 +244,8 @@ namespace CKAN
         public override bool WithinBounds(CkanModule otherModule)
             => any_of?.Any(r => r.WithinBounds(otherModule)) ?? false;
 
-        public override bool MatchesAny(ICollection<CkanModule>                      modules,
-                                        ICollection<string>?                         dlls,
+        public override bool MatchesAny(IReadOnlyCollection<CkanModule>              modules,
+                                        IReadOnlyCollection<string>?                 dlls,
                                         IDictionary<string, UnmanagedModuleVersion>? dlc,
                                         out CkanModule?                              matched)
         {
@@ -257,22 +257,22 @@ namespace CKAN
             return matched != null;
         }
 
-        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier         registry,
-                                                                     StabilityToleranceConfig stabilityTolerance,
-                                                                     GameVersionCriteria?     crit,
-                                                                     ICollection<CkanModule>? installed = null,
-                                                                     ICollection<CkanModule>? toInstall = null)
+        public override List<CkanModule> LatestAvailableWithProvides(IRegistryQuerier                 registry,
+                                                                     StabilityToleranceConfig         stabilityTolerance,
+                                                                     GameVersionCriteria?             crit,
+                                                                     IReadOnlyCollection<CkanModule>? installed = null,
+                                                                     IReadOnlyCollection<CkanModule>? toInstall = null)
             => (any_of?.SelectMany(r => r.LatestAvailableWithProvides(registry, stabilityTolerance, crit, installed, toInstall))
                        .Distinct()
                       ?? Enumerable.Empty<CkanModule>())
                       .ToList();
 
         // Exact match is not possible for any_of
-        public override CkanModule? ExactMatch(IRegistryQuerier         registry,
-                                               StabilityToleranceConfig stabilityTolerance,
-                                               GameVersionCriteria?     crit,
-                                               ICollection<CkanModule>? installed = null,
-                                               ICollection<CkanModule>? toInstall = null)
+        public override CkanModule? ExactMatch(IRegistryQuerier                 registry,
+                                               StabilityToleranceConfig         stabilityTolerance,
+                                               GameVersionCriteria?             crit,
+                                               IReadOnlyCollection<CkanModule>? installed = null,
+                                               IReadOnlyCollection<CkanModule>? toInstall = null)
             => null;
 
         public override bool Equals(RelationshipDescriptor? other)

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -371,7 +371,7 @@ namespace Tests.Core.Relationships
 
         private static void TestDepends(List<string>                                to_remove,
                                         HashSet<CkanModule>                         mods,
-                                        ICollection<string>                         dlls,
+                                        IReadOnlyCollection<string>                 dlls,
                                         IDictionary<string, UnmanagedModuleVersion> dlc,
                                         List<string>                                expected,
                                         string                                      message)


### PR DESCRIPTION
## Problem

As of recently in the dev build, modules with changed metadata can be added to the changeset for reinstallation, but the reinstallation doesn't happen. The install flow completes with zero actions taken.

## Cause

In #4369, this change was intended to prevent re-installation of dependencies that weren't supposed to be reinstalled:

https://github.com/KSP-CKAN/CKAN/blob/400d25cb8bef8deadc861262905b872609c36953/Core/IO/ModuleInstaller.cs#L1321-L1323

That only makes sense for modules we're not trying to reinstall. For modules that we _are_ trying to reinstall, this cancels the reinstallation.

## Changes

- Now explicitly requested modules are kept in the changeset used by `ModuleInstaller.Upgrade`
  - To ensure the immutability of the `modules` param of `ModuleInstaller.Upgrade`, its type signature is now `in IReadOnlyCollection`. Many other places are changed from `ICollection` to `IReadOnlyCollection` to accommodate this. These collections are treated as immutable anyway, so it's a somewhat more expressive interface now.
