### PR TITLE
Faster logic for finding removable auto-installed

### DIFF
--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -489,31 +489,77 @@ namespace CKAN
             log.DebugFormat("Finding removable autoInstalled for: {0}",
                             string.Join(", ", installed.Select(im => im.identifier)));
 
-            var autoInstMods = installed.Where(im => im.AutoInstalled).ToArray();
-            var autoInstIds  = autoInstMods.Select(im => im.Module.identifier).ToHashSet();
-
             var opts = RelationshipResolverOptions.DependsOnlyOpts(stabilityTolerance);
             opts.without_toomanyprovides_kraken = true;
             opts.without_enforce_consistency    = true;
             opts.proceed_with_inconsistencies   = true;
-            return autoInstMods.Where(
-                im => autoInstIds.IsSupersetOf(
-                    Registry.FindReverseDependencies(
-                        new string[] { im.identifier },
-                        installing,
-                        new RelationshipResolver(
-                            // DLC silently crashes the resolver
-                            installed.Where(other => !other.Module.IsDLC
-                                                     && other != im)
-                                     .Select(other => other.Module),
-                            querier.InstalledModules.Except(installed)
-                                                    .Append(im)
-                                                    .Select(other => other.Module),
-                            opts, querier, game, crit)
-                                .ModList()
-                                .ToArray(),
-                        querier.InstalledDlls,
-                        querier.InstalledDlc)));
+
+            // Calculate the full changeset for the mods we're installing
+            // (the already installed ones already have their dependencies in the registry)
+            var resolver = new RelationshipResolver(
+                               installing,
+                               querier.InstalledModules.Except(installed.Where(im => !im.AutoInstalled))
+                                                       .Select(other => other.Module),
+                               opts, querier, game, crit);
+            // Keep the mods that are not auto-installed
+            var keeping = installed.Where(im => !im.AutoInstalled)
+                                   .Select(im => im.Module)
+                                   // Don't remove anything we still need for newly installed mods
+                                   .Concat(resolver.ModList())
+                                   .Distinct()
+                                   .ToHashSet();
+            // Treat any auto-installed mods that aren't marked as needed as initially removable
+            var removable = installed.Where(im => im.AutoInstalled
+                                                  && !keeping.Contains(im.Module))
+                                     .ToList();
+            // Get the unsatisfied relationships of mods we're installing or not removing
+            var depends = keeping.SelectMany(m => m.depends
+                                                  ?? Enumerable.Empty<RelationshipDescriptor>())
+                                 .Distinct()
+                                 .Where(dep => !dep.MatchesAny(keeping, null, null))
+                                 .ToArray();
+            if (depends.Length > 0)
+            {
+                while (true)
+                {
+                    // Find previously-removable modules that satisfy previously unsatisfied relationships
+                    var stillNeeded = removable.Select(im => depends.Where(dep => dep.MatchesAny(new CkanModule[] { im.Module },
+                                                                                                 null, null))
+                                                                    .ToArray()
+                                                             is { Length: > 0 } deps
+                                                                 ? (KeyValuePair<InstalledModule, RelationshipDescriptor[]>?)
+                                                                   new KeyValuePair<InstalledModule, RelationshipDescriptor[]>(im, deps)
+                                                                 : null)
+                                               .OfType<KeyValuePair<InstalledModule, RelationshipDescriptor[]>>()
+                                               .ToDictionary();
+                    if (stillNeeded.Count > 0)
+                    {
+                        // Move this pass of mods we still need from removable into keeping
+                        removable.RemoveAll(stillNeeded.ContainsKey);
+                        keeping.UnionWith(stillNeeded.Keys.Select(im => im.Module));
+
+                        // Remove relationships that are satisfied by this pass of mods we still need
+                        depends = depends.Except(stillNeeded.Values.SelectMany(deps => deps))
+                                         // Add relationships from this pass of mods...
+                                         .Concat(stillNeeded.Keys.SelectMany(im => im.Module.depends
+                                                                                   ?? Enumerable.Empty<RelationshipDescriptor>())
+                                                            // ... except for ones that are already satisfied
+                                                            .Where(dep => !dep.MatchesAny(keeping, null, null)))
+                                         .Distinct()
+                                         .ToArray();
+                        // If no relationships still need to be satisfied, we are done
+                        if (depends.Length < 1)
+                        {
+                            return removable;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+            return removable;
         }
 
         /// <summary>

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -18,7 +18,7 @@ namespace CKAN
     public interface IRegistryQuerier
     {
         ReadOnlyDictionary<string, Repository>      Repositories     { get; }
-        IEnumerable<InstalledModule>                InstalledModules { get; }
+        IReadOnlyCollection<InstalledModule>        InstalledModules { get; }
         IReadOnlyCollection<string>                 InstalledDlls    { get; }
         IDictionary<string, UnmanagedModuleVersion> InstalledDlc     { get; }
 
@@ -515,6 +515,24 @@ namespace CKAN
                         querier.InstalledDlls,
                         querier.InstalledDlc)));
         }
+
+        /// <summary>
+        /// Find auto-installed modules that have no depending modules
+        /// or only auto-installed depending modules.
+        /// </summary>
+        /// <param name="querier">A registry</param>
+        /// <param name="instance">The game instance</param>
+        /// <returns>
+        /// Sequence of removable auto-installed modules, if any
+        /// </returns>
+        public static IEnumerable<InstalledModule> FindRemovableAutoInstalled(
+            this IRegistryQuerier querier,
+            GameInstance          instance)
+            => querier.FindRemovableAutoInstalled(querier.InstalledModules,
+                                                  Array.Empty<CkanModule>(),
+                                                  instance.game,
+                                                  instance.StabilityToleranceConfig,
+                                                  instance.VersionCriteria());
 
         private static readonly ILog log = LogManager.GetLogger(typeof(IRegistryQuerierHelpers));
     }

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -833,10 +833,10 @@ namespace CKAN
         /// Register the supplied module as having been installed, thereby keeping
         /// track of its metadata and files.
         /// </summary>
-        public void RegisterModule(CkanModule          mod,
-                                   ICollection<string> absoluteFiles,
-                                   GameInstance        inst,
-                                   bool                autoInstalled)
+        public InstalledModule RegisterModule(CkanModule          mod,
+                                              ICollection<string> absoluteFiles,
+                                              GameInstance        inst,
+                                              bool                autoInstalled)
         {
             log.DebugFormat("Registering module {0}", mod);
             EnlistWithTransaction();
@@ -890,12 +890,14 @@ namespace CKAN
                                               || relativeFiles.Contains(kvp.Value));
 
             // Finally register our module proper
-            installed_modules.Add(mod.identifier,
-                                  new InstalledModule(inst, mod, relativeFiles, autoInstalled));
+            var instMod = new InstalledModule(inst, mod, relativeFiles, autoInstalled);
+            installed_modules.Add(mod.identifier, instMod);
 
             // Installing and uninstalling mods can change compatibility due to conflicts,
             // so we'll need to reset the compatibility sorter
             InvalidateInstalledCaches();
+
+            return instMod;
         }
 
         /// <summary>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -44,7 +44,7 @@ namespace CKAN
 
         [JsonProperty]
         [JsonConverter(typeof(JsonParallelDictionaryConverter<InstalledModule>))]
-        private readonly IDictionary<string, InstalledModule> installed_modules;
+        private readonly Dictionary<string, InstalledModule> installed_modules;
 
         // filename (case insensitive on Windows) => module
         [JsonProperty]
@@ -113,7 +113,7 @@ namespace CKAN
         /// <summary>
         /// Returns all the installed modules
         /// </summary>
-        [JsonIgnore] public IEnumerable<InstalledModule> InstalledModules
+        [JsonIgnore] public IReadOnlyCollection<InstalledModule> InstalledModules
             => installed_modules.Values;
 
         /// <summary>
@@ -357,7 +357,7 @@ namespace CKAN
         }
 
         public Registry(RepositoryDataManager?               repoData,
-                        IDictionary<string, InstalledModule> installed_modules,
+                        Dictionary<string, InstalledModule>  installed_modules,
                         Dictionary<string, string>           installed_dlls,
                         IDictionary<string, string>          installed_files,
                         SortedDictionary<string, Repository> repositories)

--- a/GUI/Controls/ModInfoTabs/Relationships.cs
+++ b/GUI/Controls/ModInfoTabs/Relationships.cs
@@ -360,14 +360,16 @@ namespace CKAN.GUI
                                 .Where(r => r.MatchesAny(modules, null, null))
                                 .Select(r => IndexedNode(registry, otherMod, relationship,
                                                          r, stabilityTolerance, crit)))
-                        .OrderBy(r => r.Name)
+                        .OrderByDescending(r => registry.IsInstalled(r.Name, false))
+                        .ThenBy(r => r.Name)
                         .Concat(registry.IncompatibleModules(stabilityTolerance, crit)
                                         .SelectMany(otherMod =>
                                             GetModRelationships(otherMod, relationship)
                                                 .Where(r => r.MatchesAny(modules, null, null))
                                                 .Select(r => IndexedNode(registry, otherMod, relationship,
                                                                          r, stabilityTolerance, crit)))
-                                        .OrderBy(r => r.Name)));
+                                        .OrderByDescending(r => registry.IsInstalled(r.Name, false))
+                                        .ThenBy(r => r.Name)));
 
         private static TreeNode providesNode(string           identifier,
                                              RelationshipType relationship,

--- a/Tests/CmdLine/UpgradeTests.cs
+++ b/Tests/CmdLine/UpgradeTests.cs
@@ -666,12 +666,12 @@ namespace Tests.CmdLine
          // then upgrade to the Kopernicus-depending version
          TestCase(new string[] { "OuterPlanetsMod=1.0" },
                   new string[] { "OuterPlanetsMod" },
-                  new string[] { "OuterPlanetsMod", "Kopernicus", "ModularFlightIntegrator" }),
+                  new string[] { "OuterPlanetsMod", "Kopernicus", "ModularFlightIntegrator", "ModuleManager" }),
          // Install the Kopernicus-depending version
          // then downgrade to the old KopernicusTech-depending version,
          TestCase(new string[] { "OuterPlanetsMod" },
                   new string[] { "OuterPlanetsMod=1.0" },
-                  new string[] { "OuterPlanetsMod", "KopernicusTech" })]
+                  new string[] { "OuterPlanetsMod", "KopernicusTech", "ModuleManager" })]
         public void RunCommand_UpOrDowngradeWithAutoDepConflict_Works(string[] toInstall,
                                                                       string[] toUpgrade,
                                                                       string[] finalInstalled)

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -899,6 +899,7 @@ namespace Tests.Data
                 ""name"":       ""KopernicusTech"",
                 ""version"":    ""1.0"",
                 ""download"":   ""https://github.com/"",
+                ""depends"":    [ { ""name"": ""ModuleManager"" } ],
                 ""conflicts"":  [ { ""name"": ""Kopernicus"" } ],
                 ""install"":    [ { ""find"":       ""DogeCoinFlag"",
                                     ""install_to"": ""GameData/KopernicusTech"" } ]
@@ -908,7 +909,8 @@ namespace Tests.Data
                 ""name"":       ""Kopernicus"",
                 ""version"":    ""1.0"",
                 ""download"":   ""https://github.com/"",
-                ""depends"":    [ { ""name"": ""ModularFlightIntegrator"" } ],
+                ""depends"":    [ { ""name"": ""ModuleManager"" },
+                                  { ""name"": ""ModularFlightIntegrator"" } ],
                 ""install"":    [ { ""find"":       ""DogeCoinFlag"",
                                     ""install_to"": ""GameData/Kopernicus"" } ]
             }",
@@ -919,6 +921,14 @@ namespace Tests.Data
                 ""download"":   ""https://github.com/"",
                 ""install"":    [ { ""find"":       ""DogeCoinFlag"",
                                     ""install_to"": ""GameData/ModularFlightIntegrator"" } ]
+            }",
+            @"{
+                ""identifier"": ""ModuleManager"",
+                ""name"":       ""ModuleManager"",
+                ""version"":    ""1.0"",
+                ""download"":   ""https://github.com/"",
+                ""install"":    [ { ""find"":       ""DogeCoinFlag"",
+                                    ""install_to"": ""GameData/ModuleManager"" } ]
             }",
         };
     }

--- a/bin/ckan_merge_pr.py
+++ b/bin/ckan_merge_pr.py
@@ -30,7 +30,7 @@ class CkanRepo(Repo):
 
     def remote_primary(self) -> RemoteReference:
         """Looks up the main branch in the repo on GitHub"""
-        return next(filter(self.ref_is_head, self.refs))
+        return next(filter(self.ref_is_head, self.remotes[0].refs))
 
     @staticmethod
     def ref_is_head(ref: RemoteReference) -> bool:


### PR DESCRIPTION
## Problem

After #4369, the dev build pauses for several seconds after you click the install or upgrade checkboxes when you have many auto-installed mods installed.

## Cause

6fc2c487a05725ab881ccf2cee95acb5fd32c9d0 updated `IRegistryQuerier.FindRemovableAutoInstalled` to run a new `RelationshipResolver` for every auto-installed mod (previously only one was shared among all the mods), in order to handle complex relationship changes during upgrades. This is a non-trivial cost for an inner loop, such as for 70-ish auto-installed mods.

## Changes

Now `IRegistryQuerier.FindRemovableAutoInstalled` uses just one `RelationshipResolver` to calculate the changes needed to satisfy relationships for newly installed mods, then checks the `depends` relationships of the installed mods to determine which auto-installed mods are still needed in a more optimized way.

The tests for #930 still pass, and some new tests are added to exercise `FindRemovableAutoInstalled`'s basic functionality.

Fixes #4373.

### Side changes

- I found the Relationships tab's reverse relationships mode useful in investigating which mods were involved in keeping other mods installed, but there was a lot of scrolling and scanning to find the relevant ones.
  Now the Relationships tab sorts installed mods to the top of each sub-list when in reverse relationships mode.
- I noticed that clicking Clear for a changeset with auto-removals would change those mods to non-auto-installed unnecessarily.
  Now `ManageMods.ClearChangeSet` no longer sets auto-installed mods as non-auto-installed if some other mod depends on them (except for some circular dependencies).
