### PR TITLE
Use relative luminance to determine module label ForeColors

### DIFF
--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -323,8 +323,36 @@ namespace CKAN.GUI
 
         public static Color? ForeColorForBackColor(this Color backColor)
             => backColor == Color.Transparent || backColor == Color.Empty ? null
-             : backColor.GetBrightness() >= 0.5                           ? Color.Black
+             : backColor.GetLuminance() >= luminanceThreshold             ? Color.Black
              :                                                              Color.White;
+
+        /// <summary>
+        /// Below this is considered "dark," above is considered "light"
+        /// </summary>
+        private const double luminanceThreshold = 0.179128785;
+
+        /// <summary>
+        /// https://www.w3.org/WAI/GL/wiki/Relative_luminance
+        /// </summary>
+        /// <param name="color">The color for which to calculate the relative luminance</param>
+        /// <returns>Relative luminance (basically a better version of brightness) of the color</returns>
+        public static double GetLuminance(this Color color)
+            => GetLuminance(color.R, color.G, color.B);
+
+        private static double GetLuminance(byte R, byte G, byte B)
+            => GetLuminance(LuminanceTransform(R),
+                            LuminanceTransform(G),
+                            LuminanceTransform(B));
+
+        private static double GetLuminance(double Rs, double Gs, double Bs)
+            => (0.2126 * Rs) + (0.7152 * Gs) + (0.0722 * Bs);
+
+        private static double LuminanceTransform(byte value)
+            => LuminanceTransform(value / 255.0);
+
+        private static double LuminanceTransform(double value)
+            => value <= 0.03928 ? value / 12.92
+                                : Math.Pow((value + 0.055) / 1.055, 2.4);
 
         #endregion
 

--- a/Tests/GUI/UtilTests.cs
+++ b/Tests/GUI/UtilTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Drawing;
 
@@ -15,13 +16,14 @@ namespace Tests.GUI
          TestCase("OrangeRed"), TestCase("LightCoral"),
          TestCase("Yellow"), TestCase("Gold"), TestCase("Khaki"),
          TestCase("PaleGreen"), TestCase("Lime"),
+         TestCase("#408080" /* Paradiso */),
          TestCase("SkyBlue"), TestCase("Aqua"), TestCase("LightBlue"), TestCase("DeepSkyBlue"),
          TestCase("Violet"),
          TestCase("Gray"),
         ]
         public void ForeColorForBackColor_LightBackColor_BlackForeColor(string colorName)
         {
-            var c = Color.FromName(colorName);
+            var c = ColorFromNameOrRGB(colorName);
             Assert.AreEqual(Color.Black, c.ForeColorForBackColor(),
                             $"Foreground color for {c.Name} (brightness {c.GetBrightness()}) should be Black");
         }
@@ -31,14 +33,25 @@ namespace Tests.GUI
          TestCase("Green"),
          TestCase("DarkBlue"), TestCase("MidnightBlue"), TestCase("Navy"), TestCase("DarkSlateBlue"), TestCase("MediumBlue"),
          TestCase("Indigo"), TestCase("Purple"), TestCase("DarkViolet"),
+         TestCase("#8000FF" /* ElectricViolet */),
          TestCase("Brown"), TestCase("Sienna"),
          TestCase("DimGray"),
         ]
         public void ForeColorForBackColor_DarkBackColor_WhiteForeColor(string colorName)
         {
-            var c = Color.FromName(colorName);
+            var c = ColorFromNameOrRGB(colorName);
             Assert.AreEqual(Color.White, c.ForeColorForBackColor(),
                             $"Foreground color for {c.Name} (brightness {c.GetBrightness()}) should be White");
         }
+
+        private static Color ColorFromNameOrRGB(string nameOrRGB)
+            => nameOrRGB.StartsWith("#") ? Color.FromArgb(StringToColorChannel(nameOrRGB, 1),
+                                                          StringToColorChannel(nameOrRGB, 3),
+                                                          StringToColorChannel(nameOrRGB, 5))
+                                         : Color.FromName(nameOrRGB);
+
+        private static int StringToColorChannel(string rgb, int start)
+            => Convert.ToInt32(rgb.Substring(start, 2), 16);
+
     }
 }


### PR DESCRIPTION
## Motivation

In #4381, I noted that `#8000FF` was using black foreground text when white would be better.

@SofieBrink mentioned relative luminance, which I did come across during development, but at the time I wanted to use a standard function, of which none were available for this.

## Changes

- Now we use our own relative luminance calculation instead of `GetBrightness` to determine the actual brightness of a color
  ![image](https://github.com/user-attachments/assets/814103c9-f90b-42b3-b698-e809f2c34462)
- Test cases are added to confirm that `#408080` uses black text and `#8000FF` uses white text
