### PR TITLE
Coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,12 @@
 name: Test CKAN + NetKAN
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
   push:
-    branches-ignore:
-      - master
   workflow_call:
 
 jobs:
@@ -33,6 +36,10 @@ jobs:
           path: _build/repack/
       - name: Run tests
         run: xvfb-run ./build.sh test+only --configuration=Debug --where="Category!=FlakyNetwork"
+      - name: Report Coveralls
+        uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   # notify:
   #   needs:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+# Coverage
+Tests/coverage.*.xml
+Tests/coverage.*.acv
+
 # Don't ignore the root bin folder
 !/bin/
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [<img src="https://img.shields.io/github/downloads/KSP-CKAN/CKAN/latest/total.svg?label=%E2%A4%93Download&style=plastic" height="48px" />](https://github.com/KSP-CKAN/CKAN/releases/latest)
 
+[![Coverage Status](https://coveralls.io/repos/github/KSP-CKAN/CKAN/badge.svg?branch=master)](https://coveralls.io/github/KSP-CKAN/CKAN?branch=master)
+
 [Click here to open a new CKAN issue][6]
 
 [Click here to go to the CKAN wiki][5]

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -168,5 +169,19 @@ public partial class BuildContext : FrostingContext
         }
 
         return output;
+    }
+
+    public void RunAltCover(params string[] args)
+    {
+        if (this.StartProcess(Paths.AltCoverPath,
+                              new ProcessSettings
+                              {
+                                  WorkingDirectory = Paths.CoverageOutputDirectory,
+                                  Arguments        = string.Join(" ", args),
+                              })
+            is int exitCode and not 0)
+        {
+            throw new Exception($"AltCover failed with exit code: {exitCode}");
+        }
     }
 }

--- a/build/BuildPaths.cs
+++ b/build/BuildPaths.cs
@@ -6,7 +6,7 @@ namespace Build;
 public class BuildPaths
 {
     public DirectoryPath RootDirectory { get; init; }
-    public FilePath CoreProject { get; } 
+    public FilePath CoreProject { get; }
     public DirectoryPath BuildDirectory { get; }
     public DirectoryPath NugetDirectory { get; }
     public DirectoryPath OutDirectory { get; }
@@ -15,6 +15,13 @@ public class BuildPaths
     public FilePath CkanFile { get; }
     public FilePath UpdaterFile { get; }
     public FilePath NetkanFile { get; }
+    public DirectoryPath ToolsDirectory => BuildDirectory.Combine("tools");
+    public FilePath AltCoverPath => ToolsDirectory.Combine("altcover.api.9.0.1")
+                                                  .Combine("lib")
+                                                  .Combine("net472")
+                                                  .CombineWithFilePath("AltCover.exe");
+    public DirectoryPath CoverageOutputDirectory => BuildDirectory.Combine("test")
+                                                                  .Combine("coverage");
 
     public BuildPaths(DirectoryPath rootDirectory, string configuration, SemVersion version)
     {


### PR DESCRIPTION
## Motivation

Tests can't help with untested code. If we knew which and how much code is still untested, we could gradually reduce it by writing more tests, which would make everything more reliable.

## Changes

- Now our Cake build code uses [AltCover](https://github.com/SteveGilham/altcover) to instrument our assemblies for testing, then generates an output file at `_build/test/coverage/coverage.xml`, which can be inspected with the [`AltCover.visualizer`](https://www.nuget.org/packages/AltCover.visualizer) tool
- Now our GitHub test.yml workflow runs the [Coveralls GitHub Action](https://github.com/coverallsapp/github-action) after testing, which hopefully will read the `coverage.xml` file and annotate commits and pull requests with some status info and possibly upload to <https://coveralls.io/github/KSP-CKAN/CKAN>.
- The README now displays a coverage badge to encourage us to make the number go up.

Fixes #306.
