### PR TITLE
Mod list multi-select

### DIFF
--- a/Core/CkanTransaction.cs
+++ b/Core/CkanTransaction.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Transactions;
+#if !NET7_0_OR_GREATER
 using System.Reflection;
+#endif
 
 using log4net;
 
@@ -87,7 +89,7 @@ namespace CKAN
                     SetField(t, "s_cachedMaxTimeout", true);
                     SetField(t, "s_maximumTimeout",   timeout);
                 }
-            
+
 #endif
             }
         }

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -1,266 +1,46 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Diagnostics.CodeAnalysis;
-using System.ComponentModel;
-
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
 
-using CKAN.IO;
-using CKAN.Games;
-
 namespace CKAN.Configuration
 {
-    // DEPRECATED: We now use a JSON configuration file. This still exists to facilitate migration.
-    //
-    // N.B., you can resume using this version by changing the instance created in ServiceLocator.
+    using WinReg = Microsoft.Win32.Registry;
+
+    /// <summary>
+    /// Originally, CKAN's system level configuration was stored in the
+    /// Windows registry (and Mono's emulation of it in ~/.mono/registry/).
+    /// netstandard2.0 does not provide the Microsoft.Win32 namespace,
+    /// so this was replaced by a config.json file in the app data folder.
+    /// This class now exists solely to purge the old registry data.
+    /// </summary>
     #if NET5_0_OR_GREATER
     [SupportedOSPlatform("windows")]
     #endif
-    public class Win32RegistryConfiguration : IConfiguration
+    internal class Win32RegistryConfiguration
     {
-        private const           string CKAN_KEY           = @"HKEY_CURRENT_USER\Software\CKAN";
-        private static readonly string CKAN_KEY_NO_PREFIX = StripPrefixKey(CKAN_KEY);
-
-        private const           string authTokenKey         = CKAN_KEY + @"\AuthTokens";
-        private static readonly string authTokenKeyNoPrefix = StripPrefixKey(authTokenKey);
-
-        private static readonly string defaultDownloadCacheDir =
-            Path.Combine(CKANPathUtils.AppDataPath, "downloads");
-
-        public string? DownloadCacheDir
-        {
-            get => GetRegistryValue(@"DownloadCacheDir", defaultDownloadCacheDir);
-            set
-            {
-                if (value == null || string.IsNullOrEmpty(value))
-                {
-                    DeleteRegistryValue(@"DownloadCacheDir");
-                }
-                else
-                {
-                    if (!Path.IsPathRooted(value))
-                    {
-                        value = Path.GetFullPath(value);
-                    }
-                    SetRegistryValue(@"DownloadCacheDir", value);
-                }
-            }
-        }
-
-        public long? CacheSizeLimit
-        {
-            get
-            {
-                var val = GetRegistryValue<string?>(@"CacheSizeLimit", null);
-                return string.IsNullOrEmpty(val) ? null : Convert.ToInt64(val);
-            }
-            set
-            {
-                if (!value.HasValue)
-                {
-                    DeleteRegistryValue(@"CacheSizeLimit");
-                }
-                else
-                {
-                    SetRegistryValue(@"CacheSizeLimit", value.Value);
-                }
-            }
-        }
-
-        public int RefreshRate
-        {
-            get => GetRegistryValue(@"RefreshRate", 0);
-            set
-            {
-                if (value <= 0)
-                {
-                    DeleteRegistryValue(@"RefreshRate");
-                }
-                else
-                {
-                    SetRegistryValue(@"RefreshRate", value);
-                }
-            }
-        }
-
-        private static int InstanceCount => GetRegistryValue(@"KSPInstanceCount", 0);
-
-        public string? AutoStartInstance
-        {
-            get => GetRegistryValue(@"KSPAutoStartInstance", "");
-            #pragma warning disable IDE0027
-            set { SetAutoStartInstance(value ?? string.Empty); }
-            #pragma warning restore IDE0027
-        }
-
-        public string? Language
-        {
-            get => GetRegistryValue<string?>("Language", null);
-            set
-            {
-                if (value != null && Utilities.AvailableLanguages.Contains(value))
-                {
-                    SetRegistryValue("Language", value);
-                }
-            }
-        }
-
-        public Win32RegistryConfiguration()
-        {
-            ConstructKey(CKAN_KEY_NO_PREFIX);
-        }
-
-        private Tuple<string, string, string> GetInstance(int i)
-        {
-            return new Tuple<string, string, string>(
-                GetRegistryValue("KSPInstanceName_" + i, string.Empty),
-                GetRegistryValue("KSPInstancePath_" + i, string.Empty),
-                GetRegistryValue("KSPInstanceGame_" + i, string.Empty)
-            );
-        }
-
-        public void SetRegistryToInstances(SortedList<string, GameInstance> instances)
-        {
-            SetNumberOfInstances(instances.Count);
-
-            int i = 0;
-            foreach ((string name, GameInstance inst) in instances)
-            {
-                SetInstanceKeysTo(i++, name, inst);
-            }
-        }
-
-        public IEnumerable<Tuple<string, string, string>> GetInstances()
-            => Enumerable.Range(0, InstanceCount).Select(GetInstance).ToList();
-
-        public bool TryGetAuthToken(string host,
-                                    [NotNullWhen(returnValue: true)] out string? token)
-        {
-            try
-            {
-                token = Microsoft.Win32.Registry.GetValue(authTokenKey, host, null) as string;
-                return !string.IsNullOrEmpty(token);
-            }
-            catch
-            {
-                // If GetValue threw SecurityException, IOException, or ArgumentException,
-                // just report failure.
-                token = "";
-                return false;
-            }
-        }
-
-        public IEnumerable<string> GetAuthTokenHosts()
-        {
-            var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(authTokenKeyNoPrefix);
-            return key?.GetValueNames() ?? Array.Empty<string>();
-        }
-
-        public void SetAuthToken(string host, string? token)
-        {
-            ConstructKey(authTokenKeyNoPrefix);
-            if (!string.IsNullOrEmpty(host))
-            {
-                if (string.IsNullOrEmpty(token))
-                {
-                    var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(authTokenKeyNoPrefix, true);
-                    key?.DeleteValue(host);
-                }
-                else
-                {
-                    Microsoft.Win32.Registry.SetValue(authTokenKey, host, token);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Not implemented because the Windows registry is deprecated
-        /// </summary>
-        public string[] GetGlobalInstallFilters(IGame game) => Array.Empty<string>();
-        /// <summary>
-        /// Not implemented because the Windows registry is deprecated
-        /// </summary>
-        public void SetGlobalInstallFilters(IGame game, string[] value) { }
-
-        /// <summary>
-        /// Not implemented because the Windows registry is deprecated
-        /// </summary>
-        public string?[] PreferredHosts { get; set; } = Array.Empty<string?>();
-
-        /// <summary>
-        /// Not implemented because the Windows registry is deprecated
-        /// </summary>
-        public bool? DevBuilds { get; set; }
-
-        #pragma warning disable CS0067
-        public event PropertyChangedEventHandler? PropertyChanged;
-        #pragma warning restore CS0067
-
         public static bool DoesRegistryConfigurationExist()
-        {
-            var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(CKAN_KEY_NO_PREFIX);
-            return key != null;
-        }
+            => WinReg.CurrentUser.OpenSubKey(CKAN_KEY_NO_PREFIX) != null;
 
         public static void DeleteAllKeys()
         {
-            // This can fail if the key doesn't exist, but we don't really care...
-            try {
-                Microsoft.Win32.Registry.CurrentUser.DeleteSubKeyTree(CKAN_KEY_NO_PREFIX);
-            } catch { }
-        }
-
-        private static string StripPrefixKey(string keyname)
-        {
-            int firstBackslash = keyname.IndexOf(@"\");
-            return firstBackslash < 0
-                ? keyname
-                : keyname[(1 + firstBackslash)..];
-        }
-
-        private static void ConstructKey(string whichKey)
-        {
-            var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(whichKey);
-            if (key == null)
+            try
             {
-                Microsoft.Win32.Registry.CurrentUser.CreateSubKey(whichKey);
+                WinReg.CurrentUser.DeleteSubKeyTree(CKAN_KEY_NO_PREFIX);
+            }
+            catch
+            {
+                // This can fail if the key doesn't exist, but we don't really care...
             }
         }
 
-        private static void SetAutoStartInstance(string instanceName)
-        {
-            SetRegistryValue(@"KSPAutoStartInstance", instanceName ?? string.Empty);
-        }
+        private static string StripPrefixKey(string keyname)
+            => keyname.IndexOf(@"\") switch
+               {
+                   < 0                => keyname,
+                   var firstBackslash => keyname[(1 + firstBackslash)..],
+               };
 
-        private static void SetNumberOfInstances(int count)
-        {
-            SetRegistryValue(@"KSPInstanceCount", count);
-        }
-
-        private static void SetInstanceKeysTo(int instanceIndex, string name, GameInstance ksp)
-        {
-            SetRegistryValue(@"KSPInstanceName_" + instanceIndex, name);
-            SetRegistryValue(@"KSPInstancePath_" + instanceIndex, ksp.GameDir());
-        }
-
-        private static void SetRegistryValue<T>(string key, T value) where T: notnull
-        {
-            Microsoft.Win32.Registry.SetValue(CKAN_KEY, key, value);
-        }
-
-        private static T GetRegistryValue<T>(string key, T defaultValue)
-            => Microsoft.Win32.Registry.GetValue(CKAN_KEY, key, null) is T v
-                ? v
-                : defaultValue;
-
-        private static void DeleteRegistryValue(string name)
-        {
-            var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(CKAN_KEY_NO_PREFIX, true);
-            key?.DeleteValue(name, false);
-        }
+        private const  string CKAN_KEY           =  @"HKEY_CURRENT_USER\Software\CKAN";
+        private static string CKAN_KEY_NO_PREFIX => StripPrefixKey(CKAN_KEY);
     }
 }

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -248,10 +248,11 @@ namespace CKAN.GUI
 
         private void AlwaysUncheckAllButton_CheckedChanged(object? sender, EventArgs? e)
         {
-            if (guiConfig != null && guiConfig.SuppressRecommendations != AlwaysUncheckAllButton.Checked)
+            if (guiConfig != null && guiConfig.SuppressRecommendations != AlwaysUncheckAllButton.Checked
+                && Main.Instance?.CurrentInstance is GameInstance inst)
             {
                 guiConfig.SuppressRecommendations = AlwaysUncheckAllButton.Checked;
-                guiConfig.Save();
+                guiConfig.Save(inst);
                 if (guiConfig.SuppressRecommendations)
                 {
                     UncheckAllButton_Click(null, null);

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -350,7 +350,7 @@ namespace CKAN.GUI
             this.Description});
             this.ModGrid.Location = new System.Drawing.Point(0, 111);
             this.ModGrid.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.ModGrid.MultiSelect = false;
+            this.ModGrid.MultiSelect = true;
             this.ModGrid.Name = "ModGrid";
             this.ModGrid.RowHeadersVisible = false;
             this.ModGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
@@ -360,7 +360,6 @@ namespace CKAN.GUI
             this.ModGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModGrid_CellContentClick);
             this.ModGrid.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModGrid_CellMouseDoubleClick);
             this.ModGrid.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModGrid_HeaderMouseClick);
-            this.ModGrid.SelectionChanged += new System.EventHandler(this.ModGrid_SelectionChanged);
             this.ModGrid.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ModGrid_KeyDown);
             this.ModGrid.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ModGrid_KeyPress);
             this.ModGrid.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ModGrid_MouseDown);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -13,7 +13,6 @@ using log4net;
 
 using CKAN.Configuration;
 using CKAN.IO;
-using CKAN.Games;
 using CKAN.Extensions;
 using CKAN.GUI.Attributes;
 

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -36,7 +36,7 @@ namespace CKAN.GUI
                     Anchor                  = AnchorStyles.Top | AnchorStyles.Right,
                     FlatStyle               = FlatStyle.Flat,
                     Location                = new Point(GlobalFiltersTextBox.Right + hPadding, top),
-                    Size                    = new Size(GlobalFiltersGroupBox.Width - GlobalFiltersTextBox.Right - 2 * hPadding, 23),
+                    Size                    = new Size(GlobalFiltersGroupBox.Width - GlobalFiltersTextBox.Right - (2 * hPadding), 23),
                     Text                    = string.Format(Properties.Resources.InstallFiltersAddPreset,
                                                             name),
                     Tag                     = name,

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -57,7 +57,8 @@ namespace CKAN.GUI
                 downloader.OverallDownloadProgress += currentUser.RaiseProgress;
                 for (bool done = false; !done; )
                 {
-                    try {
+                    try
+                    {
                         downloader.DownloadModules(new List<CkanModule> { gm.ToCkanModule() });
                         done = true;
                     }

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -328,7 +328,6 @@ namespace CKAN.GUI
                     && SelectedMod == LatestAvailableMod)
                 {
                     yield return new ModUpgrade(Mod,
-                                                GUIModChangeType.Update,
                                                 SelectedMod,
                                                 false, false,
                                                 ServiceLocator.Container.Resolve<IConfiguration>());
@@ -351,7 +350,6 @@ namespace CKAN.GUI
             {
                 // Reinstall
                 yield return new ModUpgrade(Mod,
-                                            GUIModChangeType.Update,
                                             SelectedMod,
                                             false, metadataChanged,
                                             ServiceLocator.Container.Resolve<IConfiguration>());

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -148,12 +148,11 @@ namespace CKAN.GUI
     public class ModUpgrade : ModChange
     {
         public ModUpgrade(CkanModule       mod,
-                          GUIModChangeType changeType,
                           CkanModule       targetMod,
                           bool             userReinstall,
                           bool             metadataChanged,
                           IConfiguration   config)
-            : base(mod, changeType, config)
+            : base(mod, GUIModChangeType.Update, config)
         {
             this.targetMod       = targetMod;
             this.userReinstall   = userReinstall;

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -37,7 +37,7 @@ namespace CKAN.GUI
                 //Passing in null will cause a NullReferenceException if it tries to show the dialog
                 //asking for elevation permission, but we want that to happen. Doing that keeps us
                 //from getting in to a infinite loop of trying to register.
-                URLHandlers.RegisterURLHandler(null, null);
+                URLHandlers.RegisterURLHandler(null, null, null);
             }
             else
             {

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -490,6 +490,8 @@ If unchecked, only mods in the pack will be installed.</value></data>
   <data name="ManageModsHiddenLabels" xml:space="preserve"><value>Hidden labels:</value></data>
   <data name="ManageModsHiddenTags" xml:space="preserve"><value>Hidden tags:</value></data>
   <data name="ManageModsHiddenLabelsAndTags" xml:space="preserve"><value>Hidden labels and tags:</value></data>
+  <data name="ManageModsLabelAddMultiple" xml:space="preserve"><value>{0} (add {1} modules)</value></data>
+  <data name="ManageModsLabelRemoveMultiple" xml:space="preserve"><value>{0} (remove {1} modules)</value></data>
   <data name="ManageModsRefreshStaleToolTip" xml:space="preserve"><value>Your mod list was last updated {0} days ago.
 Click Refresh regularly to keep it up to date.
 Or choose "Update repositories on launch" in the settings.</value></data>

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -45,7 +45,7 @@ namespace CKAN.GUI
             }
         }
 
-        public static void RegisterURLHandler(GUIConfiguration? config, IUser? user)
+        public static void RegisterURLHandler(GUIConfiguration? config, GameInstance? instance, IUser? user)
         {
             try
             {
@@ -61,7 +61,7 @@ namespace CKAN.GUI
                     }
                     catch (UnauthorizedAccessException)
                     {
-                        if (config == null || config.URLHandlerNoNag)
+                        if (config == null || config.URLHandlerNoNag || instance == null)
                         {
                             return;
                         }
@@ -81,7 +81,7 @@ namespace CKAN.GUI
                             });
                         }
                         config.URLHandlerNoNag = true;
-                        config.Save();
+                        config.Save(instance);
                         // Don't re-throw the exception because we just dealt with it
                     }
                 }

--- a/Tests/Core/Registry/RegistryManager.cs
+++ b/Tests/Core/Registry/RegistryManager.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 
 using CKAN;
 using CKAN.Versioning;
-using CKAN.Games.KerbalSpaceProgram;
 
 using Tests.Data;
 

--- a/Tests/GUI/GUIConfiguration.cs
+++ b/Tests/GUI/GUIConfiguration.cs
@@ -1,11 +1,10 @@
 using System.IO;
-using System.Collections.Generic;
 
 using NUnit.Framework;
 
 using CKAN;
+using CKAN.IO;
 using CKAN.GUI;
-
 using Tests.Data;
 
 namespace Tests.GUI
@@ -13,49 +12,48 @@ namespace Tests.GUI
     [TestFixture]
     public class GuiConfigurationTests
     {
-        private string? tempDir;
-
-        [OneTimeSetUp]
-        public void Setup()
-        {
-            tempDir = TestData.NewTempDir();
-        }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            if (tempDir != null)
-            {
-                Directory.Delete(tempDir, true);
-            }
-        }
-
         [Test]
         public void LoadOrCreateConfiguration_MalformedXMLFile_ThrowsKraken()
         {
-            string tempFile = Path.Combine(tempDir!, "invalid.xml");
-
-            using (var stream = new StreamWriter(tempFile))
+            // Arrange
+            using (var inst = new DisposableKSP())
             {
-                stream.Write("This is not a valid XML file.");
-            }
+                var xmlPath = Path.Combine(inst.KSP.CkanDir(), "GUIConfig.xml");
+                using (var stream = new StreamWriter(Path.Combine(inst.KSP.CkanDir(),
+                                                                  "GUIConfig.xml")))
+                {
+                    stream.Write("This is not a valid XML file.");
+                }
+                var steamLib = new SteamLibrary(null);
 
-            Assert.Throws<Kraken>(() => GUIConfiguration.LoadOrCreateConfiguration(tempFile, new List<string>()));
+                // Act / Assert
+                Assert.Throws<Kraken>(() => GUIConfiguration.LoadOrCreateConfiguration(inst.KSP, steamLib));
+                Assert.IsTrue(File.Exists(xmlPath));
+            }
         }
 
         [Test]
         public void LoadOrCreateConfiguration_CorrectConfigurationFile_Loaded()
         {
-            string tempFile = Path.Combine(tempDir!, "valid.xml");
-
-            using (var stream = new StreamWriter(tempFile))
+            // Arrange
+            using (var inst = new DisposableKSP())
             {
-                stream.Write(TestData.ConfigurationFile());
+                var xmlPath  = Path.Combine(inst.KSP.CkanDir(), "GUIConfig.xml");
+                var jsonPath = Path.Combine(inst.KSP.CkanDir(), "GUIConfig.json");
+                using (var stream = new StreamWriter(xmlPath))
+                {
+                    stream.Write(TestData.ConfigurationFile());
+                }
+                var steamLib = new SteamLibrary(null);
+
+                // Act / Assert
+                var result = GUIConfiguration.LoadOrCreateConfiguration(inst.KSP, steamLib);
+                Assert.IsNotNull(result);
+                Assert.AreEqual(512, result.WindowLoc.X);
+                Assert.AreEqual(136, result.WindowLoc.Y);
+                Assert.IsFalse(File.Exists(xmlPath));
+                Assert.IsTrue(File.Exists(jsonPath));
             }
-
-            var result = GUIConfiguration.LoadOrCreateConfiguration(tempFile, new List<string>());
-
-            Assert.IsNotNull(result);
         }
     }
 }

--- a/Tests/GUI/UtilTests.cs
+++ b/Tests/GUI/UtilTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Drawing;
 
 using NUnit.Framework;

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -326,7 +326,7 @@ public sealed class TestUnitTestsOnlyTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
-        var where = context.Argument<string?>("where", null);
+        var where  = context.Argument<string?>("where", null);
         var labels = context.Argument<string>("labels", "Off");
         var nunitOutputDirectory = context.Paths.BuildDirectory
                                                 .Combine("test")
@@ -352,16 +352,16 @@ public sealed class TestUnitTestsOnlyTask : FrostingTask<BuildContext>
         // but dotnet build can handle multi-targeting on Windows
         if (context.IsRunningOnWindows())
         {
-                context.DotNetTest(context.Solution, new DotNetTestSettings
-                {
-                    Configuration    = context.BuildConfiguration,
-                    NoRestore        = true,
-                    NoBuild          = true,
-                    NoLogo           = true,
-                    Filter           = dotNetFilter,
-                    ResultsDirectory = nunitOutputDirectory,
-                    Verbosity        = DotNetVerbosity.Minimal,
-                });
+            context.DotNetTest(context.Solution, new DotNetTestSettings
+            {
+                Configuration    = context.BuildConfiguration,
+                NoRestore        = true,
+                NoBuild          = true,
+                NoLogo           = true,
+                Filter           = dotNetFilter,
+                ResultsDirectory = nunitOutputDirectory,
+                Verbosity        = DotNetVerbosity.Minimal,
+            });
         }
         else
         {


### PR DESCRIPTION
## Motivations

- Sometimes it would be nice to be able to perform an action for multiple modules at once, e.g., adding or removing labels. Currently the main mod list only allows selecting one row, which means you can only do such things for one module at a time.
- CKAN stores metadata and settings in JSON files, except for `<Game dir>/CKAN/GUIConfig.xml`, which uses an XML format. This inconsistency complicates maintenance and support, since different tools need to be used to handle this one file compared to all the others.
- #2820 moved Core configuration from the Windows registry (and Mono's emulation of it in `~/.mono/registry`) to `config.json` in the app data folder, but it intentionally left the old Windows registry data in place in case it was needed. That was 6 years ago, so any such data that still exists probably either has already been converted or is no longer relevant.

## Changes

- Now the main mod list supports multi-select when you hold Ctrl or Shift. When multiple rows are selected:
  - Pressing Space will toggle upgrading or installation for selected rows. As part of this fix, Space will no longer toggle the auto-installed checkbox, since that was never the intention.
  - The right click menu options support multiple selections:
    - The purge from cache option will purge all selected modules from the cache, and is enabled if any of the selected mods are in the cache.
    - The download option will download all selected modules to the cache, and is enabled if any of the selected mods are not in the cache.
    - The Reinstall option will reinstall all selected installed modules, and is enabled if any of the selected mods are installed and not autodetected.
    - Labels can be added to and removed from all selected rows at once. If some of the selected rows already have a label and others don't, two options appear for that label, one to add the label and one to remove it.
  Fixes #4380.
- Now `GUIConfig.xml` is replaced by `GUIConfig.json` containing the same data in JSON format. The old file will be converted and deleted if it is present without the new file.
- Now the code to save and load the Core configuration in the Windows registry is deleted, except for a remnant that we now use to delete the old Windows registry data if it exists.
