### PR TITLE
Fix 'netkan' user in Inflator

### DIFF
--- a/Dockerfile.netkan
+++ b/Dockerfile.netkan
@@ -15,7 +15,7 @@ RUN apt-get update \
 RUN apt-get clean \
     && rm -r /var/lib/apt/lists /var/log/dpkg.log /var/log/apt
 
-RUN useradd -ms /bin/bash netkan
+RUN groupmod -n netkan ubuntu && usermod -l netkan -d /home/netkan -m ubuntu
 USER netkan
 WORKDIR /home/netkan
 ADD --chown=netkan . .


### PR DESCRIPTION
ubuntu:latest has an ubuntu user by default, which changes the uid of the user we create. This causes issues with shared volume permissions. This renames the ubuntu user so we can be aligned with the rest of our containers.