### PR TITLE
Make hash caches thread-safe, Netkan warning for uncompiled plugins

### DIFF
--- a/Core/Converters/JsonParallelDictionaryConverter.cs
+++ b/Core/Converters/JsonParallelDictionaryConverter.cs
@@ -26,7 +26,7 @@ namespace CKAN
                                  serializer);
 
         private static object ParseWithProgress(JProperty[]    properties,
-                                         JsonSerializer serializer)
+                                                JsonSerializer serializer)
             => Partitioner.Create(properties, true)
                           .AsParallel()
                           .WithMergeOptions(ParallelMergeOptions.NotBuffered)

--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
-using System.Runtime.ExceptionServices;
 
 namespace CKAN.Extensions
 {
@@ -157,9 +156,9 @@ namespace CKAN.Extensions
                 {
                     return tasks.SelectMany(task => task.Result);
                 }
-                catch (AggregateException agExc) when (agExc is { InnerException: Exception exc })
+                catch (AggregateException agExc)
                 {
-                    ExceptionDispatchInfo.Capture(exc).Throw();
+                    agExc.RethrowInner();
                     throw;
                 }
             }

--- a/Core/Extensions/ExceptionExtensions.cs
+++ b/Core/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq;
+using System.Collections.ObjectModel;
+using System.Runtime.ExceptionServices;
+
+namespace CKAN.Extensions
+{
+    public static class ExceptionExtensions
+    {
+        public static void RethrowInner(this AggregateException agExc)
+        {
+            var inner = agExc switch
+            {
+                { InnerException:  Exception                     exc  } => exc,
+                { InnerExceptions: ReadOnlyCollection<Exception> excs } => excs.First(),
+                _ => agExc,
+            };
+            ExceptionDispatchInfo.Capture(inner).Throw();
+        }
+    }
+}

--- a/Core/Extensions/Polyfills.cs
+++ b/Core/Extensions/Polyfills.cs
@@ -39,6 +39,13 @@ namespace System.Linq
             => pairs.ToDictionary(kvp => kvp.Key,
                                   kvp => kvp.Value);
 
+        public static Dictionary<K, V> ToDictionary<K, V>(this IEnumerable<KeyValuePair<K, V>> pairs,
+                                                          IEqualityComparer<K>                 comparer)
+            where K: class
+            => pairs.ToDictionary(kvp => kvp.Key,
+                                  kvp => kvp.Value,
+                                  comparer);
+
         public static Dictionary<K, V> ToDictionary<K, V>(this ParallelQuery<KeyValuePair<K, V>> pairs) where K: class
             => pairs.ToDictionary(kvp => kvp.Key,
                                   kvp => kvp.Value);

--- a/Core/Net/NetAsyncModulesDownloader.cs
+++ b/Core/Net/NetAsyncModulesDownloader.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Security.Cryptography;
-using System.Runtime.ExceptionServices;
 
 using log4net;
 using Autofac;
@@ -143,14 +142,14 @@ namespace CKAN
             try
             {
                 dlTask.Wait();
-                if (dlTask.Exception is AggregateException { InnerException: Exception exc })
+                if (dlTask.Exception is AggregateException agExc)
                 {
-                    ExceptionDispatchInfo.Capture(exc).Throw();
+                    agExc.RethrowInner();
                 }
             }
-            catch (AggregateException agExc) when (agExc is { InnerException: Exception exc })
+            catch (AggregateException agExc)
             {
-                ExceptionDispatchInfo.Capture(exc).Throw();
+                agExc.RethrowInner();
             }
         }
 
@@ -164,9 +163,9 @@ namespace CKAN
                                       {
                                           blockingQueue.CompleteAdding();
                                           OneComplete -= oneComplete;
-                                          if (t.Exception is AggregateException { InnerException: Exception exc })
+                                          if (t.Exception is AggregateException agExc)
                                           {
-                                              ExceptionDispatchInfo.Capture(exc).Throw();
+                                              agExc.RethrowInner();
                                           }
                                       }),
                     blockingQueue);

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -112,24 +112,15 @@ namespace CKAN
         /// Called when upgrading registry versions. Should be a no-op
         /// if called on newer registries.
         /// </summary>
-        public void Renormalise(GameInstance ksp)
+        public void Renormalise(GameInstance inst)
         {
-            // We need case insensitive path matching on Windows
-            var normalised_installed_files = new Dictionary<string, InstalledModuleFile>(Platform.PathComparer);
-
-            foreach (var tuple in installed_files)
-            {
-                string path = CKANPathUtils.NormalizePath(tuple.Key);
-
-                if (Path.IsPathRooted(path))
-                {
-                    path = ksp.ToRelativeGameDir(path);
-                }
-
-                normalised_installed_files[path] = tuple.Value;
-            }
-
-            installed_files = normalised_installed_files;
+            installed_files = installed_files.ToDictionary(
+                                  kvp => Path.IsPathRooted(kvp.Key)
+                                             ? inst.ToRelativeGameDir(kvp.Key)
+                                             : CKANPathUtils.NormalizePath(kvp.Key),
+                                  kvp => kvp.Value,
+                                  // We need case insensitive path matching on Windows
+                                  Platform.PathComparer);
         }
 
         #endregion

--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -21,6 +21,7 @@ namespace CKAN.NetKAN.Services
         IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip, GameInstance inst);
         IEnumerable<InstallableFile> GetPlugins(CkanModule module, ZipFile zip, GameInstance inst);
         IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, GameInstance inst);
+        IEnumerable<InstallableFile> GetSourceCode(CkanModule module, ZipFile zip, GameInstance inst);
 
         SpaceWarpInfo? ParseSpaceWarpJson(string? json);
         SpaceWarpInfo? GetInternalSpaceWarpInfo(CkanModule module, ZipFile zip, GameInstance inst, string? internalFilePath = null);

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -58,7 +58,7 @@ namespace CKAN.NetKAN.Services
         /// <param name="zip">The ZipFile to search</param>
         /// <param name="inst">Game instance for generating InstallableFiles</param>
         /// <returns>Parsed contents of the file, or null if none found</returns>
-        private JObject? GetInternalCkan(CkanModule module, ZipFile zip, GameInstance inst)
+        private static JObject? GetInternalCkan(CkanModule module, ZipFile zip, GameInstance inst)
             => (module.install != null
                     // Find embedded .ckan files that would be included in the install
                     ? GetFilesBySuffix(module, zip, ".ckan", inst)
@@ -86,9 +86,24 @@ namespace CKAN.NetKAN.Services
         public IEnumerable<InstallableFile> GetCrafts(CkanModule module, ZipFile zip, GameInstance inst)
             => GetFilesBySuffix(module, zip, ".craft", inst);
 
-        private IEnumerable<InstallableFile> GetFilesBySuffix(CkanModule module, ZipFile zip, string suffix, GameInstance inst)
+        private static IEnumerable<InstallableFile> GetFilesBySuffix(CkanModule   module,
+                                                                     ZipFile      zip,
+                                                                     string       suffix,
+                                                                     GameInstance inst)
             => ModuleInstaller.FindInstallableFiles(module, zip, inst)
                               .Where(instF => instF.destination.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase));
+
+        public IEnumerable<InstallableFile> GetSourceCode(CkanModule module, ZipFile zip, GameInstance inst)
+            => GetFilesBySuffixes(module, zip, sourceCodeSuffixes, inst);
+
+        private static readonly string[] sourceCodeSuffixes = new string[] { ".cs", ".csproj", ".sln" };
+
+        private static IEnumerable<InstallableFile> GetFilesBySuffixes(CkanModule          module,
+                                                                       ZipFile             zip,
+                                                                       ICollection<string> suffixes,
+                                                                       GameInstance        inst)
+            => ModuleInstaller.FindInstallableFiles(module, zip, inst)
+                              .Where(instF => suffixes.Any(suffix => instF.destination.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase)));
 
         public IEnumerable<ZipEntry> FileSources(CkanModule module, ZipFile zip, GameInstance inst)
             => ModuleInstaller.FindInstallableFiles(module, zip, inst)

--- a/Netkan/Validators/InstallsFilesValidator.cs
+++ b/Netkan/Validators/InstallsFilesValidator.cs
@@ -77,7 +77,7 @@ namespace CKAN.NetKAN.Validators
                         .ToList();
                     if (unmatchedIncludeOnlys.Count != 0)
                     {
-                        log.WarnFormat("No matches for includes_only: {0}",
+                        log.WarnFormat("No matches for include_only: {0}",
                                        string.Join(", ", unmatchedIncludeOnlys));
                     }
                 }

--- a/Tests/AutoUpdate/ResourcesTests.cs
+++ b/Tests/AutoUpdate/ResourcesTests.cs
@@ -1,7 +1,10 @@
 using System.Linq;
 using System.Resources;
 using System.Globalization;
+
 using NUnit.Framework;
+
+using CKAN;
 
 namespace Tests.AutoUpdateHelper
 {
@@ -29,7 +32,7 @@ namespace Tests.AutoUpdateHelper
         }
 
         // The cultures to test
-        private static readonly CultureInfo[] cultures = CKAN.Utilities.AvailableLanguages
+        private static readonly CultureInfo[] cultures = Utilities.AvailableLanguages
             .Select(l => new CultureInfo(l))
             .ToArray();
     }

--- a/Tests/CmdLine/ResourcesTests.cs
+++ b/Tests/CmdLine/ResourcesTests.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 
 using NUnit.Framework;
 
+using CKAN;
+
 namespace Tests.CmdLine
 {
     [TestFixture]
@@ -19,7 +21,7 @@ namespace Tests.CmdLine
         public void PropertiesResources_LanguageResource_NotSet()
         {
             // Arrange
-            ResourceManager resources = new CKAN.SingleAssemblyResourceManager(
+            ResourceManager resources = new SingleAssemblyResourceManager(
                 "CKAN.CmdLine.Properties.Resources", typeof(CKAN.CmdLine.Properties.Resources).Assembly);
 
             // Act/Assert
@@ -30,7 +32,7 @@ namespace Tests.CmdLine
         }
 
         // The cultures to test
-        private static readonly CultureInfo[] cultures = CKAN.Utilities.AvailableLanguages
+        private static readonly CultureInfo[] cultures = Utilities.AvailableLanguages
             .Select(l => new CultureInfo(l))
             .ToArray();
     }

--- a/Tests/ConsoleUI/ResourcesTests.cs
+++ b/Tests/ConsoleUI/ResourcesTests.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 
 using NUnit.Framework;
 
+using CKAN;
+
 namespace Tests.ConsoleUI
 {
     [TestFixture]
@@ -19,7 +21,7 @@ namespace Tests.ConsoleUI
         public void PropertiesResources_LanguageResource_NotSet()
         {
             // Arrange
-            ResourceManager resources = new CKAN.SingleAssemblyResourceManager(
+            ResourceManager resources = new SingleAssemblyResourceManager(
                 "CKAN.ConsoleUI.Properties.Resources", typeof(CKAN.ConsoleUI.Properties.Resources).Assembly);
 
             // Act/Assert
@@ -30,7 +32,7 @@ namespace Tests.ConsoleUI
         }
 
         // The cultures to test
-        private static readonly CultureInfo[] cultures = CKAN.Utilities.AvailableLanguages
+        private static readonly CultureInfo[] cultures = Utilities.AvailableLanguages
             .Select(l => new CultureInfo(l))
             .ToArray();
     }

--- a/Tests/Core/Configuration/FakeConfiguration.cs
+++ b/Tests/Core/Configuration/FakeConfiguration.cs
@@ -143,7 +143,7 @@ namespace Tests.Core.Configuration
 
             set
             {
-                if (CKAN.Utilities.AvailableLanguages.Contains(value))
+                if (Utilities.AvailableLanguages.Contains(value))
                 {
                     _Language = value;
                 }

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -205,7 +205,7 @@ namespace Tests.Core.IO
         }
 
         [Test]
-        // Test includes_only and includes_only_regexp
+        // Test include_only and include_only_regexp
         public void FindInstallableFilesWithInclude()
         {
             string extra_doge = TestData.DogeCoinFlagZipWithExtras();

--- a/Tests/Core/ResourcesTests.cs
+++ b/Tests/Core/ResourcesTests.cs
@@ -1,7 +1,10 @@
 using System.Linq;
 using System.Resources;
 using System.Globalization;
+
 using NUnit.Framework;
+
+using CKAN;
 
 namespace Tests.Core
 {
@@ -18,7 +21,7 @@ namespace Tests.Core
         public void PropertiesResources_LanguageResource_NotSet()
         {
             // Arrange
-            ResourceManager resources = new CKAN.SingleAssemblyResourceManager(
+            ResourceManager resources = new SingleAssemblyResourceManager(
                 "CKAN.Properties.Resources", typeof(CKAN.Properties.Resources).Assembly);
 
             // Act/Assert
@@ -29,7 +32,7 @@ namespace Tests.Core
         }
 
         // The cultures to test
-        private static readonly CultureInfo[] cultures = CKAN.Utilities.AvailableLanguages
+        private static readonly CultureInfo[] cultures = Utilities.AvailableLanguages
             .Select(l => new CultureInfo(l))
             .ToArray();
     }

--- a/Tests/GUI/ResourcesTests.cs
+++ b/Tests/GUI/ResourcesTests.cs
@@ -10,6 +10,8 @@ using System.Windows.Forms;
 
 using NUnit.Framework;
 
+using CKAN;
+
 namespace Tests.GUI
 {
     [TestFixture]
@@ -25,7 +27,7 @@ namespace Tests.GUI
         public void PropertiesResources_AllLocales_LanguageNotSetAndAllStrings()
         {
             // Arrange
-            ResourceManager resources = new CKAN.SingleAssemblyResourceManager(
+            ResourceManager resources = new SingleAssemblyResourceManager(
                 "CKAN.GUI.Properties.Resources", typeof(CKAN.GUI.Properties.Resources).Assembly);
 
             // Act/Assert
@@ -102,7 +104,7 @@ namespace Tests.GUI
 
         // The cultures to test
         private static readonly CultureInfo[] cultures =
-            CKAN.Utilities.AvailableLanguages
+            Utilities.AvailableLanguages
                           .Select(l => new CultureInfo(l))
                           .ToArray();
     }

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -405,6 +405,7 @@ public sealed class TestUnitTestsOnlyTask : FrostingTask<BuildContext>
                                 "-p ConsoleUI",
                                 "-p GUI/Dialogs",
                                 "-p GUI/Controls",
+                                "-p GUI/Main",
                                 $"-i {testDir}",
                                 $"-o {instrumentedDir}",
                                 "--save");


### PR DESCRIPTION
## Problem

The Inflator has been emitting `Index was outside the bounds of the array.` errors for a while now, which cannot be reproduced locally. After #4398, we captured the full stack trace:

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
 at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
 at CKAN.NetFileCache.GetFileHash(String filePath, String hashSuffix, Dictionary`2 cache, Func`1 getHashAlgo, IProgress`1 progress, Nullable`1 cancelToken)
 at CKAN.NetKAN.Transformers.DownloadAttributeTransformer.Transform(Metadata metadata, TransformOptions opts)+MoveNext()
 at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
 at System.Collections.Generic.SparseArrayBuilder`1.ReserveOrAdd(IEnumerable`1 items)
 at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray()
 at System.Linq.Enumerable.Aggregate[TSource,TAccumulate](IEnumerable`1 source, TAccumulate seed, Func`3 func)
 at CKAN.NetKAN.Transformers.NetkanTransformer.Transform(Metadata metadata, TransformOptions opts)
 at CKAN.Extensions.EnumerableExtensions.<>c__DisplayClass9_1`2.<SelectManyTasks>b__2()
 at System.Threading.Tasks.Task`1.InnerInvoke()
 at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
 at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
 at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread t
```

The `Dictionary.TryInsert` call in question must be in `NetFileCache.GetFileHash`:

<https://github.com/KSP-CKAN/CKAN/blob/dd37ee257e9986bdb02cbefa967260237acc2227/Core/Net/NetFileCache.cs#L649-L682>

Later, that stack trace was replaced by one featuring `AggregateException`, which I have been trying to purge from our logs.

## Causes

- Apparently `Dictionary.Add` is thread unsafe and can throw this exception when multiple threads use it concurrently.
  <https://stackoverflow.com/questions/15095817/adding-to-a-generic-dictionary-causes-indexoutofrangeexception>
- My handling for `AggregateException` only worked when there was a single `InnerException`; if it contained multiple in the `InnerExceptions` property, it wasn't caught.

## Motivation

Twice in the past few weeks, we have had mods submitted by someone other than their primary C# coder, who didn't compile the plugin (see KSP-CKAN/NetKAN#10592 and KSP-CKAN/NetKAN#10600). If this is going to be a common pattern going forward, it would be good to detect it programmatically rather than making me dig through the ZIP file and repo to notice it.

## Changes

- Now `NetFileCache` is updated to use `ConcurrentDictionary` for those caches, which will not throw `IndexOutOfRangException` when trying to add an element.
- Now `GUI.Main` is excluded from coverage because it is a `Form` which we will not instantiate in tests.
- Now `CKAN.Extensions.ExceptionExtensions.RethrowInner` is created to wrap the more complex logic needed to pick the first element from `InnerExceptions` and rethrow it, and called by all the places where we catch `AggregateException`.
- Now if Netkan spots `*.cs`, `*.csproj`, or `*.sln` files in a ZIP and _doesn't_ see a `*.dll`, a warning is emitted, to make this problem easier to spot.
