### PR TITLE
Lookback for version_from_asset

### DIFF
--- a/Netkan/Model/RemoteRef.cs
+++ b/Netkan/Model/RemoteRef.cs
@@ -4,29 +4,26 @@ namespace CKAN.NetKAN.Model
 {
     internal class RemoteRef
     {
-        private static readonly Regex Pattern = new Regex(
-            @"^#/ckan/(?<source>[^/]+)(?:/(?<id>.+))?",
-            RegexOptions.Compiled
-        );
-
-        private readonly string _string;
-
-        public string Source { get; private set; }
-        public string? Id   { get; private set; }
-
-        public RemoteRef(string remoteRefToken)
-            : this(ParseArguments(remoteRefToken)) { }
+         public RemoteRef(string remoteRefToken)
+        {
+            if (Pattern.Match(remoteRefToken) is Match { Success: true } match)
+            {
+                Source  = match.Groups["source"].Value;
+                Id      = match.Groups["id"].Value;
+                _string = remoteRefToken;
+            }
+            else
+            {
+                throw new Kraken(string.Format(@"Could not parse reference: ""{0}""",
+                                               remoteRefToken));
+            }
+        }
 
         public RemoteRef(RemoteRef remoteRef)
-            : this(new Arguments(remoteRef.Source, remoteRef.Id)) { }
-
-        private RemoteRef(Arguments arguments)
         {
-            Source = arguments.Source;
-            Id = arguments.Id;
-
-            _string = Id == null ? $"#/ckan/{Source}"
-                                 : $"#/ckan/{Source}/{Id}";
+            Source  = remoteRef.Source;
+            Id      = remoteRef.Id;
+            _string = remoteRef.ToString();
         }
 
         public override string ToString()
@@ -37,30 +34,13 @@ namespace CKAN.NetKAN.Model
             return new RemoteRef(rref);
         }
 
-        private static Arguments ParseArguments(string refToken)
-        {
-            var match = Pattern.Match(refToken);
+        public string  Source { get; private set; }
+        public string? Id     { get; private set; }
 
-            if (match.Success)
-            {
-                return new Arguments(match.Groups["source"].Value, match.Groups["id"].Value);
-            }
-            else
-            {
-                throw new Kraken(string.Format(@"Could not parse reference: ""{0}""", refToken));
-            }
-        }
+        private static readonly Regex Pattern = new Regex(
+            @"^#/ckan/(?<source>[^/]+)(?:/(?<id>.+))?",
+            RegexOptions.Compiled);
 
-        private sealed class Arguments
-        {
-            public string  Source { get; private set; }
-            public string? Id     { get; private set; }
-
-            public Arguments(string source, string? id)
-            {
-                Source = source;
-                Id     = id;
-            }
-        }
+        private readonly string _string;
     }
 }

--- a/Netkan/Transformers/GithubTransformer.cs
+++ b/Netkan/Transformers/GithubTransformer.cs
@@ -99,7 +99,7 @@ namespace CKAN.NetKAN.Transformers
                         if (assets.Length > 1)
                         {
                             Log.WarnFormat("Multiple assets found for {0} {1} without `version_from_asset`",
-                                metadata.Identifier, rel.Tag);
+                                           metadata.Identifier, rel.Tag);
                         }
                         returnedAny = true;
                         yield return TransformOne(metadata, metadata.Json(), ghRef, ghRepo, rel,
@@ -108,17 +108,20 @@ namespace CKAN.NetKAN.Transformers
                 }
                 if (!returnedAny)
                 {
-                    if (ghRef.Filter != Constants.DefaultAssetMatchPattern)
+                    if (ghRef.AssetMatch != Constants.DefaultAssetMatchPattern)
                     {
-                        Log.WarnFormat("No releases found for {0} with asset_match {1}", ghRef.Repository, ghRef.Filter);
+                        Log.WarnFormat("No releases found for {0} with asset_match {1}",
+                                       ghRef.Repository, ghRef.AssetMatch);
                     }
                     else if (ghRef.VersionFromAsset != null)
                     {
-                        Log.WarnFormat("No releases found for {0} with version_from_asset {1}", ghRef.Repository, ghRef.VersionFromAsset);
+                        Log.WarnFormat("No releases found for {0} with version_from_asset {1}",
+                                       ghRef.Repository, ghRef.VersionFromAsset);
                     }
                     else
                     {
-                        Log.WarnFormat("No releases found for {0}", ghRef.Repository);
+                        Log.WarnFormat("No releases found for {0}",
+                                       ghRef.Repository);
                     }
                     yield return metadata;
                 }
@@ -234,6 +237,7 @@ namespace CKAN.NetKAN.Transformers
             }
             if (repo.HasIssues)
             {
+                // issues_url ends with {/number} which makes it kind of useless
                 resources.SafeAdd("bugtracker", $"{repo.HtmlUrl}/issues");
             }
             if (repo.HasDiscussions)
@@ -246,8 +250,8 @@ namespace CKAN.NetKAN.Transformers
                                    GithubRelease release)
             => repo.TraverseNodes(r => r.ParentRepo == null
                                            ? null
-                                           : _api.GetRepo(new GithubRef($"#/ckan/github/{r.ParentRepo.FullName}",
-                                                          false)))
+                                           : _api.GetRepo(new GithubRef(r.ParentRepo.Owner?.Login ?? "",
+                                                                        r.ParentRepo.Name ?? "")))
                    .Reverse()
                    .Select(r => r.Owner)
                    .Append(release.Author)

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -24,7 +24,7 @@ namespace Tests.NetKAN.Sources.Github
             {
                 var sut       = new GithubApi(new CachingHttpService(cache),
                                               Environment.GetEnvironmentVariable("GITHUB_TOKEN"));
-                var githubRef = new GithubRef("#/ckan/github/KSP-CKAN/Test", false);
+                var githubRef = new GithubRef("KSP-CKAN", "Test");
 
                 // Act
                 var repo    = sut.GetRepo(githubRef);

--- a/Tests/NetKAN/Transformers/GithubTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/GithubTransformerTests.cs
@@ -187,7 +187,7 @@ namespace Tests.NetKAN.Transformers
         {
             // Arrange
             var sut      = new GithubTransformer(new GithubApi(httpSvcMockUp.Object), false);
-            var opts     = new TransformOptions(1, 3, null, null, false, null);
+            var opts     = new TransformOptions(1, 1, null, null, false, null);
             var metadata = new Metadata(new JObject()
             {
                 { "spec_version", 1                                                                                          },


### PR DESCRIPTION
## Motivation

The `version_from_asset` option in the GItHub `$kref` fails if the latest release has no matching assets, in contrast to `asset_match`, which continues looking back to previous releases to find matches. This clutters the status page with unhelpful errors when a repo shared by multiple mods using `version_from_asset` has a release with only a subset of its mods.

## Changes

Now `version_from_asset` skips releases without matching assets.
