### PR TITLE
Migrate Mac app bundle from Mono to dotnet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,18 @@ jobs:
           key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
       - name: Build ckan.exe and netkan.exe
         run: ./build.sh --configuration=${{ inputs.configuration }}
+      - name: Build CKAN.dmg
+        if: inputs.configuration == 'Release'
+        run: |
+          sudo apt-get install -y libplist-utils xorriso rdfind symlinks
+          ./build.sh osx --configuration=${{ inputs.configuration }} --exclusive
       - name: Upload repack artifact
         id: upload-repack-artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.configuration }}-repack-unsigned
           path: _build/repack/
-          retention-days: 7
+          retention-days: 1
       - name: Upload out artifact
         uses: actions/upload-artifact@v4
         with:
@@ -61,11 +66,18 @@ jobs:
         with:
           name: unsigned
           path: _build/signpath/Release
-          retention-days: 7
+          retention-days: 1
       - name: Upload ckan.exe artifact
         if: inputs.configuration == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: ckan.exe
           path: _build/repack/Release/ckan.exe
+          retention-days: 7
+      - name: Upload CKAN.dmg artifact
+        if: inputs.configuration == 'Release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: CKAN.dmg
+          path: _build/osx/CKAN.dmg
           retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,25 @@ jobs:
           key: nuget-oldref-modules-${{ hashFiles('**/packages.config') }}-${{ hashFiles('**/*.csproj') }}
       - name: Build ckan.exe and netkan.exe
         run: ./build.sh --configuration=${{ inputs.configuration }}
+      - name: Build CKAN.app
+        if: inputs.configuration == 'Release'
+        run: |
+          sudo apt-get install -y libplist-utils rdfind symlinks genisoimage
+          ./build.sh osx-app --configuration=${{ inputs.configuration }} --exclusive
+      - name: Ad hoc codesign x86_64 binary
+        if: inputs.configuration == 'Release'
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: _build/osx/dmg/CKAN.app/Contents/MacOS/x86_64/CKAN-CmdLine
+      - name: Ad hoc codesign arm64 binary
+        if: inputs.configuration == 'Release'
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: _build/osx/dmg/CKAN.app/Contents/MacOS/arm64/CKAN-CmdLine
       - name: Build CKAN.dmg
         if: inputs.configuration == 'Release'
         run: |
-          sudo apt-get install -y libplist-utils xorriso rdfind symlinks
-          ./build.sh osx --configuration=${{ inputs.configuration }} --exclusive
+          ./build.sh osx-dmg --configuration=${{ inputs.configuration }} --exclusive
       - name: Upload repack artifact
         id: upload-repack-artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,16 +95,11 @@ jobs:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - name: Install OSX build dependencies
-        run: sudo apt-get install -y libplist-utils xorriso
-      - uses: actions/checkout@v4
-      - name: Download repack artifact
+      - name: Download CKAN.dmg artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
-      - name: Build dmg
-        run: ./build.sh osx --configuration=Release --exclusive
+          name: CKAN.dmg
+          path: _build/osx
       - name: Push dmg to S3
         run: aws s3 cp _build/osx/CKAN.dmg s3://${AWS_S3_BUCKET} --follow-symlinks
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,11 @@ jobs:
       - sign-assets
     steps:
       - uses: actions/checkout@v4
-      - name: Install OSX build dependencies
-        run: sudo apt-get install -y libplist-utils xorriso
-      - name: Download repack artifact
+      - name: Download CKAN.dmg artifact
         uses: actions/download-artifact@v4
         with:
-          name: Release-repack-unsigned
-          path: _build/repack/
-      - name: Build dmg
-        run: ./build.sh osx --configuration=Release --exclusive
+          name: CKAN.dmg
+          path: _build/osx
       - name: Upload OSX release asset
         run: gh release upload ${{ github.event.release.tag_name }} _build/osx/CKAN.dmg
         env:

--- a/Cmdline/CKAN-cmdline.csproj
+++ b/Cmdline/CKAN-cmdline.csproj
@@ -28,6 +28,7 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>IDE1006,NU1701</NoWarn>
     <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
@@ -85,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="log4net.xml" />
+    <Content Include="log4net.xml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="MakeAssemblyInfo" BeforeTargets="BeforeBuild">

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -7,6 +7,8 @@ namespace CKAN.ConsoleUI.Toolkit {
     /// </summary>
     public static class Keys {
 
+        #if NETFRAMEWORK
+
         private const char LinuxEnter   = (char)10;
         private const char WindowsEnter = (char)13;
 
@@ -18,8 +20,19 @@ namespace CKAN.ConsoleUI.Toolkit {
             ConsoleKey.Enter, false, false, false
         );
 
+        #else
+
         /// <summary>
         /// Representation of enter key for key bindings
+        /// </summary>
+        public static readonly ConsoleKeyInfo Enter = new ConsoleKeyInfo(
+            (char)13, ConsoleKey.Enter, false, false, false
+        );
+
+        #endif
+
+        /// <summary>
+        /// Representation of space bar for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo Space = new ConsoleKeyInfo(
             ' ', ConsoleKey.Spacebar, false, false, false

--- a/Core/CKAN-core.csproj
+++ b/Core/CKAN-core.csproj
@@ -94,9 +94,7 @@
                       Overwrite="true" />
   </Target>
   <ItemGroup>
-    <Content Include="log4net.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="log4net.xml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="MakeAssemblyInfo" BeforeTargets="BeforeBuild">

--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -77,9 +77,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
-    <Content Include="log4net.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="log4net.xml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <ItemGroup>

--- a/Netkan/CKAN-netkan.csproj
+++ b/Netkan/CKAN-netkan.csproj
@@ -27,6 +27,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
     <NoWarn>IDE1006,NU1701</NoWarn>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
@@ -58,7 +59,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="log4net.xml" />
+    <Content Include="log4net.xml" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="..\_build\meta\GlobalAssemblyVersionInfo.cs">
       <Link>Properties\GlobalAssemblyVersionInfo.cs</Link>
     </Compile>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -89,9 +89,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="log4net.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="log4net.xml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="MakeAssemblyInfo" BeforeTargets="BeforeBuild">

--- a/build/MakeTasks.cs
+++ b/build/MakeTasks.cs
@@ -4,13 +4,37 @@ using System.Collections.Generic;
 using Cake.Common;
 using Cake.Core.IO;
 using Cake.Frosting;
+using Cake.Common.Tools.DotNet;
+using Cake.Common.Tools.DotNet.Publish;
 
 namespace Build;
 
 [TaskName("osx")]
 [TaskDescription("Build the macOS(OSX) dmg package.")]
 [IsDependentOn(typeof(CkanTask))]
-public sealed class OsxTask() : MakeTask("macosx");
+public sealed class OsxTask() : MakeTask("macosx")
+{
+    public override void Run(BuildContext context)
+    {
+        // Publish Cmdline for Mac arm64
+        context.DotNetPublish(context.Paths.CmdlineProject.FullPath, new DotNetPublishSettings
+        {
+            Configuration  = context.BuildConfiguration,
+            Framework      = "net8.0",
+            Runtime        = "osx-arm64",
+            SelfContained  = true,
+        });
+        // Publish Cmdline for Mac x64
+        context.DotNetPublish(context.Paths.CmdlineProject.FullPath, new DotNetPublishSettings
+        {
+            Configuration  = context.BuildConfiguration,
+            Framework      = "net8.0",
+            Runtime        = "osx-x64",
+            SelfContained  = true,
+        });
+        base.Run(context);
+    }
+}
 
 [TaskName("osx-clean")]
 [TaskDescription("Clean the output directory of the macOS(OSX) package.")]
@@ -63,7 +87,10 @@ public abstract class MakeTask(string location, ProcessArgumentBuilder? args = n
         var exitCode = context.StartProcess("make", new ProcessSettings() {
             WorkingDirectory = context.Paths.RootDirectory.Combine(Location),
             Arguments = Args,
-            EnvironmentVariables = new Dictionary<string, string?> { { "CONFIGURATION", context.BuildConfiguration } }
+            EnvironmentVariables = new Dictionary<string, string?>
+            {
+                { "CONFIGURATION", context.BuildConfiguration },
+            }
         });
         if (exitCode != 0)
         {

--- a/build/MakeTasks.cs
+++ b/build/MakeTasks.cs
@@ -9,10 +9,10 @@ using Cake.Common.Tools.DotNet.Publish;
 
 namespace Build;
 
-[TaskName("osx")]
-[TaskDescription("Build the macOS(OSX) dmg package.")]
+[TaskName("osx-app")]
+[TaskDescription("Build the macOS(OSX) app bundle.")]
 [IsDependentOn(typeof(CkanTask))]
-public sealed class OsxTask() : MakeTask("macosx")
+public sealed class OsxAppTask() : MakeTask("macosx", "app")
 {
     public override void Run(BuildContext context)
     {
@@ -35,6 +35,11 @@ public sealed class OsxTask() : MakeTask("macosx")
         base.Run(context);
     }
 }
+
+[TaskName("osx-dmg")]
+[TaskDescription("Build the macOS(OSX) dmg package.")]
+[IsDependentOn(typeof(OsxAppTask))]
+public sealed class OsxDmgTask() : MakeTask("macosx");
 
 [TaskName("osx-clean")]
 [TaskDescription("Clean the output directory of the macOS(OSX) package.")]

--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -1,78 +1,12 @@
 #!/bin/bash
 
-supports_32_bit() {
-    MACOS_VER=$(sw_vers -productVersion)
-    MAJOR=$(echo $MACOS_VER | cut -d. -f1)
-    MINOR=$(echo $MACOS_VER | cut -d. -f2)
-    # 9.X => true
-    if (( $MAJOR < 10 ))
-    then
-        return 0
-    fi
-    # 11.X => false
-    if (( $MAJOR > 10 ))
-    then
-        return 1
-    fi
-    # 10.15+ => false
-    if (( $MINOR >= 15 ))
-    then
-        return 1
-    fi
-    return 0
-}
+# The script is in the same folder as the arch-specific folders, go there now.
+# uname -m is either x86_64 or arm64.
+MACOS_PATH="$(cd "$(dirname "$0")/$(uname -m)" && pwd)"
+cd "$MACOS_PATH"
 
-# Check El Capitan's Mono install location
-# And Mono 5's install location
-# And the configured location in /etc/paths.d
-MONO_FRAMEWORK_PATH=/Library/Frameworks/Mono.framework/Versions/Current
-PATH="${PATH}:/usr/local/bin:${MONO_FRAMEWORK_PATH}/Commands"
-if [ -r /etc/paths.d/mono-commands ]
-then
-    PATH="${PATH}:$(cat /etc/paths.d/mono-commands)"
-fi
-export PATH
-
-# Look for mono now that we've assembled our PATH
-MONO=$(which mono)
-
-if [ -z "$MONO" -o ! -x "$MONO" ]
-then
-    # We could not find mono. The wiki explains how to install.
-    open 'https://github.com/KSP-CKAN/CKAN/wiki/Installing-CKAN-on-macOS'
-else
-    # Mono found, so we can run CKAN
-    # The exe is called ckan.exe
-    ASSEMBLY=ckan.exe
-
-    MONO_ARGS="--arch=32"
-    for ARG in "$@"
-    do
-        # If we want to run the GUI, set mono to 32bit mode. If not, go 64bit.
-        if [[ ! $ARG =~ ^- && $ARG != gui ]]
-        then
-            MONO_ARGS="--arch=64"
-            break
-        fi
-    done
-
-    # The script and ckan.exe are in the same folder, go there now
-    MACOS_PATH="$(cd "$(dirname "$0")" && pwd)"
-    cd "$MACOS_PATH"
-    # Set up and run mono
-    export MONO_MWF_USE_CARBON_BACKEND=1
-    export GDIPLUS_NOX=1
-    export DYLD_FALLBACK_LIBRARY_PATH="$MACOS_PATH:$MONO_FRAMEWORK_PATH/lib:/lib:/usr/lib"
-
-    # Default to consoleui on Catalina and later if they double click
-    if ! supports_32_bit && [[ "$@" == "" ]]
-    then
-        osascript <<END
+osascript <<END
 tell application "Terminal"
-    do script "cd \"`pwd`\"; \"$MONO\" \"$ASSEMBLY\" consoleui"
+    do script "cd \"`pwd`\"; ./CKAN-CmdLine consoleui"
 end tell
 END
-    else
-        "$MONO" "$MONO_ARGS" "$ASSEMBLY" "$@"
-    fi
-fi

--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# dotnet uses a different SpecialFolder.LocalApplicationData path than Mono did
+MONO_DIR="${HOME}/.local/share/CKAN"
+DOTNET_DIR="${HOME}/Library/Application Support/CKAN"
+if [[ -d "${MONO_DIR}" && ! -e "${DOTNET_DIR}" ]]
+then
+    mv "${MONO_DIR}" "${DOTNET_DIR}"
+    ln -s "${DOTNET_DIR}" "${MONO_DIR}"
+fi
+
 # The script is in the same folder as the arch-specific folders, go there now.
 # uname -m is either x86_64 or arm64.
 MACOS_PATH="$(cd "$(dirname "$0")/$(uname -m)" && pwd)"

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -1,5 +1,6 @@
 .PHONY: clean
 
+CONFIGURATION?=Debug
 NAME:=CKAN
 APPNAME:=$(NAME).app
 OUTDIR:=../_build/osx
@@ -8,8 +9,10 @@ APPROOT=$(DMGROOT)/$(APPNAME)
 DMG:=$(OUTDIR)/$(NAME).dmg
 SCRIPTSRC:=CKAN
 SCRIPTDEST:=$(APPROOT)/Contents/MacOS/CKAN
-EXESRC:=../_build/repack/Release/ckan.exe
-EXEDEST:=$(APPROOT)/Contents/MacOS/ckan.exe
+BUILDDIR_x86_64_SRC:=../_build/out/CKAN-CmdLine/$(CONFIGURATION)/bin/net8.0/osx-x64/publish
+BUILDDIR_x86_64_DEST:=$(APPROOT)/Contents/MacOS/x86_64
+BUILDDIR_arm64_SRC:=../_build/out/CKAN-CmdLine/$(CONFIGURATION)/bin/net8.0/osx-arm64/publish
+BUILDDIR_arm64_DEST:=$(APPROOT)/Contents/MacOS/arm64
 ICNSSRC:=../assets/ckan.icns
 ICNSDEST:=$(APPROOT)/Contents/Resources/CKAN.icns
 PLISTSRC:=Info.plist.in
@@ -18,16 +21,19 @@ PLISTDEST:=$(APPROOT)/Contents/Info.plist
 CHANGELOGSRC:=../CHANGELOG.md
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
 
-$(DMG): $(EXEDEST) $(SCRIPTDEST) $(ICNSDEST) $(PLISTDEST)
+$(DMG): $(BUILDDIR_x86_64_DEST) $(BUILDDIR_arm64_DEST) $(SCRIPTDEST) $(ICNSDEST) $(PLISTDEST)
+	rdfind -minsize 10240 -makeresultsfile false -makesymlinks true $(BUILDDIR_x86_64_DEST) $(BUILDDIR_arm64_DEST)
+	symlinks -rc $(BUILDDIR_arm64_DEST)
 	mkdir -p $(OUTDIR)
 	xorrisofs -V $(NAME) -D -R -no-pad -o $@ $(DMGROOT)
 
-$(EXEDEST): $(EXESRC)
+$(BUILDDIR_x86_64_DEST): $(BUILDDIR_x86_64_SRC)
 	mkdir -p $(shell dirname $@)
-	ln $< $@
+	cp -r $< $@
 
-$(EXESRC):
-	cd .. && ./build.sh --configuration=Release
+$(BUILDDIR_arm64_DEST): $(BUILDDIR_arm64_SRC)
+	mkdir -p $(shell dirname $@)
+	cp -r $< $@
 
 $(SCRIPTDEST): $(SCRIPTSRC)
 	mkdir -p $(shell dirname $@)

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean
+.PHONY: clean app
 
 CONFIGURATION?=Debug
 NAME:=CKAN
@@ -21,19 +21,21 @@ PLISTDEST:=$(APPROOT)/Contents/Info.plist
 CHANGELOGSRC:=../CHANGELOG.md
 VERSION:=$(shell egrep '^\s*\#\#\s+v.*$$' $(CHANGELOGSRC) | head -1 | sed -e 's/^\s*\#\#\s\+v//' )
 
-$(DMG): $(BUILDDIR_x86_64_DEST) $(BUILDDIR_arm64_DEST) $(SCRIPTDEST) $(ICNSDEST) $(PLISTDEST)
+$(DMG): app
+	mkdir -p $(OUTDIR)
+	genisoimage -V $(NAME) -D -R -apple -no-pad -o $@ $(DMGROOT)
+
+app: $(BUILDDIR_x86_64_DEST) $(BUILDDIR_arm64_DEST) $(SCRIPTDEST) $(ICNSDEST) $(PLISTDEST)
 	rdfind -minsize 10240 -makeresultsfile false -makesymlinks true $(BUILDDIR_x86_64_DEST) $(BUILDDIR_arm64_DEST)
 	symlinks -rc $(BUILDDIR_arm64_DEST)
-	mkdir -p $(OUTDIR)
-	xorrisofs -V $(NAME) -D -R -no-pad -o $@ $(DMGROOT)
 
 $(BUILDDIR_x86_64_DEST): $(BUILDDIR_x86_64_SRC)
 	mkdir -p $(shell dirname $@)
-	cp -r $< $@
+	cp -rT $< $@
 
 $(BUILDDIR_arm64_DEST): $(BUILDDIR_arm64_SRC)
 	mkdir -p $(shell dirname $@)
-	cp -r $< $@
+	cp -rT $< $@
 
 $(SCRIPTDEST): $(SCRIPTSRC)
 	mkdir -p $(shell dirname $@)


### PR DESCRIPTION
## Motivation

- .NET Framework 4.8 was released in April 2019 and updated to 4.8.1 in August 2022. No further non-security updates are planned. We depend on it for the WinForms GUI, but for anything else it would be better to rely on code that's still supported and maintained.
- Mono, which runs .NET Framework code on Linux and Mac (and is still the _only_ way to run WinForms code on those platforms), has been all but abandoned and donated to WineHQ, who have been [maintaining it somewhat](https://gitlab.winehq.org/mono/mono/-/releases) but [not providing releases via the established channels](https://gitlab.winehq.org/mono/mono/-/issues/12).
- The last version of Mac OS X that was able to run the GUI (because it could run Mono in 32-bit mode) was 10.14, released September 2018 and ended support in November 2021. It has not received security updates in almost 4 years. It is very unlikely that any users can currently run the CKAN GUI on Mac, so our reason for sticking with Mono no longer applies. It would be nice to eliminate the requirement to install Mono.
- .NET (the post-"Framework" framework) continues marching along with LTS version 8.0 released in November 2023, 9.0 out in November of 2024, both of them updated recently, and future LTS version 10.0 available in a preview status. Each of these releases represents fixes, performance improvements, and new features that might be useful to us, while Framework and Mono just sit there bit-rotting.
- We have already migrated the Inflator (see #4387) and the metadata tester (see #4390) from Mono to dotnet, and it's working OK so far.

## Changes

- Now instead of a ~5 MiB .NET Framework executable to be run with Mono, `CKAN.app` contains a ~160 MiB native Mac build (for two architectures) that needs no external dependencies to run
  - Now `./build.sh osx` runs `dotnet publish` for the `osx-arm64` and `osx-x64` runtimes before it builds `CKAN.dmg`
  - `macosx/Makefile` now copies the `osx-arm64` and `osx-x64` directories into `_build/osx/dmg/CKAN.app/Contents/MacOS` and replaces duplicated files with relative symlinks
  - The Mono-specific logic is removed from the `CKAN` script for Mac and replaced by commands to launch the `CKAN-CmdLine` executable for the correct local system architecture
  - The `ErrorOnDuplicatePublishOutputFiles` property is set in the project files for CmdLine and Netkan so we don't have to exclude `log4net.xml` from being copied into the output dir
- Now the `build.yml` workflow builds `CKAN.dmg` and uploads it as an artifact with 7 retention days so Mac users can test this pull request, and the steps to build it in `deploy.yml` and `release.yml` are updated to download the artifact instead
  - Retention days for intermediate build artifacts are changed from 7 to 1 because they're not needed after the build finishes

Fixes #4353.
