### PR TITLE
Check arch with sysctl on Mac

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -10,8 +10,15 @@ then
 fi
 
 # The script is in the same folder as the arch-specific folders, go there now.
-# uname -m is either x86_64 or arm64.
-MACOS_PATH="$(cd "$(dirname "$0")/$(uname -m)" && pwd)"
+# Mac always runs bash scripts in an x86_64 environment if Rosetta 2 is installed,
+# which makes uname useless for determining architecture.
+if [[ $(sysctl -ni hw.optional.arm64) == 1 ]]
+then
+    ARCH=arm64
+else
+    ARCH=x86_64
+fi
+MACOS_PATH="$(cd "$(dirname "$0")/${ARCH}" && pwd)"
 cd "$MACOS_PATH"
 
 osascript <<END


### PR DESCRIPTION
## Motivation

In #4410, we updated the Mac app bundle to contain two standalone builds, for `x86_64` and `arm64`, selected at runtime by the main executable shell script based on the output of `uname -m`, which is supposed to print the system architecture.

However, [Macs apparently always launch shell scripts in app bundles as `x86_64` using a tool called Rosetta 2, even on `arm64` architectures](https://stackoverflow.com/a/77441678/2422988) (presumably for backwards compatibility with older apps), which makes `uname -m` useless for the (very ordinary and traditional) purpose for which we're using it.

## Changes

Now instead of getting the arch from `uname -m`, we check the output of `sysctl -ni hw.optional.arm64`, and if it's `1`, we use `arm64`, otherwise we use `x86_64`.

(I looked into creating a universal binary that would contain both architectures in one file, and while I was able to get that done locally with `llvm-lipo-20`, I don't think there's a way to merge the additional DLLs that need to sit alongside the binaries. For now, a shell script wrapper remains the best we can do.)

We'll need @lewisfm to test this before merge because I don't have a Mac and so can't confirm that `sysctl` is reliably available and executable for ordinary users on a Mac.
