### PR TITLE
Add more tests, fix FileExistsKraken.Message

### DIFF
--- a/AutoUpdate/Main.cs
+++ b/AutoUpdate/Main.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
+using System.Diagnostics.CodeAnalysis;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -22,6 +23,7 @@ using System.Runtime.Versioning;
 
 namespace CKAN.AutoUpdateHelper
 {
+    [ExcludeFromCodeCoverage]
     public class Program
     {
         public static int Main(string[] args)

--- a/Cmdline/Action/AuthToken.cs
+++ b/Cmdline/Action/AuthToken.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
@@ -128,6 +129,7 @@ namespace CKAN.CmdLine
         private readonly IUser               user;
     }
 
+    [ExcludeFromCodeCoverage]
     internal class AuthTokenSubOptions : VerbCommandOptions
     {
         [VerbOption("list",   HelpText = "List auth tokens")]

--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
@@ -8,6 +9,7 @@ using CKAN.Configuration;
 
 namespace CKAN.CmdLine
 {
+    [ExcludeFromCodeCoverage]
     public class CacheSubOptions : VerbCommandOptions
     {
         [VerbOption("list", HelpText = "List the download cache path")]

--- a/Cmdline/Action/Compat.cs
+++ b/Cmdline/Action/Compat.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
@@ -9,6 +10,7 @@ using CKAN.Versioning;
 
 namespace CKAN.CmdLine
 {
+    [ExcludeFromCodeCoverage]
     public class CompatSubOptions : VerbCommandOptions
     {
         [VerbOption("list", HelpText = "List compatible game versions")]

--- a/Cmdline/Action/Filter.cs
+++ b/Cmdline/Action/Filter.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
@@ -258,6 +259,7 @@ namespace CKAN.CmdLine
         private readonly IUser               user;
     }
 
+    [ExcludeFromCodeCoverage]
     internal class FilterSubOptions : VerbCommandOptions
     {
         [VerbOption("list", HelpText = "List install filters")]

--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
@@ -13,6 +14,7 @@ using CKAN.Games.KerbalSpaceProgram.DLC;
 
 namespace CKAN.CmdLine
 {
+    [ExcludeFromCodeCoverage]
     internal class InstanceSubOptions : VerbCommandOptions
     {
         [VerbOption("list",    HelpText = "List game instances")]

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
@@ -154,6 +155,7 @@ namespace CKAN.CmdLine
         private readonly IUser                 user;
     }
 
+    [ExcludeFromCodeCoverage]
     internal class MarkSubOptions : VerbCommandOptions
     {
         [VerbOption("auto", HelpText = "Mark modules as auto installed")]

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
 
 namespace CKAN.CmdLine
 {
+    [ExcludeFromCodeCoverage]
     internal class RepairSubOptions : VerbCommandOptions
     {
         [VerbOption("registry", HelpText = "Try to repair the CKAN registry")]

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using CommandLine.Text;
@@ -9,6 +10,7 @@ using log4net;
 
 namespace CKAN.CmdLine
 {
+    [ExcludeFromCodeCoverage]
     public class RepoSubOptions : VerbCommandOptions
     {
         [VerbOption("available", HelpText = "List (canonical) available repositories")]

--- a/Cmdline/Action/Stability.cs
+++ b/Cmdline/Action/Stability.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using CommandLine;
@@ -139,6 +140,7 @@ namespace CKAN.CmdLine
         private readonly IUser                 user;
     }
 
+    [ExcludeFromCodeCoverage]
     public class StabilitySubOptions: VerbCommandOptions
     {
         [VerbOption("list", HelpText = "Print stability preferences")]

--- a/Cmdline/ConsoleUser.cs
+++ b/Cmdline/ConsoleUser.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+
 using log4net;
 
 namespace CKAN.CmdLine
@@ -7,6 +9,7 @@ namespace CKAN.CmdLine
     /// <summary>
     /// The commandline implementation of the IUser interface.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ConsoleUser : IUser
     {
         /// <summary>

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -7,6 +7,7 @@ using System;
 using System.Net;
 using System.Diagnostics;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 #if WINDOWS && NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -33,6 +34,7 @@ namespace CKAN.CmdLine
          * operating system components.  Good examples of this are the Clipboard and the File Dialogs.
          */
         [STAThread]
+        [ExcludeFromCodeCoverage]
         public static int Main(string[] args)
         {
             // Launch debugger if the "--debugger" flag is present in the command line arguments.
@@ -86,6 +88,7 @@ namespace CKAN.CmdLine
             }
         }
 
+        [ExcludeFromCodeCoverage]
         public static int Execute(GameInstanceManager manager,
                                   CommonOptions?      opts,
                                   string[]            args,
@@ -199,6 +202,7 @@ namespace CKAN.CmdLine
         /// Run whatever action the user has provided
         /// </summary>
         /// <returns>The exit status that should be returned to the system.</returns>
+        [ExcludeFromCodeCoverage]
         private static int RunSimpleAction(Options cmdline, CommonOptions options, string[] args, IUser user, GameInstanceManager manager)
         {
             var repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
@@ -302,6 +306,7 @@ namespace CKAN.CmdLine
         #if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows")]
         #endif
+        [ExcludeFromCodeCoverage]
         private static int Gui(GameInstanceManager manager, GuiOptions options, string[] args)
         {
             // TODO: Sometimes when the GUI exits, we get a System.ArgumentException,
@@ -316,6 +321,7 @@ namespace CKAN.CmdLine
         }
         #endif
 
+        [ExcludeFromCodeCoverage]
         private static int ConsoleUi(GameInstanceManager manager, ConsoleUIOptions opts)
         {
             // Debug/verbose output just messes up the screen

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using log4net;
 using log4net.Core;
@@ -44,6 +45,7 @@ namespace CKAN.CmdLine
 
     // Actions supported by our client go here.
 
+    [ExcludeFromCodeCoverage]
     internal class Actions : VerbCommandOptions
     {
         #if NETFRAMEWORK || WINDOWS
@@ -218,6 +220,7 @@ namespace CKAN.CmdLine
 
     // Options common to all classes.
 
+    [ExcludeFromCodeCoverage]
     public class CommonOptions
     {
         [Option('v', "verbose", DefaultValue = false, HelpText = "Show more of what's going on when running.")]
@@ -323,6 +326,7 @@ namespace CKAN.CmdLine
         protected static readonly ILog log = LogManager.GetLogger(typeof(CommonOptions));
     }
 
+    [ExcludeFromCodeCoverage]
     public class InstanceSpecificOptions : CommonOptions
     {
         [Option("instance", HelpText = "Game instance to use")]

--- a/Core/AutoUpdate/AutoUpdate.cs
+++ b/Core/AutoUpdate/AutoUpdate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Diagnostics;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CKAN
 {
@@ -9,6 +10,7 @@ namespace CKAN
     /// CKAN client auto-updating routines. This works in conjunction with the
     /// auto-update helper to allow users to upgrade.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class AutoUpdate
     {
         public AutoUpdate()

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -16,6 +17,7 @@ namespace CKAN.Configuration
     #if NET5_0_OR_GREATER
     [SupportedOSPlatform("windows")]
     #endif
+    [ExcludeFromCodeCoverage]
     internal class Win32RegistryConfiguration
     {
         public static bool DoesRegistryConfigurationExist()

--- a/Core/Logging.cs
+++ b/Core/Logging.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 using log4net;
 using log4net.Config;
@@ -45,6 +46,7 @@ namespace CKAN
 
 #if DEBUG
 
+        [ExcludeFromCodeCoverage]
         public static void WithTimeElapsed(Action<TimeSpan> elapsedCallback,
                                            Action           toMeasure)
         {
@@ -57,6 +59,7 @@ namespace CKAN
             elapsedCallback(sw.Elapsed);
         }
 
+        [ExcludeFromCodeCoverage]
         public static T WithTimeElapsed<T>(Action<TimeSpan> elapsedCallback,
                                            Func<T>          toMeasure)
         {

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -325,23 +325,21 @@ namespace CKAN
     public class FileExistsKraken : Kraken
     {
         public FileExistsKraken(string     filename,
-                                string?    reason         = null,
                                 Exception? innerException = null)
-            : base(reason, innerException)
+            : base(null, innerException)
         {
             this.filename = filename;
         }
 
         public override string Message =>
-            base.Message
-            ?? (installingModule == null
-                    ? string.Format(Properties.Resources.KrakenFileExistsWithoutInstalling,
-                                    filename)
-                    : owningModule == null
-                        ? string.Format(Properties.Resources.KrakenFileExistsWithoutOwner,
-                                        filename, installingModule)
-                        : string.Format(Properties.Resources.KrakenFileExistsWithOwner,
-                                        filename, installingModule, owningModule.Module));
+            installingModule == null
+                ? string.Format(Properties.Resources.KrakenFileExistsWithoutInstalling,
+                                filename)
+                : owningModule == null
+                    ? string.Format(Properties.Resources.KrakenFileExistsWithoutOwner,
+                                    filename, installingModule)
+                    : string.Format(Properties.Resources.KrakenFileExistsWithOwner,
+                                    filename, installingModule, owningModule.Module);
 
         public string filename;
 

--- a/Core/Types/TimeLog.cs
+++ b/Core/Types/TimeLog.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 using Newtonsoft.Json;
+
 using CKAN.Extensions;
 
 namespace CKAN
@@ -28,6 +30,7 @@ namespace CKAN
             }
         }
 
+        [ExcludeFromCodeCoverage]
         public void Save(string path)
         {
             JsonConvert.SerializeObject(this, Formatting.Indented)
@@ -39,11 +42,13 @@ namespace CKAN
 
         private readonly Stopwatch playTime = new Stopwatch();
 
+        [ExcludeFromCodeCoverage]
         public void Start()
         {
             playTime.Restart();
         }
 
+        [ExcludeFromCodeCoverage]
         public void Stop(string dir)
         {
             if (playTime.IsRunning)

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -2150,9 +2150,7 @@ namespace CKAN.GUI
                 ? new HashSet<ModChange>()
                 : mainModList?.ComputeUserChangeSet(
                       RegistryManager.Instance(currentInstance, repoData).registry,
-                      currentInstance.VersionCriteria(),
-                      currentInstance,
-                      UpdateCol, ReplaceCol)
+                      currentInstance, UpdateCol, ReplaceCol)
                   ?? new HashSet<ModChange>();
 
         [ForbidGUICalls]
@@ -2172,8 +2170,7 @@ namespace CKAN.GUI
             List<ModChange>? full_change_set = null;
             Dictionary<GUIMod, string>? new_conflicts = null;
 
-            var gameVersion = inst.VersionCriteria();
-            var user_change_set = mainModList.ComputeUserChangeSet(registry, gameVersion, inst, UpdateCol, ReplaceCol);
+            var user_change_set = mainModList.ComputeUserChangeSet(registry, inst, UpdateCol, ReplaceCol);
             try
             {
                 // Set the target versions of upgrading mods based on what's actually allowed
@@ -2186,6 +2183,7 @@ namespace CKAN.GUI
                        gmod.SelectedMod = ch.targetMod;
                     }
                 }
+                var gameVersion = inst.VersionCriteria();
                 var tuple = mainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, inst.game,
                                                                               inst.StabilityToleranceConfig, gameVersion);
                 full_change_set = tuple.Item1.ToList();

--- a/GUI/FlatToolStripRenderer.cs
+++ b/GUI/FlatToolStripRenderer.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Windows.Forms;
+using System.Diagnostics.CodeAnalysis;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -14,6 +15,7 @@ namespace CKAN.GUI
     #if NET5_0_OR_GREATER
     [SupportedOSPlatform("windows")]
     #endif
+    [ExcludeFromCodeCoverage]
     public class FlatToolStripRenderer : ToolStripProfessionalRenderer
     {
 

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Forms;
+using System.Diagnostics.CodeAnalysis;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -14,6 +15,7 @@ namespace CKAN.GUI
     #if NET5_0_OR_GREATER
     [SupportedOSPlatform("windows")]
     #endif
+    [ExcludeFromCodeCoverage]
     public class GUIUser : IUser
     {
         public GUIUser(Main main,

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -145,7 +145,6 @@ namespace CKAN.GUI
         }
 
         public HashSet<ModChange> ComputeUserChangeSet(IRegistryQuerier     registry,
-                                                       GameVersionCriteria  crit,
                                                        GameInstance         instance,
                                                        DataGridViewColumn?  upgradeCol,
                                                        DataGridViewColumn?  replaceCol)
@@ -194,7 +193,8 @@ namespace CKAN.GUI
             return modChanges.Union(
                     registry.FindRemovableAutoInstalled(InstalledAfterChanges(registry, modChanges).ToArray(),
                                                         Array.Empty<CkanModule>(),
-                                                        instance.game, instance.StabilityToleranceConfig, crit)
+                                                        instance.game, instance.StabilityToleranceConfig,
+                                                        instance.VersionCriteria())
                         .Select(im => new ModChange(
                             im.Module, GUIModChangeType.Remove,
                             new SelectionReason.NoLongerUsed(),

--- a/GUI/Plugins/PluginController.cs
+++ b/GUI/Plugins/PluginController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+
 using log4net;
 
 namespace CKAN.GUI

--- a/GUI/TabController.cs
+++ b/GUI/TabController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Diagnostics.CodeAnalysis;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -12,6 +13,7 @@ namespace CKAN.GUI
     #if NET5_0_OR_GREATER
     [SupportedOSPlatform("windows")]
     #endif
+    [ExcludeFromCodeCoverage]
     public class TabController
     {
 

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Microsoft.Win32;
+using System.Diagnostics.CodeAnalysis;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -19,6 +20,7 @@ namespace CKAN.GUI
     #if NET5_0_OR_GREATER
     [SupportedOSPlatform("windows")]
     #endif
+    [ExcludeFromCodeCoverage]
     public static class URLHandlers
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(URLHandlers));

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 using Timer = System.Windows.Forms.Timer;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
@@ -24,6 +25,7 @@ namespace CKAN.GUI
         /// Invokes an action on the UI thread, or directly if we're
         /// on the UI thread.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public static void Invoke<T>(T obj, Action action) where T : Control
         {
             if (obj.InvokeRequired) // if we're not in the UI thread
@@ -41,6 +43,7 @@ namespace CKAN.GUI
         // utility helper to deal with multi-threading and UI
         // async version, doesn't wait for UI thread
         // use with caution, when not sure use blocking Invoke()
+        [ExcludeFromCodeCoverage]
         public static void AsyncInvoke<T>(T obj, Action action) where T : Control
         {
             if (obj.InvokeRequired) // if we're not in the UI thread
@@ -130,6 +133,7 @@ namespace CKAN.GUI
         /// Open a URL, unless it's "N/A"
         /// </summary>
         /// <param name="url">The URL</param>
+        [ExcludeFromCodeCoverage]
         public static void OpenLinkFromLinkLabel(string url)
         {
             if (url == Properties.Resources.ModInfoNSlashA)
@@ -144,6 +148,7 @@ namespace CKAN.GUI
         /// Tries to open an url using the default application.
         /// If it fails, it tries again by prepending each prefix before the url before it gives up.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public static bool TryOpenWebPage(string url, IEnumerable<string>? prefixes = null)
         {
             // Default prefixes to try if not provided
@@ -167,6 +172,7 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="url">The link's URL</param>
         /// <param name="e">The click event</param>
+        [ExcludeFromCodeCoverage]
         public static void HandleLinkClicked(string url, LinkLabelLinkClickedEventArgs? e)
         {
             switch (e?.Button)
@@ -191,6 +197,7 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="url">The URL of the link</param>
         /// <param name="c">The menu will be shown below the bottom of this control</param>
+        [ExcludeFromCodeCoverage]
         public static void LinkContextMenu(string url, Control c)
             => LinkContextMenu(url, c.PointToScreen(new Point(0, c.Height)));
 
@@ -199,6 +206,7 @@ namespace CKAN.GUI
         /// </summary>
         /// <param name="url">The URL of the link</param>
         /// <param name="where">Screen coordinates for the menu</param>
+        [ExcludeFromCodeCoverage]
         public static void LinkContextMenu(string url, Point? where = null)
         {
             var copyLink = new ToolStripMenuItem(Properties.Resources.UtilCopyLink);
@@ -225,6 +233,7 @@ namespace CKAN.GUI
         /// <returns>
         /// The first screen that overlaps the box if any, otherwise null
         /// </returns>
+        [ExcludeFromCodeCoverage]
         public static Screen? FindScreen(Point location, Size size)
         {
             var rect = new Rectangle(location, size);
@@ -426,6 +435,7 @@ namespace CKAN.GUI
         [DllImport("kernel32.dll", SetLastError=true)]
         private static extern int FreeConsole();
 
+        [ExcludeFromCodeCoverage]
         public static void HideConsoleWindow()
         {
             if (Platform.IsWindows)

--- a/Netkan/ConsoleUser.cs
+++ b/Netkan/ConsoleUser.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+
 using log4net;
 
 namespace CKAN.NetKAN
@@ -9,6 +11,7 @@ namespace CKAN.NetKAN
     /// It is exactly the same as the one of the CKAN-cmdline.
     /// At least at the time of this commit (git blame is your friend).
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ConsoleUser : IUser
     {
         /// <summary>

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Diagnostics.CodeAnalysis;
 
 using Amazon.SQS;
 using Amazon.SQS.Model;
@@ -22,6 +23,7 @@ using CKAN.Games;
 
 namespace CKAN.NetKAN.Processors
 {
+    [ExcludeFromCodeCoverage]
     public class QueueHandler
     {
         public QueueHandler(string  inputQueueName,

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 using CommandLine;
 using log4net;
@@ -20,6 +21,7 @@ using CKAN.Extensions;
 
 namespace CKAN.NetKAN
 {
+    [ExcludeFromCodeCoverage]
     public static class Program
     {
         public static int Main(string[] args)

--- a/Netkan/Services/CachingHttpService.cs
+++ b/Netkan/Services/CachingHttpService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Diagnostics.CodeAnalysis;
 
 using LazyCache;
 using log4net;
@@ -11,6 +12,7 @@ using CKAN.NetKAN.Model;
 
 namespace CKAN.NetKAN.Services
 {
+    [ExcludeFromCodeCoverage]
     internal sealed class CachingHttpService : IHttpService
     {
         public CachingHttpService(NetFileCache cache,

--- a/Tests/CmdLine/InstallTests.cs
+++ b/Tests/CmdLine/InstallTests.cs
@@ -69,11 +69,10 @@ namespace Tests.CmdLine
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
-            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 manager.SetCurrentInstance(inst.KSP);
-                regMgr.registry.RepositoriesClear();
-                regMgr.registry.RepositoriesAdd(repo.repo);
                 var module = regMgr.registry.GetModuleByVersion(identifier, version)!;
                 manager.Cache?.Store(module, TestData.DogeCoinFlagZip(), null);
                 var opts = new InstallOptions()

--- a/Tests/CmdLine/ListTests.cs
+++ b/Tests/CmdLine/ListTests.cs
@@ -479,7 +479,6 @@ namespace Tests.CmdLine
                                                            new Repository[] { repo }))
             using (var output   = new MemoryStream())
             {
-                regMgr.registry.RepositoriesAdd(repo);
                 ICommand sut    = new List(repoData.Manager, user, output);
                 var      opts   = new ListOptions() { export = "text" };
 
@@ -578,7 +577,6 @@ namespace Tests.CmdLine
                                                            new Repository[] { repo }))
             using (var output   = new MemoryStream())
             {
-                regMgr.registry.RepositoriesAdd(repo);
                 ICommand sut    = new List(repoData.Manager, user, output);
                 var      opts   = new ListOptions() { export = "markdown" };
 
@@ -677,7 +675,6 @@ namespace Tests.CmdLine
                                                            new Repository[] { repo }))
             using (var output   = new MemoryStream())
             {
-                regMgr.registry.RepositoriesAdd(repo);
                 ICommand sut    = new List(repoData.Manager, user, output);
                 var      opts   = new ListOptions() { export = "bbcode" };
 
@@ -778,7 +775,6 @@ namespace Tests.CmdLine
                                                            new Repository[] { repo }))
             using (var output   = new MemoryStream())
             {
-                regMgr.registry.RepositoriesAdd(repo);
                 ICommand sut    = new List(repoData.Manager, user, output);
                 var      opts   = new ListOptions() { export = "csv" };
 
@@ -878,7 +874,6 @@ namespace Tests.CmdLine
                                                            new Repository[] { repo }))
             using (var output   = new MemoryStream())
             {
-                regMgr.registry.RepositoriesAdd(repo);
                 ICommand sut    = new List(repoData.Manager, user, output);
                 var      opts   = new ListOptions() { export = "tsv" };
 

--- a/Tests/CmdLine/PromptTests.cs
+++ b/Tests/CmdLine/PromptTests.cs
@@ -142,7 +142,8 @@ namespace Tests.CmdLine
             {
                 { repo, RepositoryData.FromJson(TestData.TestRepository(), null)! },
             }))
-            using (var regMgr = RegistryManager.Instance(inst.KSP, repoData.Manager))
+            using (var regMgr = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                         new Repository[] { repo }))
             {
                 // Arrange
                 regMgr.registry.RepositoriesAdd(repo);

--- a/Tests/CmdLine/ReplaceTests.cs
+++ b/Tests/CmdLine/ReplaceTests.cs
@@ -61,11 +61,10 @@ namespace Tests.CmdLine
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
-            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 manager.SetCurrentInstance(inst.KSP);
-                regMgr.registry.RepositoriesClear();
-                regMgr.registry.RepositoriesAdd(repo.repo);
                 var module1 = regMgr.registry.GetModuleByVersion(ident1, version1)!;
                 var module2 = regMgr.registry.GetModuleByVersion(ident2, version2)!;
                 var opts = new ReplaceOptions()

--- a/Tests/CmdLine/UpdateTests.cs
+++ b/Tests/CmdLine/UpdateTests.cs
@@ -19,10 +19,9 @@ namespace Tests.CmdLine
             using (var repoData = new TemporaryRepositoryData(user))
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
-            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { new Repository("test", TestData.TestKANTarGz()) }))
             {
-                regMgr.registry.RepositoriesClear();
-                regMgr.registry.RepositoriesAdd(new Repository("test", TestData.TestKANTarGz()));
                 // Not an ICommand because it can update CKAN itself
                 var sut  = new Update(repoData.Manager, user, manager);
                 var opts = new UpdateOptions();

--- a/Tests/CmdLine/UpgradeTests.cs
+++ b/Tests/CmdLine/UpgradeTests.cs
@@ -70,11 +70,10 @@ namespace Tests.CmdLine
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
-            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 manager.SetCurrentInstance(inst.KSP);
-                regMgr.registry.RepositoriesClear();
-                regMgr.registry.RepositoriesAdd(repo.repo);
                 var fromModule = regMgr.registry.GetModuleByVersion(identifier, fromVersion)!;
                 var toModule   = regMgr.registry.GetModuleByVersion(identifier, toVersion)!;
                 regMgr.registry.RegisterModule(fromModule, new List<string>(), inst.KSP, false);
@@ -610,11 +609,10 @@ namespace Tests.CmdLine
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
-            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 manager.SetCurrentInstance(inst.KSP);
-                regMgr.registry.RepositoriesClear();
-                regMgr.registry.RepositoriesAdd(repo.repo);
 
                 // Register installed mods
                 var instMods = instModules.Select(CkanModule.FromJson)

--- a/Tests/Core/IO/ModuleInstallerDirTest.cs
+++ b/Tests/Core/IO/ModuleInstallerDirTest.cs
@@ -48,10 +48,9 @@ namespace Tests.Core.IO
 
             _config    = new FakeConfiguration(_instance.KSP, _instance.KSP.Name);
             _manager   = new GameInstanceManager(_nullUser, _config);
-            _registryManager = RegistryManager.Instance(_instance.KSP, repoData.Manager);
+            _registryManager = RegistryManager.Instance(_instance.KSP, repoData.Manager,
+                                                        new Repository[] { repo.repo });
             _registry  = _registryManager.registry;
-            _registry.RepositoriesClear();
-            _registry.RepositoriesAdd(repo.repo);
             _testModule = _registry.GetModuleByVersion("DogeCoinFlag", "1.01");
             Assert.IsNotNull(_testModule, "DogeCoinFlag 1.01 should exist");
 

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -1475,7 +1475,7 @@ namespace Tests.Core.IO
         }
 
         [TestCase]
-        public void Install_WithMatchedUnmanagedDll_Throws()
+        public void InstallList_WithMatchedUnmanagedDll_Throws()
         {
             const string unmanaged = "GameData/DogeCoinPlugin.1.0.0.dll";
             var kraken = Assert.Throws<DllLocationMismatchKraken>(() =>
@@ -1486,7 +1486,7 @@ namespace Tests.Core.IO
         }
 
         [TestCase]
-        public void Install_WithUnmatchedUnmanagedDll_DoesNotThrow()
+        public void InstallList_WithUnmatchedUnmanagedDll_DoesNotThrow()
         {
             Assert.DoesNotThrow(() => installTestPlugin("GameData/DogeCoinPlugin-1-0-0.dll",
                                                         TestData.DogeCoinPlugin(),
@@ -1522,7 +1522,7 @@ namespace Tests.Core.IO
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                 new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                  regMgr,
                                  ref possibleConfigOnlyDirs);
             }

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -439,8 +439,6 @@ namespace Tests.Core.IO
                 Assert.IsTrue(File.Exists(cache_path));
 
                 var registry = regMgr.registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo.repo);
 
                 Assert.AreEqual(1, registry.CompatibleModules(ksp.KSP.StabilityToleranceConfig, ksp.KSP.VersionCriteria()).Count());
 
@@ -478,8 +476,6 @@ namespace Tests.Core.IO
 
                 // Install the test mod.
                 var registry = regMgr.registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo.repo);
                 manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
                                      TestData.DogeCoinFlagZip(),
                                      new Progress<long>(bytes => {}));
@@ -524,8 +520,6 @@ namespace Tests.Core.IO
 
                 // Install the base test mod.
                 var registry = regMgr.registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo.repo);
                 manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
                                      TestData.DogeCoinFlagZip(),
                                      new Progress<long>(bytes => {}));
@@ -726,8 +720,6 @@ namespace Tests.Core.IO
                 {
                     manager.SetCurrentInstance(ksp.KSP);
                     var registry = regMgr.registry;
-                    registry.RepositoriesClear();
-                    registry.RepositoriesAdd(repo.repo);
 
                     // Copy the zip file to the cache directory.
                     manager.Cache?.Store(TestData.DogeCoinFlag_101_module(),
@@ -952,8 +944,6 @@ namespace Tests.Core.IO
             {
                 manager.SetCurrentInstance(ksp.KSP);
                 var registry = regMgr.registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo.repo);
 
                 // Copy the zip file to the cache directory.
                 manager.Cache?.Store(TestData.DogeCoinFlag_101ZipSlip_module(),
@@ -992,8 +982,6 @@ namespace Tests.Core.IO
             {
                 manager.SetCurrentInstance(ksp.KSP);
                 var registry = regMgr.registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo.repo);
 
                 // Copy the zip file to the cache directory.
                 manager.Cache?.Store(TestData.DogeCoinFlag_101ZipBomb_module(),
@@ -1351,10 +1339,6 @@ namespace Tests.Core.IO
                 var installer  = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache!);
                 var registry   = regMgr.registry;
-                registry.RepositoriesSet(new SortedDictionary<string, Repository>()
-                {
-                    { "testRepo", repo.repo }
-                });
                 IRegistryQuerier querier = registry;
                 var possibleConfigOnlyDirs = new HashSet<string>();
                 foreach (var m in regularMods)
@@ -1459,10 +1443,6 @@ namespace Tests.Core.IO
                 var installer  = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
                 var downloader = new NetAsyncModulesDownloader(nullUser, manager.Cache!);
                 var registry   = regMgr.registry;
-                registry.RepositoriesSet(new SortedDictionary<string, Repository>()
-                {
-                    { "testRepo", repo.repo }
-                });
                 var possibleConfigOnlyDirs = new HashSet<string>();
                 foreach (var m in regularInstalled)
                 {

--- a/Tests/Core/Net/NetAsyncModulesDownloaderTests.cs
+++ b/Tests/Core/Net/NetAsyncModulesDownloaderTests.cs
@@ -44,11 +44,10 @@ namespace Tests.Core.Net
             // Give us a registry to play with.
             ksp = new DisposableKSP();
             manager = new GameInstanceManager(user, new FakeConfiguration(ksp.KSP, ksp.KSP.Name));
-            registry_manager = RegistryManager.Instance(ksp.KSP, repoData.Manager);
+            registry_manager = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                                                        repos.Values);
             registry = registry_manager.registry;
             registry.Installed().Clear();
-            // Make sure we have a registry we can use.
-            registry.RepositoriesSet(repos);
 
             // General shortcuts
             cache = manager.Cache;

--- a/Tests/Core/Relationships/SanityChecker.cs
+++ b/Tests/Core/Relationships/SanityChecker.cs
@@ -41,11 +41,10 @@ namespace Tests.Core.Relationships
             var user = new NullUser();
             repoData = new TemporaryRepositoryData(user, repos.Values);
 
-            manager = RegistryManager.Instance(ksp.KSP, repoData.Manager);
+            manager = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                                               repos.Values);
             registry = manager.registry;
             registry.Installed().Clear();
-
-            registry.RepositoriesSet(repos);
         }
 
         [OneTimeTearDown]

--- a/Tests/Data/TemporaryRepositoryData.cs
+++ b/Tests/Data/TemporaryRepositoryData.cs
@@ -48,6 +48,7 @@ namespace Tests.Data
         public void Dispose()
         {
             Directory.Delete(repoDataDir, true);
+            GC.SuppressFinalize(this);
         }
 
         public readonly RepositoryDataManager Manager;

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -608,12 +608,11 @@ namespace Tests.GUI
             using (var instance = new DisposableKSP())
             using (var config   = new FakeConfiguration(instance.KSP, instance.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
-            using (var regMgr   = RegistryManager.Instance(instance.KSP, repoData.Manager))
+            using (var regMgr   = RegistryManager.Instance(instance.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
             {
                 manager.SetCurrentInstance(instance.KSP);
                 var registry = regMgr.registry;
-                registry.RepositoriesClear();
-                registry.RepositoriesAdd(repo.repo);
                 // A module with a ksp_version of "any" to repro our issue
                 var anyVersionModule = registry.GetModuleByVersion("DogeCoinFlag", "1.01")!;
                 Assert.IsNotNull(anyVersionModule, "DogeCoinFlag 1.01 should exist");

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -17,7 +17,6 @@ using Tests.Data;
 
 using CKAN;
 using CKAN.IO;
-using CKAN.Versioning;
 using CKAN.GUI;
 
 namespace Tests.GUI
@@ -28,8 +27,6 @@ namespace Tests.GUI
     [TestFixture]
     public class ModListTests
     {
-        private static readonly GameVersionCriteria crit = new GameVersionCriteria(null);
-
         [Test]
         public void IsVisible_WithAllAndNoNameFilter_ReturnsTrueForCompatible()
         {
@@ -484,7 +481,7 @@ namespace Tests.GUI
                 {
                     mod.SelectedMod = mod.LatestCompatibleMod;
                 }
-                var changeset = modlist.ComputeUserChangeSet(registry, instance.KSP.VersionCriteria(), instance.KSP, null, null);
+                var changeset = modlist.ComputeUserChangeSet(registry, instance.KSP, null, null);
 
                 // Assert
                 CollectionAssert.AreEquivalent(new string[]
@@ -500,7 +497,7 @@ namespace Tests.GUI
         }
 
         [Test]
-        public void ComputeFullChangeSetFromUserChangeSet_WithEmptyList_HasEmptyChangeSet()
+        public void ComputeUserChangeSet_WithEmptyList_HasEmptyChangeSet()
         {
             var user = new NullUser();
             using (var repoData = new TemporaryRepositoryData(user))
@@ -509,7 +506,60 @@ namespace Tests.GUI
             {
                 var item = new ModList(Array.Empty<GUIMod>(), tidy.KSP, ModuleLabelList.GetDefaultLabels(),
                                        config, new GUIConfiguration());
-                Assert.That(item.ComputeUserChangeSet(Registry.Empty(repoData.Manager), crit, tidy.KSP, null, null), Is.Empty);
+                Assert.That(item.ComputeUserChangeSet(Registry.Empty(repoData.Manager), tidy.KSP, null, null), Is.Empty);
+            }
+        }
+
+        [Test]
+        public void ComputeFullChangeSetFromUserChangeSet_B9_GetsAllDependencies()
+        {
+            // Arrange
+            var user      = new NullUser();
+            var repo      = new Repository("test", "https://github.com/");
+            var guiConfig = new GUIConfiguration();
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var repoData = new TemporaryRepositoryData(
+                                      user,
+                                      new Dictionary<Repository, RepositoryData>
+                                      {
+                                          {
+                                              repo,
+                                              RepositoryData.FromJson(TestData.TestRepository(), null)!
+                                          },
+                                      }))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo }))
+            {
+                var registry  = regMgr.registry;
+                var labels    = ModuleLabelList.GetDefaultLabels();
+                var mods      = ModList.GetGUIMods(registry, repoData.Manager, inst.KSP, labels, guiConfig)
+                                       .ToArray();
+                var modlist   = new ModList(mods, inst.KSP, labels, config, guiConfig);
+
+                // Act
+                var b9         = mods.First(m => m.Identifier == "B9");
+                b9.SelectedMod = b9.LatestCompatibleMod;
+                var changes    = modlist.ComputeUserChangeSet(registry, inst.KSP, null, null);
+                var full       = modlist.ComputeFullChangeSetFromUserChangeSet(registry, changes,
+                                                                               inst.KSP.game,
+                                                                               inst.KSP.StabilityToleranceConfig,
+                                                                               inst.KSP.VersionCriteria());
+
+                // Assert
+                CollectionAssert.AreEquivalent(new string[]
+                                               {
+                                                   "B9",
+                                                   "CrossFeedEnabler",
+                                                   "FirespitterCore",
+                                                   "KineTechAnimation",
+                                                   "KlockheedMartian-Gimbal",
+                                                   "ModuleManager",
+                                                   "RasterPropMonitor-Core",
+                                                   "ResGen",
+                                                   "VirginKalactic-NodeToggle",
+                                               },
+                                               full.Item1.Select(ch => ch.Mod.identifier).Order());
             }
         }
 
@@ -624,7 +674,7 @@ namespace Tests.GUI
                     {
                         // Install the "other" module
                         installer.InstallList(
-                            modList.ComputeUserChangeSet(Registry.Empty(repoData.Manager), crit, inst2.KSP, null, null)
+                            modList.ComputeUserChangeSet(Registry.Empty(repoData.Manager), inst2.KSP, null, null)
                                    .Select(change => change.Mod)
                                    .ToList(),
                             new RelationshipResolverOptions(inst2.KSP.StabilityToleranceConfig),

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -409,6 +409,7 @@ public sealed class TestUnitTestsOnlyTask : FrostingTask<BuildContext>
                                 "-p GUI/Dialogs",
                                 "-p GUI/Controls",
                                 "-p GUI/Main",
+                                "-a ExcludeFromCodeCoverage",
                                 $"-i {testDir}",
                                 $"-o {instrumentedDir}",
                                 "--save");


### PR DESCRIPTION
## Motivation

[Coveralls](https://coveralls.io/github/KSP-CKAN/CKAN)'s list of files with the most "missed" lines now includes:

- `ModuleInstaller`
- `GUIModList`
- A bunch of stuff that can't be tested because it deals directly with input or output which is not available in tests

## Problem

In KSP-CKAN/NetKAN#10713, [a `FileExistsKraken` was printed in a short form that didn't include the details of the problem](https://github.com/KSP-CKAN/NetKAN/actions/runs/17333592051/job/49215058437):

```
  Error: 8249 [1] ERROR CKAN.CmdLine.ConsoleUser (null) - Exception of type 'CKAN.FileExistsKraken' was thrown.
  Install canceled. Your files have been returned to their initial state.
```

## Cause

In #4398, we refactored and standardized the Kraken classes to provide `Message` themselves, mostly in their constructors. But in the case of `FileExistsKraken`, some parts of the message are not known until additional properties are populated later, so we couldn't pass the proper string to `Exception`'s constructor. Instead, we passed a default of null, then overrode `Message` to return the more detailed strings if `base.Message` was null. Unfortunately `Exception`'s constructor seems to set `Message` to a default string so it's never actually null, and we don't fall back to the messages we really want to use.

## Changes

- New tests are added for `ModuleInstaller` and `GUI.ModList`
- We now pass `-a ExcludeFromCodeCoverage` to AltCover, and many untestable classes and functions are now tagged with `[ExcludeFromCodeCoverage]`
- Now `FileExistsKraken.Message` ignores `base.Message` and instead always returns the custom messages it's supposed to. To reflect this lack of (unused) overridability, the `reason` parameter is removed from its constructor.


This should keep our Coveralls number moving in the right direction while remaining accurate and restore the previous clarity of file conflict errors.
