### PR TITLE
Add tests for ModuleInstaller

### DIFF
--- a/Core/Extensions/YamlExtensions.cs
+++ b/Core/Extensions/YamlExtensions.cs
@@ -10,9 +10,7 @@ namespace CKAN.Extensions
     public static class YamlExtensions
     {
         public static YamlMappingNode[] Parse(string input)
-        {
-            return Parse(new StringReader(input));
-        }
+            => Parse(new StringReader(input));
 
         public static YamlMappingNode[] Parse(TextReader input)
         {

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -393,22 +393,21 @@ namespace CKAN.IO
                     // Look for overwritable files if session is interactive
                     if (!User.Headless)
                     {
-                        var conflicting = FindConflictingFiles(zipfile, files, registry).Memoize();
-                        if (conflicting.Any())
+                        if (FindConflictingFiles(zipfile, files, registry).ToArray()
+                            is (InstallableFile file, bool same)[] { Length: > 0 } conflicting)
                         {
-                            var fileMsg = conflicting
-                                .OrderBy(c => c.Value)
-                                .Aggregate("", (a, b) =>
-                                    $"{a}\r\n- {instance.ToRelativeGameDir(b.Key.destination)}  ({(b.Value ? Properties.Resources.ModuleInstallerFileSame : Properties.Resources.ModuleInstallerFileDifferent)})");
-                            if (User.RaiseYesNoDialog(string.Format(
-                                Properties.Resources.ModuleInstallerOverwrite, module.name, fileMsg)))
+                            var fileMsg = string.Join(Environment.NewLine,
+                                                      conflicting.OrderBy(tuple => tuple.same)
+                                                                 .Select(tuple => $"- {instance.ToRelativeGameDir(tuple.file.destination)}  ({(tuple.same ? Properties.Resources.ModuleInstallerFileSame : Properties.Resources.ModuleInstallerFileDifferent)})"));
+                            if (User.RaiseYesNoDialog(string.Format(Properties.Resources.ModuleInstallerOverwrite,
+                                                                    module.name, fileMsg)))
                             {
-                                DeleteConflictingFiles(conflicting.Select(f => f.Key));
+                                DeleteConflictingFiles(conflicting.Select(tuple => tuple.file));
                             }
                             else
                             {
-                                throw new CancelledActionKraken(string.Format(
-                                    Properties.Resources.ModuleInstallerOverwriteCancelled, module.name));
+                                throw new CancelledActionKraken(string.Format(Properties.Resources.ModuleInstallerOverwriteCancelled,
+                                                                              module.name));
                             }
                         }
                     }
@@ -467,27 +466,25 @@ namespace CKAN.IO
         /// <returns>
         /// List of pairs: Key = file, Value = true if identical, false if different
         /// </returns>
-        private IEnumerable<KeyValuePair<InstallableFile, bool>> FindConflictingFiles(ZipFile zip, IEnumerable<InstallableFile> files, Registry registry)
-        {
-            foreach (InstallableFile file in files)
-            {
-                if (!file.source.IsDirectory
-                    && File.Exists(file.destination)
-                    && registry.FileOwner(instance.ToRelativeGameDir(file.destination)) == null)
-                {
-                    log.DebugFormat("Comparing {0}", file.destination);
-                    using (Stream zipStream = zip.GetInputStream(file.source))
-                    using (FileStream curFile = new FileStream(file.destination, FileMode.Open, FileAccess.Read))
+        private IEnumerable<(InstallableFile file, bool same)> FindConflictingFiles(ZipFile                      zip,
+                                                                                    IEnumerable<InstallableFile> files,
+                                                                                    Registry                     registry)
+            => files.Where(file => !file.source.IsDirectory
+                                   && File.Exists(file.destination)
+                                   && registry.FileOwner(instance.ToRelativeGameDir(file.destination)) == null)
+                    .Select(file =>
                     {
-                        yield return new KeyValuePair<InstallableFile, bool>(
-                            file,
-                            file.source.Size == curFile.Length
-                                && StreamsEqual(zipStream, curFile)
-                        );
-                    }
-                }
-            }
-        }
+                        log.DebugFormat("Comparing {0}", file.destination);
+                        using (Stream     zipStream = zip.GetInputStream(file.source))
+                        using (FileStream curFile   = new FileStream(file.destination,
+                                                                     FileMode.Open,
+                                                                     FileAccess.Read))
+                        {
+                            return (file,
+                                    same: file.source.Size == curFile.Length
+                                          && StreamsEqual(zipStream, curFile));
+                        }
+                    });
 
         /// <summary>
         /// Compare the contents of two streams
@@ -745,10 +742,7 @@ namespace CKAN.IO
                         progress?.Report(0);
                         StreamUtils.Copy(zipStream, writer, buffer,
                                          // This doesn't fire at all if the interval never elapses
-                                         (sender, e) =>
-                                         {
-                                             progress?.Report(e.Processed);
-                                         },
+                                         (sender, e) => progress?.Report(e.Processed),
                                          UnzipProgressInterval,
                                          entry, "InstallFile");
                     }

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -360,8 +360,8 @@ namespace CKAN.IO
 
                 try
                 {
-                    var dll = registry.DllPath(module.identifier);
-                    if (dll is not null && !string.IsNullOrEmpty(dll))
+                    if (registry.DllPath(module.identifier)
+                        is string { Length: > 0 } dll)
                     {
                         // Find where we're installing identifier.optionalversion.dll
                         // (file name might not be an exact match with manually installed)
@@ -1067,15 +1067,15 @@ namespace CKAN.IO
             }
         }
 
-        internal static void GroupFilesByRemovable(string       relRoot,
-                                                   Registry     registry,
-                                                   string[]     alreadyRemoving,
-                                                   IGame        game,
-                                                   string[]     relPaths,
-                                                   out string[] removable,
-                                                   out string[] notRemovable)
+        internal static void GroupFilesByRemovable(string                      relRoot,
+                                                   Registry                    registry,
+                                                   IReadOnlyCollection<string> alreadyRemoving,
+                                                   IGame                       game,
+                                                   IReadOnlyCollection<string> relPaths,
+                                                   out string[]                removable,
+                                                   out string[]                notRemovable)
         {
-            if (relPaths.Length < 1)
+            if (relPaths.Count < 1)
             {
                 removable    = Array.Empty<string>();
                 notRemovable = Array.Empty<string>();
@@ -1096,8 +1096,8 @@ namespace CKAN.IO
                 .ToDictionary(grp => grp.Key,
                               grp => grp.OrderByDescending(f => f.Length)
                                         .ToArray());
-            removable    = contents.TryGetValue(true,  out string[]? val1) ? val1 : Array.Empty<string>();
-            notRemovable = contents.TryGetValue(false, out string[]? val2) ? val2 : Array.Empty<string>();
+            removable    = contents.GetValueOrDefault(true)  ?? Array.Empty<string>();
+            notRemovable = contents.GetValueOrDefault(false) ?? Array.Empty<string>();
             log.DebugFormat("Got removable: {0}",    string.Join(", ", removable));
             log.DebugFormat("Got notRemovable: {0}", string.Join(", ", notRemovable));
         }

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -68,42 +68,49 @@ namespace CKAN.GUI
 
         public void PopulateSearch(ModSearch? search)
         {
-            FilterByNameTextBox.Text        = search?.Name
-                                              ?? "";
-            FilterByAuthorTextBox.Text      = search?.Authors.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterByDescriptionTextBox.Text = search?.Description
-                                              ?? "";
-            FilterByLicenseTextBox.Text     = search?.Licenses.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterByLanguageTextBox.Text    = search?.Localizations.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterByDependsTextBox.Text     = search?.DependsOn.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterByRecommendsTextBox.Text  = search?.Recommends.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterBySuggestsTextBox.Text    = search?.Suggests.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterByConflictsTextBox.Text   = search?.ConflictsWith.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterBySupportsTextBox.Text    = search?.Supports.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterByTagsTextBox.Text        = search?.TagNames.Aggregate("", CombinePieces)
-                                              ?? "";
-            FilterByLabelsTextBox.Text      = search?.LabelNames.Aggregate("", CombinePieces)
-                                              ?? "";
-
-            CompatibleToggle.Value      = search?.Compatible;
-            InstalledToggle.Value       = search?.Installed;
-            CachedToggle.Value          = search?.Cached;
-            NewlyCompatibleToggle.Value = search?.NewlyCompatible;
-            UpgradeableToggle.Value     = search?.Upgradeable;
-            ReplaceableToggle.Value     = search?.Replaceable;
+            if (search == null)
+            {
+                FilterByNameTextBox.Text        = "";
+                FilterByAuthorTextBox.Text      = "";
+                FilterByDescriptionTextBox.Text = "";
+                FilterByLicenseTextBox.Text     = "";
+                FilterByLanguageTextBox.Text    = "";
+                FilterByDependsTextBox.Text     = "";
+                FilterByRecommendsTextBox.Text  = "";
+                FilterBySuggestsTextBox.Text    = "";
+                FilterByConflictsTextBox.Text   = "";
+                FilterBySupportsTextBox.Text    = "";
+                FilterByTagsTextBox.Text        = "";
+                FilterByLabelsTextBox.Text      = "";
+                CompatibleToggle.Value          = null;
+                InstalledToggle.Value           = null;
+                CachedToggle.Value              = null;
+                NewlyCompatibleToggle.Value     = null;
+                UpgradeableToggle.Value         = null;
+                ReplaceableToggle.Value         = null;
+            }
+            else
+            {
+                FilterByNameTextBox.Text        = search.Name;
+                FilterByAuthorTextBox.Text      = string.Join(" ", search.Authors);
+                FilterByDescriptionTextBox.Text = string.Join(" ", search.Description);
+                FilterByLicenseTextBox.Text     = string.Join(" ", search.Licenses);
+                FilterByLanguageTextBox.Text    = string.Join(" ", search.Localizations);
+                FilterByDependsTextBox.Text     = string.Join(" ", search.DependsOn);
+                FilterByRecommendsTextBox.Text  = string.Join(" ", search.Recommends);
+                FilterBySuggestsTextBox.Text    = string.Join(" ", search.Suggests);
+                FilterByConflictsTextBox.Text   = string.Join(" ", search.ConflictsWith);
+                FilterBySupportsTextBox.Text    = string.Join(" ", search.Supports);
+                FilterByTagsTextBox.Text        = string.Join(" ", search.TagNames);
+                FilterByLabelsTextBox.Text      = string.Join(" ", search.LabelNames);
+                CompatibleToggle.Value          = search.Compatible;
+                InstalledToggle.Value           = search.Installed;
+                CachedToggle.Value              = search.Cached;
+                NewlyCompatibleToggle.Value     = search.NewlyCompatible;
+                UpgradeableToggle.Value         = search.Upgradeable;
+                ReplaceableToggle.Value         = search.Replaceable;
+            }
         }
-
-        private static string CombinePieces(string joined, string piece)
-            => string.IsNullOrEmpty(joined) ? piece
-                                            : $"{joined} {piece}";
 
         /// <summary>
         /// Override special settings to make this control behave like a dropdown.

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -2109,9 +2109,7 @@ namespace CKAN.GUI
             if (Conflicts != null && Conflicts.Count != 0)
             {
                 // Ask if they want to resolve conflicts
-                string confDescrip = Conflicts
-                    .Select(kvp => kvp.Value)
-                    .Aggregate((a, b) => $"{a}, {b}");
+                string confDescrip = string.Join(", ", Conflicts.Select(kvp => kvp.Value));
                 if (!Main.Instance?.YesNoDialog(string.Format(Properties.Resources.MainQuitWithConflicts, confDescrip),
                     Properties.Resources.MainQuit,
                     Properties.Resources.MainGoBack) ?? false)
@@ -2122,11 +2120,9 @@ namespace CKAN.GUI
             else if (ChangeSet?.Any() ?? false)
             {
                 // Ask if they want to discard the change set
-                string changeDescrip = ChangeSet
-                    .GroupBy(ch => ch.ChangeType, ch => ch.Mod.name)
-                    .Select(grp => $"{grp.Key}: "
-                        + grp.Aggregate((a, b) => $"{a}, {b}"))
-                    .Aggregate((a, b) => $"{a}\r\n{b}");
+                string changeDescrip = string.Join(Environment.NewLine,
+                                                   ChangeSet.GroupBy(ch => ch.ChangeType, ch => ch.Mod.name)
+                                                            .Select(grp => $"{grp.Key}: " + string.Join(", ", grp)));
                 if (!Main.Instance?.YesNoDialog(string.Format(Properties.Resources.MainQuitWithUnappliedChanges, changeDescrip),
                     Properties.Resources.MainQuit,
                     Properties.Resources.MainGoBack) ?? false)

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -958,9 +958,8 @@ namespace CKAN.GUI
                 if (incomp.Count != 0 && CurrentInstance.Version() is GameVersion gv)
                 {
                     // Warn that it might not be safe to run game with incompatible modules installed
-                    string incompatDescrip = incomp
-                        .Select(m => $"{m.Module} ({m.Module.CompatibleGameVersions(CurrentInstance.game)})")
-                        .Aggregate((a, b) => $"{a}{Environment.NewLine}{b}");
+                    string incompatDescrip = string.Join(Environment.NewLine,
+                                                         incomp.Select(m => $"{m.Module} ({m.Module.CompatibleGameVersions(CurrentInstance.game)})"));
                     var result = SuppressableYesNoDialog(
                         string.Format(Properties.Resources.MainLaunchWithIncompatible,
                                       incompatDescrip),

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -511,7 +511,7 @@ namespace Tests.Core.IO
             // Create a new disposable KSP instance to run the test on.
             using (var ksp      = new DisposableKSP())
             using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
-            using (var manager  = new GameInstanceManager(new NullUser(), config))
+            using (var manager  = new GameInstanceManager(nullUser, config))
             using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
@@ -847,11 +847,10 @@ namespace Tests.Core.IO
                 string[] dlcIdents)
         {
             // Arrange
-            var user = new NullUser();
             var crit = new GameVersionCriteria(new GameVersion(1, 12, 5));
             using (var repo     = new TemporaryRepository(availableModules.Select(Relationships.RelationshipResolverTests.MergeWithDefaults)
                                                                           .ToArray()))
-            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             using (var inst     = new DisposableKSP())
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
@@ -897,11 +896,10 @@ namespace Tests.Core.IO
                 string[] dlcIdents)
         {
             // Arrange
-            var user = new NullUser();
             var crit = new GameVersionCriteria(new GameVersion(1, 12, 5));
             using (var repo     = new TemporaryRepository(availableModules.Select(Relationships.RelationshipResolverTests.MergeWithDefaults)
                                                                           .ToArray()))
-            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             using (var inst     = new DisposableKSP())
             {
                 var registry = new CKAN.Registry(repoData.Manager, repo.repo);
@@ -1478,7 +1476,6 @@ namespace Tests.Core.IO
         public void InstallList_DLC_Throws()
         {
             // Arrange
-            var user = new NullUser();
             using (var repo     = new TemporaryRepository(
                                       @"{
                                           ""spec_version"": 1,
@@ -1497,7 +1494,7 @@ namespace Tests.Core.IO
                 var module    = registry.LatestAvailable("Fake-DLC",
                                                          inst.KSP.StabilityToleranceConfig,
                                                          inst.KSP.VersionCriteria())!;
-                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, user);
+                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
 
                 // Act / Assert
                 Assert.Throws<ModuleIsDLCKraken>(() =>
@@ -1517,7 +1514,6 @@ namespace Tests.Core.IO
         public void InstallList_IncompleteInCache_Completes()
         {
             // Arrange
-            var user = new NullUser();
             using (var inst     = new DisposableKSP())
             using (var cacheDir = new TemporaryDirectory())
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name,
@@ -1529,7 +1525,7 @@ namespace Tests.Core.IO
                                                            new Repository[] { repo.repo }))
             {
                 var registry  = regMgr.registry;
-                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, user);
+                var installer = new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser);
 
                 // Redirect the mod's download
                 var module      = registry.LatestAvailable("DogeCoinFlag",
@@ -1606,14 +1602,14 @@ namespace Tests.Core.IO
                                       null, cacheDir.Directory.FullName))
             using (var manager  = new GameInstanceManager(user, config))
             using (var repo     = new TemporaryRepository())
-            using (var repoData = new TemporaryRepositoryData(new NullUser(), repo.repo))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             using (var regMgr1  = RegistryManager.Instance(inst1.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             using (var regMgr2  = RegistryManager.Instance(inst2.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
-                var installer1 = new ModuleInstaller(inst1.KSP, manager.Cache!, config, new NullUser());
-                var sut = new ModuleInstaller(inst2.KSP, manager.Cache!, config, new NullUser());
+                var installer1 = new ModuleInstaller(inst1.KSP, manager.Cache!, config, user);
+                var sut = new ModuleInstaller(inst2.KSP, manager.Cache!, config, user);
                 HashSet<string>? possibleConfigOnlyDirs1 = null;
                 HashSet<string>? possibleConfigOnlyDirs2 = null;
                 var opts = RelationshipResolverOptions.DependsOnlyOpts(inst1.KSP.StabilityToleranceConfig);
@@ -1640,7 +1636,7 @@ namespace Tests.Core.IO
         }
 
         public static IEnumerable<string> AbsoluteInstalledPaths(GameInstance  inst,
-                                                                  CKAN.Registry registry)
+                                                                 CKAN.Registry registry)
             => registry.InstalledFileInfo()
                        .Select(ifi => ifi.relPath)
                        .Select(inst.ToAbsoluteGameDir)

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1594,6 +1594,9 @@ namespace Tests.Core.Relationships
             return incoming.ToString();
         }
 
+        public static IEnumerable<string> MergeWithDefaults(params string[] jsons)
+            => jsons.Select(MergeWithDefaults);
+
         // Unimportant required fields that we don't want to duplicate
         private static readonly JObject moduleDefaults = JObject.Parse(
             @"{

--- a/Tests/Data/DogeCoinFlag.netkan
+++ b/Tests/Data/DogeCoinFlag.netkan
@@ -1,0 +1,2 @@
+identifier: DogeCoinFlag
+$kref: '#/ckan/github/testuser/testrepo'

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -165,7 +165,7 @@ namespace Tests.Data
         public static string DogeCoinFlag_101()
             => @"
                 {
-                    ""spec_version"": 1,
+                    ""spec_version"": ""v1.10"",
                     ""identifier"": ""DogeCoinFlag"",
                     ""install"": [
                         {
@@ -409,7 +409,7 @@ namespace Tests.Data
         public static string DogeCoinPlugin()
             => @"
                 {
-                    ""spec_version"": ""v1.2"",
+                    ""spec_version"": ""v1.10"",
                     ""identifier"": ""DogeCoinPlugin"",
                     ""install"": [
                         {
@@ -747,6 +747,12 @@ namespace Tests.Data
 
         public static string TestRegistryVersion999()
             => DataDir("registry-version-999.json");
+
+        public static string TestNetkanPath()
+            => DataDir("DogeCoinFlag.netkan");
+
+        public static string TestNetkanContents()
+            => File.ReadAllText(TestNetkanPath());
 
         // Where's my mkdtemp? Instead we'll make a random file, delete it, and
         // fill its place with a directory.

--- a/Tests/NetKAN/Processors/InflatorTests.cs
+++ b/Tests/NetKAN/Processors/InflatorTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Linq;
+
+using NUnit.Framework;
+using Moq;
+
+using CKAN;
+using CKAN.Extensions;
+using CKAN.Games.KerbalSpaceProgram;
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Processors;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Transformers;
+using Tests.Data;
+
+namespace Tests.NetKAN.Processors
+{
+    [TestFixture]
+    public class InflatorTests
+    {
+        [Test]
+        public void Inflate_WithTestNetkan_Inflates()
+        {
+            // Arrange
+            using (var cacheDir = new TemporaryDirectory())
+            {
+                var http     = new Mock<IHttpService>();
+                var game     = new KerbalSpaceProgram();
+                var cache    = new NetFileCache(cacheDir.Directory.FullName);
+                var modSvc   = new ModuleService(game);
+                var fileSvc  = new FileService(cache);
+                var sut      = new Inflator(null, null, null, null,
+                                            game, cache, http.Object, modSvc, fileSvc);
+                var filename = TestData.TestNetkanPath();
+                var netkans  = YamlExtensions.Parse(TestData.TestNetkanContents())
+                                             .Select(yaml => new Metadata(yaml))
+                                             .ToArray();
+                var opts     = new TransformOptions(1, 0, null, null, false, null);
+                http.Setup(h => h.DownloadText(It.Is<Uri>(u => u.AbsolutePath.StartsWith("/repos/")
+                                                               && !u.AbsolutePath.EndsWith("/releases")),
+                                               It.IsAny<string?>(), It.IsAny<string?>()))
+                    .Returns(@"{
+                                 ""name"": ""Example Project"",
+                                 ""owner"": {
+                                     ""login"": ""authoruser"",
+                                     ""type"":  ""User""
+                                 },
+                                 ""license"": {
+                                     ""spdx_id"": ""GPL-3.0""
+                                 },
+                                 ""html_url"": ""https://github.com/ExampleAccount/ExampleProject"",
+                             }");
+                http.Setup(h => h.DownloadText(It.Is<Uri>(u => u.AbsolutePath.StartsWith("/repos/")
+                                                               && u.AbsolutePath.EndsWith("/releases")),
+                                               It.IsAny<string?>(), It.IsAny<string?>()))
+                    .Returns(@"[
+                                 {
+                                     ""author"": {
+                                         ""login"": ""ExampleProject""
+                                     },
+                                     ""tag_name"": ""1.0"",
+                                     ""published_at"": ""2025-01-05T00:00:00Z"",
+                                     ""assets"": [
+                                         {
+                                             ""name"":                 ""download.zip"",
+                                             ""browser_download_url"": ""http://github.example/download/1.0""
+                                         }
+                                     ]
+                                 }
+                             ]");
+                http.Setup(h => h.DownloadModule(It.IsAny<Metadata>()))
+                    .Returns(TestData.DogeCoinFlagImportableZip());
+
+                // Act
+                var metadatas = sut.Inflate(filename, netkans, opts)
+                                   .ToArray();
+
+                // Assert
+                CollectionAssert.IsNotEmpty(metadatas);
+            }
+        }
+
+        [Test]
+        public void ValidateCkan_ValidModule_DoesNotThrow()
+        {
+            // Arrange
+            using (var cacheDir = new TemporaryDirectory())
+            {
+                var game    = new KerbalSpaceProgram();
+                var cache   = new NetFileCache(cacheDir.Directory.FullName);
+                var http    = new Mock<IHttpService>();
+                var modSvc  = new ModuleService(game);
+                var fileSvc = new FileService(cache);
+                var sut     = new Inflator(null, null, null, null,
+                                           game, cache, http.Object, modSvc, fileSvc);
+                var ckans   = YamlExtensions.Parse(TestData.DogeCoinPlugin())
+                                            .Select(yaml => new Metadata(yaml))
+                                            .ToArray();
+                http.Setup(h => h.DownloadModule(It.IsAny<Metadata>()))
+                    .Returns(TestData.DogeCoinPluginZip());
+
+                // Act / Assert
+                Assert.DoesNotThrow(() => sut.ValidateCkan(ckans.Single()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

[Coveralls](https://coveralls.io/github/KSP-CKAN/CKAN) says that the file with the most uncovered code, by far, is `Core/IO/ModuleInstaller.cs`.

## Changes

Now several tests are added to cover previously uncovered parts of `ModuleInstaller`.
