### PR TITLE
Fix GUI exceptions for module not in available modules list

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1425,10 +1425,13 @@ namespace CKAN.GUI
                    is { Length: > 0 } and var modules)
             {
                 UseWaitCursor = true;
+                var reg = RegistryManager.Instance(currentInstance, repoData).registry;
                 manager.Cache.Purge(
-                    modules.SelectMany(m => RegistryManager.Instance(currentInstance, repoData)
-                                                           .registry
-                                                           .AvailableByIdentifier(m.Identifier))
+                    modules.SelectMany(m => Enumerable.Repeat(m.ToModule(), 1)
+                                                      .Concat(Utilities.DefaultIfThrows(
+                                                                  () => reg.AvailableByIdentifier(m.Identifier))
+                                                              ?? Enumerable.Empty<CkanModule>())
+                                                      .Distinct())
                            .ToArray());
                 UseWaitCursor = false;
             }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -129,11 +129,13 @@ namespace CKAN.GUI
         private void UpdateCachedByDownloads(CkanModule? module)
         {
             var allGuiMods = ManageMods.AllGUIMods();
+            // Find all mods that share one or more download URLs with the given module, and so on
             var affectedMods =
                 module?.GetDownloadsGroup(allGuiMods.Values
                                                     .Select(guiMod => guiMod.ToModule())
                                                     .OfType<CkanModule>())
-                       .Select(other => allGuiMods[other.identifier])
+                       .Select(other => allGuiMods.GetValueOrDefault(other.identifier))
+                       .OfType<GUIMod>()
                       ?? allGuiMods.Values;
             foreach (var otherMod in affectedMods)
             {

--- a/Tests/Core/IO/ModuleInstallerDirTest.cs
+++ b/Tests/Core/IO/ModuleInstallerDirTest.cs
@@ -6,11 +6,9 @@ using System.Linq;
 using NUnit.Framework;
 
 using CKAN;
-
+using CKAN.IO;
 using Tests.Core.Configuration;
 using Tests.Data;
-
-using CKAN.IO;
 
 namespace Tests.Core.IO
 {

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -416,15 +416,15 @@ namespace Tests.Core.IO
             // Create a new disposable KSP instance to run the test on.
             using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp      = new DisposableKSP())
-            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(nullUser, config))
-            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
-                manager.SetCurrentInstance(ksp.KSP);
+                manager.SetCurrentInstance(inst.KSP);
                 // Make sure the mod is not installed.
-                string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);
+                string mod_file_path = Path.Combine(inst.KSP.game.PrimaryModDirectory(inst.KSP), mod_file_name);
 
                 Assert.IsFalse(File.Exists(mod_file_path));
 
@@ -440,15 +440,15 @@ namespace Tests.Core.IO
 
                 var registry = regMgr.registry;
 
-                Assert.AreEqual(1, registry.CompatibleModules(ksp.KSP.StabilityToleranceConfig, ksp.KSP.VersionCriteria()).Count());
+                Assert.AreEqual(1, registry.CompatibleModules(inst.KSP.StabilityToleranceConfig, inst.KSP.VersionCriteria()).Count());
 
                 // Attempt to install it.
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                 new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                  regMgr,
                                  ref possibleConfigOnlyDirs);
 
@@ -465,14 +465,14 @@ namespace Tests.Core.IO
             // Create a new disposable KSP instance to run the test on.
             using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp      = new DisposableKSP())
-            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(nullUser, config))
-            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
-                manager.SetCurrentInstance(ksp.KSP);
-                string mod_file_path = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), mod_file_name);
+                manager.SetCurrentInstance(inst.KSP);
+                string mod_file_path = Path.Combine(inst.KSP.game.PrimaryModDirectory(inst.KSP), mod_file_name);
 
                 // Install the test mod.
                 var registry = regMgr.registry;
@@ -483,15 +483,15 @@ namespace Tests.Core.IO
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
-                    .InstallList(modules, new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
+                    .InstallList(modules, new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                  regMgr, ref possibleConfigOnlyDirs);
 
                 // Check that the module is installed.
                 Assert.IsTrue(File.Exists(mod_file_path));
 
                 // Attempt to uninstall it.
-                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .UninstallList(modules.Select(m => m.identifier),
                                    ref possibleConfigOnlyDirs, regMgr);
 
@@ -509,14 +509,14 @@ namespace Tests.Core.IO
                                                       TestData.DogeCoinPlugin()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             // Create a new disposable KSP instance to run the test on.
-            using (var ksp      = new DisposableKSP())
-            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(nullUser, config))
-            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
-                manager.SetCurrentInstance(ksp.KSP);
-                string directoryPath = Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP), emptyFolderName);
+                manager.SetCurrentInstance(inst.KSP);
+                string directoryPath = Path.Combine(inst.KSP.game.PrimaryModDirectory(inst.KSP), emptyFolderName);
 
                 // Install the base test mod.
                 var registry = regMgr.registry;
@@ -527,9 +527,9 @@ namespace Tests.Core.IO
                 var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                 new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                  regMgr, ref possibleConfigOnlyDirs);
 
                 modules.Clear();
@@ -541,9 +541,9 @@ namespace Tests.Core.IO
 
                 modules.Add(TestData.DogeCoinPlugin_module());
 
-                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                 new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                  regMgr, ref possibleConfigOnlyDirs);
 
                 modules.Clear();
@@ -556,7 +556,7 @@ namespace Tests.Core.IO
                 modules.Add(TestData.DogeCoinFlag_101_module());
                 modules.Add(TestData.DogeCoinPlugin_module());
 
-                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .UninstallList(modules.Select(m => m.identifier),
                                    ref possibleConfigOnlyDirs, regMgr);
 
@@ -712,13 +712,13 @@ namespace Tests.Core.IO
                 // Create a new disposable KSP instance to run the test on.
                 using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101()))
                 using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-                using (var ksp      = new DisposableKSP())
-                using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+                using (var inst     = new DisposableKSP())
+                using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
                 using (var manager  = new GameInstanceManager(nullUser, config))
-                using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+                using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                                new Repository[] { repo.repo }))
                 {
-                    manager.SetCurrentInstance(ksp.KSP);
+                    manager.SetCurrentInstance(inst.KSP);
                     var registry = regMgr.registry;
 
                     // Copy the zip file to the cache directory.
@@ -730,13 +730,13 @@ namespace Tests.Core.IO
                     var modules = new List<CkanModule> { TestData.DogeCoinFlag_101_module() };
 
                     HashSet<string>? possibleConfigOnlyDirs = null;
-                    new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                    new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                         .InstallList(modules,
-                                     new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                     new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                      regMgr, ref possibleConfigOnlyDirs);
 
                     // Check that the module is installed.
-                    Assert.IsTrue(File.Exists(Path.Combine(ksp.KSP.game.PrimaryModDirectory(ksp.KSP),
+                    Assert.IsTrue(File.Exists(Path.Combine(inst.KSP.game.PrimaryModDirectory(inst.KSP),
                                                            mod_file_name)));
                 }
             }
@@ -776,9 +776,9 @@ namespace Tests.Core.IO
 
             // Act
             List<InstallableFile> results;
-            using (var ksp = new DisposableKSP())
+            using (var inst = new DisposableKSP())
             {
-                results = mod.install!.First().FindInstallableFiles(zip, ksp.KSP);
+                results = mod.install!.First().FindInstallableFiles(zip, inst.KSP);
             }
 
             // Assert
@@ -816,13 +816,13 @@ namespace Tests.Core.IO
                     ]
                 }");
 
-            using (var ksp = new DisposableKSP())
+            using (var inst = new DisposableKSP())
             {
-                var results = mod.install!.First().FindInstallableFiles(zip, ksp.KSP);
+                var results = mod.install!.First().FindInstallableFiles(zip, inst.KSP);
 
                 Assert.AreEqual(
                     CKANPathUtils.NormalizePath(
-                        Path.Combine(ksp.KSP.GameDir(), "saves/scenarios/AwesomeRace.sfs")),
+                        Path.Combine(inst.KSP.GameDir(), "saves/scenarios/AwesomeRace.sfs")),
                     results.First().destination);
             }
         }
@@ -857,7 +857,7 @@ namespace Tests.Core.IO
 
                 // Act
                 var result = ModuleInstaller.FindRecommendations(inst.KSP,
-                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit))
+                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, inst.KSP.StabilityToleranceConfig, crit))
                                                                               .OfType<CkanModule>()
                                                                               .ToHashSet(),
                                                                  Array.Empty<CkanModule>(),
@@ -870,7 +870,7 @@ namespace Tests.Core.IO
                 // Assert
                 Assert.IsTrue(result, "Should return something");
                 CollectionAssert.IsNotEmpty(recommendations, "Should return recommendations");
-                CollectionAssert.AreEquivalent(dlcIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit)),
+                CollectionAssert.AreEquivalent(dlcIdents.Select(ident => registry.LatestAvailable(ident, inst.KSP.StabilityToleranceConfig, crit)),
                                                recommendations.Keys,
                                                "The DLC should be recommended");
             }
@@ -908,7 +908,7 @@ namespace Tests.Core.IO
 
                 // Act
                 var result = ModuleInstaller.FindRecommendations(inst.KSP,
-                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit))
+                                                                 installIdents.Select(ident => registry.LatestAvailable(ident, inst.KSP.StabilityToleranceConfig, crit))
                                                                               .OfType<CkanModule>()
                                                                               .ToHashSet(),
                                                                  Array.Empty<CkanModule>(),
@@ -920,7 +920,7 @@ namespace Tests.Core.IO
 
                 // Assert
                 Assert.IsFalse(result, "Should return nothing");
-                foreach (var mod in dlcIdents.Select(ident => registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, crit)))
+                foreach (var mod in dlcIdents.Select(ident => registry.LatestAvailable(ident, inst.KSP.StabilityToleranceConfig, crit)))
                 {
                     CollectionAssert.DoesNotContain(recommendations, mod,
                                                     "DLC should not be recommended");
@@ -1042,13 +1042,13 @@ namespace Tests.Core.IO
             // Arrange
             using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101ZipSlip()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp      = new DisposableKSP())
-            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(nullUser, config))
-            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
-                manager.SetCurrentInstance(ksp.KSP);
+                manager.SetCurrentInstance(inst.KSP);
                 var registry = regMgr.registry;
 
                 // Copy the zip file to the cache directory.
@@ -1064,9 +1064,9 @@ namespace Tests.Core.IO
                     delegate
                     {
                         HashSet<string>? possibleConfigOnlyDirs = null;
-                        new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                        new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                             .InstallList(modules,
-                                         new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                         new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                          regMgr, ref possibleConfigOnlyDirs);
                     },
                     "Kraken should be thrown if ZIP file attempts to exploit Zip Slip vulnerability");
@@ -1080,13 +1080,13 @@ namespace Tests.Core.IO
             // Arrange
             using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101ZipBomb()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
-            using (var ksp      = new DisposableKSP())
-            using (var config   = new FakeConfiguration(ksp.KSP, ksp.KSP.Name))
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(nullUser, config))
-            using (var regMgr   = RegistryManager.Instance(ksp.KSP, repoData.Manager,
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
             {
-                manager.SetCurrentInstance(ksp.KSP);
+                manager.SetCurrentInstance(inst.KSP);
                 var registry = regMgr.registry;
 
                 // Copy the zip file to the cache directory.
@@ -1099,9 +1099,9 @@ namespace Tests.Core.IO
 
                 // Act / Assert
                 HashSet<string>? possibleConfigOnlyDirs = null;
-                new ModuleInstaller(ksp.KSP, manager.Cache!, config, nullUser)
+                new ModuleInstaller(inst.KSP, manager.Cache!, config, nullUser)
                     .InstallList(modules,
-                                 new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                 new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                  regMgr, ref possibleConfigOnlyDirs);
             }
         }
@@ -1235,10 +1235,10 @@ namespace Tests.Core.IO
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
                 manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), null);
-                var replacement = querier.GetReplacement(replaced.identifier, ksp.KSP.StabilityToleranceConfig,
+                var replacement = querier.GetReplacement(replaced.identifier, inst.KSP.StabilityToleranceConfig,
                                                          new GameVersionCriteria(new GameVersion(1, 12)))!;
                 installer.Replace(Enumerable.Repeat(replacement, 1),
-                                  new RelationshipResolverOptions(ksp.KSP.StabilityToleranceConfig),
+                                  new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
                                   downloader, ref possibleConfigOnlyDirs, regMgr, null,
                                   false);
 
@@ -1301,7 +1301,7 @@ namespace Tests.Core.IO
                 // Act
                 registry.RegisterModule(replaced, new List<string>(), inst.KSP, false);
                 manager.Cache?.Store(replaced, TestData.DogeCoinFlagZip(), null);
-                var replacement = querier.GetReplacement(replaced.identifier, ksp.KSP.StabilityToleranceConfig,
+                var replacement = querier.GetReplacement(replaced.identifier, inst.KSP.StabilityToleranceConfig,
                                                          new GameVersionCriteria(new GameVersion(1, 11)));
 
                 // Assert
@@ -1529,7 +1529,7 @@ namespace Tests.Core.IO
 
                 // Act
                 installer.Upgrade(upgradeIdentifiers.Select(ident =>
-                                      registry.LatestAvailable(ident, ksp.KSP.StabilityToleranceConfig, inst.KSP.VersionCriteria()))
+                                      registry.LatestAvailable(ident, inst.KSP.StabilityToleranceConfig, inst.KSP.VersionCriteria()))
                                                     .OfType<CkanModule>()
                                                     .ToArray(),
                                   downloader, ref possibleConfigOnlyDirs, regMgr, null, false);


### PR DESCRIPTION
## Problems

For a .ckan file representing a mod not in the user's configured metadata repositories:

- Installing from the .ckan file in GUI causes the Downloads Failed popup to appear with an error message of "The given key was not present in the dictionary." (Though the mod will be successfully cached after download and will install successfully if you try again.)
  ```
  System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
     at System.ThrowHelper.ThrowKeyNotFoundException()
     at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
     at CKAN.GUI.Main.<>c__DisplayClass177_0.<UpdateCachedByDownloads>b__1(CkanModule other)
     at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
     at CKAN.GUI.Main.UpdateCachedByDownloads(CkanModule module)
     at CKAN.GUI.Main.OnModStoredOrPurged(CkanModule module)
     at CKAN.NetModuleCache.Store(CkanModule module, String path, IProgress`1 progress, String description, Boolean move, Nullable`1 cancelToken, Boolean validate)
     at CKAN.NetAsyncModulesDownloader.ModuleDownloadComplete(DownloadTarget target, Exception error, String etag, String sha256)
     at CKAN.NetAsyncDownloader.FileDownloadComplete(DownloadPart dl, Exception error, Boolean canceled, String etag, String hash)
  ```
- Purging it throws 
  ```
  CKAN.ModuleNotFoundKraken: Module not found: KsmUI 
     at CKAN.Registry.getAvail(String identifier)
     at CKAN.Registry.AvailableByIdentifier(String identifier)
     at CKAN.GUI.ManageMods.<purgeContentsToolStripMenuItem_Click>b__131_0(GUIMod m)
     at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
     at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
     at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
     at CKAN.GUI.ManageMods.purgeContentsToolStripMenuItem_Click(Object sender, EventArgs e)
     at System.Windows.Forms.ToolStripItem.RaiseEvent(Object key, EventArgs e)
     at System.Windows.Forms.ToolStripMenuItem.OnClick(EventArgs e)
     at System.Windows.Forms.ToolStripItem.HandleClick(EventArgs e)
     at System.Windows.Forms.ToolStripItem.HandleMouseUp(MouseEventArgs e)
     at System.Windows.Forms.ToolStrip.OnMouseUp(MouseEventArgs mea)
     at System.Windows.Forms.ToolStripDropDown.OnMouseUp(MouseEventArgs mea)
     at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
     at System.Windows.Forms.Control.WndProc(Message& m)
     at System.Windows.Forms.ToolStrip.WndProc(Message& m)
     at System.Windows.Forms.ToolStripDropDown.WndProc(Message& m)
     at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
  ```

## Causes

- After the download is added to the cache, the cache alerts GUI, and GUI tries to update the `GUIMod.IsCached` properties of any mods that can install from that ZIP from false to true. When the mod isn't in the available modules list, an exception is thrown at `allGuiMods[other.identifier]`:
  https://github.com/KSP-CKAN/CKAN/blob/92bb2e9e526735a17d0829af3550dc933a6f0cf1/GUI/Main/MainDownload.cs#L128-L142
- When purging from cache, the operation is applied to historical versions as well, not just the installed version. If the mod isn't in the available modules list, an exception is thrown when we use `Registry.AvailableByIdentifier` to find the historical versions:
  https://github.com/KSP-CKAN/CKAN/blob/92bb2e9e526735a17d0829af3550dc933a6f0cf1/GUI/Controls/ManageMods.cs#L1417-L1435

## Changes

- Now we use `GetValueOrDefault` instead of the `[]` indexer to get the modules that can be installed from the ZIP
- Now we ignore the exception thrown by `Registry.AvailableByIdentifier` when purging, because if the module isn't in our list, then we don't need to toggle `IsCached` for it

Fixes #4430.
