### PR TITLE
Even more tests

### DIFF
--- a/Cmdline/Action/AuthToken.cs
+++ b/Cmdline/Action/AuthToken.cs
@@ -152,6 +152,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line

--- a/Cmdline/Action/Cache.cs
+++ b/Cmdline/Action/Cache.cs
@@ -41,6 +41,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line
@@ -264,6 +265,7 @@ namespace CKAN.CmdLine
             }
         }
 
+        [ExcludeFromCodeCoverage]
         private void PrintUsage(string verb)
         {
             foreach (var h in CacheSubOptions.GetHelp(verb))

--- a/Cmdline/Action/Compat.cs
+++ b/Cmdline/Action/Compat.cs
@@ -39,6 +39,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line
@@ -297,6 +298,7 @@ namespace CKAN.CmdLine
             return true;
         }
 
+        [ExcludeFromCodeCoverage]
         private void PrintUsage(string verb)
         {
             foreach (var h in CompatSubOptions.GetHelp(verb))

--- a/Cmdline/Action/Filter.cs
+++ b/Cmdline/Action/Filter.cs
@@ -247,6 +247,7 @@ namespace CKAN.CmdLine
             return instance.game;
         }
 
+        [ExcludeFromCodeCoverage]
         private void PrintUsage(string verb)
         {
             foreach (var h in FilterSubOptions.GetHelp(verb))
@@ -282,6 +283,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line

--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -49,6 +49,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line
@@ -689,6 +690,7 @@ namespace CKAN.CmdLine
         }
         #endregion
 
+        [ExcludeFromCodeCoverage]
         private void PrintUsage(string verb)
         {
             foreach (var h in InstanceSubOptions.GetHelp(verb))

--- a/Cmdline/Action/Mark.cs
+++ b/Cmdline/Action/Mark.cs
@@ -142,6 +142,7 @@ namespace CKAN.CmdLine
             return Exit.ERROR;
         }
 
+        [ExcludeFromCodeCoverage]
         private void PrintUsage(string verb)
         {
             foreach (var h in MarkSubOptions.GetHelp(verb))
@@ -175,6 +176,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line

--- a/Cmdline/Action/Repair.cs
+++ b/Cmdline/Action/Repair.cs
@@ -23,6 +23,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line

--- a/Cmdline/Action/Repo.cs
+++ b/Cmdline/Action/Repo.cs
@@ -42,6 +42,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line
@@ -449,6 +450,7 @@ namespace CKAN.CmdLine
             return Exit.ERROR;
         }
 
+        [ExcludeFromCodeCoverage]
         private void PrintUsage(string verb)
         {
             foreach (var h in RepoSubOptions.GetHelp(verb))

--- a/Cmdline/Action/Stability.cs
+++ b/Cmdline/Action/Stability.cs
@@ -127,6 +127,7 @@ namespace CKAN.CmdLine
             return Exit.OK;
         }
 
+        [ExcludeFromCodeCoverage]
         private static void PrintUsage(IUser user, string verb)
         {
             foreach (var h in StabilitySubOptions.GetHelp(verb))
@@ -160,6 +161,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -142,6 +142,7 @@ namespace CKAN.CmdLine
             return ht;
         }
 
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<string> GetHelp(string verb)
         {
             // Add a usage prefix line

--- a/Core/Logging.cs
+++ b/Core/Logging.cs
@@ -10,36 +10,35 @@ using log4net.Core;
 
 namespace CKAN
 {
-    public class Logging
+    public static class Logging
     {
         public static void Initialize()
         {
-            if (LogManager.GetRepository(Assembly.GetExecutingAssembly()).Configured)
+            if (LogManager.GetRepository(Assembly.GetExecutingAssembly())
+                is { Configured: false } repo)
             {
-                return;
-            }
-
-            // if the log4net.xml file does not exist, then fall back to the existing
-            // configuration process
-            var logConfig = new FileInfo(Path.Combine(Environment.CurrentDirectory, "log4net.xml"));
-            if (!logConfig.Exists)
-            {
-                BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetExecutingAssembly()));
-                LogManager.GetRepository(Assembly.GetExecutingAssembly()).Threshold = Level.Warn;
-            }
-            else
-            {
-                // when the XML file exists, attempt to set up log4net using it
-                try
+                // if the log4net.xml file does not exist, then fall back to the existing
+                // configuration process
+                var logConfig = new FileInfo(Path.Combine(Environment.CurrentDirectory, "log4net.xml"));
+                if (!logConfig.Exists)
                 {
-                    XmlConfigurator.ConfigureAndWatch(LogManager.GetRepository(Assembly.GetExecutingAssembly()), logConfig);
+                    BasicConfigurator.Configure(repo);
+                    repo.Threshold = Level.Warn;
                 }
-                catch (Exception e)
+                else
                 {
-                    Console.WriteLine("Exception trying to configure logging!", e);
+                    // when the XML file exists, attempt to set up log4net using it
+                    try
+                    {
+                        XmlConfigurator.ConfigureAndWatch(repo, logConfig);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine("Exception trying to configure logging!", e);
 
-                    // attempt to fall back to basic
-                    BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetExecutingAssembly()));
+                        // attempt to fall back to basic
+                        BasicConfigurator.Configure(repo);
+                    }
                 }
             }
         }

--- a/Core/Net/Net.cs
+++ b/Core/Net/Net.cs
@@ -327,7 +327,7 @@ namespace CKAN
                     segments.Count < 6
                     || segments[3] is not ("blob/" or "tree/"))
                 {
-                    log.WarnFormat("Remote non-raw GitHub URL is in an unknown format, using as is.");
+                    log.InfoFormat("Remote non-raw GitHub URL is in an unknown format, using as is.");
                     return remoteUri;
                 }
 

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using ChinhDo.Transactions.FileManager;
 using log4net;
@@ -179,6 +180,7 @@ namespace CKAN
         /// <returns>
         /// true if launched, false otherwise
         /// </returns>
+        [ExcludeFromCodeCoverage]
         public static bool ProcessStartURL(string url)
         {
             try
@@ -211,6 +213,7 @@ namespace CKAN
             return false;
         }
 
+        [ExcludeFromCodeCoverage]
         public static void OpenFileBrowser(string location)
         {
             // We need the folder of the file

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -160,7 +160,9 @@ namespace CKAN.GUI
         public readonly ModuleLabel? WarningLabel = null;
         public readonly string?      Conflict     = null;
 
-        public string Mod         => Change.NameAndStatus ?? "";
+        public string Mod         => Main.Instance?.Manager?.Cache is NetModuleCache cache
+                                         ? Change.NameAndStatus(cache)
+                                         : "";
         public string ChangeType  => Change.ChangeType.LocalizeDescription();
         public string Reasons     { get; private set; }
         public Bitmap DeleteImage => Change.IsRemovable ? EmbeddedImages.textClear ?? EmptyBitmap

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1366,7 +1366,7 @@ namespace CKAN.GUI
         {
             if (SelectedModules.ToArray() is { Length: > 0 } and var modules)
             {
-                var downloadable = modules.Where(m => !m.ToModule().IsMetapackage)
+                var downloadable = modules.Where(m => !m.Module.IsMetapackage)
                                           .ToArray();
                 // Set the menu options
                 downloadContentsToolStripMenuItem.Enabled = downloadable.Any(m => !m.IsCached);
@@ -1386,7 +1386,7 @@ namespace CKAN.GUI
         private void reinstallToolStripMenuItem_Click(object? sender, EventArgs? e)
         {
             if (SelectedModules.Where(m => m.IsInstalled && !m.IsAutodetected)
-                               .Select(m => m.ToModule())
+                               .Select(m => m.Module)
                                .ToArray()
                 is { Length: > 0 } and var modules
                 && currentInstance != null)
@@ -1419,7 +1419,7 @@ namespace CKAN.GUI
             // Purge other versions as well since the user is likely to want that
             // and has no other way to achieve it
             if (currentInstance != null && manager?.Cache != null
-                && SelectedModules.Where(m => !m.ToModule().IsMetapackage
+                && SelectedModules.Where(m => !m.Module.IsMetapackage
                                               && m.IsCached)
                                   .ToArray()
                    is { Length: > 0 } and var modules)
@@ -1427,7 +1427,7 @@ namespace CKAN.GUI
                 UseWaitCursor = true;
                 var reg = RegistryManager.Instance(currentInstance, repoData).registry;
                 manager.Cache.Purge(
-                    modules.SelectMany(m => Enumerable.Repeat(m.ToModule(), 1)
+                    modules.SelectMany(m => Enumerable.Repeat(m.Module, 1)
                                                       .Concat(Utilities.DefaultIfThrows(
                                                                   () => reg.AvailableByIdentifier(m.Identifier))
                                                               ?? Enumerable.Empty<CkanModule>())
@@ -1439,7 +1439,7 @@ namespace CKAN.GUI
 
         private void downloadContentsToolStripMenuItem_Click(object? sender, EventArgs? e)
         {
-            if (SelectedModules.Where(m => !m.ToModule().IsMetapackage
+            if (SelectedModules.Where(m => !m.Module.IsMetapackage
                                            && !m.IsCached)
                                .ToArray()
                 is { Length: > 0 } and var modules)
@@ -1786,8 +1786,8 @@ namespace CKAN.GUI
         {
             var gmodA = a.Tag as GUIMod;
             var gmodB = b.Tag as GUIMod;
-            var modA = gmodA?.ToModule();
-            var modB = gmodB?.ToModule();
+            var modA = gmodA?.Module;
+            var modB = gmodB?.Module;
             var cellA = a.Cells[col.Index];
             var cellB = b.Cells[col.Index];
             if (col is DataGridViewCheckBoxColumn)

--- a/GUI/Controls/ModInfo/Contents.cs
+++ b/GUI/Controls/ModInfo/Contents.cs
@@ -43,12 +43,12 @@ namespace CKAN.GUI
                     if (selectedModule != null)
                     {
                         ContentsDownloadButton.Text = string.Format(Properties.Resources.ModInfoDownload,
-                                                                    CkanModule.FmtSize(selectedModule.ToModule().download_size));
+                                                                    CkanModule.FmtSize(selectedModule.Module.download_size));
                         selectedModule.PropertyChanged += SelectedMod_PropertyChanged;
                     }
                     Util.Invoke(ContentsPreviewTree,
                                 () => _UpdateModContentsTree(selectedModule?.InstalledMod,
-                                                             selectedModule?.ToModule()));
+                                                             selectedModule?.Module));
                 }
             }
             get => selectedModule;
@@ -118,7 +118,7 @@ namespace CKAN.GUI
         private void ContentsOpenButton_Click(object? sender, EventArgs? e)
         {
             if (SelectedModule != null
-                && manager?.Cache?.GetCachedFilename(SelectedModule.ToModule()) is string s)
+                && manager?.Cache?.GetCachedFilename(SelectedModule.Module) is string s)
             {
                 Utilities.ProcessStartURL(s);
             }

--- a/GUI/Controls/ModInfo/Metadata.cs
+++ b/GUI/Controls/ModInfo/Metadata.cs
@@ -24,7 +24,7 @@ namespace CKAN.GUI
 
         public void UpdateModInfo(GUIMod gui_module)
         {
-            CkanModule module = gui_module.ToModule();
+            CkanModule module = gui_module.Module;
 
             Util.Invoke(this, () =>
             {
@@ -61,7 +61,7 @@ namespace CKAN.GUI
 
                 var compatMod = gui_module.LatestCompatibleMod
                                 ?? gui_module.LatestAvailableMod
-                                ?? gui_module.ToModule();
+                                ?? gui_module.Module;
                 GameCompatibilityTextBox.Text = string.Format(
                     Properties.Resources.GUIModGameCompatibilityLong,
                     gui_module.GameCompatibility,

--- a/GUI/Controls/ModInfo/ModInfo.cs
+++ b/GUI/Controls/ModInfo/ModInfo.cs
@@ -126,7 +126,7 @@ namespace CKAN.GUI
 
         private void UpdateHeaderInfo(GUIMod gmod, GameVersionCriteria crit)
         {
-            var module = gmod.ToModule();
+            var module = gmod.Module;
             Util.Invoke(this, () =>
             {
                 ModInfoTabControl.SuspendLayout();

--- a/GUI/Controls/ModInfo/Relationships.cs
+++ b/GUI/Controls/ModInfo/Relationships.cs
@@ -77,7 +77,7 @@ namespace CKAN.GUI
                         ReverseRelationshipsCheckbox.CheckState = CheckState.Unchecked;
                     }
                     selectedModule = value;
-                    UpdateModDependencyGraph(selectedModule?.ToModule());
+                    UpdateModDependencyGraph(selectedModule?.Module);
                 }
             }
             get => selectedModule;
@@ -125,7 +125,7 @@ namespace CKAN.GUI
 
         private void ReverseRelationshipsCheckbox_CheckedChanged(object? sender, EventArgs? e)
         {
-            UpdateModDependencyGraph(SelectedModule?.ToModule());
+            UpdateModDependencyGraph(SelectedModule?.Module);
         }
 
         private void _UpdateModDependencyGraph(CkanModule module)

--- a/GUI/Controls/ModInfo/Versions.cs
+++ b/GUI/Controls/ModInfo/Versions.cs
@@ -330,7 +330,7 @@ namespace CKAN.GUI
                     if (startingModule.Equals(visibleGuiModule))
                     {
                         // Only show checkboxes for non-DLC modules
-                        VersionsListView.CheckBoxes = interactive && !gmod.ToModule().IsDLC;
+                        VersionsListView.CheckBoxes = interactive && !gmod.Module.IsDLC;
                         ignoreItemCheck = true;
                         VersionsListView.Items.AddRange(items);
                         VersionsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -834,7 +834,7 @@ namespace CKAN.GUI
         private GUIMod? ActiveModInfo
         {
             set {
-                if (value?.ToModule() == null)
+                if (value?.Module == null)
                 {
                     splitContainer1.Panel2Collapsed = true;
                 }
@@ -878,7 +878,7 @@ namespace CKAN.GUI
                 tabController.ShowTab(ChangesetTabPage.Name, 1, false);
                 UpdateChangesDialog(
                     changeset,
-                    conflicts.ToDictionary(item => item.Key.ToCkanModule(),
+                    conflicts.ToDictionary(item => item.Key.Module,
                                            item => item.Value));
                 AuditRecommendationsToolStripMenuItem.Enabled = false;
             }
@@ -993,7 +993,7 @@ namespace CKAN.GUI
         private void ManageMods_StartChangeSet(List<ModChange> changeset, Dictionary<GUIMod, string> conflicts)
         {
             UpdateChangesDialog(changeset,
-                                conflicts?.ToDictionary(item => item.Key.ToCkanModule(),
+                                conflicts?.ToDictionary(item => item.Key.Module,
                                                         item => item.Value));
             tabController.ShowTab(ChangesetTabPage.Name, 1);
         }

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -26,7 +26,7 @@ namespace CKAN.GUI
                 Task.Run(() =>
                 {
                     // Just pass to the existing worker
-                    downloader.DownloadModules(modules.Select(m => m.ToModule()));
+                    downloader.DownloadModules(modules.Select(m => m.Module));
                 });
             }
             else
@@ -59,7 +59,7 @@ namespace CKAN.GUI
                 {
                     try
                     {
-                        downloader.DownloadModules(modules.Select(m => m.ToModule()));
+                        downloader.DownloadModules(modules.Select(m => m.Module));
                         done = true;
                     }
                     catch (ModuleDownloadErrorsKraken k)
@@ -72,7 +72,7 @@ namespace CKAN.GUI
                                 Properties.Resources.ModDownloadsFailedColHdr,
                                 Properties.Resources.ModDownloadsFailedAbortBtn,
                                 k.Exceptions.Select(kvp => new KeyValuePair<object[], Exception>(
-                                    modules.Select(m => m.ToModule()).ToArray(), kvp.Value)),
+                                    modules.Select(m => m.Module).ToArray(), kvp.Value)),
                                 (m1, m2) => (m1 as CkanModule)?.download == (m2 as CkanModule)?.download);
                              dfd.ShowDialog(this);
                         });
@@ -132,7 +132,7 @@ namespace CKAN.GUI
             // Find all mods that share one or more download URLs with the given module, and so on
             var affectedMods =
                 module?.GetDownloadsGroup(allGuiMods.Values
-                                                    .Select(guiMod => guiMod.ToModule())
+                                                    .Select(guiMod => guiMod.Module)
                                                     .OfType<CkanModule>())
                        .Select(other => allGuiMods.GetValueOrDefault(other.identifier))
                        .OfType<GUIMod>()

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -99,7 +99,6 @@ namespace CKAN.GUI
         public string Description { get; private set; }
         public string Identifier { get; private set; }
         public bool IsNew { get; set; }
-        public bool IsCKAN => Mod != null;
         public string Abbrevation { get; private set; }
 
         public string SearchableName { get; private set; }
@@ -296,26 +295,9 @@ namespace CKAN.GUI
 
         /// <summary>
         /// Get the CkanModule associated with this GUIMod.
-        /// See <see cref="ToModule"/> for a method that doesn't throw.
-        /// </summary>
-        /// <returns>The CkanModule associated with this GUIMod</returns>
-        /// <exception cref="InvalidCastException">Thrown if no CkanModule is associated</exception>
-        public CkanModule ToCkanModule()
-        {
-            if (!IsCKAN)
-            {
-                throw new InvalidCastException(Properties.Resources.GUIModMethodNotCKAN);
-            }
-
-            var mod = Mod;
-            return mod;
-        }
-
-        /// <summary>
-        /// Get the CkanModule associated with this GUIMod.
         /// </summary>
         /// <returns>The CkanModule associated with this GUIMod or null if there is none</returns>
-        public CkanModule ToModule() => Mod;
+        public CkanModule Module => Mod;
 
         public IEnumerable<ModChange> GetModChanges(bool upgradeChecked,
                                                     bool replaceChecked,

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -99,24 +99,11 @@ namespace CKAN.GUI
         }
 
         public override bool Equals(object? obj)
-        {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            if (obj.GetType() != GetType())
-            {
-                return false;
-            }
-
-            return (obj as ModChange)?.Mod.Equals(Mod) ?? false;
-        }
+            => obj is not null
+               && (ReferenceEquals(this, obj)
+                   || (obj is ModChange ch
+                       && ch.Mod.Equals(Mod)
+                       && ch.ChangeType.Equals(ChangeType)));
 
         private static readonly int maxEnumVal = Enum.GetValues(typeof(GUIModChangeType)).Cast<int>().Max();
 
@@ -129,8 +116,8 @@ namespace CKAN.GUI
         public override string ToString()
             => $"{ChangeType.LocalizeDescription()} {Mod} ({Description})";
 
-        public virtual string? NameAndStatus
-            => Main.Instance?.Manager?.Cache?.DescribeAvailability(config, Mod);
+        public virtual string NameAndStatus(NetModuleCache cache)
+            => cache.DescribeAvailability(config, Mod);
 
         private static string DescribeGroup(IEnumerable<SelectionReason> reasons)
             => reasons.First().DescribeWith(reasons.Skip(1));
@@ -164,8 +151,8 @@ namespace CKAN.GUI
             this.metadataChanged = metadataChanged;
         }
 
-        public override string? NameAndStatus
-            => Main.Instance?.Manager?.Cache?.DescribeAvailability(config, targetMod);
+        public override string NameAndStatus(NetModuleCache cache)
+            => cache.DescribeAvailability(config, targetMod);
 
         public override string Description
             => IsReinstall

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -550,7 +550,7 @@ namespace CKAN.GUI
             var compat        = new DataGridViewTextBoxCell { Value = mod.GameCompatibility       };
             var downloadSize  = new DataGridViewTextBoxCell { Value = mod.DownloadSize            };
             var installSize   = new DataGridViewTextBoxCell { Value = mod.InstallSize             };
-            var releaseDate   = new DataGridViewTextBoxCell { Value = mod.ToModule().release_date };
+            var releaseDate   = new DataGridViewTextBoxCell { Value = mod.Module.release_date     };
             var installDate   = new DataGridViewTextBoxCell { Value = mod.InstallDate             };
             var desc          = new DataGridViewTextBoxCell { Value = ToGridText(mod.Abstract)    };
 

--- a/GUI/Model/ModSearch.cs
+++ b/GUI/Model/ModSearch.cs
@@ -580,7 +580,7 @@ namespace CKAN.GUI
 
         private bool MatchesLicenses(GUIMod mod)
         {
-            var ckm = mod.ToModule();
+            var ckm = mod.Module;
             return Licenses.Count < 1
                 || (
                     ckm.license != null
@@ -593,7 +593,7 @@ namespace CKAN.GUI
 
         private bool MatchesLocalizations(GUIMod mod)
         {
-            var ckm = mod.ToModule();
+            var ckm = mod.Module;
             return Localizations.Count < 1
                 || (
                     ckm.localizations != null
@@ -605,15 +605,15 @@ namespace CKAN.GUI
         }
 
         private bool MatchesDepends(GUIMod mod)
-            => RelationshipMatch(mod.ToModule().depends, DependsOn);
+            => RelationshipMatch(mod.Module.depends, DependsOn);
         private bool MatchesRecommends(GUIMod mod)
-            => RelationshipMatch(mod.ToModule().recommends, Recommends);
+            => RelationshipMatch(mod.Module.recommends, Recommends);
         private bool MatchesSuggests(GUIMod mod)
-            => RelationshipMatch(mod.ToModule().suggests, Suggests);
+            => RelationshipMatch(mod.Module.suggests, Suggests);
         private bool MatchesConflicts(GUIMod mod)
-            => RelationshipMatch(mod.ToModule().conflicts, ConflictsWith);
+            => RelationshipMatch(mod.Module.conflicts, ConflictsWith);
         private bool MatchesSupports(GUIMod mod)
-            => RelationshipMatch(mod.ToModule().supports, Supports);
+            => RelationshipMatch(mod.Module.supports, Supports);
         private static bool RelationshipMatch(List<RelationshipDescriptor>? rels, List<string> toFind)
             => toFind.Count < 1
                 || (rels != null && toFind.All(searchRel =>
@@ -625,8 +625,8 @@ namespace CKAN.GUI
                 || TagNames.All(tn =>
                         ShouldNegateTerm(tn, out string subTag) ^ (
                             string.IsNullOrEmpty(subTag)
-                                ? mod.ToModule().Tags == null
-                                : mod.ToModule().Tags?.Contains(subTag) ?? false));
+                                ? mod.Module.Tags == null
+                                : mod.Module.Tags?.Contains(subTag) ?? false));
 
         private bool MatchesLabels(GUIMod mod)
             => LabelsByNegation.All(kvp =>

--- a/GUI/Plugins/IGUIPlugin.cs
+++ b/GUI/Plugins/IGUIPlugin.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using CKAN.Versioning;
 
 namespace CKAN.GUI
 {
+    [ExcludeFromCodeCoverage]
     public abstract class IGUIPlugin
     {
 

--- a/GUI/Plugins/PluginController.cs
+++ b/GUI/Plugins/PluginController.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 using log4net;
 
 namespace CKAN.GUI
 {
+    [ExcludeFromCodeCoverage]
     public class PluginController
     {
         public PluginController(string path, bool activate = true)
@@ -125,7 +127,10 @@ namespace CKAN.GUI
                 }
                 catch (Exception ex)
                 {
-                    log.ErrorFormat("Failed to activate plugin \"{0} - {1}\" - {2}", plugin.GetName(), plugin.GetVersion(), ex.Message);
+                    log.ErrorFormat("Failed to activate plugin \"{0} - {1}\" - {2}",
+                                    plugin.GetName(),
+                                    plugin.GetVersion(),
+                                    ex.ToString());
                     return;
                 }
 

--- a/Netkan/Model/OverrideOptions.cs
+++ b/Netkan/Model/OverrideOptions.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -26,15 +24,5 @@ namespace CKAN.NetKAN.Model
         [JsonProperty("delete", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(JsonSingleOrArrayConverter<string>))]
         public readonly List<string>? Delete;
-
-        public override string ToString()
-        {
-            var sw = new StringWriter(new StringBuilder());
-            using (var writer = new JsonTextWriter(sw))
-            {
-                new JsonSerializer().Serialize(writer, this);
-            }
-            return sw.ToString();
-        }
     }
 }

--- a/Netkan/Sources/Jenkins/JenkinsBuild.cs
+++ b/Netkan/Sources/Jenkins/JenkinsBuild.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -34,12 +36,13 @@ namespace CKAN.NetKAN.Sources.Jenkins
                 ? UnixEpoch.AddMilliseconds(d)
                 : null;
 
+        [ExcludeFromCodeCoverage]
+        public override bool CanWrite => false;
+
+        [ExcludeFromCodeCoverage]
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            if (value is DateTime dateTime)
-            {
-                writer.WriteValue((long)(dateTime.ToUniversalTime() - UnixEpoch).TotalMilliseconds);
-            }
+            throw new NotImplementedException();
         }
 
         private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/Netkan/Transformers/SpacedockTransformer.cs
+++ b/Netkan/Transformers/SpacedockTransformer.cs
@@ -96,14 +96,14 @@ namespace CKAN.NetKAN.Transformers
             // "GPLv3" - Becomes "GPL-3.0"
             // "LGPL"  - Specific version is indeterminate
             json.SafeAdd("license",
-                         sdMod.license?.Trim().Replace(' ', '-') switch
+                         sdMod.license switch
                          {
                              "GPLv2"                        => "GPL-2.0",
                              "GPLv3"                        => "GPL-3.0",
                              "Other"                        => "unknown",
                              "ARR" or "All Rights Reserved"
                                    or "All rights reserved" => "restricted",
-                             var sdLicense                  => sdLicense,
+                             var sdLicense                  => sdLicense?.Trim().Replace(' ', '-'),
                          });
 
             // Make sure resources exist.

--- a/Tests/CmdLine/ReplaceTests.cs
+++ b/Tests/CmdLine/ReplaceTests.cs
@@ -14,39 +14,38 @@ namespace Tests.CmdLine
     [TestFixture]
     public class ReplaceTests
     {
-        [Test,
-            TestCase(new string[]
-                     {
-                         @"{
-                             ""spec_version"": 1,
-                             ""identifier"":   ""ReplaceableMod"",
-                             ""version"":      ""1.0"",
-                             ""download"":     ""https://github.com/"",
-                             ""install"": [
-                                 {
-                                     ""find"": ""DogeCoinFlag"",
-                                     ""install_to"": ""GameData""
-                                 }
-                             ],
-                             ""replaced_by"": { ""name"": ""ReplacementMod"" }
-                         }",
-                         @"{
-                             ""spec_version"": 1,
-                             ""identifier"":   ""ReplacementMod"",
-                             ""version"":      ""1.0"",
-                             ""download"":     ""https://github.com/"",
-                             ""install"": [
-                                 {
-                                     ""find"": ""DogeCoinFlag"",
-                                     ""install_to"": ""GameData""
-                                 }
-                             ]
-                         }",
-                     },
-                     "ReplaceableMod",
-                     "1.0",
-                     "ReplacementMod",
-                     "1.0"),
+        [TestCase(new string[]
+                  {
+                      @"{
+                          ""spec_version"": 1,
+                          ""identifier"":   ""ReplaceableMod"",
+                          ""version"":      ""1.0"",
+                          ""download"":     ""https://github.com/"",
+                          ""install"": [
+                              {
+                                  ""find"": ""DogeCoinFlag"",
+                                  ""install_to"": ""GameData""
+                              }
+                          ],
+                          ""replaced_by"": { ""name"": ""ReplacementMod"" }
+                      }",
+                      @"{
+                          ""spec_version"": 1,
+                          ""identifier"":   ""ReplacementMod"",
+                          ""version"":      ""1.0"",
+                          ""download"":     ""https://github.com/"",
+                          ""install"": [
+                              {
+                                  ""find"": ""DogeCoinFlag"",
+                                  ""install_to"": ""GameData""
+                              }
+                          ]
+                      }",
+                  },
+                  "ReplaceableMod",
+                  "1.0",
+                  "ReplacementMod",
+                  "1.0"),
         ]
         public void RunCommand_ReplaceableMod_Works(string[] modules,
                                                     string   ident1,
@@ -70,6 +69,80 @@ namespace Tests.CmdLine
                 var opts = new ReplaceOptions()
                 {
                     modules = new List<string> { ident1 },
+                };
+
+                // Act
+                regMgr.registry.RegisterModule(module1, new string[] { }, inst.KSP, false);
+                manager.Cache?.Store(module2, TestData.DogeCoinFlagZip(), null);
+                ICommand cmd = new Replace(manager, repoData.Manager, user);
+                cmd.RunCommand(inst.KSP, opts);
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                    CollectionAssert.AreEqual(Enumerable.Empty<string>(),
+                                              user.RaisedErrors);
+                    CollectionAssert.AreEqual(new CkanModule[] { module2 },
+                                              regMgr.registry.InstalledModules.Select(m => m.Module));
+                });
+            }
+        }
+
+        [TestCase(new string[]
+                  {
+                      @"{
+                          ""spec_version"": 1,
+                          ""identifier"":   ""ReplaceableMod"",
+                          ""version"":      ""1.0"",
+                          ""download"":     ""https://github.com/"",
+                          ""install"": [
+                              {
+                                  ""find"": ""DogeCoinFlag"",
+                                  ""install_to"": ""GameData""
+                              }
+                          ],
+                          ""replaced_by"": { ""name"": ""ReplacementMod"" }
+                      }",
+                      @"{
+                          ""spec_version"": 1,
+                          ""identifier"":   ""ReplacementMod"",
+                          ""version"":      ""1.0"",
+                          ""download"":     ""https://github.com/"",
+                          ""install"": [
+                              {
+                                  ""find"": ""DogeCoinFlag"",
+                                  ""install_to"": ""GameData""
+                              }
+                          ]
+                      }",
+                  },
+                  "ReplaceableMod",
+                  "1.0",
+                  "ReplacementMod",
+                  "1.0"),
+        ]
+        public void RunCommand_All_Works(string[] modules,
+                                                    string   ident1,
+                                                    string   version1,
+                                                    string   ident2,
+                                                    string   version2)
+        {
+            // Arrange
+            var user = new CapturingUser(false, q => true, (msg, objs) => 0);
+            using (var inst     = new DisposableKSP())
+            using (var repo     = new TemporaryRepository(modules))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager  = new GameInstanceManager(user, config))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
+            {
+                manager.SetCurrentInstance(inst.KSP);
+                var module1 = regMgr.registry.GetModuleByVersion(ident1, version1)!;
+                var module2 = regMgr.registry.GetModuleByVersion(ident2, version2)!;
+                var opts = new ReplaceOptions()
+                {
+                    replace_all = true,
                 };
 
                 // Act

--- a/Tests/CmdLine/StabilityTests.cs
+++ b/Tests/CmdLine/StabilityTests.cs
@@ -20,15 +20,29 @@ namespace Tests.CmdLine
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
             {
+                manager.SetCurrentInstance(inst.KSP);
                 ISubCommand sut     = new Stability(manager, repoData.Manager, user);
                 var         args    = new string[] { "stability", "list" };
                 var         subOpts = new SubCommandOptions(args);
+                var         stabTol = inst.KSP.StabilityToleranceConfig;
 
                 // Act
+                stabTol.SetModStabilityTolerance("mod1", ReleaseStatus.stable);
+                stabTol.SetModStabilityTolerance("mod2", ReleaseStatus.testing);
+                stabTol.SetModStabilityTolerance("mod3", ReleaseStatus.development);
                 sut.RunSubCommand(null, subOpts);
 
                 // Assert
-                CollectionAssert.AreEqual(new string[] { "Overall stability tolerance: stable" },
+                CollectionAssert.AreEqual(new string[]
+                                          {
+                                              "Overall stability tolerance: stable",
+                                              "",
+                                              "Mod   Override   ",
+                                              "----  -----------",
+                                              "mod1  stable     ",
+                                              "mod2  testing    ",
+                                              "mod3  development",
+                                          },
                                           user.RaisedMessages);
             }
         }
@@ -43,16 +57,30 @@ namespace Tests.CmdLine
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager  = new GameInstanceManager(user, config))
             {
-                ISubCommand sut = new Stability(manager, repoData.Manager, user);
-                var         args    = new string[] { "stability", "set", "testing" };
-                var         subOpts = new SubCommandOptions(args);
+                manager.SetCurrentInstance(inst.KSP);
+                var stabTol = inst.KSP.StabilityToleranceConfig;
+                ISubCommand sut      = new Stability(manager, repoData.Manager, user);
+                var         args1    = new string[] { "stability", "set", "testing" };
+                var         subOpts1 = new SubCommandOptions(args1);
+                var         args2    = new string[] { "stability", "set", "--mod", "mod1", "stable" };
+                var         subOpts2 = new SubCommandOptions(args2);
+                var         args3    = new string[] { "stability", "set", "--mod", "mod2", "testing" };
+                var         subOpts3 = new SubCommandOptions(args3);
+                var         args4    = new string[] { "stability", "set", "--mod", "mod3", "development" };
+                var         subOpts4 = new SubCommandOptions(args4);
 
                 // Act
-                sut.RunSubCommand(null, subOpts);
+                sut.RunSubCommand(null, subOpts1);
+                sut.RunSubCommand(null, subOpts2);
+                sut.RunSubCommand(null, subOpts3);
+                sut.RunSubCommand(null, subOpts4);
 
                 // Assert
-                Assert.AreEqual(ReleaseStatus.testing,
-                                inst.KSP.StabilityToleranceConfig.OverallStabilityTolerance);
+                CollectionAssert.IsEmpty(user.RaisedErrors);
+                Assert.AreEqual(ReleaseStatus.testing,     stabTol.OverallStabilityTolerance);
+                Assert.AreEqual(ReleaseStatus.stable,      stabTol.ModStabilityTolerance("mod1"));
+                Assert.AreEqual(ReleaseStatus.testing,     stabTol.ModStabilityTolerance("mod2"));
+                Assert.AreEqual(ReleaseStatus.development, stabTol.ModStabilityTolerance("mod3"));
             }
         }
     }

--- a/Tests/CmdLine/UpgradeTests.cs
+++ b/Tests/CmdLine/UpgradeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -76,7 +77,7 @@ namespace Tests.CmdLine
                 manager.SetCurrentInstance(inst.KSP);
                 var fromModule = regMgr.registry.GetModuleByVersion(identifier, fromVersion)!;
                 var toModule   = regMgr.registry.GetModuleByVersion(identifier, toVersion)!;
-                regMgr.registry.RegisterModule(fromModule, new List<string>(), inst.KSP, false);
+                regMgr.registry.RegisterModule(fromModule, Array.Empty<string>(), inst.KSP, false);
                 manager.Cache?.Store(toModule, TestData.DogeCoinFlagZip(), null);
                 var opts = new UpgradeOptions()
                 {
@@ -620,7 +621,7 @@ namespace Tests.CmdLine
                 foreach (var fromModule in instMods)
                 {
                     regMgr.registry.RegisterModule(fromModule,
-                                                   new List<string>(),
+                                                   Array.Empty<string>(),
                                                    inst.KSP, false);
                 }
                 // Pre-store mods that might be installed

--- a/Tests/Core/IO/SteamLibraryTests.cs
+++ b/Tests/Core/IO/SteamLibraryTests.cs
@@ -1,11 +1,8 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 
 using NUnit.Framework;
-using log4net;
-using log4net.Core;
 
 using CKAN.IO;
 using Tests.Data;
@@ -53,7 +50,6 @@ namespace Tests.Core.IO
         public void Constructor_WithCorruptedLibrary_Works()
         {
             // Arrange
-            LogManager.GetRepository(Assembly.GetExecutingAssembly()).Threshold = Level.Off;
             using (var dir = new TemporarySteamDirectory(
                                  new (string acfFileName, int appId, string appName)[]
                                  {
@@ -79,18 +75,21 @@ namespace Tests.Core.IO
                 File.WriteAllBytes(Path.Combine(dir.AppsDirectory.FullName, "appmanifest_253250.acf"),
                                    Enumerable.Repeat((byte)0, 128).ToArray());
 
-                // Act
-                var lib = new SteamLibrary(dir.Directory.FullName);
+                using (var noLog = new TemporaryLogSuppressor())
+                {
+                    // Act
+                    var lib = new SteamLibrary(dir.Directory.FullName);
 
-                // Assert
-                CollectionAssert.AreEquivalent(new string[]
-                                               {
-                                                   "Kerbal Space Program",
-                                                   "Kerbal Space Program 2",
-                                                   "Test Instance",
-                                                   "Empty StartDir",
-                                               },
-                                               lib.Games.Select(g => g.Name));
+                    // Assert
+                    CollectionAssert.AreEquivalent(new string[]
+                                                   {
+                                                       "Kerbal Space Program",
+                                                       "Kerbal Space Program 2",
+                                                       "Test Instance",
+                                                       "Empty StartDir",
+                                                   },
+                                                   lib.Games.Select(g => g.Name));
+                }
             }
         }
 

--- a/Tests/Core/Registry/RegistryManager.cs
+++ b/Tests/Core/Registry/RegistryManager.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Linq;
 using System.IO;
-using System.Reflection;
 
 using NUnit.Framework;
-using log4net;
-using log4net.Core;
 
 using CKAN;
 using CKAN.Versioning;
@@ -114,12 +111,11 @@ namespace Tests.Core.Registry
         public void Registry_ZeroByteRegistryJson_EmptyRegistryWithoutCrash()
         {
             // Arrange
-            LogManager.GetRepository(Assembly.GetExecutingAssembly()).Threshold = Level.Off;
-
-            // Act
             var user = new NullUser();
             using (var repo     = new TemporaryRepository())
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var noLog    = new TemporaryLogSuppressor())
+            // Act
             using (var inst     = new DisposableKSP(TestData.TestRegistryZeroBytes()))
             using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
@@ -150,6 +146,7 @@ namespace Tests.Core.Registry
             using (var repo     = new TemporaryRepository())
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
             using (var inst     = new DisposableKSP())
+            using (var noLog    = new TemporaryLogSuppressor())
             {
                 var gamedata = inst.KSP.game.PrimaryModDirectory(inst.KSP);
                 Assert.IsTrue(Path.IsPathRooted(gamedata));
@@ -205,6 +202,7 @@ namespace Tests.Core.Registry
             var user = new NullUser();
             using (var repo     = new TemporaryRepository())
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var noLog    = new TemporaryLogSuppressor())
             using (var inst     = new DisposableKSP(TestData.TestRegistryVersion1()))
             using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))

--- a/Tests/Core/Types/ModuleInstallDescriptorTests.cs
+++ b/Tests/Core/Types/ModuleInstallDescriptorTests.cs
@@ -1,8 +1,13 @@
+using System.IO;
+using System.Linq;
+
 using NUnit.Framework;
 using Newtonsoft.Json;
+using ICSharpCode.SharpZipLib.Zip;
 
 using CKAN;
 using CKAN.Games.KerbalSpaceProgram;
+using Tests.Data;
 
 namespace Tests.Core.Types
 {
@@ -51,5 +56,113 @@ namespace Tests.Core.Types
             Assert.That(act, Throws.Exception);
         }
 
+        [Test]
+        public void DefaultInstallStanza_KSP1_GameData()
+        {
+            // Arrange
+            var game = new KerbalSpaceProgram();
+            var stanza = ModuleInstallDescriptor.DefaultInstallStanza(game, "DogeCoinFlag");
+            // Same again, but screwing up the case (we see this *all the time*)
+            var stanza2 = ModuleInstallDescriptor.DefaultInstallStanza(game, "DogecoinFlag");
+
+            // Assert
+            Assert.AreEqual("GameData",     stanza.install_to);
+            Assert.AreEqual("DogeCoinFlag", stanza.find);
+            Assert.AreEqual("GameData",     stanza2.install_to);
+            Assert.AreEqual("DogecoinFlag", stanza2.find);
+        }
+
+        [TestCase("Ships")]
+        [TestCase("Ships/VAB")]
+        [TestCase("Ships/SPH")]
+        [TestCase("Ships/@thumbs")]
+        [TestCase("Ships/@thumbs/VAB")]
+        [TestCase("Ships/@thumbs/SPH")]
+        [TestCase("Ships/Script")]
+        public void AllowsInstallsToShipsDirectories(string directory)
+        {
+            // Arrange
+            var zip = ZipFile.Create(new MemoryStream());
+            zip.BeginUpdate();
+            zip.AddDirectory("ExampleShips");
+            zip.Add(new ZipEntry("ExampleShips/AwesomeShip.craft") { Size = 0, CompressedSize = 0 });
+            zip.CommitUpdate();
+
+            var mod = CkanModule.FromJson(string.Format(
+                @"{{
+                    ""spec_version"": 1,
+                    ""identifier"": ""AwesomeMod"",
+                    ""author"": ""AwesomeModder"",
+                    ""version"": ""1.0.0"",
+                    ""download"": ""https://awesomemod.example/AwesomeMod.zip"",
+                    ""install"": [
+                        {{
+                            ""file"": ""ExampleShips/AwesomeShip.craft"",
+                            ""install_to"": ""{0}""
+                        }}
+                    ]
+                }}",
+                directory));
+
+            using (var inst = new DisposableKSP())
+            {
+                // Act
+                var results = mod.install!.SelectMany(i => i.FindInstallableFiles(zip, inst.KSP))
+                                          .ToArray();
+
+                // Assert
+                CollectionAssert.AreEquivalent(
+                    new string[]
+                    {
+                        inst.KSP.ToAbsoluteGameDir($"{directory}/AwesomeShip.craft"),
+                    },
+                    results.Select(f => f.destination));
+            }
+        }
+
+        // TODO: It would be nice to merge this and the above function into one super
+        // test.
+        [Test]
+        public void AllowInstallsToScenarios()
+        {
+            // Arrange
+            // Bogus zip with example to install.
+            var zip = ZipFile.Create(new MemoryStream());
+            zip.BeginUpdate();
+            zip.AddDirectory("saves");
+            zip.AddDirectory("saves/scenarios");
+            zip.Add(new ZipEntry("saves/scenarios/AwesomeRace.sfs") { Size = 0, CompressedSize = 0 });
+            zip.CommitUpdate();
+
+            var mod = CkanModule.FromJson(@"
+                {
+                    ""spec_version"": ""v1.14"",
+                    ""identifier"": ""AwesomeMod"",
+                    ""author"": ""AwesomeModder"",
+                    ""version"": ""1.0.0"",
+                    ""download"": ""https://awesomemod.example/AwesomeMod.zip"",
+                    ""install"": [
+                        {
+                            ""file"": ""saves/scenarios/AwesomeRace.sfs"",
+                            ""install_to"": ""Scenarios""
+                        }
+                    ]
+                }");
+
+            using (var inst = new DisposableKSP())
+            {
+                // Act
+                var results = mod.install!.SelectMany(i => i.FindInstallableFiles(zip, inst.KSP))
+                                          .ToArray();
+
+                // Assert
+                CollectionAssert.AreEquivalent(
+                    new string[]
+                    {
+                        inst.KSP.ToAbsoluteGameDir("saves/scenarios/AwesomeRace.sfs"),
+                    },
+                    results.Select(f => f.destination));
+            }
+        }
     }
 }

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -35,7 +35,6 @@ namespace Tests.Data
             _disposableDir = TestData.NewTempDir();
             Utilities.CopyDirectory(_goodKsp, _disposableDir, Array.Empty<string>(), Array.Empty<string>());
             KSP = new GameInstance(game, _disposableDir, name, new NullUser());
-            Logging.Initialize();
         }
 
         public DisposableKSP(string registryFile)

--- a/Tests/Data/DogeCoinFlag.netkan
+++ b/Tests/Data/DogeCoinFlag.netkan
@@ -1,2 +1,4 @@
 identifier: DogeCoinFlag
 $kref: '#/ckan/github/testuser/testrepo'
+tags:
+  - flags

--- a/Tests/Data/TemporaryLogSuppressor.cs
+++ b/Tests/Data/TemporaryLogSuppressor.cs
@@ -1,0 +1,24 @@
+using System;
+
+using log4net;
+using log4net.Core;
+
+namespace Tests.Data
+{
+    public class TemporaryLogSuppressor : IDisposable
+    {
+        public TemporaryLogSuppressor()
+        {
+            orig = LogManager.GetRepository().Threshold;
+            LogManager.GetRepository().Threshold = Level.Off;
+        }
+
+        public void Dispose()
+        {
+            LogManager.GetRepository().Threshold = orig;
+            GC.SuppressFinalize(this);
+        }
+
+        private readonly Level orig;
+    }
+}

--- a/Tests/Data/TemporaryWarningCapturer.cs
+++ b/Tests/Data/TemporaryWarningCapturer.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+using log4net;
+using log4net.Core;
+using log4net.Filter;
+using log4net.Repository.Hierarchy;
+
+using CKAN.NetKAN;
+
+namespace Tests.Data
+{
+    public class TemporaryWarningCapturer : IDisposable
+    {
+        public TemporaryWarningCapturer(string loggerName)
+        {
+            logRoot  = (LogManager.GetRepository() as Hierarchy)?.Root!;
+            appender = GetWarningCapturer(loggerName);
+            logRoot.AddAppender(appender);
+        }
+
+        public void Dispose()
+        {
+            logRoot.RemoveAppender(appender);
+            GC.SuppressFinalize(this);
+        }
+
+        public IReadOnlyCollection<string> Warnings => appender.Warnings;
+
+        private static QueueAppender GetWarningCapturer(string loggerName)
+        {
+            var qap = new QueueAppender() { Name = "TestWarningCapturer" };
+            qap.AddFilter(new LevelMatchFilter()
+            {
+                LevelToMatch  = Level.Warn,
+                AcceptOnMatch = true,
+            });
+            qap.AddFilter(new LoggerMatchFilter() {
+                LoggerToMatch = loggerName,
+                AcceptOnMatch = true,
+            });
+            qap.AddFilter(new DenyAllFilter());
+            return qap;
+        }
+
+        private readonly QueueAppender appender;
+        private readonly Logger        logRoot;
+    }
+}

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+
 using CKAN;
 using CKAN.Versioning;
 
@@ -434,7 +435,8 @@ namespace Tests.Data
                         ""sha1"": ""9EC130C7D212DB664A97C28AFCA46CD186B73B3C"",
                         ""sha256"": ""C7D787A875C92A0DCA5B7F0B8900F92F5FAE9DC23F2FDB95509B31420F209015"",
                     },
-                    ""ksp_version"": ""0.25""
+                    ""ksp_version"": ""0.25"",
+                    ""tags"": [ ""plugin"" ]
                 }
             ";
 

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -702,7 +702,6 @@ namespace Tests.Data
         public static string KspAvcJson()
             => File.ReadAllText(DataDir("ksp-avc.version"));
 
-
         public static string KspAvcJsonOneLineVersion()
             => File.ReadAllText(DataDir("ksp-avc-one-line.version"));
 

--- a/Tests/GUI/Model/ModChangeTests.cs
+++ b/Tests/GUI/Model/ModChangeTests.cs
@@ -1,0 +1,57 @@
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
+using NUnit.Framework;
+
+using CKAN;
+using CKAN.GUI;
+using Tests.Core.Configuration;
+using Tests.Data;
+
+namespace Tests.GUI
+{
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
+    [TestFixture]
+    public class ModChangeTests
+    {
+        [Test]
+        public void AllProperties_InstallingMM_Correct()
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var inst   = new DisposableKSP())
+            using (var config = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager = new GameInstanceManager(user, config))
+            {
+
+                // Act
+                var sut = new ModChange(TestData.ModuleManagerModule(),
+                                        GUIModChangeType.Install,
+                                        config);
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                Assert.AreEqual(true, sut.IsUserRequested);
+                Assert.AreEqual("Requested by user", sut.Description);
+                Assert.AreEqual("Install ModuleManager 2.5.1 (Requested by user)", sut.ToString());
+                Assert.AreEqual(new ModChange(TestData.ModuleManagerModule(),
+                                              GUIModChangeType.Install,
+                                              config),
+                                sut);
+                Assert.AreNotEqual(new ModChange(TestData.ModuleManagerModule(),
+                                                 GUIModChangeType.Update,
+                                                 config),
+                                   sut);
+                Assert.AreNotEqual(new ModChange(TestData.BurnControllerModule(),
+                                                 GUIModChangeType.Install,
+                                                 config),
+                                   sut);
+                });
+            }
+        }
+    }
+}

--- a/Tests/GlobalTestSetup.cs
+++ b/Tests/GlobalTestSetup.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+
+using CKAN;
+
+namespace Tests
+{
+    [SetUpFixture]
+    public class GlobalTestSetup
+    {
+        [OneTimeSetUp]
+        public void GlobalSetup()
+        {
+            Logging.Initialize();
+        }
+    }
+}

--- a/Tests/NetKAN/Sources/Github/GithubApiTests.cs
+++ b/Tests/NetKAN/Sources/Github/GithubApiTests.cs
@@ -27,20 +27,21 @@ namespace Tests.NetKAN.Sources.Github
                 var githubRef = new GithubRef("KSP-CKAN", "Test");
 
                 // Act
-                var repo    = sut.GetRepo(githubRef);
-                var release = sut.GetLatestRelease(githubRef, false);
-                var members = sut.getOrgMembers(repo!.Owner!);
+                var repo    = sut.GetRepo(githubRef)!;
+                var release = sut.GetLatestRelease(githubRef, false)!;
+                var members = sut.getOrgMembers(repo.Owner!);
 
                 // Assert
-                Assert.IsNotNull(repo?.Name);
-                Assert.IsNotNull(repo?.FullName);
-                Assert.IsNotNull(repo?.Description);
-                Assert.IsNotNull(repo?.Owner);
+                Assert.IsNotNull(repo.Name);
+                Assert.IsNotNull(repo.FullName);
+                Assert.IsNotNull(repo.Description);
+                Assert.IsNotNull(repo.Owner);
 
-                Assert.IsNotNull(release?.Author);
-                Assert.IsNotNull(release?.Tag);
-                Assert.IsNotNull(release?.Assets?.FirstOrDefault());
-                Assert.IsNotNull(release?.Assets?.FirstOrDefault()?.Download);
+                Assert.IsNotNull(release.Author);
+                Assert.IsNotNull(release.Tag);
+                Assert.IsNotNull(release.Assets?.FirstOrDefault());
+                Assert.IsNotNull(release.Assets?.FirstOrDefault()?.Download);
+                Assert.IsNotNull(release.SourceArchiveAsset);
 
                 Assert.That(members.Count, Is.GreaterThanOrEqualTo(3));
                 Assert.Contains("HebaruSan", members.Select(u => u.Login).ToArray());

--- a/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/SpacedockTransformerTests.cs
@@ -16,38 +16,40 @@ namespace Tests.NetKAN.Transformers
     [TestFixture]
     public sealed class SpacedockTransformerTests
     {
-
         // GH #199: Don't pre-fill KSP version fields if we see a ksp_min/max
         [Test]
-        public void DoesNotReplaceGameVersionProperties()
+        public void Transform_WithGameVersionProperties_DoesNotReplace()
         {
             // Arrange
             var http = new Mock<IHttpService>();
             http.Setup(h => h.DownloadText(It.Is<Uri>(u => u.AbsolutePath.Contains("/api/mod/")),
                                            It.IsAny<string?>(), It.IsAny<string?>()))
-                .Returns((Uri u, string? _, string? _) => $@"{{
+                .Returns((Uri u, string? _, string? _) => @"{
                                         ""id"":                 1,
                                         ""name"":               ""Dogecoin Flag"",
                                         ""short_description"":  ""Such test. Very unit. Wow."",
                                         ""license"":            ""CC-BY"",
                                         ""author"":             ""pjf"",
+                                        ""shared_authors"":     [ { ""username"": ""CoAuthor"" } ],
+                                        ""background"":         ""https://spacedock.info/content/background.jpg"",
+                                        ""source_code"":        ""https://github.com/pjf/DogeCoinFlag"",
                                         ""default_version_id"": 1,
                                         ""versions"": [
-                                            {{
+                                            {
                                                 ""id"":               1,
                                                 ""friendly_version"": ""0.25"",
                                                 ""game_version"":     ""1.12.5"",
                                                 ""download_path"":    ""http://example.com/"",
-                                            }}
+                                            }
                                         ],
-                                    }}");
+                                    }");
 
             var mGhApi = new Mock<IGithubApi>();
             mGhApi.Setup(i => i.GetRepo(It.IsAny<GithubRef>()))
-                .Returns(new GithubRepo
-                {
-                    HtmlUrl = "https://github.com/ExampleAccount/ExampleProject"
-                });
+                  .Returns(new GithubRepo
+                  {
+                      HtmlUrl = "https://github.com/ExampleAccount/ExampleProject",
+                  });
 
             var sut      = new SpacedockTransformer(new SpacedockApi(http.Object), mGhApi.Object);
             var opts     = new TransformOptions(1, null, null, null, false, null);
@@ -66,6 +68,65 @@ namespace Tests.NetKAN.Transformers
             Assert.AreEqual(null,     (string?)transformedJson["ksp_version"]);
             Assert.AreEqual(null,     (string?)transformedJson["ksp_version_max"]);
             Assert.AreEqual("0.23.5", (string?)transformedJson["ksp_version_min"]);
+            Assert.AreEqual("https://spacedock.info/content/background.jpg",
+                            (string?)transformedJson["resources"]?["x_screenshot"]);
+            Assert.AreEqual("https://github.com/ExampleAccount/ExampleProject",
+                            (string?)transformedJson["resources"]?["repository"]);
+            CollectionAssert.AreEquivalent(new string[] { "pjf", "CoAuthor" },
+                                           ((JArray)transformedJson["author"]!).Select(a => (string)a!));
+        }
+
+        [TestCase("GPLv2",               ExpectedResult = "GPL-2.0")]
+        [TestCase("GPLv3",               ExpectedResult = "GPL-3.0")]
+        [TestCase("Other",               ExpectedResult = "unknown")]
+        [TestCase("ARR",                 ExpectedResult = "restricted")]
+        [TestCase("All Rights Reserved", ExpectedResult = "restricted")]
+        [TestCase("All rights reserved", ExpectedResult = "restricted")]
+        public string? Transform_WithKnownLicenses_Converts(string licenseFromSpaceDock)
+        {
+            // Arrange
+            var http = new Mock<IHttpService>();
+            http.Setup(h => h.DownloadText(It.Is<Uri>(u => u.AbsolutePath.Contains("/api/mod/")),
+                                           It.IsAny<string?>(), It.IsAny<string?>()))
+                .Returns((Uri u, string? _, string? _) => $@"{{
+                                        ""id"":                 1,
+                                        ""name"":               ""Dogecoin Flag"",
+                                        ""short_description"":  ""Such test. Very unit. Wow."",
+                                        ""license"":            ""{licenseFromSpaceDock}"",
+                                        ""author"":             ""pjf"",
+                                        ""default_version_id"": 1,
+                                        ""versions"": [
+                                            {{
+                                                ""id"":               1,
+                                                ""friendly_version"": ""0.25"",
+                                                ""game_version"":     ""1.12.5"",
+                                                ""download_path"":    ""http://example.com/"",
+                                            }}
+                                        ],
+                                    }}");
+
+            var mGhApi = new Mock<IGithubApi>();
+            mGhApi.Setup(i => i.GetRepo(It.IsAny<GithubRef>()))
+                  .Returns(new GithubRepo
+                  {
+                      HtmlUrl = "https://github.com/ExampleAccount/ExampleProject",
+                  });
+
+            var sut      = new SpacedockTransformer(new SpacedockApi(http.Object), mGhApi.Object);
+            var opts     = new TransformOptions(1, null, null, null, false, null);
+            var metadata = new Metadata(new JObject()
+            {
+                { "spec_version",    1                    },
+                { "$kref",           "#/ckan/spacedock/1" },
+            });
+
+            // Act
+            var result          = sut.Transform(metadata, opts).First();
+            var transformedJson = result.Json();
+
+            // Assert
+            Assert.AreEqual("1.12.5", (string?)transformedJson["ksp_version"]);
+            return (string?)transformedJson["license"]!;
         }
 
     }

--- a/Tests/NetKAN/Validators/CkanValidatorTests.cs
+++ b/Tests/NetKAN/Validators/CkanValidatorTests.cs
@@ -25,6 +25,7 @@ namespace Tests.NetKAN.Validators
             ValidCkan["author"] = "Phenomenal Author";
             ValidCkan["license"] = "GPL-3.0";
             ValidCkan["version"] = "1.0.0";
+            ValidCkan["tags"] = new JArray(new string[] { "plugin" });
             ValidCkan["download"] = "https://www.awesome-mod.example/AwesomeMod.zip";
             ValidCkan["tags"] = new JArray(new string[] { "testing" });
         }

--- a/Tests/NetKAN/Validators/SpaceWarpInfoValidatorTests.cs
+++ b/Tests/NetKAN/Validators/SpaceWarpInfoValidatorTests.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+using ICSharpCode.SharpZipLib.Zip;
+using NUnit.Framework;
+using Moq;
+
+using CKAN;
+using CKAN.SpaceWarp;
+using CKAN.NetKAN.Validators;
+using CKAN.Games.KerbalSpaceProgram;
+using CKAN.NetKAN.Sources.Github;
+using CKAN.NetKAN.Services;
+using CKAN.NetKAN.Model;
+using Tests.Data;
+
+namespace Tests.NetKAN.Validators
+{
+    [TestFixture]
+    public class SpaceWarpInfoValidatorTests
+    {
+        [Test]
+        public void Validate_WithMismatchedDeps_Warns()
+        {
+            // Arrange
+            var http = new Mock<IHttpService>();
+            http.Setup(h => h.DownloadModule(It.IsAny<Metadata>()))
+                .Returns(TestData.DogeCoinFlagZip());
+            var github = new Mock<IGithubApi>();
+            var modSvc = new Mock<IModuleService>();
+            modSvc.Setup(ms => ms.GetSpaceWarpInfo(It.IsAny<CkanModule>(),
+                                                   It.IsAny<ZipFile>(),
+                                                   It.IsAny<GameInstance>(),
+                                                   It.IsAny<IGithubApi>(),
+                                                   It.IsAny<IHttpService>(),
+                                                   It.IsAny<string?>()))
+                  .Returns(new SpaceWarpInfo()
+                           {
+                               name        = "Mod with swinfo",
+                               author      = "Mod author",
+                               description = "A mod that contains a swinfo.json and gets many properties from it",
+                               version     = "1.0.0",
+                               dependencies = new string[]
+                                              {
+                                                  "Missing1",
+                                                  "Present1",
+                                                  "With.Name.Space.Prefix.Missing2",
+                                                  "With.Name.Space.Prefix.Present2",
+                                                  "missing3",
+                                                  "present3",
+                                              }.Select(ident => new Dependency() { id = ident })
+                                               .ToArray(),
+                           });
+            var game = new KerbalSpaceProgram();
+            var sut  = new SpaceWarpInfoValidator(http.Object,
+                                                  github.Object,
+                                                  modSvc.Object,
+                                                  game);
+            var metadata = new Metadata(new JObject()
+            {
+                { "identifier", "TestMod"                     },
+                { "version",    "1.0"                         },
+                { "download",   "https://github.com/download" },
+                { "depends",    new JArray(new JObject() { { "name", "Present1" } },
+                                           new JObject() { { "name", "Present2" } },
+                                           new JObject() { { "name", "Present3" } }) },
+            });
+            using (var appender = new TemporaryWarningCapturer(nameof(SpaceWarpInfoValidator)))
+            {
+                // Act
+                sut.Validate(metadata);
+
+                // Assert
+                CollectionAssert.AreEquivalent(
+                    new string[]
+                    {
+                        "Dependencies from swinfo.json missing from module: Missing1, With.Name.Space.Prefix.Missing2, missing3"
+                    },
+                    appender.Warnings);
+            }
+        }
+    }
+}

--- a/Tests/Util.cs
+++ b/Tests/Util.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+
 using NUnit.Framework;
 
 namespace Tests


### PR DESCRIPTION
## Motivation

Another batch of updates to try to boost our [Coveralls](https://coveralls.io/github/KSP-CKAN/CKAN) stats.

## Changes

New or expanded tests:

- `ckan stability set --mod`
- `ckan replace --all`
- `ckan show` with more metadata in the test mod
- `GUI.ModChange`
- `NetKAN.GithubRelease.SourceArchiveAsset`
- Uninstalling a mod that installs crafts into `Ships`
- `SpacedockTransformer`
- `SpaceWarpInfoValidator`

Untestable code excluded from coverage:

- CmdLine help text printing code
- URL launching code
- `GUI.PluginController` because initializing a plugin implementing the `IGUIPlugin` from `ckan.exe` isn't possible outside of `ckan.exe`
  (I had to fork and update <https://github.com/KSP-CKAN/CKAN-SamplePlugins> to discover this.)

Side changes:

- `GUIMod` has an `IsCKAN` property that's always `true`, which makes `ToCkanModule()` redundant with `ToModule()`.
  Now `IsCKAN` is removed and the others are replaced by a single `Module` property.
- `Logging.Initialize()` was being called in `DisposableKSP`'s constructor, which meant that whether `log4net.xml` was applied depended on whether we were running a test that needs a fake game instance, which confounded some of my investigations using `--where=` to run only certain tests.
  Now the `Logging.Initialize()` is moved to a global test setup function tagged with `[OneTimeSetUp]` inside a class tagged with `[SetUpFixture]`.
- `OverrideOptions` had a `ToString` override that just serialized the object, which wasn't used.
  Now this is removed.
- `UnixDateTimeMillisecondsConverter` (used for handling Jenkins) had a `WriteJson` override that wasn't used.
  Now this is removed.
