### PR TITLE
Fix Missions folder cloning and hard link info retrieval

### DIFF
--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -15,6 +15,7 @@ using CKAN.Configuration;
 using CKAN.Games;
 using CKAN.Games.KerbalSpaceProgram;
 using CKAN.Games.KerbalSpaceProgram.GameVersionProviders;
+using CKAN.DLC;
 
 namespace CKAN
 {
@@ -324,7 +325,7 @@ namespace CKAN
         /// <exception cref="InstanceNameTakenKraken">Thrown if the instance name is already in use.</exception>
         /// <exception cref="NotGameDirKraken">Thrown by AddInstance() if created instance is not valid, e.g. if a write operation didn't complete for whatever reason.</exception>
         public void FakeInstance(IGame game, string newName, string newPath, GameVersion version,
-                                 Dictionary<DLC.IDlcDetector, GameVersion>? dlcs = null)
+                                 Dictionary<IDlcDetector, GameVersion>? dlcs = null)
         {
             TxFileManager fileMgr = new TxFileManager();
             using (TransactionScope transaction = CkanTransaction.CreateTransactionScope())
@@ -375,11 +376,8 @@ namespace CKAN
                 // Create the needed folder structure and the readme.txt for DLCs that should be simulated.
                 if (dlcs != null)
                 {
-                    foreach (KeyValuePair<DLC.IDlcDetector, GameVersion> dlc in dlcs)
+                    foreach ((IDlcDetector dlcDetector, GameVersion dlcVersion) in dlcs)
                     {
-                        DLC.IDlcDetector dlcDetector = dlc.Key;
-                        GameVersion dlcVersion = dlc.Value;
-
                         if (!dlcDetector.AllowedOnBaseVersion(version))
                         {
                             throw new WrongGameVersionKraken(

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -72,7 +72,6 @@ namespace CKAN.Games.KerbalSpaceProgram
             "saves",
             "Screenshots",
             "thumbs",
-            "Missions",
             "Logs",
             "CKAN/history",
             "CKAN/downloads",

--- a/Core/IO/HardLink.cs
+++ b/Core/IO/HardLink.cs
@@ -175,7 +175,7 @@ namespace CKAN.IO
             foreach (var pathsString in LimitedStringJoins(paths.Select(p => $"\"{p}\""),
                                                            " ", STAT_ARG_MAX))
             {
-                if (Process.Start(new ProcessStartInfo("stat", $"-c '{fmt}' {pathsString}")
+                if (Process.Start(new ProcessStartInfo("stat", $"-c \"{fmt}\" {pathsString}")
                                   {
                                       UseShellExecute        = false,
                                       RedirectStandardOutput = true,

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -117,16 +117,10 @@ namespace CKAN
             // Get the files in the directory and copy them to the new location
             foreach (var file in sourceDir.GetFiles())
             {
-                if (file.Name == "registry.locked")
+                if (file.Name is "registry.locked" or "playtime.json")
                 {
                     continue;
                 }
-
-                else if (file.Name == "playtime.json")
-                {
-                    continue;
-                }
-
                 InstalledFilesDeduplicator.CreateOrCopy(file,
                                                         Path.Combine(destDirPath, file.Name),
                                                         file_transaction);


### PR DESCRIPTION
## Problems

- Some of the deduplicator tests failed for me on Linux
  ```
        RunCommand_InstalledMissionInTwoInstances_Deduplicates (317ms): Error Message: System.ArgumentException : Byte array for Guid must be exactly 16 bytes long. (Parameter 'b')
        Stack Trace:
           at System.Guid..ctor(ReadOnlySpan`1 b)
           at System.Guid..ctor(Byte[] b)
           at CKAN.IO.HardLink.<>c.<GetFileIdentifiers>b__6_1(Nullable`1[] v) in /home/user/github/CKAN/Core/IO/HardLink.cs:line 110
           at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
           at System.Linq.Enumerable.ZipIterator[TFirst,TSecond](IEnumerable`1 first, IEnumerable`1 second)+MoveNext()
           at System.Linq.Enumerable.DistinctByIterator[TSource,TKey](IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)+MoveNext()
           at System.Linq.Enumerable.SelectEnumerableIterator`2.ToArray()
           at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
           at CKAN.Extensions.EnumerableExtensions.ZipBy[T,V](IEnumerable`1 source, Func`2 func) in /home/user/github/CKAN/Core/Extensions/EnumerableExtensions.cs:line 93
           at CKAN.IO.InstalledFilesDeduplicator.GetDuplicateGroups(ValueTuple`2[] tuples) in /home/user/github/CKAN/Core/IO/InstalledFilesDeduplicator.cs:line 176
           at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
           at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
           at System.Collections.Generic.SparseArrayBuilder`1.ReserveOrAdd(IEnumerable`1 items)
           at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray()
           at CKAN.IO.InstalledFilesDeduplicator.DeduplicateAll(IUser user) in /home/user/github/CKAN/Core/IO/InstalledFilesDeduplicator.cs:line 119
           at CKAN.CmdLine.Deduplicate.RunCommand() in /home/user/github/CKAN/Cmdline/Action/Deduplicate.cs:line 24
           at Tests.CmdLine.DeduplicateTests.RunCommand_InstalledMissionInTwoInstances_Deduplicates() in /home/user/github/CKAN/Tests/CmdLine/DeduplicateTests.cs:line 67
           at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
           at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
      /home/user/github/CKAN/Tests/Core/IO/ModuleInstallerTests.cs(1972): error TESTERROR: 
        InstallList_MissionInTwoInstances_Deduplicates (100ms): Error Message:   Expected: 6
          But was:  0
        
        Stack Trace:
           at Tests.Core.IO.ModuleInstallerTests.InstallList_MissionInTwoInstances_Deduplicates() in /home/user/github/CKAN/Tests/Core/IO/ModuleInstallerTests.cs:line 1972
  ```
- If you clone a KSP1 instance and don't choose to copy the `Missions` folder, the game throws exceptions complaining of a file missing there:
  ```
  [EXC 10:42:36.332] FileNotFoundException: Could not find file "/media/DataTrove/Games/KSP-thin-clone-5/Missions/MissionScoreInfo.cfg"
      System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) (at <9577ac7a62ef43179789031239ba8798>:0)
      System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options, System.String msgPath, System.Boolean bFromProxy, System.Boolean useLongPath, System.Boolean checkHost) (at <9577ac7a62ef43179789031239ba8798>:0)
      (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions,string,bool,bool,bool)
      System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize, System.Boolean checkHost) (at <9577ac7a62ef43179789031239ba8798>:0)
      System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize) (at <9577ac7a62ef43179789031239ba8798>:0)
      System.IO.StreamReader..ctor (System.String path, System.Boolean detectEncodingFromByteOrderMarks) (at <9577ac7a62ef43179789031239ba8798>:0)
      System.IO.StreamReader..ctor (System.String path) (at <9577ac7a62ef43179789031239ba8798>:0)
      (wrapper remoting-invoke-with-check) System.IO.StreamReader..ctor(string)
      System.IO.File.OpenText (System.String path) (at <9577ac7a62ef43179789031239ba8798>:0)
      System.IO.File.ReadAllLines (System.String path) (at <9577ac7a62ef43179789031239ba8798>:0)
      ConfigNode.Load (System.String fileFullName, System.Boolean bypassLocalization) (at <be370b73275e49439ea5e41ceef6700f>:0)
      ConfigNode.Load (System.String fileFullName) (at <be370b73275e49439ea5e41ceef6700f>:0)
      Expansions.Missions.MissionScoreInfo.LoadScores () (at <be370b73275e49439ea5e41ceef6700f>:0)
      Expansions.Missions.Runtime.MissionSystem+<OnLoadRoutine>d__58.MoveNext () (at <be370b73275e49439ea5e41ceef6700f>:0)
      UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at <2425394cf09642369e2109953e31f62b>:0)
  ```

Noticed while investigating #4438.

## Causes

- The `stat` command that we use to get hard link related info on Unix uses single quotes to isolate the format string argument of `-c`, which were being passed to `stat` itself. This caused the output to contain single quotes as well, which broke our attempt to parse them as `long`s. Oddly, this didn't happen in the testing containers on GitHub, which I assume must have something to do with which runtimes or runtime versions are installed and/or used.
- `Missions` is in the list of folders that can or should be left blank when cloning, but that's wrong. The game assumes it will be non-empty.

## Changes

- Now the single quotes are replaced by double quotes, which seem to be parsed by `ProcessStartInfo` and removed as intended
- Now the `Missions` folder is always copied when cloning

Investigation of #4438 will continue once I reboot into Windows for testing, but I wanted to merge these changes first.
