### PR TITLE
Don't clone with symlinks on Linux

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1524,7 +1524,7 @@ namespace CKAN.GUI
         [ForbidGUICalls]
         private bool _UpdateModsList(Dictionary<string, bool>? old_modules = null)
         {
-            if (currentInstance == null || guiConfig == null)
+            if (currentInstance == null || guiConfig == null || manager?.Cache == null)
             {
                 return false;
             }
@@ -1550,7 +1550,8 @@ namespace CKAN.GUI
 
             RaiseMessage?.Invoke(Properties.Resources.MainModListLoadingInstalled);
 
-            var guiMods = ModList.GetGUIMods(registry, repoData, currentInstance, ModuleLabelList.ModuleLabels, guiConfig)
+            var guiMods = ModList.GetGUIMods(registry, repoData, currentInstance,
+                                             ModuleLabelList.ModuleLabels, manager.Cache, guiConfig)
                                  .ToHashSet();
 
             foreach (var gmod in mainModList?.full_list_of_mod_rows
@@ -2157,7 +2158,7 @@ namespace CKAN.GUI
                 return;
             }
 
-            if (mainModList == null)
+            if (mainModList == null || manager?.Cache == null)
             {
                 return;
             }
@@ -2183,7 +2184,8 @@ namespace CKAN.GUI
                                                                               inst.StabilityToleranceConfig, gameVersion);
                 full_change_set = tuple.Item1.ToList();
                 new_conflicts = tuple.Item2.ToDictionary(
-                    item => new GUIMod(item.Key, repoData, registry, inst.StabilityToleranceConfig, gameVersion, null,
+                    item => new GUIMod(item.Key, repoData, registry, inst.StabilityToleranceConfig,
+                                       inst, manager.Cache, null,
                                        guiConfig?.HideEpochs ?? false,
                                        guiConfig?.HideV      ?? false),
                     item => item.Value);

--- a/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
@@ -193,7 +193,7 @@ namespace CKAN.GUI
             // checkBoxShareStock
             //
             this.checkBoxShareStock.AutoSize = true;
-            this.checkBoxShareStock.Checked = true;
+            this.checkBoxShareStock.Checked = false;
             this.checkBoxShareStock.CheckState = System.Windows.Forms.CheckState.Checked;
             this.checkBoxShareStock.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.checkBoxShareStock.Location = new System.Drawing.Point(181, 204);

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -39,18 +39,31 @@ namespace CKAN.GUI
             ToolTip.SetToolTip(checkBoxShareStock, Properties.Resources.CloneGameInstanceToolTipShareStock);
 
             // Populate the instances combobox with names of known instances
-            comboBoxKnownInstance.DataSource = new string[] { "" }
-                .Concat(manager.Instances.Values
-                    .Where(i => i.Valid)
-                    .OrderBy(i => i.game.ShortName)
-                    .OrderByDescending(i => i.Version())
-                    .ThenBy(i => i.Name)
-                    .Select(i => i.Name))
-                .ToList();
+            comboBoxKnownInstance.DataSource =
+                Enumerable.Repeat("", 1)
+                          .Concat(manager.Instances.Values
+                                                   .Where(i => i.Valid)
+                                                   .OrderByDescending(i => i.game.FirstReleaseDate)
+                                                   .ThenByDescending(i => i.Version())
+                                                   .ThenBy(i => i.Name)
+                                                   .Select(i => i.Name))
+                          .ToList();
             comboBoxKnownInstance.Text = selectedInstanceName
-                ?? manager.CurrentInstance?.Name
-                ?? manager.AutoStartInstance
-                ?? "";
+                                             ?? manager.CurrentInstance?.Name
+                                             ?? manager.AutoStartInstance
+                                             ?? "";
+
+            if (Platform.IsWindows)
+            {
+                checkBoxShareStock.Checked = true;
+            }
+            else
+            {
+                // Symbolic links break cloned instances on Linux
+                // (Games use paths like <GameRoot>/KSP_Data/../saves/,
+                //  which follow the symlinks to the original instance)
+                checkBoxShareStock.Visible = false;
+            }
         }
 
         #region clone
@@ -239,7 +252,6 @@ namespace CKAN.GUI
             {
                 textBoxNewPath.Text = folderBrowserDialogNewPath.SelectedPath;
             }
-
         }
 
         /// <summary>

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -851,14 +851,15 @@ namespace CKAN.GUI
 
         private void ShowSelectionModInfo(CkanModule? module)
         {
-            if (CurrentInstance != null && configuration != null)
+            if (CurrentInstance != null && configuration != null && Manager.Cache != null)
             {
                 ActiveModInfo = module == null ? null : new GUIMod(
                     module,
                     repoData,
                     RegistryManager.Instance(CurrentInstance, repoData).registry,
                     CurrentInstance.StabilityToleranceConfig,
-                    CurrentInstance.VersionCriteria(),
+                    CurrentInstance,
+                    Manager.Cache,
                     null,
                     configuration.HideEpochs,
                     configuration.HideV);

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -128,18 +128,21 @@ namespace CKAN.GUI
         [ForbidGUICalls]
         private void UpdateCachedByDownloads(CkanModule? module)
         {
-            var allGuiMods = ManageMods.AllGUIMods();
-            // Find all mods that share one or more download URLs with the given module, and so on
-            var affectedMods =
-                module?.GetDownloadsGroup(allGuiMods.Values
-                                                    .Select(guiMod => guiMod.Module)
-                                                    .OfType<CkanModule>())
-                       .Select(other => allGuiMods.GetValueOrDefault(other.identifier))
-                       .OfType<GUIMod>()
-                      ?? allGuiMods.Values;
-            foreach (var otherMod in affectedMods)
+            if (Manager.Cache is NetModuleCache cache)
             {
-                otherMod.UpdateIsCached();
+                var allGuiMods = ManageMods.AllGUIMods();
+                // Find all mods that share one or more download URLs with the given module, and so on
+                var affectedMods =
+                    module?.GetDownloadsGroup(allGuiMods.Values
+                                                        .Select(guiMod => guiMod.Module)
+                                                        .OfType<CkanModule>())
+                           .Select(other => allGuiMods.GetValueOrDefault(other.identifier))
+                           .OfType<GUIMod>()
+                          ?? allGuiMods.Values;
+                foreach (var otherMod in affectedMods)
+                {
+                    otherMod.UpdateIsCached(cache);
+                }
             }
         }
 

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -50,14 +50,15 @@ namespace CKAN.GUI
 
         private void InstallationHistory_OnSelectedModuleChanged(CkanModule m)
         {
-            if (CurrentInstance != null)
+            if (CurrentInstance != null && Manager.Cache != null)
             {
                 ActiveModInfo = m == null
                     ? null
                     : new GUIMod(m, repoData,
                                  RegistryManager.Instance(CurrentInstance, repoData).registry,
                                  CurrentInstance.StabilityToleranceConfig,
-                                 CurrentInstance.VersionCriteria(),
+                                 CurrentInstance,
+                                 Manager.Cache,
                                  null,
                                  configuration?.HideEpochs ?? false,
                                  configuration?.HideV      ?? false);

--- a/Tests/GUI/GUIConfiguration.cs
+++ b/Tests/GUI/GUIConfiguration.cs
@@ -55,5 +55,31 @@ namespace Tests.GUI
                 Assert.IsTrue(File.Exists(jsonPath));
             }
         }
+
+        [Test]
+        public void SetColumnVisibility_HideAndShow_Works()
+        {
+            // Arrange
+            var cfg = new GUIConfiguration();
+
+            // Act
+            cfg.SetColumnVisibility("A", false);
+            cfg.SetColumnVisibility("B", false);
+            cfg.SetColumnVisibility("C", false);
+            cfg.SetColumnVisibility("D", false);
+            cfg.SetColumnVisibility("E", false);
+
+            // Assert
+            CollectionAssert.AreEquivalent(new string[] { "A", "B", "C", "D", "E" },
+                                           cfg.HiddenColumnNames);
+
+            // Act
+            cfg.SetColumnVisibility("B", true);
+            cfg.SetColumnVisibility("D", true);
+
+            // Assert
+            CollectionAssert.AreEquivalent(new string[] { "A", "C", "E" },
+                                           cfg.HiddenColumnNames);
+        }
     }
 }

--- a/Tests/GUI/Model/ModChangeTests.cs
+++ b/Tests/GUI/Model/ModChangeTests.cs
@@ -22,8 +22,8 @@ namespace Tests.GUI
         {
             // Arrange
             var user = new NullUser();
-            using (var inst   = new DisposableKSP())
-            using (var config = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var inst    = new DisposableKSP())
+            using (var config  = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var manager = new GameInstanceManager(user, config))
             {
 
@@ -33,8 +33,6 @@ namespace Tests.GUI
                                         config);
 
                 // Assert
-                Assert.Multiple(() =>
-                {
                 Assert.AreEqual(true, sut.IsUserRequested);
                 Assert.AreEqual("Requested by user", sut.Description);
                 Assert.AreEqual("Install ModuleManager 2.5.1 (Requested by user)", sut.ToString());
@@ -50,7 +48,45 @@ namespace Tests.GUI
                                                  GUIModChangeType.Install,
                                                  config),
                                    sut);
-                });
+            }
+        }
+
+        [TestCase(false, false, "Re-install (missing folders or files)"),
+         TestCase(false, true,  "Re-install (metadata changed)"),
+         TestCase(true,  false, "Re-install (user requested)"),
+         TestCase(true,  true,  "Re-install (user requested)")]
+        public void AllProperties_Upgrade_Correct(bool   userReinstall,
+                                                  bool   metadataChanged,
+                                                  string reason)
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var inst    = new DisposableKSP())
+            using (var config  = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager = new GameInstanceManager(user, config))
+            {
+
+                // Act
+                var sut = new ModUpgrade(TestData.ModuleManagerModule(),
+                                         TestData.ModuleManagerModule(),
+                                         userReinstall, metadataChanged,
+                                         config);
+
+                // Assert
+                Assert.AreEqual(true, sut.IsUserRequested);
+                Assert.AreEqual(reason, sut.Description);
+                Assert.AreEqual($"Update ModuleManager 2.5.1 ({reason})",
+                                sut.ToString());
+                Assert.AreEqual(new ModUpgrade(TestData.ModuleManagerModule(),
+                                               TestData.ModuleManagerModule(),
+                                               userReinstall, metadataChanged,
+                                               config),
+                                sut);
+                Assert.AreNotEqual(new ModUpgrade(TestData.BurnControllerModule(),
+                                                  TestData.BurnControllerModule(),
+                                                  userReinstall, metadataChanged,
+                                                  config),
+                                   sut);
             }
         }
     }

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -35,7 +35,9 @@ namespace Tests.GUI
             using (var tidy     = new DisposableKSP())
             using (var config   = new FakeConfiguration(tidy.KSP, tidy.KSP.Name))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry = new Registry(repoData.Manager, repo.repo);
                 var ckan_mod = registry.GetModuleByVersion("Firespitter", "6.3.5");
                 Assert.IsNotNull(ckan_mod);
@@ -44,7 +46,7 @@ namespace Tests.GUI
                                        config, new GUIConfiguration());
                 Assert.That(item.IsVisible(
                     new GUIMod(ckan_mod!, repoData.Manager, registry,
-                               tidy.KSP.StabilityToleranceConfig, tidy.KSP.VersionCriteria(),
+                               tidy.KSP.StabilityToleranceConfig, tidy.KSP, cache,
                                null, false, false),
                     tidy.KSP, registry));
             }
@@ -75,16 +77,18 @@ namespace Tests.GUI
             using (var tidy = new DisposableKSP())
             using (var config = new FakeConfiguration(tidy.KSP, tidy.KSP.Name))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry = new Registry(repoData.Manager, repo.repo);
                 var main_mod_list = new ModList(
                     new List<GUIMod>
                     {
                         new GUIMod(TestData.FireSpitterModule(), repoData.Manager, registry,
-                                   tidy.KSP.StabilityToleranceConfig, tidy.KSP.VersionCriteria(),
+                                   tidy.KSP.StabilityToleranceConfig, tidy.KSP, cache,
                                    null, false, false),
                         new GUIMod(TestData.kOS_014_module(), repoData.Manager, registry,
-                                   tidy.KSP.StabilityToleranceConfig, tidy.KSP.VersionCriteria(),
+                                   tidy.KSP.StabilityToleranceConfig, tidy.KSP, cache,
                                    null, false, false)
                     },
                     tidy.KSP, ModuleLabelList.GetDefaultLabels(),
@@ -179,12 +183,14 @@ namespace Tests.GUI
                                       }))
             using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo }))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry = regMgr.registry;
                 var labels   = ModuleLabelList.GetDefaultLabels();
                 var favLbl   = labels.Labels.First(l => l.Name == "Favourites");
                 var mods     = ModList.GetGUIMods(registry, repoData.Manager,
-                                                  inst.KSP, labels, new GUIConfiguration())
+                                                  inst.KSP, labels, cache, new GUIConfiguration())
                                       .ToArray();
                 var modlist  = new ModList(mods, inst.KSP, labels, config, new GUIConfiguration());
                 var mod      = mods.First();
@@ -217,11 +223,13 @@ namespace Tests.GUI
                                       }))
             using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo }))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry = regMgr.registry;
                 var labels   = ModuleLabelList.GetDefaultLabels();
                 var mods     = ModList.GetGUIMods(registry, repoData.Manager,
-                                                  inst.KSP, labels, new GUIConfiguration())
+                                                  inst.KSP, labels, cache, new GUIConfiguration())
                                       .ToArray();
                 var modlist = new ModList(mods, inst.KSP, labels,
                                           config, new GUIConfiguration());
@@ -255,12 +263,15 @@ namespace Tests.GUI
             using (var instance = new DisposableKSP())
             using (var regMgr   = RegistryManager.Instance(instance.KSP, repoData.Manager,
                                                            new Repository[] { repo }))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry = regMgr.registry;
 
                 // Act
                 var mods = ModList.GetGUIMods(registry, repoData.Manager,
-                                              instance.KSP, ModuleLabelList.GetDefaultLabels(), new GUIConfiguration());
+                                              instance.KSP, ModuleLabelList.GetDefaultLabels(),
+                                              cache, new GUIConfiguration());
 
                 // Assert
                 CollectionAssert.AreEquivalent(new string[]
@@ -469,10 +480,13 @@ namespace Tests.GUI
                                       }))
             using (var regMgr   = RegistryManager.Instance(instance.KSP, repoData.Manager,
                                                            new Repository[] { repo }))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry = regMgr.registry;
                 var mods     = ModList.GetGUIMods(registry, repoData.Manager,
-                                                  instance.KSP, ModuleLabelList.GetDefaultLabels(), new GUIConfiguration())
+                                                  instance.KSP, ModuleLabelList.GetDefaultLabels(),
+                                                  cache, new GUIConfiguration())
                                       .ToArray();
                 var modlist  = new ModList(mods, instance.KSP, ModuleLabelList.GetDefaultLabels(), config, new GUIConfiguration());
 
@@ -530,10 +544,12 @@ namespace Tests.GUI
                                       }))
             using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
                                                            new Repository[] { repo }))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry  = regMgr.registry;
                 var labels    = ModuleLabelList.GetDefaultLabels();
-                var mods      = ModList.GetGUIMods(registry, repoData.Manager, inst.KSP, labels, guiConfig)
+                var mods      = ModList.GetGUIMods(registry, repoData.Manager, inst.KSP, labels, cache, guiConfig)
                                        .ToArray();
                 var modlist   = new ModList(mods, inst.KSP, labels, config, guiConfig);
 
@@ -610,7 +626,9 @@ namespace Tests.GUI
             using (var manager  = new GameInstanceManager(user, config))
             using (var regMgr   = RegistryManager.Instance(instance.KSP, repoData.Manager,
                                                            new Repository[] { repo.repo }))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 manager.SetCurrentInstance(instance.KSP);
                 var registry = regMgr.registry;
                 // A module with a ksp_version of "any" to repro our issue
@@ -645,7 +663,7 @@ namespace Tests.GUI
 
                 var modules = repoData.Manager.GetAllAvailableModules(Enumerable.Repeat(repo.repo, 1))
                     .Select(mod => new GUIMod(mod.Latest(instance.KSP.StabilityToleranceConfig)!, repoData.Manager, registry,
-                                              instance.KSP.StabilityToleranceConfig, instance.KSP.VersionCriteria(),
+                                              instance.KSP.StabilityToleranceConfig, instance.KSP, cache,
                                               null, false, false))
                     .ToList();
 

--- a/Tests/GUI/Model/ModSearchTests.cs
+++ b/Tests/GUI/Model/ModSearchTests.cs
@@ -184,7 +184,9 @@ namespace Tests.GUI
                                           ""download"":     ""https://github.com/download""
                                       }"))
             using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var cacheDir = new TemporaryDirectory())
             {
+                var cache = new NetModuleCache(cacheDir.Directory.FullName);
                 var registry = new Registry(repoData.Manager, repo.repo);
                 var search1  = ModSearch.Parse(labels, inst.KSP, "is:replaceable")!;
                 var search2  = ModSearch.Parse(labels, inst.KSP, "not:replaceable")!;
@@ -200,7 +202,7 @@ namespace Tests.GUI
                                           }"),
                                       repoData.Manager, registry,
                                       inst.KSP.StabilityToleranceConfig,
-                                      inst.KSP.VersionCriteria(),
+                                      inst.KSP, cache,
                                       null, false, false);
                 var mod2 = new GUIMod(CkanModule.FromJson(
                                           @"{
@@ -212,7 +214,7 @@ namespace Tests.GUI
                                           }"),
                                       repoData.Manager, registry,
                                       inst.KSP.StabilityToleranceConfig,
-                                      inst.KSP.VersionCriteria(),
+                                      inst.KSP, cache,
                                       null, false, false);
 
                 // Act / Assert

--- a/Tests/NetKAN/Validators/KrefValidatorTests.cs
+++ b/Tests/NetKAN/Validators/KrefValidatorTests.cs
@@ -8,23 +8,23 @@ namespace Tests.NetKAN.Validators
     [TestFixture]
     public sealed class KrefValidatorTests
     {
-        [Test,
-            TestCase(null),
-            TestCase("#/ckan/github/AGoodModder/AGoodMod"),
-            TestCase("#/ckan/http/https://mysite.org/AGoodMod.zip"),
-            TestCase("#/ckan/ksp-avc/https://mysite.org/AGoodMod.version"),
-            TestCase("#/ckan/netkan/https://mysite.org/AGoodMod.netkan"),
-            TestCase("#/ckan/jenkins/https://mysite.org/AGoodMod/"),
-            TestCase("#/ckan/spacedock/12345")
+        [TestCase(null),
+         TestCase("#/ckan/github/AGoodModder/AGoodMod"),
+         TestCase("#/ckan/gitlab/AGoodModder/AGoodMod"),
+         TestCase("#/ckan/http/https://mysite.org/AGoodMod.zip"),
+         TestCase("#/ckan/ksp-avc/https://mysite.org/AGoodMod.version"),
+         TestCase("#/ckan/jenkins/https://mysite.org/AGoodMod/"),
+         TestCase("#/ckan/netkan/https://mysite.org/AGoodMod.netkan"),
+         TestCase("#/ckan/spacedock/12345"),
+         TestCase("#/ckan/sourceforge/AGoodMod"),
         ]
         public void Validate_KnownKref_Valid(string kref)
         {
             Assert.DoesNotThrow(() => TryKref(kref));
         }
 
-        [Test,
-            TestCase("#/ckan/techman/iscool"),
-            TestCase("#/ckan/spaceport/305")
+        [TestCase("#/ckan/techman/iscool"),
+         TestCase("#/ckan/spaceport/305"),
         ]
         public void Validate_TechManIsCool_Invalid(string kref)
         {


### PR DESCRIPTION
## Problem

If you clone a KSP1 instance using the "Share stock files" option from #4129, the game throws exceptions like this:

```
[LOG 11:21:03.627] ------------------- initializing flight mode... ------------------
[LOG 11:21:03.627] No save file found for path: /media/DataTrove/Games/KSP-thin-clone-5/KSP_Data/../saves/Testing symlinks/persistent.sfs
[EXC 11:21:03.628] NullReferenceException: Object reference not set to an instance of an object
	FlightDriver.Start () (at <be370b73275e49439ea5e41ceef6700f>:0)
[EXC 11:21:03.635] NullReferenceException: Object reference not set to an instance of an object
	KSP.UI.Screens.EditorActionGroups.CreateGroups_Action () (at <be370b73275e49439ea5e41ceef6700f>:0)
	KSP.UI.Screens.EditorActionGroups.ConstructGroupList () (at <be370b73275e49439ea5e41ceef6700f>:0)
	KSP.UI.Screens.EditorActionGroups.Start () (at <be370b73275e49439ea5e41ceef6700f>:0)
[EXC 11:21:03.642] NullReferenceException: Object reference not set to an instance of an object
	ManeuverNodeEditorTabOrbitBasic.UpdateUIElements () (at <be370b73275e49439ea5e41ceef6700f>:0)
	ManeuverNodeEditorTabOrbitBasic.SetInitialValues () (at <be370b73275e49439ea5e41ceef6700f>:0)
	ManeuverNodeEditorTab.Setup (UnityEngine.Transform parent) (at <be370b73275e49439ea5e41ceef6700f>:0)
	ManeuverNodeEditorManager.setupAllTabs () (at <be370b73275e49439ea5e41ceef6700f>:0)
	ManeuverNodeEditorManager.Start () (at <be370b73275e49439ea5e41ceef6700f>:0)
[EXC 11:21:03.703] NullReferenceException: Object reference not set to an instance of an object
	VesselAutopilotUI.LateUpdate () (at <be370b73275e49439ea5e41ceef6700f>:0)
[EXC 11:21:03.712] NullReferenceException: Object reference not set to an instance of an object
	FlightGlobals.GetFoR (FoRModes mode) (at <be370b73275e49439ea5e41ceef6700f>:0)
	FlightCamera.GetCameraFoR (FoRModes mode) (at <be370b73275e49439ea5e41ceef6700f>:0)
	FlightCamera.LateUpdate () (at <be370b73275e49439ea5e41ceef6700f>:0)
```

## Cause

The `..` part of the path  `/media/DataTrove/Games/KSP-thin-clone-5/KSP_Data/../saves/Testing symlinks/persistent.sfs` resolves through the `KSP_Data` symlink created by cloning, so it ends up looking for the save file in the original game instance, where it doesn't exist. This same pattern repeats anytime the game's code or any mod uses `<GameRoot>/KSP_Data/../` to find things, which is pretty common.

On Windows we use directory junctions instead of symbolic links, and in my testing they did not suffer from this problem.

## Changes

Now the "Share stock files" checkbox is only shown and checked on Windows; on Linux it is hidden, and no symbolic links will be made during cloning. The _hard_ links from #4358 will still be used to save time and space when cloning an instance to the same storage device, so not all is lost.

Fixes #4438.

On the side, tests are added for:

- `GUIConfiguration.SetColumnVisibility`
- `GUIMod.UpdateIsCached`
- `GUI.ModUpgrade`
