### PR TITLE
Don't hardlink anything in the CKAN folder

### DIFF
--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -284,9 +284,11 @@ namespace CKAN
 
             log.Debug("Copying directory.");
             Utilities.CopyDirectory(existingInstance.GameDir, newPath,
+                                    new string[] { "CKAN/registry.locked", "CKAN/playtime.json" },
                                     shareStockFolders ? existingInstance.Game.StockFolders
                                                       : Array.Empty<string>(),
-                                    leaveEmpty);
+                                    leaveEmpty,
+                                    new string[] { "CKAN" });
 
             // Add the new instance to the config
             AddInstance(new GameInstance(existingInstance.Game, newPath, newName, User));

--- a/Tests/Core/GameInstance.cs
+++ b/Tests/Core/GameInstance.cs
@@ -24,7 +24,7 @@ namespace Tests.Core
         {
             ksp_dir = TestData.NewTempDir();
             nullUser = new NullUser();
-            Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, Array.Empty<string>(), Array.Empty<string>());
+            Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
             ksp = new GameInstance(new KerbalSpaceProgram(), ksp_dir, "test", nullUser);
         }
 
@@ -112,7 +112,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, Array.Empty<string>(), Array.Empty<string>());
+            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
             File.Delete(buildid);
             File.Delete(readme);
 
@@ -144,7 +144,7 @@ namespace Tests.Core
             }";
 
             // Generate a valid game dir except for missing buildID.txt and readme.txt
-            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, Array.Empty<string>(), Array.Empty<string>());
+            Utilities.CopyDirectory(TestData.good_ksp_dir(), gamedir, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
             File.Delete(buildid);
             File.Delete(readme);
 

--- a/Tests/Core/UtilitiesTests.cs
+++ b/Tests/Core/UtilitiesTests.cs
@@ -22,6 +22,7 @@ namespace Tests.Core
 
                 // Act
                 Utilities.CopyDirectory(goodKspDir, tempDir,
+                                        Array.Empty<string>(), Array.Empty<string>(),
                                         Array.Empty<string>(), Array.Empty<string>());
                 var fi = new FileInfo(Path.Combine(tempDir, "GameData"));
 
@@ -50,7 +51,9 @@ namespace Tests.Core
 
                 // Act
                 Utilities.CopyDirectory(Path.Combine(TestData.DataDir, "KSP"), tempDir,
-                                        new string[] { "KSP-0.25/GameData" }, Array.Empty<string>());
+                                        Array.Empty<string>(),
+                                        new string[] { "KSP-0.25/GameData" },
+                                        Array.Empty<string>(), Array.Empty<string>());
 
                 // Assert
                 var fi1 = new FileInfo(Path.Combine(tempDir, "KSP-0.25"));
@@ -79,6 +82,7 @@ namespace Tests.Core
                 // Act / Assert
                 Assert.Throws<DirectoryNotFoundKraken>(() =>
                     Utilities.CopyDirectory(sourceDir, tempDir!,
+                                            Array.Empty<string>(), Array.Empty<string>(),
                                             Array.Empty<string>(), Array.Empty<string>()));
             }
         }
@@ -97,6 +101,7 @@ namespace Tests.Core
                 // Act / Assert
                 Assert.Throws<PathErrorKraken>(() =>
                     Utilities.CopyDirectory(goodKspDir, tempDir,
+                                            Array.Empty<string>(), Array.Empty<string>(),
                                             Array.Empty<string>(), Array.Empty<string>()));
             }
         }

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -27,6 +27,8 @@ namespace Tests.Data
             Utilities.CopyDirectory(TestData.good_ksp_dir(),
                                     _disposableDir,
                                     Array.Empty<string>(),
+                                    Array.Empty<string>(),
+                                    Array.Empty<string>(),
                                     Array.Empty<string>());
             KSP = new GameInstance(game, _disposableDir,
                                    name, new NullUser());

--- a/Tests/Data/TemporaryDirectory.cs
+++ b/Tests/Data/TemporaryDirectory.cs
@@ -27,6 +27,7 @@ namespace Tests.Data
         {
             var dir = new TemporaryDirectory();
             Utilities.CopyDirectory(fromPath, dir,
+                                    Array.Empty<string>(), Array.Empty<string>(),
                                     Array.Empty<string>(), Array.Empty<string>());
             return dir;
         }


### PR DESCRIPTION
## Problem

1. Install 200+ mods
2. Clone the instance
3. Switch to the cloned instance and uninstall some mods
4. Switch back to the original instance and notice that the mods you uninstalled are now listed as not installed or "AD"

## Cause

If `CKAN/registry.json` is larger than 128 KiB, it will be hard linked instead of copied, and when it is overwritten, both instances receive the new data.

## Changes

- Now when cloning an instance, we never hard link _any_ of the files in the `CKAN` folder. This will ensure that each instance's settings are kept separate.
- A test is created to exercise cloning with a large `CKAN/registry.json`, which fails with the old code and passes with the fix.

Fixes #4467.
