### PR TITLE
Fix creating directories for Scenarios

### DIFF
--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -26,11 +26,12 @@ namespace CKAN.Games
         string         PrimaryModDirectoryRelative     { get; }
         string[]       AlternateModDirectoriesRelative { get; }
         string         PrimaryModDirectory(GameInstance inst);
-        string[]       StockFolders       { get; }
-        string[]       LeaveEmptyInClones { get; }
-        string[]       ReservedPaths      { get; }
-        string[]       CreateableDirs     { get; }
-        string[]       AutoRemovableDirs  { get; }
+        string[]       StockFolders         { get; }
+        string[]       LeaveEmptyInClones   { get; }
+        string[]       ReservedPaths        { get; }
+        string[]       CreateableInstallTos { get; }
+        string[]       CreateableDirs       { get; }
+        string[]       AutoRemovableDirs    { get; }
         bool           IsReservedDirectory(GameInstance inst, string path);
         bool           AllowInstallationIn(string name, [NotNullWhen(true)] out string? path);
         void           RebuildSubdirectories(string absGameRoot);

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -82,9 +82,14 @@ namespace CKAN.Games.KerbalSpaceProgram
             "GameData", "Ships", "Missions"
         };
 
+        public string[] CreateableInstallTos => new string[]
+        {
+            "GameData", "Tutorial", "Scenarios", "Missions",
+        };
+
         public string[] CreateableDirs => new string[]
         {
-            "GameData", "Tutorial", "Scenarios", "Missions", "Ships/Script"
+            "Ships/Script",
         };
 
         public string[] AutoRemovableDirs => new string[]

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -70,6 +70,8 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public string[] ReservedPaths => Array.Empty<string>();
 
+        public string[] CreateableInstallTos => Array.Empty<string>();
+
         public string[] CreateableDirs => new string[]
         {
             "GameData",

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -384,6 +384,8 @@ namespace CKAN
                                              .DefaultIfEmpty()
                                              .Min(match => match?.Index);
 
+            var allowDirs = AnyEqualsOrStartsWith(game.CreateableInstallTos, install_to);
+
             // O(N^2) solution, as we're walking the zipfile for each stanza.
             // Surely there's a better way, although this is fast enough we may not care.
             foreach (ZipEntry entry in zipfile)
@@ -404,7 +406,7 @@ namespace CKAN
                 yield return new InstallableFile
                 {
                     source      = entry,
-                    makedir     = AllowDirectoryCreation(game, dest),
+                    makedir     = allowDirs || AnyEqualsOrStartsWith(game.CreateableDirs, dest),
                     destination = dest,
                 };
                 ++fileCount;
@@ -423,9 +425,10 @@ namespace CKAN
         private static readonly Regex updirRegex = new Regex(@"/\.\.(/|$)",
                                                              RegexOptions.Compiled);
 
-        private static bool AllowDirectoryCreation(IGame game, string relativePath)
-            => game.CreateableDirs.Any(dir => relativePath == dir
-                                           || relativePath.StartsWith($"{dir}/"));
+        private static bool AnyEqualsOrStartsWith(IEnumerable<string> haystack,
+                                                  string              needle)
+            => haystack.Any(dir => needle == dir
+                                || needle.StartsWith($"{dir}/"));
 
         /// <summary>
         /// Transforms the name of the output. This will strip the leading directories from the stanza file from

--- a/Tests/Core/Types/ModuleInstallDescriptorTests.cs
+++ b/Tests/Core/Types/ModuleInstallDescriptorTests.cs
@@ -134,7 +134,9 @@ namespace Tests.Core.Types
                 zip.BeginUpdate();
                 zip.AddDirectory("saves");
                 zip.AddDirectory("saves/scenarios");
+                zip.AddDirectory("saves/scenarios/AwesomeRace");
                 zip.Add(new ZipEntry("saves/scenarios/AwesomeRace.sfs") { Size = 0, CompressedSize = 0 });
+                zip.Add(new ZipEntry("saves/scenarios/AwesomeRace/persistent.sfs") { Size = 0, CompressedSize = 0 });
                 zip.CommitUpdate();
 
                 var mod = CkanModule.FromJson(@"
@@ -147,6 +149,10 @@ namespace Tests.Core.Types
                         ""install"": [
                             {
                                 ""file"": ""saves/scenarios/AwesomeRace.sfs"",
+                                ""install_to"": ""Scenarios""
+                            },
+                            {
+                                ""file"": ""saves/scenarios/AwesomeRace"",
                                 ""install_to"": ""Scenarios""
                             }
                         ]
@@ -163,8 +169,11 @@ namespace Tests.Core.Types
                         new string[]
                         {
                             "saves/scenarios/AwesomeRace.sfs",
+                            "saves/scenarios/AwesomeRace",
+                            "saves/scenarios/AwesomeRace/persistent.sfs",
                         },
                         results.Select(f => f.destination));
+                    Assert.IsTrue(results.All(f => f.makedir));
                 }
             }
         }


### PR DESCRIPTION
## Problem

If you try to install a directory to an `install_to` of `Scenarios`, it won't be created, and files it contains will cause the install to fail:

```
Could not find a part of the path "/path/to/game/saves/scenarios/1_TheMartian/DQS_DataBase.cfg".
Install canceled. Your files have been returned to their initial state.
```

Noticed while reviewing KSP-CKAN/NetKAN#10839.

## Cause

In #3180, we updated the logic for allowing directory creation to include `Ships/Script`, which can be a direct `install_to` target itself, but also an implicit target via `Ships`, using `as`, etc. In the process, we switched from determining directory creation based on `install_to` to determining it based on the calculated relative path. This broke directory creation for `Scenarios` and `Tutorial`. (`Missions` would have been OK because the `install_to` is identical to the path).

## Changes

Now `IGame.CreateableDirs` has a new `IGame.CreatableInstallTos` array split off of it, containing the strings that are meant to match `install_to`. `Ships/Script` remains in `CreatableDirs`, which is checked against the relative install path.

The `AllowInstallsToScenarios` test is updated to install a directory and make sure that `InstallableFile.makedir` is `true`. It now fails on the old code and passes with the fix.
