### PR TITLE
Ensure encoding is UTF-8 when saving JSON

### DIFF
--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Collections.Generic;
 using System.Threading;
 using System.Security.Cryptography;
@@ -27,7 +28,7 @@ namespace CKAN.Extensions
         {
             using (var stream = File.Create(path, contents.Length + 1,
                                             FileOptions.WriteThrough))
-            using (var writer = new StreamWriter(stream))
+            using (var writer = new StreamWriter(stream, Encoding.UTF8))
             {
                 writer.Write(contents);
                 // If we don't Flush, the file can be truncated,

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Linq;
 using System.Transactions;
 using System.Diagnostics.CodeAnalysis;
@@ -348,7 +349,8 @@ namespace CKAN
                 foreach (var anchor in game.InstanceAnchorFiles)
                 {
                     txFileMgr.WriteAllText(Path.Combine(newPath, anchor),
-                                         version.WithoutBuild.ToString());
+                                           version.WithoutBuild.ToString(),
+                                           Encoding.UTF8);
                 }
 
                 // Don't write the buildID.txts if we have no build, otherwise it would be -1.
@@ -357,14 +359,16 @@ namespace CKAN
                     foreach (var b in KspBuildIdVersionProvider.buildIDfilenames)
                     {
                         txFileMgr.WriteAllText(Path.Combine(newPath, b),
-                                             string.Format("build id = {0}", version.Build));
+                                               string.Format("build id = {0}", version.Build),
+                                               Encoding.UTF8);
                     }
                 }
 
                 // Create the readme.txt WITHOUT build number
                 txFileMgr.WriteAllText(Path.Combine(newPath, "readme.txt"),
-                                     string.Format("Version {0}",
-                                                   version.WithoutBuild.ToString()));
+                                       string.Format("Version {0}",
+                                                     version.WithoutBuild.ToString()),
+                                       Encoding.UTF8);
 
                 // Create the needed folder structure and the readme.txt for DLCs that should be simulated.
                 if (dlcs != null)
@@ -385,7 +389,8 @@ namespace CKAN
                         txFileMgr.CreateDirectory(dlcDir);
                         txFileMgr.WriteAllText(
                             Path.Combine(dlcDir, "readme.txt"),
-                            string.Format("Version {0}", dlcVersion));
+                            string.Format("Version {0}", dlcVersion),
+                            Encoding.UTF8);
                     }
                 }
 

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -344,7 +344,8 @@ namespace CKAN
         private static Registry LoadRegistry(GameInstance          inst,
                                              RepositoryDataManager repoData)
             => Registry.FromJson(inst, repoData,
-                                 File.ReadAllText(Path.Combine(inst.CkanDir, "registry.json")));
+                                 File.ReadAllText(Path.Combine(inst.CkanDir, "registry.json"),
+                                                  Encoding.UTF8));
 
         [MemberNotNull(nameof(registry))]
         private void Create(RepositoryDataManager   repoData,
@@ -412,7 +413,7 @@ namespace CKAN
                 Directory.CreateDirectory(directoryPath);
             }
 
-            txFileMgr.WriteAllText(path, Serialize());
+            txFileMgr.WriteAllText(path, Serialize(), Encoding.UTF8);
 
             if (!Directory.Exists(gameInstance.InstallHistoryDir))
             {
@@ -448,7 +449,7 @@ namespace CKAN
             var serialized = SerializeCurrentInstall(recommends, withVersions);
             foreach (var path in paths)
             {
-                txFileMgr.WriteAllText(path, serialized);
+                txFileMgr.WriteAllText(path, serialized, Encoding.UTF8);
             }
         }
 

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -127,7 +127,8 @@ namespace CKAN
                 serializer.Serialize(writer, this);
             }
             var txFileMgr = new TxFileManager();
-            txFileMgr.WriteAllText(path, sw + Environment.NewLine);
+            txFileMgr.WriteAllText(path, sw + Environment.NewLine,
+                                   Encoding.UTF8);
         }
 
         /// <summary>
@@ -150,7 +151,7 @@ namespace CKAN
                         ? null
                         // Treat JSON parsing as the first 50%
                         : new ProgressImmediate<long>(p => progress.Report((int)(50 * p / fileSize)))))
-                using (var reader = new StreamReader(progressStream))
+                using (var reader = new StreamReader(progressStream, Encoding.UTF8))
                 using (var jStream = new JsonTextReader(reader))
                 {
                     var settings = new JsonSerializerSettings()

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -258,7 +259,7 @@ namespace CKAN
         {
             try
             {
-                etags = JsonConvert.DeserializeObject<Dictionary<Uri, string>>(File.ReadAllText(etagsPath))
+                etags = JsonConvert.DeserializeObject<Dictionary<Uri, string>>(File.ReadAllText(etagsPath, Encoding.UTF8))
                         // An empty or all-null file can deserialize as null
                         ?? new Dictionary<Uri, string>();
             }
@@ -271,7 +272,9 @@ namespace CKAN
         private void saveETags()
         {
             var txFileMgr = new TxFileManager();
-            txFileMgr.WriteAllText(etagsPath, JsonConvert.SerializeObject(etags, Formatting.Indented));
+            txFileMgr.WriteAllText(etagsPath,
+                                   JsonConvert.SerializeObject(etags, Formatting.Indented),
+                                   Encoding.UTF8);
         }
 
         private void setETag(NetAsyncDownloader.DownloadTarget target,


### PR DESCRIPTION
## Problem

1. On Windows: All Settings → Time & Language → Language & region → in Display Language section → Disable the "Beta: Use Unicode UTF-8 for worldwide language support" setting
2. Open CKAN
3. Install VaporVent
4. Close CKAN
5. Open CKAN
6. VaporVent shows up as missing some files
   <img width="376" height="52" alt="Image" src="https://github.com/user-attachments/assets/ec291bf6-238a-4e6b-8694-2f2b8800de02" />
   <img width="412" height="630" alt="Image" src="https://github.com/user-attachments/assets/bbe1b03e-883c-4608-a0f0-b9382670930d" />

## Cause

The '&eacute;' in the affected file's name seems to be written to `registry.json` in the Latin-1 encoding, then read in UTF-8, which interprets it as an invalid character.

@Clayell produced two different `registry.json` files:

- One with the '&eacute;' represented by a single `E9` byte, which is the Latin-1 encoding and doesn't work
- And one with the '&eacute;' represented by two bytes, `C3` `A9`, which is the UTF-8 encoding and works

## Changes

Now when we load or save JSON, we forcibly set the encoding to UTF-8. This should ensure that accented characters are always interpreted correctly.

Fixes #4470.
