### PR TITLE
Remove BOMs from UTF-8 output

### DIFF
--- a/ConsoleUI/Toolkit/Symbols.cs
+++ b/ConsoleUI/Toolkit/Symbols.cs
@@ -1,6 +1,9 @@
+#if !NETFRAMEWORK
 using System.Text;
+#endif
 
 namespace CKAN.ConsoleUI.Toolkit {
+    using Encoding = System.Text.Encoding;
 
     /// <summary>
     /// Glyphs for drawing text UIs

--- a/Core/Exporters/BbCodeExporter.cs
+++ b/Core/Exporters/BbCodeExporter.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace CKAN.Exporters
 {

--- a/Core/Exporters/CkanExporter.cs
+++ b/Core/Exporters/CkanExporter.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Text;
 
 namespace CKAN.Exporters
 {

--- a/Core/Exporters/DelimiterSeparatedValueExporter.cs
+++ b/Core/Exporters/DelimiterSeparatedValueExporter.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 
 namespace CKAN.Exporters
 {

--- a/Core/Exporters/MarkdownExporter.cs
+++ b/Core/Exporters/MarkdownExporter.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace CKAN.Exporters
 {

--- a/Core/Exporters/PlainTextExporter.cs
+++ b/Core/Exporters/PlainTextExporter.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace CKAN.Exporters
 {

--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text;
 using System.Collections.Generic;
 using System.Threading;
 using System.Security.Cryptography;

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Linq;
 using System.Transactions;
 using System.Diagnostics.CodeAnalysis;

--- a/Core/IO/DirectoryLink.cs
+++ b/Core/IO/DirectoryLink.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 using ChinhDo.Transactions;
@@ -183,7 +182,7 @@ namespace CKAN.IO
             public static ReparseDataBuffer FromPath(string target, out int byteCount)
             {
                 var fullTarget = $@"\??\{Path.GetFullPath(target)}";
-                byteCount = Encoding.Unicode.GetByteCount(fullTarget);
+                byteCount = System.Text.Encoding.Unicode.GetByteCount(fullTarget);
                 return new ReparseDataBuffer
                 {
                     ReparseTag           = IO_REPARSE_TAG_MOUNT_POINT,

--- a/Core/IO/Encoding.cs
+++ b/Core/IO/Encoding.cs
@@ -1,0 +1,9 @@
+using System.Text;
+
+namespace CKAN
+{
+    public static class Encoding
+    {
+        public static readonly System.Text.Encoding UTF8 = new UTF8Encoding(false);
+    }
+}

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Collections.Concurrent;

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text;
 using System.Linq;
 using System.Collections.Generic;
 

--- a/Netkan/Sources/Spacedock/SpacedockApi.cs
+++ b/Netkan/Sources/Spacedock/SpacedockApi.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Text;
 using System.Text.RegularExpressions;
 
 using log4net;

--- a/Tests/Core/IO/FileIdentifier.cs
+++ b/Tests/Core/IO/FileIdentifier.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Text;
 
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;

--- a/Tests/Data/TemporaryRepository.cs
+++ b/Tests/Data/TemporaryRepository.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text;
 
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;

--- a/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
+++ b/Tests/NetKAN/Sources/Spacedock/SpacedockApiTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.IO;
-using System.Text;
 using System.Net;
 
 using NUnit.Framework;
@@ -100,7 +99,7 @@ namespace Tests.NetKAN.Sources.Spacedock
             // Arrange
             var response = new Mock<WebResponse>();
             response.Setup(r => r.GetResponseStream())
-                    .Returns(new MemoryStream(Encoding.ASCII.GetBytes(
+                    .Returns(new MemoryStream(Encoding.UTF8.GetBytes(
                         @"{
                             ""error"":  true,
                             ""reason"": ""Fake failure reason for testing""


### PR DESCRIPTION
## Problem

After #4477 was merged, KSP-CKAN/NetKAN#10871 still fails validation, but with a different problem:

```
Traceback (most recent call last):
  File "/usr/local/bin/ckanmetatester", line 8, in <module>
    sys.exit(test_metadata())
             ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ckan_meta_tester/__init__.py", line 22, in test_metadata
    if ex.test_metadata(environ.get('INPUT_SOURCE', 'netkans'),
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ckan_meta_tester/ckan_meta_tester.py", line 113, in test_metadata
    if not self.install_ckan(file, orig_file, pr_body, meta_repo):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ckan_meta_tester/ckan_meta_tester.py", line 188, in install_ckan
    ckan = CkanInstall(file)
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/netkan/metadata.py", line 334, in __init__
    self._raw = json.loads(self.contents, object_hook=self._custom_parser)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 335, in loads
    raise JSONDecodeError("Unexpected UTF-8 BOM (decode using utf-8-sig)",
json.decoder.JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)
```

## Cause

A "BOM" is a byte order marker, two extra bytes at the beginning of a text file that are intended to mark it as UTF-8. This is very annoying in general because it requires every tool that reads such a file to understand it, such as the Python code in the above stack trace.

#4475 used `System.Text.Encoding.UTF8` to ensure stable UTF-8 file I/O, but apparently that class also causes a BOM to be emitted :facepalm:. See dotnet/runtime#51353 for more information and some discussion of this possibly being changed in the future.

This means that for about the past day, `netkan.exe` has been generating .ckan files with BOMs, and the dev build has been saving registry and repo metadata with BOMs as well. :sob:

Thankfully the Inflator does not directly save/commit .ckan files anymore but rather sends metadata to the Python back-end; otherwise we would have seen a massive wave of every unfrozen netkan's .ckan files in CKAN-meta being updated to add BOMs. :disappointed_relieved: 

## Changes

Now `CKAN.Encoding.UTF8` is created as a non-BOM emitting replacement for `System.Text.Encoding.UTF8`. Code in or using the `CKAN` namespace that references `Encoding.UTF8` will get this new object for free, so we'll no longer emit BOMs. Any code that actually needs `System.Text.Encoding` for other purposes will need to add `using Encoding = System.Text.Encoding`, which I kind of like because it will catch things like other encodings being used when UTF-8 would be better.
