### PR TITLE
Display release date in local time zone

### DIFF
--- a/GUI/Controls/ModInfo/Versions.cs
+++ b/GUI/Controls/ModInfo/Versions.cs
@@ -220,7 +220,7 @@ namespace CKAN.GUI
                         GameVersionRange.VersionSpan(currentInstance.Game,
                                                      minKsp ?? GameVersion.Any,
                                                      maxKsp ?? GameVersion.Any),
-                        module.release_date?.ToString("g") ?? ""
+                        module.release_date?.ToLocalTime().ToString("g") ?? ""
                     })
                     {
                         Tag = module,

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -556,7 +556,7 @@ namespace CKAN.GUI
             var compat        = new DataGridViewTextBoxCell { Value = mod.GameCompatibility       };
             var downloadSize  = new DataGridViewTextBoxCell { Value = mod.DownloadSize            };
             var installSize   = new DataGridViewTextBoxCell { Value = mod.InstallSize             };
-            var releaseDate   = new DataGridViewTextBoxCell { Value = mod.Module.release_date     };
+            var releaseDate   = new DataGridViewTextBoxCell { Value = mod.Module.release_date?.ToLocalTime() };
             var installDate   = new DataGridViewTextBoxCell { Value = mod.InstallDate             };
             var desc          = new DataGridViewTextBoxCell { Value = ToGridText(mod.Abstract)    };
 


### PR DESCRIPTION
## Problem

@Clayell pointed out that the install date of a mod (on the right) was earlier than its release date (on the left):

<img width="719" height="32" alt="image" src="https://github.com/user-attachments/assets/843e5d91-9d6c-45ef-90d1-376ae057642e" />

## Cause

The install date is in local time, while the release date is in UTC.

## Changes

- Now the release date in the main mod list is converted to local time
- The same conversion is also performed in the release date column of the Versions tab
