### PR TITLE
Fix freezing after startup with empty mod list

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -45,7 +45,7 @@ namespace CKAN.GUI
                                             Util.Debounce<EventArgs>((sender, e) => {},
                                                                      (sender, e) => false,
                                                                      (sender, e) => false,
-                                                                     ModGrid_SelectionChanged,
+                                                                     (sender, e) => Util.Invoke(this, () => ModGrid_SelectionChanged(sender, e)),
                                                                      100));
 
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
@@ -138,7 +138,7 @@ namespace CKAN.GUI
 
         private List<bool> descending => guiConfig?.MultiSortDescending ?? new List<bool>();
 
-        public event Action<GUIMod>? OnSelectedModuleChanged;
+        public event Action<GUIMod?>? OnSelectedModuleChanged;
         public event Action<List<ModChange>?, Dictionary<GUIMod, string>?>? OnChangeSetChanged;
         public event Action? OnRegistryChanged;
 
@@ -706,9 +706,9 @@ namespace CKAN.GUI
             }
 
             var module = SelectedModule;
+            OnSelectedModuleChanged?.Invoke(module);
             if (module != null)
             {
-                OnSelectedModuleChanged?.Invoke(module);
                 NavSelectMod(module);
             }
         }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -823,7 +823,7 @@ namespace CKAN.GUI
             return false;
         }
 
-        private void ManageMods_OnSelectedModuleChanged(GUIMod m)
+        private void ManageMods_OnSelectedModuleChanged(GUIMod? m)
         {
             if (MainTabControl.SelectedTab == ManageModsTabPage)
             {


### PR DESCRIPTION
## Problem

1. Open CKAN
2. Set a filter that matches no mods, so the mod list is empty; e.g., `is:newly-compatible` commonly works for this
3. Close CKAN
4. Open CKAN again
5. Click the `X` to clear the filter
6. The mod list populates and the mod info pane appears, but mod info is blank and the GUI freezes

## Cause

#4386 made it possible to multi-select rows in the mod list. When you shift-select a group of mods, this calls `ModGrid_SelectionChanged` many times in a row, once per mod, which made the mod info pane flicker as it loaded each mod's info, mostly before you could read it. To address this, we used `Util.Debounce` to generate an event handler for `ModGrid.SelectionChanged`, so mod info only updates once after all the rows are selected.

Internally, `Util.Debounce` uses a `System.Timers.Timer` to call the given function after the handler hasn't been called for 500 milliseconds. This call happens on a background thread, which is bad for `ModGrid_SelectionChanged` because it interacts with the GUI, which is only supposed to happen on the designated GUI thread. Somehow this causes problems when the mod info pane was hidden but not otherwise.

## Changes

- Now instead of passing  to `Debounce`, we pass a lambda that uses `Util.Invoke` to call `ModGrid_SelectionChanged` on the GUI thread.
- While investigating this, I noticed that `Main.ActiveModInfo` can handle a `null` value, but `ManageMods` never raises `OnSelectedModuleChanged` with `null`. Practically, this means that when the mod list is empty, the mod info pane isn't hidden even though there is no selected mod.
  Now `ManageMods` is updated to raise `OnSelectedModuleChanged` even when the selected mod is `null`, so the mod info pane will disappear if you empty out the mod list.

Fixes #4490.
