### PR TITLE
Remove dependencies from changeset when skipping a change

### DIFF
--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -81,8 +81,8 @@ namespace CKAN.GUI
                 && row.ConfirmUncheck())
             {
                 (ChangesGrid.DataSource as BindingList<ChangesetRow>)?.Remove(row);
-                changeset?.Remove(row.Change);
                 OnRemoveItem?.Invoke(row.Change);
+                changeset?.Remove(row.Change);
             }
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1121,6 +1121,18 @@ namespace CKAN.GUI
                     guiMod.SelectedMod = guiMod.InstalledMod?.Module;
                     switch (change.ChangeType)
                     {
+                        case GUIModChangeType.Remove:
+                            if (row.Cells[Installed.Index] is DataGridViewCheckBoxCell instCell)
+                            {
+                                instCell.Value = true;
+                            }
+                            break;
+                        case GUIModChangeType.Install:
+                            if (row.Cells[Installed.Index] is DataGridViewCheckBoxCell rmCell)
+                            {
+                                rmCell.Value = false;
+                            }
+                            break;
                         case GUIModChangeType.Replace:
                             if (row.Cells[ReplaceCol.Index] is DataGridViewCheckBoxCell checkCell)
                             {


### PR DESCRIPTION
## Motivation

@SofieBrink pointed out in Discord that using the "Skip" X to remove a mod from the changeset doesn't remove its dependencies from the visible list (even though it does remove them from what will actually be installed).

<img width="1916" height="1007" alt="image" src="https://github.com/user-attachments/assets/3afce015-b89c-43d7-9231-d4ad29ab3e50" />
<img width="1917" height="1005" alt="image" src="https://github.com/user-attachments/assets/716f705a-cb00-4fc8-9bda-1e99fad13208" />

## Changes

- Now the changeset tab notifies the mod list before removing the mod from the changeset rather than fater
- Now the mod list handles `GUIModChangeType.Remove` and `GUIModChangeType.Install` by reverting the checkboxes to their original state before recalculating the changeset

This will cause the dependencies to be removed.
