### PR TITLE
Mark virtual dependencies as auto-installed

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -118,6 +118,7 @@ namespace CKAN.CmdLine
                 without_enforce_consistency    = user.Headless,
             };
 
+            var autoInstalled = new HashSet<CkanModule>();
             for (bool done = false; !done; )
             {
                 // Install everything requested. :)
@@ -129,7 +130,8 @@ namespace CKAN.CmdLine
                                           new InstalledFilesDeduplicator(instance,
                                                                          manager.Instances.Values,
                                                                          repoData),
-                                          options?.NetUserAgent);
+                                          options?.NetUserAgent,
+                                          null, autoInstalled);
                     user.RaiseMessage("");
                     done = true;
                 }
@@ -165,6 +167,7 @@ namespace CKAN.CmdLine
 
                     // Add the module to the list.
                     modules.Add(choices[result]);
+                    autoInstalled.Add(choices[result]);
                     // DON'T return so we can loop around and try again
                 }
                 catch (CancelledActionKraken k)

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -55,6 +55,7 @@ namespace CKAN.ConsoleUI {
             if (manager.CurrentInstance != null && manager.Cache != null)
             {
                 using (TransactionScope trans = CkanTransaction.CreateTransactionScope()) {
+                    var autoInstalled = new HashSet<CkanModule>();
                     bool retry = false;
                     do {
                         Draw();
@@ -109,7 +110,7 @@ namespace CKAN.ConsoleUI {
                                                              ?? m)
                                                 .ToArray();
                                 inst.InstallList(iList, resolvOpts(stabilityTolerance), regMgr,
-                                                 ref possibleConfigOnlyDirs, deduper, userAgent, dl);
+                                                 ref possibleConfigOnlyDirs, deduper, userAgent, dl, autoInstalled);
                                 plan.Install.Clear();
                             }
                             if (plan.Upgrade.Count > 0) {
@@ -120,7 +121,7 @@ namespace CKAN.ConsoleUI {
                                                                           .Keys
                                                                           .Except(plan.Upgrade)
                                                                           .ToHashSet());
-                                inst.Upgrade(upgGroups[true], dl, ref possibleConfigOnlyDirs, regMgr, deduper);
+                                inst.Upgrade(upgGroups[true], dl, ref possibleConfigOnlyDirs, regMgr, deduper, autoInstalled);
                                 plan.Upgrade.Clear();
                             }
                             if (plan.Replace.Count > 0) {
@@ -148,6 +149,7 @@ namespace CKAN.ConsoleUI {
                             if (chosen != null) {
                                 // Use chosen to continue installing
                                 plan.Install.Add(chosen);
+                                autoInstalled.Add(chosen);
                                 retry = true;
                             }
 

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -112,6 +112,7 @@ namespace CKAN.GUI
 
                 // this will be the final list of mods we want to install
                 var toInstall   = new List<CkanModule>();
+                var autoInstalled = new HashSet<CkanModule>();
                 var toUninstall = new HashSet<CkanModule>();
                 var toUpgrade   = new HashSet<CkanModule>();
 
@@ -253,13 +254,13 @@ namespace CKAN.GUI
                             if (!canceled && toInstall.Count > 0)
                             {
                                 installer.InstallList(toInstall, options, registry_manager, ref possibleConfigOnlyDirs,
-                                                      deduper, userAgent, downloader, false);
+                                                      deduper, userAgent, downloader, autoInstalled, false);
                                 toInstall.Clear();
                             }
                             if (!canceled && toUpgrade.Count > 0)
                             {
                                 installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager,
-                                                  deduper, true, false);
+                                                  deduper, autoInstalled, true, false);
                                 toUpgrade.Clear();
                             }
                             if (canceled)
@@ -345,6 +346,7 @@ namespace CKAN.GUI
                             {
                                 // User picked a mod, queue it up for installation
                                 toInstall.Add(chosen);
+                                autoInstalled.Add(chosen);
                                 // DON'T return so we can loop around and try the above InstallList call again
                                 tabController.ShowTab(WaitTabPage.Name);
                                 Util.Invoke(this, () => StatusProgress.Visible = true);

--- a/Tests/Core/IO/ModuleInstallerDirTest.cs
+++ b/Tests/Core/IO/ModuleInstallerDirTest.cs
@@ -60,7 +60,7 @@ namespace Tests.Core.IO
             _manager.Cache?.Store(_testModule!, testModFile, new Progress<long>(bytes => {}));
             HashSet<string>? possibleConfigOnlyDirs = null;
             _installer.InstallList(
-                new List<CkanModule>() { _testModule! },
+                new CkanModule[] { _testModule! },
                 new RelationshipResolverOptions(_instance.KSP.StabilityToleranceConfig),
                 _registryManager,
                 ref possibleConfigOnlyDirs);

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -1608,7 +1608,7 @@ namespace Tests.Core.IO
                                       registry.LatestAvailable(ident, inst.KSP.StabilityToleranceConfig, inst.KSP.VersionCriteria()))
                                                     .OfType<CkanModule>()
                                                     .ToArray(),
-                                  downloader, ref possibleConfigOnlyDirs, regMgr, null, false);
+                                  downloader, ref possibleConfigOnlyDirs, regMgr, null, null, false);
 
                 // Assert
                 CollectionAssert.AreEquivalent(correctRemainingIdentifiers,
@@ -1706,7 +1706,7 @@ namespace Tests.Core.IO
                     installer.Upgrade(toUpgrade.Select(CkanModule.FromJson)
                                                .ToArray(),
                                       downloader, ref possibleConfigOnlyDirs,
-                                      regMgr, null, false);
+                                      regMgr, null, null, false);
                 });
                 CollectionAssert.AreEquivalent(registry.InstalledModules.Select(im => im.Module),
                                                autoInstalled.Select(CkanModule.FromJson)

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -777,7 +777,7 @@ namespace Tests.GUI
 
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 installer.InstallList(
-                    new List<CkanModule> { anyVersionModule },
+                    new CkanModule[] { anyVersionModule },
                     new RelationshipResolverOptions(instance.KSP.StabilityToleranceConfig),
                     regMgr,
                     ref possibleConfigOnlyDirs,
@@ -825,7 +825,7 @@ namespace Tests.GUI
                         installer.InstallList(
                             modList.ComputeUserChangeSet(Registry.Empty(repoData.Manager), inst2.KSP, null, null)
                                    .Select(change => change.Mod)
-                                   .ToList(),
+                                   .ToArray(),
                             new RelationshipResolverOptions(inst2.KSP.StabilityToleranceConfig),
                             regMgr,
                             ref possibleConfigOnlyDirs,


### PR DESCRIPTION
## Problem / Motivation

1. Install a mod with a virtual dependency (i.e., one in which the user is asked to choose which module to use to satisfy it)
2. Pick whatever when prompted
3. Finish installing
4. The dependency is not marked as auto-installed, even though it is only there because another mod needed it and would probably make sense to remove if the user removes the depending mod

## Cause

Virtual dependency choice is driven by a `TooManyModsProvideKraken` exception that halts the install. Then the UI prompts the user to choose, adds their choice to the changeset, and re-starts the install. So virtual dependencies are always in the changeset, making them appear as manual user choices. (xref #2753)

## Changes

Now when the user chooses a mod to satisfy a virtual dependency, each UI adds the module to a list of mods that should be marked as auto-installed, which is passed to `InstallList` and `Upgrade` and used to set the `autoInstalled` parameter of `Registry.RegisterModule`.

Fixes #4428.

### Caveats / Objections

I don't love adding a new parameter to `InstallList` and `Upgrade` for this, or making this common requirement live in UI-specific code. I anticipate a future project to:

- Remove `InstallList`, `Upgrade`, and `UninstallList` from `ModuleInstaller`
- Eliminate `TooManyModsProvideKraken`
- Add a `ModChange` object to Core
- Add an `ApplyChanges` to `ModuleInstaller` that:
  - has a parameter for a read only collection of `ModChange`s
  - has a parameter for a callback to choose a module to satisfy a virtual dependency
  - has its own list of auto-installed modules to which it adds such virtual dependencies

This would dramatically simplify the per-UI code for installing by better encapsulating the common/redundant logic in one place in Core.

... but that's a pretty big change, and for now this way of doing it is pretty minimal and safe and will serve as an anchor to ensure this feature is incorporated into that future rewrite, should it occur.
