### PR TITLE
Remove redundant duplicate check

### DIFF
--- a/Cmdline/Action/Filter.cs
+++ b/Cmdline/Action/Filter.cs
@@ -117,18 +117,6 @@ namespace CKAN.CmdLine
             if (opts.global)
             {
                 var game = GetGame(opts.gameId, instance);
-                var duplicates = manager.Configuration
-                                        .GetGlobalInstallFilters(game)
-                                        .Intersect(opts.filters ?? Enumerable.Empty<string>())
-                                        .ToArray();
-                if (duplicates.Length > 0)
-                {
-                    user.RaiseError(Properties.Resources.FilterAddGlobalDuplicateError,
-                                    string.Join(", ", duplicates));
-                    return Exit.BADOPT;
-                }
-                else
-                {
                     manager.Configuration.SetGlobalInstallFilters(
                         game,
                         manager.Configuration
@@ -136,26 +124,13 @@ namespace CKAN.CmdLine
                                .Concat(opts.filters ?? Enumerable.Empty<string>())
                                .Distinct()
                                .ToArray());
-                }
             }
             else
             {
-                var duplicates = instance.InstallFilters
-                                         .Intersect(opts.filters ?? Enumerable.Empty<string>())
-                                         .ToArray();
-                    if (duplicates.Length > 0)
-                    {
-                        user.RaiseError(Properties.Resources.FilterAddInstanceDuplicateError,
-                                         string.Join(", ", duplicates));
-                        return Exit.BADOPT;
-                    }
-                    else
-                    {
                         instance.InstallFilters = instance.InstallFilters
                             .Concat(opts.filters ?? Enumerable.Empty<string>())
                             .Distinct()
                             .ToArray();
-                    }
             }
             return Exit.OK;
         }


### PR DESCRIPTION
.Distinct() already removes the duplicates.
This change makes sure users don't have to manually make sure they don't enter duplicates.