### PR TITLE
Don't leave launch shell waiting for CKAN to close

### DIFF
--- a/debian/ckan
+++ b/debian/ckan
@@ -3,15 +3,15 @@
 if [ -n "$*" ]
 then
     # If command line arguments are given, use them
-    mono /usr/lib/ckan/ckan.exe "$@"
+    exec mono /usr/lib/ckan/ckan.exe "$@"
 else
     # No command line arguments
     if [ -n "$WAYLAND_DISPLAY" -o -n "$DISPLAY" ]
     then
         # Default to GUI if there's an X11 display or a Wayland display
-        mono /usr/lib/ckan/ckan.exe gui
+        exec mono /usr/lib/ckan/ckan.exe gui
     else
         # Run the retro text UI if graphics aren't available
-        mono /usr/lib/ckan/ckan.exe consoleui
+        exec mono /usr/lib/ckan/ckan.exe consoleui
     fi
 fi


### PR DESCRIPTION
This is a pretty trivial change to the Debian launch script. The `/usr/bin/ckan` script currently keeps the shell open until CKAN is actually closed. `exec` is a shell builtin that tells the shell to replace itself with the called program, preventing this. It's standardized in POSIX, and implemented by both `dash` and `bash`, so there shouldn't be any compatibility concerns.

While this won't save *much* memory or performance, it's such a trivial change with no downside that I can't see a reason not to do it.