### PR TITLE
Fix symlinks being generated on Linux

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="ini-parser" Version="3.4.0" />
+    <PackageReference Include="ini-parser" Version="2.5.2" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />

--- a/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.Designer.cs
@@ -194,7 +194,7 @@ namespace CKAN.GUI
             //
             this.checkBoxShareStock.AutoSize = true;
             this.checkBoxShareStock.Checked = false;
-            this.checkBoxShareStock.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxShareStock.CheckState = System.Windows.Forms.CheckState.Unchecked;
             this.checkBoxShareStock.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.checkBoxShareStock.Location = new System.Drawing.Point(181, 204);
             this.checkBoxShareStock.Name = "checkBoxShareStock";


### PR DESCRIPTION
## Problem

#4441 intended to suppress symlinks when cloning instances on Linux, but it didn't work; symlinks are still being generated.

Reported by @PewPewCricket on Discord and <https://github.com/KSP-CKAN/CKAN/pull/4441#issuecomment-3978053277>.

## Cause

I updated the default for the `Checked` property, but `CheckedState` is set to the opposite value on the next line, so the hidden checkbox was still always checked. 🤦

## Changes

- Now `CheckedState` defaults to `Unchecked`, so there will actually not be symlinks on Linux.
- [`ini-parser`](https://www.nuget.org/packages/ini-parser)'s actual latest version is 2.5.2; 3.4.0 was a typo'd duplicate of 2.4.0 that was de-listed from Nuget. However, Nuget does not allow fully deleting releases, because it would break builds.
  Our reference is now updated from 3.4.0 to 2.5.2.
