### PR TITLE
Only scroll ConsoleUI log messages for small popups

### DIFF
--- a/ConsoleUI/ProgressScreen.cs
+++ b/ConsoleUI/ProgressScreen.cs
@@ -90,9 +90,12 @@ namespace CKAN.ConsoleUI {
                 return false;
             });
 
-            // Scroll messages
-            d.AddTip(Properties.Resources.CursorKeys, Properties.Resources.ScrollMessages);
-            messages.AddScrollBindings(d, theme, true);
+            // Scroll log messages beneath popup if message is one line (otherwise the popup itself will scroll)
+            if (!question.Contains(Environment.NewLine))
+            {
+                d.AddTip(Properties.Resources.CursorKeys, Properties.Resources.ScrollMessages);
+                messages.AddScrollBindings(d, theme, true);
+            }
 
             bool val = d.Run() == 0;
             DrawBackground();

--- a/ConsoleUI/Toolkit/ConsoleMessageDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleMessageDialog.cs
@@ -68,6 +68,17 @@ namespace CKAN.ConsoleUI.Toolkit {
             SetDimensions(l, t, r, b);
             int btnRow = GetBottom() - 2;
 
+            int btnLeft = (Console.WindowWidth - btnW) / 2;
+            for (int i = 0; i < btns.Count; ++i) {
+                string cap = btns[i];
+                int j = i;
+                AddObject(new ConsoleButton(btnLeft, btnRow, btnLeft + buttonWidth - 1, cap, () => {
+                    selectedButton = j;
+                    Quit();
+                }));
+                btnLeft += buttonWidth + buttonPadding;
+            }
+
             var tb = new ConsoleTextBox(
                 GetLeft() + 2, GetTop() + 2, GetRight() - 2, GetBottom() - 2 - (btns.Count > 0 ? 2 : 0),
                 false,
@@ -84,17 +95,6 @@ namespace CKAN.ConsoleUI.Toolkit {
                 // Scroll
                 AddTip(Properties.Resources.CursorKeys, Properties.Resources.Scroll);
                 tb.AddScrollBindings(this, theme);
-            }
-
-            int btnLeft = (Console.WindowWidth - btnW) / 2;
-            for (int i = 0; i < btns.Count; ++i) {
-                string cap = btns[i];
-                int j = i;
-                AddObject(new ConsoleButton(btnLeft, btnRow, btnLeft + buttonWidth - 1, cap, () => {
-                    selectedButton = j;
-                    Quit();
-                }));
-                btnLeft += buttonWidth + buttonPadding;
             }
         }
 

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -136,7 +136,7 @@ namespace CKAN
         /// </summary>
         /// <param name="path">Filename of the JSON file to load</param>
         /// <param name="progress">Progress notifier to receive updates of percent completion of this file</param>
-        /// <returns>A repo data object or null if loading fails</returns>
+        /// <returns>A repo data object or null if there is no such file</returns>
         public static RepositoryData? FromJson(string path, IProgress<int>? progress)
         {
             try
@@ -169,9 +169,10 @@ namespace CKAN
                                          .Deserialize<RepositoryData>(jStream);
                 }
             }
-            catch (Exception exc)
+            catch (FileNotFoundException exc)
             {
-                log.DebugFormat("Valid repository data not found at {0}: {1}", path, exc.Message);
+                log.DebugFormat("Valid repository data not found at {0}: {1}",
+                                path, exc.Message);
                 return null;
             }
         }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -999,9 +999,11 @@ namespace CKAN.GUI
             tabController.ShowTab(ChangesetTabPage.Name, 1);
         }
 
-        private void RefreshModList(bool allowAutoUpdate, Dictionary<string, bool>? oldModules = null)
+        private void RefreshModList(bool                      allowAutoUpdate,
+                                    Dictionary<string, bool>? oldModules = null)
         {
-            tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainModListWaitTitle);
+            tabController.RenameTab(WaitTabPage.Name,
+                                    Properties.Resources.MainModListWaitTitle);
             ShowWaitDialog();
             DisableMainWindow();
             ActiveModInfo = null;
@@ -1009,14 +1011,25 @@ namespace CKAN.GUI
                 ManageMods.Update,
                 (sender, e) =>
                 {
-                    if (e != null)
+                    switch (e)
                     {
-                        if (allowAutoUpdate && e.Result is bool b && !b)
-                        {
+                        case { Error: Kraken k }:
+                            currentUser.RaiseMessage("{0}", k.Message);
+                            EnableMainWindow();
+                            Wait.Finish();
+                            break;
+
+                        case { Error: Exception exc }:
+                            currentUser.RaiseMessage("{0}", exc.ToString());
+                            EnableMainWindow();
+                            Wait.Finish();
+                            break;
+
+                        case { Result: false } when allowAutoUpdate:
                             UpdateRepo();
-                        }
-                        else
-                        {
+                            break;
+
+                        default:
                             UpdateTrayInfo();
                             HideWaitDialog();
                             EnableMainWindow();
@@ -1028,7 +1041,7 @@ namespace CKAN.GUI
                                 // Only do it the first time
                                 focusIdent = null;
                             }
-                        }
+                            break;
                     }
                 },
                 false,


### PR DESCRIPTION
## Motivation

While investigating #4503, we discovered that JSON parsing exceptions for repo metadata are being caught silently, which obscures the problem reported in that issue.

## Problems

When ConsoleUI asks the user whether to overwrite a manually-installed mods files, some problems are apparent:

<img width="567" height="342" alt="Image" src="https://github.com/user-attachments/assets/b31cef98-7d6b-44e9-8d98-07de140875c0" />

- The buttons look inactive, which may lead the user to think the application is frozen
- Scrolling up or down renders some of the underlying log messages on top of the popup

## Causes

- The text box has focus, so the buttons are rendered as non-focused
- In order to allow the user to view the whole mod list during the initial confirmation prompt, the progress screen overrides the yes/no prompt to bind the cursor keys to scroll the underlying log messages. This feature is active for all yes/no prompts, and when the message is long (such as for the file override), there isn't room to see the log messages, so they are drawn on top.

## Changes

- Now JSON parsing errors are allowed to propagate out to the UI, and GUI is updated to display them in the message log
- Now the text box is moved to the end of the tab order, so the focus defaults to the first button. The text box will still be scrollable with the arrow keys if needed because those keys are bound at the dialog level.
- Now the log message scrolling key bindings are only set up if the yes/no prompt is short (has no newlines). This will disable it for the file overwrite prompt, so scrolling will just scroll the dialog.

Fixes #4545.
