### PR TITLE
Exclude other versions of mods already in changeset from satisfying relationships

### DIFF
--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -350,6 +350,7 @@ Free up space on that device or change your settings to use another location.
   <data name="RelationshipResolverReplacementReason" xml:space="preserve"><value>Replacing {0}</value></data>
   <data name="RelationshipResolverSuggestedReason" xml:space="preserve"><value>Suggested by {0}</value></data>
   <data name="RelationshipResolverDependsReason" xml:space="preserve"><value>Dependency of {0}</value></data>
+  <data name="RelationshipResolverVirtualDependsReason" xml:space="preserve"><value>Dependency of {0} to satisfy {1}</value></data>
   <data name="RelationshipResolverRecommendedReason" xml:space="preserve"><value>Recommended by {0}</value></data>
   <data name="ResolvedRelationshipsTreeUnsatisfied" xml:space="preserve"><value>Could not satisfy {0} while installing:
 {1}</value></data>

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -346,7 +346,13 @@ namespace CKAN
                 if (conflicting_mod == null)
                 {
                     // Okay, looks like we want this one. Adding.
-                    Add(candidate, reason);
+                    Add(candidate,
+                        descriptor is ModuleRelationshipDescriptor rel
+                        && rel.name != candidate.identifier
+                        && reason is SelectionReason.Depends depRsn
+                               ? new SelectionReason.VirtualDepends(depRsn.Parent,
+                                                                    descriptor.ToString() ?? "")
+                               : reason);
                     Resolve(candidate, options, stanza);
                 }
                 else if (options.proceed_with_inconsistencies)
@@ -404,8 +410,9 @@ namespace CKAN
                     else
                     {
                         // We should never add the same module twice!
-                        log.ErrorFormat("Assertion failed: Adding {0} twice in relationship resolution", module.identifier);
-                        throw new ArgumentException("Already contains module: " + module.identifier);
+                        log.ErrorFormat("Assertion failed: Already added {0}, can't add {1} ({2})",
+                                        possibleDup, module, reason);
+                        throw new ArgumentException($"Already added {possibleDup}, can't add {module} ({reason})");
                     }
                 }
                 else

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -281,9 +281,7 @@ namespace CKAN
                 IReadOnlyList<CkanModule>? candidates = null;
                 try
                 {
-                    candidates = resolved.Candidates(descriptor,
-                                                     modlist.Values.Except(user_requested_mods)
-                                                                   .ToArray(),
+                    candidates = resolved.Candidates(descriptor, modlist.Values,
                                                      registry, game);
                     log.DebugFormat("Got {0} candidates for {1}",
                                     candidates.Count, descriptor);

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -79,7 +79,12 @@ namespace CKAN
                     // We need to have this loop at this level to accumulate the list of candidates
                     foreach ((CkanModule module, ResolvedRelationship[] rrs) in resRel.resolved)
                     {
-                        if (module.BadRelationships(installing)
+                        if (installing.Any(m => m.identifier == module.identifier
+                                                && m.version != module.version))
+                        {
+                            // Skip other versions of mods being installed
+                        }
+                        else if (module.BadRelationships(installing)
                                   .Select(r => relationshipCache.GetValueOrDefault(r.Descriptor))
                                   .OfType<ResolvedRelationship>()
                                   .Select(badRR => new ResolvedRelationship[] { resRel, badRR })

--- a/Core/Relationships/SelectionReason.cs
+++ b/Core/Relationships/SelectionReason.cs
@@ -90,7 +90,7 @@ namespace CKAN
 
             public override string ToString()
                 => string.Format(Properties.Resources.RelationshipResolverReplacementReason,
-                                 Parent.name);
+                                 Parent);
 
             public override string DescribeWith(IEnumerable<SelectionReason> others)
                 => string.Format(Properties.Resources.RelationshipResolverReplacementReason,
@@ -98,7 +98,7 @@ namespace CKAN
                                              Enumerable.Repeat(this, 1)
                                                        .Concat(others)
                                                        .OfType<RelationshipReason>()
-                                                       .Select(r => r.Parent.name)));
+                                                       .Select(r => r.Parent.ToString())));
         }
 
         public sealed class Suggested : RelationshipReason
@@ -110,10 +110,10 @@ namespace CKAN
 
             public override string ToString()
                 => string.Format(Properties.Resources.RelationshipResolverSuggestedReason,
-                                 Parent.name);
+                                 Parent);
         }
 
-        public sealed class Depends : RelationshipReason
+        public class Depends : RelationshipReason
         {
             public Depends(CkanModule module)
                 : base(module)
@@ -122,7 +122,7 @@ namespace CKAN
 
             public override string ToString()
                 => string.Format(Properties.Resources.RelationshipResolverDependsReason,
-                                 Parent.name);
+                                 Parent);
 
             public override string DescribeWith(IEnumerable<SelectionReason> others)
                 => string.Format(Properties.Resources.RelationshipResolverDependsReason,
@@ -130,7 +130,31 @@ namespace CKAN
                                              Enumerable.Repeat(this, 1)
                                                        .Concat(others)
                                                        .OfType<RelationshipReason>()
-                                                       .Select(r => r.Parent.name)));
+                                                       .Select(r => r.Parent.ToString())));
+        }
+
+        public sealed class VirtualDepends : Depends
+        {
+            public VirtualDepends(CkanModule module, string virtualIdentifier)
+                : base(module)
+            {
+                VirtualIdentifier = virtualIdentifier;
+            }
+
+            public override string ToString()
+                => string.Format(Properties.Resources.RelationshipResolverVirtualDependsReason,
+                                 Parent, VirtualIdentifier);
+
+            public override string DescribeWith(IEnumerable<SelectionReason> others)
+                => string.Format(Properties.Resources.RelationshipResolverVirtualDependsReason,
+                                 string.Join(", ",
+                                             Enumerable.Repeat(this, 1)
+                                                       .Concat(others)
+                                                       .OfType<RelationshipReason>()
+                                                       .Select(r => r.Parent.ToString())),
+                                 VirtualIdentifier);
+
+            private readonly string VirtualIdentifier;
         }
 
         public sealed class Recommended : RelationshipReason
@@ -148,7 +172,7 @@ namespace CKAN
 
             public override string ToString()
                 => string.Format(Properties.Resources.RelationshipResolverRecommendedReason,
-                                 Parent.name);
+                                 Parent);
         }
     }
 }

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -372,6 +372,7 @@ namespace CKAN.GUI
             // Installed
             //
             this.Installed.Name = "Installed";
+            this.Installed.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.Installed.Frozen = true;
             this.Installed.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.Installed.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
@@ -381,6 +382,7 @@ namespace CKAN.GUI
             // AutoInstalled
             //
             this.AutoInstalled.Name = "AutoInstalled";
+            this.AutoInstalled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.AutoInstalled.Frozen = true;
             this.AutoInstalled.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.AutoInstalled.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
@@ -390,6 +392,7 @@ namespace CKAN.GUI
             // UpdateCol
             //
             this.UpdateCol.Name = "UpdateCol";
+            this.UpdateCol.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.UpdateCol.Frozen = true;
             this.UpdateCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.UpdateCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
@@ -399,6 +402,7 @@ namespace CKAN.GUI
             // ReplaceCol
             //
             this.ReplaceCol.Name = "ReplaceCol";
+            this.ReplaceCol.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ReplaceCol.Frozen = true;
             this.ReplaceCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
             this.ReplaceCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;

--- a/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.Designer.cs
@@ -99,6 +99,7 @@ namespace CKAN.GUI
             this.RetryColumn.Name = "RetryColumn";
             this.RetryColumn.DataPropertyName = "Retry";
             this.RetryColumn.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.RetryColumn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.RetryColumn.Width = 46;
             this.RetryColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             resources.ApplyResources(this.RetryColumn, "RetryColumn");
@@ -108,6 +109,7 @@ namespace CKAN.GUI
             this.SkipColumn.Name = "SkipColumn";
             this.SkipColumn.DataPropertyName = "Skip";
             this.SkipColumn.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.SkipColumn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.SkipColumn.Width = 46;
             this.SkipColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             resources.ApplyResources(this.SkipColumn, "SkipColumn");

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -98,6 +98,10 @@ namespace CKAN.GUI
                 };
 
                 var registry_manager = RegistryManager.Instance(CurrentInstance, repoData);
+
+                currentUser.RaiseMessage(Properties.Resources.MainRepoScanning);
+                registry_manager.ScanUnmanagedFiles();
+
                 var registry = registry_manager.registry;
                 var stabilityTolerance = CurrentInstance.StabilityToleranceConfig;
                 var installer = new ModuleInstaller(CurrentInstance, Manager.Cache,

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1934,6 +1934,34 @@ namespace Tests.Core.Relationships
             }
         }
 
+        [Test]
+        public void Constructor_DuplicateInChangeset_Throws()
+        {
+            // Arrange
+            var user   = new NullUser();
+            var crit   = new GameVersionCriteria(new GameVersion(1, 12, 5));
+            var modGen = new RandomModuleGenerator(new Random());
+            var mod    = modGen.GenerateRandomModule();
+            var other  = modGen.GenerateRandomModule(identifier: mod.identifier);
+            var inst   = new CkanModule[] { mod, other };
+            using (var repo     = new TemporaryRepository(mod.ToJson(), other.ToJson()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+
+                // Act / Assert
+                var exc = Assert.Throws<ArgumentException>(() =>
+                {
+                    var sut = new RelationshipResolver(
+                        inst, null,
+                        RelationshipResolverOptions.DependsOnlyOpts(stabilityTolerance),
+                        registry, game, crit);
+                });
+                Assert.AreEqual($"Already added {mod}, can't add {other} (Requested by user)",
+                                exc?.Message);
+            }
+        }
+
         public static string MergeWithDefaults(string json)
         {
             var incoming = JObject.Parse(json);

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1595,8 +1595,8 @@ namespace Tests.Core.Relationships
                                                            string[] goodSubstrings,
                                                            string[] badSubstrings)
         {
+            // Arrange
             var user = new NullUser();
-            var game = new KerbalSpaceProgram();
             var crit = new GameVersionCriteria(new GameVersion(1, 12, 5));
             using (var repo     = new TemporaryRepository(availableModules.Select(MergeWithDefaults)
                                                                           .ToArray()))
@@ -1863,6 +1863,73 @@ namespace Tests.Core.Relationships
                 {
                     var sut = new RelationshipResolver(toInstall, Array.Empty<CkanModule>(), opts,
                                                        registry, inst.KSP.Game, inst.KSP.VersionCriteria());
+                });
+            }
+        }
+
+        [TestCase(new string[]
+                  {
+                      @"{
+                          ""identifier"": ""JNSQ"",
+                          ""version"":    ""0.8.6"",
+                          ""provides"":   [ ""Kronometer"" ]
+                      }",
+                      @"{
+                          ""identifier"": ""JNSQ"",
+                          ""version"":    ""0.10.2"",
+                          ""depends"":    [ { ""name"": ""Kronometer"" } ]
+                      }",
+                      @"{
+                          ""identifier"": ""Kronometer"",
+                          ""version"":    ""v1.12.0.2""
+                      }",
+                  },
+                  new string[]  { "JNSQ" }),
+         TestCase(new string[]
+                  {
+                      @"{
+                          ""identifier"": ""JNSQ"",
+                          ""version"":    ""0.8.6"",
+                          ""provides"":   [ ""Kronometer"" ]
+                      }",
+                      @"{
+                          ""identifier"": ""JNSQ"",
+                          ""version"":    ""0.10.2"",
+                          ""depends"":    [ { ""name"": ""Kronometer"" } ]
+                      }",
+                      @"{
+                          ""identifier"": ""Kronometer"",
+                          ""version"":    ""v1.12.0.2""
+                      }",
+                      @"{
+                          ""identifier"": ""JNSQ-RibbonPack"",
+                          ""version"":    ""0.10.2"",
+                          ""depends"":    [ { ""name"": ""JNSQ"" } ]
+                      }",
+                  },
+                  new string[] { "JNSQ-RibbonPack" }),
+        ]
+        public void Constructor_OldSelfDependsLoop_DoesNotThrow(string[] availableModules,
+                                                                string[] installIdents)
+        {
+            // Arrange
+            var user = new NullUser();
+            var crit = new GameVersionCriteria(new GameVersion(1, 12, 5));
+            using (var repo     = new TemporaryRepository(availableModules.Select(MergeWithDefaults)
+                                                                          .ToArray()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+
+                // Act / Assert
+                Assert.DoesNotThrow(() =>
+                {
+                    var sut = new RelationshipResolver(
+                        installIdents.Select(ident => registry.LatestAvailable(ident, stabilityTolerance, crit))
+                                     .OfType<CkanModule>(),
+                        null,
+                        RelationshipResolverOptions.DependsOnlyOpts(stabilityTolerance),
+                        registry, game, crit);
                 });
             }
         }

--- a/Tests/Core/Relationships/SelectionReasonTests.cs
+++ b/Tests/Core/Relationships/SelectionReasonTests.cs
@@ -1,0 +1,84 @@
+using System;
+
+using NUnit.Framework;
+
+using CKAN;
+using Tests.Data;
+
+namespace Tests.Core.Relationships
+{
+    [TestFixture]
+    public class SelectionReasonTests
+    {
+        [Test]
+        public void ToStringAndDescribeWith_VariousReasons_MatchExpected()
+        {
+            // Arrange
+            var modGen = new RandomModuleGenerator(new Random());
+            var mod    = modGen.GenerateRandomModule();
+            var other  = modGen.GenerateRandomModule();
+            var others = new SelectionReason[] { new SelectionReason.Depends(other) };
+
+            // Act / Assert
+            Assert.AreEqual("Currently installed",
+                            new SelectionReason.Installed().ToString());
+            Assert.AreEqual("Currently installed",
+                            new SelectionReason.Installed().DescribeWith(others));
+            Assert.AreEqual("Requested by user",
+                            new SelectionReason.UserRequested().ToString());
+            Assert.AreEqual("Requested by user",
+                            new SelectionReason.UserRequested().DescribeWith(others));
+            Assert.AreEqual("Dependency removed",
+                            new SelectionReason.DependencyRemoved().ToString());
+            Assert.AreEqual("Dependency removed",
+                            new SelectionReason.DependencyRemoved().DescribeWith(others));
+            Assert.AreEqual("Auto-installed, depending modules removed",
+                            new SelectionReason.NoLongerUsed().ToString());
+            Assert.AreEqual("Auto-installed, depending modules removed",
+                            new SelectionReason.NoLongerUsed().DescribeWith(others));
+            Assert.AreEqual($"Replacing {mod}",
+                            new SelectionReason.Replacement(mod).ToString());
+            Assert.AreEqual($"Replacing {mod}, {other}",
+                            new SelectionReason.Replacement(mod).DescribeWith(others));
+            Assert.AreEqual($"Suggested by {mod}",
+                            new SelectionReason.Suggested(mod).ToString());
+            Assert.AreEqual($"Suggested by {mod}",
+                            new SelectionReason.Suggested(mod).DescribeWith(others));
+            Assert.AreEqual($"Recommended by {mod}",
+                            new SelectionReason.Recommended(mod, 0).ToString());
+            Assert.AreEqual($"Recommended by {mod}",
+                            new SelectionReason.Recommended(mod, 0).WithIndex(1).ToString());
+            Assert.AreEqual($"Recommended by {mod}",
+                            new SelectionReason.Recommended(mod, 0).DescribeWith(others));
+            Assert.AreEqual($"Dependency of {mod}",
+                            new SelectionReason.Depends(mod).ToString());
+            Assert.AreEqual($"Dependency of {mod}, {other}",
+                            new SelectionReason.Depends(mod).DescribeWith(others));
+            Assert.AreEqual($"Dependency of {mod} to satisfy VirtIdent",
+                            new SelectionReason.VirtualDepends(mod, "VirtIdent").ToString());
+            Assert.AreEqual($"Dependency of {mod}, {other} to satisfy VirtIdent",
+                            new SelectionReason.VirtualDepends(mod, "VirtIdent").DescribeWith(others));
+        }
+
+        [Test]
+        public void Equals_VariousCombinations_Correct()
+        {
+            // Arrange
+            var modGen = new RandomModuleGenerator(new Random());
+            var mod    = modGen.GenerateRandomModule();
+            var other  = modGen.GenerateRandomModule();
+
+            // Act / Assert
+            Assert.IsTrue(new SelectionReason.NoLongerUsed()
+                                             .Equals(new SelectionReason.NoLongerUsed()));
+            Assert.IsFalse(new SelectionReason.NoLongerUsed()
+                                              .Equals(new SelectionReason.DependencyRemoved()));
+            Assert.IsTrue(new SelectionReason.Depends(mod)
+                                             .Equals(new SelectionReason.Depends(mod)));
+            Assert.IsFalse(new SelectionReason.Depends(mod)
+                                              .Equals(new SelectionReason.Depends(other)));
+            Assert.IsFalse(new SelectionReason.Depends(mod)
+                                              .Equals(new SelectionReason.Suggested(mod)));
+        }
+    }
+}


### PR DESCRIPTION
## Problems

- If you add KSP1 1.7 as compatible and try to install JNSQ 0.11.2, you'll be prompted to choose between Kronometer and JNSQ 0.8.6 to satisfy the Kronometer dependency:
  <img width="562" height="100" alt="Image" src="https://github.com/user-attachments/assets/de16e5aa-81a8-44e5-bf6a-8ccb04873c10" />
  If you choose JNSQ 0.8.6, an exception `System.ArgumentException: Already contains module: JNSQ` will be thrown.
- If you If you add KSP1 1.7 as compatible and try to install a mod that _depends on_ JNSQ (such as JNSQ-RibbonPack), you get an exception instead of a prompt
- If you manually install a mod to the wrong path, CKAN raises the "not where CKAN would install it" error. If you then delete the file and try again, it still doesn't work.
  You have to click Refresh (or close and re-open CKAN), and then it will work.

## Causes

- JNSQ 0.8.6 `provides` Kronometer and is only compatible with KSP1 1.6–1.7. JNSQ 0.11.2 `depends` on Kronometer.
  The older version should be excluded from satisfying dependencies-of-dependencies, but currently it's not.
- The registry maintains a list of manually installed DLLs, which GUI updates when you click Refresh and any other time the mod list changes. But if you attempt an install, then change files in the game folder and retry the install, the list isn't updated.

## Changes

- Now when the relationship resolver queries the resolved relationship tree for candidates to satisfy a relationship, other versions of installing modules are excluded from the results. This fixes both issues with installing JNSQ with KSP1 1.7 marked as compatible.
  Fixes #4484.
  - Tests are added to catch regressions of this
  - To make issues like this easier to investigate, some of the logging now displays more information like the specific mods and versions involved.
- Now GUI re-scans unmanaged files before applying changes (just like CmdLine does, FWIW), which will ensure the list of manually installed DLLs is up to date.
  Note that there is a slight risk here of the install screen disagreeing with the preceding changeset screen, because the changeset won't re-scan unmanaged files because that's potentially expensive. But once the install screen does the scan, that discrepancy will be resolved.
  Fixes #4549.
- I noticed there's a `FlatStyle` property for the `DataGridViewCheckBoxColumn` class, which we now set to `FlatStyle.Flat` for consistency with the rest of the app.
