### PR TITLE
Properly recalculate compatible mods on stability tolerance change

### DIFF
--- a/Core/Configuration/StabilityToleranceConfig.cs
+++ b/Core/Configuration/StabilityToleranceConfig.cs
@@ -10,7 +10,7 @@ using CKAN.Extensions;
 namespace CKAN.Configuration
 {
     [JsonObject(MemberSerialization.OptIn)]
-    public class StabilityToleranceConfig
+    public class StabilityToleranceConfig : IEquatable<StabilityToleranceConfig>
     {
         public StabilityToleranceConfig(string path)
         {
@@ -23,6 +23,14 @@ namespace CKAN.Configuration
             {
                 // File doesn't exist yet, we can create it at save
             }
+        }
+
+        public StabilityToleranceConfig(StabilityToleranceConfig orig)
+        {
+            path = orig.path;
+            overallStabilityTolerance = orig.overallStabilityTolerance;
+            modStabilityTolerance = new SortedDictionary<string, ReleaseStatus>(
+                                        orig.modStabilityTolerance);
         }
 
         public bool Save()
@@ -72,6 +80,25 @@ namespace CKAN.Configuration
         public IReadOnlyCollection<string> OverriddenModIdentifiers => modStabilityTolerance.Keys;
 
         public event Action<string?, ReleaseStatus?>? Changed;
+
+        public override bool Equals(object? other)
+            => Equals(other as StabilityToleranceConfig);
+
+        public bool Equals(StabilityToleranceConfig? other)
+            => other != null
+               && overallStabilityTolerance == other?.overallStabilityTolerance
+               && modStabilityTolerance.DictionaryEquals(other.modStabilityTolerance);
+
+        public static bool operator ==(StabilityToleranceConfig? left,
+                                       StabilityToleranceConfig? right)
+            => Equals(left, right);
+
+        public static bool operator !=(StabilityToleranceConfig? left,
+                                       StabilityToleranceConfig? right)
+            => !Equals(left, right);
+
+        public override int GetHashCode()
+            => (overallStabilityTolerance, modStabilityTolerance.DictionaryHashcode()).GetHashCode();
 
         [JsonProperty("overall_stability_tolerance", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [DefaultValue(ReleaseStatus.stable)]

--- a/Core/Extensions/DictionaryExtensions.cs
+++ b/Core/Extensions/DictionaryExtensions.cs
@@ -12,5 +12,9 @@ namespace CKAN.Extensions
                            && a.Keys.All(b.ContainsKey)
                            && b.Keys.All(k => a.ContainsKey(k)
                                               && EqualityComparer<V>.Default.Equals(a[k], b[k]));
+
+        public static int DictionaryHashcode<K, V>(this IDictionary<K, V> dict)
+            => dict.Select(kvp => (kvp.Key, kvp.Value))
+                   .ToSequenceHashCode();
     }
 }

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -35,7 +35,7 @@ namespace CKAN
                                    IReadOnlyCollection<string>                      dlls,
                                    IDictionary<string, UnmanagedModuleVersion>      dlc)
         {
-            StabilityTolerance = stabilityTolerance;
+            StabilityTolerance = new StabilityToleranceConfig(stabilityTolerance);
             CompatibleVersions = crit;
             this.installed = installed;
             this.dlls = dlls;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -646,7 +646,7 @@ namespace CKAN.GUI
             }
         }
 
-        private string CmdLineHelp(string cmdLine)
+        private static string CmdLineHelp(string cmdLine)
             => manager?.SteamLibrary.Games.Length > 0
                 ? SteamLibrary.IsSteamCmdLine(cmdLine)
                     ? Properties.Resources.ManageModsSteamPlayTimeYesTooltip

--- a/Tests/Core/Configuration/StabilityToleranceConfigTests.cs
+++ b/Tests/Core/Configuration/StabilityToleranceConfigTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Collections.Generic;
 
 using NUnit.Framework;
 
@@ -30,6 +31,7 @@ namespace Tests.Core.Configuration
                 orig.SetModStabilityTolerance("mod2", ReleaseStatus.testing);
                 orig.SetModStabilityTolerance("mod3", null);
                 var loaded = new StabilityToleranceConfig(path);
+                var hashSet = new HashSet<StabilityToleranceConfig>() { orig, loaded };
 
                 // Assert
                 Assert.AreEqual(3, changedCount);
@@ -37,6 +39,9 @@ namespace Tests.Core.Configuration
                 Assert.AreEqual(ReleaseStatus.stable,      loaded.ModStabilityTolerance("mod1"));
                 Assert.AreEqual(ReleaseStatus.testing,     loaded.ModStabilityTolerance("mod2"));
                 Assert.AreEqual(null,                      loaded.ModStabilityTolerance("mod3"));
+                Assert.AreEqual(orig, loaded);
+                Assert.IsTrue(orig == loaded);
+                Assert.AreEqual(1, hashSet.Count);
             }
         }
     }


### PR DESCRIPTION
## Problem

1. Open CKAN with the default stability settings (stable only)
2. Find RasterPropMonitor-Core
3. Note that the relationships are for 1.0.2
4. In the Versions tab, note there's a 1.0.3 prerelease
6. Set a stability override of Testing for this mod
7. Everything refreshes and 1.0.3 now shows up as installable
8. However, the Relationships tab still shows the relationships for 1.0.2

Pointed out by @JonnyOThan in Discord.

## Cause

CompatibilitySorter retains a `readonly` reference to the StabilityToleranceConfig that was used to generate its LatestCompatible property. Registry.CompatibleModules compares this property to the current settings received from its parameter and recalculates the compatible mods if needed.

That comparison gives the wrong answer because the reference held by CompatibilitySorter points to the same object that the other code modifies when you change the settings. So when the mod list is refreshed after the stability config change, the list of compatible mods is left the same as it was before, so the mod list isn't changed, and mod info receives the same mod as before.

## Changes

- Now StabilityToleranceConfig has a copy constructor that makes a deep clone, and CompatibilitySorter uses it to capture an immtuable copy of its stability settings
- Now StabilityToleranceConfig implements `IEquatable<StabilityToleranceConfig>` and overrides `operator!=` to make sure the comparison is accurate

After this, changing the compatibility override for a mod will show the correct relationships on the Relationships tab.
