### PR TITLE
Don't copy Steam command lines into cloned instances

### DIFF
--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -266,11 +266,11 @@ namespace CKAN
         /// <exception cref="DirectoryNotFoundKraken">Thrown by CopyDirectory() if directory doesn't exist. Should never be thrown here.</exception>
         /// <exception cref="PathErrorKraken">Thrown by CopyDirectory() if the target folder already exists and is not empty.</exception>
         /// <exception cref="IOException">Thrown by CopyDirectory() if something goes wrong during the process.</exception>
-        public void CloneInstance(GameInstance existingInstance,
-                                  string       newName,
-                                  string       newPath,
-                                  string[]     leaveEmpty,
-                                  bool         shareStockFolders = false)
+        public GameInstance CloneInstance(GameInstance existingInstance,
+                                          string       newName,
+                                          string       newPath,
+                                          string[]     leaveEmpty,
+                                          bool         shareStockFolders = false)
         {
             if (HasInstance(newName))
             {
@@ -297,14 +297,14 @@ namespace CKAN
 
             log.Debug("Copying directory.");
             Utilities.CopyDirectory(existingInstance.GameDir, newPath,
-                                    new string[] { "CKAN/registry.locked", "CKAN/playtime.json" },
+                                    new string[] { "CKAN/registry.locked", "CKAN/playtime.json", "CKAN/GUIConfig.json" },
                                     shareStockFolders ? existingInstance.Game.StockFolders
                                                       : Array.Empty<string>(),
                                     leaveEmpty,
                                     new string[] { "CKAN" });
 
             // Add the new instance to the config
-            AddInstance(new GameInstance(existingInstance.Game, newPath, newName, User));
+            return AddInstance(new GameInstance(existingInstance.Game, newPath, newName, User));
         }
 
         /// <summary>

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -11,6 +11,7 @@ using System.Runtime.Versioning;
 using Autofac;
 
 using CKAN.Games;
+using CKAN.IO;
 
 namespace CKAN.GUI
 {
@@ -167,14 +168,18 @@ namespace CKAN.GUI
                 {
                     if (instanceToClone.Valid)
                     {
-                        manager.CloneInstance(instanceToClone, newName, newPath,
-                                              OptionalPathsListView.Items
-                                                                   .OfType<ListViewItem>()
-                                                                   .Where(lvi => !lvi.Checked)
-                                                                   .Select(lvi => lvi.Tag)
-                                                                   .OfType<string>()
-                                                                   .ToArray(),
-                                              checkBoxShareStock.Checked);
+                        var cloned = manager.CloneInstance(instanceToClone, newName, newPath,
+                                                           OptionalPathsListView.Items
+                                                                                .OfType<ListViewItem>()
+                                                                                .Where(lvi => !lvi.Checked)
+                                                                                .Select(lvi => lvi.Tag)
+                                                                                .OfType<string>()
+                                                                                .ToArray(),
+                                                           checkBoxShareStock.Checked);
+                        var newGuiConfig = GUIConfiguration.LoadOrCreateConfiguration(instanceToClone, manager.SteamLibrary);
+                        // Don't clone Steam command lines
+                        newGuiConfig.CommandLines.RemoveAll(SteamLibrary.IsSteamCmdLine);
+                        newGuiConfig.Save(cloned);
                     }
                     else
                     {


### PR DESCRIPTION
## Problem

1. Open CKAN and clone your Steam instance
2. In the cloned instance, hover the Play button
3. There is a `steam://` command line that launches the original instance, not the cloned instance

Noted by @JonnyOThan on Discord.

## Cause

The command lines are stored in `CKAN/GUIConfig.json`, which is copied forward to cloned instances along with everything else.

## Changes

- Now the core instance cloning method doesn't copy `CKAN/GUIConfig.json`, because it doesn't make sense for it to do things that are GUI-specific
- Now after the core cloning logic completes, the GUI clone dialog makes its own separate copy of `CKAN/GUIConfig.json` that excludes Steam command lines.

### Considered and not done

- For my first iteration of this, I just excluded `CKAN/GUIConfig.json` from copying.
  By itself, this was annoying because it brought back the prompts about whether to check for client updates and new metadata and lost my column sort settings.
- We could also revert the command lines to the defaults, or clear them out, which would have the same effect.
  This would be annoying for users with custom command lines that wish to preserve them in clones (e.g. running the game via Proton or somesuch).
