### PR TITLE
Apply installed module constraints to changeset

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -261,8 +261,10 @@ namespace CKAN.GUI
                                            GameInstance inst,
                                            Registry     registry)
         {
-            var row = MainModList?.ReapplyLabels(guiMod, conflicted, inst, registry);
-            if (row != null)
+            if (MainModList?.ReapplyLabels(guiMod, conflicted, inst, registry)
+                is DataGridViewRow row
+                && ModGrid.Rows.Contains(row)
+                && row.Index >= 0)
             {
                 foreach (DataGridViewCell cell in row.Cells)
                 {

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -198,7 +198,11 @@ namespace CKAN.GUI
                 {
                     LatestCompatibleMod = registry.LatestAvailable(Identifier,
                                                                    stabilityTolerance,
-                                                                   instance.VersionCriteria());
+                                                                   instance.VersionCriteria(),
+                                                                   null,
+                                                                   registry.InstalledModules
+                                                                           .Select(im => im.Module)
+                                                                           .ToArray());
                     latest_version = LatestCompatibleMod?.version;
                 }
                 catch (ModuleNotFoundKraken)
@@ -217,7 +221,10 @@ namespace CKAN.GUI
 
             try
             {
-                LatestAvailableMod = registry.LatestAvailable(Identifier, stabilityTolerance, null);
+                LatestAvailableMod = registry.LatestAvailable(Identifier, stabilityTolerance, null, null,
+                                                              registry.InstalledModules
+                                                                      .Select(im => im.Module)
+                                                                      .ToArray());
             }
             catch
             { }


### PR DESCRIPTION
## Problems

- 1. Install RasterPropMonitor-Core 1.0.3
  2. Click MechJeb2
  3. Check the Versions tab; RPM's conflict suggests MechJeb2 2.14.3.0 will be installed, but if you click the checkbox on the main mod list it will try to install the latest version, which conflicts with RasterPropMonitor-Core 1.0.3
- 1. Install RasterPropMonitor-Core 1.0.3
  2. Try to install the latest MJ2
  3. Note the conflict
  4. Click Shift+Refresh
  5. An exception is thrown:
     ```
     System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
     Parameter name: rowIndex
     ```

## Causes

- The version to install comes from GUIMod.LatestCompatibleMod, which is generated without considering the installed modules.
- When we refresh the mod list, the conflicts are cleared, which triggers code that clears the conflicting row color. But the conflicting row has already been removed from the grid, so its Index is -1, which we then incorrectly use to invalidate the now colorless row

## Changes

- Now we check the installed modules when calculating GUIMod.LatestCompatibleMod, which makes it pick MechJeb2 2.14.3.0 in the above flow.
  Fixes #4554.
- Now before we attempt to invalidate a conflicting row, we check that it's actually in the grid and has a valid Index

## Side effects

Note that if you click to _uninstall_ RasterPropMonitor-Core in the same changeset, it will still pick MechJeb2 2.14.3.0 to install, because GUIMod.LatestCompatibleMod is not recalculated on the fly based on other changeset entries.
Instead, you can apply that change first, and then it'll let you upgrade to the latest MechJeb2 after that.
