### PR TITLE
Try to stop users from cloning instances into themselves

### DIFF
--- a/Core/Extensions/IOExtensions.cs
+++ b/Core/Extensions/IOExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.IO;
 using System.Collections.Generic;
 using System.Threading;
@@ -16,6 +17,11 @@ namespace CKAN.Extensions
         /// <returns>The DriveInfo associated with this directory, if any, else null</returns>
         public static DriveInfo? GetDrive(this DirectoryInfo dir)
             => Utilities.DefaultIfThrows(() => new DriveInfo(dir.FullName));
+
+        public static bool AncestorPathOf(this DirectoryInfo outer, DirectoryInfo inner)
+            => inner.TraverseNodes(di => di.Parent)
+                    .Select(di => di.FullName)
+                    .Any(di => outer.FullName.Equals(di, Platform.PathComparison));
 
         /// <summary>
         /// File.WriteAllText replacement that doesn't sometimes write all NULs instead on Windows.

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -338,6 +338,7 @@ Free up space on that device or change your settings to use another location.
   <data name="KrakenInstanceNameTaken" xml:space="preserve"><value>This instance name is already taken: {0}</value></data>
   <data name="KrakenNoInstance" xml:space="preserve"><value>No instance with this name or at this path: {0}</value></data>
   <data name="DirectoryNotEmpty" xml:space="preserve"><value>Directory not empty: {0}</value></data>
+  <data name="CannotCloneIntoSelf" xml:space="preserve"><value>Cannot clone {0} into itself</value></data>
   <data name="RelationshipResolverConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="RelationshipResolverConflictingModDescription" xml:space="preserve"><value>{0} (needed for: {1})</value></data>
   <data name="RelationshipResolverRequiredButResolver" xml:space="preserve"><value>{0} required, but an incompatible version is in the resolver</value></data>

--- a/Core/Utilities.cs
+++ b/Core/Utilities.cs
@@ -126,6 +126,13 @@ namespace CKAN
                                                         destDirPath));
             }
 
+            if (new DirectoryInfo(sourceDirPath).AncestorPathOf(new DirectoryInfo(destDirPath)))
+            {
+                throw new PathErrorKraken(destDirPath,
+                                          string.Format(Properties.Resources.CannotCloneIntoSelf,
+                                                        Platform.FormatPath(sourceDirPath)));
+            }
+
             // Get the files in the directory and copy them to the new location
             foreach (var file in sourceDir.GetFiles())
             {

--- a/Tests/Core/GameInstanceManager.cs
+++ b/Tests/Core/GameInstanceManager.cs
@@ -208,6 +208,21 @@ namespace Tests.Core
             }
         }
 
+        [Test]
+        public void CloneInstance_TargetInsideSource_Throws()
+        {
+            // Arrange
+            var inst = tidy!.KSP;
+            string instanceName = "newInstance";
+            var target = Path.Combine(inst.GameDir, "subclone");
+
+            // Act / Assert
+            var exc = Assert.Throws<PathErrorKraken>(() =>
+            {
+                manager!.CloneInstance(inst, instanceName, target);
+            });
+        }
+
         // FakeInstance
 
         [Test]


### PR DESCRIPTION
## Motivation

If a user clones a game instance into a subfolder of itself, the copy goes on forever and eventually fills the disk if not stopped.

## Changes

Now when you clone an instance, we check whether any of the parent folders of the destination are the same as the source, and if so we emit an error and abort the clone.
A test is included to exercise this.

Fixes #4520.

### Known limitations

Note that catching all ways to try to copy a directory into itself is a well-known impossible task, because different paths can point to the same location in obfuscated ways:

- Make a junction / symbolic link to the game instance, then clone from the original folder into the symbolic link
- Mount a network share at one drive letter and a subfolder of it at another drive letter, then clone from one drive to the other
- And so on for any OS capability to assign arbitrary names to paths

While we can't detect everything, catching the very simplest case where everything is a normal directory is still easy enough to be worth it.
