### PR TITLE
Remove symlink-based DLL deduplication from MacOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build CKAN.app
         run: |
           chmod a+x _build/out/Build/*/bin/net8.0/Build _build/out/Build/*/obj/*/net8.0/apphost
-          sudo apt-get install -y libplist-utils rdfind symlinks genisoimage
+          sudo apt-get install -y libplist-utils genisoimage
           ./build.sh osx-app --configuration=${{ inputs.configuration }} --exclusive
       - name: Ad hoc codesign x86_64 binary
         uses: indygreg/apple-code-sign-action@v1

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -26,8 +26,6 @@ $(DMG): app
 	genisoimage -V $(NAME) -D -R -apple -no-pad -o $@ $(DMGROOT)
 
 app: $(BUILDDIR_x86_64_DEST) $(BUILDDIR_arm64_DEST) $(SCRIPTDEST) $(ICNSDEST) $(PLISTDEST)
-	rdfind -minsize 10240 -makeresultsfile false -makesymlinks true $(BUILDDIR_x86_64_DEST) $(BUILDDIR_arm64_DEST)
-	symlinks -rc $(BUILDDIR_arm64_DEST)
 
 $(BUILDDIR_x86_64_DEST): $(BUILDDIR_x86_64_SRC)
 	mkdir -p $(shell dirname $@)


### PR DESCRIPTION
## Problem

A Mac user reported this error on launch:

```
cd "/Applications/CKAN.app/Contents/MacOS/arm64"; ./CKAN-CmdLine consoleui
➜  ~ cd "/Applications/CKAN.app/Contents/MacOS/arm64"; ./CKAN-CmdLine consoleui
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.

File name: 'System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
[1]    68035 abort      ./CKAN-CmdLine consoleui
➜  arm64 
```

## Cause

This is still being investigated, but my current best guess is that System.Runtime.dll isn't loading because it's a symlink to the identical copy of that file in `../x86_64/`. I thought we had tested this already in #4410 and #4418, but maybe those tests were flawed somehow.

## Changes

Now we just build the big bloated version of the CKAN.app with two copies of many files, one per architecture, instead of replacing duplicates with symlinks. This will allow us to test whether this solves the problem.

Fixes #4542 (maybe, needs confirmation from @robism05).

Looks like the file size difference is about 14 MB:

Before:  <img width="1112" height="84" alt="image" src="https://github.com/user-attachments/assets/95819198-b7ee-4d1d-93ff-f47d2f3bcac8" />
After:  <img width="574" height="41" alt="image" src="https://github.com/user-attachments/assets/b3b00bc7-eefd-47df-af2a-ed6643b28b55" />
