### PR TITLE
Fix missing conflicting recommendations

### DIFF
--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -281,7 +281,10 @@ namespace CKAN
                 IReadOnlyList<CkanModule>? candidates = null;
                 try
                 {
-                    candidates = resolved.Candidates(descriptor, modlist.Values,
+                    candidates = resolved.Candidates(descriptor,
+                                                     options.get_recommenders
+                                                         ? Dependencies().ToArray()
+                                                         : modlist.Values,
                                                      registry, game);
                     log.DebugFormat("Got {0} candidates for {1}",
                                     candidates.Count, descriptor);
@@ -338,7 +341,10 @@ namespace CKAN
                 // Finally, check our candidate against everything which might object
                 // to it being installed; that's all the mods which are fixed in our
                 // list thus far, as well as everything on the system.
-                var fixed_mods = modlist.Values.Concat(installed_modules).ToHashSet();
+                var fixed_mods = (options.get_recommenders ? Dependencies()
+                                                           : modlist.Values)
+                                     .Concat(installed_modules)
+                                     .ToHashSet();
 
                 var conflicting_mod = fixed_mods.FirstOrDefault(mod => mod.ConflictsWith(candidate));
                 if (conflicting_mod == null)

--- a/GUI/Controls/InstallationHistory.Designer.cs
+++ b/GUI/Controls/InstallationHistory.Designer.cs
@@ -69,7 +69,7 @@ namespace CKAN.GUI
             //
             // InstallButton
             //
-            //this.InstallButton.Image = global::CKAN.GUI.Properties.Resources.install;
+            this.InstallButton.Image = global::CKAN.GUI.EmbeddedImages.apply;
             this.InstallButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.InstallButton.Name = "InstallButton";
             this.InstallButton.Size = new System.Drawing.Size(114, 56);

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -974,6 +974,55 @@ namespace Tests.Core.IO
             }
         }
 
+        [Test]
+        public void FindRecommendations_WithConflictingRecommendations_FindsAll()
+        {
+            // Arrange
+            var user            = new NullUser();
+            var modGen          = new RandomModuleGenerator(new Random());
+            var recommendation1 = modGen.GenerateRandomModule();
+            var recommendation2 = modGen.GenerateRandomModule(conflicts: new List<RelationshipDescriptor>()
+            {
+                new ModuleRelationshipDescriptor() { name = recommendation1.identifier },
+            });
+            var recommendation3 = modGen.GenerateRandomModule(conflicts: new List<RelationshipDescriptor>()
+            {
+                new ModuleRelationshipDescriptor() { name = recommendation1.identifier },
+                new ModuleRelationshipDescriptor() { name = recommendation2.identifier },
+            });
+            var recommender = modGen.GenerateRandomModule(recommends: new List<RelationshipDescriptor>()
+            {
+                new ModuleRelationshipDescriptor() { name = recommendation3.identifier },
+                new ModuleRelationshipDescriptor() { name = recommendation1.identifier },
+                new ModuleRelationshipDescriptor() { name = recommendation2.identifier },
+            });
+            using (var inst = new DisposableKSP())
+            using (var repo = new TemporaryRepository(recommendation1.ToJson(),
+                                                      recommendation2.ToJson(),
+                                                      recommendation3.ToJson(),
+                                                      recommender.ToJson()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+
+                // Act
+                var result = ModuleInstaller.FindRecommendations(inst.KSP,
+                                                                 new CkanModule[] { recommender },
+                                                                 new CkanModule[] { recommender },
+                                                                 new CkanModule[] { },
+                                                                 new CkanModule[] { },
+                                                                 registry,
+                                                                 out var recs,
+                                                                 out var sugs,
+                                                                 out var sups);
+
+                // Assert
+                Assert.IsTrue(result);
+                CollectionAssert.AreEquivalent(new CkanModule[] { recommendation1, recommendation2, recommendation3 },
+                                               recs.Keys);
+            }
+        }
+
         [TestCase(new string[]
                   {
                       @"{

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -1004,6 +1004,7 @@ namespace Tests.Data
             GameVersion?                  ksp_version = null,
             List<RelationshipDescriptor>? conflicts   = null,
             List<RelationshipDescriptor>? depends     = null,
+            List<RelationshipDescriptor>? recommends  = null,
             List<RelationshipDescriptor>? suggests    = null,
             List<string>?                 provides    = null,
             string?                       identifier  = null,
@@ -1021,6 +1022,7 @@ namespace Tests.Data
                 ksp_version = ksp_version,
                 conflicts   = conflicts,
                 depends     = depends,
+                recommends  = recommends,
                 suggests    = suggests,
                 provides    = provides,
             };


### PR DESCRIPTION
## Problem

1. Start installing a module with several recommendations, some of which conflict with one another
2. In the recommendations screen, note that recommendations that conflict with earlier recommendations do not appear

## Cause

The relationship resolver checks for conflicts with mods already in its changeset. When we use it to find recommendations, the recommendations all go into the changeset, even though they're not all actually being installed.

## Motivation

The Install button in Installation History is hard to notice.

## Changes

- Now when we're finding recommendations, we only check for conflicts with mods in the changeset and their direct dependencies, not other recommendations.
  A test is included to catch regressions of this.
- Now the Install button in Installation History has a green checkmark icon to make it more noticeable.

Fixes #4510.
