### PR TITLE
DPI-based font scaling for Mono

### DIFF
--- a/Core/Net/RedirectWebClient.cs
+++ b/Core/Net/RedirectWebClient.cs
@@ -11,6 +11,7 @@ namespace CKAN
         public RedirectWebClient(string userAgent)
         {
             Headers.Add("User-Agent", userAgent);
+            Encoding = System.Text.Encoding.UTF8;
         }
 
         protected override WebRequest GetWebRequest(Uri address)

--- a/Core/Net/RedirectingTimeoutWebClient.cs
+++ b/Core/Net/RedirectingTimeoutWebClient.cs
@@ -32,6 +32,7 @@ namespace CKAN
             this.userAgent = userAgent;
             this.timeout   = timeout;
             this.mimeType  = mimeType;
+            Encoding       = System.Text.Encoding.UTF8;
         }
 
         protected override WebRequest GetWebRequest(Uri address)

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -17,6 +17,11 @@ namespace CKAN
 {
     public class ResumingWebClient : WebClient
     {
+        public ResumingWebClient()
+        {
+            Encoding = System.Text.Encoding.UTF8;
+        }
+
         /// <summary>
         /// A version of DownloadFileAsync that appends to its destination
         /// file if it already exists and skips downloading the bytes

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -22,6 +22,8 @@ namespace CKAN.GUI
         public Changeset()
         {
             InitializeComponent();
+            ChangesGrid.ScaleFonts();
+            CloseTheGameLabel.ScaleFonts();
             // Reduce the grid's flickering
             ChangesGrid.GetType()
                        .GetProperty("DoubleBuffered",

--- a/GUI/Controls/EditModSearchDetails.cs
+++ b/GUI/Controls/EditModSearchDetails.cs
@@ -23,6 +23,7 @@ namespace CKAN.GUI
         public EditModSearchDetails()
         {
             InitializeComponent();
+            this.ScaleFonts();
             // Float over other controls
             SetTopLevel(true);
         }

--- a/GUI/Controls/InstallationHistory.cs
+++ b/GUI/Controls/InstallationHistory.cs
@@ -17,6 +17,7 @@ namespace CKAN.GUI
         public InstallationHistory()
         {
             InitializeComponent();
+            Toolbar.ScaleFonts();
         }
 
         public void LoadHistory(GameInstance          inst,

--- a/GUI/Controls/LabeledProgressBar.cs
+++ b/GUI/Controls/LabeledProgressBar.cs
@@ -22,7 +22,6 @@ namespace CKAN.GUI
             SetStyle(ControlStyles.OptimizedDoubleBuffer
                      | ControlStyles.UserPaint,
                      true);
-            Font = SystemFonts.DefaultFont;
             Text = "";
         }
 

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -26,6 +26,17 @@ namespace CKAN.GUI
         public ManageMods()
         {
             InitializeComponent();
+            Toolbar.ScaleFonts();
+            ModGrid.ScaleFonts();
+            ModListContextMenuStrip.ScaleFonts();
+            ModListHeaderContextMenuStrip.ScaleFonts();
+            uninstallingFont = new Font(SystemFonts.DefaultFont, FontStyle.Strikeout);
+            if (Platform.IsMono
+                && (int)CreateGraphics().DpiX is int dpi
+                && dpi != 96)
+            {
+                uninstallingFont = uninstallingFont.Scale(dpi);
+            }
 
             ToolTip.SetToolTip(InstallAllCheckbox, Properties.Resources.ManageModsInstallAllCheckboxTooltip);
             FilterCompatibleButton.ToolTipText      = Properties.Resources.FilterLinkToolTip;
@@ -90,7 +101,7 @@ namespace CKAN.GUI
         private DateTime lastSearchTime;
         private string? lastSearchKey;
         private readonly NavigationHistory<GUIMod> navHistory;
-        private static readonly Font uninstallingFont = new Font(SystemFonts.DefaultFont, FontStyle.Strikeout);
+        private readonly Font uninstallingFont;
 
         private List<ModChange>?            currentChangeSet;
         private Dictionary<GUIMod, string>? conflicts;
@@ -197,7 +208,7 @@ namespace CKAN.GUI
                         else if (row.DefaultCellStyle.Font != null)
                         {
                             // Clear strikeout font for rows not being uninstalled
-                            row.DefaultCellStyle.Font = null;
+                            row.DefaultCellStyle.Font = ModGrid.DefaultCellStyle.Font;
                         }
                     }
                 }

--- a/GUI/Controls/ModInfo/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo/ModInfo.Designer.cs
@@ -78,7 +78,7 @@ namespace CKAN.GUI
             // MetadataModuleNameTextBox
             //
             this.MetadataModuleNameTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleNameTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.MetadataModuleNameTextBox.Font = new System.Drawing.Font(System.Drawing.SystemFonts.CaptionFont, System.Drawing.FontStyle.Bold);
             this.MetadataModuleNameTextBox.Location = new System.Drawing.Point(3, 0);
             this.MetadataModuleNameTextBox.Name = "MetadataModuleNameTextBox";
             this.MetadataModuleNameTextBox.Size = new System.Drawing.Size(494, 46);

--- a/GUI/Controls/ModInfo/ModInfo.cs
+++ b/GUI/Controls/ModInfo/ModInfo.cs
@@ -20,6 +20,9 @@ namespace CKAN.GUI
         public ModInfo()
         {
             InitializeComponent();
+            MetadataModuleNameTextBox.ScaleFonts();
+            MetadataModuleAbstractLabel.ScaleFonts();
+            MetadataModuleDescriptionTextBox.ScaleFonts();
             Contents.OnDownloadClick += gmod => OnDownloadClick?.Invoke(gmod);
             Relationships.ModuleDoubleClicked += mod => ModuleDoubleClicked?.Invoke(mod);
             tagsLabelsLinkList.ShowHideTag += t => ShowHideTag?.Invoke(t);

--- a/GUI/Controls/ModInfo/Relationships.Designer.cs
+++ b/GUI/Controls/ModInfo/Relationships.Designer.cs
@@ -124,7 +124,7 @@ namespace CKAN.GUI
             // LegendInstalledLabel
             //
             this.LegendInstalledLabel.AutoSize = true;
-            this.LegendInstalledLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 8, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.LegendInstalledLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont, System.Drawing.FontStyle.Bold);
             this.LegendInstalledLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 6);
             resources.ApplyResources(this.LegendInstalledLabel, "LegendInstalledLabel");
             //

--- a/GUI/Controls/ModInfo/Relationships.cs
+++ b/GUI/Controls/ModInfo/Relationships.cs
@@ -25,6 +25,7 @@ namespace CKAN.GUI
         public Relationships()
         {
             InitializeComponent();
+            LegendInstalledLabel.ScaleFonts();
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
 
             ToolTip.SetToolTip(ReverseRelationshipsCheckbox, Properties.Resources.ModInfoToolTipReverseRelationships);

--- a/GUI/Controls/ModInfo/Versions.Designer.cs
+++ b/GUI/Controls/ModInfo/Versions.Designer.cs
@@ -148,7 +148,7 @@ namespace CKAN.GUI
             // InstalledLabel
             //
             this.InstalledLabel.AutoSize = true;
-            this.InstalledLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 8F, System.Drawing.FontStyle.Bold);
+            this.InstalledLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont, System.Drawing.FontStyle.Bold);
             this.InstalledLabel.BackColor = System.Drawing.SystemColors.Window;
             this.InstalledLabel.ForeColor = System.Drawing.SystemColors.WindowText;
             this.InstalledLabel.Location = new System.Drawing.Point(0, 55);
@@ -157,13 +157,12 @@ namespace CKAN.GUI
             this.InstalledLabel.Name = "InstalledLabel";
             this.InstalledLabel.Size = new System.Drawing.Size(131, 13);
             this.InstalledLabel.TabIndex = 7;
-            this.InstalledLabel.Visible = false;
             resources.ApplyResources(this.InstalledLabel, "InstalledLabel");
             //
             // PrereleaseLabel
             //
             this.PrereleaseLabel.AutoSize = true;
-            this.PrereleaseLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.Name, 8F, System.Drawing.FontStyle.Italic);
+            this.PrereleaseLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont, System.Drawing.FontStyle.Italic);
             this.PrereleaseLabel.BackColor = System.Drawing.Color.Gold;
             this.PrereleaseLabel.ForeColor = System.Drawing.SystemColors.WindowText;
             this.PrereleaseLabel.Location = new System.Drawing.Point(0, 74);
@@ -172,7 +171,6 @@ namespace CKAN.GUI
             this.PrereleaseLabel.Name = "PrereleaseLabel";
             this.PrereleaseLabel.Size = new System.Drawing.Size(131, 13);
             this.PrereleaseLabel.TabIndex = 7;
-            this.PrereleaseLabel.Visible = false;
             resources.ApplyResources(this.PrereleaseLabel, "PrereleaseLabel");
             //
             // StabilityToleranceLabel

--- a/GUI/Controls/ModInfo/Versions.cs
+++ b/GUI/Controls/ModInfo/Versions.cs
@@ -29,6 +29,8 @@ namespace CKAN.GUI
         public Versions()
         {
             InitializeComponent();
+            InstalledLabel.ScaleFonts();
+            PrereleaseLabel.ScaleFonts();
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
         }
 
@@ -227,7 +229,7 @@ namespace CKAN.GUI
                     };
                     if (installedVersion != null && installedVersion.Equals(module.version))
                     {
-                        toRet.Font = new Font(toRet.Font,
+                        toRet.Font = new Font(VersionsListView.Font,
                                               module.release_status <= stabilityTolerance
                                                   ? InstalledLabel.Font.Style
                                                   : InstalledLabel.Font.Style
@@ -235,7 +237,7 @@ namespace CKAN.GUI
                     }
                     else if (module.release_status > stabilityTolerance)
                     {
-                        toRet.Font = new Font(toRet.Font, PrereleaseLabel.Font.Style);
+                        toRet.Font = new Font(VersionsListView.Font, PrereleaseLabel.Font.Style);
                     }
                     if (module.release_status > stabilityTolerance)
                     {

--- a/GUI/Controls/PlayTime.cs
+++ b/GUI/Controls/PlayTime.cs
@@ -25,6 +25,7 @@ namespace CKAN.GUI
         public PlayTime()
         {
             InitializeComponent();
+            PlayTimeGrid.ScaleFonts();
         }
 
         /// <summary>

--- a/GUI/Controls/TagsLabelsLinkList.cs
+++ b/GUI/Controls/TagsLabelsLinkList.cs
@@ -149,6 +149,7 @@ namespace CKAN.GUI
                 menu.Renderer = new FlatToolStripRenderer();
             }
             menu.Items.AddRange(options);
+            menu.ScaleFonts();
             menu.Show(label.PointToScreen(new Point(0, label.Height)));
         }
 

--- a/GUI/Controls/ThemedListView.cs
+++ b/GUI/Controls/ThemedListView.cs
@@ -33,7 +33,21 @@ namespace CKAN.GUI
             rect.Offset(0, -1);
             e.Graphics.DrawRectangle(SystemPens.ControlDark, rect);
             // Text
-            e.DrawText(TextFormatFlags.VerticalCenter | TextFormatFlags.Left);
+            if (Platform.IsMono
+                && (int)e.Graphics.DpiX is int dpi
+                && dpi != 96
+                && e.Font is Font f)
+            {
+                var replacementEventArgs = new DrawListViewColumnHeaderEventArgs(
+                                               e.Graphics, e.Bounds, e.ColumnIndex, e.Header,
+                                               e.State, e.ForeColor, e.BackColor,
+                                               f.Scale(dpi));
+                replacementEventArgs.DrawText(TextFormatFlags.VerticalCenter | TextFormatFlags.Left);
+            }
+            else
+            {
+                e.DrawText(TextFormatFlags.VerticalCenter | TextFormatFlags.Left);
+            }
             // Alert event subscribers
             base.OnDrawColumnHeader(e);
         }

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -20,6 +20,7 @@ namespace CKAN.GUI
         public Wait()
         {
             InitializeComponent();
+            DialogProgressBar.ScaleFonts();
             emptyHeight = VerticalSplitter.SplitterDistance;
             bgWorker.DoWork             += DoWork;
             bgWorker.RunWorkerCompleted += RunWorkerCompleted;

--- a/GUI/Dialogs/AboutDialog.Designer.cs
+++ b/GUI/Dialogs/AboutDialog.Designer.cs
@@ -48,7 +48,7 @@ namespace CKAN.GUI
             this.projectNameLabel.AutoSize = true;
             this.projectNameLabel.Location = new System.Drawing.Point(6, 5);
             this.projectNameLabel.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.projectNameLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.projectNameLabel.Font = new System.Drawing.Font(System.Drawing.SystemFonts.CaptionFont, System.Drawing.FontStyle.Bold);
             this.projectNameLabel.Name = "projectNameLabel";
             this.projectNameLabel.Size = new System.Drawing.Size(380, 13);
             this.projectNameLabel.TabIndex = 0;

--- a/GUI/Dialogs/AboutDialog.cs
+++ b/GUI/Dialogs/AboutDialog.cs
@@ -13,6 +13,8 @@ namespace CKAN.GUI
         public AboutDialog()
         {
             InitializeComponent();
+            projectNameLabel.ScaleFonts();
+            this.ScaleFonts();
             ApplyFormCompatibilityFixes();
             versionLabel.Text = string.Format(Properties.Resources.AboutDialogLabel2Text, Meta.GetVersion());
         }

--- a/GUI/Dialogs/AskUserForAutoUpdatesDialog.cs
+++ b/GUI/Dialogs/AskUserForAutoUpdatesDialog.cs
@@ -1,12 +1,21 @@
 using System.Windows.Forms;
+using System.Diagnostics.CodeAnalysis;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
 
 namespace CKAN.GUI
 {
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
+    [ExcludeFromCodeCoverage]
     public partial class AskUserForAutoUpdatesDialog : Form
     {
         public AskUserForAutoUpdatesDialog()
         {
             InitializeComponent();
+            this.ScaleFonts();
         }
     }
 }

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -36,6 +36,7 @@ namespace CKAN.GUI
             this.user    = user;
 
             InitializeComponent();
+            this.ScaleFonts();
 
             ToolTip.SetToolTip(checkBoxShareStock, Properties.Resources.CloneGameInstanceToolTipShareStock);
 

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.cs
@@ -28,6 +28,7 @@ namespace CKAN.GUI
         {
             _inst = inst;
             InitializeComponent();
+            this.ScaleFonts();
 
             if (centerScreen)
             {

--- a/GUI/Dialogs/DownloadsFailedDialog.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.cs
@@ -56,6 +56,8 @@ namespace CKAN.GUI
             Func<object, object, bool> rowsLinked)
         {
             InitializeComponent();
+            GridContextMenuStrip.ScaleFonts();
+            this.ScaleFonts();
             if (Platform.IsMono)
             {
                 GridContextMenuStrip.Renderer = new FlatToolStripRenderer();

--- a/GUI/Dialogs/EditLabelsDialog.cs
+++ b/GUI/Dialogs/EditLabelsDialog.cs
@@ -18,6 +18,8 @@ namespace CKAN.GUI
         public EditLabelsDialog(IUser user, GameInstanceManager manager, ModuleLabelList labels)
         {
             InitializeComponent();
+            LabelSelectionTree.ScaleFonts();
+            this.ScaleFonts();
             this.user    = user;
             this.labels  = labels;
             InstanceNameComboBox.DataSource = new string[] { "" }

--- a/GUI/Dialogs/ErrorDialog.cs
+++ b/GUI/Dialogs/ErrorDialog.cs
@@ -20,6 +20,7 @@ namespace CKAN.GUI
         public ErrorDialog()
         {
             InitializeComponent();
+            this.ScaleFonts();
         }
 
         [ForbidGUICalls]

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.cs
@@ -17,6 +17,8 @@ namespace CKAN.GUI
         public GameCommandLineOptionsDialog()
         {
             InitializeComponent();
+            CmdLineGrid.ScaleFonts();
+            this.ScaleFonts();
             if (Platform.IsMono)
             {
                 // Mono's DataGridView has showstopper bugs with AllowUserToAddRows,

--- a/GUI/Dialogs/InstallFiltersDialog.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.cs
@@ -20,6 +20,7 @@ namespace CKAN.GUI
         public InstallFiltersDialog(IConfiguration globalConfig, GameInstance instance)
         {
             InitializeComponent();
+            this.ScaleFonts();
             this.globalConfig = globalConfig;
             this.instance     = instance;
             presets           = instance.Game.InstallFilterPresets;

--- a/GUI/Dialogs/ManageGameInstancesDialog.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.cs
@@ -33,6 +33,9 @@ namespace CKAN.GUI
             manager = mgr;
             this.user = user;
             InitializeComponent();
+            InstanceListContextMenuStrip.ScaleFonts();
+            AddNewMenu.ScaleFonts();
+            this.ScaleFonts();
             DialogResult = DialogResult.Cancel;
 
             instanceDialog.Filter = GameFolderFilter();

--- a/GUI/Dialogs/NewRepoDialog.cs
+++ b/GUI/Dialogs/NewRepoDialog.cs
@@ -18,6 +18,7 @@ namespace CKAN.GUI
         {
             this.repos = repos;
             InitializeComponent();
+            this.ScaleFonts();
         }
 
         public Repository Selection

--- a/GUI/Dialogs/NewUpdateDialog.Designer.cs
+++ b/GUI/Dialogs/NewUpdateDialog.Designer.cs
@@ -40,7 +40,7 @@ namespace CKAN.GUI
             // label1
             //
             this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont, System.Drawing.FontStyle.Bold);
             this.label1.Location = new System.Drawing.Point(9, 9);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(53, 13);
@@ -50,7 +50,7 @@ namespace CKAN.GUI
             // VersionLabel
             //
             this.VersionLabel.AutoSize = true;
-            this.VersionLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont, System.Drawing.FontStyle.Bold);
             this.VersionLabel.Location = new System.Drawing.Point(68, 9);
             this.VersionLabel.Name = "VersionLabel";
             this.VersionLabel.Size = new System.Drawing.Size(43, 13);

--- a/GUI/Dialogs/NewUpdateDialog.cs
+++ b/GUI/Dialogs/NewUpdateDialog.cs
@@ -18,6 +18,7 @@ namespace CKAN.GUI
         public NewUpdateDialog(string version, string? releaseNotes)
         {
             InitializeComponent();
+            this.ScaleFonts();
             VersionLabel.Text = version;
             ReleaseNotesTextbox.Text = releaseNotes?.Trim() ?? "";
         }

--- a/GUI/Dialogs/PluginsDialog.cs
+++ b/GUI/Dialogs/PluginsDialog.cs
@@ -14,6 +14,7 @@ namespace CKAN.GUI
         public PluginsDialog()
         {
             InitializeComponent();
+            this.ScaleFonts();
         }
 
         private static PluginController? pluginController => Main.Instance?.pluginController;

--- a/GUI/Dialogs/PreferredHostsDialog.cs
+++ b/GUI/Dialogs/PreferredHostsDialog.cs
@@ -18,6 +18,10 @@ namespace CKAN.GUI
         public PreferredHostsDialog(IConfiguration config, Registry registry)
         {
             InitializeComponent();
+            ExplanationLabel.ScaleFonts();
+            PreferredHostsLabel.ScaleFonts();
+            AvailableHostsLabel.ScaleFonts();
+            this.ScaleFonts();
             this.config = config;
             allHosts    = registry.GetAllHosts().ToArray();
             placeholder = Properties.Resources.PreferredHostsPlaceholder;

--- a/GUI/Dialogs/RenameInstanceDialog.cs
+++ b/GUI/Dialogs/RenameInstanceDialog.cs
@@ -13,6 +13,7 @@ namespace CKAN.GUI
         public RenameInstanceDialog()
         {
             InitializeComponent();
+            this.ScaleFonts();
 
             // Set the default actions for pressing Enter and Escape.
             AcceptButton = OKButton;

--- a/GUI/Dialogs/SelectionDialog.cs
+++ b/GUI/Dialogs/SelectionDialog.cs
@@ -17,6 +17,7 @@ namespace CKAN.GUI
         public SelectionDialog()
         {
             InitializeComponent();
+            this.ScaleFonts();
             currentSelected = 0;
         }
 

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -51,6 +51,7 @@ namespace CKAN.GUI
             this.CachePathSaveButton = new System.Windows.Forms.Button();
             this.CachePathCancelButton = new System.Windows.Forms.Button();
             this.CacheSummary = new System.Windows.Forms.Label();
+            this.CacheLimitPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.CacheLimitPreLabel = new System.Windows.Forms.Label();
             this.CacheLimit = new System.Windows.Forms.TextBox();
             this.CacheLimitPostLabel = new System.Windows.Forms.Label();
@@ -352,9 +353,7 @@ namespace CKAN.GUI
             this.CacheGroupBox.Controls.Add(this.CachePathSaveButton);
             this.CacheGroupBox.Controls.Add(this.CachePathCancelButton);
             this.CacheGroupBox.Controls.Add(this.CacheSummary);
-            this.CacheGroupBox.Controls.Add(this.CacheLimitPreLabel);
-            this.CacheGroupBox.Controls.Add(this.CacheLimit);
-            this.CacheGroupBox.Controls.Add(this.CacheLimitPostLabel);
+            this.CacheGroupBox.Controls.Add(this.CacheLimitPanel);
             this.CacheGroupBox.Controls.Add(this.ChangeCacheButton);
             this.CacheGroupBox.Controls.Add(this.ClearCacheButton);
             this.CacheGroupBox.Controls.Add(this.ResetCacheButton);
@@ -432,6 +431,17 @@ namespace CKAN.GUI
             this.CacheSummary.TabIndex = 24;
             resources.ApplyResources(this.CacheSummary, "CacheSummary");
             //
+            // CacheLimitPanel
+            //
+            this.CacheLimitPanel.AutoSize = true;
+            this.CacheLimitPanel.Controls.Add(this.CacheLimitPreLabel);
+            this.CacheLimitPanel.Controls.Add(this.CacheLimit);
+            this.CacheLimitPanel.Controls.Add(this.CacheLimitPostLabel);
+            this.CacheLimitPanel.Location = new System.Drawing.Point(9, 65);
+            this.CacheLimitPanel.Name = "CacheLimitPanel";
+            this.CacheLimitPanel.Size = new System.Drawing.Size(500, 20);
+            this.CacheLimitPanel.TabIndex = 25;
+            //
             // CacheLimitPreLabel
             //
             this.CacheLimitPreLabel.AutoSize = true;
@@ -466,7 +476,7 @@ namespace CKAN.GUI
             // ChangeCacheButton
             //
             this.ChangeCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ChangeCacheButton.Location = new System.Drawing.Point(12, 89);
+            this.ChangeCacheButton.Location = new System.Drawing.Point(12, 100);
             this.ChangeCacheButton.Name = "ChangeCacheButton";
             this.ChangeCacheButton.Size = new System.Drawing.Size(75, 25);
             this.ChangeCacheButton.TabIndex = 28;
@@ -476,7 +486,7 @@ namespace CKAN.GUI
             // ClearCacheButton
             //
             this.ClearCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ClearCacheButton.Location = new System.Drawing.Point(93, 89);
+            this.ClearCacheButton.Location = new System.Drawing.Point(93, 100);
             this.ClearCacheButton.Menu = this.ClearCacheMenu;
             this.ClearCacheButton.Name = "ClearCacheButton";
             this.ClearCacheButton.Size = new System.Drawing.Size(75, 25);
@@ -508,7 +518,7 @@ namespace CKAN.GUI
             // ResetCacheButton
             //
             this.ResetCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ResetCacheButton.Location = new System.Drawing.Point(174, 89);
+            this.ResetCacheButton.Location = new System.Drawing.Point(174, 100);
             this.ResetCacheButton.Name = "ResetCacheButton";
             this.ResetCacheButton.Size = new System.Drawing.Size(75, 25);
             this.ResetCacheButton.TabIndex = 30;
@@ -518,7 +528,7 @@ namespace CKAN.GUI
             // OpenCacheButton
             //
             this.OpenCacheButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.OpenCacheButton.Location = new System.Drawing.Point(255, 89);
+            this.OpenCacheButton.Location = new System.Drawing.Point(255, 100);
             this.OpenCacheButton.Name = "OpenCacheButton";
             this.OpenCacheButton.Size = new System.Drawing.Size(75, 25);
             this.OpenCacheButton.TabIndex = 31;
@@ -778,6 +788,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.Button CachePathSaveButton;
         private System.Windows.Forms.Button CachePathCancelButton;
         private System.Windows.Forms.Label CacheSummary;
+        private System.Windows.Forms.FlowLayoutPanel CacheLimitPanel;
         private System.Windows.Forms.Label CacheLimitPreLabel;
         private System.Windows.Forms.TextBox CacheLimit;
         private System.Windows.Forms.Label CacheLimitPostLabel;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -30,6 +30,8 @@ namespace CKAN.GUI
                               string?          userAgent)
         {
             InitializeComponent();
+            ClearCacheMenu.ScaleFonts();
+            this.ScaleFonts();
 
             ToolTip.SetToolTip(RefreshTextBox,    Properties.Resources.SettingsToolTipRefreshTextBox);
             ToolTip.SetToolTip(ChangeCacheButton, Properties.Resources.SettingsToolTipChangeCacheButton);
@@ -623,6 +625,7 @@ namespace CKAN.GUI
             newAuthTokenPopup.Controls.Add(cancelButton);
             newAuthTokenPopup.AcceptButton = acceptButton;
             newAuthTokenPopup.CancelButton = cancelButton;
+            newAuthTokenPopup.ScaleFonts();
 
             switch (newAuthTokenPopup.ShowDialog(this))
             {

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -18,6 +18,7 @@ namespace CKAN.GUI
         public YesNoDialog()
         {
             InitializeComponent();
+            this.ScaleFonts();
             defaultYes = YesButton.Text;
             defaultNo  = NoButton.Text;
         }

--- a/GUI/Extensions/WinFormsExtensions.cs
+++ b/GUI/Extensions/WinFormsExtensions.cs
@@ -47,6 +47,33 @@ namespace CKAN.GUI
 
         #endregion
 
+        public static Font Scale(this Font f, int dpi)
+            => new Font(f.FontFamily, f.Size * dpi / 96, f.Style);
+
+        public static void ScaleFonts(this Control control)
+        {
+            if (Platform.IsMono
+                && (int)control.CreateGraphics().DpiX is int dpi
+                && dpi != 96)
+            {
+                control.Font = control.Font.Scale(dpi);
+                if (control is DataGridView grid)
+                {
+                    grid.DefaultCellStyle.Font = grid.DefaultCellStyle.Font.Scale(dpi);
+                    grid.ColumnHeadersDefaultCellStyle.Font = grid.ColumnHeadersDefaultCellStyle.Font.Scale(dpi);
+                }
+            }
+        }
+
+        public static void ScaleFonts(this ToolStripItem item)
+        {
+            if (Platform.IsMono
+                && (int)Graphics.FromImage(new Bitmap(1, 1)).DpiX is int dpi
+                && dpi != 96)
+            {
+                item.Font = item.Font.Scale(dpi);
+            }
+        }
 
     }
 }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -106,6 +106,12 @@ namespace CKAN.GUI
             Application.AddMessageFilter(this);
 
             InitializeComponent();
+            MainMenu.ScaleFonts();
+            StatusLabel.ScaleFonts();
+            StatusInstanceLabel.ScaleFonts();
+            StatusProgress.ScaleFonts();
+            minimizedContextMenuStrip.ScaleFonts();
+            this.ScaleFonts();
             // React when the user clicks a tag or filter link in mod info
             ModInfo.OnChangeFilter += ManageMods.Filter;
             ModInfo.ModuleDoubleClicked += ManageMods.ResetFilterAndSelectModOnList;

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -32,13 +32,13 @@ namespace CKAN.GUI
             Logging.Initialize();
 
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionEventHandler;
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
             if (Platform.IsWindows)
             {
                 // By default, Windows will stretch the window and make it blurry; tell it not to.
                 SetProcessDPIAware();
             }
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
 
             if (args.Contains(URLHandlers.UrlRegistrationArgument))
             {

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -218,6 +218,7 @@ namespace CKAN.GUI
                 menu.Renderer = new FlatToolStripRenderer();
             }
             menu.Items.Add(copyLink);
+            menu.ScaleFonts();
             menu.Show(where ?? Cursor.Position);
         }
 


### PR DESCRIPTION
## Motivation

Pixels are smaller than they used to be. 96 DPI was traditional, but 120 and 144 DPI are now common. I recently upgraded to a 144 DPI setup, and the CKAN GUI looks quite tiny and hard to read in Linux.

#4543 addressed this for Windows by switching to DPI-based auto-scaling and point-based font sizes. Mono's WinForms implementation seems to auto scale the sizes of controls based on those things, but not the fonts.

<img width="1557" height="1181" alt="image" src="https://github.com/user-attachments/assets/fff08ad7-98e7-45ea-b183-06f20c7fefd5" />

#4465 did some work for configurable font scaling, but it needed some new tests to avoid decreasing the coverage percentage and wasn't finished.

## Changes

- Now when the GUI loads in Mono, we adjust the font sizes to fit the DPI if it's not 96. The font should be visually about the same size and readability on all displays regardless of their pixel density.
- Several more hard-coded font sizes are eliminated
- We now set `WebClient.Encoding` to UTF-8, which is a superior solution to #4288 than #4289 because it will work regardless of how the surrounding environment is set up.

Fixes #878.

<img width="1557" height="1181" alt="image" src="https://github.com/user-attachments/assets/6bd2a0f8-53b8-457b-bbcc-af6168bb73ed" />
