### PR TITLE
Fix item with the same key exception

### DIFF
--- a/Core/Extensions/Polyfills.cs
+++ b/Core/Extensions/Polyfills.cs
@@ -66,6 +66,16 @@ namespace System.Linq
             => seq.GroupBy(func).Select(grp => grp.First());
 
         /// <summary>
+        /// Eliminate duplicate elements based on the value returned by a callback and a comparer
+        /// </summary>
+        /// <param name="seq">Sequence of elements to check</param>
+        /// <param name="func">Function to return a value per element</param>
+        /// <param name="comparer">Comparer to check whether two values are the same</param>
+        /// <returns>Sequence where each element has a unique return value</returns>
+        public static IEnumerable<T> DistinctBy<T, U>(this IEnumerable<T> seq, Func<T, U> func, IEqualityComparer<U> comparer)
+            => seq.GroupBy(func, comparer).Select(grp => grp.First());
+
+        /// <summary>
         /// Make pairs out of the elements of two sequences
         /// </summary>
         /// <param name="seq1">The first sequence</param>

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -213,7 +213,8 @@ namespace CKAN
             {
                 // We need case insensitive path matching on Windows
                 // (already done when replacing this object in the above block, hence the 'else')
-                installed_files = new Dictionary<string, string>(installed_files, Platform.PathComparer);
+                installed_files = installed_files.DistinctBy(kvp => kvp.Key, Platform.PathComparer)
+                                                 .ToDictionary(Platform.PathComparer);
             }
 
             // Fix control lock, which previously was indexed with an invalid identifier.


### PR DESCRIPTION
## Problem

The Artemis II KSP revival continues to summon new and interesting problems to the Discord:

```
System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at System.Collections.Generic.Dictionary`2..ctor(IDictionary`2 dictionary, IEqualityComparer`1 comparer)
   at CKAN.Registry.DeSerialisationFixes(StreamingContext context)
```

Reported by Discord user JLSkyzer.

## Cause

The user had installed both KOSHUD and kOS-Computer on Windows using a version of CKAN older than #3479, so their `registry.json`'s `installed_files` object contained both of these:

```json
"Ships/Script/Boot": "KOSHUD",
"Ships/Script/boot": "kOS-Computer",
```

These represent the same folder on Windows, so when we load that registry, newer versions of CKAN use `Platform.PathComparer` to coalesce them into one entry. Unfortunately that causes an exception to be thrown.

## Changes

Now we filter out duplicate keys before we make the dictionary.
