### PR TITLE
Silently skip Steam libraries on missing drives

### DIFF
--- a/Core/IO/SteamLibrary.cs
+++ b/Core/IO/SteamLibrary.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 using log4net;
 using ValveKeyValue;
@@ -13,6 +14,7 @@ namespace CKAN.IO
 {
     public class SteamLibrary
     {
+        [ExcludeFromCodeCoverage]
         public SteamLibrary()
             : this(SteamPaths.FirstOrDefault(p => !string.IsNullOrEmpty(p)
                                                   && Directory.Exists(p)
@@ -85,15 +87,20 @@ namespace CKAN.IO
 
         private static IEnumerable<GameBase> LibraryPathGames(KVSerializer acfParser,
                                                               string       appPath)
-            => Directory.EnumerateFiles(appPath, "*.acf")
-                        .SelectWithCatch(acfFile => DeserializeAll<SteamGame>(acfParser, File.OpenRead(acfFile))
+            => Utilities.DefaultIfThrows(() => Directory.EnumerateFiles(appPath, "*.acf"),
+                                         exc => {
+                                             log.Warn($"Failed to enumerate files for {appPath}", exc);
+                                             return null;
+                                         })
+                        ?.SelectWithCatch(acfFile => DeserializeAll<SteamGame>(acfParser, File.OpenRead(acfFile))
                                                         .NormalizeDir(Path.Combine(appPath, "common")),
                                          (acfFile, exc) =>
                                          {
                                              log.Warn($"Failed to parse {acfFile}:", exc);
                                              return default;
                                          })
-                        .OfType<GameBase>();
+                         .OfType<GameBase>()
+                        ?? Enumerable.Empty<GameBase>();
 
         private static IEnumerable<GameBase> ShortcutsFileGames(KVSerializer vdfParser,
                                                                 string       path)
@@ -121,6 +128,7 @@ namespace CKAN.IO
         /// <returns>
         ///     The application data folder, e.g. <code>/Users/USER/Library/Application Support</code>
         /// </returns>
+        [ExcludeFromCodeCoverage]
         private static string GetMacOSApplicationDataFolder()
         {
             Debug.Assert(Platform.IsMac);
@@ -136,6 +144,7 @@ namespace CKAN.IO
 
         private const  string   registryKey   = @"HKEY_CURRENT_USER\Software\Valve\Steam";
         private const  string   registryValue = @"SteamPath";
+        [ExcludeFromCodeCoverage]
         private static string[] SteamPaths
             => Platform.IsWindows
                // First check the registry

--- a/Tests/Core/IO/SteamLibraryTests.cs
+++ b/Tests/Core/IO/SteamLibraryTests.cs
@@ -44,11 +44,14 @@ namespace Tests.Core.IO
                                                    "Test Instance",
                                                },
                                                lib.Games.Select(g => g.Name));
+                CollectionAssert.AreEquivalent(new Uri[] { new Uri("steam://rungameid/220200") },
+                                               lib.GameAppURLs(new DirectoryInfo(Path.Combine(dir, "SteamApps", "common",
+                                                                                              "Kerbal Space Program"))));
             }
         }
 
         [Test]
-        public void Constructor_WithCorruptedLibrary_Works()
+        public void Constructor_WithEmptyAndNullManifestsAndBadNonSteamGame_Works()
         {
             // Arrange
             using (var nonSteamGameDir = TemporaryDirectory.CopiedFromDir(TestData.good_ksp_dir()))
@@ -91,6 +94,46 @@ namespace Tests.Core.IO
                                                        "Empty StartDir",
                                                    },
                                                    lib.Games.Select(g => g.Name));
+                }
+            }
+        }
+
+        [Test]
+        public void Constructor_WithBadLibraryFolderAndShortcuts_Works()
+        {
+            // Arrange
+            using (var dir = new TemporarySteamDirectory(
+                                 new (string acfFileName, int appId, string appName)[] { },
+                                 new (string name, string absPath)[] { }))
+            {
+                File.WriteAllBytes(Path.Combine(dir, "config", "libraryfolders.vdf"),
+                                   Enumerable.Repeat((byte)0, 128).ToArray());
+
+                File.WriteAllBytes(Path.Combine(dir, "userdata", "1", "config", "shortcuts.vdf"),
+                                   Enumerable.Repeat((byte)0, 128).ToArray());
+
+                // Act / Assert
+                using (var noLog = new TemporaryLogSuppressor())
+                {
+                    var lib = new SteamLibrary(dir);
+                }
+            }
+        }
+
+        [Test]
+        public void Constructor_WithMissingLibraryFolderConfig_Works()
+        {
+            // Arrange
+            using (var dir = new TemporarySteamDirectory(
+                                 new (string acfFileName, int appId, string appName)[] { },
+                                 new (string name, string absPath)[] { }))
+            {
+                File.Delete(Path.Combine(dir, "config", "libraryfolders.vdf"));
+
+                // Act / Assert
+                using (var noLog = new TemporaryLogSuppressor())
+                {
+                    var lib = new SteamLibrary(dir);
                 }
             }
         }


### PR DESCRIPTION
## Problem

```
System.IO.IOException: A device which does not exist was specified.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileSystemEnumerableIterator`1.CommonInit()
   at System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost)
   at System.IO.Directory.EnumerateFiles(String path, String searchPattern)
   at CKAN.IO.SteamLibrary.LibraryPathGames(KVSerializer acfParser, String appPath)
   at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
   at System.Linq.Enumerable.<ConcatIterator>d__59`1.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at CKAN.IO.SteamLibrary..ctor(String libraryPath)
   at CKAN.GameInstanceManager.get_SteamLibrary()
   at CKAN.GUI.Main.OnLoad(EventArgs e)
   at System.Windows.Forms.Form.OnCreateControl()
   at System.Windows.Forms.Control.CreateControl(Boolean fIgnoreVisible)
   at System.Windows.Forms.Control.CreateControl()
   at System.Windows.Forms.Control.WmShowWindow(Message& m)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.Form.WmShowWindow(Message& m)
   at CKAN.GUI.Main.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Cause

The user had a Steam library on a drive that was no longer available. Those paths were still in the Steam config files, so CKAN was trying to check that drive for KSP instances.

## Change

Now if `Directory.EnumerateFiles` throws an exception, we `log.Warn` it and ignore that path.

Fixes #4567.
