### PR TITLE
Fit mod choice prompt to screen height in ConsoleUI

### DIFF
--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -59,12 +59,12 @@ namespace CKAN.ConsoleUI {
                     bool retry = false;
                     do {
                         Draw();
+                        var regMgr   = RegistryManager.Instance(manager.CurrentInstance, repoData);
+                        var registry = regMgr.registry;
                         try {
                             // Reset this so we stop unless an exception sets it to true
                             retry = false;
 
-                            var regMgr   = RegistryManager.Instance(manager.CurrentInstance, repoData);
-                            var registry = regMgr.registry;
                             var stabilityTolerance = manager.CurrentInstance.StabilityToleranceConfig;
 
                             // GUI prompts user to choose recs/sugs,
@@ -136,13 +136,14 @@ namespace CKAN.ConsoleUI {
                             HandlePossibleConfigOnlyDirs(theme, registry, possibleConfigOnlyDirs);
 
                         } catch (TooManyModsProvideKraken ex) {
-
                             var ch = new ConsoleChoiceDialog<CkanModule>(
                                 theme,
                                 ex.Message,
                                 Properties.Resources.InstallTooManyModsNameHeader,
                                 ex.modules.ToList(),
-                                mod => mod.ToString()
+                                mod => mod.ToString(),
+                                (a, b) => (repoData.GetDownloadCount(registry.Repositories.Values, b.identifier) ?? 0)
+                                          - (repoData.GetDownloadCount(registry.Repositories.Values, a.identifier) ?? 0)
                             );
                             var chosen = ch.Run();
                             DrawBackground();

--- a/ConsoleUI/Toolkit/ConsoleChoiceDialog.cs
+++ b/ConsoleUI/Toolkit/ConsoleChoiceDialog.cs
@@ -28,7 +28,8 @@ namespace CKAN.ConsoleUI.Toolkit {
             // Resize the window to fit the content
             List<string> msgLines = Formatting.WordWrap(m, w - 4);
 
-            int h = 2 + msgLines.Count + 1 + 1 + c.Count + 2;
+            int h = Math.Min(2 + msgLines.Count + 1 + 1 + c.Count + 2,
+                             Console.WindowHeight - 4);
             int t = (Console.WindowHeight - h) / 2;
             int b = t + h - 1;
 

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -677,11 +677,13 @@ namespace CKAN
                            .OfType<Uri>()
                            .ToArray()
                        is Uri[] { Length: > 0 } urls
-                           ? Properties.Resources.KrakenIsDLC
+                           ? string.Format(Properties.Resources.KrakenIsDLC,
+                                           module.name)
                              + string.Format(Properties.Resources.KrakenIsDLCStorePage,
                                              string.Join(Environment.NewLine,
                                                          urls.Select(u => $"- {u}")))
-                           : Properties.Resources.KrakenIsDLC))
+                           : string.Format(Properties.Resources.KrakenIsDLC,
+                                           module.name)))
         {
             this.module = module;
         }


### PR DESCRIPTION
## Problems

- If you try to install a mod that depends on a DLC you don't have (easiest to do in ConsoleUI), the error message says `{0}` where the DLC name should be
- If you start ConsoleUI at a small size (80x24 is small enough), and choose to install Scatterer and the default scatterer config, the prompt to choose a sunflare overflows the screen and doesn't respond to keyboard inputs
- The mod choice prompt in ConsoleUI is sorted lexicographically, which makes it hard to find the most frequently chosen option

Reported by DIscord user nullseii.

## Causes

- I forgot to call `string.Format`
- The height of the dialog was set based on the number of entries without checking the screen height
- No comparer was passed to the dialog

## Changes

- Now the error message says which DLC it is
- Now the mod choice prompt will fit on the screen
- Now the mod choice prompt sorts the most-downloaded mods to the top
