### PR TITLE
Purge ZIPs corrupted after downloading

### DIFF
--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -291,31 +291,41 @@ namespace CKAN.IO
             User.RaiseMessage(Properties.Resources.ModuleInstallerInstallingMod,
                               $"{module.name} {module.version}");
 
-            using (var transaction = CkanTransaction.CreateTransactionScope())
+            try
             {
-                // Install all the things!
-                var files = InstallModule(module, filename, registry, candidateDuplicates,
-                                          ref possibleConfigOnlyDirs, out int filteredCount, progress);
-
-                // Register our module and its files.
-                registry.RegisterModule(module, files, instance, autoInstalled);
-
-                // Finish our transaction, but *don't* save the registry; we may be in an
-                // intermediate, inconsistent state.
-                // This is fine from a transaction standpoint, as we may not have an enclosing
-                // transaction, and if we do, they can always roll us back.
-                transaction.Complete();
-
-                if (filteredCount > 0)
+                using (var transaction = CkanTransaction.CreateTransactionScope())
                 {
-                    User.RaiseMessage(Properties.Resources.ModuleInstallerInstalledModFiltered,
-                                      $"{module.name} {module.version}", filteredCount);
+                    // Install all the things!
+                    var files = InstallModule(module, filename, registry, candidateDuplicates,
+                                              ref possibleConfigOnlyDirs, out int filteredCount, progress);
+
+                    // Register our module and its files.
+                    registry.RegisterModule(module, files, instance, autoInstalled);
+
+                    // Finish our transaction, but *don't* save the registry; we may be in an
+                    // intermediate, inconsistent state.
+                    // This is fine from a transaction standpoint, as we may not have an enclosing
+                    // transaction, and if we do, they can always roll us back.
+                    transaction.Complete();
+
+                    if (filteredCount > 0)
+                    {
+                        User.RaiseMessage(Properties.Resources.ModuleInstallerInstalledModFiltered,
+                                          $"{module.name} {module.version}", filteredCount);
+                    }
+                    else
+                    {
+                        User.RaiseMessage(Properties.Resources.ModuleInstallerInstalledMod,
+                                          $"{module.name} {module.version}");
+                    }
                 }
-                else
-                {
-                    User.RaiseMessage(Properties.Resources.ModuleInstallerInstalledMod,
-                                      $"{module.name} {module.version}");
-                }
+            }
+            catch (ZipException zexc)
+            {
+                cache.Purge(module);
+                throw new InvalidModuleFileKraken(module, filename ?? "",
+                                                  string.Format(Properties.Resources.ModuleInstallerCorruptInCache,
+                                                                module, zexc.Message));
             }
 
             // Fire our callback that we've installed a module, if we have one.

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -143,7 +143,7 @@ namespace CKAN
             if (e.ChangeType == WatcherChangeTypes.Deleted)
             {
                 log.DebugFormat("Purging hashes reactively: {0}", e.FullPath);
-                PurgeHashes(null, e.FullPath);
+                PurgeHashes(e.FullPath);
             }
         }
 
@@ -232,7 +232,7 @@ namespace CKAN
                     // Local file too old, delete it
                     log.Debug("Found stale file, deleting it");
                     File.Delete(file);
-                    PurgeHashes(null, file);
+                    PurgeHashes(file);
                 }
             }
             else
@@ -422,7 +422,7 @@ namespace CKAN
             string targetPath = Path.Combine(cachePath.FullName, fullName);
 
             // Purge hashes associated with the new file
-            PurgeHashes(txFileMgr, targetPath);
+            PurgeHashes(targetPath);
 
             log.InfoFormat("Storing {0} in {1}", path, targetPath);
 
@@ -454,11 +454,10 @@ namespace CKAN
             if (GetCachedFilename(url) is string file
                 && File.Exists(file))
             {
-                var txFileMgr = new TxFileManager();
-                txFileMgr.Delete(file);
+                File.Delete(file);
                 // We've changed our cache, so signal that immediately.
                 cachedFiles?.Remove(CreateURLHash(url));
-                PurgeHashes(txFileMgr, file);
+                PurgeHashes(file);
                 return true;
             }
             return false;
@@ -470,16 +469,14 @@ namespace CKAN
                    .ToArray()
                    .Any(found => found);
 
-        private void PurgeHashes(TxFileManager? txFileMgr, string file)
+        private void PurgeHashes(string file)
         {
             try
             {
                 sha1Cache.TryRemove(file, out _);
                 sha256Cache.TryRemove(file, out _);
-
-                txFileMgr ??= new TxFileManager();
-                txFileMgr.Delete($"{file}.sha1");
-                txFileMgr.Delete($"{file}.sha256");
+                File.Delete($"{file}.sha1");
+                File.Delete($"{file}.sha256");
             }
             catch
             {

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -265,6 +265,10 @@ Please remove manually before trying to install it.</value></data>
   <data name="ModuleInstallerImportNotFound" xml:space="preserve"><value>Not found in index: {0}</value></data>
   <data name="ModuleInstallerImportInstallPrompt" xml:space="preserve"><value>Install {0} compatible imported mods in game instance {1} ({2})?</value></data>
   <data name="ModuleInstallerImportDeletePrompt" xml:space="preserve"><value>Scanning complete. Delete {0} old files after import?</value></data>
+  <data name="ModuleInstallerCorruptInCache" xml:space="preserve"><value>Download for {0} was corrupted and has been purged.
+This may be due to a failing storage device; you should back up all important data, scan your storage device for errors, and replace it as soon as you can.
+If you try installing this module again, it will be re-downloaded and may succeed.
+Exception details: {1}</value></data>
   <data name="KrakenDependencyNotSatisfied" xml:space="preserve"><value>Dependency on {0} version {1} not satisfied</value></data>
   <data name="KrakenDependencyModuleNotFound" xml:space="preserve"><value>Module not found: {0} {1}</value></data>
   <data name="KrakenProvidedByMoreThanOne" xml:space="preserve"><value>{1} requires {0}, which can be provided by multiple mods.

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -2322,6 +2322,39 @@ namespace Tests.Core.IO
             }
         }
 
+        [Test]
+        public void InstallList_CorruptInCache_PurgesAndThrows()
+        {
+            // Arrange
+            using (var repo     = new TemporaryRepository(TestData.DogeCoinFlag_101()))
+            using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            {
+                var installer = new ModuleInstaller(inst.KSP, cache, config, nullUser);
+                var cachePath = cache.Store(TestData.DogeCoinFlag_101_module(),
+                                            TestData.DogeCoinFlagZip(),
+                                            null)!;
+                File.Copy(TestData.DogeCoinFlagZipCorrupt(), cachePath, true);
+
+                // Act / Assert
+                var exc = Assert.Throws<InvalidModuleFileKraken>(() =>
+                {
+                    HashSet<string>? possibleConfigOnlyDirs = null;
+                    installer.InstallList(new CkanModule[] { TestData.DogeCoinFlag_101_module() },
+                                          new RelationshipResolverOptions(inst.KSP.StabilityToleranceConfig),
+                                          regMgr, ref possibleConfigOnlyDirs);
+                });
+                FileAssert.DoesNotExist(cachePath);
+                Assert.AreEqual("Download for DogeCoinFlag 1.01 was corrupted and has been purged.\r\nThis may be due to a failing storage device; you should back up all important data, scan your storage device for errors, and replace it as soon as you can.\r\nIf you try installing this module again, it will be re-downloaded and may succeed.\r\nException details: Cannot find central directory",
+                                exc?.Message);
+            }
+        }
+
         public static IEnumerable<string> AbsoluteInstalledPaths(GameInstance  inst,
                                                                  CKAN.Registry registry)
             => registry.InstalledFileInfo()


### PR DESCRIPTION
## Motivation

If your hard drive starts failing, ZIP files that CKAN already validated and stored to cache may become corrupted. This causes a `ZipException` to be thrown, and all the user sees is a stack trace, which doesn't tell them what happened or what to do about it.

<img width="2060" height="315" alt="image" src="https://github.com/user-attachments/assets/9d00c43b-222d-411f-9e98-38eba7f96f48" />

Brought up by Discord user Giborg (Данила).

## Changes

Now if this happens:

- We purge the corrupted file automatically
- The stack trace is replaced by an error message explaining what happened and what to do about it
  <img width="1106" height="334" alt="image" src="https://github.com/user-attachments/assets/b40b3636-743a-420f-8575-50837940fd8c" />

After this, all the user has to do is click Retry to re-download (but they should probably exit and make backups of all their data instead).
