### PR TITLE
Layout and scaling related fixes

### DIFF
--- a/Core/Extensions/Polyfills.cs
+++ b/Core/Extensions/Polyfills.cs
@@ -56,6 +56,38 @@ namespace System.Linq
 
         #if NETFRAMEWORK || NETSTANDARD2_0
 
+        public static TSource? MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+                                                    Func<TSource, TKey>       keySelector,
+                                                    IComparer<TKey>?          comparer = null)
+        {
+            using (var iterator = source.GetEnumerator())
+            {
+                if (!iterator.MoveNext())
+                {
+                    if (default(TSource) == null)
+                    {
+                        return default;
+                    }
+                    throw new InvalidOperationException("Sequence contains no elements");
+                }
+
+                comparer ??= Comparer<TKey>.Default;
+                var maxElement = iterator.Current;
+                var maxKey     = keySelector(maxElement);
+                while (iterator.MoveNext())
+                {
+                    var currentElement = iterator.Current;
+                    var currentKey     = keySelector(currentElement);
+                    if (comparer.Compare(currentKey, maxKey) > 0)
+                    {
+                        maxElement = currentElement;
+                        maxKey     = currentKey;
+                    }
+                }
+                return maxElement;
+            }
+        }
+
         /// <summary>
         /// Eliminate duplicate elements based on the value returned by a callback
         /// </summary>

--- a/Core/Games/IGame.cs
+++ b/Core/Games/IGame.cs
@@ -54,6 +54,7 @@ namespace CKAN.Games
         Uri DefaultRepositoryURL  { get; }
         Uri RepositoryListURL     { get; }
         Uri MetadataBugtrackerURL { get; }
+        Uri DiscordURL            { get; }
         Uri ModSupportURL         { get; }
     }
 }

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -299,6 +299,8 @@ namespace CKAN.Games.KerbalSpaceProgram
 
         public Uri MetadataBugtrackerURL => new Uri("https://github.com/KSP-CKAN/NetKAN/issues/new/choose");
 
+        public Uri DiscordURL => new Uri("https://discord.gg/65hp7G7");
+
         public Uri ModSupportURL => new Uri("https://forum.kerbalspaceprogram.com/forum/70-ksp1-technical-support-pc-modded-installs/");
 
         private static string Missions(GameInstance inst)

--- a/Core/Games/KerbalSpaceProgram2.cs
+++ b/Core/Games/KerbalSpaceProgram2.cs
@@ -245,6 +245,8 @@ namespace CKAN.Games.KerbalSpaceProgram2
 
         public Uri MetadataBugtrackerURL => new Uri("https://github.com/KSP-CKAN/KSP2-NetKAN/issues/new/choose");
 
+        public Uri DiscordURL => new Uri("https://discord.gg/ZbMp7RjVhU");
+
         public Uri ModSupportURL => new Uri("https://forum.kerbalspaceprogram.com/forum/137-ksp2-technical-support-pc-modded-installs/");
 
         private const string DataDir = "KSP2_x64_Data";

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -27,7 +27,7 @@ namespace CKAN
         /// the specified game version.
         /// </summary>
         IEnumerable<CkanModule> CompatibleModules(StabilityToleranceConfig stabilityTolerance,
-                                                  GameVersionCriteria?     ksp_version);
+                                                  GameVersionCriteria      ksp_version);
 
         /// <summary>
         /// Get full JSON metadata string for a mod's available versions

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -637,13 +637,9 @@ namespace CKAN
         /// <see cref="IRegistryQuerier.CompatibleModules"/>
         /// </summary>
         public IEnumerable<CkanModule> CompatibleModules(StabilityToleranceConfig stabilityTolerance,
-                                                         GameVersionCriteria?     crit)
+                                                         GameVersionCriteria      crit)
             // Set up our compatibility partition
-            => crit != null ? SetCompatibleVersion(stabilityTolerance, crit).LatestCompatible
-                            : repoDataMgr?.GetAllAvailableModules(Repositories.Values)
-                                          .Select(am => am.Latest(stabilityTolerance))
-                                          .OfType<CkanModule>()
-                                         ?? Enumerable.Empty<CkanModule>();
+            => SetCompatibleVersion(stabilityTolerance, crit).LatestCompatible;
 
         /// <summary>
         /// <see cref="IRegistryQuerier.IncompatibleModules"/>
@@ -692,8 +688,7 @@ namespace CKAN
             => getAvail(identifier).Select(am => am.Latest(stabilityTolerance, gameVersion, relationshipDescriptor,
                                                            installed, toInstall))
                                    .OfType<CkanModule>()
-                                   .OrderByDescending(m => m.version)
-                                   .FirstOrDefault();
+                                   .MaxBy(m => m.version);
 
         /// <summary>
         /// Find modules with a given identifier
@@ -834,7 +829,9 @@ namespace CKAN
                     ? provs.Select(am => am.Latest(stabilityTolerance, gameVersion, relationship, installed, toInstall))
                            .OfType<CkanModule>()
                            .Where(m => m.ProvidesList.Contains(identifier))
-                           .Distinct()
+                           .GroupBy(m => m.identifier)
+                           .Select(grp => grp.MaxBy(m => m.version))
+                           .OfType<CkanModule>()
                            // Put the most popular one on top
                            .OrderByDescending(m => repoDataMgr?.GetDownloadCount(Repositories.Values, m.identifier)
                                                               ?? 0)

--- a/GUI/Controls/DownloadStatistics/DownloadStatisticsPieChart.cs
+++ b/GUI/Controls/DownloadStatistics/DownloadStatisticsPieChart.cs
@@ -19,13 +19,6 @@ namespace CKAN.GUI
     {
         public DownloadStatisticsPieChart() : base()
         {
-            Model = new PlotModel()
-            {
-                Title               = Properties.Resources.DownloadStatisticsPieChartTitle,
-                TitleColor          = SystemColors.ControlText.ToOxyColor(),
-                TextColor           = SystemColors.ControlText.ToOxyColor(),
-                PlotAreaBorderColor = SystemColors.Control.ToOxyColor(),
-            };
             Controller = new PlotController();
             // Get rid of the weird click-toooltip thing
             Controller.UnbindMouseDown(OxyMouseButton.Left);
@@ -33,6 +26,13 @@ namespace CKAN.GUI
 
         public void SetData(IReadOnlyDictionary<string, long> bytesPerHost)
         {
+            Model = new PlotModel()
+            {
+                Title               = Properties.Resources.DownloadStatisticsPieChartTitle,
+                TitleColor          = SystemColors.ControlText.ToOxyColor(),
+                TextColor           = SystemColors.ControlText.ToOxyColor(),
+                PlotAreaBorderColor = SystemColors.Control.ToOxyColor(),
+            };
             var totalSize = bytesPerHost.Values.Sum();
             var numLabels = bytesPerHost.Values.Count(size => size >= totalSize * 5 / 100) + 1;
             Model.Series.Clear();

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -371,6 +371,7 @@ namespace CKAN.GUI
             //
             // Installed
             //
+            this.Installed.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Installed.Name = "Installed";
             this.Installed.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.Installed.Frozen = true;
@@ -381,6 +382,7 @@ namespace CKAN.GUI
             //
             // AutoInstalled
             //
+            this.AutoInstalled.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.AutoInstalled.Name = "AutoInstalled";
             this.AutoInstalled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.AutoInstalled.Frozen = true;
@@ -391,6 +393,7 @@ namespace CKAN.GUI
             //
             // UpdateCol
             //
+            this.UpdateCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.UpdateCol.Name = "UpdateCol";
             this.UpdateCol.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.UpdateCol.Frozen = true;
@@ -401,6 +404,7 @@ namespace CKAN.GUI
             //
             // ReplaceCol
             //
+            this.ModName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.ReplaceCol.Name = "ReplaceCol";
             this.ReplaceCol.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ReplaceCol.Frozen = true;
@@ -411,22 +415,25 @@ namespace CKAN.GUI
             //
             // ModName
             //
+            this.ModName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.ModName.Name = "ModName";
             this.ModName.ReadOnly = true;
             this.ModName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.ModName.Width = 250;
+            this.ModName.MinimumWidth = 250;
             resources.ApplyResources(this.ModName, "ModName");
             //
             // Author
             //
+            this.Author.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.Author.Name = "Author";
             this.Author.ReadOnly = true;
             this.Author.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Author.Width = 120;
+            this.Author.MinimumWidth = 120;
             resources.ApplyResources(this.Author, "Author");
             //
             // InstalledVersion
             //
+            this.InstalledVersion.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.InstalledVersion.Name = "InstalledVersion";
             this.InstalledVersion.ReadOnly = true;
             this.InstalledVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -435,14 +442,16 @@ namespace CKAN.GUI
             //
             // LatestVersion
             //
+            this.LatestVersion.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.LatestVersion.Name = "LatestVersion";
             this.LatestVersion.ReadOnly = true;
             this.LatestVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.LatestVersion.Width = 70;
+            this.LatestVersion.MinimumWidth = 70;
             resources.ApplyResources(this.LatestVersion, "LatestVersion");
             //
             // GameCompatibility
             //
+            this.GameCompatibility.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.GameCompatibility.Name = "GameCompatibility";
             this.GameCompatibility.ReadOnly = true;
             this.GameCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -451,6 +460,7 @@ namespace CKAN.GUI
             //
             // DownloadSize
             //
+            this.DownloadSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.DownloadSize.Name = "DownloadSize";
             this.DownloadSize.ReadOnly = true;
             this.DownloadSize.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -459,6 +469,7 @@ namespace CKAN.GUI
             //
             // InstallSize
             //
+            this.InstallSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.InstallSize.Name = "InstallSize";
             this.InstallSize.ReadOnly = true;
             this.InstallSize.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -467,6 +478,7 @@ namespace CKAN.GUI
             //
             // ReleaseDate
             //
+            this.ReleaseDate.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.ReleaseDate.Name = "ReleaseDate";
             this.ReleaseDate.ReadOnly = true;
             this.ReleaseDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -475,6 +487,7 @@ namespace CKAN.GUI
             //
             // InstallDate
             //
+            this.InstallDate.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.InstallDate.Name = "InstallDate";
             this.InstallDate.ReadOnly = true;
             this.InstallDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -483,6 +496,7 @@ namespace CKAN.GUI
             //
             // DownloadCount
             //
+            this.DownloadCount.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.DownloadCount.Name = "DownloadCount";
             this.DownloadCount.ReadOnly = true;
             this.DownloadCount.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -492,10 +506,11 @@ namespace CKAN.GUI
             //
             // Description
             //
+            this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.Description.Name = "Description";
             this.Description.ReadOnly = true;
             this.Description.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.Description.Width = 821;
+            this.Description.MinimumWidth = 600;
             resources.ApplyResources(this.Description, "Description");
             //
             // ModListContextMenuStrip

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1649,7 +1649,8 @@ namespace CKAN.GUI
             // Update our mod listing
             MainModList = new ModList(guiMods, currentInstance,
                                       ModuleLabelList.ModuleLabels, ModuleTagList.ModuleTags,
-                                      ServiceLocator.Container.Resolve<IConfiguration>(), guiConfig, ChangeSet);
+                                      ServiceLocator.Container.Resolve<IConfiguration>(), guiConfig,
+                                      CreateGraphics(), ChangeSet);
             MainModList.ModFiltersUpdated += UpdateFilters;
 
             UpdateChangeSetAndConflicts(currentInstance, registry);

--- a/GUI/Controls/ModInfo/Contents.Designer.cs
+++ b/GUI/Controls/ModInfo/Contents.Designer.cs
@@ -61,7 +61,7 @@ namespace CKAN.GUI
             //
             this.NotCachedLabel.Dock = System.Windows.Forms.DockStyle.Top;
             this.NotCachedLabel.Location = new System.Drawing.Point(3, 3);
-            this.NotCachedLabel.Padding = new System.Windows.Forms.Padding(0, 6, 0, 6);
+            this.NotCachedLabel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 6);
             this.NotCachedLabel.Name = "NotCachedLabel";
             this.NotCachedLabel.Size = new System.Drawing.Size(494, 30);
             this.NotCachedLabel.TabIndex = 0;

--- a/GUI/Controls/ModInfo/Metadata.Designer.cs
+++ b/GUI/Controls/ModInfo/Metadata.Designer.cs
@@ -161,7 +161,7 @@ namespace CKAN.GUI
             //
             this.AuthorsPanel.AutoSize = true;
             this.AuthorsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AuthorsPanel.Margin = new System.Windows.Forms.Padding(0, 0, 0, 10);
+            this.AuthorsPanel.Margin = new System.Windows.Forms.Padding(4, 0, 0, 10);
             this.AuthorsPanel.Padding = new System.Windows.Forms.Padding(0);
             this.AuthorsPanel.Location = new System.Drawing.Point(0, 0);
             this.AuthorsPanel.Name = "AuthorsPanel";

--- a/GUI/Controls/ModInfo/Metadata.cs
+++ b/GUI/Controls/ModInfo/Metadata.cs
@@ -100,7 +100,8 @@ namespace CKAN.GUI
                     AddResourceLink(Properties.Resources.ModInfoGogStoreLabel,              res.gogstore);
                     AddResourceLink(Properties.Resources.ModInfoEpicStoreLabel,             res.epicstore);
                 }
-                MetadataTable.ResumeLayout();
+                MetadataTable.ResumeLayout(true);
+                ResizeResourceRows();
             });
         }
 
@@ -112,7 +113,7 @@ namespace CKAN.GUI
             AuthorsPanel.Controls.Clear();
             AuthorsPanel.Controls.AddRange(
                 authors.Select(AuthorLink).ToArray());
-            AuthorsPanel.ResumeLayout();
+            AuthorsPanel.ResumeLayout(true);
         }
 
         private LinkLabel AuthorLink(string name)
@@ -212,7 +213,7 @@ namespace CKAN.GUI
 
         private void AddResourceLink(string label, Uri? link)
         {
-            const int vPadding = 5;
+            const int vPadding = 3;
             if (link != null)
             {
                 Label lbl = new Label()
@@ -251,6 +252,7 @@ namespace CKAN.GUI
             {
                 MetadataTable.SuspendLayout();
                 var rWidth = RightColumnWidth;
+                var g = CreateGraphics();
                 for (int row = staticRowCount; row < MetadataTable.RowStyles.Count; ++row)
                 {
                     if (MetadataTable.GetControlFromPosition(0, row) is Label lab
@@ -258,11 +260,11 @@ namespace CKAN.GUI
                     {
                         MetadataTable.RowStyles[row].Height = Math.Max(
                             // "Remote version file" wraps
-                            Util.LabelStringHeight(CreateGraphics(), lab),
+                            Util.LabelStringHeight(g, lab),
                             LinkLabelStringHeight(link, rWidth));
                     }
                 }
-                MetadataTable.ResumeLayout();
+                MetadataTable.ResumeLayout(true);
             }
         }
 

--- a/GUI/Controls/ModInfo/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo/ModInfo.Designer.cs
@@ -78,7 +78,7 @@ namespace CKAN.GUI
             // MetadataModuleNameTextBox
             //
             this.MetadataModuleNameTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleNameTextBox.Font = new System.Drawing.Font(System.Drawing.SystemFonts.CaptionFont, System.Drawing.FontStyle.Bold);
+            this.MetadataModuleNameTextBox.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.FontFamily, 13, System.Drawing.FontStyle.Bold, System.Drawing.SystemFonts.CaptionFont.Unit);
             this.MetadataModuleNameTextBox.Location = new System.Drawing.Point(3, 0);
             this.MetadataModuleNameTextBox.Name = "MetadataModuleNameTextBox";
             this.MetadataModuleNameTextBox.Size = new System.Drawing.Size(494, 46);
@@ -153,14 +153,13 @@ namespace CKAN.GUI
             this.MetadataTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.MetadataTabPage.Controls.Add(this.Metadata);
             this.MetadataTabPage.Name = "MetadataTabPage";
-            this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.MetadataTabPage.Padding = new System.Windows.Forms.Padding(6);
             this.MetadataTabPage.TabIndex = 5;
             resources.ApplyResources(this.MetadataTabPage, "MetadataTabPage");
             //
             // Metadata
             //
             this.Metadata.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Metadata.Margin = new System.Windows.Forms.Padding(2);
             this.Metadata.Name = "Metadata";
             this.Metadata.TabIndex = 6;
             this.Metadata.OnChangeFilter += this.Metadata_OnChangeFilter;
@@ -170,7 +169,7 @@ namespace CKAN.GUI
             this.RelationshipTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.RelationshipTabPage.Controls.Add(this.Relationships);
             this.RelationshipTabPage.Name = "RelationshipTabPage";
-            this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.RelationshipTabPage.Padding = new System.Windows.Forms.Padding(6);
             this.RelationshipTabPage.Size = new System.Drawing.Size(494, 300);
             this.RelationshipTabPage.TabIndex = 7;
             resources.ApplyResources(this.RelationshipTabPage, "RelationshipTabPage");
@@ -178,7 +177,6 @@ namespace CKAN.GUI
             // Relationships
             //
             this.Relationships.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Relationships.Margin = new System.Windows.Forms.Padding(2);
             this.Relationships.Name = "Relationships";
             this.Relationships.Size = new System.Drawing.Size(494, 300);
             this.Relationships.TabIndex = 8;
@@ -188,14 +186,13 @@ namespace CKAN.GUI
             this.ContentTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.ContentTabPage.Controls.Add(this.Contents);
             this.ContentTabPage.Name = "ContentTabPage";
-            this.ContentTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.ContentTabPage.Padding = new System.Windows.Forms.Padding(6);
             this.ContentTabPage.TabIndex = 9;
             resources.ApplyResources(this.ContentTabPage, "ContentTabPage");
             //
             // Contents
             //
             this.Contents.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Contents.Margin = new System.Windows.Forms.Padding(2);
             this.Contents.Name = "Contents";
             this.Contents.TabIndex = 10;
             //
@@ -203,7 +200,7 @@ namespace CKAN.GUI
             //
             this.VersionsTabPage.BackColor = System.Drawing.SystemColors.Control;
             this.VersionsTabPage.Controls.Add(this.Versions);
-            this.VersionsTabPage.Margin = new System.Windows.Forms.Padding(3);
+            this.VersionsTabPage.Padding = new System.Windows.Forms.Padding(6);
             this.VersionsTabPage.Name = "VersionsTabPage";
             this.VersionsTabPage.TabIndex = 11;
             resources.ApplyResources(this.VersionsTabPage, "VersionsTabPage");
@@ -211,7 +208,6 @@ namespace CKAN.GUI
             // Versions
             //
             this.Versions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Versions.Margin = new System.Windows.Forms.Padding(2);
             this.Versions.Name = "Versions";
             this.Versions.TabIndex = 12;
             //

--- a/GUI/Controls/ModInfo/Relationships.Designer.cs
+++ b/GUI/Controls/ModInfo/Relationships.Designer.cs
@@ -67,6 +67,7 @@ namespace CKAN.GUI
             this.DependsGraphTree.Name = "DependsGraphTree";
             this.DependsGraphTree.Size = new System.Drawing.Size(494, 340);
             this.DependsGraphTree.TabIndex = 0;
+            this.DependsGraphTree.Margin = new System.Windows.Forms.Padding(0);
             this.DependsGraphTree.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.DependsGraphTree_NodeMouseDoubleClick);
             this.DependsGraphTree.ShowNodeToolTips = true;
             this.DependsGraphTree.ImageList = new System.Windows.Forms.ImageList(this.components)
@@ -113,7 +114,7 @@ namespace CKAN.GUI
             this.LegendTable.Location = new System.Drawing.Point(0, 0);
             this.LegendTable.Name = "LegendTable";
             this.LegendTable.Padding = new System.Windows.Forms.Padding(0, 6, 0, 0);
-            this.LegendTable.Margin = new System.Windows.Forms.Padding(0, 0, 0, 0);
+            this.LegendTable.Margin = new System.Windows.Forms.Padding(0);
             this.LegendTable.RowCount = 3;
             this.LegendTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
             this.LegendTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));

--- a/GUI/Controls/ModInfo/Versions.Designer.cs
+++ b/GUI/Controls/ModInfo/Versions.Designer.cs
@@ -205,7 +205,6 @@ namespace CKAN.GUI
             this.Controls.Add(this.OverallSummaryLabel);
             this.Controls.Add(this.LabelTable);
             this.Name = "Versions";
-            this.Padding = new System.Windows.Forms.Padding(6);
             this.Size = new System.Drawing.Size(500, 500);
             resources.ApplyResources(this, "$this");
             this.LabelTable.ResumeLayout(false);

--- a/GUI/Controls/PlayTime.Designer.cs
+++ b/GUI/Controls/PlayTime.Designer.cs
@@ -80,6 +80,7 @@ namespace CKAN.GUI
             this.PlayTimeGrid.Size = new System.Drawing.Size(1536, 837);
             this.PlayTimeGrid.StandardTab = false;
             this.PlayTimeGrid.TabIndex = 1;
+            this.PlayTimeGrid.CurrentCellChanged += this.PlayTimeGrid_CurrentCellChanged;
             this.PlayTimeGrid.CellValueChanged += this.PlayTimeGrid_CellValueChanged;
             // 
             // NameColumn

--- a/GUI/Controls/PlayTime.cs
+++ b/GUI/Controls/PlayTime.cs
@@ -68,6 +68,31 @@ namespace CKAN.GUI
             }
         }
 
+        private void PlayTimeGrid_CurrentCellChanged(object sender, EventArgs e)
+        {
+            // DataGridView doesn't like changing the current cell in the notification
+            // for current cell changed
+            if (IsHandleCreated)
+            {
+                BeginInvoke(new MethodInvoker(SkipReadOnlyCells));
+            }
+        }
+
+        private void SkipReadOnlyCells()
+        {
+            // Bounce out of uneditable cells
+            if (PlayTimeGrid.CurrentCell is
+                {
+                    OwningColumn: { ReadOnly: true },
+                    RowIndex:     int row,
+                    ColumnIndex:  int col,
+                }
+                && col + 1 < PlayTimeGrid.ColumnCount)
+            {
+                PlayTimeGrid.CurrentCell = PlayTimeGrid.Rows[row].Cells[col + 1];
+            }
+        }
+
         private void PlayTimeGrid_CellValueChanged(object sender, DataGridViewCellEventArgs evt)
         {
             ShowTotal();

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.Designer.cs
@@ -84,7 +84,7 @@ namespace CKAN.GUI
             this.MainContentsPanel.Controls.Add(this.SaveButton);
             this.MainContentsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MainContentsPanel.Name = "MainContentsPanel";
-            this.MainContentsPanel.Size = new System.Drawing.Size(443, 383);
+            this.MainContentsPanel.Size = new System.Drawing.Size(443, 418);
             //
             // InstancePathLabel
             //
@@ -103,13 +103,14 @@ namespace CKAN.GUI
             this.ActualInstancePathLabel.AutoSize = false;
             this.ActualInstancePathLabel.Location = new System.Drawing.Point(100, 11);
             this.ActualInstancePathLabel.Name = "ActualInstancePathLabel";
-            this.ActualInstancePathLabel.Size = new System.Drawing.Size(336, 32);
+            this.ActualInstancePathLabel.Size = new System.Drawing.Size(336, 36);
             this.ActualInstancePathLabel.TabIndex = 1;
             resources.ApplyResources(this.ActualInstancePathLabel, "ActualInstancePathLabel");
             //
             // GameVersionLabel
             //
-            this.GameVersionLabel.Location = new System.Drawing.Point(12, 43);
+            this.GameVersionLabel.AutoSize = true;
+            this.GameVersionLabel.Location = new System.Drawing.Point(12, 48);
             this.GameVersionLabel.Name = "GameVersionLabel";
             this.GameVersionLabel.Size = new System.Drawing.Size(75, 13);
             this.GameVersionLabel.TabIndex = 2;
@@ -118,7 +119,7 @@ namespace CKAN.GUI
             // ActualGameVersionLabel
             //
             this.ActualGameVersionLabel.AutoSize = true;
-            this.ActualGameVersionLabel.Location = new System.Drawing.Point(100, 43);
+            this.ActualGameVersionLabel.Location = new System.Drawing.Point(100, 48);
             this.ActualGameVersionLabel.Name = "ActualGameVersionLabel";
             this.ActualGameVersionLabel.Size = new System.Drawing.Size(53, 13);
             this.ActualGameVersionLabel.TabIndex = 3;
@@ -126,6 +127,7 @@ namespace CKAN.GUI
             //
             // ListHeaderLabel
             //
+            this.ListHeaderLabel.AutoSize = true;
             this.ListHeaderLabel.Location = new System.Drawing.Point(12, 73);
             this.ListHeaderLabel.Name = "ListHeaderLabel";
             this.ListHeaderLabel.Size = new System.Drawing.Size(422, 13);
@@ -140,9 +142,9 @@ namespace CKAN.GUI
             | System.Windows.Forms.AnchorStyles.Right)));
             this.SelectedVersionsCheckedListBox.CheckOnClick = true;
             this.SelectedVersionsCheckedListBox.FormattingEnabled = true;
-            this.SelectedVersionsCheckedListBox.Location = new System.Drawing.Point(12, 88);
+            this.SelectedVersionsCheckedListBox.Location = new System.Drawing.Point(12, 100);
             this.SelectedVersionsCheckedListBox.Name = "selectedVersionsCheckedListBox";
-            this.SelectedVersionsCheckedListBox.Size = new System.Drawing.Size(419, 115);
+            this.SelectedVersionsCheckedListBox.Size = new System.Drawing.Size(419, 103);
             this.SelectedVersionsCheckedListBox.TabIndex = 5;
             //
             // clearSelectionButton
@@ -163,7 +165,7 @@ namespace CKAN.GUI
             //
             this.AddVersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.AddVersionLabel.AutoSize = true;
-            this.AddVersionLabel.Location = new System.Drawing.Point(111, 216);
+            this.AddVersionLabel.Location = new System.Drawing.Point(150, 216);
             this.AddVersionLabel.Name = "AddVersionLabel";
             this.AddVersionLabel.Size = new System.Drawing.Size(93, 13);
             this.AddVersionLabel.TabIndex = 7;
@@ -175,9 +177,9 @@ namespace CKAN.GUI
             | System.Windows.Forms.AnchorStyles.Right));
             this.AddVersionToListTextBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.AddVersionToListTextBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.AddVersionToListTextBox.Location = new System.Drawing.Point(242, 211);
+            this.AddVersionToListTextBox.Location = new System.Drawing.Point(262, 211);
             this.AddVersionToListTextBox.Name = "addVersionToListTextBox";
-            this.AddVersionToListTextBox.Size = new System.Drawing.Size(113, 15);
+            this.AddVersionToListTextBox.Size = new System.Drawing.Size(93, 15);
             this.AddVersionToListTextBox.TabIndex = 8;
             //
             // AddVersionToListButton
@@ -201,7 +203,7 @@ namespace CKAN.GUI
             | System.Windows.Forms.AnchorStyles.Right));
             this.WildcardExplanationLabel.Location = new System.Drawing.Point(12, 240);
             this.WildcardExplanationLabel.Name = "WildcardExplanationLabel";
-            this.WildcardExplanationLabel.Size = new System.Drawing.Size(419, 32);
+            this.WildcardExplanationLabel.Size = new System.Drawing.Size(419, 40);
             this.WildcardExplanationLabel.TabIndex = 10;
             resources.ApplyResources(this.WildcardExplanationLabel, "WildcardExplanationLabel");
             //
@@ -209,10 +211,10 @@ namespace CKAN.GUI
             //
             this.FutureUpdatesLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right));
-            this.FutureUpdatesLabel.Location = new System.Drawing.Point(12, 273);
+            this.FutureUpdatesLabel.Location = new System.Drawing.Point(12, 283);
             this.FutureUpdatesLabel.Name = "FutureUpdatesLabel";
-            this.FutureUpdatesLabel.Size = new System.Drawing.Size(419, 32);
-            this.FutureUpdatesLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.FutureUpdatesLabel.Size = new System.Drawing.Size(419, 40);
+            // this.FutureUpdatesLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.FutureUpdatesLabel.TabIndex = 11;
             resources.ApplyResources(this.FutureUpdatesLabel, "FutureUpdatesLabel");
             //
@@ -221,9 +223,9 @@ namespace CKAN.GUI
             this.WarningLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right));
             this.WarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.WarningLabel.Location = new System.Drawing.Point(12, 315);
+            this.WarningLabel.Location = new System.Drawing.Point(12, 326);
             this.WarningLabel.Name = "WarningLabel";
-            this.WarningLabel.Size = new System.Drawing.Size(419, 32);
+            this.WarningLabel.Size = new System.Drawing.Size(419, 40);
             this.WarningLabel.TabIndex = 12;
             resources.ApplyResources(this.WarningLabel, "WarningLabel");
             //
@@ -234,7 +236,7 @@ namespace CKAN.GUI
             this.CancelChooseCompatibleVersionsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.CancelChooseCompatibleVersionsButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CancelChooseCompatibleVersionsButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelChooseCompatibleVersionsButton.Location = new System.Drawing.Point(275, 350);
+            this.CancelChooseCompatibleVersionsButton.Location = new System.Drawing.Point(275, 380);
             this.CancelChooseCompatibleVersionsButton.Name = "cancelButton";
             this.CancelChooseCompatibleVersionsButton.Size = new System.Drawing.Size(75, 23);
             this.CancelChooseCompatibleVersionsButton.TabIndex = 14;
@@ -248,7 +250,7 @@ namespace CKAN.GUI
             this.SaveButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.SaveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.SaveButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.SaveButton.Location = new System.Drawing.Point(356, 350);
+            this.SaveButton.Location = new System.Drawing.Point(356, 380);
             this.SaveButton.Name = "saveButton";
             this.SaveButton.Size = new System.Drawing.Size(75, 23);
             this.SaveButton.TabIndex = 13;
@@ -259,16 +261,14 @@ namespace CKAN.GUI
             // CompatibleGameVersionsDialog
             //
             this.AcceptButton = this.SaveButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.CancelChooseCompatibleVersionsButton;
-            this.ClientSize = new System.Drawing.Size(443, 383);
+            this.ClientSize = new System.Drawing.Size(443, 418);
             this.Controls.Add(this.MainContentsPanel);
             this.Controls.Add(this.MessageLabel);
             this.Icon = EmbeddedImages.AppIcon;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(443, 383);
+            this.MinimumSize = new System.Drawing.Size(443, 418);
             this.HelpButton = true;
             this.Name = "CompatibleGameVersionsDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
@@ -278,6 +278,8 @@ namespace CKAN.GUI
             this.MainContentsPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
         }
 
         #endregion

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.resx
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.resx
@@ -124,9 +124,9 @@
   <data name="ClearSelectionButton.Text" xml:space="preserve"><value>Clear selection</value></data>
   <data name="AddVersionLabel.Text" xml:space="preserve"><value>Add version to list:</value></data>
   <data name="AddVersionToListButton.Text" xml:space="preserve"><value>Add</value></data>
-  <data name="WildcardExplanationLabel.Text" xml:space="preserve"><value>Note: Adding a version like "1.12" will force all mods compatible with 1.12.x (1.12.0, 1.12.1, etc.) to be compatible with this game instance.</value></data>
-  <data name="FutureUpdatesLabel.Text" xml:space="preserve"><value>If the game is updated this dialog will be shown again so you can adjust your settings.</value></data>
-  <data name="WarningLabel.Text" xml:space="preserve"><value>Warning! There is no way to check if mod is truly compatible with versions selected here! Please act carefully.</value></data>
+  <data name="WildcardExplanationLabel.Text" xml:space="preserve"><value>Note: Adding a version like "1.12" will force all mods compatible with 1.12.x (1.12.0, 1.12.1, etc.) to be treated as compatible with this game instance.</value></data>
+  <data name="FutureUpdatesLabel.Text" xml:space="preserve"><value>If the game is updated, this dialog will be shown again so you can adjust your settings.</value></data>
+  <data name="WarningLabel.Text" xml:space="preserve"><value>Warning! There is no way to check if a mod is truly compatible with versions selected here! Please choose carefully.</value></data>
   <data name="CancelChooseCompatibleVersionsButton.Text" xml:space="preserve"><value>Cancel</value></data>
   <data name="SaveButton.Text" xml:space="preserve"><value>Accept</value></data>
 </root>

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
@@ -100,7 +100,7 @@ namespace CKAN.GUI
             this.ResetToDefaultsButton.Location = new System.Drawing.Point(316, 51);
             this.ResetToDefaultsButton.Margin = new System.Windows.Forms.Padding(0, 4, 8, 4);
             this.ResetToDefaultsButton.Name = "ResetToDefaultsButton";
-            this.ResetToDefaultsButton.Size = new System.Drawing.Size(75, 23);
+            this.ResetToDefaultsButton.Size = new System.Drawing.Size(75, 12);
             this.ResetToDefaultsButton.TabIndex = 2;
             this.ResetToDefaultsButton.UseVisualStyleBackColor = true;
             this.ResetToDefaultsButton.Click += this.ResetToDefaultsButton_Click;
@@ -114,7 +114,7 @@ namespace CKAN.GUI
             this.AddButton.Location = new System.Drawing.Point(316, 51);
             this.AddButton.Margin = new System.Windows.Forms.Padding(0, 4, 8, 4);
             this.AddButton.Name = "AddButton";
-            this.AddButton.Size = new System.Drawing.Size(75, 23);
+            this.AddButton.Size = new System.Drawing.Size(75, 12);
             this.AddButton.TabIndex = 2;
             this.AddButton.UseVisualStyleBackColor = true;
             this.AddButton.Visible = false;
@@ -130,7 +130,7 @@ namespace CKAN.GUI
             this.CancelChangesButton.Location = new System.Drawing.Point(316, 51);
             this.CancelChangesButton.Margin = new System.Windows.Forms.Padding(8, 4, 0, 4);
             this.CancelChangesButton.Name = "CancelChangesButton";
-            this.CancelChangesButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelChangesButton.Size = new System.Drawing.Size(75, 12);
             this.CancelChangesButton.TabIndex = 2;
             this.CancelChangesButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.CancelChangesButton, "CancelChangesButton");
@@ -144,7 +144,7 @@ namespace CKAN.GUI
             this.AcceptChangesButton.Location = new System.Drawing.Point(397, 51);
             this.AcceptChangesButton.Margin = new System.Windows.Forms.Padding(8, 4, 0, 4);
             this.AcceptChangesButton.Name = "AcceptChangesButton";
-            this.AcceptChangesButton.Size = new System.Drawing.Size(75, 23);
+            this.AcceptChangesButton.Size = new System.Drawing.Size(75, 12);
             this.AcceptChangesButton.TabIndex = 3;
             this.AcceptChangesButton.UseVisualStyleBackColor = true;
             this.AcceptChangesButton.Click += this.AcceptChangesButton_Click;
@@ -154,7 +154,7 @@ namespace CKAN.GUI
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(320, 180);
+            this.ClientSize = new System.Drawing.Size(360, 220);
             this.ControlBox = false;
             this.Controls.Add(this.CmdLineGrid);
             this.Controls.Add(this.BottomButtonPanel);

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.Designer.cs
@@ -70,6 +70,7 @@ namespace CKAN.GUI
             this.CmdLineGrid.StandardTab = false;
             this.CmdLineGrid.TabIndex = 1;
             this.CmdLineGrid.EditingControlShowing += this.CmdLineGrid_EditingControlShowing;
+            this.CmdLineGrid.CellValueChanged += this.CmdLineGrid_CellValueChanged;
             this.CmdLineGrid.UserDeletingRow += this.CmdLineGrid_UserDeletingRow;
             //
             // CmdLineColumn

--- a/GUI/Dialogs/GameCommandLineOptionsDialog.cs
+++ b/GUI/Dialogs/GameCommandLineOptionsDialog.cs
@@ -40,6 +40,7 @@ namespace CKAN.GUI
                                          AllowRemove = true,
                                      };
             this.defaults = defaults;
+            EnableDisableReset();
             return ShowDialog(parent);
         }
 
@@ -67,6 +68,11 @@ namespace CKAN.GUI
             }
         }
 
+        private void CmdLineGrid_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            EnableDisableReset();
+        }
+
         private void CmdLineGrid_UserDeletingRow(object sender, DataGridViewRowCancelEventArgs e)
         {
             // You can't delete the last row
@@ -74,6 +80,12 @@ namespace CKAN.GUI
             {
                 e.Cancel = true;
             }
+            EnableDisableReset();
+        }
+
+        private void EnableDisableReset()
+        {
+            ResetToDefaultsButton.Enabled = defaults != null && !Results.SequenceEqual(defaults);
         }
 
         private void ResetToDefaultsButton_Click(object? sender, EventArgs? e)
@@ -86,6 +98,7 @@ namespace CKAN.GUI
                                          AllowEdit   = true,
                                          AllowRemove = true,
                                      };
+            EnableDisableReset();
         }
 
         private void AddButton_Click(object? sender, EventArgs? e)
@@ -101,6 +114,7 @@ namespace CKAN.GUI
                 CmdLineGrid.CurrentCell = first;
             }
             CmdLineGrid.BeginEdit(false);
+            EnableDisableReset();
         }
 
         private void AcceptChangesButton_Click(object? sender, EventArgs? e)

--- a/GUI/Dialogs/InstallFiltersDialog.Designer.cs
+++ b/GUI/Dialogs/InstallFiltersDialog.Designer.cs
@@ -95,11 +95,11 @@ namespace CKAN.GUI
             //
             // WarningLabel
             //
-            this.WarningLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.WarningLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.WarningLabel.ForeColor = System.Drawing.Color.Red;
             this.WarningLabel.Location = new System.Drawing.Point(9, 354);
             this.WarningLabel.Name = "WarningLabel";
-            this.WarningLabel.Size = new System.Drawing.Size(360, 32);
+            this.WarningLabel.Size = new System.Drawing.Size(360, 40);
             this.WarningLabel.TabIndex = 5;
             resources.ApplyResources(this.WarningLabel, "WarningLabel");
             //

--- a/GUI/Dialogs/SettingsDialog.Designer.cs
+++ b/GUI/Dialogs/SettingsDialog.Designer.cs
@@ -353,12 +353,12 @@ namespace CKAN.GUI
             this.CacheGroupBox.Controls.Add(this.CachePathSaveButton);
             this.CacheGroupBox.Controls.Add(this.CachePathCancelButton);
             this.CacheGroupBox.Controls.Add(this.CacheSummary);
-            this.CacheGroupBox.Controls.Add(this.CacheLimitPanel);
             this.CacheGroupBox.Controls.Add(this.ChangeCacheButton);
             this.CacheGroupBox.Controls.Add(this.ClearCacheButton);
             this.CacheGroupBox.Controls.Add(this.ResetCacheButton);
             this.CacheGroupBox.Controls.Add(this.OpenCacheButton);
             this.CacheGroupBox.Controls.Add(this.MoveCacheProgressBar);
+            this.CacheGroupBox.Controls.Add(this.CacheLimitPanel);
             this.CacheGroupBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.CacheGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.CacheGroupBox.Location = new System.Drawing.Point(280, 144);
@@ -434,12 +434,13 @@ namespace CKAN.GUI
             // CacheLimitPanel
             //
             this.CacheLimitPanel.AutoSize = true;
+            this.CacheLimitPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.CacheLimitPanel.Controls.Add(this.CacheLimitPreLabel);
             this.CacheLimitPanel.Controls.Add(this.CacheLimit);
             this.CacheLimitPanel.Controls.Add(this.CacheLimitPostLabel);
             this.CacheLimitPanel.Location = new System.Drawing.Point(9, 65);
             this.CacheLimitPanel.Name = "CacheLimitPanel";
-            this.CacheLimitPanel.Size = new System.Drawing.Size(500, 20);
+            this.CacheLimitPanel.Size = new System.Drawing.Size(40, 13);
             this.CacheLimitPanel.TabIndex = 25;
             //
             // CacheLimitPreLabel
@@ -459,7 +460,7 @@ namespace CKAN.GUI
             this.CacheLimit.Location = new System.Drawing.Point(117, 63);
             this.CacheLimit.Margin = new System.Windows.Forms.Padding(2);
             this.CacheLimit.Name = "CacheLimit";
-            this.CacheLimit.Size = new System.Drawing.Size(50, 20);
+            this.CacheLimit.Size = new System.Drawing.Size(50, 13);
             this.CacheLimit.TabIndex = 26;
             this.CacheLimit.TextChanged += new System.EventHandler(this.CacheLimit_TextChanged);
             this.CacheLimit.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.CacheLimit_KeyPress);

--- a/GUI/Extensions/WinFormsExtensions.cs
+++ b/GUI/Extensions/WinFormsExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Drawing;
 using System.Windows.Forms;
@@ -75,5 +77,39 @@ namespace CKAN.GUI
             }
         }
 
+        public static IEnumerable<string> WordWrap(this Graphics g,
+                                                   string        orig,
+                                                   float         maxPixelWidth,
+                                                   Font?         font = null,
+                                                   string        delim = " ")
+        {
+            font ??= SystemFonts.DefaultFont;
+            var delims = new string[] { delim };
+            var delimWidth = g.MeasureString(delim, font).Width;
+            foreach (var line in orig.Split(new string[] {"\r\n", "\n"}, StringSplitOptions.None))
+            {
+                var piece      = "";
+                var pieceWidth = 0f;
+                foreach (var word in line.Split(delims, StringSplitOptions.None))
+                {
+                    var wordWidth = g.MeasureString(word, font).Width;
+                    if (pieceWidth + (pieceWidth > 0 ? delimWidth : 0) + g.MeasureString(word, font).Width < maxPixelWidth)
+                    {
+                        piece      += (pieceWidth > 0 ? delim      : "") + word;
+                        pieceWidth += (pieceWidth > 0 ? delimWidth :  0) + wordWidth;
+                    }
+                    else
+                    {
+                        yield return piece;
+                        piece      = word;
+                        pieceWidth = wordWidth;
+                    }
+                }
+                if (piece is { Length: > 0 })
+                {
+                    yield return piece;
+                }
+            }
+        }
     }
 }

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -58,9 +58,11 @@ namespace CKAN.GUI
             this.GameCommandlineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compatibleGameVersionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gameDiscordToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.modSupportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.HelpToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.userGuideToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.discordToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.modSupportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportClientIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportMetadataIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -352,15 +354,31 @@ namespace CKAN.GUI
             // helpToolStripMenuItem
             //
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.gameDiscordToolStripMenuItem,
+            this.modSupportToolStripMenuItem,
+            this.HelpToolStripSeparator,
             this.userGuideToolStripMenuItem,
             this.discordToolStripMenuItem,
-            this.modSupportToolStripMenuItem,
             this.reportClientIssueToolStripMenuItem,
             this.reportMetadataIssueToolStripMenuItem,
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
             resources.ApplyResources(this.helpToolStripMenuItem, "helpToolStripMenuItem");
+            //
+            // gameDiscordToolStripMenuItem
+            //
+            this.gameDiscordToolStripMenuItem.Name = "gameDiscordToolStripMenuItem";
+            this.gameDiscordToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.gameDiscordToolStripMenuItem.Click += new System.EventHandler(this.gameDiscordToolStripMenuItem_Click);
+            resources.ApplyResources(this.gameDiscordToolStripMenuItem, "gameDiscordToolStripMenuItem");
+            //
+            // modSupportToolStripMenuItem
+            //
+            this.modSupportToolStripMenuItem.Name = "modSupportToolStripMenuItem";
+            this.modSupportToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.modSupportToolStripMenuItem.Click += new System.EventHandler(this.modSupportToolStripMenuItem_Click);
+            resources.ApplyResources(this.modSupportToolStripMenuItem, "modSupportToolStripMenuItem");
             //
             // userGuideToolStripMenuItem
             //
@@ -375,13 +393,6 @@ namespace CKAN.GUI
             this.discordToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
             this.discordToolStripMenuItem.Click += new System.EventHandler(this.discordToolStripMenuItem_Click);
             resources.ApplyResources(this.discordToolStripMenuItem, "discordToolStripMenuItem");
-            //
-            // modSupportToolStripMenuItem
-            //
-            this.modSupportToolStripMenuItem.Name = "modSupportToolStripMenuItem";
-            this.modSupportToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
-            this.modSupportToolStripMenuItem.Click += new System.EventHandler(this.modSupportToolStripMenuItem_Click);
-            resources.ApplyResources(this.modSupportToolStripMenuItem, "modSupportToolStripMenuItem");
             //
             // reportClientIssueToolStripMenuItem
             //
@@ -990,9 +1001,11 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem GameCommandlineToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem compatibleGameVersionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem gameDiscordToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem modSupportToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator HelpToolStripSeparator;
         private System.Windows.Forms.ToolStripMenuItem userGuideToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem discordToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem modSupportToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportClientIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reportMetadataIssueToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -457,6 +457,9 @@ namespace CKAN.GUI
                                             .Resolve<IConfiguration>(),
                               configuration);
 
+            gameDiscordToolStripMenuItem.Text = string.Format("{0} Discord",
+                                                              CurrentInstance.Game.ShortName);
+
             if (configuration.CheckForUpdatesOnLaunch && CheckForCKANUpdate())
             {
                 UpdateCKAN();

--- a/GUI/Main/Main.resx
+++ b/GUI/Main/Main.resx
@@ -154,9 +154,14 @@
   <data name="installFiltersToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Prevent some mod files from being installed</value></data>
   <data name="pluginsToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Plugins</value></data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve"><value>&amp;Help</value></data>
+  <data name="gameDiscordToolStripMenuItem.Text" xml:space="preserve"><value>Game &amp;Discord</value></data>
+  <data name="gameDiscordToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Chat about game related topics
+(dump your B9PartSwitch error screenshots here!)</value></data>
+  <data name="modSupportToolStripMenuItem.Text" xml:space="preserve"><value>Get help for an in-game problem with mods</value></data>
   <data name="userGuideToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;user guide</value></data>
   <data name="discordToolStripMenuItem.Text" xml:space="preserve"><value>CKAN &amp;Discord</value></data>
-  <data name="modSupportToolStripMenuItem.Text" xml:space="preserve"><value>Get help for an in-game problem with mods</value></data>
+  <data name="discordToolStripMenuItem.ToolTipText" xml:space="preserve"><value>Discuss CKAN and get help with CKAN-related problems
+(see the other Discord option for in-game help with mods)</value></data>
   <data name="reportClientIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with the CKAN &amp;client</value></data>
   <data name="reportMetadataIssueToolStripMenuItem.Text" xml:space="preserve"><value>Report an issue with mod &amp;metadata</value></data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve"><value>&amp;About</value></data>

--- a/GUI/Main/MainMenu.cs
+++ b/GUI/Main/MainMenu.cs
@@ -183,14 +183,12 @@ namespace CKAN.GUI
 
         #region Help menu
 
-        private void userGuideToolStripMenuItem_Click(object? sender, EventArgs? e)
+        private void gameDiscordToolStripMenuItem_Click(object? sender, EventArgs? e)
         {
-            Utilities.ProcessStartURL(HelpURLs.UserGuide);
-        }
-
-        private void discordToolStripMenuItem_Click(object? sender, EventArgs? e)
-        {
-            Utilities.ProcessStartURL(HelpURLs.CKANDiscord);
+            if (CurrentInstance != null)
+            {
+                Utilities.ProcessStartURL(CurrentInstance.Game.DiscordURL.ToString());
+            }
         }
 
         private void modSupportToolStripMenuItem_Click(object? sender, EventArgs? e)
@@ -199,6 +197,16 @@ namespace CKAN.GUI
             {
                 Utilities.ProcessStartURL(CurrentInstance.Game.ModSupportURL.ToString());
             }
+        }
+
+        private void userGuideToolStripMenuItem_Click(object? sender, EventArgs? e)
+        {
+            Utilities.ProcessStartURL(HelpURLs.UserGuide);
+        }
+
+        private void discordToolStripMenuItem_Click(object? sender, EventArgs? e)
+        {
+            Utilities.ProcessStartURL(HelpURLs.CKANDiscord);
         }
 
         private void reportClientIssueToolStripMenuItem_Click(object? sender, EventArgs? e)

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -35,6 +35,7 @@ namespace CKAN.GUI
         /// <param name="allTags">All tag definitions</param>
         /// <param name="coreConfig">Core configuration</param>
         /// <param name="guiConfig">GUI configuration</param>
+        /// <param name="graphics">Graphics object for calculating word wrap</param>
         /// <param name="mc">Changes the user has made</param>
         /// <returns>The mod list</returns>
         public ModList(IReadOnlyCollection<GUIMod> modules,
@@ -43,12 +44,14 @@ namespace CKAN.GUI
                        ModuleTagList               allTags,
                        IConfiguration              coreConfig,
                        GUIConfiguration            guiConfig,
+                       Graphics                    graphics,
                        List<ModChange>?            mc = null)
         {
             this.allLabels        = allLabels;
             this.allTags          = allTags;
             this.coreConfig       = coreConfig;
             this.guiConfig        = guiConfig;
+            this.graphics         = graphics;
             activeSearches        = guiConfig.DefaultSearches
                                              ?.Select(s => ModSearch.Parse(allLabels, instance, s))
                                               .OfType<ModSearch>()
@@ -226,7 +229,16 @@ namespace CKAN.GUI
             var installSize   = new DataGridViewTextBoxCell { Value = mod.InstallSize             };
             var releaseDate   = new DataGridViewTextBoxCell { Value = mod.Module.release_date?.ToLocalTime() };
             var installDate   = new DataGridViewTextBoxCell { Value = mod.InstallDate             };
-            var desc          = new DataGridViewTextBoxCell { Value = ToGridText(mod.Abstract)    };
+            var desc          = new DataGridViewTextBoxCell
+                                {
+                                    Value       = ToGridText(mod.Abstract),
+                                    ToolTipText = mod.Description is { Length: > 0 }
+                                                      ? string.Join(Environment.NewLine,
+                                                                    graphics.WordWrap(mod.Description, 600)
+                                                                            .Prepend("")
+                                                                            .Prepend(mod.Abstract))
+                                                      : mod.Abstract,
+                                };
 
             item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, downloadSize, installSize, releaseDate, installDate, downloadCount, desc);
 
@@ -674,6 +686,7 @@ namespace CKAN.GUI
         private readonly ModuleTagList                  allTags;
         private readonly IConfiguration                 coreConfig;
         private readonly GUIConfiguration               guiConfig;
+        private readonly Graphics                       graphics;
         private          IReadOnlyCollection<ModSearch> activeSearches;
 
         private static readonly Color conflictColor = Color.FromArgb(255, 64, 64);

--- a/Netkan/Extensions/JObjectExtensions.cs
+++ b/Netkan/Extensions/JObjectExtensions.cs
@@ -103,5 +103,37 @@ namespace CKAN.NetKAN.Extensions
             };
         }
 
+        public static JObject StripProperties(this JObject json, Func<JProperty, bool> match)
+        {
+            var propertiesToRemove = new List<string>();
+            foreach (var property in json.Properties())
+            {
+                if (match(property))
+                {
+                    propertiesToRemove.Add(property.Name);
+                }
+                else
+                {
+                    switch (property.Value)
+                    {
+                        case JObject jobj:
+                            jobj.StripProperties(match);
+                            break;
+                        case JArray jarr:
+                            foreach (var element in jarr.OfType<JObject>())
+                            {
+                                element.StripProperties(match);
+                            }
+                            break;
+                    }
+                }
+            }
+            foreach (var propertyName in propertiesToRemove)
+            {
+                json.Remove(propertyName);
+            }
+            return json;
+        }
+
     }
 }

--- a/Netkan/Processors/Inflator.cs
+++ b/Netkan/Processors/Inflator.cs
@@ -5,10 +5,12 @@ using System.Linq;
 using System.Diagnostics.CodeAnalysis;
 
 using Autofac;
+using Newtonsoft.Json.Linq;
 using log4net;
 
 using CKAN.Configuration;
 using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Extensions;
 using CKAN.NetKAN.Services;
 using CKAN.NetKAN.Transformers;
 using CKAN.NetKAN.Validators;
@@ -82,7 +84,7 @@ namespace CKAN.NetKAN.Processors
                 {
                     // Mix properties between sections if they don't start with x_netkan
                     var stripped = netkans.Select(nk => nk.Json())
-                                          .Select(StripNetkanMetadataTransformer.Strip)
+                                          .Select(json => json.StripProperties(IsHostRelated))
                                           .ToArray();
                     netkans = netkans.Select(nk => nk.MergeFrom(stripped))
                                      .ToArray();
@@ -137,6 +139,9 @@ namespace CKAN.NetKAN.Processors
                 throw;
             }
         }
+
+        private static bool IsHostRelated(JProperty prop)
+            => prop.Name.StartsWith("x_netkan") || prop.Name == "$kref";
 
         internal void ValidateCkan(Metadata ckan)
         {

--- a/Netkan/Transformers/StripNetkanMetadataTransformer.cs
+++ b/Netkan/Transformers/StripNetkanMetadataTransformer.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using CKAN.NetKAN.Model;
+
 using log4net;
 using Newtonsoft.Json.Linq;
+
+using CKAN.NetKAN.Model;
+using CKAN.NetKAN.Extensions;
 
 namespace CKAN.NetKAN.Transformers
 {
@@ -23,46 +25,14 @@ namespace CKAN.NetKAN.Transformers
             Log.Debug("Executing strip Netkan metadata transformation");
             Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, metadata.AllJson);
 
-            Strip(json);
+            json.StripProperties(IsNetkanProperty);
 
             Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
 
             yield return new Metadata(json);
         }
 
-        private static bool IsNetkanProperty(string propertyName)
-            => propertyName.StartsWith("x_netkan") || propertyName is "$kref" or "$vref";
-
-        public static JObject Strip(JObject json)
-        {
-            var propertiesToRemove = new List<string>();
-            foreach (var property in json.Properties())
-            {
-                if (IsNetkanProperty(property.Name))
-                {
-                    propertiesToRemove.Add(property.Name);
-                }
-                else
-                {
-                    switch (property.Value)
-                    {
-                        case JObject jobj:
-                            Strip(jobj);
-                            break;
-                        case JArray jarr:
-                            foreach (var element in jarr.OfType<JObject>())
-                            {
-                                Strip(element);
-                            }
-                            break;
-                    }
-                }
-            }
-            foreach (var propertyName in propertiesToRemove)
-            {
-                json.Remove(propertyName);
-            }
-            return json;
-        }
+        private static bool IsNetkanProperty(JProperty prop)
+            => prop.Name.StartsWith("x_netkan") || prop.Name is "$kref" or "$vref";
     }
 }

--- a/Tests/Core/Registry/CompatibilitySorter.cs
+++ b/Tests/Core/Registry/CompatibilitySorter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -98,6 +99,61 @@ namespace Tests.Core.Registry
                 Assert.AreEqual(highPrio!.ToJson(),
                                 sorter.LatestCompatible.First(m => m.identifier == identifier).ToJson());
             }
+        }
+
+        [Test]
+        public void LatestCompatible_SameIdentifierInMultipleRepos_SinglePerIdentifier()
+        {
+            // Arrange
+            var gameVer1 = GameVersion.Parse("1.2.2");
+            var gameVer2 = GameVersion.Parse("1.12.5");
+            var modgen = new RandomModuleGenerator(new Random());
+            var avail1 = new AvailableModule("mod1", new CkanModule[]
+            {
+                modgen.GenerateRandomModule(identifier: "mod1", version: new ModuleVersion("3:1.0"), ksp_version: gameVer1),
+            });
+            var avail2 = new AvailableModule("mod2", new CkanModule[]
+            {
+                modgen.GenerateRandomModule(identifier: "mod2", version: new ModuleVersion("3:2.0"), ksp_version: gameVer2),
+                modgen.GenerateRandomModule(identifier: "mod2", version: new ModuleVersion("3:3.0"), ksp_version: gameVer2),
+            });
+            var avail3 = new AvailableModule("mod1", new CkanModule[]
+            {
+                modgen.GenerateRandomModule(identifier: "mod1", version: new ModuleVersion("1.0"), ksp_version: gameVer1),
+            });
+            var avail4 = new AvailableModule("mod2", new CkanModule[]
+            {
+                modgen.GenerateRandomModule(identifier: "mod2", version: new ModuleVersion("2.0"), ksp_version: gameVer2),
+                modgen.GenerateRandomModule(identifier: "mod2", version: new ModuleVersion("3.0"), ksp_version: gameVer2),
+            });
+
+            // Act
+            var sorter = new CompatibilitySorter(new StabilityToleranceConfig(""),
+                                                 new GameVersionCriteria(gameVer2),
+                                                 new Dictionary<string, AvailableModule>[]
+                                                 {
+                                                     new Dictionary<string, AvailableModule> { { "mod1", avail1 }, },
+                                                     new Dictionary<string, AvailableModule> { { "mod2", avail2 }, },
+                                                     new Dictionary<string, AvailableModule> { { "mod1", avail3 }, },
+                                                     new Dictionary<string, AvailableModule> { { "mod2", avail4 }, },
+                                                 },
+                                                 new Dictionary<string, AvailableModule[]>
+                                                 {
+                                                     { "mod1", new AvailableModule[] { avail1, avail3 } },
+                                                     { "mod2", new AvailableModule[] { avail2, avail4 } },
+                                                 },
+                                                 new Dictionary<string, InstalledModule> {},
+                                                 new string[] {},
+                                                 new Dictionary<string, UnmanagedModuleVersion> {});
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                CollectionAssert.AreEquivalent(new CkanModule[] { avail2.ByVersion(new ModuleVersion("3:3.0"))! },
+                                               sorter.LatestCompatible);
+                CollectionAssert.AreEquivalent(new CkanModule[] { avail1.ByVersion(new ModuleVersion("3:1.0"))! },
+                                               sorter.LatestIncompatible);
+            });
         }
     }
 }

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -60,6 +60,27 @@ namespace Tests.Core.Registry
         }
 
         [Test]
+        public void LatestAvailableWithProvides_SameIdentifierInMultipleRepos_SinglePerIdentifier()
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var repo1 = new TemporaryRepository(TestData.kOS_014()))
+            using (var repo2 = new TemporaryRepository(TestData.kOS_014_epoch()))
+            using (var repoData = new TemporaryRepositoryData(user, repo1.repo, repo2.repo))
+            {
+                repo2.repo.name = "temp2";
+                var registry = new CKAN.Registry(repoData.Manager, repo1.repo, repo2.repo);
+
+                // Act
+                var found = registry.LatestAvailableWithProvides("kOS", stabilityTolerance, null);
+
+                // Assert
+                CollectionAssert.AreEquivalent(new CkanModule[] { TestData.kOS_014_epoch_module() },
+                                               found);
+            }
+        }
+
+        [Test]
         public void CompatibleModules_NoDLCInstalled_ExcludesModulesDependingOnMH()
         {
             // Arrange

--- a/Tests/Data/DogeCoinFlag.netkan
+++ b/Tests/Data/DogeCoinFlag.netkan
@@ -1,4 +1,8 @@
 identifier: DogeCoinFlag
 $kref: '#/ckan/github/testuser/testrepo'
+---
+identifier: DogeCoinFlag
+$kref: '#/ckan/spacedock/1234'
+$vref: '#/ckan/ksp-avc'
 tags:
   - flags

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel;
+using System.Drawing;
 using System.Windows.Forms;
 using System.Globalization;
 using System.Threading;
@@ -28,6 +29,11 @@ namespace Tests.GUI
     [TestFixture]
     public class ModListTests
     {
+        public ModListTests()
+        {
+            this.graphics = Graphics.FromImage(EmbeddedImages.apply);
+        }
+
         [Test]
         public void IsVisible_WithAllAndNoNameFilter_ReturnsTrueForCompatible()
         {
@@ -45,7 +51,7 @@ namespace Tests.GUI
 
                 var item = new ModList(Array.Empty<GUIMod>(), tidy.KSP,
                                        ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                       config, new GUIConfiguration());
+                                       config, new GUIConfiguration(), graphics);
                 Assert.That(item.IsVisible(
                     new GUIMod(ckan_mod!, repoData.Manager, registry,
                                tidy.KSP.StabilityToleranceConfig, tidy.KSP, cache,
@@ -87,7 +93,7 @@ namespace Tests.GUI
                 }
                 var modlist   = new ModList(modules, inst.KSP,
                                             labels, tags,
-                                            config, guiConfig);
+                                            config, guiConfig, graphics);
 
                 // Act / Assert
                 Assert.AreEqual(!hide, modlist.IsVisible(modules.First(), inst.KSP, registry));
@@ -105,7 +111,7 @@ namespace Tests.GUI
             {
                 var item = new ModList(Array.Empty<GUIMod>(), tidy.KSP,
                                        ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                       config, new GUIConfiguration());
+                                       config, new GUIConfiguration(), graphics);
                 Assert.That(item.CountModsByFilter(tidy.KSP, filter), Is.EqualTo(0));
             }
         }
@@ -136,8 +142,7 @@ namespace Tests.GUI
                     },
                     tidy.KSP,
                     ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                    config, new GUIConfiguration()
-                );
+                    config, new GUIConfiguration(), graphics);
                 Assert.That(main_mod_list.full_list_of_mod_rows.Values, Has.Count.EqualTo(2));
             }
         }
@@ -152,7 +157,7 @@ namespace Tests.GUI
                 var guiConfig = new GUIConfiguration();
                 var modlist   = new ModList(Array.Empty<GUIMod>(), inst.KSP,
                                             ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                            config, guiConfig);
+                                            config, guiConfig, graphics);
                 bool called   = false;
                 modlist.ModFiltersUpdated += () => { called = true; };
                 var nonEmptySearches = new List<ModSearch>
@@ -239,7 +244,7 @@ namespace Tests.GUI
                                       .ToArray();
                 var modlist  = new ModList(mods, inst.KSP,
                                            labels, new ModuleTagList(),
-                                           config, new GUIConfiguration());
+                                           config, new GUIConfiguration(), graphics);
                 var mod      = mods.First();
 
                 // Act
@@ -280,7 +285,7 @@ namespace Tests.GUI
                                       .ToArray();
                 var modlist = new ModList(mods, inst.KSP,
                                           labels, new ModuleTagList(),
-                                          config, new GUIConfiguration());
+                                          config, new GUIConfiguration(), graphics);
                 var grid = new DataGridView();
                 grid.Columns.AddRange(StandardColumns);
                 grid.Rows.AddRange(modlist.full_list_of_mod_rows.Values.ToArray());
@@ -342,7 +347,7 @@ namespace Tests.GUI
                                        .ToArray();
                 var modlist   = new ModList(modules, inst.KSP,
                                             labels, tags,
-                                            config, guiConfig);
+                                            config, guiConfig, graphics);
                 var grid      = new DataGridView();
                 grid.Columns.AddRange(StandardColumns);
                 grid.Rows.AddRange(modlist.full_list_of_mod_rows.Values.ToArray());
@@ -616,7 +621,7 @@ namespace Tests.GUI
                                       .ToArray();
                 var modlist  = new ModList(mods, instance.KSP,
                                            ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                           config, new GUIConfiguration());
+                                           config, new GUIConfiguration(), graphics);
 
                 // Act
                 foreach (var mod in mods.OrderBy(m => m.Identifier).Take(5))
@@ -648,7 +653,7 @@ namespace Tests.GUI
             {
                 var item = new ModList(Array.Empty<GUIMod>(), tidy.KSP,
                                        ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                       config, new GUIConfiguration());
+                                       config, new GUIConfiguration(), graphics);
                 Assert.That(item.ComputeUserChangeSet(Registry.Empty(repoData.Manager), tidy.KSP, null, null), Is.Empty);
             }
         }
@@ -682,7 +687,7 @@ namespace Tests.GUI
                                        .ToArray();
                 var modlist   = new ModList(mods, inst.KSP,
                                             labels, new ModuleTagList(),
-                                            config, guiConfig);
+                                            config, guiConfig, graphics);
 
                 // Act
                 var b9         = mods.First(m => m.Identifier == "B9");
@@ -800,7 +805,7 @@ namespace Tests.GUI
 
                 var modList = new ModList(modules, instance.KSP,
                                           ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                          config, new GUIConfiguration());
+                                          config, new GUIConfiguration(), graphics);
                 Assert.IsFalse(modList.HasVisibleInstalled());
 
                 listGui.Rows.AddRange(modList.full_list_of_mod_rows.Values.ToArray());
@@ -843,6 +848,8 @@ namespace Tests.GUI
         private const int numCheckboxCols = 4;
 
         private const int numTextCols     = 11;
+
+        private readonly Graphics graphics;
 
         private static DataGridViewColumn[] StandardColumns
             => Enumerable.Range(1, numCheckboxCols)

--- a/Tests/NetKAN/Processors/InflatorTests.cs
+++ b/Tests/NetKAN/Processors/InflatorTests.cs
@@ -68,6 +68,10 @@ namespace Tests.NetKAN.Processors
                                      ]
                                  }
                              ]");
+                http.Setup(h => h.DownloadText(It.Is<Uri>(u => u.Host == "spacedock.info"),
+                                               It.IsAny<string?>(), It.IsAny<string?>()))
+                    .Returns(@"{""name"":""Doge Coin Flag"",""id"":1234,""game"":""Kerbal Space Program"",""game_id"":3102,""short_description"":""A fake mod for testing"",""downloads"":0,""followers"":0,""author"":""pjf"",""default_version_id"":1,""shared_authors"":[],""license"":""MIT"",""url"":""/mod/1234/DogeCoinFlag"",""versions"":[{""friendly_version"":""1.0"",""game_version"":""1.2.2"",""id"":1,""download_path"":""/mod/1234/DogeCoinFlag/download/1.0"",""downloads"":0}],""description"":""A fake mod for testing""}");
+
                 http.Setup(h => h.DownloadModule(It.IsAny<Metadata>()))
                     .Returns(TestData.DogeCoinFlagImportableZip());
 

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -9,6 +9,8 @@ using System.Runtime.InteropServices;
 using Cake.Common;
 using Cake.Common.Diagnostics;
 using Cake.Common.IO;
+using Cake.Common.Tools.ILMerge;
+using Cake.Common.Tools.ILRepack;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Frosting;
@@ -135,6 +137,37 @@ public partial class BuildContext : FrostingContext
                 Paths.RootDirectory.GetRelativePath(target),
                 Paths.RootDirectory.GetRelativePath(log));
         }
+    }
+
+    public void Repack(FilePath               target,
+                       DirectoryPath          assembliesPath,
+                       string                 sourceFilename,
+                       TargetPlatformVersion? targetPlatform,
+                       FilePath               logFile)
+    {
+        this.CreateDirectory(target.GetDirectory());
+        this.CreateDirectory(logFile.GetDirectory());
+        var source     = assembliesPath.CombineWithFilePath(sourceFilename);
+        var assemblyPaths = this.GetFiles($"{assembliesPath}/*.dll");
+        // Need facade to instantiate types from netstandard2.0 DLLs on Mono
+        assemblyPaths.Add(FacadesDirectory().CombineWithFilePath("netstandard.dll"));
+        assemblyPaths.Add(this.GetFiles($"{assembliesPath}/*/*.resources.dll"));
+        if (target.FullPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            assemblyPaths.Add(this.GetFiles($"{assembliesPath}/*.exe"));
+        }
+        assemblyPaths.Remove(source);
+        ReportRepacking(target, logFile);
+        this.ILRepack(target, source, assemblyPaths,
+                      new ILRepackSettings
+                      {
+                          Libs                 = [assembliesPath],
+                          TargetPlatform       = targetPlatform,
+                          Parallel             = true,
+                          Verbose              = false,
+                          SetupProcessSettings = RepackSilently,
+                          Log                  = logFile.FullPath,
+                      });
     }
 
     public static void RepackSilently(ProcessSettings settings)

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -36,7 +36,7 @@ public static class Program
                     .Combine("_build")
                     .Combine("tools"));
             })
-            .InstallTool(new Uri("nuget:?package=ILRepack&version=2.0.27"))
+            .InstallTool(new Uri("nuget:?package=ILRepack&version=2.0.44"))
             .InstallTool(new Uri("nuget:?package=NUnit.ConsoleRunner&version=3.16.3"))
             .InstallTool(new Uri("nuget:?package=altcover&version=9.0.1"))
             .InstallTool(new Uri("nuget:?package=altcover.api&version=9.0.1"))

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -176,67 +176,29 @@ public sealed class RepackCkanTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
-        context.CreateDirectory(context.Paths.RepackDirectory.Combine(context.BuildConfiguration));
-
-        var cmdLineBinDirectory = context.Paths.OutDirectory
-                                               .Combine("CKAN-CmdLine")
-                                               .Combine(context.BuildConfiguration)
-                                               .Combine("bin")
-                                               .Combine(context.BuildNetFramework);
-        var assemblyPaths = context.GetFiles($"{cmdLineBinDirectory}/*.dll");
-        assemblyPaths.Add(cmdLineBinDirectory.CombineWithFilePath("CKAN-GUI.exe"));
-        assemblyPaths.Add(cmdLineBinDirectory.CombineWithFilePath("CKAN-ConsoleUI.exe"));
-        var cmdlinePath = context.Paths.OutDirectory.Combine("CKAN-CmdLine")
-            .Combine(context.BuildConfiguration)
-            .Combine("bin")
-            .Combine(context.BuildNetFramework);
-        assemblyPaths.Add(context.GetFiles($"{cmdlinePath}/*/*.resources.dll"));
-        // Need facade to instantiate types from netstandard2.0 DLLs on Mono
-        assemblyPaths.Add(context.FacadesDirectory().CombineWithFilePath("netstandard.dll"));
-        var ckanLogFile = context.Paths.RepackDirectory.Combine(context.BuildConfiguration)
-                                         .CombineWithFilePath("ckan.log");
-        context.ReportRepacking(context.Paths.CkanFile, ckanLogFile);
-        context.ILRepack(
-            context.Paths.CkanFile,
-            cmdLineBinDirectory.CombineWithFilePath("CKAN-CmdLine.exe"),
-            assemblyPaths,
-            new ILRepackSettings
-            {
-                Libs                 = [cmdLineBinDirectory],
-                TargetPlatform       = TargetPlatformVersion.v4,
-                Parallel             = true,
-                Verbose              = false,
-                SetupProcessSettings = BuildContext.RepackSilently,
-                Log                  = ckanLogFile.FullPath,
-            });
-
-        var autoupdateBinDirectory = context.Paths.OutDirectory.Combine("CKAN-AutoUpdateHelper")
+        var repackPath = context.Paths.RepackDirectory.Combine(context.BuildConfiguration);
+        context.Repack(context.Paths.CkanFile,
+                       context.Paths.OutDirectory.Combine("CKAN-CmdLine")
                                                  .Combine(context.BuildConfiguration)
                                                  .Combine("bin")
-                                                 .Combine(context.BuildNetFramework);
-        var updaterLogFile = context.Paths.RepackDirectory.Combine(context.BuildConfiguration)
-                                            .CombineWithFilePath("AutoUpdater.log");
-        context.ReportRepacking(context.Paths.UpdaterFile, updaterLogFile);
-        context.ILRepack(
-            context.Paths.UpdaterFile,
-            autoupdateBinDirectory.CombineWithFilePath("CKAN-AutoUpdateHelper.exe"),
-            context.GetFiles($"{autoupdateBinDirectory}/*/*.resources.dll"),
-            new ILRepackSettings
-            {
-                Libs           = [autoupdateBinDirectory],
-                TargetPlatform = TargetPlatformVersion.v4,
-                Parallel       = true,
-                Verbose        = false,
-                SetupProcessSettings = BuildContext.RepackSilently,
-                Log            = updaterLogFile.FullPath,
-            });
+                                                 .Combine(context.BuildNetFramework),
+                       "CKAN-CmdLine.exe",
+                       TargetPlatformVersion.v4,
+                       repackPath.CombineWithFilePath("ckan.log"));
+        context.Repack(context.Paths.UpdaterFile,
+                       context.Paths.OutDirectory.Combine("CKAN-AutoUpdateHelper")
+                                                 .Combine(context.BuildConfiguration)
+                                                 .Combine("bin")
+                                                 .Combine(context.BuildNetFramework),
+                       "CKAN-AutoUpdateHelper.exe",
+                       TargetPlatformVersion.v4,
+                       repackPath.CombineWithFilePath("AutoUpdater.log"));
 
         var finalExePath = context.Paths.BuildDirectory.CombineWithFilePath(context.Paths.CkanFile.GetFilename());
         context.CopyFile(context.Paths.CkanFile, finalExePath);
         BuildContext.ChmodExecutable(finalExePath);
     }
 }
-
 
 [TaskName("Repack-Netkan")]
 [TaskDescription("Intermediate - Merge all the separate DLLs and EXEs to a single executable.")]
@@ -246,30 +208,15 @@ public sealed class RepackNetkanTask : FrostingTask<BuildContext>
     public override void Run(BuildContext context)
     {
         context.CreateDirectory(context.Paths.RepackDirectory.Combine(context.BuildConfiguration));
-        var netkanBinDirectory = context.Paths.OutDirectory.Combine("CKAN-NetKAN")
-            .Combine(context.BuildConfiguration)
-            .Combine("bin")
-            .Combine(context.BuildNetFramework);
-        var netkanLogFile = context.Paths.RepackDirectory.Combine(context.BuildConfiguration)
-            .CombineWithFilePath("netkan.log");
-        var assemblyPaths = context.GetFiles($"{netkanBinDirectory}/*.dll");
-        // Need facade to instantiate types from netstandard2.0 DLLs on Mono
-        assemblyPaths.Add(context.FacadesDirectory().CombineWithFilePath("netstandard.dll"));
-        context.ReportRepacking(context.Paths.NetkanFile, netkanLogFile);
-        context.ILRepack(
-            context.Paths.NetkanFile,
-            netkanBinDirectory.CombineWithFilePath("CKAN-NetKAN.exe"),
-            assemblyPaths,
-            new ILRepackSettings
-            {
-                Libs           = [netkanBinDirectory],
-                TargetPlatform = TargetPlatformVersion.v4,
-                Parallel       = true,
-                Verbose        = false,
-                SetupProcessSettings = BuildContext.RepackSilently,
-                Log            = netkanLogFile.FullPath,
-            }
-        );
+        context.Repack(context.Paths.NetkanFile,
+                       context.Paths.OutDirectory.Combine("CKAN-NetKAN")
+                                                 .Combine(context.BuildConfiguration)
+                                                 .Combine("bin")
+                                                 .Combine(context.BuildNetFramework),
+                       "CKAN-NetKAN.exe",
+                       TargetPlatformVersion.v4,
+                       context.Paths.RepackDirectory.Combine(context.BuildConfiguration)
+                                                    .CombineWithFilePath("netkan.log"));
 
         var finalExePath = context.Paths.BuildDirectory.CombineWithFilePath(context.Paths.NetkanFile.GetFilename());
         context.CopyFile(context.Paths.NetkanFile, finalExePath);


### PR DESCRIPTION
## Problems and motivations

- In #4579, a user saw multiple versions of the same mod treated oddly as if they were sometimes different mods. From a support perspective, the fix was to remove the extra metadata repo that contained a bunch of modules with bad `version` properties. But that really should have worked better, since multiple repos providing versions of the same mods is supposed to be supported.
  <img width="462" height="427" alt="Image" src="https://github.com/user-attachments/assets/4631715b-dd55-47df-8a32-af542edec679" /><img width="455" height="532" alt="Image" src="https://github.com/user-attachments/assets/45b28250-57ef-40a5-be1f-b6581e453f8c" />
- When a .netkan has multiple sections, certain metadata properties are automatically mirrored among all the sections, and some are not. Anything pertaining exclusively to the _contents_ of the ZIP file makes sense to mirror, since all sections deal with the same contents; `$vref` is one such property but is not mirrored, which is inconvenient for maintenance.
- The PlayTime grid lets you focus uneditable cells, which isn't useful and gives a bad UI cue for how it works.
- The command line options popup has a Reset button that changes you rsettings to the default according to CKAN and your Steam library. Currently it is always enabled, so you can click it when it will do nothing, which may create confusion about what it does.
- Many users join the CKAN Discord to ask non-CKAN related questions
- Opening the download statistics screen twice in the same session would cause the pie chart to not appear
- The mod list columns' default widths don't scale with the DPI
- The rightmost mod list column with the abstract can be hard to read, and the description isn't shown at all
- The resource links in mod info aren't always rendered nicely
- The compatible versions popup looks pretty messed up

Many thanks to @KerballOne for reporting many of the layout problems on Discord.

## Causes

- Unlike `CompatibilitySorter` (which drives the main mod list rows and many other things), `Registry.LatestAvailableWithProvides` did not account for de-duplicating `AvailableModule`s with the same identifier.
- The mirroring used `StripNetkanMetadataTransformer.Strip` to determine which properties to mirror, which unfortunately caused `$vref` to be excluded.
- The Help menu lists the CKAN Discord prominently near the top, so users may think it is the go-to for all possible questions they may have
- The pie chart control appears not to like re-using the same `PlotModel` with different collections of `Series`
- #4543 made a number of changes related to scaling, which can be complex and need some massaging to reach full maturity.
- Somehow the initial sizing we give to the resource link cells isn't good enough and only the full resize-rows call fixes them
- The compatible versions popup was originally done to a kind of weird scaling, so the DPI-based scaling messes up various aspects of it

## Changes

- Now `Registry.LatestAvailableWithProvides` only returns the module with the highest version per identifier.
  Fixes #4579.
- Now `Inflator.IsHostRelated` defines which properties are mirrored, and it allows `$vref` to be mirrored. This will be easier for maintenance.
- Now if you click on one of the left column cells, the focus goes to the right cell on the same column, in case you want to edit. This also improves the initial focus.
- Now the Reset button on the command line options popup is disabled when your settings are the same as the defaults and enabled when different.
- Now a new game-related Discord menu option is the first option in the Help menu, followed by the link to the support forum, and then a separator before the CKAN-specific options. Hopefully this will steer people to the most useful places to ask their questions.
  <img width="455" height="269" alt="image" src="https://github.com/user-attachments/assets/e39563d5-25fb-4430-b090-9936202541c1" /> <img width="462" height="266" alt="image" src="https://github.com/user-attachments/assets/125162cd-d4c4-436e-ab14-6a5d93ceaf2c" />
- Now we create a new `PlotModel` every time we load new data for the download statistics screen
- Now the mod list columns are auto-sized to fit their contents or to distribute the space among columns that are too wide for that
- Now the description column in the mod list has a tooltip that shows the abstract followed by a blank line and a word-wrapped rendering of the description
- Now the mod info resource links look better
- The mod name in mod info is slightly bigger
- Several instances of subtle misalignments in padding are fixed
- Now the scaling of the compatible versions popup is fixed
