### PR TITLE
Game instance cloning for ConsoleUI

### DIFF
--- a/ConsoleUI/CloneInstanceDialog.cs
+++ b/ConsoleUI/CloneInstanceDialog.cs
@@ -1,0 +1,95 @@
+using System;
+
+using CKAN.ConsoleUI.Toolkit;
+
+namespace CKAN.ConsoleUI {
+
+    /// <summary>
+    /// Popup to let user specify how they want to clone an instance
+    /// </summary>
+    public class CloneInstanceDialog : ConsoleDialog {
+
+        /// <summary>
+        /// Initialize the dialog
+        /// </summary>
+        /// <param name="theme"></param>
+        public CloneInstanceDialog(ConsoleTheme theme)
+            : base(theme)
+        {
+            int t = GetTop(),
+                b = t + 8;
+            SetDimensions(Console.WindowWidth  / 6, t,
+                          5 * Console.WindowWidth  / 6, b);
+            int l = GetLeft(),
+                r = GetRight();
+
+            CenterHeader = () => Properties.Resources.CloneInstanceTitle;
+
+            AddObject(new ConsoleLabel(l + 2, t + 2, l + 2 + labelW,
+                                       () => Properties.Resources.CloneInstanceName,
+                                       th => th.PopupBg,
+                                       th => th.PopupFg));
+            nameField = new ConsoleField(l + 2 + labelW + wPad, t + 2, r - 3)
+                        {
+                            GhostText = () => Properties.Resources.CloneInstanceNameGhostText,
+                        };
+            AddObject(nameField);
+
+            AddObject(new ConsoleLabel(l + 2, t + 4, l + 2 + labelW,
+                                       () => Properties.Resources.CloneInstancePath,
+                                       th => th.PopupBg,
+                                       th => th.PopupFg));
+            pathField = new ConsoleField(l + 2 + labelW + wPad, t + 4, r - 3)
+                        {
+                            GhostText = () => Properties.Resources.CloneInstancePathGhostText,
+                        };
+            AddObject(pathField);
+
+            int btnW = (2 * buttonWidth) + buttonPadding;
+            int btnLeft = (Console.WindowWidth - btnW) / 2;
+
+            AddObject(new ConsoleButton(btnLeft, t + 6, btnLeft + buttonWidth,
+                                        Properties.Resources.Accept,
+                                        () => {
+                                            if (nameField.Value is { Length: > 0 }
+                                                && pathField.Value is { Length: > 0 })
+                                            {
+                                                Proceed = true;
+                                                Quit();
+                                            }
+                                        }));
+            AddObject(new ConsoleButton(btnLeft + buttonWidth + buttonPadding, t + 6,
+                                        btnLeft + (2 * buttonWidth) + buttonPadding,
+                                        Properties.Resources.Cancel,
+                                        () => { Proceed = false; Quit(); }));
+
+            AddBinding(Keys.Escape, sender => { Proceed = false; return false; });
+            AddTip(Properties.Resources.Esc, Properties.Resources.Cancel);
+        }
+
+        /// <summary>
+        /// true if the user confirmed the clone, false if they cancelled
+        /// </summary>
+        public bool Proceed { get; private set; }
+
+        /// <summary>
+        /// Name for the newly cloned instance
+        /// </summary>
+        public string NewName => nameField.Value;
+
+        /// <summary>
+        /// Location to put the newly cloned instance
+        /// </summary>
+        public string NewPath => pathField.Value;
+
+        private const  int buttonWidth   = 10;
+        private const  int buttonPadding = 3;
+        private const  int wPad          = 2;
+        private static int labelW =>
+            Math.Max(6, Math.Max(Properties.Resources.CloneInstanceName.Length,
+                                 Properties.Resources.CloneInstancePath.Length));
+
+        private readonly ConsoleField nameField;
+        private readonly ConsoleField pathField;
+    }
+}

--- a/ConsoleUI/GameInstanceListScreen.cs
+++ b/ConsoleUI/GameInstanceListScreen.cs
@@ -112,6 +112,27 @@ namespace CKAN.ConsoleUI {
                 instanceList.SetData(manager.Instances.Values);
                 return true;
             });
+
+            instanceList.AddTip("C", Properties.Resources.InstanceListClone);
+            instanceList.AddBinding(Keys.C, sender =>
+            {
+                if (instanceList.Selection is GameInstance inst) {
+                    try {
+                        var cd = new CloneInstanceDialog(theme);
+                        cd.Run();
+                        if (cd.Proceed)
+                        {
+                            manager.CloneInstance(inst, cd.NewName, cd.NewPath, Platform.IsWindows);
+                            instanceList.SetData(manager.Instances.Values);
+                        }
+                    } catch (Exception exc) {
+                        RaiseError("{0}", exc.Message);
+                    }
+                    DrawBackground();
+                }
+                return true;
+            });
+
             instanceList.AddTip("R", Properties.Resources.Remove);
             instanceList.AddBinding(Keys.R, sender =>
             {

--- a/ConsoleUI/Properties/Resources.resx
+++ b/ConsoleUI/Properties/Resources.resx
@@ -220,6 +220,12 @@
   <data name="InstanceListLoadingError" xml:space="preserve"><value>Error loading {0}:
 {1}</value></data>
   <data name="InstanceListNoVersion" xml:space="preserve"><value>&lt;NONE&gt;</value></data>
+  <data name="InstanceListClone" xml:space="preserve"><value>Clone</value></data>
+  <data name="CloneInstanceTitle" xml:space="preserve"><value>Clone Game Instance</value></data>
+  <data name="CloneInstanceName" xml:space="preserve"><value>New instance name:</value></data>
+  <data name="CloneInstanceNameGhostText" xml:space="preserve"><value>&lt;Name for cloned instance (required)&gt;</value></data>
+  <data name="CloneInstancePath" xml:space="preserve"><value>Destination path:</value></data>
+  <data name="CloneInstancePathGhostText" xml:space="preserve"><value>&lt;Location for cloned instance (required)&gt;</value></data>
   <data name="InstallTitle" xml:space="preserve"><value>Installing, Upgrading, and Removing Mods</value></data>
   <data name="InstallMessage" xml:space="preserve"><value>Calculating...</value></data>
   <data name="InstallFilesReverted" xml:space="preserve"><value>Game files reverted.</value></data>

--- a/ConsoleUI/Toolkit/ConsoleField.cs
+++ b/ConsoleUI/Toolkit/ConsoleField.cs
@@ -84,7 +84,7 @@ namespace CKAN.ConsoleUI.Toolkit {
             Console.BackgroundColor = theme.FieldBg;
             if (string.IsNullOrEmpty(Value)) {
                 Console.ForegroundColor = theme.FieldGhostFg;
-                Console.Write(GhostText().PadRight(w));
+                Console.Write(FormatExactWidth(GhostText(), w));
             } else {
                 Console.ForegroundColor = focused
                     ? theme.FieldFocusedFg

--- a/ConsoleUI/Toolkit/Keys.cs
+++ b/ConsoleUI/Toolkit/Keys.cs
@@ -247,6 +247,13 @@ namespace CKAN.ConsoleUI.Toolkit {
         );
 
         /// <summary>
+        /// Representation of letter 'c' for key bindings
+        /// </summary>
+        public static readonly ConsoleKeyInfo C = new ConsoleKeyInfo(
+            'c', ConsoleKey.C, false, false, false
+        );
+
+        /// <summary>
         /// Representation of letter 'd' for key bindings
         /// </summary>
         public static readonly ConsoleKeyInfo D = new ConsoleKeyInfo(

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -243,15 +243,13 @@ namespace CKAN
         /// <exception cref="DirectoryNotFoundKraken">Thrown by CopyDirectory() if directory doesn't exist. Should never be thrown here.</exception>
         /// <exception cref="PathErrorKraken">Thrown by CopyDirectory() if the target folder already exists and is not empty.</exception>
         /// <exception cref="IOException">Thrown by CopyDirectory() if something goes wrong during the process.</exception>
-        public void CloneInstance(GameInstance existingInstance,
-                                  string       newName,
-                                  string       newPath,
-                                  bool         shareStockFolders = false)
-        {
-            CloneInstance(existingInstance, newName, newPath,
-                          existingInstance.Game.LeaveEmptyInClones,
-                          shareStockFolders);
-        }
+        public GameInstance CloneInstance(GameInstance existingInstance,
+                                          string       newName,
+                                          string       newPath,
+                                          bool         shareStockFolders = false)
+            => CloneInstance(existingInstance, newName, newPath,
+                             existingInstance.Game.LeaveEmptyInClones,
+                             shareStockFolders);
 
         /// <summary>
         /// Clones an existing game installation.


### PR DESCRIPTION
## Motivation

A Mac user asked about game instances recently, and I realized that ConsoleUI doesn't have a UI for cloning game instances. Mac users can still use ⌘C / ⌘V to copy their game folders manually, but CKAN's clone feature uses less space thanks to the hard link feature, and it also skips files and folders that can be disruptive to copy.

## Changes

- Now a **C**lone option appears in the list of instances
  <img width="405" height="140" alt="image" src="https://github.com/user-attachments/assets/679ed053-6103-424b-b0bb-5eef44b1f2bf" />
- Pressing `C` opens a popup that prompts the user for the name and path of the cloned instance
  - The Accept button will attempt the clone if both fields are populated
  - The Cancel button will close the popup
  <img width="1681" height="770" alt="image" src="https://github.com/user-attachments/assets/a86df63b-496a-4c26-9521-3c8adc20d3e5" />
