### PR TITLE
Leave mod files alone for relationship-only metadata changes

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -190,7 +190,7 @@ namespace CKAN.CmdLine
                 (ModuleInstaller installer, NetAsyncModulesDownloader downloader, RegistryManager regMgr, ref HashSet<string>? possibleConfigOnlyDirs, ISet<CkanModule> autoInstalled) =>
                     installer.Upgrade(modules, downloader,
                                       ref possibleConfigOnlyDirs,
-                                      regMgr, deduper, autoInstalled, true, true),
+                                      regMgr, deduper, autoInstalled, null, true, true),
                 modules.Add);
         }
 
@@ -251,7 +251,7 @@ namespace CKAN.CmdLine
                     if (to_upgrade.Count > 0)
                     {
                         installer.Upgrade(to_upgrade, downloader,
-                                          ref possibleConfigOnlyDirs, regMgr, deduper, autoInstalled, true);
+                                          ref possibleConfigOnlyDirs, regMgr, deduper, autoInstalled, null, true);
                     }
                 },
                 m => identsAndVersions.Add(m.identifier));

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -1295,6 +1295,7 @@ namespace CKAN.IO
                             RegistryManager                    registry_manager,
                             InstalledFilesDeduplicator?        deduper            = null,
                             ISet<CkanModule>?                  autoInstalled      = null,
+                            ISet<CkanModule>?                  skipFiles          = null,
                             bool                               enforceConsistency = true,
                             bool                               ConfirmPrompt      = true)
         {
@@ -1328,11 +1329,13 @@ namespace CKAN.IO
                 fullChangeset.Remove(ident);
             }
 
-            // Only install stuff that's already there if explicitly requested in param
             var toInstall = fullChangeset.Values
+                                         // Only install stuff that's already there if explicitly requested in param
                                          .Except(registry.InstalledModules
                                                          .Select(im => im.Module)
                                                          .Except(modules))
+                                         // Don't touch files for mods in skipFiles (still need to handle their dependencies though)
+                                         .Except(skipFiles ?? new HashSet<CkanModule>())
                                          .ToArray();
             autoInstalled ??= new HashSet<CkanModule>();
             autoInstalled.UnionWith(toInstall.Where(resolver.IsAutoInstalled));
@@ -1439,6 +1442,13 @@ namespace CKAN.IO
                 throw new CancelledActionKraken(Properties.Resources.ModuleInstallerUpgradeUserDeclined);
             }
 
+            if (skipFiles != null)
+            {
+                foreach (var module in skipFiles.Intersect(modules))
+                {
+                    registry.ReregisterModule(instance, module);
+                }
+            }
             AddRemove(ref possibleConfigOnlyDirs,
                       registry_manager,
                       resolver,

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -219,7 +219,7 @@ namespace CKAN
             // Check if the installed module is up to date
             var comp = latestMod.version.CompareTo(instVer);
             if (comp == -1
-                || (comp == 0 && !querier.MetadataChanged(identifier)
+                || (comp == 0 && !querier.MetadataChanged(identifier, out _)
                               // Check if any of the files or directories are missing
                               && (!checkMissingFiles
                                   || instance == null
@@ -334,15 +334,18 @@ namespace CKAN
         /// </summary>
         /// <param name="querier">A registry</param>
         /// <param name="identifier">Identifier of mod to check</param>
+        /// <param name="installedFilesChanged">Set to true if the changed properties affect how/which files get installed</param>
         /// <returns>True if any property has changed that can affect how the mod is installed</returns>
-        public static bool MetadataChanged(this IRegistryQuerier querier, string identifier)
+        public static bool MetadataChanged(this IRegistryQuerier querier, string identifier,
+                                                                          out bool installedFilesChanged)
         {
+            installedFilesChanged = false;
             try
             {
                 var installed = querier.InstalledModule(identifier)?.Module;
                 return installed != null
                     && (!querier.GetModuleByVersion(identifier, installed.version)
-                                ?.MetadataEquals(installed)
+                                ?.MetadataEquals(installed, out installedFilesChanged)
                                 ?? false);
             }
             catch

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -954,6 +954,18 @@ namespace CKAN
             InvalidateInstalledCaches();
         }
 
+        public void ReregisterModule(GameInstance inst, CkanModule module)
+        {
+            EnlistWithTransaction();
+            sorter = null;
+            if (installed_modules.TryGetValue(module.identifier, out InstalledModule? instMod))
+            {
+                installed_modules[module.identifier] = new InstalledModule(inst, module,
+                                                                           instMod.Files, instMod.AutoInstalled);
+            }
+            InvalidateInstalledCaches();
+        }
+
         /// <summary>
         /// Set the list of manually installed DLLs to the given mapping.
         /// Files registered to a mod are not allowed and will be ignored.

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -404,7 +404,7 @@ namespace CKAN
                 if (possibleDup.identifier == module.identifier)
                 {
                     if (possibleDup.version == module.version
-                        && !possibleDup.MetadataEquals(module))
+                        && !possibleDup.MetadataEquals(module, out _))
                     {
                         // If the version is the same and the metadata changed,
                         // queue this up as a reinstall (remove the old version)

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -566,8 +566,9 @@ namespace CKAN
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType() && Equals((CkanModule)obj)));
 
-        public bool MetadataEquals(CkanModule other)
+        public bool MetadataEquals(CkanModule other, out bool installedFilesChanged)
         {
+            installedFilesChanged = true;
             if ((install == null) != (other.install == null)
                     || (install != null && other.install != null
                         && install.Length != other.install.Length))
@@ -599,6 +600,10 @@ namespace CKAN
             {
                 return false;
             }
+
+            // Conditions above this line affect the files that get installed for this mod;
+            // conditions after this line do not.
+            installedFilesChanged = false;
 
             if (!RelationshipsAreEquivalent(conflicts,  other.conflicts))
             {

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1459,7 +1459,7 @@ namespace CKAN.GUI
                                                       registry.GetModuleByVersion(module.identifier,
                                                                                   module.version)
                                                               ?? module,
-                                                      true, false, config)
+                                                      true, false, true, config)
                                        as ModChange)
                            .ToList(),
                     null);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1663,7 +1663,7 @@ namespace CKAN.GUI
             // Update our mod listing
             MainModList = new ModList(guiMods, currentInstance,
                                       ModuleLabelList.ModuleLabels, ModuleTagList.ModuleTags,
-                                      ServiceLocator.Container.Resolve<IConfiguration>(), guiConfig,
+                                      guiConfig,
                                       CreateGraphics(), ChangeSet);
             MainModList.ModFiltersUpdated += UpdateFilters;
 
@@ -2227,9 +2227,8 @@ namespace CKAN.GUI
                        gmod.SelectedMod = ch.targetMod;
                     }
                 }
-                var gameVersion = inst.VersionCriteria();
-                var tuple = MainModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set, inst.Game,
-                                                                              inst.StabilityToleranceConfig, gameVersion);
+                var tuple = ModList.ComputeFullChangeSetFromUserChangeSet(registry, user_change_set,
+                                                                          ServiceLocator.Container.Resolve<IConfiguration>(), inst);
                 full_change_set = tuple.Item1.ToList();
                 new_conflicts = tuple.Item2.ToDictionary(
                     item => new GUIMod(item.Key, repoData, registry, inst.StabilityToleranceConfig,

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -723,7 +723,7 @@ namespace CKAN.GUI
                                 // Metapackages aren't intending to prompt users to choose providing mods
                                 rel.ExactMatch(registry_manager.registry, stabilityTolerance, crit, installed, toInstall)
                                 // Otherwise look for incompatible
-                                ?? rel.ExactMatch(registry_manager.registry, stabilityTolerance, null, installed, toInstall))
+                                ?? rel.ExactMatch(registry_manager.registry, stabilityTolerance, null, null, null))
                             .OfType<CkanModule>());
                     }
                     toInstall.Add(module);
@@ -733,7 +733,6 @@ namespace CKAN.GUI
                     currentUser.RaiseError("{0}", kraken.InnerException == null
                         ? kraken.Message
                         : $"{kraken.Message}: {kraken.InnerException.Message}");
-
                     continue;
                 }
                 catch (Exception ex)
@@ -751,7 +750,7 @@ namespace CKAN.GUI
 
             var modpacks = toInstall.Where(m => m.IsMetapackage)
                                     .ToArray();
-            if (modpacks.Any())
+            if (modpacks is { Length: > 0 })
             {
                 CkanModule.GetMinMaxVersions(modpacks,
                                              out _, out _,
@@ -796,10 +795,13 @@ namespace CKAN.GUI
                                Properties.Resources.AllModVersionsInstallYes,
                                Properties.Resources.AllModVersionsInstallNo))
             {
-                UpdateChangesDialog(toInstall.Select(m => new ModChange(m, GUIModChangeType.Install,
-                                                                        ServiceLocator.Container.Resolve<IConfiguration>()))
-                                             .ToList(),
-                                    null);
+                var tuple = ModList.ComputeFullChangeSetFromUserChangeSet(
+                    registry_manager.registry,
+                    toInstall.Select(m => new ModChange(m, GUIModChangeType.Install,
+                                                        ServiceLocator.Container.Resolve<IConfiguration>()))
+                             .ToHashSet(),
+                    ServiceLocator.Container.Resolve<IConfiguration>(), CurrentInstance);
+                UpdateChangesDialog(tuple.Item1.ToList(), tuple.Item2);
                 tabController.ShowTab(ChangesetTabPage.Name, 1);
             }
         }

--- a/GUI/Main/MainHistory.cs
+++ b/GUI/Main/MainHistory.cs
@@ -27,14 +27,12 @@ namespace CKAN.GUI
             if (CurrentInstance != null && ManageMods.MainModList != null)
             {
                 InstallationHistory_Done();
-                var tuple = ManageMods.MainModList.ComputeFullChangeSetFromUserChangeSet(
+                var tuple = ModList.ComputeFullChangeSetFromUserChangeSet(
                     RegistryManager.Instance(CurrentInstance, repoData).registry,
                     modules.Select(mod => new ModChange(mod, GUIModChangeType.Install,
                                                         ServiceLocator.Container.Resolve<IConfiguration>()))
                            .ToHashSet(),
-                    CurrentInstance.Game,
-                    CurrentInstance.StabilityToleranceConfig,
-                    CurrentInstance.VersionCriteria());
+                    ServiceLocator.Container.Resolve<IConfiguration>(), CurrentInstance);
                 UpdateChangesDialog(tuple.Item1.ToList(), tuple.Item2);
                 tabController.ShowTab(ChangesetTabPage.Name, 1);
             }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -126,6 +126,11 @@ namespace CKAN.GUI
                 var needRemoveForAuto = changes.All(ch => ch.ChangeType == GUIModChangeType.Install
                                                           || ch.IsAutoRemoval);
 
+                var skipFiles = changes.OfType<ModUpgrade>()
+                                       .Where(ch => ch.SkipReinstallingFiles)
+                                       .Select(ch => ch.targetMod)
+                                       .ToHashSet();
+
                 // First compose sets of what the user wants installed, upgraded, and removed.
                 foreach (ModChange change in changes)
                 {
@@ -271,7 +276,7 @@ namespace CKAN.GUI
                             if (!canceled && toUpgrade.Count > 0)
                             {
                                 installer.Upgrade(toUpgrade, downloader, ref possibleConfigOnlyDirs, registry_manager,
-                                                  deduper, autoInstalled, true, false);
+                                                  deduper, autoInstalled, skipFiles, true, false);
                                 toUpgrade.Clear();
                             }
                             if (canceled)

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -308,7 +308,8 @@ namespace CKAN.GUI
 
         public IEnumerable<ModChange> GetModChanges(bool upgradeChecked,
                                                     bool replaceChecked,
-                                                    bool metadataChanged)
+                                                    bool metadataChanged,
+                                                    bool installedFilesChanged)
         {
             var installed = InstalledMod?.Module;
             if (replaceChecked)
@@ -328,7 +329,7 @@ namespace CKAN.GUI
                 {
                     yield return new ModUpgrade(Mod,
                                                 SelectedMod,
-                                                false, false,
+                                                false, false, false,
                                                 ServiceLocator.Container.Resolve<IConfiguration>());
                 }
                 else
@@ -350,7 +351,7 @@ namespace CKAN.GUI
                 // Reinstall
                 yield return new ModUpgrade(Mod,
                                             SelectedMod,
-                                            false, metadataChanged,
+                                            false, metadataChanged, installedFilesChanged,
                                             ServiceLocator.Container.Resolve<IConfiguration>());
             }
         }

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -143,12 +143,14 @@ namespace CKAN.GUI
                           CkanModule       targetMod,
                           bool             userReinstall,
                           bool             metadataChanged,
+                          bool             installedFilesChanged,
                           IConfiguration   config)
             : base(mod, GUIModChangeType.Update, config)
         {
-            this.targetMod       = targetMod;
-            this.userReinstall   = userReinstall;
-            this.metadataChanged = metadataChanged;
+            this.targetMod             = targetMod;
+            this.userReinstall         = userReinstall;
+            this.metadataChanged       = metadataChanged;
+            this.installedFilesChanged = installedFilesChanged;
         }
 
         public override string NameAndStatus(NetModuleCache cache)
@@ -171,7 +173,11 @@ namespace CKAN.GUI
             => targetMod.identifier == Mod.identifier
                 && targetMod.version == Mod.version;
 
+        public bool SkipReinstallingFiles
+            => metadataChanged && !installedFilesChanged;
+
         private readonly bool userReinstall;
         private readonly bool metadataChanged;
+        private readonly bool installedFilesChanged;
     }
 }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -453,7 +453,8 @@ namespace CKAN.GUI
                                         replaceCol?.Visible == true
                                         && row.Cells[replaceCol.Index] is DataGridViewCheckBoxCell replaceCell
                                         && replaceCell.Value is true,
-                                        registry.MetadataChanged(gmod.Identifier))
+                                        registry.MetadataChanged(gmod.Identifier, out bool installedFilesChanged),
+                                        installedFilesChanged)
                    : Enumerable.Empty<ModChange>();
 
         public static Tuple<ICollection<ModChange>, Dictionary<CkanModule, string>, List<string>> ComputeFullChangeSetFromUserChangeSet(

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -33,7 +33,6 @@ namespace CKAN.GUI
         /// <param name="instance">Game instance for getting labels</param>
         /// <param name="allLabels">All label definitions</param>
         /// <param name="allTags">All tag definitions</param>
-        /// <param name="coreConfig">Core configuration</param>
         /// <param name="guiConfig">GUI configuration</param>
         /// <param name="graphics">Graphics object for calculating word wrap</param>
         /// <param name="mc">Changes the user has made</param>
@@ -42,14 +41,12 @@ namespace CKAN.GUI
                        GameInstance                instance,
                        ModuleLabelList             allLabels,
                        ModuleTagList               allTags,
-                       IConfiguration              coreConfig,
                        GUIConfiguration            guiConfig,
                        Graphics                    graphics,
                        List<ModChange>?            mc = null)
         {
             this.allLabels        = allLabels;
             this.allTags          = allTags;
-            this.coreConfig       = coreConfig;
             this.guiConfig        = guiConfig;
             this.graphics         = graphics;
             activeSearches        = guiConfig.DefaultSearches
@@ -459,11 +456,20 @@ namespace CKAN.GUI
                                         registry.MetadataChanged(gmod.Identifier))
                    : Enumerable.Empty<ModChange>();
 
+        public static Tuple<ICollection<ModChange>, Dictionary<CkanModule, string>, List<string>> ComputeFullChangeSetFromUserChangeSet(
+            IRegistryQuerier         registry,
+            HashSet<ModChange>       changeSet,
+            IConfiguration           coreConfig,
+            GameInstance             instance)
+            => ComputeFullChangeSetFromUserChangeSet(registry, changeSet, coreConfig,
+                                                     instance.Game, instance.StabilityToleranceConfig, instance.VersionCriteria());
+
         /// <summary>
         /// Returns a changeset and conflicts based on the selections of the user.
         /// </summary>
         /// <param name="registry">The registry for getting available mods</param>
         /// <param name="changeSet">User's choices of installation and removal</param>
+        /// <param name="coreConfig">Core configuration</param>
         /// <param name="game">Game of the game instance</param>
         /// <param name="stabilityTolerance">Prerelease configuration</param>
         /// <param name="version">The version of the current game instance</param>
@@ -473,9 +479,10 @@ namespace CKAN.GUI
         /// 2. Mapping from conflicting mods to description of the conflict
         /// 3. Descriptions of all conflicts
         /// </returns>
-        public Tuple<ICollection<ModChange>, Dictionary<CkanModule, string>, List<string>> ComputeFullChangeSetFromUserChangeSet(
+        public static Tuple<ICollection<ModChange>, Dictionary<CkanModule, string>, List<string>> ComputeFullChangeSetFromUserChangeSet(
             IRegistryQuerier         registry,
             HashSet<ModChange>       changeSet,
+            IConfiguration           coreConfig,
             IGame                    game,
             StabilityToleranceConfig stabilityTolerance,
             GameVersionCriteria      version)
@@ -684,7 +691,6 @@ namespace CKAN.GUI
 
         private readonly ModuleLabelList                allLabels;
         private readonly ModuleTagList                  allTags;
-        private readonly IConfiguration                 coreConfig;
         private readonly GUIConfiguration               guiConfig;
         private readonly Graphics                       graphics;
         private          IReadOnlyCollection<ModSearch> activeSearches;

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -1657,7 +1657,7 @@ namespace Tests.Core.IO
                                       registry.LatestAvailable(ident, inst.KSP.StabilityToleranceConfig, inst.KSP.VersionCriteria()))
                                                     .OfType<CkanModule>()
                                                     .ToArray(),
-                                  downloader, ref possibleConfigOnlyDirs, regMgr, null, null, false);
+                                  downloader, ref possibleConfigOnlyDirs, regMgr, null, null, null, false);
 
                 // Assert
                 CollectionAssert.AreEquivalent(correctRemainingIdentifiers,
@@ -1755,7 +1755,7 @@ namespace Tests.Core.IO
                     installer.Upgrade(toUpgrade.Select(CkanModule.FromJson)
                                                .ToArray(),
                                       downloader, ref possibleConfigOnlyDirs,
-                                      regMgr, null, null, false);
+                                      regMgr, null, null, null, false);
                 });
                 CollectionAssert.AreEquivalent(registry.InstalledModules.Select(im => im.Module),
                                                autoInstalled.Select(CkanModule.FromJson)
@@ -1822,6 +1822,42 @@ namespace Tests.Core.IO
                                       regMgr,
                                       ConfirmPrompt: false);
                 });
+            }
+        }
+
+        [Test]
+        public void Upgrade_WithSkipFiles_FilesNotTouched()
+        {
+            // Arrange
+            var repo = new Repository("test", "https://github.com/");
+            using (var inst     = new DisposableKSP(TestData.TestRegistry()))
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, new RepositoryDataManager(),
+                                                           new Repository[] { repo }))
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            {
+                var registry  = regMgr.registry;
+                var installer = new ModuleInstaller(inst.KSP, cache, config, nullUser);
+                var module    = TestData.DogeCoinFlag_101_module_find();
+
+                // Act
+                HashSet<string>? possibleConfigOnlyDirs = null;
+                installer.Upgrade(new CkanModule[] { module },
+                                  new NetAsyncModulesDownloader(nullUser, cache),
+                                  ref possibleConfigOnlyDirs,regMgr,
+                                  null, null,
+                                  new HashSet<CkanModule> { module });
+
+                // Assert
+                var gameDataPath = Path.Combine(inst.KSP.GameDir, "GameData");
+                CollectionAssert.AreEquivalent(new string[]
+                                               {
+                                                   CKANPathUtils.NormalizePath(Path.Combine(gameDataPath, "README.md"))
+                                               },
+                                               new DirectoryInfo(gameDataPath).EnumerateFileSystemInfos()
+                                                                              .Select(fsi => fsi.FullName)
+                                                                              .Select(CKANPathUtils.NormalizePath));
             }
         }
 

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -287,6 +287,26 @@ namespace Tests.Core.Registry
         }
 
         [Test]
+        public void ReregisterModule_WithInstalledModule_Works()
+        {
+            // Arrange
+            var repo = new Repository("test", "https://github.com/");
+            using (var inst   = new DisposableKSP(TestData.TestRegistry()))
+            using (var regMgr = RegistryManager.Instance(inst.KSP, new RepositoryDataManager(),
+                                                         new Repository[] { repo }))
+            {
+                var registry = regMgr.registry;
+                Assert.IsNull(registry.InstalledModule("DogeCoinFlag")?.Module.install?[0].find);
+
+                // Act
+                registry.ReregisterModule(inst.KSP, TestData.DogeCoinFlag_101_module_find());
+
+                // Assert
+                Assert.AreEqual("DogeCoinFlag", registry.InstalledModule("DogeCoinFlag")?.Module.install?[0].find);
+            }
+        }
+
+        [Test]
         public void HasUpdate_WithUpgradeableManuallyInstalledMod_ReturnsTrue()
         {
             // Arrange

--- a/Tests/GUI/Model/ModChangeTests.cs
+++ b/Tests/GUI/Model/ModChangeTests.cs
@@ -35,7 +35,7 @@ namespace Tests.GUI
                                         config);
 
                 // Assert
-                Assert.AreEqual(true, sut.IsUserRequested);
+                Assert.IsTrue(sut.IsUserRequested);
                 Assert.AreEqual("Requested by user", sut.Description);
                 Assert.AreEqual("Install ModuleManager 2.5.1 (Requested by user)", sut.ToString());
                 Assert.AreEqual(new ModChange(TestData.ModuleManagerModule(),
@@ -53,12 +53,14 @@ namespace Tests.GUI
             }
         }
 
-        [TestCase(false, false, "Re-install (missing folders or files)"),
-         TestCase(false, true,  "Re-install (metadata changed)"),
-         TestCase(true,  false, "Re-install (user requested)"),
-         TestCase(true,  true,  "Re-install (user requested)")]
+        [TestCase(false, false, false, "Re-install (missing folders or files)"),
+         TestCase(false, true,  false, "Re-install (metadata changed)"),
+         TestCase(false, true,  true,  "Re-install (metadata changed)"),
+         TestCase(true,  false, false, "Re-install (user requested)"),
+         TestCase(true,  true,  false, "Re-install (user requested)")]
         public void AllProperties_Upgrade_Correct(bool   userReinstall,
                                                   bool   metadataChanged,
+                                                  bool   installedFilesChanged,
                                                   string reason)
         {
             // Arrange
@@ -71,22 +73,24 @@ namespace Tests.GUI
                 // Act
                 var sut = new ModUpgrade(TestData.ModuleManagerModule(),
                                          TestData.ModuleManagerModule(),
-                                         userReinstall, metadataChanged,
+                                         userReinstall, metadataChanged, installedFilesChanged,
                                          config);
 
                 // Assert
-                Assert.AreEqual(true, sut.IsUserRequested);
+                Assert.IsTrue(sut.IsUserRequested);
+                Assert.AreEqual(metadataChanged && !installedFilesChanged,
+                                sut.SkipReinstallingFiles);
                 Assert.AreEqual(reason, sut.Description);
                 Assert.AreEqual($"Update ModuleManager 2.5.1 ({reason})",
                                 sut.ToString());
                 Assert.AreEqual(new ModUpgrade(TestData.ModuleManagerModule(),
                                                TestData.ModuleManagerModule(),
-                                               userReinstall, metadataChanged,
+                                               userReinstall, metadataChanged, false,
                                                config),
                                 sut);
                 Assert.AreNotEqual(new ModUpgrade(TestData.BurnControllerModule(),
                                                   TestData.BurnControllerModule(),
-                                                  userReinstall, metadataChanged,
+                                                  userReinstall, metadataChanged, false,
                                                   config),
                                    sut);
             }

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -51,7 +51,7 @@ namespace Tests.GUI
 
                 var item = new ModList(Array.Empty<GUIMod>(), tidy.KSP,
                                        ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                       config, new GUIConfiguration(), graphics);
+                                       new GUIConfiguration(), graphics);
                 Assert.That(item.IsVisible(
                     new GUIMod(ckan_mod!, repoData.Manager, registry,
                                tidy.KSP.StabilityToleranceConfig, tidy.KSP, cache,
@@ -93,7 +93,7 @@ namespace Tests.GUI
                 }
                 var modlist   = new ModList(modules, inst.KSP,
                                             labels, tags,
-                                            config, guiConfig, graphics);
+                                            guiConfig, graphics);
 
                 // Act / Assert
                 Assert.AreEqual(!hide, modlist.IsVisible(modules.First(), inst.KSP, registry));
@@ -111,7 +111,7 @@ namespace Tests.GUI
             {
                 var item = new ModList(Array.Empty<GUIMod>(), tidy.KSP,
                                        ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                       config, new GUIConfiguration(), graphics);
+                                       new GUIConfiguration(), graphics);
                 Assert.That(item.CountModsByFilter(tidy.KSP, filter), Is.EqualTo(0));
             }
         }
@@ -142,7 +142,7 @@ namespace Tests.GUI
                     },
                     tidy.KSP,
                     ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                    config, new GUIConfiguration(), graphics);
+                    new GUIConfiguration(), graphics);
                 Assert.That(main_mod_list.full_list_of_mod_rows.Values, Has.Count.EqualTo(2));
             }
         }
@@ -157,7 +157,7 @@ namespace Tests.GUI
                 var guiConfig = new GUIConfiguration();
                 var modlist   = new ModList(Array.Empty<GUIMod>(), inst.KSP,
                                             ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                            config, guiConfig, graphics);
+                                            guiConfig, graphics);
                 bool called   = false;
                 modlist.ModFiltersUpdated += () => { called = true; };
                 var nonEmptySearches = new List<ModSearch>
@@ -244,7 +244,7 @@ namespace Tests.GUI
                                       .ToArray();
                 var modlist  = new ModList(mods, inst.KSP,
                                            labels, new ModuleTagList(),
-                                           config, new GUIConfiguration(), graphics);
+                                           new GUIConfiguration(), graphics);
                 var mod      = mods.First();
 
                 // Act
@@ -285,7 +285,7 @@ namespace Tests.GUI
                                       .ToArray();
                 var modlist = new ModList(mods, inst.KSP,
                                           labels, new ModuleTagList(),
-                                          config, new GUIConfiguration(), graphics);
+                                          new GUIConfiguration(), graphics);
                 var grid = new DataGridView();
                 grid.Columns.AddRange(StandardColumns);
                 grid.Rows.AddRange(modlist.full_list_of_mod_rows.Values.ToArray());
@@ -347,7 +347,7 @@ namespace Tests.GUI
                                        .ToArray();
                 var modlist   = new ModList(modules, inst.KSP,
                                             labels, tags,
-                                            config, guiConfig, graphics);
+                                            guiConfig, graphics);
                 var grid      = new DataGridView();
                 grid.Columns.AddRange(StandardColumns);
                 grid.Rows.AddRange(modlist.full_list_of_mod_rows.Values.ToArray());
@@ -621,7 +621,7 @@ namespace Tests.GUI
                                       .ToArray();
                 var modlist  = new ModList(mods, instance.KSP,
                                            ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                           config, new GUIConfiguration(), graphics);
+                                           new GUIConfiguration(), graphics);
 
                 // Act
                 foreach (var mod in mods.OrderBy(m => m.Identifier).Take(5))
@@ -653,7 +653,7 @@ namespace Tests.GUI
             {
                 var item = new ModList(Array.Empty<GUIMod>(), tidy.KSP,
                                        ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                       config, new GUIConfiguration(), graphics);
+                                       new GUIConfiguration(), graphics);
                 Assert.That(item.ComputeUserChangeSet(Registry.Empty(repoData.Manager), tidy.KSP, null, null), Is.Empty);
             }
         }
@@ -687,16 +687,14 @@ namespace Tests.GUI
                                        .ToArray();
                 var modlist   = new ModList(mods, inst.KSP,
                                             labels, new ModuleTagList(),
-                                            config, guiConfig, graphics);
+                                            guiConfig, graphics);
 
                 // Act
                 var b9         = mods.First(m => m.Identifier == "B9");
                 b9.SelectedMod = b9.LatestCompatibleMod;
                 var changes    = modlist.ComputeUserChangeSet(registry, inst.KSP, null, null);
-                var full       = modlist.ComputeFullChangeSetFromUserChangeSet(registry, changes,
-                                                                               inst.KSP.Game,
-                                                                               inst.KSP.StabilityToleranceConfig,
-                                                                               inst.KSP.VersionCriteria());
+                var full       = ModList.ComputeFullChangeSetFromUserChangeSet(registry, changes,
+                                                                               config, inst.KSP);
 
                 // Assert
                 CollectionAssert.AreEquivalent(new string[]
@@ -805,7 +803,7 @@ namespace Tests.GUI
 
                 var modList = new ModList(modules, instance.KSP,
                                           ModuleLabelList.GetDefaultLabels(), new ModuleTagList(),
-                                          config, new GUIConfiguration(), graphics);
+                                          new GUIConfiguration(), graphics);
                 Assert.IsFalse(modList.HasVisibleInstalled());
 
                 listGui.Rows.AddRange(modList.full_list_of_mod_rows.Values.ToArray());

--- a/metadata.Dockerfile.dockerignore
+++ b/metadata.Dockerfile.dockerignore
@@ -66,8 +66,6 @@
 **/System.ServiceProcess.dll
 **/System.Text.Encoding.CodePages.dll
 **/System.Text.Encoding.dll
-**/System.Text.Encodings.Web.dll
-**/System.Text.Json.dll
 **/System.Threading.Overlapped.dll
 **/System.Threading.Tasks.Dataflow.dll
 **/System.Threading.Tasks.dll

--- a/netkan.Dockerfile.dockerignore
+++ b/netkan.Dockerfile.dockerignore
@@ -62,8 +62,6 @@
 **/System.ServiceProcess.dll
 **/System.Text.Encoding.CodePages.dll
 **/System.Text.Encoding.dll
-**/System.Text.Encodings.Web.dll
-**/System.Text.Json.dll
 **/System.Threading.Overlapped.dll
 **/System.Threading.Tasks.Dataflow.dll
 **/System.Threading.Tasks.dll


### PR DESCRIPTION
## Motivation

@Clayell suggested on Discord that we try to skip the file remove/unzip step when re-installing a mod that still installs identical files the same way:

<img width="661" height="144" alt="image" src="https://github.com/user-attachments/assets/67b30571-047d-4049-a868-a04ec2c22932" />

## Problems

- We have been seeing a wave of support requests about unsatisfied dependencies when installing modpacks, very late in the process:
  - <img width="2032" height="225" alt="image" src="https://github.com/user-attachments/assets/973c5d5d-dde2-4ffa-93ba-6b269f074ce4" />
  - <img width="1038" height="221" alt="image" src="https://github.com/user-attachments/assets/77e52700-73a9-4ec6-8b0f-a799b8e1dc0f" />
  Commonly these are due to conflicts between installed mods and mods in the modpack.
- After #4594, the latest build of the inflator threw this on startup, and we had to revert to a previous image (same for the metadata validator):
  ```
  415 [1] FATAL CKAN.NetKAN.Program (null) - Could not load file or assembly 'System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.
  ```
  If you fix that, it complains again:
  ```
  161 [1] FATAL CKAN.NetKAN.Program (null) - Could not load file or assembly 'System.Text.Encodings.Web, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.
  ```

## Causes

- The modpack installation code doesn't check conflicts; instead, conflicting modules are simply excluded from the changeset, and the unsatisfied dependency is caught at the end of the installation process.
- The Inflator build really should not have changed at all, since we are still building it for recent .NET using the standard `dotnet` tools and still targeting `linux-x64`. We only changed two things: we updated from net8.0 to net10.0, and the build and publish now take place in a `windows-latest` container instead of `ubuntu-22.04`. If I had to speculate, I would guess that net10.0 is the culprit, but I wouldn't rule out the container OS entirely.

## Changes

- Now if the metadata changes for an installed module but the download hash and the `install` stanza are the same, the files will not be removed and re-installed.
  (Right-click re-install is unchanged and so can still be used as a repair tool when users break their installs.)
- Now conflicting mods will be included in the changeset and their conflicts will be detected and passed to the changeset tab, to alert users to problems much earlier and give them hints about how to solve them:
  <img width="1388" height="607" alt="image" src="https://github.com/user-attachments/assets/30b31252-ed69-4a31-9201-2a1c96b9b0ee" />
- Now the containers for the Inflator and the metadata validator no longer exclude `System.Text.Json.dll` or `System.Text.Encodings.Web.dll`, which should allow them to work with the latest net10.0 builds out of the box
