### PR TITLE
Fix ckan://identifier

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -35,7 +35,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="ini-parser" Version="2.5.2" />
     <PackageReference Include="log4net" Version="3.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1341,7 +1341,8 @@ namespace CKAN.GUI
                     bool row_match;
                     if (exactMatch)
                     {
-                        row_match = mod?.Name == key || mod?.Identifier == key;
+                        row_match = mod?.Name == key
+                                    || string.Equals(mod?.Identifier, key, StringComparison.OrdinalIgnoreCase);
                     }
                     else
                     {

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1350,7 +1350,8 @@ namespace CKAN.GUI
                     bool row_match;
                     if (exactMatch)
                     {
-                        row_match = mod?.Name == key || mod?.Identifier == key;
+                        row_match = mod?.Name == key
+                                    || string.Equals(mod?.Identifier, key, StringComparison.OrdinalIgnoreCase);
                     }
                     else
                     {

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -68,8 +68,9 @@ namespace CKAN.GUI
             log.Info("Starting the GUI");
             if (//cmdlineArgs is [_, string focusIdent, ..]
                 cmdlineArgs.Length > 1
-                && cmdlineArgs[1] is string { Length: >= 2 } focusIdentArg
+                && cmdlineArgs[1] is string { Length: >= 2 } focusIdentArg)
             {
+                // Strip any leading `//` or any leading `ckan://`.
                 if (//focusIdentArg is ['/', '/', .. var rest]
                     focusIdentArg.Length > 2
                     && focusIdentArg.StartsWith("//"))
@@ -82,10 +83,13 @@ namespace CKAN.GUI
                 {
                     focusIdent = focusIdentArg[7..];
                 }
+
+                // Strip any trailing forward slashes.
                 if (//focusIdent is [.. var start, '/']
-                    focusIdentArg.EndsWith("/"))
+                    focusIdent is { Length: > 1 }
+                    && focusIdent.EndsWith("/"))
                 {
-                    focusIdent = focusIdentArg[..^1];
+                    focusIdent = focusIdent.TrimEnd('/');
                 }
             }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -70,6 +70,8 @@ namespace CKAN.GUI
                 cmdlineArgs.Length > 1
                 && cmdlineArgs[1] is string { Length: >= 2 } focusIdentArg)
             {
+                focusIdent = focusIdentArg;
+
                 // Strip any leading "//" or any leading "ckan://".
                 if (//focusIdentArg is ['/', '/', .. var rest]
                     focusIdentArg.Length > 2

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -68,22 +68,23 @@ namespace CKAN.GUI
             log.Info("Starting the GUI");
             if (//cmdlineArgs is [_, string focusIdent, ..]
                 cmdlineArgs.Length > 1
-                && cmdlineArgs[1] is string focusIdent)
+                && cmdlineArgs[1] is string focusIdentArg
+                && focusIdentArg.Length >= 2)
             {
                 if (//focusIdent is ['/', '/', .. var rest]
-                    focusIdent.Length > 2)
+                    focusIdentArg.StartsWith("//"))
                 {
-                    focusIdent = focusIdent[2..];
+                    focusIdent = focusIdentArg[2..];
                 }
                 else if (//focusIdent is ['c', 'k', 'a', 'n', ':', '/', '/', .. var rest2]
-                    focusIdent.StartsWith("ckan://"))
+                    focusIdentArg.StartsWith("ckan://"))
                 {
-                    focusIdent = focusIdent[7..];
+                    focusIdent = focusIdentArg[7..];
                 }
                 if (//focusIdent is [.. var start, '/']
-                    focusIdent.EndsWith("/"))
+                    focusIdentArg.EndsWith("/"))
                 {
-                    focusIdent = focusIdent[..^1];
+                    focusIdent = focusIdentArg[..^1];
                 }
             }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -68,16 +68,17 @@ namespace CKAN.GUI
             log.Info("Starting the GUI");
             if (//cmdlineArgs is [_, string focusIdent, ..]
                 cmdlineArgs.Length > 1
-                && cmdlineArgs[1] is string focusIdentArg
-                && focusIdentArg.Length >= 2)
+                && cmdlineArgs[1] is string { Length: >= 2 } focusIdentArg
             {
-                if (//focusIdent is ['/', '/', .. var rest]
-                    focusIdentArg.StartsWith("//"))
+                if (//focusIdentArg is ['/', '/', .. var rest]
+                    focusIdentArg.Length > 2
+                    && focusIdentArg.StartsWith("//"))
                 {
                     focusIdent = focusIdentArg[2..];
                 }
-                else if (//focusIdent is ['c', 'k', 'a', 'n', ':', '/', '/', .. var rest2]
-                    focusIdentArg.StartsWith("ckan://"))
+                else if (//focusIdenArg is ['c', 'k', 'a', 'n', ':', '/', '/', .. var rest2]
+                    focusIdentArg.Length > 7
+                    && focusIdentArg.StartsWith("ckan://"))
                 {
                     focusIdent = focusIdentArg[7..];
                 }

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -70,7 +70,7 @@ namespace CKAN.GUI
                 cmdlineArgs.Length > 1
                 && cmdlineArgs[1] is string { Length: >= 2 } focusIdentArg)
             {
-                // Strip any leading `//` or any leading `ckan://`.
+                // Strip any leading "//" or any leading "ckan://".
                 if (//focusIdentArg is ['/', '/', .. var rest]
                     focusIdentArg.Length > 2
                     && focusIdentArg.StartsWith("//"))

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 #if !NET5_0_OR_GREATER
 using System.Reflection;
 #endif
@@ -10,25 +11,16 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 #endif
 
-using CKAN.Extensions;
-
-using IniParser;
-using IniParser.Exceptions;
-using IniParser.Model;
 using log4net;
 
 namespace CKAN.GUI
 {
-    #if NET5_0_OR_GREATER
-    [SupportedOSPlatform("windows")]
-    #endif
     [ExcludeFromCodeCoverage]
     public static class URLHandlers
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(URLHandlers));
         public  const  string UrlRegistrationArgument = "registerUrl";
 
-        private static readonly string MimeAppsListPath = "mimeapps.list";
         private static readonly string ApplicationsPath = ".local/share/applications/";
         private const           string HandlerFileName  = "ckan-handler.desktop";
 
@@ -47,7 +39,6 @@ namespace CKAN.GUI
                     ApplicationsPath = Path.Combine(home, ApplicationsPath);
                 }
                 Directory.CreateDirectory(ApplicationsPath);
-                MimeAppsListPath = Path.Combine(ApplicationsPath, MimeAppsListPath);
             }
         }
 
@@ -155,73 +146,71 @@ namespace CKAN.GUI
         #endif
         private static void RegisterURLHandler_Linux()
         {
-            var parser = new FileIniDataParser();
-
-            // Yes, 'Assigment' is the spelling used by the library.
-            parser.Parser.Configuration.AssigmentSpacer = "";
-            IniData data;
-
             log.InfoFormat("Trying to register URL handler");
-
-            if (!File.Exists(MimeAppsListPath))
-            {
-                log.InfoFormat("{0} does not exist, trying to create it", MimeAppsListPath);
-                File.WriteAllLines(MimeAppsListPath, new string[] { "[Default Applications]" });
-            }
-
-            try
-            {
-                data = parser.ReadFile(MimeAppsListPath);
-            }
-            catch (DirectoryNotFoundException ex)
-            {
-                log.InfoFormat("Skipping URL handler: {0}", ex.Message);
-                return;
-            }
-            catch (FileNotFoundException ex)
-            {
-                log.InfoFormat("Skipping URL handler: {0}", ex.Message);
-                return;
-            }
-            catch (ParsingException ex)
-            {
-                log.InfoFormat("Skipping URL handler: {0}", ex.Message);
-                return;
-            }
-
-            if (data["Added Associations"] == null)
-            {
-                data.Sections.AddSection("Added Associations");
-            }
-            data["Added Associations"].RemoveKey("x-scheme-handler/ckan");
-            data["Added Associations"].AddKey("x-scheme-handler/ckan", HandlerFileName);
-
-            parser.WriteFile(MimeAppsListPath, data);
 
             var handlerPath = Path.Combine(ApplicationsPath, HandlerFileName);
 
-            if (File.Exists(handlerPath))
+            #if NET5_0_OR_GREATER
+            var desiredExec = "\"" + PathToRunningExe() + "\" gui %u";
+            #else
+            var desiredExec = "mono \"" + PathToRunningExe() + "\" gui %u";
+            #endif
+
+            var desiredContent = new StringBuilder()
+                .AppendLine("[Desktop Entry]")
+                .AppendLine("Version=1.0")
+                .AppendLine("Type=Application")
+                .AppendLine($"Exec={desiredExec}")
+                .AppendLine("Icon=ckan")
+                .AppendLine("StartupNotify=true")
+                .AppendLine("NoDisplay=true")
+                .AppendLine("Terminal=false")
+                .AppendLine("Categories=Utility")
+                .AppendLine("MimeType=x-scheme-handler/ckan")
+                .AppendLine("Name=CKAN Launcher")
+                .AppendLine("Comment=Launch CKAN")
+                .ToString();
+
+            var existingContent = File.Exists(handlerPath)
+                ? File.ReadAllText(handlerPath)
+                : null;
+
+            if (existingContent != desiredContent)
             {
-                File.Delete(handlerPath);
+                log.InfoFormat("Writing URL handler desktop file to {0}", handlerPath);
+
+                // Write without a Byte Order Mark. update-desktop-database errors on BOM-prefixed files.
+                File.WriteAllText(handlerPath, desiredContent, new UTF8Encoding(false));
+                AutoUpdate.SetExecutable(handlerPath);
+
+                RunCommand("xdg-mime", $"default {HandlerFileName} x-scheme-handler/ckan");
+                RunCommand("update-desktop-database", ApplicationsPath);
             }
+            else
+            {
+                log.InfoFormat("URL handler desktop file is already up to date");
+            }
+        }
 
-            "".WriteThroughTo(handlerPath);
-            data = parser.ReadFile(handlerPath);
-            data.Sections.AddSection("Desktop Entry");
-            data["Desktop Entry"].AddKey("Version", "1.0");
-            data["Desktop Entry"].AddKey("Type", "Application");
-            data["Desktop Entry"].AddKey("Exec", "mono \"" + PathToRunningExe() + "\" gui %u");
-            data["Desktop Entry"].AddKey("Icon", "ckan");
-            data["Desktop Entry"].AddKey("StartupNotify", "true");
-            data["Desktop Entry"].AddKey("NoDisplay", "true");
-            data["Desktop Entry"].AddKey("Terminal", "false");
-            data["Desktop Entry"].AddKey("Categories", "Utility");
-            data["Desktop Entry"].AddKey("MimeType", "x-scheme-handler/ckan");
-            data["Desktop Entry"].AddKey("Name", "CKAN Launcher");
-            data["Desktop Entry"].AddKey("Comment", "Launch CKAN");
-
-            parser.WriteFile(handlerPath, data);
-            AutoUpdate.SetExecutable(handlerPath);
+        private static void RunCommand(string command, string args)
+        {
+            try
+            {
+                log.InfoFormat("Running {0} {1}", command, args);
+                using var process = Process.Start(new ProcessStartInfo
+                {
+                    FileName = command,
+                    Arguments = args,
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                });
+                process?.WaitForExit();
+            }
+            catch (Exception ex)
+            {
+                // xdg-mime and update-desktop-database are not guaranteed to be on all systems.
+                log.WarnFormat("Could not run {0}: {1}", command, ex.Message);
+            }
         }
     }
 }

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -194,12 +194,22 @@ namespace CKAN.GUI
                 log.InfoFormat("Running {0} {1}", command, args);
                 using var process = Process.Start(new ProcessStartInfo
                 {
-                    FileName = command,
-                    Arguments = args,
-                    UseShellExecute = false,
-                    RedirectStandardError = true,
+                    FileName               = command,
+                    Arguments              = args,
+                    UseShellExecute        = false,
+                    RedirectStandardError  = true,
+                    RedirectStandardOutput = true,
                 });
-                process?.WaitForExit();
+                if (process != null)
+                {
+                    var stderr = process.StandardError.ReadToEnd();
+                    process.WaitForExit();
+                    if (process.ExitCode != 0)
+                    {
+                        log.WarnFormat("{0} exited with code {1}: {2}",
+                                       command, process.ExitCode, stderr);
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -149,12 +149,7 @@ namespace CKAN.GUI
             log.InfoFormat("Trying to register URL handler");
 
             var handlerPath = Path.Combine(ApplicationsPath, HandlerFileName);
-
-            #if NET5_0_OR_GREATER
-            var desiredExec = "\"" + PathToRunningExe() + "\" gui %u";
-            #else
             var desiredExec = "mono \"" + PathToRunningExe() + "\" gui %u";
-            #endif
 
             var desiredContent = new StringBuilder()
                 .AppendLine("[Desktop Entry]")


### PR DESCRIPTION
- this.focusIdent was hidden by local variable focusIdent. Renamed focusIdent to focusIdentArg.

- When stripping focusIdent, StartsWith("ckan://") condition  was unreachable due to prior Length > 2 condition.

These issues seemed to be introduced in https://github.com/KSP-CKAN/CKAN/pull/4176.

The context is that I'm working on an in-game helper for finding recolour mods to reduce the number of people getting stuck trying to use Lazy Painter.

<img width="360" height="191" alt="image" src="https://github.com/user-attachments/assets/8922bd3f-877e-452d-9397-61793729a4d6" />

For future reference, it would be good to look at how to have the URL handler talk to the running process instead of starting a new process every time.

Fixes #4633.
