### PR TITLE
Better free space check for single disk systems

### DIFF
--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -83,19 +83,11 @@ namespace CKAN.IO
                 throw new ModuleIsDLCKraken(dlc.First());
             }
 
-            // Make sure we have enough space to install this stuff
-            var installBytes = modsToInstall.Sum(m => m.install_size);
-            CKANPathUtils.CheckFreeSpace(new DirectoryInfo(instance.GameDir),
-                                         installBytes,
-                                         Properties.Resources.NotEnoughSpaceToInstall);
-
+            // Check which mods need to be downloaded
             var cached    = new List<CkanModule>();
             var downloads = new List<CkanModule>();
-            User.RaiseMessage(Properties.Resources.ModuleInstallerAboutToInstall);
-            User.RaiseMessage("");
             foreach (var module in modsToInstall)
             {
-                User.RaiseMessage(" * {0}", cache.DescribeAvailability(config, module));
                 if (!module.IsMetapackage && !cache.IsMaybeCachedZip(module))
                 {
                     downloads.Add(module);
@@ -105,13 +97,30 @@ namespace CKAN.IO
                     cached.Add(module);
                 }
             }
+
+            // Make sure we have enough space to install this stuff
+            var installBytes  = modsToInstall.Sum(m => m.install_size);
+            var downloadBytes = CkanModule.GroupByDownloads(downloads)
+                                          .Sum(grp => grp.First().download_size);
+            CKANPathUtils.CheckFreeSpace(new DirectoryInfo(instance.GameDir),
+                                         cache.OnSameDevice(new DirectoryInfo(instance.GameDir))
+                                             // Check for combined download+install space if same device
+                                             ? downloadBytes + installBytes
+                                             : installBytes,
+                                         Properties.Resources.NotEnoughSpaceToInstall);
+
+            // Prompt user for confirmation, if needed
+            User.RaiseMessage(Properties.Resources.ModuleInstallerAboutToInstall);
+            User.RaiseMessage("");
+            foreach (var module in modsToInstall)
+            {
+                User.RaiseMessage(" * {0}", cache.DescribeAvailability(config, module));
+            }
             if (ConfirmPrompt && !User.RaiseYesNoDialog(Properties.Resources.ModuleInstallerContinuePrompt))
             {
                 throw new CancelledActionKraken(Properties.Resources.ModuleInstallerUserDeclined);
             }
 
-            var downloadBytes = CkanModule.GroupByDownloads(downloads)
-                                          .Sum(grp => grp.First().download_size);
             var rateCounter = new ByteRateCounter()
             {
                 Size      = downloadBytes + installBytes,

--- a/Core/Net/NetFileCache.cs
+++ b/Core/Net/NetFileCache.cs
@@ -575,6 +575,11 @@ namespace CKAN
             }
         }
 
+        public bool OnSameDevice(DirectoryInfo dir)
+            => HardLink.GetDeviceIdentifiers(cachePath.FullName, dir.FullName)
+                       .Distinct()
+                       .Count() < 2;
+
         /// <summary>
         /// Generate the hash used for caching
         /// </summary>

--- a/Core/Net/NetModuleCache.cs
+++ b/Core/Net/NetModuleCache.cs
@@ -79,6 +79,8 @@ namespace CKAN
         {
             cache.CheckFreeSpace(bytesToStore);
         }
+        public bool OnSameDevice(DirectoryInfo dir)
+            => cache.OnSameDevice(dir);
 
         public FileInfo? GetInProgressFileName(CkanModule m)
             => m.download == null

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -34,13 +34,7 @@ namespace CKAN.GUI
             {
                 ModGrid.BorderStyle = BorderStyle.None;
             }
-            uninstallingFont = new Font(SystemFonts.DefaultFont, FontStyle.Strikeout);
-            if (Platform.IsMono
-                && (int)CreateGraphics().DpiX is int dpi
-                && dpi != 96)
-            {
-                uninstallingFont = uninstallingFont.Scale(dpi);
-            }
+            uninstallingFont = new Font(ModGrid.Font, FontStyle.Strikeout);
 
             ToolTip.SetToolTip(InstallAllCheckbox, Properties.Resources.ManageModsInstallAllCheckboxTooltip);
             FilterCompatibleButton.ToolTipText      = Properties.Resources.FilterLinkToolTip;

--- a/metadata.Dockerfile
+++ b/metadata.Dockerfile
@@ -16,7 +16,7 @@ ENV PATH="$PATH:/root/.local/bin"
 RUN apt-get update \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        ca-certificates libicu74 git libffi-dev \
+        ca-certificates libicu78 git libffi-dev \
         python3 python-is-python3
 
 # Trust all git repos

--- a/netkan.Dockerfile
+++ b/netkan.Dockerfile
@@ -9,7 +9,7 @@ ENV LANG=C.utf-8
 # Install dotnet dependencies
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates libicu74
+    && apt-get install -y --no-install-recommends ca-certificates libicu78
 
 # Purge APT download cache, package lists, and logs
 RUN apt-get clean \


### PR DESCRIPTION
## Problems

- Discord user ЯOTΔUGΣΠKILLΣR reported that some CKAN-installed mods showed up as "AD" after running out of space during an installation, even though we already check that there's enough free space to download the needed mods _and_ that there's enough free space to install them
-  When you click to uninstall a mod on Windows, the mods to uninstall are shown in ~~strikethrough~~ font, but the font size might be slightly different than the regular rows
- #4603 just had `smoke.yml` fail with this message:
  ```
  4.522 E: Unable to locate package libicu74
  ```

## Causes

- If the download cache and the game dir are on the same disk, then we also need to check that the download bytes PLUS the install bytes will fit in the free space.
  For example, suppose your changeset will take 1 GB to download and 2 GB to install, and you have 2.5 GB of free space remaining. Checking both separately would allow the install to proceed and fill up the disk (1 &lt; 2.5, 2 &lt; 2.5), whereas checking them together would halt the install (3 &gt; 2.5).
  In theory, the filesystem transaction stuff should prevent "AD" mods by rolling back all changes, but that probably doesn't work when the disk is full.
- `ManageMods.uninstallingFont` was derived from `SystemFonts.DefaultFont`, which is not necessarily the same as `ModGrid.Font`
- Apparently `ubuntu:latest` updated 12-ish hours ago, and `libicu74` was replaced by `libicu78`

## Changes

- Now if the download cache and game dir are on the same device, the free space check looks for enough bytes to both download _and_ install, together
- Now `ManageMods.uninstallingFont` is derived from `ModGrid.Font`
- Now the Dockerfiles install `libicu78` instead of `libicu74`. If this works, we'll rebase #4603 on top of these changes.
