### PR TITLE
Non-Latin letter search

### DIFF
--- a/Cmdline/Action/Search.cs
+++ b/Cmdline/Action/Search.cs
@@ -139,8 +139,8 @@ namespace CKAN.CmdLine
                                               bool              searchIncompatible = false)
         {
             // Remove spaces and special characters from the search term.
-            term   = string.IsNullOrWhiteSpace(term)   ? "" : CkanModule.nonAlphaNums.Replace(term, "");
-            author = string.IsNullOrWhiteSpace(author) ? "" : CkanModule.nonAlphaNums.Replace(author, "");
+            term   = string.IsNullOrWhiteSpace(term)   ? "" : CkanModule.nonAlphaNumsAnyLanguage.Replace(term, "");
+            author = string.IsNullOrWhiteSpace(author) ? "" : CkanModule.nonAlphaNumsAnyLanguage.Replace(author, "");
 
             var registry = RegistryManager.Instance(instance, repoData).registry;
 

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -345,9 +345,8 @@ namespace CKAN
 
                 foreach (var anchor in game.InstanceAnchorFiles)
                 {
-                    txFileMgr.WriteAllText(Path.Combine(newPath, anchor),
-                                           version.WithoutBuild.ToString(),
-                                           Encoding.UTF8);
+                    txFileMgr.WriteAllBytes(Path.Combine(newPath, anchor),
+                                            Encoding.UTF8.GetBytes(version.WithoutBuild.ToString() ?? ""));
                 }
 
                 // Don't write the buildID.txts if we have no build, otherwise it would be -1.
@@ -355,17 +354,15 @@ namespace CKAN
                 {
                     foreach (var b in KspBuildIdVersionProvider.buildIDfilenames)
                     {
-                        txFileMgr.WriteAllText(Path.Combine(newPath, b),
-                                               string.Format("build id = {0}", version.Build),
-                                               Encoding.UTF8);
+                        txFileMgr.WriteAllBytes(Path.Combine(newPath, b),
+                                                Encoding.UTF8.GetBytes(string.Format("build id = {0}", version.Build)));
                     }
                 }
 
                 // Create the readme.txt WITHOUT build number
-                txFileMgr.WriteAllText(Path.Combine(newPath, "readme.txt"),
-                                       string.Format("Version {0}",
-                                                     version.WithoutBuild.ToString()),
-                                       Encoding.UTF8);
+                txFileMgr.WriteAllBytes(Path.Combine(newPath, "readme.txt"),
+                                        Encoding.UTF8.GetBytes(string.Format("Version {0}",
+                                                     version.WithoutBuild.ToString())));
 
                 // Create the needed folder structure and the readme.txt for DLCs that should be simulated.
                 if (dlcs != null)
@@ -384,10 +381,9 @@ namespace CKAN
 
                         string dlcDir = Path.Combine(newPath, dlcDetector.InstallPath());
                         txFileMgr.CreateDirectory(dlcDir);
-                        txFileMgr.WriteAllText(
+                        txFileMgr.WriteAllBytes(
                             Path.Combine(dlcDir, "readme.txt"),
-                            string.Format("Version {0}", dlcVersion),
-                            Encoding.UTF8);
+                            Encoding.UTF8.GetBytes(string.Format("Version {0}", dlcVersion)));
                     }
                 }
 

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -413,7 +413,7 @@ namespace CKAN
                 Directory.CreateDirectory(directoryPath);
             }
 
-            txFileMgr.WriteAllText(path, Serialize(), Encoding.UTF8);
+            txFileMgr.WriteAllBytes(path, Encoding.UTF8.GetBytes(Serialize()));
 
             if (!Directory.Exists(gameInstance.InstallHistoryDir))
             {
@@ -449,7 +449,7 @@ namespace CKAN
             var serialized = SerializeCurrentInstall(recommends, withVersions);
             foreach (var path in paths)
             {
-                txFileMgr.WriteAllText(path, serialized, Encoding.UTF8);
+                txFileMgr.WriteAllBytes(path, Encoding.UTF8.GetBytes(serialized));
             }
         }
 

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -127,8 +127,7 @@ namespace CKAN
                 serializer.Serialize(writer, this);
             }
             var txFileMgr = new TxFileManager();
-            txFileMgr.WriteAllText(path, sw + Environment.NewLine,
-                                   Encoding.UTF8);
+            txFileMgr.WriteAllBytes(path, Encoding.UTF8.GetBytes(sw + Environment.NewLine));
         }
 
         /// <summary>

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -271,9 +271,8 @@ namespace CKAN
         private void saveETags()
         {
             var txFileMgr = new TxFileManager();
-            txFileMgr.WriteAllText(etagsPath,
-                                   JsonConvert.SerializeObject(etags, Formatting.Indented),
-                                   Encoding.UTF8);
+            txFileMgr.WriteAllBytes(etagsPath,
+                                    Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(etags, Formatting.Indented)));
         }
 
         private void setETag(NetAsyncDownloader.DownloadTarget target,

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -216,6 +216,9 @@ namespace CKAN
         [JsonIgnore]
         public static readonly Regex nonAlphaNums = new Regex("[^a-zA-Z0-9]", RegexOptions.Compiled);
 
+        [JsonIgnore]
+        public static readonly Regex nonAlphaNumsAnyLanguage = new Regex(@"[^\p{L}0-9]", RegexOptions.Compiled);
+
         #endregion
 
         #region Constructors
@@ -384,10 +387,10 @@ namespace CKAN
         private void CalculateSearchables()
         {
             SearchableIdentifier  = identifier  == null ? "" : nonAlphaNums.Replace(identifier, "");
-            SearchableName        = name        == null ? "" : nonAlphaNums.Replace(name, "");
-            SearchableAbstract    = @abstract   == null ? "" : nonAlphaNums.Replace(@abstract, "");
-            SearchableDescription = description == null ? "" : nonAlphaNums.Replace(description, "");
-            SearchableAuthors     = author?.Select(auth => nonAlphaNums.Replace(auth, ""))
+            SearchableName        = name        == null ? "" : nonAlphaNumsAnyLanguage.Replace(name, "");
+            SearchableAbstract    = @abstract   == null ? "" : nonAlphaNumsAnyLanguage.Replace(@abstract, "");
+            SearchableDescription = description == null ? "" : nonAlphaNumsAnyLanguage.Replace(description, "");
+            SearchableAuthors     = author?.Select(auth => nonAlphaNumsAnyLanguage.Replace(auth, ""))
                                            .ToList()
                                           ?? new List<string> { "" };
         }

--- a/GUI/Model/ModSearch.cs
+++ b/GUI/Model/ModSearch.cs
@@ -55,10 +55,10 @@ namespace CKAN.GUI
         {
             Instance = instance;
             Name = (ShouldNegateTerm(byName, out string subName) ? "-" : "")
-                + CkanModule.nonAlphaNums.Replace(subName, "");
+                + CkanModule.nonAlphaNumsAnyLanguage.Replace(subName, "");
             initStringList(Authors, byAuthors);
             Description = (ShouldNegateTerm(byDescription, out string subDesc) ? "-" : "")
-                + CkanModule.nonAlphaNums.Replace(subDesc, "");
+                + CkanModule.nonAlphaNumsAnyLanguage.Replace(subDesc, "");
             initStringList(Localizations, localizations);
             initStringList(Licenses,      licenses);
 
@@ -200,7 +200,7 @@ namespace CKAN.GUI
                 allLabels,
                 instance,
                 // Can't search for spaces, so massage them like SearchableAuthors
-                "", authors.Select(a => CkanModule.nonAlphaNums.Replace(a, "")).ToList(), "",
+                "", authors.Select(a => CkanModule.nonAlphaNumsAnyLanguage.Replace(a, "")).ToList(), "",
                 null, null,
                 null, null, null, null, null,
                 null, null,
@@ -382,7 +382,7 @@ namespace CKAN.GUI
                 }
                 else if (TryPrefix(s, Properties.Resources.ModSearchDescriptionPrefix, out string desc))
                 {
-                    byDescription += (ShouldNegateTerm(desc, out string subDesc) ? "-" : "") + CkanModule.nonAlphaNums.Replace(subDesc, "");
+                    byDescription += (ShouldNegateTerm(desc, out string subDesc) ? "-" : "") + CkanModule.nonAlphaNumsAnyLanguage.Replace(subDesc, "");
                 }
                 else if (TryPrefix(s, Properties.Resources.ModSearchLicensePrefix, out string lic))
                 {
@@ -477,7 +477,7 @@ namespace CKAN.GUI
                 else
                 {
                     // No special format = search names and identifiers
-                    byName += (ShouldNegateTerm(s, out string subS) ? "-" : "") + CkanModule.nonAlphaNums.Replace(subS, "");
+                    byName += (ShouldNegateTerm(s, out string subS) ? "-" : "") + CkanModule.nonAlphaNumsAnyLanguage.Replace(subS, "");
                 }
             }
             return new ModSearch(


### PR DESCRIPTION
## Problems

- If you search for "Σκοπός", all mods are treated as matching, as if you hadn't entered a search at all, even though there is exactly one mod with exactly that `name`
- Users with Chinese language settings at the operating system level have reported empty mod lists with the Update all button enabled, which after #4547 have been replaced with explicitly logged exceptions:
  <img width="999" height="633" alt="Image" src="https://github.com/user-attachments/assets/f01044c0-71de-4857-8179-7c4df1dcbc6f" />

## Causes

- To handle varying usages of punctuation, we remove all non-alphanumeric characters from search strings and the strings they match against in each mod. This way the user does not have to remember whether and where each mod uses `-` or `_` or `:` or `.` or nothing in its weird name and description. Unfortunately that also removes non-Latin characters like Greek letters, etc.
- The repository data JSON files are ending up with strange sequences including incorrect backslashes in place of UTF-8 encoded unicode characters (such as alpha in this case):
  <img width="1014" height="375" alt="Image" src="https://github.com/user-attachments/assets/79c95ba6-3262-4c60-b5d9-8fb1bdcf364a" />
  This causes the JSON parser to throw an exception, which breaks loading of the cached repo data.
  Making some inferences based on feedback from Discord user Asada_Fuyuki, this appears to be caused by `TxFileManager.WriteAllText` sometimes ignoring its encoding parameter, which presumably would cause files to be written in the encoding configured at the operating system level.

## Changes

- Now a new `CkanModule.nonAlphaNumsAnyLanguage` regex uses [`\p{L}`](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#unicode-category-or-unicode-block-p) to match all letters in any language, and code dealing with names, abstracts, descriptions, and authors is updated to use this instead of `CkanModule.nonAlphaNums`, so searching for Σκοπός will work as expected.
  (Identifiers are still expected to use only `A-Za-z0-9`.)
- Now instead of requesting UTF-8 from `TxFileManager.WriteAllText`, we convert the string to `byte[]` ourselves with `Encoding.UTF8.GetBytes`, and then pass that to `TxFileManager.WriteAllBytes`. Since we are no longer relying on `TxFileManager` to handle locales, we won't be affected by any problems with how it does so, and Discord user Asada_Fuyuki reports that this seems to solve the problem.
  This is done for all usages of `TxFileManager.WriteAllText`, including the repo data JSONs, the registry, and the files we create when making fake instances.
  Fixes #4503.
