### PR TITLE
Automatically pull focus for the Terminal window on MacOS

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -23,6 +23,7 @@ cd "$MACOS_PATH"
 
 osascript <<END
 tell application "Terminal"
-    do script "cd \"`pwd`\"; ./CKAN-CmdLine consoleui" in front window
+    activate
+    do script "cd \"`pwd`\"; ./CKAN-CmdLine consoleui"
 end tell
 END

--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -23,6 +23,6 @@ cd "$MACOS_PATH"
 
 osascript <<END
 tell application "Terminal"
-    do script "cd \"`pwd`\"; ./CKAN-CmdLine consoleui"
+    do script "cd \"`pwd`\"; ./CKAN-CmdLine consoleui" in front window
 end tell
 END


### PR DESCRIPTION
When you open CKAN in MacOS, it doesn't automatically focus the Terminal window. This means it gets hidden behind other windows, and you have to alt-tab to find and focus it.

This PR automatically focuses the Terminal window.