### PR TITLE
Resets Play Button state if the game launch is cancelled

### DIFF
--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -978,6 +978,7 @@ namespace CKAN.GUI
                         Properties.Resources.MainGoBack);
                     if (result.Item1 != DialogResult.Yes)
                     {
+                        ManageMods.OnGameExit();
                         return;
                     }
                     else if (result.Item2)


### PR DESCRIPTION
I realized that when a mod conflict or error gets detected upon clicking the "Play" button, and the user cancel the game launch, the button becomes semi-permanently inactive until CKAN restart. Hope this fixes it.