### PR TITLE
Improve error messages for provide conflicts

### DIFF
--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -282,6 +282,7 @@ Which {0} provider would you like to install?</value></data>
 If the game is still running, close it and try again. Otherwise check the permissions.</value></data>
   <data name="KrakenMissingDependency" xml:space="preserve"><value>Unsatisfied dependency {1} needed for: {0}</value></data>
   <data name="KrakenMissingDependencyNeededFor" xml:space="preserve"><value>needed for {0}</value></data>
+  <data name="KrakenRejectedProvidesConflict" xml:space="preserve"><value>{0} is needed for {3}, but cannot be installed because it conflicts with {2} which also provides {1}</value></data>
   <data name="KrakenConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="KrakenFileExistsWithOwner" xml:space="preserve"><value>Oh no! We tried to overwrite a file owned by another mod!
 

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -283,6 +283,7 @@ If the game is still running, close it and try again. Otherwise check the permis
   <data name="KrakenMissingDependency" xml:space="preserve"><value>Unsatisfied dependency {1} needed for: {0}</value></data>
   <data name="KrakenMissingDependencyNeededFor" xml:space="preserve"><value>needed for {0}</value></data>
   <data name="KrakenRejectedProvidesConflict" xml:space="preserve"><value>{0} is needed for {3}, but cannot be installed because it conflicts with {2} which also provides {1}</value></data>
+  <data name="KrakenRejectedConflict" xml:space="preserve"><value>{0} is needed for {2}, but cannot be installed because it conflicts with {1}</value></data>
   <data name="KrakenConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="KrakenFileExistsWithOwner" xml:space="preserve"><value>Oh no! We tried to overwrite a file owned by another mod!
 

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -284,6 +284,8 @@ If the game is still running, close it and try again. Otherwise check the permis
   <data name="KrakenMissingDependencyNeededFor" xml:space="preserve"><value>needed for {0}</value></data>
   <data name="KrakenRejectedProvidesConflict" xml:space="preserve"><value>{0} is needed for {3}, but cannot be installed because it conflicts with {2} which also provides {1}</value></data>
   <data name="KrakenRejectedConflict" xml:space="preserve"><value>{0} is needed for {2}, but cannot be installed because it conflicts with {1}</value></data>
+  <data name="KrakenRejectedVersionMismatch" xml:space="preserve"><value>Version conflict: {0} is needed for {2}, but {1} is already being installed</value></data>
+  <data name="KrakenRejectedVersionMismatchFor" xml:space="preserve"><value>Version conflict: {0} is needed for {2}, and {1} is needed for {3}, but both cannot be installed at the same time</value></data>
   <data name="KrakenConflictsWith" xml:space="preserve"><value>{0} conflicts with {1}</value></data>
   <data name="KrakenFileExistsWithOwner" xml:space="preserve"><value>Oh no! We tried to overwrite a file owned by another mod!
 

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -282,7 +282,7 @@ Which {0} provider would you like to install?</value></data>
 If the game is still running, close it and try again. Otherwise check the permissions.</value></data>
   <data name="KrakenMissingDependency" xml:space="preserve"><value>Unsatisfied dependency {1} needed for: {0}</value></data>
   <data name="KrakenMissingDependencyNeededFor" xml:space="preserve"><value>needed for {0}</value></data>
-  <data name="KrakenRejectedProvidesConflict" xml:space="preserve"><value>{0} is needed for {3}, but cannot be installed because it conflicts with {2} which also provides {1}</value></data>
+  <data name="KrakenRejectedProvidesConflict" xml:space="preserve"><value>{0} is needed for {3}, but cannot be installed because it conflicts with {2}, which also provides {1}</value></data>
   <data name="KrakenRejectedConflict" xml:space="preserve"><value>{0} is needed for {2}, but cannot be installed because it conflicts with {1}</value></data>
   <data name="KrakenRejectedVersionMismatch" xml:space="preserve"><value>Version conflict: {0} is needed for {2}, but {1} is already being installed</value></data>
   <data name="KrakenRejectedVersionMismatchFor" xml:space="preserve"><value>Version conflict: {0} is needed for {2}, and {1} is needed for {3}, but both cannot be installed at the same time</value></data>

--- a/Core/Relationships/RejectedProvider.cs
+++ b/Core/Relationships/RejectedProvider.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CKAN
+{
+    public abstract class RejectedProvider
+    {
+        public readonly CkanModule provider;
+
+        protected RejectedProvider(CkanModule provider)
+        {
+            this.provider = provider;
+        }
+    }
+
+    public sealed class RejectedByRelationship : RejectedProvider
+    {
+        public readonly Relationship violation;
+
+        public RejectedByRelationship(CkanModule provider, Relationship violation)
+            : base(provider)
+        {
+            this.violation = violation;
+        }
+
+        public static IEnumerable<RejectedByRelationship> WrapMany(
+                CkanModule                candidate,
+                IEnumerable<Relationship> violations)
+            => violations.Select(r => new RejectedByRelationship(candidate, r));
+
+        [ExcludeFromCodeCoverage]
+        public override bool Equals(object? other)
+            => other is RejectedByRelationship r
+               && provider.Equals(r.provider)
+               && violation.Equals(r.violation);
+
+        public override int GetHashCode()
+            => (provider, violation).GetHashCode();
+    }
+
+    public sealed class RejectedByConflict : RejectedProvider
+    {
+        public readonly string?    sharedProvidesId;
+        public readonly CkanModule blockingMod;
+        public readonly bool       blockerIsInstalled;
+
+        public RejectedByConflict(CkanModule provider,
+                                  string?    sharedProvidesId,
+                                  CkanModule blockingMod,
+                                  bool       blockerIsInstalled)
+            : base(provider)
+        {
+            this.sharedProvidesId   = sharedProvidesId;
+            this.blockingMod        = blockingMod;
+            this.blockerIsInstalled = blockerIsInstalled;
+        }
+
+        [ExcludeFromCodeCoverage]
+        public override bool Equals(object? other)
+            => other is RejectedByConflict r
+               && provider.Equals(r.provider)
+               && sharedProvidesId == r.sharedProvidesId
+               && blockingMod.Equals(r.blockingMod)
+               && blockerIsInstalled == r.blockerIsInstalled;
+
+        public override int GetHashCode()
+            => (provider, sharedProvidesId, blockingMod, blockerIsInstalled).GetHashCode();
+
+        [ExcludeFromCodeCoverage]
+        public override string ToString()
+            => $"{provider}, {sharedProvidesId}, {blockingMod}, {blockerIsInstalled}";
+    }
+
+    public sealed class RejectedByVersionMismatch : RejectedProvider
+    {
+        public readonly CkanModule             blockingMod;
+        public readonly ResolvedRelationship[] blockerChain;
+
+        public RejectedByVersionMismatch(CkanModule              provider,
+                                         CkanModule              blockingMod,
+                                         ResolvedRelationship[]? blockerChain = null)
+            : base(provider)
+        {
+            this.blockingMod  = blockingMod;
+            this.blockerChain = blockerChain ?? Array.Empty<ResolvedRelationship>();
+        }
+
+        [ExcludeFromCodeCoverage]
+        public override bool Equals(object? other)
+            => other is RejectedByVersionMismatch r
+               && provider.Equals(r.provider)
+               && blockingMod.Equals(r.blockingMod);
+
+        public override int GetHashCode()
+            => (provider, blockingMod).GetHashCode();
+    }
+
+}

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -291,8 +291,25 @@ namespace CKAN
                     log.DebugFormat("Got {0} candidates for {1}",
                                     candidates.Count, descriptor);
                 }
+                catch (DependenciesNotSatisfiedKraken k)
+                when (options.proceed_with_inconsistencies)
+                {
+                    foreach (var u in k.unsatisfied)
+                    {
+                        switch (u.rejection)
+                        {
+                            case RejectedByConflict rjc:
+                                AddReason(rjc.provider,
+                                          u.depends.LastOrDefault()?.reason ?? reason);
+                                conflicts.Add(new ModPair(rjc.provider, rjc.blockingMod));
+                                conflicts.Add(new ModPair(rjc.blockingMod, rjc.provider));
+                                break;
+                        }
+                    }
+                    continue;
+                }
                 catch
-                when (soft_resolve || options.proceed_with_inconsistencies)
+                when (soft_resolve)
                 {
                     log.InfoFormat("{0} is recommended/suggested but it is not listed in the index, or not available for your game version.",
                                    descriptor);
@@ -575,7 +592,7 @@ namespace CKAN
         /// <summary>
         /// Return descriptions of all the current conflicts.
         /// Avoids duplicates and explains why dependencies are in the list.
-        /// Use for reporting the conflicts to the user, use ConflictsList for coloring rows.
+        /// Use for reporting the conflicts to the user, use ConflictList for coloring rows.
         /// </summary>
         public IEnumerable<string> ConflictDescriptions
             => conflicts.Where(kvp => kvp.Value == null

--- a/Core/Relationships/ResolutionContext.cs
+++ b/Core/Relationships/ResolutionContext.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+using CKAN.Configuration;
+using CKAN.Versioning;
+
+namespace CKAN
+{
+
+    public sealed class ResolutionContext
+    {
+        public readonly IRegistryQuerier                Registry;
+        public readonly IReadOnlyCollection<CkanModule> Installed;
+        public readonly IReadOnlyCollection<CkanModule> Installing;
+        public readonly StabilityToleranceConfig        StabilityTolerance;
+        public readonly GameVersionCriteria             Crit;
+
+        public ResolutionContext(IRegistryQuerier                registry,
+                                 IReadOnlyCollection<CkanModule> installed,
+                                 IReadOnlyCollection<CkanModule> installing,
+                                 StabilityToleranceConfig        stabilityTolerance,
+                                 GameVersionCriteria             crit)
+        {
+            Registry           = registry;
+            Installed          = installed;
+            Installing         = installing;
+            StabilityTolerance = stabilityTolerance;
+            Crit               = crit;
+        }
+    }
+}

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -30,6 +30,11 @@ namespace CKAN
             this.violation = violation;
         }
 
+        public static IEnumerable<RejectedByRelationship> WrapMany(
+                CkanModule                candidate,
+                IEnumerable<Relationship> violations)
+            => violations.Select(r => new RejectedByRelationship(candidate, r));
+
         public override bool Equals(object? other)
             => other is RejectedByRelationship r
                && provider.Equals(r.provider)
@@ -39,31 +44,31 @@ namespace CKAN
             => (provider, violation).GetHashCode();
     }
 
-    public sealed class RejectedByProvidesConflict : ProviderRejection
+    public sealed class RejectedByConflict : ProviderRejection
     {
-        public readonly string     providedIdentifier;
+        public readonly string?    sharedProvidesId;
         public readonly CkanModule blockingMod;
         public readonly bool       blockerIsInstalled;
-        public RejectedByProvidesConflict(CkanModule provider,
-                                          string     providedIdentifier,
-                                          CkanModule blockingMod,
-                                          bool       blockerIsInstalled)
+        public RejectedByConflict(CkanModule provider,
+                                  string?    sharedProvidesId,
+                                  CkanModule blockingMod,
+                                  bool       blockerIsInstalled)
             : base(provider)
         {
-            this.providedIdentifier = providedIdentifier;
+            this.sharedProvidesId   = sharedProvidesId;
             this.blockingMod        = blockingMod;
             this.blockerIsInstalled = blockerIsInstalled;
         }
 
         public override bool Equals(object? other)
-            => other is RejectedByProvidesConflict r
+            => other is RejectedByConflict r
                && provider.Equals(r.provider)
-               && providedIdentifier == r.providedIdentifier
+               && sharedProvidesId == r.sharedProvidesId
                && blockingMod.Equals(r.blockingMod)
                && blockerIsInstalled == r.blockerIsInstalled;
 
         public override int GetHashCode()
-            => (provider, providedIdentifier, blockingMod, blockerIsInstalled).GetHashCode();
+            => (provider, sharedProvidesId, blockingMod, blockerIsInstalled).GetHashCode();
     }
 
     public sealed class ResolutionContext
@@ -362,10 +367,9 @@ namespace CKAN
                 var unsatisfied = new List<UnsatisfiedRelation>();
                 foreach ((CkanModule module, ResolvedRelationship[] resRels) in resolved)
                 {
-                    if (module.BadRelationships(installing)
-                              .Select(r => new UnsatisfiedRelation(new ResolvedRelationship[] { this },
-                                                                   new RejectedByRelationship(module, r)))
-                              .ToArray()
+                    if (RejectedByRelationship.WrapMany(module, module.BadRelationships(installing))
+                            .Select(rej => new UnsatisfiedRelation(new ResolvedRelationship[] { this }, rej))
+                            .ToArray()
                         is { Length: > 0 } badRels)
                     {
                         unsatisfied.AddRange(badRels);
@@ -404,11 +408,13 @@ namespace CKAN
             foreach (var module in relationship.LatestAvailableWithProvides(
                          context.Registry, context.StabilityTolerance, context.Crit, null, null))
             {
-                var rejection = FindProvidesConflict(module, context.Installing, context.Installed)
-                                ?? module.BadRelationships(context.Installed)
-                                          .Concat(module.BadRelationships(context.Installing))
-                                          .Select(r => (ProviderRejection)new RejectedByRelationship(module, r))
-                                          .FirstOrDefault();
+                var rejection = FindConflict(module, context.Installing, context.Installed)
+                                ?? (ProviderRejection?)RejectedByRelationship.WrapMany(
+                                       module,
+                                       module.BadRelationships(context.Installed)
+                                             .Concat(module.BadRelationships(context.Installing))
+                                             .Where(r => r.Type == RelationshipType.Depends))
+                                   .FirstOrDefault();
                 if (rejection != null)
                 {
                     yield return new UnsatisfiedRelation(
@@ -417,10 +423,11 @@ namespace CKAN
             }
         }
 
-        // Find modules that conflict with each other through a provides relation.
-        // This only happens when one of the mods involved explicitly conflicts with
-        // either the virtual provides id, or each other.
-        public static ProviderRejection? FindProvidesConflict(
+        // Find a mod that explicitly conflicts with the candidate (in either
+        // direction). Returns a rejection naming both sides; if they happen to
+        // share a virtual provides id, that's recorded for nicer messaging but
+        // is not required for the rejection to fire.
+        public static ProviderRejection? FindConflict(
             CkanModule                      candidate,
             IReadOnlyCollection<CkanModule> installing,
             IReadOnlyCollection<CkanModule> installed)
@@ -428,37 +435,36 @@ namespace CKAN
             foreach (var blocker in installed)
             {
                 if (blocker.identifier != candidate.identifier
-                    && ProvidesConflictId(candidate, blocker) is string id)
+                    && HasExplicitConflict(candidate, blocker))
                 {
-                    return new RejectedByProvidesConflict(candidate, id, blocker, blockerIsInstalled: true);
+                    return new RejectedByConflict(candidate, SharedProvidesId(candidate, blocker),
+                                                  blocker, blockerIsInstalled: true);
                 }
             }
 
             foreach (var blocker in installing)
             {
                 if (blocker.identifier != candidate.identifier
-                    && ProvidesConflictId(candidate, blocker) is string id)
+                    && HasExplicitConflict(candidate, blocker))
                 {
-                    return new RejectedByProvidesConflict(candidate, id, blocker, blockerIsInstalled: false);
+                    return new RejectedByConflict(candidate, SharedProvidesId(candidate, blocker),
+                                                  blocker, blockerIsInstalled: false);
                 }
             }
 
             return null;
         }
 
-        private static string? ProvidesConflictId(CkanModule candidate, CkanModule blocker)
-        {
-            // Only flag when there's an explicit conflicts clause (either direction).
-            // Multiple modules providing the same id is fine on its own.
-            if (!candidate.BadRelationships(new[] { blocker })
-                          .Any(r => r.Type == RelationshipType.Conflicts))
-            {
-                return null;
-            }
+        private static bool HasExplicitConflict(CkanModule candidate, CkanModule blocker)
+            => candidate.BadRelationships(new[] { blocker })
+                        .Any(r => r.Type == RelationshipType.Conflicts);
 
-            // Find a shared id for the message — include each side's identifier as
-            // an implicit provide so identifier-shadowing cases still produce a
-            // meaningful name.
+        // Best-effort: find a shared virtual id between the two mods so the
+        // message can name it. Each side's identifier is treated as an implicit
+        // provide so identifier-shadowing cases still produce a meaningful name.
+        // Returns null when there is no shared id; the conflict still stands.
+        private static string? SharedProvidesId(CkanModule candidate, CkanModule blocker)
+        {
             var blockerIds = new HashSet<string>(blocker.provides ?? Enumerable.Empty<string>())
             {
                 blocker.identifier,

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -12,6 +12,78 @@ namespace CKAN
 {
     using RelationshipCache = ConcurrentDictionary<RelationshipDescriptor, ResolvedRelationship>;
 
+    public abstract class ProviderRejection
+    {
+        public readonly CkanModule provider;
+        protected ProviderRejection(CkanModule provider)
+        {
+            this.provider = provider;
+        }
+    }
+
+    public sealed class RejectedByRelationship : ProviderRejection
+    {
+        public readonly Relationship violation;
+        public RejectedByRelationship(CkanModule provider, Relationship violation)
+            : base(provider)
+        {
+            this.violation = violation;
+        }
+
+        public override bool Equals(object? other)
+            => other is RejectedByRelationship r
+               && provider.Equals(r.provider)
+               && violation.Equals(r.violation);
+
+        public override int GetHashCode()
+            => (provider, violation).GetHashCode();
+    }
+
+    public sealed class RejectedByProvidesConflict : ProviderRejection
+    {
+        public readonly string     providedIdentifier;
+        public readonly CkanModule blockingMod;
+        public readonly bool       blockerIsInstalled;
+        public RejectedByProvidesConflict(CkanModule provider,
+                                          string     providedIdentifier,
+                                          CkanModule blockingMod,
+                                          bool       blockerIsInstalled)
+            : base(provider)
+        {
+            this.providedIdentifier = providedIdentifier;
+            this.blockingMod        = blockingMod;
+            this.blockerIsInstalled = blockerIsInstalled;
+        }
+
+        public override bool Equals(object? other)
+            => other is RejectedByProvidesConflict r
+               && provider.Equals(r.provider)
+               && providedIdentifier == r.providedIdentifier
+               && blockingMod.Equals(r.blockingMod)
+               && blockerIsInstalled == r.blockerIsInstalled;
+
+        public override int GetHashCode()
+            => (provider, providedIdentifier, blockingMod, blockerIsInstalled).GetHashCode();
+    }
+
+    public sealed class RejectedByVersionMismatch : ProviderRejection
+    {
+        public readonly CkanModule blockingMod;
+        public RejectedByVersionMismatch(CkanModule provider, CkanModule blockingMod)
+            : base(provider)
+        {
+            this.blockingMod = blockingMod;
+        }
+
+        public override bool Equals(object? other)
+            => other is RejectedByVersionMismatch r
+               && provider.Equals(r.provider)
+               && blockingMod.Equals(r.blockingMod);
+
+        public override int GetHashCode()
+            => (provider, blockingMod).GetHashCode();
+    }
+
     public abstract class ResolvedRelationship : IEquatable<ResolvedRelationship>
     {
         public ResolvedRelationship(CkanModule             source,
@@ -56,13 +128,13 @@ namespace CKAN
             => (source, relationship, reason).GetHashCode();
 
 
-        public virtual IEnumerable<ResolvedRelationship[]> UnsatisfiedFrom()
+        public virtual IEnumerable<UnsatisfiedRelation> UnsatisfiedFrom()
             => reason is SelectionReason.Depends && Unsatisfied()
-                   ? Enumerable.Repeat(new ResolvedRelationship[] { this }, 1)
-                   : Enumerable.Empty<ResolvedRelationship[]>();
+                   ? Enumerable.Repeat(new UnsatisfiedRelation(new ResolvedRelationship[] { this }, null), 1)
+                   : Enumerable.Empty<UnsatisfiedRelation>();
 
-        public virtual IReadOnlyCollection<(ResolvedRelationship[], Relationship)> BadRelationships(IReadOnlyCollection<CkanModule> installing)
-            => Array.Empty<(ResolvedRelationship[], Relationship)>();
+        public virtual IReadOnlyCollection<UnsatisfiedRelation> BadRelationships(IReadOnlyCollection<CkanModule> installing)
+            => Array.Empty<UnsatisfiedRelation>();
     }
 
     public class ResolvedByInstalled : ResolvedRelationship
@@ -218,7 +290,7 @@ namespace CKAN
                                 : new ResolvedByNew(newSrc, relationship, newRsn, resolved);
 
 
-        public override IEnumerable<ResolvedRelationship[]> UnsatisfiedFrom()
+        public override IEnumerable<UnsatisfiedRelation> UnsatisfiedFrom()
         {
             // Our goal here is to return an array of ResolvedRelationships for each full
             // trace from rr to a relationship we can't satisfy.
@@ -228,7 +300,7 @@ namespace CKAN
                 // Now if this relationship itself can't be resolved directly, return it.
                 if (Unsatisfied())
                 {
-                    return Enumerable.Repeat(new ResolvedRelationship[] { this }, 1);
+                    return Enumerable.Repeat(new UnsatisfiedRelation(new ResolvedRelationship[] { this }, null), 1);
                 }
                 // Now we know it's a dependency that has at least one option for satisfying it,
                 // but those options may or may not be fully satisfied when considering _their_ dependencies.
@@ -242,29 +314,32 @@ namespace CKAN
 
                 return unsats.Any(u => u.Length == 0)
                     // One of the dependencies is fully satisfied
-                    ? Enumerable.Empty<ResolvedRelationship[]>()
-                    : unsats.SelectMany(uns => uns.Select(u => u.Prepend(this).ToArray()));
+                    ? Enumerable.Empty<UnsatisfiedRelation>()
+                    : unsats.SelectMany(uns => uns.Select(u => new UnsatisfiedRelation(
+                                                                   u.depends.Prepend(this).ToArray(),
+                                                                   u.rejection)));
             }
-            return Enumerable.Empty<ResolvedRelationship[]>();
+            return Enumerable.Empty<UnsatisfiedRelation>();
         }
 
-        public override IReadOnlyCollection<(ResolvedRelationship[], Relationship)> BadRelationships(IReadOnlyCollection<CkanModule> installing)
+        public override IReadOnlyCollection<UnsatisfiedRelation> BadRelationships(IReadOnlyCollection<CkanModule> installing)
         {
             if (reason is SelectionReason.Depends)
             {
-                var unsatisfied = new List<(ResolvedRelationship[], Relationship)>();
+                var unsatisfied = new List<UnsatisfiedRelation>();
                 foreach ((CkanModule module, ResolvedRelationship[] resRels) in resolved)
                 {
                     if (module.BadRelationships(installing)
-                              .Select(r => (new ResolvedRelationship[] { this }, r))
+                              .Select(r => new UnsatisfiedRelation(new ResolvedRelationship[] { this },
+                                                                   new RejectedByRelationship(module, r)))
                               .ToArray()
                         is { Length: > 0 } badRels)
                     {
                         unsatisfied.AddRange(badRels);
                     }
                     else if (resRels.SelectMany(rr => rr.BadRelationships(installing))
-                                    .Select(tuple => (tuple.Item1.Prepend(this).ToArray(),
-                                                      tuple.Item2))
+                                    .Select(u => new UnsatisfiedRelation(u.depends.Prepend(this).ToArray(),
+                                                                         u.rejection))
                                     .ToArray()
                              is { Length: > 0 } badRRs)
                     {
@@ -273,12 +348,32 @@ namespace CKAN
                     else
                     {
                         // This relationship is satisfied
-                        return Array.Empty<(ResolvedRelationship[], Relationship)>();
+                        return Array.Empty<UnsatisfiedRelation>();
                     }
                 }
                 return unsatisfied;
             }
-            return Array.Empty<(ResolvedRelationship[], Relationship)>();
+            return Array.Empty<UnsatisfiedRelation>();
+        }
+    }
+
+    public sealed class UnsatisfiedRelation
+    {
+        /// <summary>
+        /// The dependency chain to reach this relationship.
+        /// </summary>
+        public readonly ResolvedRelationship[] depends;
+
+        /// <summary>
+        /// The reason that this relationship could not be satisfied, if any.
+        /// </summary>
+        public readonly ProviderRejection? rejection;
+
+        public UnsatisfiedRelation(ResolvedRelationship[] depends,
+                                   ProviderRejection? rejection)
+        {
+            this.depends = depends;
+            this.rejection = rejection;
         }
     }
 }

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -66,6 +66,28 @@ namespace CKAN
             => (provider, providedIdentifier, blockingMod, blockerIsInstalled).GetHashCode();
     }
 
+    public sealed class ResolutionContext
+    {
+        public readonly IRegistryQuerier                Registry;
+        public readonly IReadOnlyCollection<CkanModule> Installed;
+        public readonly IReadOnlyCollection<CkanModule> Installing;
+        public readonly StabilityToleranceConfig        StabilityTolerance;
+        public readonly GameVersionCriteria             Crit;
+
+        public ResolutionContext(IRegistryQuerier                registry,
+                                 IReadOnlyCollection<CkanModule> installed,
+                                 IReadOnlyCollection<CkanModule> installing,
+                                 StabilityToleranceConfig        stabilityTolerance,
+                                 GameVersionCriteria             crit)
+        {
+            Registry           = registry;
+            Installed          = installed;
+            Installing         = installing;
+            StabilityTolerance = stabilityTolerance;
+            Crit               = crit;
+        }
+    }
+
     public sealed class RejectedByVersionMismatch : ProviderRejection
     {
         public readonly CkanModule blockingMod;
@@ -210,10 +232,12 @@ namespace CKAN
         public ResolvedByNew(CkanModule                                              source,
                              RelationshipDescriptor                                  relationship,
                              SelectionReason                                         reason,
-                             IReadOnlyDictionary<CkanModule, ResolvedRelationship[]> resolved)
+                             IReadOnlyDictionary<CkanModule, ResolvedRelationship[]> resolved,
+                             ResolutionContext?                                      context = null)
               : base(source, relationship, reason)
         {
             this.resolved = resolved;
+            this.context  = context;
         }
 
         public ResolvedByNew(CkanModule             source,
@@ -252,7 +276,10 @@ namespace CKAN
                                                        providers.Count == 1
                                                            ? relationshipCache
                                                            : new RelationshipCache(relationshipCache))
-                                                       .ToArray()))
+                                                       .ToArray()),
+                    new ResolutionContext(registry, installed,
+                                          allInstalling.Append(source).ToArray(),
+                                          stabilityTolerance, crit))
         {
         }
 
@@ -261,6 +288,11 @@ namespace CKAN
         /// If this is empty, then the relationship cannot be satisfied.
         /// </summary>
         public readonly IReadOnlyDictionary<CkanModule, ResolvedRelationship[]> resolved;
+
+        /// <summary>
+        /// The world this relationship was resolved against, if known.
+        /// </summary>
+        public readonly ResolutionContext? context;
 
         public override bool Contains(CkanModule mod)
             => resolved.Any(rr => rr.Key == mod || rr.Value.Any(rrr => rrr.Contains(mod)));
@@ -287,7 +319,7 @@ namespace CKAN
 
         public override ResolvedRelationship WithSource(CkanModule newSrc, SelectionReason newRsn)
             => source == newSrc ? this
-                                : new ResolvedByNew(newSrc, relationship, newRsn, resolved);
+                                : new ResolvedByNew(newSrc, relationship, newRsn, resolved, context);
 
 
         public override IEnumerable<UnsatisfiedRelation> UnsatisfiedFrom()
@@ -354,6 +386,66 @@ namespace CKAN
                 return unsatisfied;
             }
             return Array.Empty<UnsatisfiedRelation>();
+        }
+
+        /// <summary>
+        /// Re-resolves this relationship without filters and returns a list of
+        /// <see cref="UnsatisfiedRelation"/> that describe why each candidate
+        /// would be rejected.
+        /// </summary>
+        public IEnumerable<UnsatisfiedRelation> UnsatisfiedCandidates()
+        {
+            if (context == null)
+            {
+                yield break;
+            }
+
+            foreach (var module in relationship.LatestAvailableWithProvides(
+                         context.Registry, context.StabilityTolerance, context.Crit, null, null))
+            {
+                var rejection = FindProvidesConflict(module, context.Installing, context.Installed)
+                                ?? module.BadRelationships(context.Installed)
+                                          .Concat(module.BadRelationships(context.Installing))
+                                          .Select(r => (ProviderRejection)new RejectedByRelationship(module, r))
+                                          .FirstOrDefault();
+                if (rejection != null)
+                {
+                    yield return new UnsatisfiedRelation(
+                        new ResolvedRelationship[] { this }, rejection);
+                }
+            }
+        }
+
+        public static ProviderRejection? FindProvidesConflict(
+            CkanModule                      candidate,
+            IReadOnlyCollection<CkanModule> installing,
+            IReadOnlyCollection<CkanModule> installed)
+        {
+            if (candidate.provides == null)
+            {
+                return null;
+            }
+
+            foreach (var providedId in candidate.provides)
+            {
+                var installedConflict = installed.FirstOrDefault(m => m.identifier != candidate.identifier
+                                                                   && (m.identifier == providedId
+                                                                       || (m.provides?.Contains(providedId) ?? false)));
+                if (installedConflict != null)
+                {
+                    return new RejectedByProvidesConflict(candidate, providedId, installedConflict, blockerIsInstalled: true);
+                }
+
+                var installingConflict = installing.FirstOrDefault(m => m.identifier != candidate.identifier
+                                                                     && (m.identifier == providedId
+                                                                         || (m.provides?.Contains(providedId) ?? false)));
+                if (installingConflict != null)
+                {
+                    return new RejectedByProvidesConflict(candidate, providedId, installingConflict, blockerIsInstalled: false);
+                }
+            }
+
+            return null;
         }
     }
 

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -279,7 +279,8 @@ namespace CKAN
                                                        .ToArray()),
                     new ResolutionContext(registry, installed,
                                           allInstalling.Append(source).ToArray(),
-                                          stabilityTolerance, crit))
+                                          new StabilityToleranceConfig(stabilityTolerance),
+                                          crit))
         {
         }
 

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -416,36 +416,56 @@ namespace CKAN
             }
         }
 
+        // Find modules that conflict with each other through a provides relation.
+        // This only happens when one of the mods involved explicitly conflicts with
+        // either the virtual provides id, or each other.
         public static ProviderRejection? FindProvidesConflict(
             CkanModule                      candidate,
             IReadOnlyCollection<CkanModule> installing,
             IReadOnlyCollection<CkanModule> installed)
         {
-            if (candidate.provides == null)
+            foreach (var blocker in installed)
             {
-                return null;
+                if (blocker.identifier != candidate.identifier
+                    && ProvidesConflictId(candidate, blocker) is string id)
+                {
+                    return new RejectedByProvidesConflict(candidate, id, blocker, blockerIsInstalled: true);
+                }
             }
 
-            foreach (var providedId in candidate.provides)
+            foreach (var blocker in installing)
             {
-                var installedConflict = installed.FirstOrDefault(m => m.identifier != candidate.identifier
-                                                                   && (m.identifier == providedId
-                                                                       || (m.provides?.Contains(providedId) ?? false)));
-                if (installedConflict != null)
+                if (blocker.identifier != candidate.identifier
+                    && ProvidesConflictId(candidate, blocker) is string id)
                 {
-                    return new RejectedByProvidesConflict(candidate, providedId, installedConflict, blockerIsInstalled: true);
-                }
-
-                var installingConflict = installing.FirstOrDefault(m => m.identifier != candidate.identifier
-                                                                     && (m.identifier == providedId
-                                                                         || (m.provides?.Contains(providedId) ?? false)));
-                if (installingConflict != null)
-                {
-                    return new RejectedByProvidesConflict(candidate, providedId, installingConflict, blockerIsInstalled: false);
+                    return new RejectedByProvidesConflict(candidate, id, blocker, blockerIsInstalled: false);
                 }
             }
 
             return null;
+        }
+
+        private static string? ProvidesConflictId(CkanModule candidate, CkanModule blocker)
+        {
+            // Only flag when there's an explicit conflicts clause (either direction).
+            // Multiple modules providing the same id is fine on its own.
+            if (!candidate.BadRelationships(new[] { blocker })
+                          .Any(r => r.Type == RelationshipType.Conflicts))
+            {
+                return null;
+            }
+
+            // Find a shared id for the message — include each side's identifier as
+            // an implicit provide so identifier-shadowing cases still produce a
+            // meaningful name.
+            var blockerIds = new HashSet<string>(blocker.provides ?? Enumerable.Empty<string>())
+            {
+                blocker.identifier,
+            };
+
+            return (candidate.provides ?? Enumerable.Empty<string>())
+                       .Append(candidate.identifier)
+                       .FirstOrDefault(blockerIds.Contains);
         }
     }
 

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -95,11 +95,15 @@ namespace CKAN
 
     public sealed class RejectedByVersionMismatch : ProviderRejection
     {
-        public readonly CkanModule blockingMod;
-        public RejectedByVersionMismatch(CkanModule provider, CkanModule blockingMod)
+        public readonly CkanModule             blockingMod;
+        public readonly ResolvedRelationship[] blockerChain;
+        public RejectedByVersionMismatch(CkanModule              provider,
+                                         CkanModule              blockingMod,
+                                         ResolvedRelationship[]? blockerChain = null)
             : base(provider)
         {
-            this.blockingMod = blockingMod;
+            this.blockingMod  = blockingMod;
+            this.blockerChain = blockerChain ?? Array.Empty<ResolvedRelationship>();
         }
 
         public override bool Equals(object? other)

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -12,109 +12,6 @@ namespace CKAN
 {
     using RelationshipCache = ConcurrentDictionary<RelationshipDescriptor, ResolvedRelationship>;
 
-    public abstract class ProviderRejection
-    {
-        public readonly CkanModule provider;
-        protected ProviderRejection(CkanModule provider)
-        {
-            this.provider = provider;
-        }
-    }
-
-    public sealed class RejectedByRelationship : ProviderRejection
-    {
-        public readonly Relationship violation;
-        public RejectedByRelationship(CkanModule provider, Relationship violation)
-            : base(provider)
-        {
-            this.violation = violation;
-        }
-
-        public static IEnumerable<RejectedByRelationship> WrapMany(
-                CkanModule                candidate,
-                IEnumerable<Relationship> violations)
-            => violations.Select(r => new RejectedByRelationship(candidate, r));
-
-        public override bool Equals(object? other)
-            => other is RejectedByRelationship r
-               && provider.Equals(r.provider)
-               && violation.Equals(r.violation);
-
-        public override int GetHashCode()
-            => (provider, violation).GetHashCode();
-    }
-
-    public sealed class RejectedByConflict : ProviderRejection
-    {
-        public readonly string?    sharedProvidesId;
-        public readonly CkanModule blockingMod;
-        public readonly bool       blockerIsInstalled;
-        public RejectedByConflict(CkanModule provider,
-                                  string?    sharedProvidesId,
-                                  CkanModule blockingMod,
-                                  bool       blockerIsInstalled)
-            : base(provider)
-        {
-            this.sharedProvidesId   = sharedProvidesId;
-            this.blockingMod        = blockingMod;
-            this.blockerIsInstalled = blockerIsInstalled;
-        }
-
-        public override bool Equals(object? other)
-            => other is RejectedByConflict r
-               && provider.Equals(r.provider)
-               && sharedProvidesId == r.sharedProvidesId
-               && blockingMod.Equals(r.blockingMod)
-               && blockerIsInstalled == r.blockerIsInstalled;
-
-        public override int GetHashCode()
-            => (provider, sharedProvidesId, blockingMod, blockerIsInstalled).GetHashCode();
-    }
-
-    public sealed class ResolutionContext
-    {
-        public readonly IRegistryQuerier                Registry;
-        public readonly IReadOnlyCollection<CkanModule> Installed;
-        public readonly IReadOnlyCollection<CkanModule> Installing;
-        public readonly StabilityToleranceConfig        StabilityTolerance;
-        public readonly GameVersionCriteria             Crit;
-
-        public ResolutionContext(IRegistryQuerier                registry,
-                                 IReadOnlyCollection<CkanModule> installed,
-                                 IReadOnlyCollection<CkanModule> installing,
-                                 StabilityToleranceConfig        stabilityTolerance,
-                                 GameVersionCriteria             crit)
-        {
-            Registry           = registry;
-            Installed          = installed;
-            Installing         = installing;
-            StabilityTolerance = stabilityTolerance;
-            Crit               = crit;
-        }
-    }
-
-    public sealed class RejectedByVersionMismatch : ProviderRejection
-    {
-        public readonly CkanModule             blockingMod;
-        public readonly ResolvedRelationship[] blockerChain;
-        public RejectedByVersionMismatch(CkanModule              provider,
-                                         CkanModule              blockingMod,
-                                         ResolvedRelationship[]? blockerChain = null)
-            : base(provider)
-        {
-            this.blockingMod  = blockingMod;
-            this.blockerChain = blockerChain ?? Array.Empty<ResolvedRelationship>();
-        }
-
-        public override bool Equals(object? other)
-            => other is RejectedByVersionMismatch r
-               && provider.Equals(r.provider)
-               && blockingMod.Equals(r.blockingMod);
-
-        public override int GetHashCode()
-            => (provider, blockingMod).GetHashCode();
-    }
-
     public abstract class ResolvedRelationship : IEquatable<ResolvedRelationship>
     {
         public ResolvedRelationship(CkanModule             source,
@@ -413,7 +310,7 @@ namespace CKAN
                          context.Registry, context.StabilityTolerance, context.Crit, null, null))
             {
                 var rejection = FindConflict(module, context.Installing, context.Installed)
-                                ?? (ProviderRejection?)RejectedByRelationship.WrapMany(
+                                ?? (RejectedProvider?)RejectedByRelationship.WrapMany(
                                        module,
                                        module.BadRelationships(context.Installed)
                                              .Concat(module.BadRelationships(context.Installing))
@@ -431,7 +328,7 @@ namespace CKAN
         // direction). Returns a rejection naming both sides; if they happen to
         // share a virtual provides id, that's recorded for nicer messaging but
         // is not required for the rejection to fire.
-        public static ProviderRejection? FindConflict(
+        public static RejectedProvider? FindConflict(
             CkanModule                      candidate,
             IReadOnlyCollection<CkanModule> installing,
             IReadOnlyCollection<CkanModule> installed)
@@ -480,23 +377,4 @@ namespace CKAN
         }
     }
 
-    public sealed class UnsatisfiedRelation
-    {
-        /// <summary>
-        /// The dependency chain to reach this relationship.
-        /// </summary>
-        public readonly ResolvedRelationship[] depends;
-
-        /// <summary>
-        /// The reason that this relationship could not be satisfied, if any.
-        /// </summary>
-        public readonly ProviderRejection? rejection;
-
-        public UnsatisfiedRelation(ResolvedRelationship[] depends,
-                                   ProviderRejection? rejection)
-        {
-            this.depends = depends;
-            this.rejection = rejection;
-        }
-    }
 }

--- a/Core/Relationships/ResolvedRelationship.cs
+++ b/Core/Relationships/ResolvedRelationship.cs
@@ -27,9 +27,11 @@ namespace CKAN
         public readonly RelationshipDescriptor relationship;
         public readonly SelectionReason        reason;
 
+        [ExcludeFromCodeCoverage]
         public virtual bool Contains(CkanModule mod)
             => false;
 
+        [ExcludeFromCodeCoverage]
         protected virtual bool Unsatisfied()
             => false;
 
@@ -44,6 +46,7 @@ namespace CKAN
         public abstract ResolvedRelationship WithSource(CkanModule      newSrc,
                                                         SelectionReason newRsn);
 
+        [ExcludeFromCodeCoverage]
         public override bool Equals(object? other)
             => Equals(other as ResolvedRelationship);
 
@@ -78,6 +81,7 @@ namespace CKAN
 
         public readonly CkanModule installed;
 
+        [ExcludeFromCodeCoverage]
         public override bool Contains(CkanModule mod)
             => installed == mod;
 
@@ -103,6 +107,7 @@ namespace CKAN
 
         public readonly CkanModule installing;
 
+        [ExcludeFromCodeCoverage]
         public override bool Contains(CkanModule mod)
             => installing == mod;
 
@@ -144,14 +149,6 @@ namespace CKAN
         {
             this.resolved = resolved;
             this.context  = context;
-        }
-
-        public ResolvedByNew(CkanModule             source,
-                             RelationshipDescriptor relationship,
-                             SelectionReason        reason)
-             : this(source, relationship, reason,
-                    new Dictionary<CkanModule, ResolvedRelationship[]>())
-        {
         }
 
         public ResolvedByNew(CkanModule                      source,
@@ -201,6 +198,7 @@ namespace CKAN
         /// </summary>
         public readonly ResolutionContext? context;
 
+        [ExcludeFromCodeCoverage]
         public override bool Contains(CkanModule mod)
             => resolved.Any(rr => rr.Key == mod || rr.Value.Any(rrr => rrr.Contains(mod)));
 

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -31,11 +31,6 @@ namespace CKAN
                                          GameVersionCriteria             crit,
                                          OptionalRelationships           optRels)
         {
-            this.modules = modules;
-            this.registry = registry;
-            this.installed = installed;
-            this.stabilityTolerance = stabilityTolerance;
-            this.crit = crit;
             resolved = ResolveManyCached(modules, registry, dlls, installed, stabilityTolerance, crit, optRels, relationshipCache).ToArray();
         }
 
@@ -68,19 +63,13 @@ namespace CKAN
         // This augments the unsatisfied relation with potential candidates that were
         // filtered out so that we can give a better explanation of why they couldn't
         // be used.
-        private UnsatisfiedRelation EnrichRejection(UnsatisfiedRelation u)
-        {
-            if (u.rejection != null
-                || u.depends.LastOrDefault() is not ResolvedByNew last
-                || last.resolved.Count > 0)
-            {
-                return u;
-            }
-
-            return UnsatisfiedCandidates(last.relationship, last, modules).FirstOrDefault() is { } found
-                ? new UnsatisfiedRelation(u.depends, found.rejection)
-                : u;
-        }
+        private static UnsatisfiedRelation EnrichRejection(UnsatisfiedRelation u)
+            => u.rejection == null
+               && u.depends.LastOrDefault() is ResolvedByNew last
+               && last.resolved.Count == 0
+               && last.UnsatisfiedCandidates().FirstOrDefault() is { } found
+                   ? new UnsatisfiedRelation(u.depends, found.rejection)
+                   : u;
 
         public IReadOnlyList<CkanModule> Candidates(RelationshipDescriptor          rel,
                                                     IReadOnlyCollection<CkanModule> installing,
@@ -112,7 +101,9 @@ namespace CKAN
                             continue;
                         }
 
-                        var providesConflict = FindProvidesConflict(module, installing, installed);
+                        var providesConflict = ResolvedByNew.FindProvidesConflict(
+                            module, installing,
+                            resRel.context?.Installed ?? Array.Empty<CkanModule>());
                         if (providesConflict != null)
                         {
                             unresolved.Add(new UnsatisfiedRelation(new ResolvedRelationship[] { resRel },
@@ -172,7 +163,7 @@ namespace CKAN
             if (unresolved.Count == 0
                 && relationshipCache.GetValueOrDefault(rel) is ResolvedByNew cached)
             {
-                unresolved.AddRange(UnsatisfiedCandidates(rel, cached, installing));
+                unresolved.AddRange(cached.UnsatisfiedCandidates());
             }
 
             if (unresolved.Count == 0)
@@ -216,58 +207,6 @@ namespace CKAN
             return chain.Count == u.depends.Length
                 ? u
                 : new UnsatisfiedRelation(chain.ToArray(), u.rejection);
-        }
-
-        private IEnumerable<UnsatisfiedRelation> UnsatisfiedCandidates(
-            RelationshipDescriptor          rel,
-            ResolvedByNew                   resolved,
-            IReadOnlyCollection<CkanModule> installing)
-        {
-            foreach (var module in rel.LatestAvailableWithProvides(registry, stabilityTolerance, crit, null, null))
-            {
-                var rejection = FindProvidesConflict(module, installing, installed)
-                                ?? module.BadRelationships(installed)
-                                            .Concat(module.BadRelationships(installing))
-                                            .Select(r => (ProviderRejection)new RejectedByRelationship(module, r))
-                                            .FirstOrDefault();
-                if (rejection != null)
-                {
-                    yield return new UnsatisfiedRelation(
-                        new ResolvedRelationship[] { resolved }, rejection);
-                }
-            }
-        }
-
-        private static ProviderRejection? FindProvidesConflict(
-            CkanModule                      candidate,
-            IReadOnlyCollection<CkanModule> installing,
-            IReadOnlyCollection<CkanModule> installed)
-        {
-            if (candidate.provides == null)
-            {
-                return null;
-            }
-
-            foreach (var providedId in candidate.provides)
-            {
-                var installedConflict = installed.FirstOrDefault(m => m.identifier != candidate.identifier
-                                                                   && (m.identifier == providedId
-                                                                       || (m.provides?.Contains(providedId) ?? false)));
-                if (installedConflict != null)
-                {
-                    return new RejectedByProvidesConflict(candidate, providedId, installedConflict, blockerIsInstalled: true);
-                }
-
-                var installingConflict = installing.FirstOrDefault(m => m.identifier != candidate.identifier
-                                                                     && (m.identifier == providedId
-                                                                         || (m.provides?.Contains(providedId) ?? false)));
-                if (installingConflict != null)
-                {
-                    return new RejectedByProvidesConflict(candidate, providedId, installingConflict, blockerIsInstalled: false);
-                }
-            }
-
-            return null;
         }
 
         [ExcludeFromCodeCoverage]
@@ -335,12 +274,7 @@ namespace CKAN
                                                                    crit, optRels, relationshipCache))
                                 .WithSource(source, reason);
 
-        private readonly ResolvedRelationship[]          resolved;
-        private readonly IReadOnlyCollection<CkanModule> modules;
-        private readonly IRegistryQuerier                registry;
-        private readonly IReadOnlyCollection<CkanModule> installed;
-        private readonly StabilityToleranceConfig        stabilityTolerance;
-        private readonly GameVersionCriteria             crit;
-        private readonly RelationshipCache               relationshipCache = new RelationshipCache();
+        private readonly ResolvedRelationship[] resolved;
+        private readonly RelationshipCache      relationshipCache = new RelationshipCache();
     }
 }

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -31,6 +31,11 @@ namespace CKAN
                                          GameVersionCriteria             crit,
                                          OptionalRelationships           optRels)
         {
+            this.modules = modules;
+            this.registry = registry;
+            this.installed = installed;
+            this.stabilityTolerance = stabilityTolerance;
+            this.crit = crit;
             resolved = ResolveManyCached(modules, registry, dlls, installed, stabilityTolerance, crit, optRels, relationshipCache).ToArray();
         }
 
@@ -55,8 +60,27 @@ namespace CKAN
                     : ResolveRelationships(module, module.suggests, new SelectionReason.Suggested(module),
                                            definitelyInstalling, allInstalling, registry, dlls, installed, stabilityTolerance, crit, optRels, relationshipCache));
 
-        public IEnumerable<ResolvedRelationship[]> Unsatisfied()
-            => resolved.SelectMany(rr => rr.UnsatisfiedFrom());
+        public IEnumerable<UnsatisfiedRelation> Unsatisfied()
+            => resolved.SelectMany(rr => rr.UnsatisfiedFrom())
+                       .Select(EnrichRejection);
+
+        // Sometimes we end up with a ResolvedByNew with no modules that satisfy it.
+        // This augments the unsatisfied relation with potential candidates that were
+        // filtered out so that we can give a better explanation of why they couldn't
+        // be used.
+        private UnsatisfiedRelation EnrichRejection(UnsatisfiedRelation u)
+        {
+            if (u.rejection != null
+                || u.depends.LastOrDefault() is not ResolvedByNew last
+                || last.resolved.Count > 0)
+            {
+                return u;
+            }
+
+            return UnsatisfiedCandidates(last.relationship, last, modules).FirstOrDefault() is { } found
+                ? new UnsatisfiedRelation(u.depends, found.rejection)
+                : u;
+        }
 
         public IReadOnlyList<CkanModule> Candidates(RelationshipDescriptor          rel,
                                                     IReadOnlyCollection<CkanModule> installing,
@@ -64,7 +88,7 @@ namespace CKAN
                                                     IGame                           game)
         {
             var candidates = new List<CkanModule>();
-            var unresolved = new List<ResolvedRelationship[]>();
+            var unresolved = new List<UnsatisfiedRelation>();
             switch (relationshipCache.GetValueOrDefault(rel))
             {
                 case ResolvedByInstalling resInstalling:
@@ -79,53 +103,171 @@ namespace CKAN
                     // We need to have this loop at this level to accumulate the list of candidates
                     foreach ((CkanModule module, ResolvedRelationship[] rrs) in resRel.resolved)
                     {
-                        if (installing.Any(m => m.identifier == module.identifier
-                                                && m.version != module.version))
+                        var versionClash = installing.FirstOrDefault(m => m.identifier == module.identifier
+                                                                          && m.version  != module.version);
+                        if (versionClash != null)
                         {
-                            // Skip other versions of mods being installed
+                            unresolved.Add(new UnsatisfiedRelation(new ResolvedRelationship[] { resRel },
+                                                                   new RejectedByVersionMismatch(module, versionClash)));
+                            continue;
                         }
-                        else if (module.BadRelationships(installing)
-                                  .Select(r => relationshipCache.GetValueOrDefault(r.Descriptor))
-                                  .OfType<ResolvedRelationship>()
-                                  .Select(badRR => new ResolvedRelationship[] { resRel, badRR })
+
+                        var providesConflict = FindProvidesConflict(module, installing, installed);
+                        if (providesConflict != null)
+                        {
+                            unresolved.Add(new UnsatisfiedRelation(new ResolvedRelationship[] { resRel },
+                                                                   providesConflict));
+                            continue;
+                        }
+
+                        if (module.BadRelationships(installing)
+                                  .Select(r => new UnsatisfiedRelation(
+                                                   relationshipCache.GetValueOrDefault(r.Descriptor) is ResolvedRelationship leaf
+                                                       ? new ResolvedRelationship[] { resRel, leaf }
+                                                       : new ResolvedRelationship[] { resRel },
+                                                   new RejectedByRelationship(module, r)))
                                   .ToArray()
                             is { Length: > 0 } badRels)
                         {
                             unresolved.AddRange(badRels);
+                            continue;
                         }
-                        else if (rrs.SelectMany(subRR => subRR.BadRelationships(installing))
-                                    .Select(tuple => tuple.Item2.Type == RelationshipType.Depends
-                                                     && relationshipCache.TryGetValue(tuple.Item2.Descriptor,
-                                                                                      out ResolvedRelationship? leaf)
-                                                         ? tuple.Item1.Prepend(resRel).Append(leaf).ToArray()
-                                                         : tuple.Item1.Prepend(resRel).ToArray())
-                                    .ToArray()
-                                 is { Length: > 0 } badRRs)
+                        
+                        if (rrs.SelectMany(subRR => subRR.BadRelationships(installing))
+                                .Select(u =>
+                                {
+                                    ResolvedRelationship[] chain;
+                                    if (u.rejection is RejectedByRelationship inner
+                                        && inner.violation.Type == RelationshipType.Depends
+                                        && relationshipCache.TryGetValue(inner.violation.Descriptor,
+                                                                         out ResolvedRelationship? leaf))
+                                    {
+                                        chain = u.depends.Prepend(resRel).Append(leaf).ToArray();
+                                    }
+                                    else
+                                    {
+                                        chain = u.depends.Prepend(resRel).ToArray();
+                                    }
+                                    return new UnsatisfiedRelation(chain, u.rejection);
+                                })
+                                .ToArray()
+                            is { Length: > 0 } badRRs)
                         {
                             unresolved.AddRange(badRRs);
+                            continue;
                         }
-                        else
-                        {
-                            candidates.Add(module);
-                        }
+
+                        candidates.Add(module);
                     }
                     break;
             }
-            if (candidates.Count == 0)
+
+            if (candidates.Count != 0)
             {
-                if (unresolved.Count > 0)
+                return candidates;
+            }
+
+            // We weren't able to find anything. Redo the lookup without filters so
+            // we can describe what couldn't be satisfied.
+            if (unresolved.Count == 0
+                && relationshipCache.GetValueOrDefault(rel) is ResolvedByNew cached)
+            {
+                unresolved.AddRange(UnsatisfiedCandidates(rel, cached, installing));
+            }
+
+            if (unresolved.Count == 0)
+            {
+                throw new InconsistentKraken(string.Format(
+                    Properties.Resources.ResolvedRelationshipsTreeUnsatisfied,
+                    rel,
+                    string.Join(Environment.NewLine, installing.OrderBy(i => i.identifier))));
+            }
+
+            throw new DependenciesNotSatisfiedKraken(unresolved.Select(PrependAncestors).ToArray(),
+                                                     registry, game, this);
+        }
+
+        // The chains we build inside Candidates() only see the ResolvedByNew that the
+        // descriptor maps to; the wider ancestor context (e.g. Parent -> Intermediate ->
+        // this) lives in other cache entries. Walk up by finding the cached ResolvedByNew
+        // whose `resolved` keys contain the current head's source, and prepend it.
+        private UnsatisfiedRelation PrependAncestors(UnsatisfiedRelation u)
+        {
+            if (u.depends.Length == 0)
+            {
+                return u;
+            }
+            var chain = u.depends.ToList();
+            var current = chain[0];
+            while (true)
+            {
+                var parent = relationshipCache.Values
+                                              .OfType<ResolvedByNew>()
+                                              .FirstOrDefault(r => r != current
+                                                                   && !chain.Contains(r)
+                                                                   && r.resolved.ContainsKey(current.source));
+                if (parent == null)
                 {
-                    throw new DependenciesNotSatisfiedKraken(unresolved, registry, game, this);
+                    break;
                 }
-                else
+                chain.Insert(0, parent);
+                current = parent;
+            }
+            return chain.Count == u.depends.Length
+                ? u
+                : new UnsatisfiedRelation(chain.ToArray(), u.rejection);
+        }
+
+        private IEnumerable<UnsatisfiedRelation> UnsatisfiedCandidates(
+            RelationshipDescriptor          rel,
+            ResolvedByNew                   resolved,
+            IReadOnlyCollection<CkanModule> installing)
+        {
+            foreach (var module in rel.LatestAvailableWithProvides(registry, stabilityTolerance, crit, null, null))
+            {
+                var rejection = FindProvidesConflict(module, installing, installed)
+                                ?? module.BadRelationships(installed)
+                                            .Concat(module.BadRelationships(installing))
+                                            .Select(r => (ProviderRejection)new RejectedByRelationship(module, r))
+                                            .FirstOrDefault();
+                if (rejection != null)
                 {
-                    throw new InconsistentKraken(string.Format(Properties.Resources.ResolvedRelationshipsTreeUnsatisfied,
-                                                               rel,
-                                                               string.Join(Environment.NewLine,
-                                                                           installing.OrderBy(i => i.identifier))));
+                    yield return new UnsatisfiedRelation(
+                        new ResolvedRelationship[] { resolved }, rejection);
                 }
             }
-            return candidates;
+        }
+
+        private static ProviderRejection? FindProvidesConflict(
+            CkanModule                      candidate,
+            IReadOnlyCollection<CkanModule> installing,
+            IReadOnlyCollection<CkanModule> installed)
+        {
+            if (candidate.provides == null)
+            {
+                return null;
+            }
+
+            foreach (var providedId in candidate.provides)
+            {
+                var installedConflict = installed.FirstOrDefault(m => m.identifier != candidate.identifier
+                                                                   && (m.identifier == providedId
+                                                                       || (m.provides?.Contains(providedId) ?? false)));
+                if (installedConflict != null)
+                {
+                    return new RejectedByProvidesConflict(candidate, providedId, installedConflict, blockerIsInstalled: true);
+                }
+
+                var installingConflict = installing.FirstOrDefault(m => m.identifier != candidate.identifier
+                                                                     && (m.identifier == providedId
+                                                                         || (m.provides?.Contains(providedId) ?? false)));
+                if (installingConflict != null)
+                {
+                    return new RejectedByProvidesConflict(candidate, providedId, installingConflict, blockerIsInstalled: false);
+                }
+            }
+
+            return null;
         }
 
         [ExcludeFromCodeCoverage]
@@ -193,7 +335,12 @@ namespace CKAN
                                                                    crit, optRels, relationshipCache))
                                 .WithSource(source, reason);
 
-        private readonly ResolvedRelationship[] resolved;
-        private readonly RelationshipCache      relationshipCache = new RelationshipCache();
+        private readonly ResolvedRelationship[]          resolved;
+        private readonly IReadOnlyCollection<CkanModule> modules;
+        private readonly IRegistryQuerier                registry;
+        private readonly IReadOnlyCollection<CkanModule> installed;
+        private readonly StabilityToleranceConfig        stabilityTolerance;
+        private readonly GameVersionCriteria             crit;
+        private readonly RelationshipCache               relationshipCache = new RelationshipCache();
     }
 }

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -101,23 +101,26 @@ namespace CKAN
                             continue;
                         }
 
-                        var providesConflict = ResolvedByNew.FindProvidesConflict(
+                        var conflict = ResolvedByNew.FindConflict(
                             module, installing,
                             resRel.context?.Installed ?? Array.Empty<CkanModule>());
-                        if (providesConflict != null)
+                        if (conflict != null)
                         {
                             unresolved.Add(new UnsatisfiedRelation(new ResolvedRelationship[] { resRel },
-                                                                   providesConflict));
+                                                                   conflict));
                             continue;
                         }
 
-                        if (module.BadRelationships(installing)
-                                  .Select(r => new UnsatisfiedRelation(
-                                                   relationshipCache.GetValueOrDefault(r.Descriptor) is ResolvedRelationship leaf
+                        if (RejectedByRelationship.WrapMany(
+                                module,
+                                module.BadRelationships(installing)
+                                      .Where(r => r.Type == RelationshipType.Depends))
+                                .Select(rej => new UnsatisfiedRelation(
+                                                   relationshipCache.GetValueOrDefault(rej.violation.Descriptor) is ResolvedRelationship leaf
                                                        ? new ResolvedRelationship[] { resRel, leaf }
                                                        : new ResolvedRelationship[] { resRel },
-                                                   new RejectedByRelationship(module, r)))
-                                  .ToArray()
+                                                   rej))
+                                .ToArray()
                             is { Length: > 0 } badRels)
                         {
                             unresolved.AddRange(badRels);

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -96,8 +96,10 @@ namespace CKAN
                                                                           && m.version  != module.version);
                         if (versionClash != null)
                         {
-                            unresolved.Add(new UnsatisfiedRelation(new ResolvedRelationship[] { resRel },
-                                                                   new RejectedByVersionMismatch(module, versionClash)));
+                            unresolved.Add(new UnsatisfiedRelation(
+                                new ResolvedRelationship[] { resRel },
+                                new RejectedByVersionMismatch(module, versionClash,
+                                                              FindBlockerChain(versionClash))));
                             continue;
                         }
 
@@ -185,13 +187,13 @@ namespace CKAN
         // descriptor maps to; the wider ancestor context (e.g. Parent -> Intermediate ->
         // this) lives in other cache entries. Walk up by finding the cached ResolvedByNew
         // whose `resolved` keys contain the current head's source, and prepend it.
-        private UnsatisfiedRelation PrependAncestors(UnsatisfiedRelation u)
+        private ResolvedRelationship[] PrependAncestors(ResolvedRelationship[] initialChain)
         {
-            if (u.depends.Length == 0)
+            if (initialChain.Length == 0)
             {
-                return u;
+                return initialChain;
             }
-            var chain = u.depends.ToList();
+            var chain = initialChain.ToList();
             var current = chain[0];
             while (true)
             {
@@ -207,10 +209,27 @@ namespace CKAN
                 chain.Insert(0, parent);
                 current = parent;
             }
-            return chain.Count == u.depends.Length
-                ? u
-                : new UnsatisfiedRelation(chain.ToArray(), u.rejection);
+            return chain.Count == initialChain.Length
+                ? initialChain
+                : chain.ToArray();
         }
+
+        private UnsatisfiedRelation PrependAncestors(UnsatisfiedRelation u)
+            => PrependAncestors(u.depends) is var chain && chain != u.depends
+                   ? new UnsatisfiedRelation(chain, u.rejection)
+                   : u;
+
+        // For a mod that's already in the live changeset, locate the cached
+        // ResolvedByNew that selected it as a candidate, then walk up to a
+        // top-level ancestor. Returns an empty chain when the mod was added
+        // outside the cache (e.g. directly by the user).
+        private ResolvedRelationship[] FindBlockerChain(CkanModule blocker)
+            => relationshipCache.Values
+                                .OfType<ResolvedByNew>()
+                                .FirstOrDefault(r => r.resolved.ContainsKey(blocker))
+               is ResolvedByNew bottom
+                   ? PrependAncestors(new ResolvedRelationship[] { bottom })
+                   : Array.Empty<ResolvedRelationship>();
 
         [ExcludeFromCodeCoverage]
         public override string ToString()

--- a/Core/Relationships/ResolvedRelationshipsTree.cs
+++ b/Core/Relationships/ResolvedRelationshipsTree.cs
@@ -128,7 +128,6 @@ namespace CKAN
                             unresolved.AddRange(badRels);
                             continue;
                         }
-                        
                         if (rrs.SelectMany(subRR => subRR.BadRelationships(installing))
                                 .Select(u =>
                                 {

--- a/Core/Relationships/UnsatisfiedRelation.cs
+++ b/Core/Relationships/UnsatisfiedRelation.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CKAN
+{
+    public sealed class UnsatisfiedRelation
+    {
+        /// <summary>
+        /// The dependency chain to reach this relationship.
+        /// </summary>
+        public readonly ResolvedRelationship[] depends;
+
+        /// <summary>
+        /// The reason that this relationship could not be satisfied, if any.
+        /// </summary>
+        public readonly RejectedProvider? rejection;
+
+        public UnsatisfiedRelation(ResolvedRelationship[] depends,
+                                   RejectedProvider?      rejection)
+        {
+            this.depends   = depends;
+            this.rejection = rejection;
+        }
+
+        [ExcludeFromCodeCoverage]
+        public override string ToString()
+            => string.Join(Environment.NewLine + Environment.NewLine,
+                           depends.Select(d => d.ToString())
+                                  .Prepend(rejection?.ToString() ?? ""));
+    }
+}

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -175,11 +175,16 @@ namespace CKAN
 
             return rejection switch
             {
-                RejectedByProvidesConflict p => string.Format(
+                RejectedByConflict c when c.sharedProvidesId != null => string.Format(
                     Properties.Resources.KrakenRejectedProvidesConflict,
-                    p.provider,
-                    p.providedIdentifier,
-                    p.blockingMod,
+                    c.provider,
+                    c.sharedProvidesId,
+                    c.blockingMod,
+                    depends),
+                RejectedByConflict c => string.Format(
+                    Properties.Resources.KrakenRejectedConflict,
+                    c.provider,
+                    c.blockingMod,
                     depends),
                 _ => string.Format(
                     Properties.Resources.KrakenMissingDependency,

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -115,25 +115,17 @@ namespace CKAN
         /// <summary>
         /// Initialize the exception representing failed dependency resolution
         /// </summary>
-        /// <param name="unsatisfied">List of chain of relationships with last one unsatisfied</param>
+        /// <param name="unsatisfied">Dependency chains with optional rejection reason for each unsatisfiable provider</param>
         /// <param name="registry">Registry to use for formatting</param>
         /// <param name="game">Game to use for formatting</param>
         /// <param name="resolved">Resolved relationships tree</param>
         /// <param name="innerException">Originating exception parameter for base class</param>
-        public DependenciesNotSatisfiedKraken(IReadOnlyCollection<ResolvedRelationship[]> unsatisfied,
-                                              IRegistryQuerier                            registry,
-                                              IGame                                       game,
-                                              ResolvedRelationshipsTree                   resolved,
-                                              Exception?                                  innerException = null)
-            : base(string.Join(Environment.NewLine + Environment.NewLine,
-                               unsatisfied.GroupBy(rrs => rrs.Last().relationship)
-                                          .OrderByDescending(grp => grp.Count())
-                                          .ThenBy(grp => grp.Key.ToString())
-                                          .Select(grp => string.Format(Properties.Resources.KrakenMissingDependency,
-                                                                       string.Join("; ",
-                                                                                   grp.DistinctBy(rrs => rrs.Last().source)
-                                                                                      .Select(FormatDependsChain)),
-                                                                       grp.Key.ToStringWithCompat(registry, game)))),
+        public DependenciesNotSatisfiedKraken(IReadOnlyCollection<UnsatisfiedRelation> unsatisfied,
+                                              IRegistryQuerier                         registry,
+                                              IGame                                    game,
+                                              ResolvedRelationshipsTree                resolved,
+                                              Exception?                               innerException = null)
+            : base(BuildMessage(unsatisfied, registry, game),
                    innerException)
         {
             this.unsatisfied = unsatisfied;
@@ -146,12 +138,55 @@ namespace CKAN
                                               IGame                     game,
                                               ResolvedRelationshipsTree resolved,
                                               Exception?                innerException = null)
-            : this(new ResolvedRelationship[][] { new ResolvedRelationship[] { badOne } },
+            : this(new[] { new UnsatisfiedRelation(new ResolvedRelationship[] { badOne }, null) },
                    registry, game, resolved, innerException)
         {
         }
 
-        public readonly IReadOnlyCollection<ResolvedRelationship[]> unsatisfied;
+        public readonly IReadOnlyCollection<UnsatisfiedRelation> unsatisfied;
+
+        private static string BuildMessage(IReadOnlyCollection<UnsatisfiedRelation> unsatisfied,
+                                           IRegistryQuerier                         registry,
+                                           IGame                                    game)
+        {
+            var errors = unsatisfied
+                .GroupBy(u => (u.depends.Last().relationship, u.rejection))
+                .OrderByDescending(grp => grp.Count())
+                .ThenBy(grp => grp.Key.relationship.ToString())
+                .Select(grp =>
+                {
+                    var (relation, rejection) = grp.Key;
+                    return FormatRelation(relation, rejection, grp, registry, game);
+                });
+
+            return string.Join(Environment.NewLine + Environment.NewLine, errors);
+        }
+
+        private static string FormatRelation(RelationshipDescriptor           relation,
+                                             ProviderRejection?               rejection,
+                                             IEnumerable<UnsatisfiedRelation> unsatisfied,
+                                             IRegistryQuerier                 registry,
+                                             IGame                            game)
+        {
+            var sources = unsatisfied
+                .DistinctBy(u => u.depends.Last().source)
+                .Select(u => FormatDependsChain(u.depends));
+            var depends = string.Join("; ", sources);
+
+            return rejection switch
+            {
+                RejectedByProvidesConflict p => string.Format(
+                    Properties.Resources.KrakenRejectedProvidesConflict,
+                    p.provider,
+                    p.providedIdentifier,
+                    p.blockingMod,
+                    depends),
+                _ => string.Format(
+                    Properties.Resources.KrakenMissingDependency,
+                    depends,
+                    relation.ToStringWithCompat(registry, game) ?? "")
+            };
+        }
 
         private static string FormatDependsChain(ResolvedRelationship[] dependsChain)
             => dependsChain.Length == 1

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -186,6 +186,17 @@ namespace CKAN
                     c.provider,
                     c.blockingMod,
                     depends),
+                RejectedByVersionMismatch v when v.blockerChain.Length > 0 => string.Format(
+                    Properties.Resources.KrakenRejectedVersionMismatchFor,
+                    v.provider,
+                    v.blockingMod,
+                    depends,
+                    FormatDependsChain(v.blockerChain)),
+                RejectedByVersionMismatch v => string.Format(
+                    Properties.Resources.KrakenRejectedVersionMismatch,
+                    v.provider,
+                    v.blockingMod,
+                    depends),
                 _ => string.Format(
                     Properties.Resources.KrakenMissingDependency,
                     depends,

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -133,16 +133,6 @@ namespace CKAN
                             resolved);
         }
 
-        public DependenciesNotSatisfiedKraken(ResolvedRelationship      badOne,
-                                              IRegistryQuerier          registry,
-                                              IGame                     game,
-                                              ResolvedRelationshipsTree resolved,
-                                              Exception?                innerException = null)
-            : this(new[] { new UnsatisfiedRelation(new ResolvedRelationship[] { badOne }, null) },
-                   registry, game, resolved, innerException)
-        {
-        }
-
         public readonly IReadOnlyCollection<UnsatisfiedRelation> unsatisfied;
 
         private static string BuildMessage(IReadOnlyCollection<UnsatisfiedRelation> unsatisfied,

--- a/Core/Types/Kraken.cs
+++ b/Core/Types/Kraken.cs
@@ -148,61 +148,59 @@ namespace CKAN
         private static string BuildMessage(IReadOnlyCollection<UnsatisfiedRelation> unsatisfied,
                                            IRegistryQuerier                         registry,
                                            IGame                                    game)
-        {
-            var errors = unsatisfied
-                .GroupBy(u => (u.depends.Last().relationship, u.rejection))
-                .OrderByDescending(grp => grp.Count())
-                .ThenBy(grp => grp.Key.relationship.ToString())
-                .Select(grp =>
-                {
-                    var (relation, rejection) = grp.Key;
-                    return FormatRelation(relation, rejection, grp, registry, game);
-                });
-
-            return string.Join(Environment.NewLine + Environment.NewLine, errors);
-        }
+            => string.Join(Environment.NewLine + Environment.NewLine,
+                           unsatisfied.GroupBy(u => (u.depends.Last().relationship, u.rejection))
+                                      .OrderByDescending(grp => grp.Count())
+                                      .ThenBy(grp => grp.Key.relationship.ToString())
+                                      .Select(grp => FormatRelation(grp.Key.relationship,
+                                                                    grp.Key.rejection,
+                                                                    grp, registry, game)));
 
         private static string FormatRelation(RelationshipDescriptor           relation,
-                                             ProviderRejection?               rejection,
+                                             RejectedProvider?                rejection,
                                              IEnumerable<UnsatisfiedRelation> unsatisfied,
                                              IRegistryQuerier                 registry,
                                              IGame                            game)
-        {
-            var sources = unsatisfied
-                .DistinctBy(u => u.depends.Last().source)
-                .Select(u => FormatDependsChain(u.depends));
-            var depends = string.Join("; ", sources);
+            => FormatRelation(relation, rejection,
+                              string.Join("; ",
+                                          unsatisfied.DistinctBy(u => u.depends.Last().source)
+                                                     .Select(u => FormatDependsChain(u.depends))),
+                              registry, game);
 
-            return rejection switch
-            {
-                RejectedByConflict c when c.sharedProvidesId != null => string.Format(
-                    Properties.Resources.KrakenRejectedProvidesConflict,
-                    c.provider,
-                    c.sharedProvidesId,
-                    c.blockingMod,
-                    depends),
-                RejectedByConflict c => string.Format(
-                    Properties.Resources.KrakenRejectedConflict,
-                    c.provider,
-                    c.blockingMod,
-                    depends),
-                RejectedByVersionMismatch v when v.blockerChain.Length > 0 => string.Format(
-                    Properties.Resources.KrakenRejectedVersionMismatchFor,
-                    v.provider,
-                    v.blockingMod,
-                    depends,
-                    FormatDependsChain(v.blockerChain)),
-                RejectedByVersionMismatch v => string.Format(
-                    Properties.Resources.KrakenRejectedVersionMismatch,
-                    v.provider,
-                    v.blockingMod,
-                    depends),
-                _ => string.Format(
-                    Properties.Resources.KrakenMissingDependency,
-                    depends,
-                    relation.ToStringWithCompat(registry, game) ?? "")
-            };
-        }
+        private static string FormatRelation(RelationshipDescriptor relation,
+                                             RejectedProvider?      rejection,
+                                             string                 dependsDescription,
+                                             IRegistryQuerier       registry,
+                                             IGame                  game)
+            => rejection switch
+               {
+                   RejectedByConflict c when c.sharedProvidesId != null => string.Format(
+                       Properties.Resources.KrakenRejectedProvidesConflict,
+                       c.provider,
+                       c.sharedProvidesId,
+                       c.blockingMod,
+                       dependsDescription),
+                   RejectedByConflict c => string.Format(
+                       Properties.Resources.KrakenRejectedConflict,
+                       c.provider,
+                       c.blockingMod,
+                       dependsDescription),
+                   RejectedByVersionMismatch v when v.blockerChain.Length > 0 => string.Format(
+                       Properties.Resources.KrakenRejectedVersionMismatchFor,
+                       v.provider,
+                       v.blockingMod,
+                       dependsDescription,
+                       FormatDependsChain(v.blockerChain)),
+                   RejectedByVersionMismatch v => string.Format(
+                       Properties.Resources.KrakenRejectedVersionMismatch,
+                       v.provider,
+                       v.blockingMod,
+                       dependsDescription),
+                   _ => string.Format(
+                       Properties.Resources.KrakenMissingDependency,
+                       dependsDescription,
+                       relation.ToStringWithCompat(registry, game) ?? "")
+               };
 
         private static string FormatDependsChain(ResolvedRelationship[] dependsChain)
             => dependsChain.Length == 1

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -62,7 +62,11 @@ namespace CKAN.GUI
                 row.DefaultCellStyle.ForeColor = obj?.WarningLabel != null
                                                  ? Color.Red : SystemColors.WindowText;
                 row.DefaultCellStyle.BackColor = obj?.Conflict != null
-                                                 ? Color.LightCoral : Color.Empty;
+                                                 ? ModList.ConflictBackColor
+                                                 : Color.Empty;
+                row.DefaultCellStyle.ForeColor = obj?.Conflict != null
+                                                 ? ModList.ConflictForeColor
+                                                 : Color.Empty;
                 if (obj?.Change.IsRemovable ?? false)
                 {
                     foreach (var icon in row.Cells.OfType<DataGridViewImageCell>())

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -173,7 +173,7 @@ namespace CKAN.GUI
                                                       .OfType<ListViewItem>()
                                                       .Where(item => item.Tag is CkanModule mod
                                                                      && k.unsatisfied.Any(stack =>
-                                                                         stack.Any(rr => rr.Contains(mod))));
+                                                                         stack.depends.Any(rr => rr.Contains(mod))));
                     foreach (var row in rows)
                     {
                         row.BackColor = Color.LightCoral;

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -160,9 +160,9 @@ namespace CKAN.GUI
                     // ... so the Items list can contain null!!
                     foreach (var item in RecommendedModsListView.Items.OfType<ListViewItem>())
                     {
-                        item.BackColor = item.Tag is CkanModule m && conflicts.ContainsKey(m)
-                            ? Color.LightCoral
-                            : Color.Empty;
+                        bool conflicted = item.Tag is CkanModule m && conflicts.ContainsKey(m);
+                        item.BackColor = conflicted ? ModList.ConflictBackColor : Color.Empty;
+                        item.ForeColor = conflicted ? ModList.ConflictForeColor : Color.Empty;
                     }
                     RecommendedModsContinueButton.Enabled = conflicts.Count == 0;
                     OnConflictFound?.Invoke(string.Join("; ", resolver.ConflictDescriptions));
@@ -176,7 +176,8 @@ namespace CKAN.GUI
                                                                          stack.depends.Any(rr => rr.Contains(mod))));
                     foreach (var row in rows)
                     {
-                        row.BackColor = Color.LightCoral;
+                        row.BackColor = ModList.ConflictBackColor;
+                        row.ForeColor = ModList.ConflictForeColor;
                     }
                     RecommendedModsContinueButton.Enabled = false;
                     OnConflictFound?.Invoke(k.Message);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -2247,7 +2247,7 @@ namespace CKAN.GUI
             {
                 RaiseError?.Invoke(k.Message);
                 var identifiers = k.unsatisfied
-                                   .SelectMany(uns => uns.Select(rr => rr.source.identifier))
+                                   .SelectMany(uns => uns.depends.Select(rr => rr.source.identifier))
                                    .Distinct();
 
                 foreach (var ident in identifiers)

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -2281,7 +2281,7 @@ namespace CKAN.GUI
             {
                 RaiseError?.Invoke(k.Message);
                 var identifiers = k.unsatisfied
-                                   .SelectMany(uns => uns.Select(rr => rr.source.identifier))
+                                   .SelectMany(uns => uns.depends.Select(rr => rr.source.identifier))
                                    .Distinct();
 
                 foreach (var ident in identifiers)

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -340,7 +340,7 @@ namespace CKAN.GUI
 
         private Color GetRowBackground(GUIMod mod, bool conflicted, GameInstance instance)
             => conflicted
-                   ? conflictColor
+                   ? ConflictBackColor
                    : Util.BlendColors(allLabels.LabelsFor(instance.Name)
                                                .Where(l => l.ContainsModule(instance.Game,
                                                                             mod.Identifier))
@@ -687,7 +687,8 @@ namespace CKAN.GUI
         private readonly Graphics                       graphics;
         private          IReadOnlyCollection<ModSearch> activeSearches;
 
-        private static readonly Color conflictColor = Color.FromArgb(255, 64, 64);
+        public  static readonly Color ConflictBackColor = Color.FromArgb(255, 64, 64);
+        public  static readonly Color ConflictForeColor = ConflictBackColor.ForeColorForBackColor() ?? SystemColors.WindowText;
 
         private static readonly ILog log = LogManager.GetLogger(typeof(ModList));
     }

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1975,6 +1975,40 @@ namespace Tests.Core.Relationships
             new string[] { "InstalledProvider" },
             new string[] { "Parent" },
             new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
+        ),
+        TestCase(
+            // Mirrors installing Sol-Configs (depends on Sol-Core, which depends on
+            // ParallaxContinued-KTL) into an install that already has the original
+            // Parallax. ParallaxContinued has an explicit "conflicts: Parallax"
+            // clause, but Parallax declares no provides matching anything
+            // ParallaxContinued provides, so there is no shared virtual id for
+            // FindProvidesConflict to anchor on. The candidate falls through to
+            // BadRelationships, producing a RejectedByRelationship — but
+            // DependenciesNotSatisfiedKraken.FormatRelation only specially
+            // formats RejectedByProvidesConflict, so the conflict information
+            // is dropped and the user sees the generic "Unsatisfied dependency"
+            // template with no hint that an already-installed Parallax is the
+            // blocker. The expected message captures that current-but-unhelpful
+            // output.
+            new string[] {
+                @"{ ""identifier"": ""Parallax"" }",
+                @"{
+                    ""identifier"": ""ParallaxContinued"",
+                    ""provides"":   [ ""ParallaxContinuedAlias"" ],
+                    ""conflicts"":  [ { ""name"": ""Parallax"" } ]
+                }",
+                @"{
+                    ""identifier"": ""SolCore"",
+                    ""depends"":    [ { ""name"": ""ParallaxContinued"" } ]
+                }",
+                @"{
+                    ""identifier"": ""SolConfigs"",
+                    ""depends"":    [ { ""name"": ""SolCore"" } ]
+                }"
+            },
+            new string[] { "Parallax" },
+            new string[] { "SolConfigs" },
+            new string[] { "Unsatisfied dependency ParallaxContinued (KSP All versions) needed for: SolCore 1.0 (needed for SolConfigs 1.0)" }
         )]
         public void Constructor_ProvidesConflict_Throws(string[] availableModules,
                                                         string[] alreadyInstalled,

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -2130,6 +2130,64 @@ namespace Tests.Core.Relationships
             });
         }
 
+        [TestCase(
+            // Here we attempt to install two different versions of the same mod.
+            new string[]
+            {
+                @"{
+                    ""identifier"": ""Lib"",
+                    ""version"":    ""1.0"",
+                    ""provides"":   [ ""OldVirtual"" ]
+                }",
+                @"{
+                    ""identifier"": ""Lib"",
+                    ""version"":    ""2.0"",
+                    ""provides"":   [ ""NewVirtual"" ]
+                }",
+                @"{
+                    ""identifier"": ""ModA"",
+                    ""depends"":    [ { ""name"": ""OldVirtual"" } ]
+                }",
+                @"{
+                    ""identifier"": ""ModB"",
+                    ""depends"":    [ { ""name"": ""NewVirtual"" } ]
+                }"
+            },
+            new string[] { "ModA", "ModB" },
+            new string[] { "Version conflict: Lib 2.0 is needed for ModB 1.0, and Lib 1.0 is needed for ModA 1.0, but both cannot be installed at the same time" }
+        )]
+        public void Constructor_VersionMismatch_Throws(string[] availableModules,
+                                                       string[] newInstalls,
+                                                       string[] errors)
+        {
+            var user = new NullUser();
+            using var inst     = new DisposableKSP();
+            using var repo     = new TemporaryRepository(availableModules.Select(MergeWithDefaults).ToArray());
+            using var repoData = new TemporaryRepositoryData(user, repo.repo);
+            using var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager, new Repository[] { repo.repo });
+
+            var registry  = regMgr.registry;
+            var toInstall = newInstalls
+                .Select(ident => registry.LatestAvailable(ident,
+                                                          inst.KSP.StabilityToleranceConfig,
+                                                          inst.KSP.VersionCriteria()))
+                .OfType<CkanModule>()
+                .ToArray();
+
+            var exc = Assert.Throws<DependenciesNotSatisfiedKraken>(() =>
+            {
+                var rr = new RelationshipResolver(
+                    toInstall, null,
+                    RelationshipResolverOptions.DependsOnlyOpts(stabilityTolerance),
+                    registry, game, crit);
+            })!;
+
+            CollectionAssert.AreEqual(
+                errors,
+                exc.Message.Split(new string[] { Environment.NewLine },
+                                  StringSplitOptions.RemoveEmptyEntries));
+        }
+
         [TestCase(new string[]
                   {
                       @"{

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1868,25 +1868,6 @@ namespace Tests.Core.Relationships
         }
 
         [TestCase(
-            new string[]
-            {
-                @"{ ""identifier"": ""InstalledProvider"" }",
-                @"{
-                    ""identifier"": ""AlternateProvider"",
-                    ""provides"": [ ""InstalledProvider"" ]
-                }",
-                @"{
-                    ""identifier"": ""Parent"",
-                    ""depends"": [
-                        { ""name"": ""AlternateProvider"" }
-                    ]
-                }"
-            },
-            new string[] { "InstalledProvider" },
-            new string[] { "Parent" },
-            new string[] { "AlternateProvider 1.0 is needed for Parent 1.0, but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides InstalledProvider" }
-        ),
-        TestCase(
             // Same as the above test case, but now with an explicit conflicts clause.
             new string[]
             {
@@ -1994,35 +1975,6 @@ namespace Tests.Core.Relationships
             new string[] { "InstalledProvider" },
             new string[] { "Parent" },
             new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
-        ),
-        TestCase(
-            // Now without an explicit conflict, just the implicit provides conflict.
-            new string[]
-            {
-                @"{
-                    ""identifier"": ""InstalledProvider"",
-                    ""provides"": [ ""Thing"" ]
-                }",
-                @"{
-                    ""identifier"": ""AlternateProvider"",
-                    ""provides"":  [ ""Thing"" ],
-                }",
-                @"{
-                    ""identifier"": ""Intermediate"",
-                    ""depends"": [
-                        { ""name"": ""AlternateProvider"" }
-                    ]
-                }",
-                @"{
-                    ""identifier"": ""Parent"",
-                    ""depends"": [
-                        { ""name"": ""Intermediate"" }
-                    ]
-                }"
-            },
-            new string[] { "InstalledProvider" },
-            new string[] { "Parent" },
-            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
         )]
         public void Constructor_ProvidesConflict_Throws(string[] availableModules,
                                                         string[] alreadyInstalled,
@@ -2067,6 +2019,92 @@ namespace Tests.Core.Relationships
                 errors,
                 exc.Message.Split(new string[] { Environment.NewLine },
                                   StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        [TestCase(
+            new string[]
+            {
+                @"{ ""identifier"": ""InstalledProvider"" }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"": [ ""InstalledProvider"" ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" }
+        ),
+        TestCase(
+            // It is OK to have multiple types that provide the same id as
+            // long as they don't conflict.
+            new string[]
+            {
+                @"{
+                    ""identifier"": ""InstalledProvider"",
+                    ""provides"": [ ""Thing"" ]
+                }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"":  [ ""Thing"" ],
+                }",
+                @"{
+                    ""identifier"": ""Intermediate"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""Intermediate"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" }
+        )]
+        public void Constructor_ProvidesConflict_DoesNotThrow(string[] availableModules,
+                                                              string[] alreadyInstalled,
+                                                              string[] newInstalls)
+        {
+            var user = new NullUser();
+            using var inst     = new DisposableKSP();
+            using var repo     = new TemporaryRepository(availableModules.Select(MergeWithDefaults).ToArray());
+            using var repoData = new TemporaryRepositoryData(user, repo.repo);
+            using var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager, new Repository[] { repo.repo });
+
+            var registry  = regMgr.registry;
+            var opts      = RelationshipResolverOptions.DefaultOpts(inst.KSP.StabilityToleranceConfig);
+            var toInstall = newInstalls
+                .Select(ident => registry.LatestAvailable(ident,
+                                                          inst.KSP.StabilityToleranceConfig,
+                                                          inst.KSP.VersionCriteria()))
+                .OfType<CkanModule>()
+                .ToArray();
+
+            foreach (var module in alreadyInstalled)
+            {
+                registry.RegisterModule(
+                    registry.LatestAvailable(module,
+                                             inst.KSP.StabilityToleranceConfig,
+                                             inst.KSP.VersionCriteria())!,
+                    Array.Empty<string>(),
+                    inst.KSP,
+                    false);
+            }
+
+            Assert.DoesNotThrow(() =>
+            {
+                var rr = new RelationshipResolver(
+                    toInstall, null,
+                    RelationshipResolverOptions.DependsOnlyOpts(stabilityTolerance),
+                    registry, game, crit);
+            });
         }
 
         [TestCase(new string[]

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1977,19 +1977,8 @@ namespace Tests.Core.Relationships
             new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
         ),
         TestCase(
-            // Mirrors installing Sol-Configs (depends on Sol-Core, which depends on
-            // ParallaxContinued-KTL) into an install that already has the original
-            // Parallax. ParallaxContinued has an explicit "conflicts: Parallax"
-            // clause, but Parallax declares no provides matching anything
-            // ParallaxContinued provides, so there is no shared virtual id for
-            // FindProvidesConflict to anchor on. The candidate falls through to
-            // BadRelationships, producing a RejectedByRelationship — but
-            // DependenciesNotSatisfiedKraken.FormatRelation only specially
-            // formats RejectedByProvidesConflict, so the conflict information
-            // is dropped and the user sees the generic "Unsatisfied dependency"
-            // template with no hint that an already-installed Parallax is the
-            // blocker. The expected message captures that current-but-unhelpful
-            // output.
+            // This is an explicit conflict that doesn't go through any provide
+            // relationships.
             new string[] {
                 @"{ ""identifier"": ""Parallax"" }",
                 @"{
@@ -2008,12 +1997,12 @@ namespace Tests.Core.Relationships
             },
             new string[] { "Parallax" },
             new string[] { "SolConfigs" },
-            new string[] { "Unsatisfied dependency ParallaxContinued (KSP All versions) needed for: SolCore 1.0 (needed for SolConfigs 1.0)" }
+            new string[] { "ParallaxContinued 1.0 is needed for SolCore 1.0 (needed for SolConfigs 1.0), but cannot be installed because it conflicts with Parallax 1.0" }
         )]
-        public void Constructor_ProvidesConflict_Throws(string[] availableModules,
-                                                        string[] alreadyInstalled,
-                                                        string[] newInstalls,
-                                                        string[] errors)
+        public void Constructor_Conflict_Throws(string[] availableModules,
+                                                string[] alreadyInstalled,
+                                                string[] newInstalls,
+                                                string[] errors)
         {
             var user = new NullUser();
             using var inst     = new DisposableKSP();

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1867,6 +1867,208 @@ namespace Tests.Core.Relationships
             }
         }
 
+        [TestCase(
+            new string[]
+            {
+                @"{ ""identifier"": ""InstalledProvider"" }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"": [ ""InstalledProvider"" ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" },
+            new string[] { "AlternateProvider 1.0 is needed for Parent 1.0, but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides InstalledProvider" }
+        ),
+        TestCase(
+            // Same as the above test case, but now with an explicit conflicts clause.
+            new string[]
+            {
+                @"{ ""identifier"": ""InstalledProvider"" }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"":  [ ""InstalledProvider"" ],
+                    ""conflicts"": [ { ""name"": ""InstalledProvider"" } ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" },
+            new string[] { "AlternateProvider 1.0 is needed for Parent 1.0, but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides InstalledProvider" }
+        ),
+        TestCase(
+            // Now the conflicting provider is reached transitively.
+            new string[]
+            {
+                @"{ ""identifier"": ""InstalledProvider"" }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"":  [ ""InstalledProvider"" ],
+                    ""conflicts"": [ { ""name"": ""InstalledProvider"" } ]
+                }",
+                @"{
+                    ""identifier"": ""Intermediate"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""Intermediate"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" },
+            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides InstalledProvider" }
+        ),
+        TestCase(
+            // Now the provide is indirect, so there's no installed module with that
+            // specific indentifier.
+            new string[]
+            {
+                @"{
+                    ""identifier"": ""InstalledProvider"",
+                    ""provides"": [ ""Thing"" ]
+                }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"":  [ ""Thing"" ],
+                    ""conflicts"": [ { ""name"": ""InstalledProvider"" } ]
+                }",
+                @"{
+                    ""identifier"": ""Intermediate"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""Intermediate"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" },
+            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
+        ),
+        TestCase(
+            // Now with AlternateProvider conflicting on the virtual dep.
+            new string[]
+            {
+                @"{
+                    ""identifier"": ""InstalledProvider"",
+                    ""provides"": [ ""Thing"" ]
+                }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"":  [ ""Thing"" ],
+                    ""conflicts"": [ { ""name"": ""Thing"" } ]
+                }",
+                @"{
+                    ""identifier"": ""Intermediate"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""Intermediate"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" },
+            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
+        ),
+        TestCase(
+            // Now without an explicit conflict, just the implicit provides conflict.
+            new string[]
+            {
+                @"{
+                    ""identifier"": ""InstalledProvider"",
+                    ""provides"": [ ""Thing"" ]
+                }",
+                @"{
+                    ""identifier"": ""AlternateProvider"",
+                    ""provides"":  [ ""Thing"" ],
+                }",
+                @"{
+                    ""identifier"": ""Intermediate"",
+                    ""depends"": [
+                        { ""name"": ""AlternateProvider"" }
+                    ]
+                }",
+                @"{
+                    ""identifier"": ""Parent"",
+                    ""depends"": [
+                        { ""name"": ""Intermediate"" }
+                    ]
+                }"
+            },
+            new string[] { "InstalledProvider" },
+            new string[] { "Parent" },
+            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
+        )]
+        public void Constructor_ProvidesConflict_Throws(string[] availableModules,
+                                                        string[] alreadyInstalled,
+                                                        string[] newInstalls,
+                                                        string[] errors)
+        {
+            var user = new NullUser();
+            using var inst     = new DisposableKSP();
+            using var repo     = new TemporaryRepository(availableModules.Select(MergeWithDefaults).ToArray());
+            using var repoData = new TemporaryRepositoryData(user, repo.repo);
+            using var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager, new Repository[] { repo.repo });
+
+            var registry  = regMgr.registry;
+            var opts      = RelationshipResolverOptions.DefaultOpts(inst.KSP.StabilityToleranceConfig);
+            var toInstall = newInstalls
+                .Select(ident => registry.LatestAvailable(ident,
+                                                          inst.KSP.StabilityToleranceConfig,
+                                                          inst.KSP.VersionCriteria()))
+                .OfType<CkanModule>()
+                .ToArray();
+
+            foreach (var module in alreadyInstalled)
+            {
+                registry.RegisterModule(
+                    registry.LatestAvailable(module,
+                                             inst.KSP.StabilityToleranceConfig,
+                                             inst.KSP.VersionCriteria())!,
+                    Array.Empty<string>(),
+                    inst.KSP,
+                    false);
+            }
+
+            var exc = Assert.Throws<DependenciesNotSatisfiedKraken>(() =>
+            {
+                var rr = new RelationshipResolver(
+                    toInstall, null,
+                    RelationshipResolverOptions.DependsOnlyOpts(stabilityTolerance),
+                    registry, game, crit);
+            })!;
+
+            CollectionAssert.AreEqual(
+                errors,
+                exc.Message.Split(new string[] { Environment.NewLine },
+                                  StringSplitOptions.RemoveEmptyEntries));
+        }
+
         [TestCase(new string[]
                   {
                       @"{

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -2154,8 +2154,29 @@ namespace Tests.Core.Relationships
                 }"
             },
             new string[] { "ModA", "ModB" },
-            new string[] { "Version conflict: Lib 2.0 is needed for ModB 1.0, and Lib 1.0 is needed for ModA 1.0, but both cannot be installed at the same time" }
-        )]
+            new string[] { "Version conflict: Lib 2.0 is needed for ModB 1.0, and Lib 1.0 is needed for ModA 1.0, but both cannot be installed at the same time" }),
+        TestCase(
+            // Here we attempt to install two different versions of the same mod.
+            new string[]
+            {
+                @"{
+                    ""identifier"": ""Lib"",
+                    ""version"":    ""1.0"",
+                    ""provides"":   [ ""OldVirtual"" ]
+                }",
+                @"{
+                    ""identifier"": ""Lib"",
+                    ""version"":    ""2.0"",
+                    ""provides"":   [ ""NewVirtual"" ]
+                }",
+                @"{
+                    ""identifier"": ""ModA"",
+                    ""depends"":    [ { ""name"": ""OldVirtual"" } ]
+                }",
+            },
+            new string[] { "ModA", "Lib" },
+            new string[] { "Version conflict: Lib 1.0 is needed for ModA 1.0, but Lib 2.0 is already being installed" }),
+        ]
         public void Constructor_VersionMismatch_Throws(string[] availableModules,
                                                        string[] newInstalls,
                                                        string[] errors)

--- a/Tests/Core/Relationships/RelationshipResolverTests.cs
+++ b/Tests/Core/Relationships/RelationshipResolverTests.cs
@@ -1886,7 +1886,7 @@ namespace Tests.Core.Relationships
             },
             new string[] { "InstalledProvider" },
             new string[] { "Parent" },
-            new string[] { "AlternateProvider 1.0 is needed for Parent 1.0, but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides InstalledProvider" }
+            new string[] { "AlternateProvider 1.0 is needed for Parent 1.0, but cannot be installed because it conflicts with InstalledProvider 1.0, which also provides InstalledProvider" }
         ),
         TestCase(
             // Now the conflicting provider is reached transitively.
@@ -1913,7 +1913,7 @@ namespace Tests.Core.Relationships
             },
             new string[] { "InstalledProvider" },
             new string[] { "Parent" },
-            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides InstalledProvider" }
+            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0, which also provides InstalledProvider" }
         ),
         TestCase(
             // Now the provide is indirect, so there's no installed module with that
@@ -1944,7 +1944,7 @@ namespace Tests.Core.Relationships
             },
             new string[] { "InstalledProvider" },
             new string[] { "Parent" },
-            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
+            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0, which also provides Thing" }
         ),
         TestCase(
             // Now with AlternateProvider conflicting on the virtual dep.
@@ -1974,7 +1974,7 @@ namespace Tests.Core.Relationships
             },
             new string[] { "InstalledProvider" },
             new string[] { "Parent" },
-            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0 which also provides Thing" }
+            new string[] { "AlternateProvider 1.0 is needed for Intermediate 1.0 (needed for Parent 1.0), but cannot be installed because it conflicts with InstalledProvider 1.0, which also provides Thing" }
         ),
         TestCase(
             // This is an explicit conflict that doesn't go through any provide


### PR DESCRIPTION
Currently, if you try to install a mod that provides X, but there is some other mod already installed that also provides X, then you get an error message that looks like

    Unsatisfied dependency Y needed for: ...

This tells the users nothing about what is wrong or how to fix it. This commit is an attempt to improve the error message here. The new error message is now

    X is needed for Y, but cannot be installed because it conflicts with Z, which also provides W.

This commit changes:
* Instead of just getting a dependency chain, DependenciesNotSatisfiedKraken now takes a list of UnsatisfiedRelation. These also optionally store a reason that the relation could not be satisfied, which can then be used for better error messages.
* ResolvedRelationshipsTree.Candidates now explicitly checks for provides conflicts and records unresolved relations accordingly.
* In cases where there are no candidates and no unresolved relations then we redo the lookup without filtering in order to find modules that could have satisfied the relation, under different conditions.
* DependenciesNotSatisfiedKraken now takes the ProviderRejection into account when coming up with the error message.

I have also added some test cases that validate that the correct error message is emitted under a number of different conditions.

I'm not sure that this necessarily the right approach. It feels like I am pulling stuff into `ResolvedRelationshipTree` that isn't really supposed to be there. On the other hand the "if error then re-resolve to get unsatisfied candidates" bit does actually feel right to me, so I'm not sure what the correct balance is here.

---

> The easiest one to test is probably this:
> - Add the sol repo
> - Install parallax continued
> - Apply
> - Install Sol-Configs
