### PR TITLE
Make  .NET 10 build self-contained

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -208,7 +208,7 @@ public sealed class RepackCkanTask : FrostingTask<BuildContext>
                                       Framework         = $"{context.BuildDotNet}-windows",
                                       Runtime           = "win-x64",
                                       PublishSingleFile = true,
-                                      SelfContained     = false,
+                                      SelfContained     = true,
                                   });
             context.CopyFile(context.Paths.OutDirectory.Combine("CKAN-CmdLine")
                                                        .Combine(context.BuildConfiguration)


### PR DESCRIPTION
## Motivation

@Clayell just asked about trying out dark mode on DIscord, so I shared the link. He didn't have .NET 10 installed, which ended up being quite a speedbump. I don't think walking all users through that is going to be feasible.

## Changes

Now the `ckan-windows.exe` .NET 10 build is self-contained. This increases the size from 14 MB to 127 MB, but it should no longer require the runtime.
