### PR TITLE
Add edit labels option to labels filter dropdown

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -50,6 +50,8 @@ namespace CKAN.GUI
             this.FilterIncompatibleButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterAllButton = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterLabelsToolButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.FilterLabelsToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.FilterLabelsEditToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.FilterTagsToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.NavBackwardToolButton = new System.Windows.Forms.ToolStripMenuItem();
             this.NavForwardToolButton = new System.Windows.Forms.ToolStripMenuItem();
@@ -78,7 +80,7 @@ namespace CKAN.GUI
             this.tagFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.untaggedFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.labelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.labelToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.labelsToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.editLabelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -278,6 +280,13 @@ namespace CKAN.GUI
             this.FilterLabelsToolButton.Size = new System.Drawing.Size(179, 22);
             resources.ApplyResources(this.FilterLabelsToolButton, "FilterLabelsToolButton");
             this.FilterLabelsToolButton.DropDown.Opening += new System.ComponentModel.CancelEventHandler(FilterLabelsToolButton_DropDown_Opening);
+            //
+            // FilterLabelsEditToolStripMenuItem
+            //
+            this.FilterLabelsEditToolStripMenuItem.Name = "FilterLabelsEditToolStripMenuItem";
+            this.FilterLabelsEditToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
+            this.FilterLabelsEditToolStripMenuItem.Click += new System.EventHandler(this.editLabelsToolStripMenuItem_Click);
+            resources.ApplyResources(this.FilterLabelsEditToolStripMenuItem, "FilterLabelsEditToolStripMenuItem");
             //
             // NavBackwardToolButton
             //
@@ -632,6 +641,8 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem FilterIncompatibleButton;
         private System.Windows.Forms.ToolStripMenuItem FilterAllButton;
         private System.Windows.Forms.ToolStripMenuItem FilterLabelsToolButton;
+        private System.Windows.Forms.ToolStripSeparator FilterLabelsToolStripSeparator;
+        private System.Windows.Forms.ToolStripMenuItem FilterLabelsEditToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem FilterTagsToolButton;
         private System.Windows.Forms.ToolStripMenuItem NavBackwardToolButton;
         private System.Windows.Forms.ToolStripMenuItem NavForwardToolButton;
@@ -659,7 +670,7 @@ namespace CKAN.GUI
         private System.Windows.Forms.ContextMenuStrip LabelsContextMenuStrip;
         private System.Windows.Forms.ContextMenuStrip ModListHeaderContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem labelsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator labelToolStripSeparator;
+        private System.Windows.Forms.ToolStripSeparator labelsToolStripSeparator;
         private System.Windows.Forms.ToolStripMenuItem editLabelsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -358,6 +358,8 @@ namespace CKAN.GUI
                                                        ToolTipText = Properties.Resources.FilterLinkToolTip,
                                                    })
                                    .ToArray());
+                FilterLabelsToolButton.DropDownItems.Add(FilterLabelsToolStripSeparator);
+                FilterLabelsToolButton.DropDownItems.Add(FilterLabelsEditToolStripMenuItem);
             }
         }
 
@@ -400,7 +402,7 @@ namespace CKAN.GUI
                             });
                     }
                 }
-                LabelsContextMenuStrip.Items.Add(labelToolStripSeparator);
+                LabelsContextMenuStrip.Items.Add(labelsToolStripSeparator);
                 LabelsContextMenuStrip.Items.Add(editLabelsToolStripMenuItem);
                 e.Cancel = false;
             }

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -158,5 +158,6 @@
   <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Purge from cache</value></data>
   <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels</value></data>
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Edit labels...</value></data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve"><value>Edit labels...</value></data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve"><value>Ctrl-click or Shift-click to re-download metadata even if there are no changes since last refresh</value></data>
 </root>

--- a/GUI/Localization/de-DE/ManageMods.de-DE.resx
+++ b/GUI/Localization/de-DE/ManageMods.de-DE.resx
@@ -240,6 +240,9 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Labels bearbeiten...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Labels bearbeiten...</value>
+  </data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve">
     <value>[Strg + Klick] oder [Shift + Klick], um Metadaten erneut herunterzuladen, auch wenn keine Änderungen gefunden wurden</value>
   </data>

--- a/GUI/Localization/es-ES/ManageMods.es-ES.resx
+++ b/GUI/Localization/es-ES/ManageMods.es-ES.resx
@@ -240,6 +240,9 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Editar categorías...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Editar categorías...</value>
+  </data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve">
     <value>Ctrl-clic o Mayúscula-clic para volver a descargar metadatos incluso si no hay cambios desde la última actualización</value>
   </data>

--- a/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
+++ b/GUI/Localization/fr-FR/ManageMods.fr-FR.resx
@@ -240,6 +240,9 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Modifier les labels...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Modifier les labels...</value>
+  </data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve">
     <value>Ctrl-clic ou Maj-clic pour re-télécharger les métadonnées, même si elles sont identiques</value>
   </data>

--- a/GUI/Localization/it-IT/ManageMods.it-IT.resx
+++ b/GUI/Localization/it-IT/ManageMods.it-IT.resx
@@ -240,6 +240,9 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Modifica etichette...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Modifica etichette...</value>
+  </data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve">
     <value>Fai clic con il tasto Ctrl o Shift per scaricare nuovamente i metadati anche se non ci sono state modifiche dall'ultimo aggiornamento</value>
   </data>

--- a/GUI/Localization/ja-JP/ManageMods.ja-JP.resx
+++ b/GUI/Localization/ja-JP/ManageMods.ja-JP.resx
@@ -234,4 +234,7 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>ラベルを編集...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>ラベルを編集...</value>
+  </data>
 </root>

--- a/GUI/Localization/ko-KR/ManageMods.ko-KR.resx
+++ b/GUI/Localization/ko-KR/ManageMods.ko-KR.resx
@@ -231,4 +231,7 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>라벨 수정...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>라벨 수정...</value>
+  </data>
 </root>

--- a/GUI/Localization/nl-NL/ManageMods.nl-NL.resx
+++ b/GUI/Localization/nl-NL/ManageMods.nl-NL.resx
@@ -231,4 +231,7 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Wijzig Labels...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Wijzig Labels...</value>
+  </data>
 </root>

--- a/GUI/Localization/pl-PL/ManageMods.pl-PL.resx
+++ b/GUI/Localization/pl-PL/ManageMods.pl-PL.resx
@@ -240,6 +240,9 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Edytuj etykiety...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Edytuj etykiety...</value>
+  </data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve">
     <value>Kliknij Ctrl lub Shift, aby ponownie pobrać metadane, nawet jeśli nie było żadnych zmian od ostatniego odświeżenia</value>
   </data>

--- a/GUI/Localization/pt-BR/ManageMods.pt-BR.resx
+++ b/GUI/Localization/pt-BR/ManageMods.pt-BR.resx
@@ -231,6 +231,9 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Editar rótulos...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Editar rótulos...</value>
+  </data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve">
     <value>Ctrl-clique ou Shift-clique para baixar novamente os metadados mesmo que não haja mudanças desde a última atualização</value>
   </data>

--- a/GUI/Localization/ru-RU/ManageMods.ru-RU.resx
+++ b/GUI/Localization/ru-RU/ManageMods.ru-RU.resx
@@ -231,4 +231,7 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>Изменить ярлыки...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>Изменить ярлыки...</value>
+  </data>
 </root>

--- a/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
+++ b/GUI/Localization/zh-CN/ManageMods.zh-CN.resx
@@ -240,6 +240,9 @@
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve">
     <value>编辑标签...</value>
   </data>
+  <data name="FilterLabelsEditToolStripMenuItem.Text" xml:space="preserve">
+    <value>编辑标签...</value>
+  </data>
   <data name="RefreshToolButton.ToolTipText" xml:space="preserve">
     <value>Ctrl-单击或Shift-单击重新下载元数据，即使自上次刷新以来没有变化</value>
   </data>

--- a/GUI/Main/Main.Designer.cs
+++ b/GUI/Main/Main.Designer.cs
@@ -68,12 +68,6 @@ namespace CKAN.GUI
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.splitContainer1 = new CKAN.GUI.UsableSplitContainer();
-            this.LabelsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.modListToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-            this.tagFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-            this.untaggedFilterToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-            this.labelToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-            this.editLabelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ModInfo = new CKAN.GUI.ModInfo();
             this.StatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.StatusInstanceLabel = new System.Windows.Forms.ToolStripStatusLabel();
@@ -999,12 +993,6 @@ namespace CKAN.GUI
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private CKAN.GUI.UsableSplitContainer splitContainer1;
-        private System.Windows.Forms.ToolStripSeparator modListToolStripSeparator;
-        private System.Windows.Forms.ToolStripSeparator tagFilterToolStripSeparator;
-        private System.Windows.Forms.ToolStripSeparator untaggedFilterToolStripSeparator;
-        private System.Windows.Forms.ContextMenuStrip LabelsContextMenuStrip;
-        private System.Windows.Forms.ToolStripSeparator labelToolStripSeparator;
-        private System.Windows.Forms.ToolStripMenuItem editLabelsToolStripMenuItem;
         private CKAN.GUI.ModInfo ModInfo;
         private System.Windows.Forms.ToolStripStatusLabel StatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel StatusInstanceLabel;


### PR DESCRIPTION
## Motivation

The "Edit labels..." option is only available in the right click menu, which is not very discoverable.

## Changes

Now this option also appears in the labels submenu of the filters dropdown.

<img width="611" height="727" alt="image" src="https://github.com/user-attachments/assets/95579482-02aa-4c3c-a65c-2ceb899c7f18" />
