### PR TITLE
Scale tooltips on Mono

### DIFF
--- a/GUI/Controls/DownloadStatistics/DownloadStatisticsTable.cs
+++ b/GUI/Controls/DownloadStatistics/DownloadStatisticsTable.cs
@@ -24,13 +24,14 @@ namespace CKAN.GUI
 
             ResumeLayout();
 
-            tooltip = new ToolTip()
+            ToolTip = new ToolTip()
                       {
                           AutoPopDelay = 10000,
                           InitialDelay = 250,
                           ReshowDelay  = 250,
                           ShowAlways   = true,
                       };
+            ToolTip.ScaleFonts();
         }
 
         public void SetData(IReadOnlyDictionary<string, long> bytesPerHost)
@@ -92,7 +93,7 @@ namespace CKAN.GUI
                            TabStop      = true,
                            LinkColor    = BackColor.LinkColorForBackColor(),
                        };
-            tooltip.SetToolTip(link, tooltipText);
+            ToolTip.SetToolTip(link, tooltipText);
             link.LinkClicked += (sender, e) => Util.HandleLinkClicked(url, e);
             link.KeyDown     += (sender, e) =>
                                 {
@@ -119,6 +120,6 @@ namespace CKAN.GUI
             { "archive.org",    "https://archive.org/donate"        },
         };
 
-        private readonly ToolTip tooltip;
+        private readonly ToolTip ToolTip;
     }
 }

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -26,6 +26,7 @@ namespace CKAN.GUI
             InitializeComponent();
 
             ToolTip.SetToolTip(ExpandButton, Properties.Resources.EditModSearchTooltipExpandButton);
+            ToolTip.ScaleFonts();
 
             // TextBox resizes unpredictably at runtime, so we need special logic
             // to line up the button with it

--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -21,6 +21,7 @@ namespace CKAN.GUI
         {
             InitializeComponent();
             ToolTip.SetToolTip(AddSearchButton, Properties.Resources.EditModSearchesTooltipAddSearchButton);
+            ToolTip.ScaleFonts();
         }
 
         public event Action?                  SurrenderFocus;

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -41,6 +41,7 @@ namespace CKAN.GUI
             ToolTip.SetToolTip(IgnoreRadioButton,       Properties.Resources.EditModpackTooltipIgnore);
             ToolTip.SetToolTip(CancelExportButton,      Properties.Resources.EditModpackTooltipCancel);
             ToolTip.SetToolTip(ExportModpackButton,     Properties.Resources.EditModpackTooltipExport);
+            ToolTip.ScaleFonts();
         }
 
         [ForbidGUICalls]

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -37,6 +37,7 @@ namespace CKAN.GUI
             uninstallingFont = new Font(ModGrid.Font, FontStyle.Strikeout);
 
             ToolTip.SetToolTip(InstallAllCheckbox, Properties.Resources.ManageModsInstallAllCheckboxTooltip);
+            ToolTip.ScaleFonts();
             FilterCompatibleButton.ToolTipText      = Properties.Resources.FilterLinkToolTip;
             FilterInstalledButton.ToolTipText       = Properties.Resources.FilterLinkToolTip;
             FilterInstalledUpdateButton.ToolTipText = Properties.Resources.FilterLinkToolTip;

--- a/GUI/Controls/ModInfo/Metadata.cs
+++ b/GUI/Controls/ModInfo/Metadata.cs
@@ -19,6 +19,7 @@ namespace CKAN.GUI
         public Metadata()
         {
             InitializeComponent();
+            ToolTip.ScaleFonts();
             staticRowCount = MetadataTable.RowCount;
         }
 

--- a/GUI/Controls/ModInfo/Relationships.cs
+++ b/GUI/Controls/ModInfo/Relationships.cs
@@ -30,6 +30,7 @@ namespace CKAN.GUI
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
 
             ToolTip.SetToolTip(ReverseRelationshipsCheckbox, Properties.Resources.ModInfoToolTipReverseRelationships);
+            ToolTip.ScaleFonts();
 
             DependsGraphTree.BeforeExpand += BeforeExpand;
         }

--- a/GUI/Controls/TagsLabelsLinkList.cs
+++ b/GUI/Controls/TagsLabelsLinkList.cs
@@ -18,6 +18,12 @@ namespace CKAN.GUI
     #endif
     public partial class TagsLabelsLinkList : FlowLayoutPanel
     {
+        public TagsLabelsLinkList()
+            : base()
+        {
+            ToolTip.ScaleFonts();
+        }
+
         [ForbidGUICalls]
         public void UpdateTagsAndLabels(IEnumerable<ModuleTag>?   tags,
                                         IEnumerable<ModuleLabel>? labels)

--- a/GUI/Controls/TriStateToggle.cs
+++ b/GUI/Controls/TriStateToggle.cs
@@ -24,6 +24,7 @@ namespace CKAN.GUI
                 ReshowDelay  = 250,
                 ShowAlways   = true,
             };
+            ToolTip.ScaleFonts();
 
             YesRadioButton  = MakeRadioButton(0, EmbeddedImages.triToggleYes,
                 Properties.Resources.TriStateToggleYesTooltip);

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -39,6 +39,7 @@ namespace CKAN.GUI
             this.ScaleFonts();
 
             ToolTip.SetToolTip(checkBoxShareStock, Properties.Resources.CloneGameInstanceToolTipShareStock);
+            ToolTip.ScaleFonts();
 
             // Populate the instances combobox with names of known instances
             comboBoxKnownInstance.DataSource =

--- a/GUI/Dialogs/EditLabelsDialog.cs
+++ b/GUI/Dialogs/EditLabelsDialog.cs
@@ -38,6 +38,7 @@ namespace CKAN.GUI
             ToolTip.SetToolTip(IgnoreMissingFilesCheckBox, Properties.Resources.EditLabelsToolTipIgnoreMissingFiles);
             ToolTip.SetToolTip(MoveUpButton, Properties.Resources.EditLabelsToolTipMoveUp);
             ToolTip.SetToolTip(MoveDownButton, Properties.Resources.EditLabelsToolTipMoveDown);
+            ToolTip.ScaleFonts();
         }
 
         private void LoadTree()

--- a/GUI/Dialogs/PreferredHostsDialog.cs
+++ b/GUI/Dialogs/PreferredHostsDialog.cs
@@ -30,6 +30,7 @@ namespace CKAN.GUI
             ToolTip.SetToolTip(MoveLeftButton,  Properties.Resources.PreferredHostsTooltipMoveLeft);
             ToolTip.SetToolTip(MoveUpButton,    Properties.Resources.PreferredHostsTooltipMoveUp);
             ToolTip.SetToolTip(MoveDownButton,  Properties.Resources.PreferredHostsTooltipMoveDown);
+            ToolTip.ScaleFonts();
         }
 
         /// <summary>

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -38,6 +38,7 @@ namespace CKAN.GUI
             ToolTip.SetToolTip(ResetCacheButton,  Properties.Resources.SettingsToolTipResetCacheButton);
             ToolTip.SetToolTip(OpenCacheButton,   Properties.Resources.SettingsToolTipOpenCacheButton);
             ToolTip.SetToolTip(ClearCacheButton,  Properties.Resources.SettingsToolTipClearCacheButton);
+            ToolTip.ScaleFonts();
 
             this.coreConfig = coreConfig;
             this.guiConfig  = guiConfig;

--- a/GUI/Extensions/WinFormsExtensions.cs
+++ b/GUI/Extensions/WinFormsExtensions.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Windows.Forms;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 #if NET5_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -65,6 +66,10 @@ namespace CKAN.GUI
                     grid.DefaultCellStyle.Font = grid.DefaultCellStyle.Font?.Scale(dpi);
                     grid.ColumnHeadersDefaultCellStyle.Font = grid.ColumnHeadersDefaultCellStyle.Font?.Scale(dpi);
                 }
+                if (control is ToolStrip strip)
+                {
+                    strip.ScaleToolTipFonts();
+                }
             }
         }
 
@@ -75,6 +80,34 @@ namespace CKAN.GUI
                 && dpi != 96)
             {
                 item.Font = item.Font.Scale(dpi);
+            }
+        }
+
+        public static void ScaleFonts(this ToolTip tip)
+        {
+            if (Platform.IsMono
+                && tip.GetType().GetField("tooltip_window",
+                                          BindingFlags.Instance | BindingFlags.NonPublic)
+                                ?.GetValue(tip)
+                   is Control control)
+            {
+                control.ScaleFonts();
+            }
+        }
+
+        public static void ScaleToolTipFonts(this ToolStrip strip)
+        {
+            if (Platform.IsMono
+                && typeof(ToolStrip).GetProperty("ToolTipWindow",
+                                                 BindingFlags.NonPublic | BindingFlags.Instance)
+                                    ?.GetValue(strip)
+                   is ToolTip tooltip)
+            {
+                tooltip.ScaleFonts();
+                foreach (var item in strip.Items.OfType<ToolStripMenuItem>())
+                {
+                    item.DropDown.ScaleToolTipFonts();
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

Tooltips on 4K monitors are tiny on Linux.

## Cause

The font that the `ToolTip` object uses is hidden in the `Font` property of in a private `Control` field, and Mono doesn't do any font scaling of its own (see #4566).

## Changes

Now tooltips are scaled appropriately by using reflection to access the private field where the font is hidden.

Note that an extra step of reflection is needed for menus and toolbars, and this has to be carefully recursive to handle submenus.
