### PR TITLE
Fix installation of unrecognized imported ZIPs

### DIFF
--- a/Core/IO/ModuleImporter.cs
+++ b/Core/IO/ModuleImporter.cs
@@ -70,7 +70,10 @@ namespace CKAN.IO
             var cachedGroups = matched.SelectMany(kvp => kvp.Value.DistinctBy(m => m.download?.First())
                                                                   .Select(m => (File:   kvp.Key,
                                                                                 Module: m)))
-                                      .ToGroupedDictionary(tuple => Cache.IsMaybeCachedZip(tuple.Module));
+                                      .ToGroupedDictionary(tuple => Cache.IsMaybeCachedZip(tuple.Module)
+                                                                    // Overwrite if different size
+                                                                    && Cache.GetCachedFilename(tuple.Module) is string cachedPath
+                                                                    && new FileInfo(cachedPath).Length == tuple.File.Length);
             if (cachedGroups.TryGetValue(true, out (FileInfo File, CkanModule Module)[]? alreadyStored))
             {
                 // Notify about files that are already cached
@@ -184,7 +187,7 @@ namespace CKAN.IO
             // CkanModule.download is required for cache management, set a default if missing
             foreach (var ckan in internalCkans)
             {
-                ckan["download"] ??= $"https://ckan/imported-from-zip/{ckan["identifier"]}/{zip.Name}";
+                ckan["download"] ??= $"https://ckan/imported-from-zip/{ckan["identifier"]}/{Path.GetFileName(zip.Name)}";
             }
             // Set the version and compatibility if we can
             foreach (var grp in internalCkans.GroupBy(ckan => (string?)ckan["$vref"] ?? ""))

--- a/GUI/Controls/TagsLabelsLinkList.cs
+++ b/GUI/Controls/TagsLabelsLinkList.cs
@@ -118,6 +118,10 @@ namespace CKAN.GUI
                         TagClicked?.Invoke(t, ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift));
                         break;
 
+                    case { Button: MouseButtons.Middle }:
+                        TagClicked?.Invoke(t, true);
+                        break;
+
                     case { Button: MouseButtons.Right }:
                         var showHideLink = new ToolStripMenuItem(string.Format(Properties.Resources.UtilShowHideLink,
                                                                                t.Name));
@@ -137,6 +141,9 @@ namespace CKAN.GUI
                 {
                     case { Button: MouseButtons.Left }:
                         LabelClicked?.Invoke(l, ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift));
+                        break;
+                    case { Button: MouseButtons.Middle }:
+                        LabelClicked?.Invoke(l, true);
                         break;
                     case { Button: MouseButtons.Right }:
                         var addRemoveLink = new ToolStripMenuItem(string.Format(Properties.Resources.UtilAddRemoveModuleLink,

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -4,10 +4,10 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Linq;
 
-using CKAN.IO;
+using Autofac;
 
-// Don't warn if we use our own obsolete properties
-#pragma warning disable 0618
+using CKAN.Configuration;
+using CKAN.IO;
 
 namespace CKAN.GUI
 {
@@ -44,42 +44,57 @@ namespace CKAN.GUI
                     Wait.StartWaiting(
                         (sender, e) =>
                         {
-                            if (e != null && Manager?.Cache != null && ManageMods.MainModList != null)
+                            if (e != null && Manager?.Cache != null)
                             {
-                                e.Result = ModuleImporter.ImportFiles(
-                                    GetFiles(dlg.FileNames),
-                                    currentUser,
-                                    mod =>
-                                    {
-                                        if (ManageMods.MainModList
-                                                      .full_list_of_mod_rows
-                                                      .TryGetValue(mod.identifier,
-                                                                   out DataGridViewRow? row)
-                                            && row.Tag is GUIMod gmod)
-                                        {
-                                            gmod.SelectedMod = mod;
-                                        }
-                                    },
-                                    RegistryManager.Instance(CurrentInstance, repoData).registry,
-                                    CurrentInstance, Manager.Cache);
+                                var toInstall = new List<CkanModule>();
+                                e.Result = (success: ModuleImporter.ImportFiles(
+                                                         GetFiles(dlg.FileNames),
+                                                         currentUser,
+                                                         toInstall.Add,
+                                                         RegistryManager.Instance(CurrentInstance, repoData).registry,
+                                                         CurrentInstance, Manager.Cache),
+                                            toInstall);
                             }
                         },
                         (sender, e) =>
                         {
                             EnableMainWindow();
-                            if (e?.Error == null && e?.Result is bool result && result)
+                            switch (e)
                             {
-                                // Put GUI back the way we found it
-                                HideWaitDialog();
-                            }
-                            else
-                            {
-                                if (e?.Error is Exception exc)
-                                {
+                                case { Error: Kraken k }:
+                                    log.Error(k.Message, k);
+                                    currentUser.RaiseMessage("{0}", k.Message);
+                                    Wait.Finish();
+                                    break;
+
+                                case { Error: Exception exc }:
                                     log.Error(exc.Message, exc);
-                                    currentUser.RaiseMessage("{0}", exc.Message);
-                                }
-                                Wait.Finish();
+                                    currentUser.RaiseMessage("{0}", exc.ToString());
+                                    Wait.Finish();
+                                    break;
+
+                                case { Result: (false, _) }:
+                                    // Failed, error already shown by importer
+                                    Wait.Finish();
+                                    break;
+
+                                case { Result: (true, List<CkanModule> { Count: < 1 }) }:
+                                    // Succeeded, nothing to import; put GUI back the way we found it
+                                    HideWaitDialog();
+                                    break;
+
+                                case { Result: (true, List<CkanModule> { Count: > 0 } toInstall) }:
+                                    var regMgr = RegistryManager.Instance(CurrentInstance, repoData);
+                                    var tuple = ModList.ComputeFullChangeSetFromUserChangeSet(
+                                        regMgr.registry,
+                                        toInstall.Select(m => new ModChange(m, GUIModChangeType.Install,
+                                                                            ServiceLocator.Container.Resolve<IConfiguration>()))
+                                                 .ToHashSet(),
+                                        ServiceLocator.Container.Resolve<IConfiguration>(), CurrentInstance);
+                                    UpdateChangesDialog(tuple.Item1.ToList(), tuple.Item2);
+                                    HideWaitDialog();
+                                    tabController.ShowTab(ChangesetTabPage.Name, 1);
+                                    break;
                             }
                         },
                         false,

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -459,7 +459,7 @@ Or choose "Update repositories on launch" in the settings.</value></data>
   <data name="RepoDownloadsFailedAbortBtn" xml:space="preserve"><value>Abort whole update</value></data>
   <data name="AuthorSearchName"><value>Mods by {0}</value></data>
   <data name="FilterLinkToolTip"><value>Click to search
-Ctrl-click or Shift-click to combine with current search</value></data>
+Ctrl-click or Shift-click or middle click to combine with current search</value></data>
   <data name="FolderContainsManagedFiles"><value>Can't delete {0} because it contains files that were installed by CKAN.
 If you wish to remove this folder, uninstall these mods normally.</value></data>
   <data name="DeleteUnmanagedFileConfirmation"><value>Are you sure you want to delete {0}?

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -498,7 +498,7 @@ namespace CKAN.GUI
                         ?.StandardOutput.ReadToEnd().Contains(checkFor);
 
         #if NET10_0_OR_GREATER
-        private const string DarkModeKey = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\CurrentVersion\Themes\Personalize";
+        private const string DarkModeKey = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
         #endif
 
         // Hides the console window on Windows

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -184,6 +184,7 @@ namespace CKAN.GUI
             switch (e?.Button)
             {
                 case MouseButtons.Left:
+                case MouseButtons.Middle:
                     OpenLinkFromLinkLabel(url);
                     if (e.Link != null)
                     {


### PR DESCRIPTION
## Problem

If you try to import an unrecognized ZIP file containing a sufficient internal .ckan file and say Yes when asked whether to install it, the install doesn't happen.

## Cause

Since the importer was originally designed solely as a replacement for CKAN's own downloading functions, it relied on marking modules to install in the mod list. This doesn't work when the mod isn't in the mod list.

(I think when I was developing #4327, I didn't continue all the way through to testing the installation but instead stopped at the install prompt. Now that I have a mocked-up fake version of TrueVolumetricClouds courtesy of @JonnyOThan's file listing, I can try the whole flow: [FakeVolumetricClouds.zip](https://github.com/user-attachments/files/27773124/FakeVolumetricClouds.zip))

## Motivations

- The registry key that we use to check for dark mode is technically wrong (`\Windows\` is missing between `\Microsoft\CurrentVersion\`), even though it still works thanks to Windows automatically correcting it for us
- Middle clicking links opens a new tab in typical browsers but does nothing in CKAN

## Changes

- Now when you choose to install the mods that you just imported, the changeset screen appears with those mods listed (along with their dependencies), and clicking Apply will continue the install
- Now the registry key is fixed
  Fixes #4620
- Now middle clicking a link opens it (for URLs) or behaves the same as Shift+Click or Ctrl+Click (for authors, labels, and tags)
