### PR TITLE
Auto-size grid rows to ensure high-DPI visibility of checkboxes

### DIFF
--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -327,18 +327,16 @@ namespace CKAN.GUI
             //
             // ModGrid
             //
-            this.ModGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ModGrid.AllowUserToAddRows = false;
             this.ModGrid.AllowUserToDeleteRows = false;
             this.ModGrid.AllowUserToResizeRows = false;
+            this.ModGrid.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.DisplayedCellsExceptHeaders;
             this.ModGrid.BackgroundColor = System.Drawing.SystemColors.Window;
-            this.ModGrid.EnableHeadersVisualStyles = false;
+            this.ModGrid.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             this.ModGrid.ColumnHeadersDefaultCellStyle.BackColor = System.Drawing.SystemColors.Control;
             this.ModGrid.ColumnHeadersDefaultCellStyle.SelectionBackColor = System.Drawing.SystemColors.Control;
             this.ModGrid.ColumnHeadersDefaultCellStyle.ForeColor = System.Drawing.SystemColors.ControlText;
             this.ModGrid.ColumnHeadersDefaultCellStyle.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.ModGrid.DefaultCellStyle.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.ModGrid.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             this.ModGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.ModGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Installed,
@@ -356,6 +354,10 @@ namespace CKAN.GUI
             this.InstallDate,
             this.DownloadCount,
             this.Description});
+            this.ModGrid.DefaultCellStyle.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.ModGrid.DefaultCellStyle.Padding = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.ModGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ModGrid.EnableHeadersVisualStyles = false;
             this.ModGrid.Location = new System.Drawing.Point(0, 111);
             this.ModGrid.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ModGrid.MultiSelect = true;

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -23,7 +23,8 @@ namespace CKAN.GUI
         private CkanModule       Mod                 { get; set; }
         public  CkanModule?      LatestCompatibleMod { get; private set; }
         public  CkanModule?      LatestAvailableMod  { get; private set; }
-        public  InstalledModule? InstalledMod        { get; private set; }
+        public  InstalledModule? InstalledMod => registry.InstalledModule(Identifier);
+        private readonly IRegistryQuerier registry;
 
         /// <summary>
         /// The module of the checkbox that is checked in the MainAllModVersions list if any,
@@ -146,7 +147,7 @@ namespace CKAN.GUI
                    incompatible, hideEpochs, hideV)
         {
             IsInstalled      = true;
-            InstalledMod     = instMod;
+            this.registry    = registry;
             selectedMod      = registry.GetModuleByVersion(instMod.identifier, instMod.Module.version)
                                ?? instMod.Module;
             InstallDate      = instMod.InstallTime;
@@ -183,6 +184,7 @@ namespace CKAN.GUI
                       bool  hideEpochs,
                       bool  hideV)
         {
+            this.registry  = registry;
             Identifier     = mod.identifier;
             IsAutodetected = registry.IsAutodetected(Identifier);
             DownloadCount  = repoDataMgr.GetDownloadCount(registry.Repositories.Values, Identifier);

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -177,7 +177,15 @@ namespace Tests.GUI
             using (var cacheDir = new TemporaryDirectory())
             using (var cache    = new NetModuleCache(cacheDir))
             {
-                var sut     = new GUIMod(instMod, repoData, Registry.Empty(repoData),
+                var registry = new Registry(repoData,
+                                            new Dictionary<string, InstalledModule>()
+                                            {
+                                                { instMod.identifier, instMod },
+                                            },
+                                            new Dictionary<string, string>(),
+                                            new Dictionary<string, string>(),
+                                            new SortedDictionary<string, Repository>());
+                var sut     = new GUIMod(instMod, repoData, registry,
                                          inst.KSP.StabilityToleranceConfig, inst.KSP,
                                          cache, false, true, true);
                 var callbackCount = 0;

--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Version: @VERSION@
 Architecture: all
 Section: utils
 Priority: optional
-Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-servicemodel4.0a-cil
+Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-servicemodel4.0a-cil, libmono-system-componentmodel-composition4.0-cil
 Maintainer: The CKAN authors <debian@ksp-ckan.space>
 Description: KSP-CKAN official client.
  Official client for the Comprehensive Kerbal Archive Network (CKAN).


### PR DESCRIPTION
## Problems

- If you install the .deb on Linux without `mono-complete`, runing CKAN throws an exception:
  ```
  System.IO.FileNotFoundException: Could not load file or assembly 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' or one of its dependencies.
  File name: 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
  ```
- Discord user Jonno reported that the checkboxes in the main mod list sometimes don't show up on a 189 DPI monitor with 150% UI scaling.
  <img width="2559" height="1599" alt="Image" src="https://github.com/user-attachments/assets/217c3607-7765-4e41-a1d3-3cd04813a979" />
- After a failed install, toggling the auto-installed checkboxes for installed mods doesn't work as expected. Mods that were marked as auto-installed before the failed install will still be auto-removed when their depending mods are removed, even if you change them to not-auto-installed.
  <img width="570" height="514" alt="Image" src="https://github.com/user-attachments/assets/004ecb45-be7e-4249-8ac4-3f27b92a5da7" />

## Causees

- Apparently when `dotnet` compiles for net481 on Windows, it generates a build that needs more dependencies than when Mono compiles for net481 on Linux, since we don't use `System.ComponentModel.Composition` explicitly anywhere in our own code.
- Presumably the grid rows are not scaled proportionally to the UI/font scaling by default.
- `GUIMod.InstalledMod` becomes stale when an installation failure causes the current `Registry` to be restored from its internal backup. A new `InstalledModule` is deserialized and used by the registry, and meanwhile the corresponding `GUIMod` retains a reference to the old object, so when it changes that object's `AutoInstalled` property, the registry's object still has the old value.

## Changes

- Now `libmono-system-componentmodel-composition4.0-cil` is added to the dependencies of the .deb package. In my testing, this makes CKAN work properly after `sudo apt install ckan` on a fresh Ubuntu.
  Fixes #4600.
- Now the mod grid's `AutoSizeRowsMode ` property is set to `DisplayedCellsExceptHeaders`, which Jonno reported fixes the issue. The `DefaultCellStyle.Padding` property is set to try to keep the appearance rougly the same, since by default the auto-sizing packs the rows more tightly.
  Fixes #4629.
- Now `GUIMod.InstalledMod` is retrieved from the `Registry` on the fly as needed, so it will always return the currently correct object.
  Fixes #4626.
