### PR TITLE
Don't offer to delete paid mod ZIPs after import

### DIFF
--- a/Core/IO/ModuleImporter.cs
+++ b/Core/IO/ModuleImporter.cs
@@ -60,7 +60,10 @@ namespace CKAN.IO
                                             .Where(m => m.IsCompatible(instance.VersionCriteria()))
                                             .ToHashSet();
 
-            var deletable = matched.Keys.ToList();
+            // Don't offer to delete mods w/ no metadata in main repo (probably paid mods w/ internal .ckans)
+            var deletable = matched.Where(kvp => kvp.Value.All(m => registry.GetModuleByVersion(m.identifier, m.version) != null))
+                                   .Select(kvp => kvp.Key)
+                                   .ToList();
             var delete    = allowDelete
                             && deletable.Count > 0
                             && user.RaiseYesNoDialog(string.Format(Properties.Resources.ModuleInstallerImportDeletePrompt,

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -201,70 +201,70 @@ namespace CKAN.GUI
             //
             this.FilterCompatibleButton.Name = "FilterCompatibleButton";
             this.FilterCompatibleButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterCompatibleButton.Click += new System.EventHandler(this.FilterCompatibleButton_Click);
+            this.FilterCompatibleButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterCompatibleButton_Click);
             resources.ApplyResources(this.FilterCompatibleButton, "FilterCompatibleButton");
             //
             // FilterInstalledButton
             //
             this.FilterInstalledButton.Name = "FilterInstalledButton";
             this.FilterInstalledButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterInstalledButton.Click += new System.EventHandler(this.FilterInstalledButton_Click);
+            this.FilterInstalledButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterInstalledButton_Click);
             resources.ApplyResources(this.FilterInstalledButton, "FilterInstalledButton");
             //
             // FilterInstalledUpdateButton
             //
             this.FilterInstalledUpdateButton.Name = "FilterInstalledUpdateButton";
             this.FilterInstalledUpdateButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterInstalledUpdateButton.Click += new System.EventHandler(this.FilterInstalledUpdateButton_Click);
+            this.FilterInstalledUpdateButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterInstalledUpdateButton_Click);
             resources.ApplyResources(this.FilterInstalledUpdateButton, "FilterInstalledUpdateButton");
             //
             // FilterReplaceableButton
             //
             this.FilterReplaceableButton.Name = "FilterReplaceableButton";
             this.FilterReplaceableButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterReplaceableButton.Click += new System.EventHandler(this.FilterReplaceableButton_Click);
+            this.FilterReplaceableButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterReplaceableButton_Click);
             resources.ApplyResources(this.FilterReplaceableButton, "FilterReplaceableButton");
             //
             // FilterCachedButton
             //
             this.FilterCachedButton.Name = "FilterCachedButton";
             this.FilterCachedButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterCachedButton.Click += new System.EventHandler(this.FilterCachedButton_Click);
+            this.FilterCachedButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterCachedButton_Click);
             resources.ApplyResources(this.FilterCachedButton, "FilterCachedButton");
             //
             // FilterUncachedButton
             //
             this.FilterUncachedButton.Name = "FilterUncachedButton";
             this.FilterUncachedButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterUncachedButton.Click += new System.EventHandler(this.FilterUncachedButton_Click);
+            this.FilterUncachedButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterUncachedButton_Click);
             resources.ApplyResources(this.FilterUncachedButton, "FilterUncachedButton");
             //
             // FilterNewButton
             //
             this.FilterNewButton.Name = "FilterNewButton";
             this.FilterNewButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterNewButton.Click += new System.EventHandler(this.FilterNewButton_Click);
+            this.FilterNewButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterNewButton_Click);
             resources.ApplyResources(this.FilterNewButton, "FilterNewButton");
             //
             // FilterNotInstalledButton
             //
             this.FilterNotInstalledButton.Name = "FilterNotInstalledButton";
             this.FilterNotInstalledButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterNotInstalledButton.Click += new System.EventHandler(this.FilterNotInstalledButton_Click);
+            this.FilterNotInstalledButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterNotInstalledButton_Click);
             resources.ApplyResources(this.FilterNotInstalledButton, "FilterNotInstalledButton");
             //
             // FilterIncompatibleButton
             //
             this.FilterIncompatibleButton.Name = "FilterIncompatibleButton";
             this.FilterIncompatibleButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterIncompatibleButton.Click += new System.EventHandler(this.FilterIncompatibleButton_Click);
+            this.FilterIncompatibleButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterIncompatibleButton_Click);
             resources.ApplyResources(this.FilterIncompatibleButton, "FilterIncompatibleButton");
             //
             // FilterAllButton
             //
             this.FilterAllButton.Name = "FilterAllButton";
             this.FilterAllButton.Size = new System.Drawing.Size(307, 30);
-            this.FilterAllButton.Click += new System.EventHandler(this.FilterAllButton_Click);
+            this.FilterAllButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FilterAllButton_Click);
             resources.ApplyResources(this.FilterAllButton, "FilterAllButton");
             //
             // FilterTagsToolButton

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -320,22 +320,20 @@ namespace CKAN.GUI
                 FilterTagsToolButton.DropDownItems.Clear();
                 FilterTagsToolButton.DropDownItems.AddRange(
                     registry.Tags.OrderBy(kvp => kvp.Key)
-                                 .Select(kvp => new ToolStripMenuItem(
-                                                    $"{kvp.Key} ({kvp.Value.ModuleIdentifiers.Count})",
-                                                    null, tagFilterButton_Click)
+                                 .Select(kvp => AddMouseDownHandler(new ToolStripMenuItem(
+                                                    $"{kvp.Key} ({kvp.Value.ModuleIdentifiers.Count})")
                                                 {
                                                     Tag         = kvp.Value,
                                                     ToolTipText = Properties.Resources.FilterLinkToolTip,
-                                                })
+                                                }, tagFilterButton_Click))
                                  .OfType<ToolStripItem>()
                                  .Append(untaggedFilterToolStripSeparator)
-                                 .Append(new ToolStripMenuItem(
+                                 .Append(AddMouseDownHandler(new ToolStripMenuItem(
                                              string.Format(Properties.Resources.MainLabelsUntagged,
-                                                           registry.Untagged.Count),
-                                             null, tagFilterButton_Click)
+                                                           registry.Untagged.Count))
                                          {
                                              Tag = null
-                                         })
+                                         }, tagFilterButton_Click))
                                  .ToArray());
             }
         }
@@ -348,16 +346,15 @@ namespace CKAN.GUI
                 FilterLabelsToolButton.DropDownItems.AddRange(
                     ModuleLabelList.ModuleLabels
                                    .LabelsFor(currentInstance.Name)
-                                   .Select(mlbl => new ToolStripMenuItem(
-                                                       $"{mlbl.Name} ({mlbl.ModuleCount(currentInstance.Game)})",
-                                                       null, customFilterButton_Click)
+                                   .Select(mlbl => AddMouseDownHandler(new ToolStripMenuItem(
+                                                       $"{mlbl.Name} ({mlbl.ModuleCount(currentInstance.Game)})")
                                                    {
                                                        Tag         = mlbl,
                                                        BackColor   = mlbl.Color ?? Color.Transparent,
                                                        ForeColor   = mlbl.Color?.ForeColorForBackColor()
                                                                                ?? SystemColors.ControlText,
                                                        ToolTipText = Properties.Resources.FilterLinkToolTip,
-                                                   })
+                                                   }, customFilterButton_Click))
                                    .ToArray());
                 FilterLabelsToolButton.DropDownItems.Add(FilterLabelsToolStripSeparator);
                 FilterLabelsToolButton.DropDownItems.Add(FilterLabelsEditToolStripMenuItem);
@@ -441,77 +438,83 @@ namespace CKAN.GUI
             }
         }
 
+        private static ToolStripMenuItem AddMouseDownHandler(ToolStripMenuItem item, MouseEventHandler handler)
+        {
+            item.MouseDown += handler;
+            return item;
+        }
+
         #endregion
 
-        private void tagFilterButton_Click(object? sender, EventArgs? e)
+        private void tagFilterButton_Click(object? sender, MouseEventArgs? e)
         {
             var clicked = sender as ToolStripMenuItem;
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Tag, ModuleLabelList.ModuleLabels, clicked?.Tag as ModuleTag, null), merge);
         }
 
-        private void customFilterButton_Click(object? sender, EventArgs? e)
+        private void customFilterButton_Click(object? sender, MouseEventArgs? e)
         {
             var clicked = sender as ToolStripMenuItem;
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.CustomLabel, ModuleLabelList.ModuleLabels, null, clicked?.Tag as ModuleLabel), merge);
         }
 
-        private void FilterCompatibleButton_Click(object? sender, EventArgs? e)
+        private void FilterCompatibleButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Compatible, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterInstalledButton_Click(object? sender, EventArgs? e)
+        private void FilterInstalledButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Installed, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterInstalledUpdateButton_Click(object? sender, EventArgs? e)
+        private void FilterInstalledUpdateButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.InstalledUpdateAvailable, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterReplaceableButton_Click(object? sender, EventArgs? e)
+        private void FilterReplaceableButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Replaceable, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterCachedButton_Click(object? sender, EventArgs? e)
+        private void FilterCachedButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Cached, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterUncachedButton_Click(object? sender, EventArgs? e)
+        private void FilterUncachedButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Uncached, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterNewButton_Click(object? sender, EventArgs? e)
+        private void FilterNewButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.NewInRepository, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterNotInstalledButton_Click(object? sender, EventArgs? e)
+        private void FilterNotInstalledButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.NotInstalled, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterIncompatibleButton_Click(object? sender, EventArgs? e)
+        private void FilterIncompatibleButton_Click(object? sender, MouseEventArgs? e)
         {
-            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift);
+            var merge = ModifierKeys.HasAnyFlag(Keys.Control, Keys.Shift) || e?.Button == MouseButtons.Middle;
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.Incompatible, ModuleLabelList.ModuleLabels), merge);
         }
 
-        private void FilterAllButton_Click(object? sender, EventArgs? e)
+        private void FilterAllButton_Click(object? sender, MouseEventArgs? e)
         {
             Filter(ModList.FilterToSavedSearch(currentInstance!, GUIModFilter.All, ModuleLabelList.ModuleLabels), false);
         }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -79,6 +79,9 @@ namespace CKAN.GUI
 
             if (Platform.IsMono)
             {
+                // Mono renders all blank cells if we add padding
+                ModGrid.DefaultCellStyle.Padding = new Padding(0);
+                // Mono doesn't resize column headers correctly
                 ModGrid.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
                 ResizeColumnHeaders();
                 ModGrid.ColumnWidthChanged += (sender, e) => ResizeColumnHeaders();


### PR DESCRIPTION
## Motivation

- If you import a ZIP file, the first Yes/No prompt asks whether you want to delete it after importing:
  <img width="631" height="205" alt="image" src="https://github.com/user-attachments/assets/ff51890a-3b4f-47f7-98e8-2c15801d7534" />
  This option made sense for importing normal mods that are indexed in CKAN, since those downloads become redundant as soon as they're imported. But as of #4327 and #4628, we are intending this feature to be used for paid mods as well, for which this prompt creates two problems:
  - If you have paid for a ZIP file, it's a very bad idea to delete it, so CKAN is pointing a loaded gun right at the users' feet.
  - If you ever want to install such a mod again, the only way to do that is via importing, which is no longer possible if the file you need to import was deleted.

## Problems

- The mod grid has mostly empty cells on Linux in the current dev build:
  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ba1be641-4f56-49f8-9e68-c1643d55e912" />
  Reported by Discord user Greatspace2019KSP.
- The tooltip for the filter dropdown options mentions "middle click" in the current dev build, but actually middle clicking does nothing
  <img width="709" height="515" alt="image" src="https://github.com/user-attachments/assets/e0e998d9-65ed-4817-96aa-4ff7d73c461b" />

## Cause

- Apparently Mono's `DataGridView` cannot handle cell padding (but only when the build was generated on Windows...somehow?), which #4630 added to compensate for auto-sizing shrinking the rows.
- #4628 added support for middle-clicking links, tags, and labels, and updated the tooltip to reflect this. However, the tooltip is shared with the filter menu items, which only respond to left click.

## Changes

- Now we exclude non-indexed mods from the deletion option; if you choose to import _only_ a paid mod (probably the 99% case eventually), then the deletion prompt is skipped and the installation prompt appears immediately.
- Now the grid's cell padding is removed on Mono, which restores visibility of the contents.
- Now we handle `MouseClick` instead of `Click` for the filter dropdown options, because it fires for all clicks rather than just left click and allows us to check which button was clicked. If the middle button was clicked, then we do the same thing we do for Ctrl+Click and Shift+Click.
