### PR TITLE
Apply all subdocuments of internal .ckans

### DIFF
--- a/Netkan/Services/IModuleService.cs
+++ b/Netkan/Services/IModuleService.cs
@@ -13,7 +13,7 @@ namespace CKAN.NetKAN.Services
     {
         Tuple<ZipEntry, bool>? FindInternalAvc(CkanModule module, ZipFile zipfile, string internalFilePath);
         AvcVersion? GetInternalAvc(CkanModule module, string filePath, string? internalFilePath = null);
-        JObject? GetInternalCkan(CkanModule module, string zipPath);
+        IEnumerable<JObject> GetInternalCkans(CkanModule module, string zipPath);
         bool HasInstallableFiles(CkanModule module, string filePath);
 
         IEnumerable<InstallableFile> GetConfigFiles(CkanModule module, ZipFile zip);

--- a/Netkan/Services/ModuleService.cs
+++ b/Netkan/Services/ModuleService.cs
@@ -44,8 +44,8 @@ namespace CKAN.NetKAN.Services
         /// <param name="zipPath">Where the ZIP file is</param>
         /// <param name="inst">Game instance for generating InstallableFiles</param>
         /// <returns>Parsed contents of the file, or null if none found</returns>
-        public JObject? GetInternalCkan(CkanModule module, string zipPath)
-            => GetInternalCkan(module, new ZipFile(zipPath), game);
+        public IEnumerable<JObject> GetInternalCkans(CkanModule module, string zipPath)
+            => GetInternalCkans(module, new ZipFile(zipPath), game);
 
         /// <summary>
         /// Find and parse a .ckan file in the ZIP.
@@ -56,7 +56,7 @@ namespace CKAN.NetKAN.Services
         /// <param name="zip">The ZipFile to search</param>
         /// <param name="inst">Game instance for generating InstallableFiles</param>
         /// <returns>Parsed contents of the file, or null if none found</returns>
-        private static JObject? GetInternalCkan(CkanModule module, ZipFile zip, IGame game)
+        private static IEnumerable<JObject> GetInternalCkans(CkanModule module, ZipFile zip, IGame game)
             => (module.install != null
                     // Find embedded .ckan files that would be included in the install
                     ? GetFilesBySuffix(module, zip, ".ckan", game)
@@ -64,9 +64,7 @@ namespace CKAN.NetKAN.Services
                     // Find embedded .ckan files anywhere in the ZIP
                     : zip.OfType<ZipEntry>()
                          .Where(ModuleInstaller.IsInternalCkan))
-                .Select(entry => DeserializeFromStream(
-                                    zip.GetInputStream(entry)))
-                .FirstOrDefault();
+                .SelectMany(entry => DeserializeFromStream(zip.GetInputStream(entry)));
 
         public bool HasInstallableFiles(CkanModule module, string filePath)
             => Utilities.DefaultIfThrows(() =>
@@ -115,12 +113,11 @@ namespace CKAN.NetKAN.Services
         /// Return a parsed JObject from a stream.
         /// Courtesy https://stackoverflow.com/questions/8157636/can-json-net-serialize-deserialize-to-from-a-stream/17788118#17788118
         /// </summary>
-        private static JObject? DeserializeFromStream(Stream stream)
+        private static IEnumerable<JObject> DeserializeFromStream(Stream stream)
         {
             using (var sr = new StreamReader(stream))
             {
-                // Only one document per internal .ckan
-                return YamlExtensions.Parse(sr).FirstOrDefault()?.ToJObject();
+                return YamlExtensions.Parse(sr).Select(yaml => yaml.ToJObject());
             }
         }
 

--- a/Netkan/Transformers/InternalCkanTransformer.cs
+++ b/Netkan/Transformers/InternalCkanTransformer.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
 using log4net;
 
 using CKAN.NetKAN.Extensions;
@@ -37,30 +39,32 @@ namespace CKAN.NetKAN.Transformers
                 // Set it to a default if missing so CkanModule can initialize.
                 var moduleJson = metadata.Json();
                 moduleJson.SafeAdd("version", "1");
-                CkanModule   mod  = CkanModule.FromJson(moduleJson.ToString());
-                var internalJson = _moduleService.GetInternalCkan(mod, contents);
-
-                if (internalJson != null)
+                CkanModule mod = CkanModule.FromJson(moduleJson.ToString());
+                if (_moduleService.GetInternalCkans(mod, contents).ToArray()
+                    is { Length: > 0 } internalJsons)
                 {
                     var json = metadata.Json();
-                    Log.InfoFormat("Executing internal CKAN transformation with {0}", metadata.Kref);
-                    Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, metadata.AllJson);
-
-                    foreach (var property in internalJson.Properties())
+                    foreach (var internalJson in internalJsons)
                     {
-                        // We've already got the file, too late to tell us where it lives
-                        if (property.Name == "$kref")
+                        Log.InfoFormat("Executing internal CKAN transformation with {0}", metadata.Kref);
+                        Log.DebugFormat("Input metadata:{0}{1}", Environment.NewLine, metadata.AllJson);
+
+                        foreach (var property in internalJson.Properties())
                         {
-                            Log.DebugFormat("Skipping $kref property: {0}", property.Value);
-                            continue;
+                            // We've already got the file, too late to tell us where it lives
+                            if (property.Name == "$kref")
+                            {
+                                Log.DebugFormat("Skipping $kref property: {0}", property.Value);
+                                continue;
+                            }
+                            json.SafeAdd(property.Name, property.Value);
                         }
-                        json.SafeAdd(property.Name, property.Value);
+
+                        GameVersion.SetJsonCompatibility(json, null, null, null);
+                        json.SafeMerge("resources", internalJson["resources"]);
+
+                        Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
                     }
-
-                    GameVersion.SetJsonCompatibility(json, null, null, null);
-                    json.SafeMerge("resources", internalJson["resources"]);
-
-                    Log.DebugFormat("Transformed metadata:{0}{1}", Environment.NewLine, json);
                     yield return new Metadata(json);
                     yield break;
                 }

--- a/Tests/NetKAN/Services/ModuleServiceTests.cs
+++ b/Tests/NetKAN/Services/ModuleServiceTests.cs
@@ -64,7 +64,7 @@ namespace Tests.NetKAN.Services
             CkanModule mod = CkanModule.FromJson(TestData.DogeCoinFlag_101());
 
             // Act
-            var result = sut.GetInternalCkan(mod, TestData.DogeCoinFlagZip());
+            var result = sut.GetInternalCkans(mod, TestData.DogeCoinFlagZip()).FirstOrDefault();
 
             // Assert
             Assert.That(result, Is.Not.Null,

--- a/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
+++ b/Tests/NetKAN/Transformers/InternalCkanTransformerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 using Moq;
@@ -17,14 +18,16 @@ namespace Tests.NetKAN.Transformers
         private readonly TransformOptions opts = new TransformOptions(1, null, null, null, false, null);
 
         [Test]
-        public void AddsMissingProperties()
+        public void Transform_WithMissingProperties_Adds()
         {
             // Arrange
             const string filePath = "/DoesNotExist.zip";
 
-            var internalCkan = new JObject();
-            internalCkan["spec_version"] = 1;
-            internalCkan["foo"] = "bar";
+            var internalCkan = new JObject()
+            {
+                { "spec_version", 1 },
+                { "foo",          "bar" },
+            };
 
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
@@ -32,18 +35,20 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
-            mModuleService.Setup(i => i.GetInternalCkan(
+            mModuleService.Setup(i => i.GetInternalCkans(
                     It.IsAny<CkanModule>(), It.IsAny<string>()))
-                .Returns(internalCkan);
+                .Returns(new JObject[] { internalCkan });
 
             var sut = new InternalCkanTransformer(mHttp.Object, mModuleService.Object);
 
-            var json = new JObject();
-            json["spec_version"] = 1;
-            json["identifier"] = "DoesNotExist";
-            json["author"] = "DidNotCreate";
-            json["version"] = "1.0";
-            json["download"] = "https://awesomemod.example/AwesomeMod.zip";
+            var json = new JObject()
+            {
+                { "spec_version", 1 },
+                { "identifier",   "DoesNotExist" },
+                { "author",       "DidNotCreate" },
+                { "version",      "1.0" },
+                { "download",     "https://awesomemod.example/AwesomeMod.zip" },
+            };
 
             // Act
             var result = sut.Transform(new Metadata(json), opts).First();
@@ -56,14 +61,17 @@ namespace Tests.NetKAN.Transformers
         }
 
         [Test]
-        public void DoesNotOverrideExistingProperties()
+        public void Transform_WithExistingProperties_DoesNotOverride()
         {
             // Arrange
             const string filePath = "/DoesNotExist.zip";
 
-            var internalCkan = new JObject();
-            internalCkan["spec_version"] = 1;
-            internalCkan["foo"] = "bar";
+            var internalCkan = new JObject()
+            {
+                { "spec_version", 1 },
+                { "foo",          "bar" },
+                { "$kref",        "#/ckan/github/ThisShould/BeIgnored"},
+            };
 
             var mHttp = new Mock<IHttpService>();
             var mModuleService = new Mock<IModuleService>();
@@ -71,19 +79,21 @@ namespace Tests.NetKAN.Transformers
             mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
                 .Returns(filePath);
 
-            mModuleService.Setup(i => i.GetInternalCkan(
+            mModuleService.Setup(i => i.GetInternalCkans(
                     It.IsAny<CkanModule>(), It.IsAny<string>()))
-                .Returns(internalCkan);
+                .Returns(new JObject[] { internalCkan });
 
             var sut = new InternalCkanTransformer(mHttp.Object, mModuleService.Object);
 
-            var json = new JObject();
-            json["spec_version"] = 1;
-            json["identifier"] = "DoesNotExist";
-            json["author"] = "DidNotCreate";
-            json["version"] = "1.0";
-            json["foo"] = "baz";
-            json["download"] = "https://awesomemod.example/AwesomeMod.zip";
+            var json = new JObject()
+            {
+                { "spec_version", 1 },
+                { "identifier",   "DoesNotExist" },
+                { "author",       "DidNotCreate" },
+                { "version",      "1.0" },
+                { "foo",          "baz" },
+                { "download",     "https://awesomemod.example/AwesomeMod.zip" },
+            };
 
             // Act
             var result = sut.Transform(new Metadata(json), opts).First();
@@ -93,6 +103,43 @@ namespace Tests.NetKAN.Transformers
             Assert.That((string?)transformedJson["foo"], Is.EqualTo("baz"),
                 "InternalCkanTransformer should not override existing properties."
             );
+            Assert.IsFalse(transformedJson.ContainsKey("$kref"));
+        }
+
+        [Test]
+        public void Transform_NoInternalCkan_DoesNothing()
+        {
+            // Arrange
+            const string filePath = "/DoesNotExist.zip";
+
+            var mHttp = new Mock<IHttpService>();
+            var mModuleService = new Mock<IModuleService>();
+
+            mHttp.Setup(i => i.DownloadModule(It.IsAny<Metadata>()))
+                .Returns(filePath);
+
+            mModuleService.Setup(i => i.GetInternalCkans(
+                    It.IsAny<CkanModule>(), It.IsAny<string>()))
+                .Returns(Array.Empty<JObject>());
+
+            var sut = new InternalCkanTransformer(mHttp.Object, mModuleService.Object);
+
+            var json = new JObject()
+            {
+                { "spec_version", 1 },
+                { "identifier",   "DoesNotExist" },
+                { "author",       "DidNotCreate" },
+                { "version",      "1.0" },
+                { "foo",          "baz" },
+                { "download",     "https://awesomemod.example/AwesomeMod.zip" },
+            };
+
+            // Act
+            var result = sut.Transform(new Metadata(json), opts).First();
+            var transformedJson = result.Json();
+
+            // Assert
+            Assert.AreEqual(json, transformedJson);
         }
     }
 }


### PR DESCRIPTION
## Problem

ChemicalPropulsionNuclear recently added an internal .ckan file, mostly a copy of the existing .netkan:

- <https://github.com/CharleRoger/ChemicalPropulsion/blob/main/Extras/ChemicalPropulsionThermal/ChemicalPropulsionThermal.ckan>

```yaml
identifier: ChemicalPropulsionThermal
$kref: '#/ckan/github/CharleRoger/ChemicalPropulsion'
$vref: '#/ckan/ksp-avc'
---
identifier: ChemicalPropulsionThermal
name: Chemical Propulsion - Thermal
abstract: >-
  An extension pack for Chemical Propulsion which
  adds high-thrust, low-isp propellant options to thermal rockets
$kref: '#/ckan/spacedock/3866'
$vref: '#/ckan/ksp-avc'
tags:
  - config
depends:
  - name: ModuleManager
  - name: B9PartSwitch
  - name: CommunityResourcePack
  - name: ChemicalCore
  - name: ChemicalPropulsion
  - name: Ignition
install:
  - find: ChemicalPropulsionThermal
    install_to: GameData
```

However, even if we remove `abstract` and `depends` from the .netkan, the values from the internal .ckan are not applied.

## Cause

`ModuleService.GetInternalCkan` only returns the first document from the first .ckan file if there are multiple.
Since `abstract` and `depends` are defined only in the second document, they are not included.

## Changes

Now if an internal .ckan file contains multiple documents, we apply all of them instead of just the first.
