### PR TITLE
Replace NavigationHistory.IsReadOnly with same-value check

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -62,7 +62,7 @@ namespace CKAN.GUI
 
             // History is read-only until the UI is started. We switch
             // out of it at the end of OnLoad() when we call NavInit().
-            navHistory = new NavigationHistory<GUIMod> { IsReadOnly = true };
+            navHistory = new NavigationHistory<GUIMod>();
 
             // Initialize navigation. This should be called as late as
             // possible, once the UI is "settled" from its initial load.
@@ -2083,7 +2083,6 @@ namespace CKAN.GUI
         private void NavInit()
         {
             navHistory.OnHistoryChange += NavOnHistoryChange;
-            navHistory.IsReadOnly = false;
             var currentMod = SelectedModule;
             if (currentMod != null)
             {
@@ -2116,9 +2115,7 @@ namespace CKAN.GUI
         {
             // Focusing on a mod also causes navigation, but we don't want
             // this to affect the history, so we switch to read-only mode.
-            navHistory.IsReadOnly = true;
             FocusMod(module.Name, true);
-            navHistory.IsReadOnly = false;
         }
 
         private void NavOnHistoryChange()

--- a/GUI/NavigationHistory.cs
+++ b/GUI/NavigationHistory.cs
@@ -11,23 +11,13 @@ namespace CKAN.GUI
     public class NavigationHistory<T>
         where T : notnull
     {
-        private readonly List<T> m_navigationHistory;
-        private int m_currentIndex;
-
-        public NavigationHistory()
-        {
-            m_navigationHistory = new List<T>();
-            m_currentIndex = -1;
-            IsReadOnly = false;
-        }
-
         #region Events
 
         public delegate void HistoryChangeHandler();
 
         public event HistoryChangeHandler? OnHistoryChange;
 
-        public void InvokeOnHistoryChange()
+        private void InvokeOnHistoryChange()
         {
             OnHistoryChange?.Invoke();
         }
@@ -45,77 +35,83 @@ namespace CKAN.GUI
         public bool CanNavigateForward => m_currentIndex < (m_navigationHistory.Count - 1);
 
         /// <summary>
-        /// Indicates whether the history is in read-only mode.
-        /// During read-only mode, all calls that could modify the state of the
-        /// history are silenly ignored.
-        /// </summary>
-        public bool IsReadOnly { get; set; }
-
-        /// <summary>
         /// Adds the given item to the head of the navigation history.
         /// </summary>
         /// <param name="item"></param>
         public void AddToHistory(T item)
         {
-            if (IsReadOnly)
+            lock (mutex)
             {
-                return;
+                if (m_currentIndex >= 0 && m_currentIndex < m_navigationHistory.Count
+                    && item.Equals(m_navigationHistory[m_currentIndex]))
+                {
+                    // Don't add (or truncate) if same as current item
+                    return;
+                }
+
+                if (CanNavigateForward)
+                {
+                    /*
+                     * This operation removes all history AHEAD of the current index,
+                     * adds a new item to the head of the list, and advances the index.
+                     *
+                     * Let's say this is your current state:
+                     *
+                     * =============
+                     * |x|y|z|a|b|c|
+                     * =============
+                     *      ^
+                     *
+                     * When you add an item to the history ('d'),
+                     * the next state will be:
+                     *
+                     * =========
+                     * |x|y|z|d|
+                     * =========
+                     *        ^
+                     */
+                    m_navigationHistory.RemoveRange(m_currentIndex + 1, m_navigationHistory.Count - (m_currentIndex + 1));
+                }
+
+                m_navigationHistory.Add(item);
+                m_currentIndex++;
+
+                InvokeOnHistoryChange();
             }
-
-            /*
-             * This operation removes all history AHEAD of the current index,
-             * adds a new item to the head of the list, and advances the index.
-             *
-             * Let's say this is your current state:
-             *
-             * =============
-             * |x|y|z|a|b|c|
-             * =============
-             *      ^
-             *
-             * When you add an item to the history ('d'),
-             * the next state will be:
-             *
-             * =========
-             * |x|y|z|d|
-             * =========
-             *        ^
-             */
-
-            if (CanNavigateForward)
-            {
-                m_navigationHistory.RemoveRange(m_currentIndex + 1, m_navigationHistory.Count - (m_currentIndex + 1));
-            }
-
-            m_navigationHistory.Add(item);
-            m_currentIndex++;
-
-            InvokeOnHistoryChange();
         }
 
         public bool TryGoBackward([NotNullWhen(true)] out T? newCurrentItem)
         {
-            if (!IsReadOnly && CanNavigateBackward)
+            lock (mutex)
             {
-                newCurrentItem = m_navigationHistory[--m_currentIndex];
-                InvokeOnHistoryChange();
-                return true;
+                if (CanNavigateBackward)
+                {
+                    newCurrentItem = m_navigationHistory[--m_currentIndex];
+                    InvokeOnHistoryChange();
+                    return true;
+                }
+                newCurrentItem = default;
+                return false;
             }
-            newCurrentItem = default;
-            return false;
         }
 
         public bool TryGoForward([NotNullWhen(true)] out T? newCurrentItem)
         {
-            if (!IsReadOnly && CanNavigateForward)
+            lock (mutex)
             {
-                newCurrentItem = m_navigationHistory[++m_currentIndex];
-                InvokeOnHistoryChange();
-                return true;
+                if (CanNavigateForward)
+                {
+                    newCurrentItem = m_navigationHistory[++m_currentIndex];
+                    InvokeOnHistoryChange();
+                    return true;
+                }
+                newCurrentItem = default;
+                return false;
             }
-            newCurrentItem = default;
-            return false;
         }
 
+        private readonly List<T> m_navigationHistory = new List<T>();
+        private readonly object mutex = new object();
+        private int m_currentIndex = -1;
     }
 }

--- a/Tests/GUI/NavigationHistoryTests.cs
+++ b/Tests/GUI/NavigationHistoryTests.cs
@@ -59,6 +59,35 @@ namespace Tests.GUI
         }
 
         [Test]
+        public void After_DuplicateHistoryItem_NoChange()
+        {
+            // Arrange
+            var nav = new NavigationHistory<int>();
+
+            // Act / Assert
+            nav.AddToHistory(1);
+            Assert.IsFalse(nav.TryGoForward(out int val));
+            Assert.AreEqual(default(int), val);
+            nav.AddToHistory(2);
+            nav.AddToHistory(3);
+            Assert.IsTrue(nav.TryGoBackward(out val));
+            Assert.AreEqual(2, val);
+            nav.AddToHistory(2);
+            nav.AddToHistory(2);
+            Assert.IsTrue(nav.TryGoForward(out val));
+            Assert.AreEqual(3, val);
+            Assert.IsFalse(nav.CanNavigateForward);
+            Assert.IsTrue(nav.TryGoBackward(out val));
+            Assert.AreEqual(2, val);
+            Assert.IsTrue(nav.TryGoBackward(out val));
+            Assert.AreEqual(1, val);
+            Assert.IsTrue(nav.CanNavigateForward);
+            Assert.IsFalse(nav.TryGoBackward(out val));
+            Assert.AreEqual(default(int), val);
+        }
+
+
+        [Test]
         public void While_AtHeadOfHistory_CannotNavigateForward()
         {
             // arrange
@@ -199,142 +228,6 @@ namespace Tests.GUI
             Assert.IsFalse(navForwAfterNine);
             Assert.AreEqual(1, one);
             Assert.AreEqual(9, nine);
-        }
-
-        [Test]
-        public void ReadOnlyMode_BlocksAddingToHistory()
-        {
-            // arrange
-
-            var nav = new NavigationHistory<int>
-            {
-                IsReadOnly = true
-            };
-
-            // act
-
-            nav.AddToHistory(1);
-            nav.AddToHistory(2);
-            nav.AddToHistory(3);
-
-            nav.IsReadOnly = false;
-
-            // assert
-
-            Assert.IsFalse(nav.CanNavigateBackward);
-            Assert.IsFalse(nav.CanNavigateForward);
-        }
-
-        [Test]
-        public void ReadOnlyMode_BlocksBackwardNavigation()
-        {
-            // arrange
-
-            var nav = new NavigationHistory<int>();
-
-            nav.AddToHistory(1);
-            nav.AddToHistory(2);
-            nav.AddToHistory(3);
-
-            nav.IsReadOnly = true;
-
-            // act
-
-            nav.TryGoBackward(out _);
-            nav.TryGoBackward(out _);
-            nav.TryGoBackward(out _);
-
-            var canStillNavigate = nav.CanNavigateBackward;
-
-            nav.IsReadOnly = false;
-
-            nav.TryGoBackward(out var two);
-
-            // assert
-
-            Assert.True(canStillNavigate);
-            Assert.AreEqual(2, two);
-        }
-
-        [Test]
-        public void ReadOnlyMode_BlocksForwardNavigation()
-        {
-            // arrange
-
-            var nav = new NavigationHistory<int>();
-
-            nav.AddToHistory(1);
-            nav.AddToHistory(2);
-            nav.AddToHistory(3);
-
-            nav.TryGoBackward(out _);
-            nav.TryGoBackward(out _);
-
-            nav.IsReadOnly = true;
-
-            // act
-
-            nav.TryGoForward(out _);
-            nav.TryGoForward(out _);
-            nav.TryGoForward(out _);
-
-            var canStillNavigate = nav.CanNavigateForward;
-
-            nav.IsReadOnly = false;
-
-            nav.TryGoForward(out var two);
-
-            // assert
-
-            Assert.True(canStillNavigate);
-            Assert.AreEqual(2, two);
-        }
-
-        [Test]
-        public void BackwardsNavigation_DuringReadOnlyMode_ProducesDefaultValue()
-        {
-            // arrange
-
-            var nav = new NavigationHistory<int>();
-
-            nav.AddToHistory(1);
-            nav.AddToHistory(2);
-            nav.AddToHistory(3);
-
-            nav.IsReadOnly = true;
-
-            // act
-
-            nav.TryGoBackward(out var zero);
-
-            // assert
-
-            Assert.AreEqual(default(int), zero);
-        }
-
-        [Test]
-        public void ForwardsNavigation_DuringReadOnlyMode_ProducesDefaultValue()
-        {
-            // arrange
-
-            var nav = new NavigationHistory<int>();
-
-            nav.AddToHistory(1);
-            nav.AddToHistory(2);
-            nav.AddToHistory(3);
-
-            nav.TryGoBackward(out _);
-            nav.TryGoBackward(out _);
-
-            nav.IsReadOnly = true;
-
-            // act
-
-            nav.TryGoForward(out var zero);
-
-            // assert
-
-            Assert.AreEqual(default(int), zero);
         }
 
         [Test]


### PR DESCRIPTION
## Problem

The back/forward buttons on the main mod list are broken. If you click the back button, the forward button becomes disabled; it is supposed to remain enabled so you can navigate back and forth in the history.

## Cause

Support for multi-select was added in #4386, which caused many row-select events, one per mod in the group, to be fired in sequence when the user shift-clicked a block of rows. This initially caused the mod info pane to be loaded for every one of those mods, which caused a lot of flickering and slowness. To solve this, we debounced the row selection event, such that if multiple of them happen within 100 milliseconds, only the last one will be handled.

Unfortunately, the `NavigationHistory` implementation strongly assumed that the handling of this event would be synchronous and single-threaded. It relied on setting an `IsReadOnly` property to prevent navigation within the history from affecting the history itself. Now that the event is handled asynchronously, the `NavigationHistory` corrupts itself when used, truncating the future history when navigating backwards.

## Changes

- The `IsReadOnly` property is removed
- Now when a new element is requested to be added to the history, we check whether it's equal to the currently active element. If so, no changes are made. This will work regardless of whether the event handling implementation is synchronous or asynchronous.

After these changes, the back/forward buttons work normally again.
