### PR TITLE
Sync certs from newer location in RPM package

### DIFF
--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -60,8 +60,6 @@ namespace CKAN.GUI
 
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
 
-            // History is read-only until the UI is started. We switch
-            // out of it at the end of OnLoad() when we call NavInit().
             navHistory = new NavigationHistory<GUIMod>();
 
             // Initialize navigation. This should be called as late as

--- a/GUI/Controls/ModInfo/Relationships.cs
+++ b/GUI/Controls/ModInfo/Relationships.cs
@@ -116,7 +116,7 @@ namespace CKAN.GUI
                 DependsGraphTree.Nodes.Add(root);
                 AddChildren(registry, Manager.CurrentInstance.StabilityToleranceConfig, root);
                 root.Expand();
-                // Expand virtual depends nodes
+                // Expand virtual nodes
                 foreach (var node in root.Nodes.OfType<TreeNode>()
                                                .Where(nd => nd.Nodes.Count > 0))
                 {

--- a/rpm/ckan.spec
+++ b/rpm/ckan.spec
@@ -28,8 +28,7 @@ Official client for the Comprehensive Kerbal Archive Network (CKAN).
 Acts as a mod manager for Kerbal Space Program mods.
 
 %post
-cert-sync /etc/pki/tls/certs/ca-bundle.crt
-cert-sync --user /etc/pki/tls/cert.pem
+cert-sync /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 %install
 umask 0022


### PR DESCRIPTION
## Background

Mono has its own cert store, which ships empty, and CKAN doesn't work without certs. The `cert-sync` utility can import certs from the sytem store into Mono's:

- <https://www.mono-project.com/docs/faq/security/>

## Problem

The install of the RPM package fails on Fedora 44.

- <https://github.com/KSP-CKAN/CKAN/blob/master/doc/rpm-repo.md>

```
mai 15 18:27:57 fedora rpm-ostree(ckan.post)[8480]: Unknown option or file not found '/etc/pki/tls/certs/ca-bundle.crt'.
mai 15 18:27:57 fedora rpm-ostree(ckan.post)[8480]: Mono Certificate Store Sync - version 6.14.1.0
mai 15 18:27:57 fedora rpm-ostree(ckan.post)[8480]: Populate Mono certificate store from a concatenated list of certificates.
mai 15 18:27:57 fedora rpm-ostree(ckan.post)[8480]: Copyright 2002, 2003 Motus Technologies. Copyright 2004-2008 Novell. BSD licensed.
mai 15 18:27:57 fedora rpm-ostree(ckan.post)[8480]: Usage: cert-sync [--quiet] [--user] system-ca-bundle.crt
mai 15 18:27:57 fedora rpm-ostree(ckan.post)[8480]: Where system-ca-bundle.crt is in PEM format
mai 15 18:27:58 fedora rpm-ostree(ckan.post)[8484]: Unknown option or file not found '/etc/pki/tls/cert.pem'.
mai 15 18:27:58 fedora rpm-ostree(ckan.post)[8484]: Mono Certificate Store Sync - version 6.14.1.0
mai 15 18:27:58 fedora rpm-ostree(ckan.post)[8484]: Populate Mono certificate store from a concatenated list of certificates.
mai 15 18:27:58 fedora rpm-ostree(ckan.post)[8484]: Copyright 2002, 2003 Motus Technologies. Copyright 2004-2008 Novell. BSD licensed.
mai 15 18:27:58 fedora rpm-ostree(ckan.post)[8484]: Usage: cert-sync [--quiet] [--user] system-ca-bundle.crt
mai 15 18:27:58 fedora rpm-ostree(ckan.post)[8484]: Where system-ca-bundle.crt is in PEM format
```

## Cause

Fedora deleted `/etc/pki/tls/certs/ca-bundle.crt` and `/etc/pki/tls/cert.pem`, and replaced them with `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`, see:

- <https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile>

Our RPM package's `%post` step tries to import the deleted files into Mono's cert store, which fails.

## Changes

Now we sync certs from `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` instead, which is the replacement path according the above documentation. I confirmed that this file exists in the `fedora:latest` Docker image and that `cert-sync` doesn't fail to import it.
(It did say `I already trust 146, your new list has 146`, which suggests to me that the certs are already imported, but I don't trust that we can rely on that always being the case for all users on all RPM-based distros.)

Fixes #4632.
